### PR TITLE
feat: add bulk, chain, and mixed workloads with per-workload CSVs

### DIFF
--- a/crates/aether-mail-spike-host/results/README.md
+++ b/crates/aether-mail-spike-host/results/README.md
@@ -8,13 +8,23 @@ The numbers that *do* land in history go through ADR-0003, which records the ver
 
 ## CSV columns
 
-`workload, n_actors, work_per_actor, iterations, total_ms, frames_per_sec, mails_per_sec, mean_us, p50_us, p95_us, p99_us`
+Each workload writes its own CSV with its own dimension columns. Common columns:
 
-- `workload` — name of the workload (`broadcast`, later `bulk`, `chain`, `mixed`).
-- `n_actors`, `work_per_actor` — the matrix cell.
+`workload, <dim_a>, <dim_b>, iterations, total_ms, frames_per_sec, mean_us, p50_us, p95_us, p99_us`
+
+- `workload` — name of the workload (`broadcast`, `bulk`, `chain`, `mixed`).
 - `iterations` — how many full frames ran inside the per-cell time budget.
-- `frames_per_sec`, `mails_per_sec` — derived throughput.
+- `frames_per_sec` — derived throughput.
 - `mean_us` / `p50_us` / `p95_us` / `p99_us` — per-frame latency distribution in microseconds.
+
+Per-workload dimensions:
+
+| Workload | dim_a | dim_b | What it sweeps |
+| --- | --- | --- | --- |
+| `broadcast` | `n_actors` | `work_per_actor` | Fanout × per-actor work |
+| `bulk` | `batch_size` | `work_per_item` | One sender → one receiver, varying batch size; tests batching amortization |
+| `chain` | `depth` | `work_per_link` | Sequential dispatch through D actors |
+| `mixed` | `n_actors` | `work_per_actor` | Broadcast tick + neighbor phase, 2N mails per frame |
 
 ## How to plot
 

--- a/crates/aether-mail-spike-host/src/main.rs
+++ b/crates/aether-mail-spike-host/src/main.rs
@@ -1,10 +1,10 @@
-// Mail-runtime spike, slice 2: mail envelope, actor abstraction, broadcast
-// workload, matrix bench harness, CSV output. Throwaway code; abstractions
-// kept as small as the spike needs and no smaller. See issue #7.
+// Mail-runtime spike: mail envelope, actor abstraction, and the four workloads
+// from issue #7 (broadcast, bulk, chain, mixed) with matrix bench harness and
+// CSV output. Throwaway code; abstractions kept as small as the spike needs.
 
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
@@ -27,6 +27,16 @@ struct Mail<'a> {
     kind: MailKind,
     batch_bytes: &'a [u8],
     batch_count: u32,
+}
+
+/// View a `&[u32]` as `&[u8]` without copying. Sound on all our targets
+/// because u32 has no padding and wasm32 linear memory is little-endian
+/// just like the hosts we run on.
+fn u32_slice_as_bytes(slice: &[u32]) -> &[u8] {
+    let len = std::mem::size_of_val(slice);
+    // SAFETY: u32 is plain-old-data with no invalid representations; we're
+    // narrowing the element type without changing the byte view.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast::<u8>(), len) }
 }
 
 /// One wasm instance plus the cached handles needed to deliver mail to it.
@@ -65,9 +75,9 @@ impl Actor {
     }
 }
 
-/// Workload 1 from #7. One `tick` mail to every actor each frame; each
-/// actor does `work_per_actor` units of plain-data work; frame ends when
-/// every actor has returned.
+/// Workload 1 from #7. One tick mail to every actor each frame; each actor
+/// does `work_per_actor` units of plain-data work; frame ends when every
+/// actor has returned.
 struct BroadcastWorkload {
     actors: Vec<Actor>,
     work_per_actor: u32,
@@ -104,10 +114,139 @@ impl BroadcastWorkload {
     }
 }
 
+/// Workload 2 from #7. One sender + one receiver. Each frame the sender
+/// hands the receiver a batch of `batch_size` u32 items; receiver runs
+/// `work_per_item` work units on each. Tests how batching amortizes
+/// per-mail boundary cost as the batch grows.
+struct BulkWorkload {
+    receiver: Actor,
+    batch: Vec<u32>,
+}
+
+impl BulkWorkload {
+    fn new(
+        engine: &Engine,
+        module: &Module,
+        batch_size: usize,
+        work_per_item: u32,
+    ) -> wasmtime::Result<Self> {
+        Ok(Self {
+            receiver: Actor::new(engine, module)?,
+            batch: vec![work_per_item; batch_size],
+        })
+    }
+
+    fn tick(&mut self) -> wasmtime::Result<()> {
+        let mail = Mail {
+            recipient: 0,
+            kind: KIND_TICK,
+            batch_bytes: u32_slice_as_bytes(&self.batch),
+            batch_count: self.batch.len() as u32,
+        };
+        self.receiver.deliver(&mail)?;
+        Ok(())
+    }
+}
+
+/// Workload 3 from #7. A chain of `depth` actors, dispatched sequentially
+/// each frame. Per-link work is fixed; this measures the per-actor
+/// dispatch cost as depth grows. The serial-dependency cost in this slice
+/// is just the sequential dispatch (single-threaded execution); the
+/// meaningful contrast against broadcast materializes once internal
+/// parallelism lands and broadcast can run actors concurrently while
+/// chain still cannot.
+struct ChainWorkload {
+    actors: Vec<Actor>,
+    work_per_link: u32,
+}
+
+impl ChainWorkload {
+    fn new(
+        engine: &Engine,
+        module: &Module,
+        depth: usize,
+        work_per_link: u32,
+    ) -> wasmtime::Result<Self> {
+        let actors = (0..depth)
+            .map(|_| Actor::new(engine, module))
+            .collect::<wasmtime::Result<Vec<_>>>()?;
+        Ok(Self {
+            actors,
+            work_per_link,
+        })
+    }
+
+    fn tick(&mut self) -> wasmtime::Result<()> {
+        let payload = self.work_per_link.to_le_bytes();
+        for actor in &mut self.actors {
+            let mail = Mail {
+                recipient: 0,
+                kind: KIND_TICK,
+                batch_bytes: &payload,
+                batch_count: 1,
+            };
+            actor.deliver(&mail)?;
+        }
+        Ok(())
+    }
+}
+
+/// Workload 4 from #7. A frame-shaped composite: a tick broadcast to all N
+/// actors, followed by one small "neighbor" mail per actor (stand-in for
+/// cross-subsystem coordination). Two phases per frame, 2N total mails.
+struct MixedWorkload {
+    actors: Vec<Actor>,
+    work_per_actor: u32,
+}
+
+impl MixedWorkload {
+    fn new(
+        engine: &Engine,
+        module: &Module,
+        n_actors: usize,
+        work_per_actor: u32,
+    ) -> wasmtime::Result<Self> {
+        let actors = (0..n_actors)
+            .map(|_| Actor::new(engine, module))
+            .collect::<wasmtime::Result<Vec<_>>>()?;
+        Ok(Self {
+            actors,
+            work_per_actor,
+        })
+    }
+
+    fn tick(&mut self) -> wasmtime::Result<()> {
+        let tick_payload = self.work_per_actor.to_le_bytes();
+        for actor in &mut self.actors {
+            let mail = Mail {
+                recipient: 0,
+                kind: KIND_TICK,
+                batch_bytes: &tick_payload,
+                batch_count: 1,
+            };
+            actor.deliver(&mail)?;
+        }
+        // Cross-subsystem coordination phase: a small follow-up mail per
+        // actor. Fixed small workload to keep the phase cheap relative to
+        // the main tick.
+        let neighbor_payload = 10u32.to_le_bytes();
+        for actor in &mut self.actors {
+            let mail = Mail {
+                recipient: 0,
+                kind: KIND_TICK,
+                batch_bytes: &neighbor_payload,
+                batch_count: 1,
+            };
+            actor.deliver(&mail)?;
+        }
+        Ok(())
+    }
+}
+
 struct CellResult {
     workload: &'static str,
-    n_actors: usize,
-    work_per_actor: u32,
+    dim_a: usize,
+    dim_b: u32,
     iterations: usize,
     total: Duration,
     p50: Duration,
@@ -124,19 +263,16 @@ fn percentile(sorted: &[Duration], pct: f64) -> Duration {
     sorted[idx.min(sorted.len() - 1)]
 }
 
-fn bench_broadcast(
-    engine: &Engine,
-    module: &Module,
-    n_actors: usize,
-    work_per_actor: u32,
+fn bench_loop(
+    workload: &'static str,
+    dim_a: usize,
+    dim_b: u32,
     budget: Duration,
+    mut tick: impl FnMut() -> wasmtime::Result<()>,
 ) -> wasmtime::Result<CellResult> {
-    let mut workload = BroadcastWorkload::new(engine, module, n_actors, work_per_actor)?;
-
-    // Warm up for ~5% of the budget so JIT and caches settle before timing.
     let warmup_until = Instant::now() + budget / 20;
     while Instant::now() < warmup_until {
-        workload.tick()?;
+        tick()?;
     }
 
     let mut latencies: Vec<Duration> = Vec::with_capacity(1024);
@@ -144,7 +280,7 @@ fn bench_broadcast(
     let stop_at = started + budget;
     while Instant::now() < stop_at {
         let t = Instant::now();
-        workload.tick()?;
+        tick()?;
         latencies.push(t.elapsed());
     }
     let total = started.elapsed();
@@ -158,9 +294,9 @@ fn bench_broadcast(
     };
 
     Ok(CellResult {
-        workload: "broadcast",
-        n_actors,
-        work_per_actor,
+        workload,
+        dim_a,
+        dim_b,
         iterations: latencies.len(),
         total,
         p50: percentile(&latencies, 50.0),
@@ -170,14 +306,19 @@ fn bench_broadcast(
     })
 }
 
-fn write_csv(path: &PathBuf, rows: &[CellResult]) -> std::io::Result<()> {
+fn write_csv(
+    path: &Path,
+    dim_a_name: &str,
+    dim_b_name: &str,
+    rows: &[CellResult],
+) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     let mut w = BufWriter::new(File::create(path)?);
     writeln!(
         w,
-        "workload,n_actors,work_per_actor,iterations,total_ms,frames_per_sec,mails_per_sec,mean_us,p50_us,p95_us,p99_us"
+        "workload,{dim_a_name},{dim_b_name},iterations,total_ms,frames_per_sec,mean_us,p50_us,p95_us,p99_us"
     )?;
     for r in rows {
         let total_secs = r.total.as_secs_f64();
@@ -186,17 +327,15 @@ fn write_csv(path: &PathBuf, rows: &[CellResult]) -> std::io::Result<()> {
         } else {
             0.0
         };
-        let mps = fps * r.n_actors as f64;
         writeln!(
             w,
-            "{},{},{},{},{:.3},{:.2},{:.2},{:.3},{:.3},{:.3},{:.3}",
+            "{},{},{},{},{:.3},{:.2},{:.3},{:.3},{:.3},{:.3}",
             r.workload,
-            r.n_actors,
-            r.work_per_actor,
+            r.dim_a,
+            r.dim_b,
             r.iterations,
             r.total.as_secs_f64() * 1000.0,
             fps,
-            mps,
             r.mean.as_secs_f64() * 1_000_000.0,
             r.p50.as_secs_f64() * 1_000_000.0,
             r.p95.as_secs_f64() * 1_000_000.0,
@@ -206,36 +345,103 @@ fn write_csv(path: &PathBuf, rows: &[CellResult]) -> std::io::Result<()> {
     Ok(())
 }
 
+fn print_cell(r: &CellResult) {
+    eprintln!(
+        "             iters={}  fps={:.0}  mean={:.1}us  p99={:.1}us",
+        r.iterations,
+        r.iterations as f64 / r.total.as_secs_f64(),
+        r.mean.as_secs_f64() * 1_000_000.0,
+        r.p99.as_secs_f64() * 1_000_000.0,
+    );
+}
+
 fn main() -> wasmtime::Result<()> {
     let engine = Engine::default();
     let module = Module::new(&engine, GUEST_WASM)?;
+    let budget = Duration::from_secs(2);
+    let results_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("results");
 
-    // Matrix from #7. Capped at 32 actors per ADR-0002's granularity
-    // discipline; see the issue for rationale.
+    // Workload 1 — broadcast: full matrix from #7.
     let actor_counts = [1usize, 2, 4, 8, 16, 32];
     let work_sizes = [100u32, 1_000, 10_000, 100_000];
-    let budget_per_cell = Duration::from_secs(2);
-
-    let mut results = Vec::new();
+    let mut broadcast_results = Vec::new();
     for &n in &actor_counts {
         for &w in &work_sizes {
             eprintln!("broadcast  n={n:<3}  work={w:<7}  ...");
-            let r = bench_broadcast(&engine, &module, n, w, budget_per_cell)?;
-            eprintln!(
-                "             iters={}  fps={:.0}  mean={:.1}us  p99={:.1}us",
-                r.iterations,
-                r.iterations as f64 / r.total.as_secs_f64(),
-                r.mean.as_secs_f64() * 1_000_000.0,
-                r.p99.as_secs_f64() * 1_000_000.0,
-            );
-            results.push(r);
+            let mut wl = BroadcastWorkload::new(&engine, &module, n, w)?;
+            let r = bench_loop("broadcast", n, w, budget, || wl.tick())?;
+            print_cell(&r);
+            broadcast_results.push(r);
         }
     }
+    write_csv(
+        &results_dir.join("broadcast.csv"),
+        "n_actors",
+        "work_per_actor",
+        &broadcast_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let out_path = manifest_dir.join("results").join("broadcast.csv");
-    write_csv(&out_path, &results).map_err(|e| wasmtime::Error::msg(e.to_string()))?;
-    eprintln!("\nwrote {}", out_path.display());
+    // Workload 2 — bulk: 1 receiver, sweep batch_size with fixed per-item work.
+    let batch_sizes = [1usize, 16, 256, 4096];
+    let work_per_item = 100u32;
+    let mut bulk_results = Vec::new();
+    for &k in &batch_sizes {
+        eprintln!("bulk       k={k:<5}  per_item={work_per_item}  ...");
+        let mut wl = BulkWorkload::new(&engine, &module, k, work_per_item)?;
+        let r = bench_loop("bulk", k, work_per_item, budget, || wl.tick())?;
+        print_cell(&r);
+        bulk_results.push(r);
+    }
+    write_csv(
+        &results_dir.join("bulk.csv"),
+        "batch_size",
+        "work_per_item",
+        &bulk_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
 
+    // Workload 3 — chain: sweep depth with fixed per-link work.
+    let depths = [2usize, 4, 8, 16];
+    let work_per_link = 1_000u32;
+    let mut chain_results = Vec::new();
+    for &d in &depths {
+        eprintln!("chain      d={d:<3}    per_link={work_per_link}  ...");
+        let mut wl = ChainWorkload::new(&engine, &module, d, work_per_link)?;
+        let r = bench_loop("chain", d, work_per_link, budget, || wl.tick())?;
+        print_cell(&r);
+        chain_results.push(r);
+    }
+    write_csv(
+        &results_dir.join("chain.csv"),
+        "depth",
+        "work_per_link",
+        &chain_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
+
+    // Workload 4 — mixed: full matrix, broadcast tick + neighbor phase per frame.
+    let mut mixed_results = Vec::new();
+    for &n in &actor_counts {
+        for &w in &work_sizes {
+            eprintln!("mixed      n={n:<3}  work={w:<7}  ...");
+            let mut wl = MixedWorkload::new(&engine, &module, n, w)?;
+            let r = bench_loop("mixed", n, w, budget, || wl.tick())?;
+            print_cell(&r);
+            mixed_results.push(r);
+        }
+    }
+    write_csv(
+        &results_dir.join("mixed.csv"),
+        "n_actors",
+        "work_per_actor",
+        &mixed_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
+
+    eprintln!(
+        "\nwrote {}/{{broadcast,bulk,chain,mixed}}.csv",
+        results_dir.display()
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary
Third slice of the mail spike (#7). Builds on the harness from #11 to add the remaining three workloads from the spike issue.

### Workloads added
- **`BulkWorkload`** — 1 sender + 1 receiver, sweeps batch_size *K* ∈ {1, 16, 256, 4096} with fixed per-item work. Tests how batching amortizes per-mail boundary cost.
- **`ChainWorkload`** — *D* actors dispatched sequentially each frame, fixed per-link work, sweeps *D* ∈ {2, 4, 8, 16}. The serial-dependency contrast with broadcast is muted in single-threaded execution and becomes meaningful only once internal parallelism lands.
- **`MixedWorkload`** — full broadcast tick + neighbor follow-up phase per frame (2N mails). Same matrix as broadcast.

### Refactors
- Extracted `bench_loop` helper; each workload's bench is now three lines.
- `CellResult` uses generic `dim_a` / `dim_b` fields. CSV writer accepts per-workload column names. Per-workload meanings documented in `results/README.md`.
- Added `u32_slice_as_bytes` helper for bulk's batched payload (sound on all our targets — u32 has no padding, wasm32 is little-endian).

Each workload writes to `results/{broadcast,bulk,chain,mixed}.csv`.

## Early findings (formal verdict in the next PR's ADR-0003)
- **Gate cell** (n=8 × work=10k): broadcast 20.7µs, mixed 21.0µs — **~800× under the 16.67ms budget**.
- **Bulk batching pays off**: per-item amortized cost drops from ~75ns at K=1 to ~24ns at K=4096. ~3× win, matches ADR-0002's batching prediction.
- **Chain scales linearly**: ~0.27µs per link consistently from D=2 through D=16.
- **Mixed ≈ 2× broadcast** as expected.

## Out of scope
- Plotting script
- ADR-0003 recording the verdict and recommended next step

Both land in the final spike PR.

## Test plan
- [ ] All 6 required checks pass
- [ ] Locally verified: full bench produces 4 CSVs and exits clean
- [ ] CI suite green locally

## Related
- Refs #7
- Builds on #11 (harness + broadcast)