### PR TITLE
feat(substrate): add library shape — mail, registry, scheduler, host_fns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,10 @@ dependencies = [
 [[package]]
 name = "aether-substrate"
 version = "0.1.0"
+dependencies = [
+ "wasmtime",
+ "wat",
+]
 
 [[package]]
 name = "allocator-api2"

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -4,3 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+wasmtime = "30"
+
+[dev-dependencies]
+wat = "1"

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -1,0 +1,55 @@
+// A loaded WASM component: its wasmtime `Store<SubstrateCtx>`, instance,
+// and the cached handles needed to deliver mail. Milestone 1 uses a
+// static-offset convention (mail payload written at `MAIL_OFFSET`) to
+// match the spike; a guest-side allocator is future work per issue #18.
+
+use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
+
+use crate::ctx::SubstrateCtx;
+use crate::mail::Mail;
+
+const MAIL_OFFSET: u32 = 1024;
+
+/// Contract with the guest: it exports a `receive(kind, ptr, count) -> u32`
+/// entrypoint and a `memory` named `memory`. Matches the spike's contract;
+/// generalization (component lifecycle, richer ABI) is deferred.
+pub struct Component {
+    store: Store<SubstrateCtx>,
+    memory: Memory,
+    receive: TypedFunc<(u32, u32, u32), u32>,
+}
+
+impl Component {
+    /// Instantiate a component from a compiled `Module`. `ctx` becomes
+    /// the store data and is what every host function call against this
+    /// component will see.
+    pub fn instantiate(
+        engine: &Engine,
+        linker: &Linker<SubstrateCtx>,
+        module: &Module,
+        ctx: SubstrateCtx,
+    ) -> wasmtime::Result<Self> {
+        let mut store = Store::new(engine, ctx);
+        let instance = linker.instantiate(&mut store, module)?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
+        let receive = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "receive")?;
+        Ok(Self {
+            store,
+            memory,
+            receive,
+        })
+    }
+
+    /// Deliver a mail into the component's linear memory and invoke
+    /// `receive`. Returns the guest's return value (contract is
+    /// currently informational; host-visible errors propagate as
+    /// `wasmtime::Error`).
+    pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
+        self.memory
+            .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
+        self.receive
+            .call(&mut self.store, (mail.kind, MAIL_OFFSET, mail.count))
+    }
+}

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -1,0 +1,44 @@
+// The per-component context stored as wasmtime `Store` data. Holds the
+// sender's own `MailboxId`, a handle to the shared mail queue, and a
+// handle to the registry so the `send_mail` host function can route
+// without consulting the scheduler's internals.
+//
+// Deliberately does NOT hold the scheduler's full shared state — doing
+// so would create an Arc cycle through `Scheduler owns Actor, Actor
+// owns Store<SubstrateCtx>, SubstrateCtx back to Scheduler`. By holding
+// only `Arc<Registry>` and `Arc<MailQueue>` the cycle is broken: neither
+// of those owns any actor.
+
+use std::sync::Arc;
+
+use crate::mail::{Mail, MailKind, MailboxId};
+use crate::queue::MailQueue;
+use crate::registry::{MailboxEntry, Registry};
+
+pub struct SubstrateCtx {
+    pub sender: MailboxId,
+    pub registry: Arc<Registry>,
+    pub queue: Arc<MailQueue>,
+}
+
+impl SubstrateCtx {
+    /// Dispatch mail. If the recipient is a sink, the handler runs inline
+    /// on the caller's thread. If it's a component, the mail is enqueued
+    /// for a worker to deliver. Unknown recipients are dropped.
+    pub fn send(&self, recipient: MailboxId, kind: MailKind, payload: Vec<u8>, count: u32) {
+        match self.registry.entry(recipient) {
+            Some(MailboxEntry::Sink(handler)) => {
+                handler(&payload, count);
+            }
+            Some(MailboxEntry::Component) => {
+                self.queue.push(Mail::new(recipient, kind, payload, count));
+            }
+            None => {
+                eprintln!(
+                    "substrate: dropped mail from {:?} to unknown mailbox {:?}",
+                    self.sender, recipient
+                );
+            }
+        }
+    }
+}

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -1,0 +1,47 @@
+// Host-function surface exposed to WASM components. Adding one is an
+// explicit capability decision per ADR-0002 — every host function
+// becomes reachable by every component that gets linked against this
+// surface. Growth of this surface should be reviewed as deliberately
+// as any other architectural change.
+
+use wasmtime::{Caller, Linker};
+
+use crate::ctx::SubstrateCtx;
+use crate::mail::MailboxId;
+
+/// Register the substrate host functions on `linker`. Components that
+/// want these capabilities must be instantiated via a linker that this
+/// function has been called on.
+pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        "aether",
+        "send_mail",
+        |mut caller: Caller<'_, SubstrateCtx>,
+         recipient: u32,
+         kind: u32,
+         ptr: u32,
+         len: u32,
+         count: u32|
+         -> u32 {
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return 1, // guest exports no memory
+            };
+
+            // Copy the bytes out of guest memory so the mail outlives
+            // the current host-function call (queues, other threads).
+            let data = memory.data(&caller);
+            let start = ptr as usize;
+            let end = match start.checked_add(len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return 2, // out-of-bounds
+            };
+            let payload = data[start..end].to_vec();
+
+            let ctx = caller.data();
+            ctx.send(MailboxId(recipient), kind, payload, count);
+            0
+        },
+    )?;
+    Ok(())
+}

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -1,0 +1,23 @@
+// aether-substrate: the thin native base layer that owns hardware and
+// hosts the WASM runtime. See ADR-0002 for the architecture and
+// ADR-0004 for the scheduler baseline this library embodies.
+//
+// Milestone 1 (issue #18) provides the library shape only: mail
+// envelope, mailbox registry, WASM component wrapper, worker-pool
+// scheduler, and the `send_mail` host function. Milestone 1 PR B
+// wires these into a real frame-loop binary with a first component.
+
+pub mod component;
+pub mod ctx;
+pub mod host_fns;
+pub mod mail;
+pub mod queue;
+pub mod registry;
+pub mod scheduler;
+
+pub use component::Component;
+pub use ctx::SubstrateCtx;
+pub use mail::{Mail, MailKind, MailboxId};
+pub use queue::MailQueue;
+pub use registry::{MailboxEntry, Registry, SinkHandler};
+pub use scheduler::Scheduler;

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -1,0 +1,35 @@
+// Mail envelope types. Owned by value because mails cross thread
+// boundaries through the scheduler's queue.
+
+/// Addressing token for any mailbox — component or substrate-owned sink.
+/// Opaque `u32` newtype so it can't be accidentally mixed with wasmtime
+/// indices or raw integers.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MailboxId(pub u32);
+
+/// Host/guest contract tag for the payload layout. The substrate and the
+/// components that talk to it agree on a specific layout per kind. Typed
+/// facade over this is deferred to a later milestone per issue #18.
+pub type MailKind = u32;
+
+/// The transport envelope. `payload` is the exact byte layout the kind
+/// implies; `count` is the number of items the layout implies, where
+/// applicable.
+#[derive(Debug)]
+pub struct Mail {
+    pub recipient: MailboxId,
+    pub kind: MailKind,
+    pub payload: Vec<u8>,
+    pub count: u32,
+}
+
+impl Mail {
+    pub fn new(recipient: MailboxId, kind: MailKind, payload: Vec<u8>, count: u32) -> Self {
+        Self {
+            recipient,
+            kind,
+            payload,
+            count,
+        }
+    }
+}

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -1,3 +1,12 @@
+// Milestone 1 / PR A lands the substrate library pieces only; the
+// real frame-loop driver is built in PR B (issue #18). This binary
+// exists so the crate still produces an executable artifact during
+// the interim.
+
 fn main() {
-    println!("Hello, world!");
+    eprintln!(
+        "aether-substrate {}: milestone 1 library shape (PR A). \
+         Frame loop lands in PR B (issue #18).",
+        env!("CARGO_PKG_VERSION"),
+    );
 }

--- a/crates/aether-substrate/src/queue.rs
+++ b/crates/aether-substrate/src/queue.rs
@@ -1,0 +1,128 @@
+// Shared mail queue + frame barrier. Held by Arc so workers, host-function
+// contexts, and the scheduler owner all share one instance.
+//
+// Invariants:
+//   - `push` increments `outstanding` BEFORE pushing into the deque. A
+//     worker cannot pop the mail and race its completion-decrement past
+//     a main-thread `wait_idle` observing zero.
+//   - Workers decrement after processing. When the counter hits zero they
+//     signal `done_cv`.
+//   - `wait_idle` blocks until the counter reaches zero. Safe to call
+//     multiple times in sequence (the next frame's pushes re-raise it).
+//   - `shutdown` is checked by workers before sleeping on an empty queue.
+//     A scheduler drop sets it and broadcasts `pending_cv` to wake parked
+//     workers so they can notice and exit.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Condvar, Mutex};
+
+use crate::mail::Mail;
+
+pub struct MailQueue {
+    pending: Mutex<VecDeque<Mail>>,
+    pending_cv: Condvar,
+    outstanding: Mutex<usize>,
+    done_cv: Condvar,
+    shutdown: AtomicBool,
+}
+
+impl MailQueue {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(VecDeque::new()),
+            pending_cv: Condvar::new(),
+            outstanding: Mutex::new(0),
+            done_cv: Condvar::new(),
+            shutdown: AtomicBool::new(false),
+        }
+    }
+
+    /// Enqueue mail. Caller-thread synchronous. Wakes exactly one worker.
+    pub fn push(&self, mail: Mail) {
+        {
+            let mut n = self.outstanding.lock().unwrap();
+            *n += 1;
+        }
+        {
+            let mut q = self.pending.lock().unwrap();
+            q.push_back(mail);
+        }
+        self.pending_cv.notify_one();
+    }
+
+    /// Block until every mail enqueued so far has been processed. Used
+    /// by the frame loop to wait for a frame to drain.
+    pub fn wait_idle(&self) {
+        let mut n = self.outstanding.lock().unwrap();
+        while *n > 0 {
+            n = self.done_cv.wait(n).unwrap();
+        }
+    }
+
+    pub(crate) fn pop_blocking(&self) -> Option<Mail> {
+        let mut q = self.pending.lock().unwrap();
+        loop {
+            if let Some(m) = q.pop_front() {
+                return Some(m);
+            }
+            if self.shutdown.load(Ordering::SeqCst) {
+                return None;
+            }
+            q = self.pending_cv.wait(q).unwrap();
+        }
+    }
+
+    pub(crate) fn mark_completed(&self) {
+        let mut n = self.outstanding.lock().unwrap();
+        *n -= 1;
+        if *n == 0 {
+            self.done_cv.notify_all();
+        }
+    }
+
+    pub(crate) fn initiate_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        self.pending_cv.notify_all();
+    }
+}
+
+impl Default for MailQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+    use crate::mail::{Mail, MailboxId};
+
+    #[test]
+    fn push_pop_roundtrip_and_idle() {
+        let q = Arc::new(MailQueue::new());
+        let qc = Arc::clone(&q);
+        let worker = thread::spawn(move || {
+            let m = qc.pop_blocking().expect("got mail");
+            assert_eq!(m.recipient, MailboxId(3));
+            qc.mark_completed();
+        });
+        q.push(Mail::new(MailboxId(3), 1, vec![], 0));
+        q.wait_idle();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn shutdown_unblocks_parked_worker() {
+        let q = Arc::new(MailQueue::new());
+        let qc = Arc::clone(&q);
+        let worker = thread::spawn(move || qc.pop_blocking());
+        // Give the worker a moment to park on the empty queue.
+        thread::sleep(std::time::Duration::from_millis(20));
+        q.initiate_shutdown();
+        assert!(worker.join().unwrap().is_none());
+    }
+}

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -1,0 +1,145 @@
+// Mailbox registry. Maps stable string names to `MailboxId`s and records
+// whether each mailbox is a WASM component or a substrate-owned sink.
+// Fixed at substrate boot for milestone 1; dynamic registration is a
+// later-milestone concern (issue #18).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::mail::MailboxId;
+
+/// Handler invoked when mail is delivered to a substrate-owned sink.
+/// Called on a scheduler worker thread; must be `Send + Sync`. Argument
+/// is the payload bytes; second argument is the kind-implied count.
+pub type SinkHandler = Arc<dyn Fn(&[u8], u32) + Send + Sync + 'static>;
+
+/// What a given mailbox actually is. The registry records this so the
+/// scheduler can dispatch appropriately without a per-mail type check.
+pub enum MailboxEntry {
+    /// Mail goes to a WASM component's `receive` function on a worker.
+    Component,
+    /// Mail is handled inline by a substrate-native closure.
+    Sink(SinkHandler),
+}
+
+pub struct Registry {
+    by_name: HashMap<String, MailboxId>,
+    entries: Vec<MailboxEntry>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self {
+            by_name: HashMap::new(),
+            entries: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, name: impl Into<String>, entry: MailboxEntry) -> MailboxId {
+        let name = name.into();
+        if self.by_name.contains_key(&name) {
+            panic!("mailbox name already registered: {name}");
+        }
+        let id = MailboxId(self.entries.len() as u32);
+        self.entries.push(entry);
+        self.by_name.insert(name, id);
+        id
+    }
+
+    /// Register a WASM component under `name`. The returned `MailboxId`
+    /// is handed to the scheduler alongside the component's `Actor`.
+    pub fn register_component(&mut self, name: impl Into<String>) -> MailboxId {
+        self.insert(name, MailboxEntry::Component)
+    }
+
+    /// Register a substrate-owned sink. Mail to this mailbox is handled
+    /// inline on the thread that delivered it (or on the host-function
+    /// caller thread if a component sent it).
+    pub fn register_sink(&mut self, name: impl Into<String>, handler: SinkHandler) -> MailboxId {
+        self.insert(name, MailboxEntry::Sink(handler))
+    }
+
+    pub fn lookup(&self, name: &str) -> Option<MailboxId> {
+        self.by_name.get(name).copied()
+    }
+
+    pub fn entry(&self, id: MailboxId) -> Option<&MailboxEntry> {
+        self.entries.get(id.0 as usize)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn register_and_lookup_component() {
+        let mut r = Registry::new();
+        let id = r.register_component("physics");
+        assert_eq!(id, MailboxId(0));
+        assert_eq!(r.lookup("physics"), Some(id));
+        assert!(matches!(r.entry(id), Some(MailboxEntry::Component)));
+    }
+
+    #[test]
+    fn sink_handler_runs_on_call() {
+        let mut r = Registry::new();
+        let counter = Arc::new(AtomicU32::new(0));
+        let c2 = Arc::clone(&counter);
+        let id = r.register_sink(
+            "heartbeat",
+            Arc::new(move |_bytes, count| {
+                c2.fetch_add(count, Ordering::SeqCst);
+            }),
+        );
+        let Some(MailboxEntry::Sink(h)) = r.entry(id) else {
+            panic!("expected sink")
+        };
+        h(&[], 7);
+        h(&[], 3);
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+    }
+
+    #[test]
+    fn mailbox_ids_are_dense_and_sequential() {
+        let mut r = Registry::new();
+        let a = r.register_component("a");
+        let b = r.register_sink("b", Arc::new(|_, _| {}));
+        let c = r.register_component("c");
+        assert_eq!(a, MailboxId(0));
+        assert_eq!(b, MailboxId(1));
+        assert_eq!(c, MailboxId(2));
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "mailbox name already registered")]
+    fn duplicate_name_panics() {
+        let mut r = Registry::new();
+        r.register_component("x");
+        r.register_component("x");
+    }
+
+    #[test]
+    fn lookup_missing_returns_none() {
+        let r = Registry::new();
+        assert!(r.lookup("nope").is_none());
+        assert!(r.entry(MailboxId(42)).is_none());
+    }
+}

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -1,0 +1,117 @@
+// Worker-pool scheduler. Shape borrowed from
+// `aether-mail-spike-host/src/scheduler.rs` per ADR-0004: shared queue,
+// per-component `Mutex`, frame-barrier counter, all under `std`
+// primitives only. The spike crate is not a dependency.
+//
+// Design notes carried from ADR-0004:
+//   - Single `Mutex<VecDeque<Mail>>` + `Condvar` as the shared queue.
+//     Work-stealing per-worker deques are the identified next-lever
+//     candidate but are not pulled here.
+//   - Sinks are NOT dispatched here. They are handled inline by
+//     `SubstrateCtx::send` when a component invokes the `send_mail`
+//     host function; they never enter the queue under normal use.
+//     If mail for a sink does end up in the queue (e.g. a future
+//     caller chooses to enqueue one), the worker handles it in line
+//     with the component path — lookup, call, decrement.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use crate::component::Component;
+use crate::mail::MailboxId;
+use crate::queue::MailQueue;
+use crate::registry::{MailboxEntry, Registry};
+
+/// Owned by the scheduler, shared with every worker. Separate from the
+/// public `Scheduler` handle so workers can keep running even while the
+/// owner thread is asleep waiting on a frame drain.
+struct WorkerContext {
+    queue: Arc<MailQueue>,
+    registry: Arc<Registry>,
+    components: HashMap<MailboxId, Mutex<Component>>,
+}
+
+pub struct Scheduler {
+    ctx: Arc<WorkerContext>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl Scheduler {
+    /// Build a scheduler over `components` keyed by `MailboxId`. The
+    /// registry is the same one every component's `SubstrateCtx` holds
+    /// — it defines what mailbox names resolve to what entries.
+    pub fn new(
+        registry: Arc<Registry>,
+        queue: Arc<MailQueue>,
+        components: HashMap<MailboxId, Component>,
+        k_workers: usize,
+    ) -> Self {
+        assert!(k_workers >= 1, "need at least one worker");
+
+        let ctx = Arc::new(WorkerContext {
+            queue,
+            registry,
+            components: components
+                .into_iter()
+                .map(|(id, c)| (id, Mutex::new(c)))
+                .collect(),
+        });
+
+        let mut workers = Vec::with_capacity(k_workers);
+        for _ in 0..k_workers {
+            let ctx = Arc::clone(&ctx);
+            workers.push(thread::spawn(move || worker_loop(ctx)));
+        }
+
+        Self { ctx, workers }
+    }
+
+    pub fn queue(&self) -> &Arc<MailQueue> {
+        &self.ctx.queue
+    }
+
+    pub fn registry(&self) -> &Arc<Registry> {
+        &self.ctx.registry
+    }
+}
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        self.ctx.queue.initiate_shutdown();
+        for h in self.workers.drain(..) {
+            let _ = h.join();
+        }
+    }
+}
+
+fn worker_loop(ctx: Arc<WorkerContext>) {
+    while let Some(mail) = ctx.queue.pop_blocking() {
+        let recipient = mail.recipient;
+        match ctx.registry.entry(recipient) {
+            Some(MailboxEntry::Sink(handler)) => {
+                handler(&mail.payload, mail.count);
+            }
+            Some(MailboxEntry::Component) => match ctx.components.get(&recipient) {
+                Some(lock) => {
+                    let mut c = lock.lock().unwrap();
+                    c.deliver(&mail).expect("component.deliver failed");
+                }
+                None => {
+                    eprintln!(
+                        "substrate: mail to registered-component mailbox {:?} \
+                         but no component bound to it — dropped",
+                        recipient
+                    );
+                }
+            },
+            None => {
+                eprintln!(
+                    "substrate: mail to unknown mailbox {:?} — dropped",
+                    recipient
+                );
+            }
+        }
+        ctx.queue.mark_completed();
+    }
+}

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -1,0 +1,85 @@
+// End-to-end wiring test for milestone 1 PR A. Uses an inline WAT guest
+// to avoid pulling in a separate guest crate at this stage — PR B adds
+// the real `aether-hello-component` guest and the build.rs integration.
+//
+// The test is deliberately shaped like the real substrate flow:
+//   1. Registry populated with one component mailbox + one sink.
+//   2. Queue + scheduler constructed over the component.
+//   3. A single mail enqueued to the component.
+//   4. The component's `receive` calls the `aether::send_mail` host
+//      function, targeting the sink.
+//   5. We wait for the queue to drain and assert the sink handler ran.
+// That round-trip exercises: host-fn linking, SubstrateCtx routing,
+// the Component/Sink dispatch branch inside the worker, and the frame
+// barrier's push/decrement/wait cycle.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use aether_substrate::{
+    Component, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    mail::{Mail, MailboxId},
+};
+use wasmtime::{Engine, Linker, Module};
+
+const WAT: &str = r#"
+(module
+  (import "aether" "send_mail"
+    (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (func (export "receive") (param $kind i32) (param $ptr i32) (param $count i32) (result i32)
+    ;; Forward a send_mail call to mailbox 1 (the sink in this test).
+    ;; recipient=1, kind=99, ptr=0, len=0, count=<same as incoming count>.
+    i32.const 1
+    i32.const 99
+    i32.const 0
+    i32.const 0
+    local.get $count
+    call $send_mail))
+"#;
+
+#[test]
+fn tick_roundtrip_component_to_sink() {
+    let engine = Engine::default();
+    let module = Module::new(&engine, WAT).expect("compile wat");
+
+    let mut registry = Registry::new();
+    let component_mbox = registry.register_component("hello");
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let c2 = Arc::clone(&counter);
+    let sink_mbox = registry.register_sink(
+        "heartbeat",
+        Arc::new(move |_bytes, count| {
+            c2.fetch_add(count, Ordering::SeqCst);
+        }),
+    );
+    assert_eq!(component_mbox, MailboxId(0));
+    assert_eq!(sink_mbox, MailboxId(1));
+
+    let registry = Arc::new(registry);
+    let queue = Arc::new(MailQueue::new());
+
+    let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+    host_fns::register(&mut linker).expect("register host fns");
+
+    let ctx = SubstrateCtx {
+        sender: component_mbox,
+        registry: Arc::clone(&registry),
+        queue: Arc::clone(&queue),
+    };
+    let component = Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
+
+    let mut components = std::collections::HashMap::new();
+    components.insert(component_mbox, component);
+    let _scheduler = Scheduler::new(registry, Arc::clone(&queue), components, 2);
+
+    // Drive three "frames" — each frame, enqueue one tick mail and wait.
+    for frame in 1..=3u32 {
+        queue.push(Mail::new(component_mbox, 1, vec![], frame));
+        queue.wait_idle();
+    }
+
+    // Sink saw count=1 + count=2 + count=3 = 6.
+    assert_eq!(counter.load(Ordering::SeqCst), 1 + 2 + 3);
+}


### PR DESCRIPTION
## Summary

PR A of two for issue #18 (substrate milestone 1: headless frame loop). This PR lands the library shape only; PR B wires it into a running frame loop with a first real WASM component.

Modules added to `aether-substrate`:

- **`mail`** — `MailboxId(u32)` newtype + owned `Mail` envelope (owned because mails cross threads through the queue).
- **`registry`** — name → `MailboxId` map with `Component` / `Sink(SinkHandler)` entries. Fixed at boot; dynamic registration deferred per issue #18.
- **`queue`** — shared `Mutex<VecDeque<Mail>> + Condvar` + `Mutex<usize> + Condvar` frame barrier. `push` / `wait_idle` shape pre-established for frame-loop use.
- **`ctx`** — `SubstrateCtx` (wasmtime `Store` data): sender id + `Arc<Registry>` + `Arc<MailQueue>`. Deliberately omits any handle to scheduler-owned actors — holding one would close an Arc cycle (`Scheduler` owns `Component` owns `Store<SubstrateCtx>` that would reference back to `Scheduler`). Dispatches sink mail inline, enqueues component mail.
- **`component`** — `Component` wrapping `Store<SubstrateCtx>` + `Instance` + cached `Memory` + `receive` typed function. Static-offset delivery convention carried from the spike.
- **`host_fns`** — `aether::send_mail(recipient, kind, ptr, len, count)` registered on `Linker<SubstrateCtx>`. Adding a host function is a deliberate capability decision (ADR-0002); this is the only one in milestone 1.
- **`scheduler`** — worker-pool scheduler adapted from ADR-0004's baseline (shared queue, per-component `Mutex`, frame barrier). Spike crate is not a dependency; shape re-implemented as real code per ADR-0004's reference-artefact framing.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 8 new tests pass
    - Unit tests: registry insert/lookup/duplicate-name-panic/sink-dispatch; queue push-pop/shutdown-wake.
    - **Integration (`tests/end_to_end.rs`)**: compiles an inline WAT component that imports `aether::send_mail`, registers it alongside a sink, runs three frames through the scheduler, and asserts the sink counter = 1 + 2 + 3 = 6. Exercises the full stack: host-fn linking, `SubstrateCtx` routing, both Sink and Component dispatch branches inside the worker, and the frame barrier's push/decrement/wait cycle.
- [ ] CI green

## Follow-up (PR B, same milestone)

- New `aether-hello-component` guest crate + `build.rs` integration.
- Real `main.rs` running N frames at unthrottled tick rate, with shutdown logging heartbeat counts.
- Integration test becomes superseded by the real binary run.

Related: #18 (milestone), ADR-0002 (architecture), ADR-0004 (scheduler shape).