### PR TITLE
fix: correct PR title example in /adr skill

### DIFF
--- a/.claude/skills/adr.md
+++ b/.claude/skills/adr.md
@@ -25,7 +25,7 @@ Creates a new ADR in `docs/adr/` from `docs/adr/TEMPLATE.md`. Use when the user 
    - Leave `Status: Proposed` (flip to `Accepted` at merge, or later).
    - Leave the Context / Decision / Consequences / Alternatives sections untouched — those are for the author to fill.
 
-7. **Report back** the new file path and branch name. Ask the user for the substance. Do **not** commit, push, or open a PR yet — the ADR needs content first. Once the content is written, the normal PR flow applies (conventional PR title, e.g. `docs: ADR-NNNN <title>`).
+7. **Report back** the new file path and branch name. Ask the user for the substance. Do **not** commit, push, or open a PR yet — the ADR needs content first. Once the content is written, the normal PR flow applies (conventional PR title, e.g. `docs: add ADR-NNNN <title>`).
 
 ## Constraints and notes
 


### PR DESCRIPTION
## Summary
- One-word fix in `.claude/skills/adr.md`: change the example PR title `docs: ADR-NNNN <title>` to `docs: add ADR-NNNN <title>`.
- The previous example would fail the repo's PR-title lint (requires subject to start with a lowercase letter). It caught me on #5 and would catch anyone else following the skill's own example.

## Test plan
- [ ] All 6 required checks pass

## Related
- Caused by: #4 (added the skill with the misleading example)
- Caught on: #5 (lint failed, title had to be edited post-open)