### PR TITLE
feat(substrate): add hello-component guest and headless frame-loop runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-hello-component"
+version = "0.1.0"
+
+[[package]]
 name = "aether-mail-spike-guest"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/aether-substrate",
+    "crates/aether-hello-component",
     "crates/aether-mail-spike-host",
     "crates/aether-mail-spike-guest",
 ]

--- a/crates/aether-hello-component/Cargo.toml
+++ b/crates/aether-hello-component/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aether-hello-component"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -1,0 +1,38 @@
+// First real aether component. Each frame the substrate ticks this
+// component, and it replies by sending a heartbeat mail to a sink
+// mailbox. Proves bidirectional host↔component flow for milestone 1.
+//
+// Mailbox ids for milestone 1 are hardcoded. The substrate assigns
+// them deterministically at boot (component=0, heartbeat sink=1);
+// symbolic name resolution at component init is future work per
+// issue #18's open sub-questions.
+//
+// `#[cfg(target_arch = "wasm32")]` guards the bodies so the crate
+// still compiles for the host target in `cargo test --workspace`
+// (where the `send_mail` import is not resolvable at link time).
+
+#[cfg(target_arch = "wasm32")]
+const HEARTBEAT_SINK: u32 = 1;
+#[cfg(target_arch = "wasm32")]
+const KIND_HEARTBEAT: u32 = 42;
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "aether")]
+unsafe extern "C" {
+    fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+}
+
+/// # Safety
+/// Host contract: `ptr` points to `count`-item payload for `kind` within
+/// linear memory. Milestone 1's only inbound kind is the tick (the host
+/// pushes a single-item payload we do not read), so no pointer use here.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn receive(_kind: u32, _ptr: u32, count: u32) -> u32 {
+    #[cfg(target_arch = "wasm32")]
+    unsafe {
+        send_mail(HEARTBEAT_SINK, KIND_HEARTBEAT, 0, 0, count);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = count;
+    0
+}

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-substrate"
 version.workspace = true
 edition.workspace = true
+build = "build.rs"
 
 [dependencies]
 wasmtime = "30"

--- a/crates/aether-substrate/build.rs
+++ b/crates/aether-substrate/build.rs
@@ -1,0 +1,53 @@
+// Builds aether-hello-component for wasm32-unknown-unknown into a private
+// target directory under OUT_DIR, then copies the resulting `.wasm` into
+// `OUT_DIR/hello_component.wasm` so `main.rs` can `include_bytes!` it.
+//
+// A separate target dir avoids the cargo build-lock collision that occurs
+// when an inner cargo invocation shares the outer build's target dir.
+//
+// The guest is built with the same profile as the host — release host →
+// release guest, debug host → debug guest. Milestone 1 runs at any
+// profile; the shape matches the spike crate for consistency.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let guest_dir = workspace_root.join("crates").join("aether-hello-component");
+
+    println!("cargo:rerun-if-changed={}", guest_dir.join("src").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        guest_dir.join("Cargo.toml").display()
+    );
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let guest_target = out_dir.join("guest-target");
+
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".into());
+    let release = profile == "release";
+
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.arg("build");
+    if release {
+        cmd.arg("--release");
+    }
+    cmd.args(["--target", "wasm32-unknown-unknown", "--manifest-path"])
+        .arg(guest_dir.join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(&guest_target);
+
+    let status = cmd.status().expect("failed to invoke cargo to build guest");
+    assert!(status.success(), "hello-component wasm build failed");
+
+    let built = guest_target
+        .join("wasm32-unknown-unknown")
+        .join(&profile)
+        .join("aether_hello_component.wasm");
+    let dest = out_dir.join("hello_component.wasm");
+    std::fs::copy(&built, &dest).expect("failed to copy hello_component.wasm into OUT_DIR");
+}

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -1,12 +1,94 @@
-// Milestone 1 / PR A lands the substrate library pieces only; the
-// real frame-loop driver is built in PR B (issue #18). This binary
-// exists so the crate still produces an executable artifact during
-// the interim.
+// Milestone 1 frame-loop driver. Compiles the `aether-hello-component`
+// WASM guest (baked in by build.rs), sets up the registry with the
+// component and a heartbeat sink, builds a scheduler with a small
+// worker pool, and runs N frames at unthrottled rate. Each frame
+// pushes one tick mail to the component; the component responds with
+// a heartbeat mail to the sink. The sink increments a shared counter
+// which we read at shutdown.
+//
+// Throttling is not this milestone's concern — winit owns timing in
+// milestone 2.
 
-fn main() {
-    eprintln!(
-        "aether-substrate {}: milestone 1 library shape (PR A). \
-         Frame loop lands in PR B (issue #18).",
-        env!("CARGO_PKG_VERSION"),
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use aether_substrate::{
+    Component, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    mail::{Mail, MailboxId},
+};
+use wasmtime::{Engine, Linker, Module};
+
+const HELLO_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/hello_component.wasm"));
+
+const TOTAL_FRAMES: u64 = 600;
+const LOG_EVERY: u64 = 100;
+const KIND_TICK: u32 = 1;
+const WORKERS: usize = 2;
+
+fn main() -> wasmtime::Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(&engine, HELLO_WASM)?;
+
+    let mut registry = Registry::new();
+    let component_mbox = registry.register_component("hello");
+
+    let heartbeats = Arc::new(AtomicU64::new(0));
+    let hb_for_sink = Arc::clone(&heartbeats);
+    let sink_mbox = registry.register_sink(
+        "heartbeat",
+        Arc::new(move |_bytes, count| {
+            hb_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
+        }),
     );
+
+    // Fixed mailbox contract for milestone 1: component=0, heartbeat sink=1.
+    // The component's send_mail calls hardcode id 1; assert here so the
+    // contract breaking is a loud panic, not a silent dropped mail.
+    assert_eq!(component_mbox, MailboxId(0));
+    assert_eq!(sink_mbox, MailboxId(1));
+
+    let registry = Arc::new(registry);
+    let queue = Arc::new(MailQueue::new());
+
+    let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+    host_fns::register(&mut linker)?;
+
+    let ctx = SubstrateCtx {
+        sender: component_mbox,
+        registry: Arc::clone(&registry),
+        queue: Arc::clone(&queue),
+    };
+    let component = Component::instantiate(&engine, &linker, &module, ctx)?;
+
+    let mut components = HashMap::new();
+    components.insert(component_mbox, component);
+    let _scheduler = Scheduler::new(registry, Arc::clone(&queue), components, WORKERS);
+
+    eprintln!(
+        "aether-substrate: milestone 1 frame loop — {TOTAL_FRAMES} frames, {WORKERS} worker threads"
+    );
+
+    let started = Instant::now();
+    for frame in 1..=TOTAL_FRAMES {
+        queue.push(Mail::new(component_mbox, KIND_TICK, vec![], 1));
+        queue.wait_idle();
+        if frame % LOG_EVERY == 0 {
+            eprintln!(
+                "  frame {frame:>4} / {TOTAL_FRAMES}  heartbeats={}",
+                heartbeats.load(Ordering::Relaxed)
+            );
+        }
+    }
+    let elapsed = started.elapsed();
+
+    let total = heartbeats.load(Ordering::Relaxed);
+    eprintln!(
+        "\nran {TOTAL_FRAMES} frames in {:.2}ms ({:.1} fps) — heartbeats received = {total}",
+        elapsed.as_secs_f64() * 1000.0,
+        TOTAL_FRAMES as f64 / elapsed.as_secs_f64(),
+    );
+    assert_eq!(total, TOTAL_FRAMES, "expected one heartbeat per frame");
+    Ok(())
 }


### PR DESCRIPTION
## Summary

PR B of two for issue #18 (substrate milestone 1). Closes the milestone by pairing PR #19's library shape with a real WASM component and a running frame loop.

**`aether-hello-component`** is the first real component. Each frame the substrate ticks it via mail; it responds by calling `aether::send_mail` to a heartbeat sink the substrate owns. The `send_mail` import and the `receive` body are gated on `target_arch = "wasm32"` so the crate still builds cleanly for the host target under `cargo test --workspace` — same trick we would have otherwise had to reach for to keep the workspace coherent.

**Mailbox contract for milestone 1 is small and hardcoded.** Component = `MailboxId(0)`, heartbeat sink = `MailboxId(1)`. `main.rs` asserts those ids after registration so any future reordering breaks loudly instead of silently dropping mail. Symbolic-name resolution at component init is future work per issue #18's open sub-questions — noted inline.

**`crates/aether-substrate/build.rs`** builds the guest for `wasm32-unknown-unknown` into `OUT_DIR/hello_component.wasm`. Shape matches the spike host's build.rs (profile-matching, private target dir to avoid cargo lock collisions). `main.rs` `include_bytes!` it, compiles the `Module`, wires `Registry` + `Scheduler` + `Component`, and runs 600 frames at unthrottled rate. Each frame pushes one tick mail and waits for the queue to drain. Shutdown asserts `heartbeats_received == frames_run` so silently-dropped mail crashes the process.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean across the whole workspace (including host-target build of `aether-hello-component`)
- [x] `cargo test --workspace` — all 8 prior tests still pass; no new tests added because the end-to-end test from PR #19 already covers the host↔component↔sink cycle and this PR's main.rs is the production demo of the same path.
- [x] `cargo run --release -p aether-substrate` — 600 frames in ~3.7ms, heartbeat count matches frame count.
- [ ] CI green

## What this closes

Issue #18. Both acceptance criteria are met:
1. ✓ `aether-substrate` hosts a WASM component, ticks it over a frame loop, and routes bidirectional mail through the registry.
2. ✓ Shape is clean enough to be the base for hello-winit (milestone 2) without re-architecture.

## What's next (separate issue to file)

Milestone 2 — **hello-winit**. Open the substrate's frame loop to winit's cadence, route input events as mail to the component, extend the registry to include a substrate-owned "input" mailbox that receives from the winit event loop. No rendering yet.

Related: #18, #19 (PR A), ADR-0002, ADR-0004.