### PR TITLE
ci: add fmt/clippy/test matrix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-targets
+      - run: cargo test --all-targets


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on PRs and pushes to `main`.
- Jobs: `Format` (cargo fmt --check), `Clippy` (cargo clippy --all-targets -D warnings), `Test` matrix across ubuntu-latest, macos-latest, windows-latest (cargo build + cargo test).
- Uses `Swatinem/rust-cache` for build/clippy caching. `fail-fast: false` so one OS failing doesn't cancel the others.

## Test plan
- [ ] All three `Test` matrix legs go green
- [ ] `Format` passes
- [ ] `Clippy` passes
- [ ] On merge, configure branch protection on `main` (require PR, 1 approval, all four checks green, block force-push, squash-merge only)
- [ ] Open follow-up `chore/commit-lint` PR adding PR-title linting