### PR TITLE
docs: add ADR-0004 concurrent-scheduler findings and plots

### DIFF
--- a/crates/aether-mail-spike-host/results/README.md
+++ b/crates/aether-mail-spike-host/results/README.md
@@ -21,10 +21,16 @@ Per-workload dimensions:
 
 | Workload | dim_a | dim_b | What it sweeps |
 | --- | --- | --- | --- |
-| `broadcast` | `n_actors` | `work_per_actor` | Fanout × per-actor work |
+| `broadcast` | `n_actors` | `work_per_actor` | Fanout × per-actor work (sequential; ADR-0003) |
 | `bulk` | `batch_size` | `work_per_item` | One sender → one receiver, varying batch size; tests batching amortization |
 | `chain` | `depth` | `work_per_link` | Sequential dispatch through D actors |
-| `mixed` | `n_actors` | `work_per_actor` | Broadcast tick + neighbor phase, 2N mails per frame |
+| `mixed` | `n_actors` | `work_per_actor` | Broadcast tick + neighbor phase, 2N mails per frame (sequential) |
+| `parallel_broadcast` | `n_actors` | `k_workers` | Concurrent fanout across K worker threads (issue #14) |
+| `parallel_mixed` | `n_actors` | `k_workers` | Two barriered phases per frame (heavy tick + light neighbor) |
+| `churn` | `n_actors` | `k_workers` | Tiny work per tick — isolates scheduler dispatch floor |
+
+Sequential CSVs come from `cargo run --release -p aether-mail-spike-host`.
+Concurrent CSVs come from `cargo run --release -p aether-mail-spike-host --bin concurrent`.
 
 ## How to plot
 
@@ -41,3 +47,6 @@ uv resolves and caches the deps in an isolated environment on first run; subsequ
 - `mixed_mean.png`, `mixed_p99.png` — same shape as broadcast.
 - `bulk.png` — two-panel: per-mail latency vs batch size (log-log) and amortized cost per item.
 - `chain.png` — per-frame latency vs depth (mean and p99).
+- `parallel_broadcast_{mean,p99}.png`, `parallel_mixed_{mean,p99}.png`, `churn_{mean,p99}.png` — heatmaps over `n_actors × k_workers` for each concurrent workload.
+- `scheduler_speedup.png` — three subplots (one per concurrent workload) showing speedup vs K per N, with an ideal-linear reference line.
+- `churn_dispatch_floor.png` — per-tick scheduler cost (mean_us / N, in ns) vs K for each N; rising curves are the signature of shared-queue contention.

--- a/crates/aether-mail-spike-host/results/plot.py
+++ b/crates/aether-mail-spike-host/results/plot.py
@@ -166,8 +166,79 @@ def plot_chain(rows: list[Row], out: Path) -> None:
     print(f"wrote {out.name}")
 
 
+def plot_speedup(workload_to_rows: dict[str, list[Row]], out: Path) -> None:
+    """Speedup vs K per N, one subplot per workload. Speedup = T(K=1) / T(K).
+    Ideal linear speedup is drawn as a dashed reference line."""
+    names = list(workload_to_rows.keys())
+    fig, axes = plt.subplots(1, len(names), figsize=(5.2 * len(names), 4.4), sharey=True)
+    if len(names) == 1:
+        axes = [axes]
+
+    for ax, name in zip(axes, names):
+        rows = workload_to_rows[name]
+        ns = sorted({r.dim_a for r in rows})
+        ks = sorted({r.dim_b for r in rows})
+        for n in ns:
+            t_by_k = {r.dim_b: r.mean_us for r in rows if r.dim_a == n}
+            if 1 not in t_by_k:
+                continue
+            baseline = t_by_k[1]
+            xs = [k for k in ks if k in t_by_k]
+            ys = [baseline / t_by_k[k] for k in xs]
+            ax.plot(xs, ys, "o-", label=f"N={n}")
+        max_k = max(ks)
+        ax.plot([1, max_k], [1, max_k], "k--", alpha=0.3, label="ideal")
+        ax.set_xscale("log", base=2)
+        ax.set_xlabel("workers K")
+        ax.set_title(name)
+        ax.grid(True, which="both", alpha=0.4)
+        ax.set_xticks(ks)
+        ax.set_xticklabels([str(k) for k in ks])
+    axes[0].set_ylabel("speedup vs K=1")
+    axes[-1].legend(loc="upper left", fontsize=8)
+    fig.suptitle("scheduler: speedup vs worker count")
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print(f"wrote {out.name}")
+
+
+def plot_dispatch_floor(rows: list[Row], out: Path) -> None:
+    """Per-tick cost = mean_us / N. For churn (work=10), this isolates the
+    scheduler's end-to-end cost per dispatched tick. Flat curves at low K
+    that rise with K are the signature of shared-queue contention."""
+    ns = sorted({r.dim_a for r in rows})
+    ks = sorted({r.dim_b for r in rows})
+
+    fig, ax = plt.subplots(figsize=(7.5, 5))
+    for n in ns:
+        xs, ys = [], []
+        for k in ks:
+            match = [r for r in rows if r.dim_a == n and r.dim_b == k]
+            if not match:
+                continue
+            xs.append(k)
+            ys.append(match[0].mean_us * 1000.0 / n)  # µs → ns, per-tick
+        ax.plot(xs, ys, "o-", label=f"N={n}")
+
+    ax.set_xscale("log", base=2)
+    ax.set_xlabel("workers K")
+    ax.set_ylabel("per-tick cost (ns)")
+    ax.set_title("churn: per-tick scheduler cost vs K\n(rising curves = shared-queue contention)")
+    ax.set_xticks(ks)
+    ax.set_xticklabels([str(k) for k in ks])
+    ax.grid(True, which="both", alpha=0.4)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print(f"wrote {out.name}")
+
+
 def main() -> int:
     any_done = False
+
+    # Sequential-spike CSVs (issue #7 / ADR-0003).
     for name, dim_a, dim_b in [
         ("broadcast", "n_actors", "work_per_actor"),
         ("mixed", "n_actors", "work_per_actor"),
@@ -189,8 +260,30 @@ def main() -> int:
         plot_fn(load_csv(path), HERE / f"{name}.png")
         any_done = True
 
+    # Concurrent-spike CSVs (issue #14 / ADR-0004).
+    concurrent_workloads = ["parallel_broadcast", "parallel_mixed", "churn"]
+    concurrent_rows: dict[str, list[Row]] = {}
+    for name in concurrent_workloads:
+        path = HERE / f"{name}.csv"
+        if not path.exists():
+            print(f"missing {path.name}, skipping")
+            continue
+        rows = load_csv(path)
+        concurrent_rows[name] = rows
+        plot_matrix(rows, "n_actors", "k_workers", "mean_us", f"{name}: mean per-frame latency", HERE / f"{name}_mean.png")
+        plot_matrix(rows, "n_actors", "k_workers", "p99_us", f"{name}: p99 per-frame latency", HERE / f"{name}_p99.png")
+        any_done = True
+
+    if concurrent_rows:
+        plot_speedup(concurrent_rows, HERE / "scheduler_speedup.png")
+    if "churn" in concurrent_rows:
+        plot_dispatch_floor(concurrent_rows["churn"], HERE / "churn_dispatch_floor.png")
+
     if not any_done:
-        print("no CSVs found — run `cargo run --release -p aether-mail-spike-host` first")
+        print(
+            "no CSVs found — run `cargo run --release -p aether-mail-spike-host` and/or\n"
+            "`cargo run --release -p aether-mail-spike-host --bin concurrent` first"
+        )
         return 1
     return 0
 

--- a/docs/adr/0004-concurrent-scheduler-spike-findings.md
+++ b/docs/adr/0004-concurrent-scheduler-spike-findings.md
@@ -1,0 +1,82 @@
+# ADR-0004: Concurrent-scheduler spike findings
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+
+## Context
+
+ADR-0003 validated the per-mail boundary cost of the pure-mail architecture single-threaded, with several orders of magnitude of headroom against the 60Hz frame budget. The remaining open scaling question — *can the substrate dispatch N actors' ticks concurrently across a worker threadpool, and how does it scale?* — was specified as issue #14 and implemented across PRs #15 and #16.
+
+The model under test is the simplest honest baseline: K worker threads sharing a single `Mutex<VecDeque<Tick>>` + `Condvar` queue, with a `Mutex<usize>` + `Condvar` frame barrier. No work-stealing, no per-worker deques, no batch compaction. Hand-rolled with `std` primitives only — if we are measuring a scheduler, we own it end to end.
+
+This ADR records the verdict and the resulting engineering posture.
+
+## Decision
+
+**The worker-pool scheduler clears the 60Hz frame budget across the entire N×K matrix — N up to 4096 actors, K up to 12 workers — and proceeds as the scheduler baseline for the first real substrate.** Scaling is visibly sub-linear and the single shared queue is the limiting term; work-stealing per-worker deques are identified as the most-likely-next optimization lever but are **not** pulled now. No re-architecture.
+
+## Evidence
+
+Numbers below are from the same single developer macOS machine as ADR-0003 (Apple Silicon, 12 hardware threads, release build, wasmtime 30). Absolute values will vary by hardware; the scaling shapes and ratios are what carry across.
+
+### Budget
+
+| Workload | worst cell (mean) | worst cell (p99) | Budget vs 16.67ms |
+| --- | --- | --- | --- |
+| parallel_broadcast | N=4096, K=1 → 11.3ms | 12.1ms | fits |
+| parallel_mixed | N=4096, K=1 → 11.9ms | 12.8ms | fits |
+| churn | N=4096, K=12 → 1.13ms | 1.41ms | ~15× under |
+
+Every cell in the measured matrix clears the 16.67ms budget. The tightest cell (parallel_mixed N=4096 K=1) still has ~5ms of headroom.
+
+### Speedup
+
+At the cells with enough exposed parallelism to matter (high N):
+
+| Workload, N=4096 | K=1 | K=2 | K=4 | K=12 | K=12 speedup |
+| --- | --- | --- | --- | --- | --- |
+| parallel_broadcast | 11.3ms | 5.8ms | 3.0ms | 3.0ms | ~3.8× |
+| parallel_mixed | 11.9ms | 6.7ms | 3.7ms | 4.3ms | ~2.8× |
+
+Speedup saturates between K=2 and K=4 and then goes flat (or backward for parallel_mixed). On 12 hardware threads we never get closer than ~3.8× linear. The scheduler is leaving cores idle.
+
+### Contention — the shape behind the sub-linearity
+
+`churn` uses the same dispatch pattern as parallel_broadcast with `work_per_actor = 10` (nominal) — guest work is ~100× smaller than broadcast's, so the frame cost is dispatch-dominated. That makes scheduler overhead directly visible:
+
+| N | K=1 | K=2 | K=4 | K=12 |
+| --- | --- | --- | --- | --- |
+| 64 | 7.7µs | 13.6µs | 18.7µs | 38.1µs |
+| 512 | 47.3µs | 62.2µs | 74.9µs | 157.5µs |
+| 4096 | 545.7µs | 436.4µs | 585.2µs | 1133.3µs |
+
+Adding workers *actively hurts* dispatch-dominated workloads: at N=64 the frame cost grows 5× from K=1 to K=12; at N=4096 it grows ~2×. This is the single shared queue's mutex contention. The scheduler floor (churn mean ÷ N, at the best K per N) is ~**100–150ns per tick** — the same order of magnitude as ADR-0003's ~75ns per-mail boundary cost, consistent with *"the queue's lock is on the critical path of every dispatch."*
+
+### Small-N regression
+
+At low N the pattern inverts in a different way: parallel_broadcast at N=1 goes from 6.7µs at K=1 to 16.1µs at K=12. With only one actor there is no parallel work to absorb, and the worker-wakeup / signalling overhead just piles up. A real scheduler should not scale K blindly with hardware threads — the right K is bounded by exposed parallelism.
+
+## Caveats — what this spike does NOT prove
+
+- **Single shared hardware.** Same caveat as ADR-0003. Ratios should carry; absolute numbers will not.
+- **wasmtime only.** No comparison to other WASM runtimes.
+- **ALU-bound guest work.** The `do_work` loop is still register-bound with no memory or cache pressure; a real subsystem's per-tick cost will be dominated by memory behaviour this spike does not exercise. The **scheduler** numbers here are honest; the **per-tick totals** are not predictive of real subsystem frames.
+- **Memory footprint not measured programmatically.** N=4096 actors ran to completion on a 16GB developer laptop without visible pressure, which is a loose upper bound (<~64KB per actor is plausible for wasmtime's default linear memory) — not a real characterization. A proper measurement is future work if per-actor footprint becomes a binding constraint.
+- **Scheduler design is deliberately the simplest honest baseline.** Work-stealing, per-worker deques, lock-free queues, NUMA-aware placement — all unimplemented here. The point was not to land the final scheduler, but to measure where the unoptimized baseline breaks.
+- **Chain workload not re-measured.** Serial cross-actor dependencies (ADR-0003's chain) were not added to the concurrent matrix; they would not parallelize at all under this model by construction, and the spike focuses on the concurrent-throughput question. When a real workload exposes meaningful cross-actor serial critical paths, that's a separate measurement.
+
+## Consequences
+
+- **The worker-pool scheduler shape moves forward** into the first real substrate: shared `wasmtime::Engine`, per-actor `Mutex<Actor>`, shared queue, frame barrier. Implementation details (atomic counters, condvar signaling choice, actor registry shape) are free to change; the model isn't.
+- **Work-stealing per-worker deques are the first-lever candidate** when real scaling requires it. The evidence is churn's K>1 regression at high N: any scheduler improvement that *reduces per-dispatch lock contention* would flatten that curve. Pre-work-stealing options (sharded queues, batched-dispatch-under-one-lock, lock-free queues) can be measured against the same harness when a specific workload asks for it.
+- **K should not track hardware threads blindly.** Small-N regression shows that adding workers above exposed parallelism costs latency. A first real scheduler should either cap K based on current actor count, let workers park more aggressively, or adopt a stealing model that leaves idle workers passive rather than polling.
+- **ADR-0002's deferred levers stay deferred** (hierarchical shared memory, substrate fast paths, read-only caches, mail compaction). Nothing in this spike motivated any of them over work-stealing, and none are being pre-emptively pulled.
+- **The scheduler baseline (~100–150ns per tick under contention, ~75ns per mail, budget-clearing at N=4096)** is the operating baseline that future engine-design discussions can reason against — alongside ADR-0003's per-mail boundary number.
+- **`bin/concurrent.rs`, `scheduler.rs`, and the concurrent-matrix CSV plumbing become reference artefacts** alongside the ADR-0003 spike crates. Throwaway/educational code. The real substrate can borrow shape from `scheduler.rs` but should not depend on it.
+
+## Alternatives considered
+
+- **Pull work-stealing now while the spike is fresh.** Rejected: same principle as ADR-0003 rejected pulling hierarchical shared memory. Every lever is justified by a workload that fails without it. Churn's contention signal is *expected* from the baseline and does not break any real requirement; pulling work-stealing pre-emptively violates the "tighten only when measurement demands" principle.
+- **Replace `std::thread` + `Mutex` with `rayon` or `tokio`.** Rejected for the spike: we want to measure our scheduler, not a library's. A rayon-based implementation may be the right answer for the real substrate once measurement demands it; that's a separate, later decision.
+- **Defer Acceptance until real subsystem code characterizes per-tick cost.** Rejected: the spike answered issue #14's actual question (does concurrent dispatch meet the budget, and where does it saturate?). Real-subsystem cost is a different, later question — the same partition ADR-0003 drew.
+- **Add programmatic memory measurement before accepting.** Considered. Rejected as scope creep: N=4096 completed on a commodity laptop, no workload presently depends on a tight per-actor memory bound, and the measurement is cheap to add later if it starts mattering.


### PR DESCRIPTION
## Summary

PR C (final) for issue #14. Records the verdict on the concurrent-scheduler spike and extends the plotting harness to cover the new workloads.

**ADR-0004** accepts the worker-pool scheduler shape (shared `wasmtime::Engine`, per-actor `Mutex<Actor>`, `Mutex<VecDeque>` + `Condvar` queue, frame-barrier counter) as the baseline for the first real substrate. Headline findings:

- **Budget cleared across the full matrix.** N up to 4096 × K up to 12 × three workloads, every cell inside 16.67ms.
- **Scaling is sub-linear and saturates at K≈4 on a 12-core machine.** At N=4096: broadcast gets ~3.8× speedup at K=12; mixed ~2.8×.
- **`churn` exposes single-shared-queue mutex contention as the limiting term.** At N=64, frame cost grows 5× from K=1 to K=12; at N=4096, ~2×. Per-tick scheduler floor ≈ 100–150ns, consistent with "the queue lock is on the critical path of every dispatch."
- **Small-N regresses with more workers** — at N=1, K=1→K=12 goes 6.7µs→16.1µs. A real scheduler should bound K by exposed parallelism, not blindly by hardware threads.

Consequent engineering posture: work-stealing per-worker deques are identified as the **most-likely-next optimization lever** but are not pulled now — consistent with ADR-0002's "tighten only when measurement demands" principle. No re-architecture.

Plotting additions in `results/plot.py`:
- Heatmaps for `parallel_broadcast` / `parallel_mixed` / `churn` over `n_actors × k_workers` (mean + p99, red border on cells exceeding budget).
- `scheduler_speedup.png` — one subplot per workload, speedup = T(K=1)/T(K), with an ideal-linear reference line.
- `churn_dispatch_floor.png` — per-tick scheduler cost (churn mean ÷ N, in ns) vs K; rising curves are the contention signature.

`results/README.md` updated to document the new CSV columns and plot outputs.

## Test plan

- [x] `uv run plot.py` generates all 14 PNGs (6 sequential + 6 concurrent heatmaps + speedup + dispatch-floor) from the committed workflows' outputs on my machine.
- [x] No code changes outside `docs/adr/` and `results/`; spike binaries and scheduler are untouched (this is the docs+plots PR).
- [ ] CI green (no Rust changes, so only the fmt/clippy/test jobs' cache hit matters).

Related: closes #14, builds on #15 and #16 (PRs A and B), continues the ADR-0002 → ADR-0003 → ADR-0004 spike chain.