### PR TITLE
ci: lint PR titles against conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            perf
+            build
+            ci
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-title.yml` using `amannn/action-semantic-pull-request@v5` to validate PR titles against Conventional Commits.
- Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `style`, `revert`. Scope optional. Subject must start lowercase.
- Repo is already configured to squash-merge with PR title as the squash subject, so this guarantees every commit on `main` is conventional.

## Follow-up after merge
- [ ] Add `Lint PR title` as a required status check on `main` branch protection.

## Test plan
- [ ] `Lint PR title` check passes on this PR (the title is itself valid: `ci: lint PR titles against conventional commits`)
- [ ] All 5 existing required checks pass (fmt, clippy, 3x test matrix)