### PR TITLE
feat: add parallel_mixed and churn workloads to concurrent spike

### DIFF
--- a/crates/aether-mail-spike-host/src/bin/concurrent.rs
+++ b/crates/aether-mail-spike-host/src/bin/concurrent.rs
@@ -1,9 +1,16 @@
-// Concurrent-scheduler spike (issue #14, PR A): parallel broadcast workload
-// only. Dispatches a tick to every actor each frame across K worker threads
-// using the hand-rolled `scheduler::Scheduler` from the lib. Matrix sweeps
-// N (actor count) × K (worker count). Writes parallel_broadcast.csv.
+// Concurrent-scheduler spike (issue #14). Dispatches ticks to N actors
+// across K worker threads using the hand-rolled `scheduler::Scheduler`
+// from the lib. Three workloads × 5 N × 4 K = 60 cells.
 //
-// Mixed + churn workloads come in PR B; verdict + plotting + ADR-0004 in PR C.
+//   parallel_broadcast — one tick per actor per frame, work=10_000.
+//     Measures dispatch + scheduler scaling with real per-tick work.
+//   parallel_mixed     — two phases per frame: tick (work=10_000) +
+//     neighbor follow-up (work=10). 2N ticks/frame; measures the cost
+//     of two barriers per logical frame.
+//   churn              — one tick per actor per frame, work=10. Isolates
+//     scheduler overhead from actor work; finds the dispatch-cost floor.
+//
+// Verdict + plotting + ADR-0004 land in PR C.
 
 use std::path::PathBuf;
 use std::thread;
@@ -16,16 +23,61 @@ use aether_mail_spike_host::{
 };
 use wasmtime::{Engine, Module};
 
-/// Held constant across the N×K matrix. ADR-0003 already swept per-actor
-/// work single-threaded; this spike is about the scheduler, not the
-/// guest's ALU loop. 10k matches issue #7's gate cell.
-const WORK_PER_ACTOR: u32 = 10_000;
+/// Representative per-actor work for the non-churn workloads. Matches
+/// issue #7's gate cell so the scheduler numbers stay comparable to
+/// ADR-0003's single-threaded baseline.
+const WORK_HEAVY: u32 = 10_000;
+/// Small neighbor-phase / churn work. Deliberately tiny so scheduler
+/// cost is the dominant term.
+const WORK_LIGHT: u32 = 10;
 
+/// One tick per actor per frame, uniform work. Used for both
+/// parallel_broadcast (work=WORK_HEAVY) and churn (work=WORK_LIGHT) —
+/// same dispatch shape, different work cost, exposes the floor.
 struct ParallelBroadcastWorkload {
     scheduler: Scheduler,
+    work_per_actor: u32,
 }
 
 impl ParallelBroadcastWorkload {
+    fn new(
+        engine: &Engine,
+        module: &Module,
+        n_actors: usize,
+        k_workers: usize,
+        work_per_actor: u32,
+    ) -> wasmtime::Result<Self> {
+        let actors = (0..n_actors)
+            .map(|_| Actor::new(engine, module))
+            .collect::<wasmtime::Result<Vec<_>>>()?;
+        Ok(Self {
+            scheduler: Scheduler::new(actors, k_workers),
+            work_per_actor,
+        })
+    }
+
+    fn tick(&mut self) -> wasmtime::Result<()> {
+        let n = self.scheduler.n_actors();
+        let ticks: Vec<Tick> = (0..n)
+            .map(|id| Tick {
+                actor_id: id as u32,
+                work_units: self.work_per_actor,
+            })
+            .collect();
+        self.scheduler.run_frame(ticks);
+        Ok(())
+    }
+}
+
+/// Two barriered phases per frame: broadcast tick (WORK_HEAVY) then
+/// neighbor follow-up (WORK_LIGHT). Matches sequential MixedWorkload's
+/// shape. Each phase is its own `run_frame()` call so the frame barrier
+/// fires twice — the cost of that extra sync shows up in the numbers.
+struct ParallelMixedWorkload {
+    scheduler: Scheduler,
+}
+
+impl ParallelMixedWorkload {
     fn new(
         engine: &Engine,
         module: &Module,
@@ -42,13 +94,21 @@ impl ParallelBroadcastWorkload {
 
     fn tick(&mut self) -> wasmtime::Result<()> {
         let n = self.scheduler.n_actors();
-        let ticks: Vec<Tick> = (0..n)
+        let tick_phase: Vec<Tick> = (0..n)
             .map(|id| Tick {
                 actor_id: id as u32,
-                work_units: WORK_PER_ACTOR,
+                work_units: WORK_HEAVY,
             })
             .collect();
-        self.scheduler.run_frame(ticks);
+        self.scheduler.run_frame(tick_phase);
+
+        let neighbor_phase: Vec<Tick> = (0..n)
+            .map(|id| Tick {
+                actor_id: id as u32,
+                work_units: WORK_LIGHT,
+            })
+            .collect();
+        self.scheduler.run_frame(neighbor_phase);
         Ok(())
     }
 }
@@ -68,24 +128,63 @@ fn main() -> wasmtime::Result<()> {
 
     eprintln!("detected {all_cores} hardware threads (used as 'all-cores' K)");
 
-    let mut results: Vec<CellResult> = Vec::new();
+    let mut broadcast_results: Vec<CellResult> = Vec::new();
     for &n in &actor_counts {
         for &k in &worker_counts {
-            eprintln!("parallel_broadcast  n={n:<5}  k={k:<3}  work={WORK_PER_ACTOR}  ...");
-            let mut wl = ParallelBroadcastWorkload::new(&engine, &module, n, k)?;
+            eprintln!("parallel_broadcast  n={n:<5}  k={k:<3}  work={WORK_HEAVY}  ...");
+            let mut wl = ParallelBroadcastWorkload::new(&engine, &module, n, k, WORK_HEAVY)?;
             let r = bench_loop("parallel_broadcast", n, k as u32, budget, || wl.tick())?;
             print_cell(&r);
-            results.push(r);
+            broadcast_results.push(r);
         }
     }
     write_csv(
         &results_dir.join("parallel_broadcast.csv"),
         "n_actors",
         "k_workers",
-        &results,
+        &broadcast_results,
     )
     .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
 
-    eprintln!("\nwrote {}/parallel_broadcast.csv", results_dir.display());
+    let mut mixed_results: Vec<CellResult> = Vec::new();
+    for &n in &actor_counts {
+        for &k in &worker_counts {
+            eprintln!("parallel_mixed      n={n:<5}  k={k:<3}  ...");
+            let mut wl = ParallelMixedWorkload::new(&engine, &module, n, k)?;
+            let r = bench_loop("parallel_mixed", n, k as u32, budget, || wl.tick())?;
+            print_cell(&r);
+            mixed_results.push(r);
+        }
+    }
+    write_csv(
+        &results_dir.join("parallel_mixed.csv"),
+        "n_actors",
+        "k_workers",
+        &mixed_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
+
+    let mut churn_results: Vec<CellResult> = Vec::new();
+    for &n in &actor_counts {
+        for &k in &worker_counts {
+            eprintln!("churn               n={n:<5}  k={k:<3}  work={WORK_LIGHT}  ...");
+            let mut wl = ParallelBroadcastWorkload::new(&engine, &module, n, k, WORK_LIGHT)?;
+            let r = bench_loop("churn", n, k as u32, budget, || wl.tick())?;
+            print_cell(&r);
+            churn_results.push(r);
+        }
+    }
+    write_csv(
+        &results_dir.join("churn.csv"),
+        "n_actors",
+        "k_workers",
+        &churn_results,
+    )
+    .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
+
+    eprintln!(
+        "\nwrote {}/{{parallel_broadcast,parallel_mixed,churn}}.csv",
+        results_dir.display()
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

PR B for issue #14. Completes the concurrent-scheduler spike's workload matrix. Last PR in the split is **C**: ADR-0004 verdict + plotting additions.

- **parallel_mixed** mirrors sequential `MixedWorkload`'s shape: two barriered phases per logical frame — a heavy broadcast tick (`WORK_HEAVY=10_000`) then a light neighbor follow-up (`WORK_LIGHT=10`). 2N mails per frame, two `run_frame()` calls, so the frame barrier fires twice. Measures whether double-barriered frames cost more than one barrier at 2N.
- **churn** reuses the broadcast-shape workload but with `WORK_LIGHT` (10 units) per actor. Same dispatch pattern as broadcast, 1000× less guest work. Isolates scheduler overhead from per-actor work — the dispatch floor.
- Small refactor: `WORK_PER_ACTOR` promoted from a `const` to a per-instance field on `ParallelBroadcastWorkload` so churn can reuse the same struct with a different work size.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [x] Full 60-cell matrix runs cleanly end-to-end, no deadlocks, writes all three CSVs. Signal summary:
    - `parallel_mixed` ~20% slower than broadcast at matching N×K (e.g. N=4096 K=12: 4.3ms vs 3.0ms). The 2N mails + second barrier shows up exactly where expected.
    - `churn` exposes single-shared-mutex contention cleanly: at N=64, K=1→K=12 goes from 7.7µs to 38µs — adding workers makes dispatch *slower*. At N=4096: 546µs → 1133µs. Motivates per-worker deques / work-stealing as a future lever, but this PR intentionally doesn't pull it.
    - Dispatch floor (churn N=4096 K=1 / 4096 ticks) ≈ **133ns per tick** end-to-end, comparable magnitude to ADR-0003's ~75ns per-mail boundary cost.
- [ ] CI green

Follow-ups:
- PR C — ADR-0004 with the verdict. Plotting additions: speedup-vs-K per N, per-workload heatmaps, dispatch-floor plot from churn, per-actor memory extrapolation.

Related: #14 (spike), ADR-0002 (architecture), ADR-0003 (single-threaded baseline), #15 (PR A).