### PR TITLE
docs: establish ADR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR change and why? 1-3 bullets. -->
+
+## Test plan
+
+<!-- Checklist of how this was verified. -->
+- [ ]
+
+## Related
+
+<!-- Link the issue this closes and any relevant ADR(s). Delete lines that don't apply. -->
+- Closes #
+- ADR:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-This is a freshly-initialized Rust project (Rust edition 2024). It currently contains only the default `cargo new` scaffolding: a single `src/main.rs` printing "Hello, world!" and a `Cargo.toml` with no dependencies. There is no architecture to describe yet — treat early work here as greenfield.
+Early-stage Rust project (edition 2024). Vision: a game engine where Claude sits in a harness as assistant/engineer/designer. Architectural direction (see `docs/adr/`): a thin native kernel owns I/O, GPU, audio, and hosts a WASM runtime; engine components run as WASM modules and communicate via a mail system.
+
+## Workflow
+
+- **Exploration and design discussion** happens in chat with the user. No artifact required.
+- **Planned work** (spikes, features, open investigations) lives in GitHub Issues. Referenced by the PR that closes them.
+- **Load-bearing architectural decisions** are recorded as ADRs in `docs/adr/NNNN-title.md`. Use `docs/adr/TEMPLATE.md` when starting a new one. Number sequentially. An ADR is reviewed via a PR like any other change.
+- **Branches**: `type/short-slug` (e.g. `chore/ci-bootstrap`, `feat/mail-runtime`, `docs/adr-workflow`).
+- **Commits and PR titles** follow Conventional Commits (`type(scope): subject`). Enforced in CI against PR titles. Main uses squash-merge with PR title as the commit subject, so PR title quality matters.
+- **Merging**: `main` is protected (PR required, all CI checks required, linear history, no force-push). Claude does not push to `main`, does not force-push reviewed branches, does not self-merge, and asks before destructive operations.
+- **PRs** should be small and focused — one concept per PR.
 
 ## Commands
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,32 @@
+# ADR-0001: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+
+## Context
+
+Aether will accumulate architectural decisions over time — renderer choice, scripting substrate, component model, scheduling, Claude integration shape, and more. Some are load-bearing enough that future contributors (human or Claude) will need to understand not just *what* was chosen but *why*, and under what constraints.
+
+Chat is too ephemeral to serve as the record. Issues work for tracked work but aren't indexed for decisions. Commit messages are too terse. We need a dedicated, versioned, reviewable home for decisions.
+
+## Decision
+
+We use Architecture Decision Records (ADRs), stored as markdown files in `docs/adr/NNNN-title.md` with sequential numbering. Each ADR captures context, the decision, and consequences. ADRs are reviewed via PR like any other change, so the decision itself is subject to the same review bar as code.
+
+`docs/adr/TEMPLATE.md` is the starting point for new ADRs.
+
+## Consequences
+
+- Decisions are grep-able, linkable from PRs and issues, and versioned alongside the code they govern.
+- When a decision is revisited, the old ADR stays in history with its status updated to `Superseded by ADR-XXXX`. No rewriting past reasoning.
+- There is a small discipline cost per decision. We mitigate this by only requiring ADRs for *load-bearing* architectural choices — not every design detail. Target order of magnitude: ~10s of ADRs over the project's life, not 100s.
+- The workflow complements, rather than replaces, chat discussion and issues:
+  - **Chat**: exploration, pressure-testing, fast dialogue.
+  - **Issues**: planned work, open investigations, spike tasks.
+  - **ADRs**: the decisions that survive.
+
+## Alternatives considered
+
+- **Issues-only** — decisions buried in closed-issue threads. Hard to find, hard to distill the conclusion from the dialogue.
+- **A single `DECISIONS.md` log** — works at small scale, becomes a merge-conflict and organization nightmare past a dozen entries.
+- **Wiki** — lives outside the repo, drifts from code, not part of the review flow.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: {{title}}
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What problem are we solving? What constraints, prior decisions, or forces are at play? Enough background that a future reader can judge whether this decision still applies.
+
+## Decision
+
+What we decided, stated plainly.
+
+## Consequences
+
+What changes as a result — positive, negative, and neutral. Include follow-on work this decision creates or forecloses.
+
+## Alternatives considered
+
+Options we evaluated and rejected, with one-line reasons. Optional but encouraged when the choice wasn't obvious.


### PR DESCRIPTION
## Summary
- Adds `docs/adr/0001-record-architecture-decisions.md` — the meta-ADR documenting the decision to use ADRs.
- Adds `docs/adr/TEMPLATE.md` for future ADRs.
- Adds `.github/pull_request_template.md` with Summary / Test plan / Related (issue + ADR) sections.
- Updates `CLAUDE.md` with a Workflow section so future sessions (Claude or human) pick up the same conventions: chat for exploration, issues for planned work, ADRs for load-bearing decisions.

## Test plan
- [ ] All 6 required checks pass
- [ ] PR template renders correctly on this PR (expect the new template to appear on the next PR, not this one — PR was created before the template landed on main)

## Related
- ADR: `docs/adr/0001-record-architecture-decisions.md` (in this PR)

## Follow-up
- Add `.claude/skills/adr.md` to automate ADR creation in a separate PR.
- Then ADR-0002 capturing the WASM-on-kernel + mail-first architecture from recent design discussion.