### PR TITLE
feat: add hand-rolled worker-pool scheduler with parallel broadcast spike

### DIFF
--- a/crates/aether-mail-spike-host/src/bin/concurrent.rs
+++ b/crates/aether-mail-spike-host/src/bin/concurrent.rs
@@ -1,0 +1,91 @@
+// Concurrent-scheduler spike (issue #14, PR A): parallel broadcast workload
+// only. Dispatches a tick to every actor each frame across K worker threads
+// using the hand-rolled `scheduler::Scheduler` from the lib. Matrix sweeps
+// N (actor count) × K (worker count). Writes parallel_broadcast.csv.
+//
+// Mixed + churn workloads come in PR B; verdict + plotting + ADR-0004 in PR C.
+
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+use aether_mail_spike_host::{
+    Actor, CellResult, GUEST_WASM, bench_loop, print_cell,
+    scheduler::{Scheduler, Tick},
+    write_csv,
+};
+use wasmtime::{Engine, Module};
+
+/// Held constant across the N×K matrix. ADR-0003 already swept per-actor
+/// work single-threaded; this spike is about the scheduler, not the
+/// guest's ALU loop. 10k matches issue #7's gate cell.
+const WORK_PER_ACTOR: u32 = 10_000;
+
+struct ParallelBroadcastWorkload {
+    scheduler: Scheduler,
+}
+
+impl ParallelBroadcastWorkload {
+    fn new(
+        engine: &Engine,
+        module: &Module,
+        n_actors: usize,
+        k_workers: usize,
+    ) -> wasmtime::Result<Self> {
+        let actors = (0..n_actors)
+            .map(|_| Actor::new(engine, module))
+            .collect::<wasmtime::Result<Vec<_>>>()?;
+        Ok(Self {
+            scheduler: Scheduler::new(actors, k_workers),
+        })
+    }
+
+    fn tick(&mut self) -> wasmtime::Result<()> {
+        let n = self.scheduler.n_actors();
+        let ticks: Vec<Tick> = (0..n)
+            .map(|id| Tick {
+                actor_id: id as u32,
+                work_units: WORK_PER_ACTOR,
+            })
+            .collect();
+        self.scheduler.run_frame(ticks);
+        Ok(())
+    }
+}
+
+fn main() -> wasmtime::Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(&engine, GUEST_WASM)?;
+    let budget = Duration::from_secs(2);
+    let results_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("results");
+
+    let all_cores = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let actor_counts = [1usize, 8, 64, 512, 4096];
+    let worker_counts = [1usize, 2, 4, all_cores];
+
+    eprintln!("detected {all_cores} hardware threads (used as 'all-cores' K)");
+
+    let mut results: Vec<CellResult> = Vec::new();
+    for &n in &actor_counts {
+        for &k in &worker_counts {
+            eprintln!("parallel_broadcast  n={n:<5}  k={k:<3}  work={WORK_PER_ACTOR}  ...");
+            let mut wl = ParallelBroadcastWorkload::new(&engine, &module, n, k)?;
+            let r = bench_loop("parallel_broadcast", n, k as u32, budget, || wl.tick())?;
+            print_cell(&r);
+            results.push(r);
+        }
+    }
+    write_csv(
+        &results_dir.join("parallel_broadcast.csv"),
+        "n_actors",
+        "k_workers",
+        &results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
+
+    eprintln!("\nwrote {}/parallel_broadcast.csv", results_dir.display());
+    Ok(())
+}

--- a/crates/aether-mail-spike-host/src/lib.rs
+++ b/crates/aether-mail-spike-host/src/lib.rs
@@ -1,0 +1,194 @@
+// Shared pieces for the spike binaries in this crate. Both the sequential
+// mail-boundary spike (`src/main.rs`, issue #7 / ADR-0003) and the concurrent
+// scheduler spike (`src/bin/concurrent.rs`, issue #14) need the same Actor /
+// Mail types, wasm guest bytes, timing harness, and CSV writer — extracted
+// here so they don't drift. Spike code; abstractions kept minimal.
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
+
+pub mod scheduler;
+
+pub const GUEST_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/guest.wasm"));
+
+pub type ActorId = u32;
+pub type MailKind = u32;
+
+pub const KIND_TICK: MailKind = 1;
+
+/// One mail. The recipient identifies which actor; the kind says how the
+/// guest should interpret `batch_bytes`; `batch_count` is the number of
+/// items the kind's layout implies (host and guest agree on per-item size).
+pub struct Mail<'a> {
+    // unused in some dispatch paths; kept because the envelope concept
+    // includes addressing
+    #[allow(dead_code)]
+    pub recipient: ActorId,
+    pub kind: MailKind,
+    pub batch_bytes: &'a [u8],
+    pub batch_count: u32,
+}
+
+/// View a `&[u32]` as `&[u8]` without copying. Sound on all our targets
+/// because u32 has no padding and wasm32 linear memory is little-endian
+/// just like the hosts we run on.
+pub fn u32_slice_as_bytes(slice: &[u32]) -> &[u8] {
+    let len = std::mem::size_of_val(slice);
+    // SAFETY: u32 is plain-old-data with no invalid representations; we're
+    // narrowing the element type without changing the byte view.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast::<u8>(), len) }
+}
+
+/// One wasm instance plus the cached handles needed to deliver mail to it.
+/// One `Store` per actor — wasmtime stores are not shareable across
+/// concurrently-executing code paths (they are `Send` but not `Sync`).
+pub struct Actor {
+    store: Store<()>,
+    memory: Memory,
+    receive: TypedFunc<(u32, u32, u32), u32>,
+}
+
+impl Actor {
+    pub fn new(engine: &Engine, module: &Module) -> wasmtime::Result<Self> {
+        let mut store = Store::new(engine, ());
+        let instance = Instance::new(&mut store, module, &[])?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| wasmtime::Error::msg("guest exports no memory"))?;
+        let receive = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "receive")?;
+        Ok(Self {
+            store,
+            memory,
+            receive,
+        })
+    }
+
+    /// Writes the mail's bytes into the actor's linear memory at a fixed
+    /// offset and invokes `receive`. Static-buffer convention for the spike;
+    /// no guest-side allocator yet.
+    pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
+        const MAIL_OFFSET: u32 = 1024;
+        self.memory
+            .write(&mut self.store, MAIL_OFFSET as usize, mail.batch_bytes)?;
+        self.receive
+            .call(&mut self.store, (mail.kind, MAIL_OFFSET, mail.batch_count))
+    }
+}
+
+pub struct CellResult {
+    pub workload: &'static str,
+    pub dim_a: usize,
+    pub dim_b: u32,
+    pub iterations: usize,
+    pub total: Duration,
+    pub p50: Duration,
+    pub p95: Duration,
+    pub p99: Duration,
+    pub mean: Duration,
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * pct / 100.0).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+/// Run `tick` repeatedly inside `budget` (after a short warmup) and return
+/// the per-frame latency distribution. Warmup is 5% of the budget.
+pub fn bench_loop(
+    workload: &'static str,
+    dim_a: usize,
+    dim_b: u32,
+    budget: Duration,
+    mut tick: impl FnMut() -> wasmtime::Result<()>,
+) -> wasmtime::Result<CellResult> {
+    let warmup_until = Instant::now() + budget / 20;
+    while Instant::now() < warmup_until {
+        tick()?;
+    }
+
+    let mut latencies: Vec<Duration> = Vec::with_capacity(1024);
+    let started = Instant::now();
+    let stop_at = started + budget;
+    while Instant::now() < stop_at {
+        let t = Instant::now();
+        tick()?;
+        latencies.push(t.elapsed());
+    }
+    let total = started.elapsed();
+
+    latencies.sort_unstable();
+    let mean = if latencies.is_empty() {
+        Duration::ZERO
+    } else {
+        let sum: Duration = latencies.iter().sum();
+        sum / (latencies.len() as u32)
+    };
+
+    Ok(CellResult {
+        workload,
+        dim_a,
+        dim_b,
+        iterations: latencies.len(),
+        total,
+        p50: percentile(&latencies, 50.0),
+        p95: percentile(&latencies, 95.0),
+        p99: percentile(&latencies, 99.0),
+        mean,
+    })
+}
+
+pub fn write_csv(
+    path: &Path,
+    dim_a_name: &str,
+    dim_b_name: &str,
+    rows: &[CellResult],
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut w = BufWriter::new(File::create(path)?);
+    writeln!(
+        w,
+        "workload,{dim_a_name},{dim_b_name},iterations,total_ms,frames_per_sec,mean_us,p50_us,p95_us,p99_us"
+    )?;
+    for r in rows {
+        let total_secs = r.total.as_secs_f64();
+        let fps = if total_secs > 0.0 {
+            r.iterations as f64 / total_secs
+        } else {
+            0.0
+        };
+        writeln!(
+            w,
+            "{},{},{},{},{:.3},{:.2},{:.3},{:.3},{:.3},{:.3}",
+            r.workload,
+            r.dim_a,
+            r.dim_b,
+            r.iterations,
+            r.total.as_secs_f64() * 1000.0,
+            fps,
+            r.mean.as_secs_f64() * 1_000_000.0,
+            r.p50.as_secs_f64() * 1_000_000.0,
+            r.p95.as_secs_f64() * 1_000_000.0,
+            r.p99.as_secs_f64() * 1_000_000.0,
+        )?;
+    }
+    Ok(())
+}
+
+pub fn print_cell(r: &CellResult) {
+    eprintln!(
+        "             iters={}  fps={:.0}  mean={:.1}us  p99={:.1}us",
+        r.iterations,
+        r.iterations as f64 / r.total.as_secs_f64(),
+        r.mean.as_secs_f64() * 1_000_000.0,
+        r.p99.as_secs_f64() * 1_000_000.0,
+    );
+}

--- a/crates/aether-mail-spike-host/src/main.rs
+++ b/crates/aether-mail-spike-host/src/main.rs
@@ -1,79 +1,15 @@
-// Mail-runtime spike: mail envelope, actor abstraction, and the four workloads
-// from issue #7 (broadcast, bulk, chain, mixed) with matrix bench harness and
-// CSV output. Throwaway code; abstractions kept as small as the spike needs.
+// Sequential mail-runtime spike: the four workloads from issue #7
+// (broadcast, bulk, chain, mixed) with matrix bench harness and CSV output.
+// Verdict recorded in ADR-0003. Shared types live in `lib.rs`.
 
-use std::fs::{self, File};
-use std::io::{BufWriter, Write};
-use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::Duration;
 
-use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
-
-const GUEST_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/guest.wasm"));
-
-type ActorId = u32;
-type MailKind = u32;
-
-const KIND_TICK: MailKind = 1;
-
-/// One mail. The recipient identifies which actor; the kind says how the
-/// guest should interpret `batch_bytes`; `batch_count` is the number of
-/// items the kind's layout implies (host and guest agree on per-item size).
-struct Mail<'a> {
-    // unused in the bench loop's direct dispatch; kept because the envelope
-    // concept includes addressing
-    #[allow(dead_code)]
-    recipient: ActorId,
-    kind: MailKind,
-    batch_bytes: &'a [u8],
-    batch_count: u32,
-}
-
-/// View a `&[u32]` as `&[u8]` without copying. Sound on all our targets
-/// because u32 has no padding and wasm32 linear memory is little-endian
-/// just like the hosts we run on.
-fn u32_slice_as_bytes(slice: &[u32]) -> &[u8] {
-    let len = std::mem::size_of_val(slice);
-    // SAFETY: u32 is plain-old-data with no invalid representations; we're
-    // narrowing the element type without changing the byte view.
-    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast::<u8>(), len) }
-}
-
-/// One wasm instance plus the cached handles needed to deliver mail to it.
-/// One `Store` per actor — wasmtime stores are not shareable across
-/// concurrently-executing code paths.
-struct Actor {
-    store: Store<()>,
-    memory: Memory,
-    receive: TypedFunc<(u32, u32, u32), u32>,
-}
-
-impl Actor {
-    fn new(engine: &Engine, module: &Module) -> wasmtime::Result<Self> {
-        let mut store = Store::new(engine, ());
-        let instance = Instance::new(&mut store, module, &[])?;
-        let memory = instance
-            .get_memory(&mut store, "memory")
-            .ok_or_else(|| wasmtime::Error::msg("guest exports no memory"))?;
-        let receive = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "receive")?;
-        Ok(Self {
-            store,
-            memory,
-            receive,
-        })
-    }
-
-    /// Writes the mail's bytes into the actor's linear memory at a fixed
-    /// offset and invokes `receive`. Static-buffer convention for the spike;
-    /// no guest-side allocator yet (see #7's open sub-questions).
-    fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
-        const MAIL_OFFSET: u32 = 1024;
-        self.memory
-            .write(&mut self.store, MAIL_OFFSET as usize, mail.batch_bytes)?;
-        self.receive
-            .call(&mut self.store, (mail.kind, MAIL_OFFSET, mail.batch_count))
-    }
-}
+use aether_mail_spike_host::{
+    Actor, CellResult, GUEST_WASM, KIND_TICK, Mail, bench_loop, print_cell, u32_slice_as_bytes,
+    write_csv,
+};
+use wasmtime::{Engine, Module};
 
 /// Workload 1 from #7. One tick mail to every actor each frame; each actor
 /// does `work_per_actor` units of plain-data work; frame ends when every
@@ -103,7 +39,7 @@ impl BroadcastWorkload {
         let payload = self.work_per_actor.to_le_bytes();
         for (id, actor) in self.actors.iter_mut().enumerate() {
             let mail = Mail {
-                recipient: id as ActorId,
+                recipient: id as u32,
                 kind: KIND_TICK,
                 batch_bytes: &payload,
                 batch_count: 1,
@@ -243,118 +179,6 @@ impl MixedWorkload {
     }
 }
 
-struct CellResult {
-    workload: &'static str,
-    dim_a: usize,
-    dim_b: u32,
-    iterations: usize,
-    total: Duration,
-    p50: Duration,
-    p95: Duration,
-    p99: Duration,
-    mean: Duration,
-}
-
-fn percentile(sorted: &[Duration], pct: f64) -> Duration {
-    if sorted.is_empty() {
-        return Duration::ZERO;
-    }
-    let idx = ((sorted.len() as f64 - 1.0) * pct / 100.0).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
-}
-
-fn bench_loop(
-    workload: &'static str,
-    dim_a: usize,
-    dim_b: u32,
-    budget: Duration,
-    mut tick: impl FnMut() -> wasmtime::Result<()>,
-) -> wasmtime::Result<CellResult> {
-    let warmup_until = Instant::now() + budget / 20;
-    while Instant::now() < warmup_until {
-        tick()?;
-    }
-
-    let mut latencies: Vec<Duration> = Vec::with_capacity(1024);
-    let started = Instant::now();
-    let stop_at = started + budget;
-    while Instant::now() < stop_at {
-        let t = Instant::now();
-        tick()?;
-        latencies.push(t.elapsed());
-    }
-    let total = started.elapsed();
-
-    latencies.sort_unstable();
-    let mean = if latencies.is_empty() {
-        Duration::ZERO
-    } else {
-        let sum: Duration = latencies.iter().sum();
-        sum / (latencies.len() as u32)
-    };
-
-    Ok(CellResult {
-        workload,
-        dim_a,
-        dim_b,
-        iterations: latencies.len(),
-        total,
-        p50: percentile(&latencies, 50.0),
-        p95: percentile(&latencies, 95.0),
-        p99: percentile(&latencies, 99.0),
-        mean,
-    })
-}
-
-fn write_csv(
-    path: &Path,
-    dim_a_name: &str,
-    dim_b_name: &str,
-    rows: &[CellResult],
-) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut w = BufWriter::new(File::create(path)?);
-    writeln!(
-        w,
-        "workload,{dim_a_name},{dim_b_name},iterations,total_ms,frames_per_sec,mean_us,p50_us,p95_us,p99_us"
-    )?;
-    for r in rows {
-        let total_secs = r.total.as_secs_f64();
-        let fps = if total_secs > 0.0 {
-            r.iterations as f64 / total_secs
-        } else {
-            0.0
-        };
-        writeln!(
-            w,
-            "{},{},{},{},{:.3},{:.2},{:.3},{:.3},{:.3},{:.3}",
-            r.workload,
-            r.dim_a,
-            r.dim_b,
-            r.iterations,
-            r.total.as_secs_f64() * 1000.0,
-            fps,
-            r.mean.as_secs_f64() * 1_000_000.0,
-            r.p50.as_secs_f64() * 1_000_000.0,
-            r.p95.as_secs_f64() * 1_000_000.0,
-            r.p99.as_secs_f64() * 1_000_000.0,
-        )?;
-    }
-    Ok(())
-}
-
-fn print_cell(r: &CellResult) {
-    eprintln!(
-        "             iters={}  fps={:.0}  mean={:.1}us  p99={:.1}us",
-        r.iterations,
-        r.iterations as f64 / r.total.as_secs_f64(),
-        r.mean.as_secs_f64() * 1_000_000.0,
-        r.p99.as_secs_f64() * 1_000_000.0,
-    );
-}
-
 fn main() -> wasmtime::Result<()> {
     let engine = Engine::default();
     let module = Module::new(&engine, GUEST_WASM)?;
@@ -364,7 +188,7 @@ fn main() -> wasmtime::Result<()> {
     // Workload 1 — broadcast: full matrix from #7.
     let actor_counts = [1usize, 2, 4, 8, 16, 32];
     let work_sizes = [100u32, 1_000, 10_000, 100_000];
-    let mut broadcast_results = Vec::new();
+    let mut broadcast_results: Vec<CellResult> = Vec::new();
     for &n in &actor_counts {
         for &w in &work_sizes {
             eprintln!("broadcast  n={n:<3}  work={w:<7}  ...");

--- a/crates/aether-mail-spike-host/src/scheduler.rs
+++ b/crates/aether-mail-spike-host/src/scheduler.rs
@@ -1,0 +1,154 @@
+// Hand-rolled worker-pool scheduler for the issue #14 spike.
+//
+// Model:
+//   - K worker threads, each owning nothing; all state is shared via `Arc`.
+//   - Actors live in a shared `Vec<Mutex<Actor>>`. Each `wasmtime::Store` is
+//     `Send` but not `Sync`, so only one worker touches an actor at a time.
+//   - A single shared queue (`Mutex<VecDeque<Tick>>` + `Condvar`) feeds
+//     workers. No per-worker deques, no work-stealing — simplest honest
+//     baseline. If lock contention shows up at high K, that IS the finding.
+//   - Frame barrier is an `outstanding` counter guarded by its own mutex +
+//     condvar. Main submits N ticks, waits for outstanding to reach 0.
+//
+// Primitives are std-only (no rayon, no crossbeam) so the scheduler we are
+// measuring is end-to-end ours.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+use crate::{Actor, KIND_TICK, Mail};
+
+/// One unit of work handed to the scheduler. For PR A every tick carries a
+/// single u32 payload (`work_units`) that the guest interprets as
+/// KIND_TICK. Future workloads will grow this into an enum.
+pub struct Tick {
+    pub actor_id: u32,
+    pub work_units: u32,
+}
+
+struct Shared {
+    queue: Mutex<VecDeque<Tick>>,
+    queue_cv: Condvar,
+    // Ticks submitted this frame that haven't yet been processed to
+    // completion. Main blocks on `done_cv` until this reaches 0.
+    outstanding: Mutex<usize>,
+    done_cv: Condvar,
+    shutdown: AtomicBool,
+}
+
+pub struct Scheduler {
+    shared: Arc<Shared>,
+    actors: Arc<Vec<Mutex<Actor>>>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl Scheduler {
+    pub fn new(actors: Vec<Actor>, k_workers: usize) -> Self {
+        assert!(k_workers >= 1, "need at least one worker");
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(VecDeque::new()),
+            queue_cv: Condvar::new(),
+            outstanding: Mutex::new(0),
+            done_cv: Condvar::new(),
+            shutdown: AtomicBool::new(false),
+        });
+        let actors: Arc<Vec<Mutex<Actor>>> = Arc::new(actors.into_iter().map(Mutex::new).collect());
+
+        let mut workers = Vec::with_capacity(k_workers);
+        for _ in 0..k_workers {
+            let shared = Arc::clone(&shared);
+            let actors = Arc::clone(&actors);
+            workers.push(thread::spawn(move || worker_loop(shared, actors)));
+        }
+
+        Self {
+            shared,
+            actors,
+            workers,
+        }
+    }
+
+    pub fn n_actors(&self) -> usize {
+        self.actors.len()
+    }
+
+    /// Submit every tick in `ticks` for this frame and block until all of
+    /// them have been processed. `ticks.len()` sets the frame's
+    /// outstanding counter; callers must not call `run_frame` reentrantly.
+    pub fn run_frame(&self, ticks: Vec<Tick>) {
+        let n = ticks.len();
+        if n == 0 {
+            return;
+        }
+
+        // Set outstanding BEFORE pushing ticks so a worker can't pop a tick
+        // and race the done-signal past main's wait. (Invariant:
+        // outstanding >= queue.len() + in_flight at every observable point.)
+        {
+            let mut outstanding = self.shared.outstanding.lock().unwrap();
+            debug_assert_eq!(*outstanding, 0, "previous frame did not drain");
+            *outstanding = n;
+        }
+        {
+            let mut q = self.shared.queue.lock().unwrap();
+            q.extend(ticks);
+        }
+        self.shared.queue_cv.notify_all();
+
+        let mut outstanding = self.shared.outstanding.lock().unwrap();
+        while *outstanding > 0 {
+            outstanding = self.shared.done_cv.wait(outstanding).unwrap();
+        }
+    }
+}
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        self.shared.shutdown.store(true, Ordering::SeqCst);
+        self.shared.queue_cv.notify_all();
+        for h in self.workers.drain(..) {
+            let _ = h.join();
+        }
+    }
+}
+
+fn worker_loop(shared: Arc<Shared>, actors: Arc<Vec<Mutex<Actor>>>) {
+    loop {
+        // Pop a tick, or exit on shutdown.
+        let tick = {
+            let mut q = shared.queue.lock().unwrap();
+            loop {
+                if let Some(t) = q.pop_front() {
+                    break t;
+                }
+                if shared.shutdown.load(Ordering::SeqCst) {
+                    return;
+                }
+                q = shared.queue_cv.wait(q).unwrap();
+            }
+        };
+
+        // Deliver. One worker at a time per actor (Mutex<Actor>).
+        {
+            let mut actor = actors[tick.actor_id as usize].lock().unwrap();
+            let payload = tick.work_units.to_le_bytes();
+            let mail = Mail {
+                recipient: tick.actor_id,
+                kind: KIND_TICK,
+                batch_bytes: &payload,
+                batch_count: 1,
+            };
+            actor.deliver(&mail).expect("actor.deliver failed");
+        }
+
+        // Signal completion. Grab the outstanding mutex, decrement, and
+        // notify main only on the last-tick transition.
+        let mut outstanding = shared.outstanding.lock().unwrap();
+        *outstanding -= 1;
+        if *outstanding == 0 {
+            shared.done_cv.notify_all();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR A for issue #14 (concurrent-scheduler spike). Three-part split: **A** = threading infrastructure + parallel broadcast, **B** = mixed + churn workloads, **C** = ADR-0004 + plotting.

- Extracts `Actor` / `Mail` / `bench_loop` / `write_csv` / guest bytes out of `main.rs` into `lib.rs` so both the existing sequential binary (ADR-0003) and the new concurrent binary share one source of truth. Sequential binary is unchanged in behaviour.
- Adds `src/scheduler.rs`: a **std-only, hand-rolled worker pool**. No rayon, no crossbeam — if we're measuring our scheduler, we own it end to end.
    - `Mutex<VecDeque<Tick>>` + `Condvar` as the shared actors-with-pending-mail queue.
    - `Mutex<usize>` + `Condvar` as the frame-barrier (outstanding counter; main blocks until 0).
    - Shared `wasmtime::Engine`; per-actor `Mutex<Actor>` (stores are `Send` but not `Sync`).
    - Single shared queue, no work-stealing. Simplest honest baseline — if lock contention shows up at high K, that IS the finding, not a failure. Stealing is a potential measured follow-up.
- Adds `src/bin/concurrent.rs` driving the `parallel_broadcast` workload over an N×K matrix: N ∈ {1, 8, 64, 512, 4096}, K ∈ {1, 2, 4, all-cores}. Work size held constant at 10k (ADR-0003 already swept work size single-threaded; this spike is about the scheduler, not the guest ALU loop). Writes `parallel_broadcast.csv`.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [x] Smoke run: `cargo run --release -p aether-mail-spike-host --bin concurrent` completes all 20 cells, writes CSV, no deadlocks. Speedup shape: N=4096 K=1→K=12 ≈ 3.9× (sub-linear — the single shared queue is visibly contended at high K, which is the expected signal from this baseline). Small-N regresses with added workers (condvar/queue overhead dominates when there's little parallel work) — also expected.
- [ ] CI green

Follow-ups (out of scope):
- PR B — `parallel_mixed` + `churn` workloads, completing the issue-#14 matrix.
- PR C — ADR-0004 with the verdict + plotting additions (speedup-vs-K, memory extrapolation).

Related: #14 (spike), ADR-0002 (architecture), ADR-0003 (single-threaded spike this builds on).