### PR TITLE
docs: rename kernel to substrate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-Early-stage Rust project (edition 2024). Vision: a game engine where Claude sits in a harness as assistant/engineer/designer. Architectural direction (see `docs/adr/`): a thin native kernel owns I/O, GPU, audio, and hosts a WASM runtime; engine components run as WASM modules and communicate via a mail system.
+Early-stage Rust project (edition 2024). Vision: a game engine where Claude sits in a harness as assistant/engineer/designer. Architectural direction (see `docs/adr/`): a thin native **substrate** owns I/O, GPU, audio, and hosts a WASM runtime; engine **components** run as WASM modules and communicate via a **mail** system. (The whole system — substrate + components + tooling — is "Aether" or "the engine"; the substrate is just the native base layer.)
 
 ## Workflow
 

--- a/docs/adr/0002-mail-first-architecture.md
+++ b/docs/adr/0002-mail-first-architecture.md
@@ -1,4 +1,4 @@
-# ADR-0002: Pure-mail actor model on a WASM-hosted kernel
+# ADR-0002: Pure-mail actor model on a WASM-hosted substrate
 
 - **Status:** Proposed
 - **Date:** 2026-04-13
@@ -17,13 +17,15 @@ We are in a research phase. The intent is to start from the loosest abstraction 
 
 ## Decision
 
-Aether is built as a **thin native kernel** hosting a **WASM runtime** (initial target: `wasmtime`). Most of the engine runs as WASM components above the kernel. Components communicate **exclusively via mail** — a pure message-passing actor model with no shared memory between components.
+Aether is built as a **thin native substrate** hosting a **WASM runtime** (initial target: `wasmtime`). Most of the engine runs as WASM components above the substrate. Components communicate **exclusively via mail** — a pure message-passing actor model with no shared memory between components.
 
-### Kernel responsibilities (native Rust)
+The vocabulary this ADR adopts: **substrate** is the native base layer that owns hardware and hosts the runtime; **components** are WASM modules running above it; **mail** is the protocol between components. Each word does one job; the whole system ("Aether" or "the engine") is the three together plus tooling.
+
+### Substrate responsibilities (native Rust)
 
 - GPU rendering (wgpu)
 - Windowing and input event loop (winit)
-- Audio output — kernel-owned because the hardware latency budget (~10ms) cannot tolerate boundary crossings regardless of the component model above it
+- Audio output — substrate-owned because the hardware latency budget (~10ms) cannot tolerate boundary crossings regardless of the component model above it
 - Disk and network I/O
 - WASM runtime hosting, component lifecycle, and hot-reload
 - The scheduler that ticks the mail graph and dispatches work across a threadpool
@@ -50,7 +52,7 @@ Claude sends mail to components like any other participant. There is no privileg
 - **Capability gating falls out naturally.** A build target determines which mailboxes are registered and reachable. Claude in a Player build cannot address what isn't on its mail graph.
 - **The "in-process SDK vs. out-of-process server" question dissolves** into a transport choice. Recipients don't care where mail came from.
 - **Hot-swap is real.** WASM provides a stable ABI, so components can be unloaded and reloaded without the host-side contortions other mechanisms require.
-- **Crash isolation.** A misbehaving component traps in its VM; the kernel survives.
+- **Crash isolation.** A misbehaving component traps in its VM; the substrate survives.
 - **Determinism** is available when desired — WASM is deterministic given stable host-function responses, which helps replay and networked simulation.
 - **Performance is the open risk.** The design is deliberately loose and unoptimized. It is expected — not assumed — that measurement will expose specific places where pure mail cannot meet a requirement. The next concrete step is a spike that measures this on representative workloads before this ADR moves from Proposed to Accepted.
 - **Granularity discipline matters more than the mechanism.** A pure-mail system with component-per-entity granularity fails. A pure-mail system with component-per-subsystem granularity has a real chance of meeting requirements. Project conventions and review must enforce the latter.
@@ -61,8 +63,8 @@ Claude sends mail to components like any other participant. There is no privileg
 These are levers we have identified but are explicitly *not* taking now. They exist so future-us can reach for them in a known order rather than reinventing:
 
 - **Hierarchical shared memory.** Components could be organized into a tree; a parent could map a memory region into each child's linear memory, and siblings could declare shared-variable access for scheduler-coordinated concurrent reads. Adds structure but tightens per-frame data access for workloads that the spike shows pure mail cannot handle.
-- **Kernel-hosted fast paths.** Specific high-volume message types could be handled by native code in the kernel rather than round-tripping through a component, when that component's logic is simple enough to live as a host function.
-- **Read-only caches.** The kernel could expose immutable snapshots of specific state to components that only need to read it, avoiding per-frame mail for that state.
+- **Substrate-hosted fast paths.** Specific high-volume message types could be handled by native code in the substrate rather than round-tripping through a component, when that component's logic is simple enough to live as a host function.
+- **Read-only caches.** The substrate could expose immutable snapshots of specific state to components that only need to read it, avoiding per-frame mail for that state.
 - **Batched mail compaction.** The mail dispatcher could coalesce equivalent mails to the same recipient within a tick.
 
 None of these are binding. They are documented to prevent the reflex of inventing a new lever under pressure when one we already know about would do.
@@ -70,5 +72,5 @@ None of these are binding. They are documented to prevent the reflex of inventin
 ## Alternatives considered
 
 - **Shared memory as the primary substrate, messages as a secondary layer.** Components share a memory space; a scheduler coordinates access via declared dependencies; messages are used only for coarse coordination. Higher potential per-frame throughput, but makes Claude's integration a side-channel: Claude must understand the memory layout and scheduling contract rather than simply knowing who to mail. Rejected as the primary model. Elements of it may be reintroduced selectively as optimization paths if measurement requires them.
-- **An embedded scripting substrate** (a dynamic, interpreted language VM hosted by the kernel) instead of WASM. Considered and deferred. WASM keeps the engine Rust-all-the-way-down, provides sandboxing and hot-reload on the same footing, and avoids introducing a second language surface for Claude to author in. May be revisited if the actor model turns out to want smaller, more dynamic component units than WASM modules naturally support.
+- **An embedded scripting runtime** (a dynamic, interpreted language VM hosted natively) instead of WASM. Considered and deferred. WASM keeps the engine Rust-all-the-way-down, provides sandboxing and hot-reload on the same footing, and avoids introducing a second language surface for Claude to author in. May be revisited if the actor model turns out to want smaller, more dynamic component units than WASM modules naturally support.
 - **A privileged Claude API separate from the component interface.** Rejected: creates two parallel mutation paths, undermines capability-by-reachability, and introduces a special-case surface to design, secure, and evolve.


### PR DESCRIPTION
## Summary
- Renames the native base layer from **kernel** → **substrate** throughout ADR-0002 and CLAUDE.md.
- Reason: "kernel" collides with OS kernels and GPU compute kernels — both adjacent in this project's conceptual space. "Substrate" is unloaded and precisely captures "foundation layer on which components are built."
- Adds a short vocabulary note to ADR-0002 making the intended usage explicit: **substrate** (native base), **components** (WASM modules), **mail** (protocol). The whole system is "Aether" or "the engine."
- Rephrases the one place the ADR used "scripting substrate" generically so it doesn't collide with the new formal term.

## Test plan
- [ ] All 6 required checks pass
- [ ] ADR-0002 reads coherently after the rename
- [ ] No lingering `kernel` in repo: verified locally with grep

## Related
- Affects vocabulary in ADR-0002 (`docs/adr/0002-mail-first-architecture.md`).
- After merge, edit issue #7 to match the new vocabulary.
- Unblocks the Cargo workspace restructure PR (crate named `substrate` instead of `kernel`).