### PR TITLE
feat(mail): add aether-mail crate and typed substrate kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,18 @@ dependencies = [
 [[package]]
 name = "aether-hello-component"
 version = "0.1.0"
+dependencies = [
+ "aether-substrate-mail",
+]
+
+[[package]]
+name = "aether-mail"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "postcard",
+ "serde",
+]
 
 [[package]]
 name = "aether-mail-spike-guest"
@@ -46,11 +58,22 @@ dependencies = [
 name = "aether-substrate"
 version = "0.1.0"
 dependencies = [
+ "aether-mail",
+ "aether-substrate-mail",
+ "bytemuck",
  "pollster",
  "wasmtime",
  "wat",
  "wgpu",
  "winit",
+]
+
+[[package]]
+name = "aether-substrate-mail"
+version = "0.1.0"
+dependencies = [
+ "aether-mail",
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 resolver = "3"
 members = [
     "crates/aether-substrate",
+    "crates/aether-substrate-mail",
     "crates/aether-hello-component",
+    "crates/aether-mail",
     "crates/aether-mail-spike-host",
     "crates/aether-mail-spike-guest",
 ]

--- a/crates/aether-hello-component/Cargo.toml
+++ b/crates/aether-hello-component/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+aether-substrate-mail = { path = "../aether-substrate-mail" }

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -1,33 +1,56 @@
-// First real aether component. Milestone 3b: on each tick the
-// component emits a triangle as KIND_DRAW_TRIANGLE mail to the
-// substrate's render sink. Positions are already clip-space; the
-// component has no camera/transform story yet.
+// First real aether component. On each tick the component emits a
+// triangle as KIND_DRAW_TRIANGLE mail to the substrate's render sink.
+// Positions are clip-space; the component has no camera/transform story
+// yet.
+//
+// Kind ids and payload types are imported from `aether-substrate-mail`
+// per ADR-0005 — the substrate's mail vocabulary is a crate components
+// depend on, not a duplicated wire constant.
 //
 // Mailbox ids remain hardcoded (component=0, render sink=1); symbolic
-// name resolution at component init is future work per issue #18.
+// name resolution at component init is future work per ADR-0005's
+// kind-registry-at-init follow-up.
 //
-// `#[cfg(target_arch = "wasm32")]` guards the bodies so the crate
-// still compiles for the host target in `cargo test --workspace`
-// (where the `send_mail` import is not resolvable at link time, and
-// where `ptr as u32` would truncate a 64-bit host pointer).
+// `#[cfg(target_arch = "wasm32")]` guards the bodies so the crate still
+// compiles for the host target in `cargo test --workspace` (where the
+// `send_mail` import is not resolvable at link time, and where
+// `ptr as u32` would truncate a 64-bit host pointer).
+
+#[cfg(target_arch = "wasm32")]
+use aether_substrate_mail::{DrawTriangle, KIND_DRAW_TRIANGLE, KIND_TICK, Vertex};
 
 #[cfg(target_arch = "wasm32")]
 const RENDER_SINK: u32 = 1;
-#[cfg(target_arch = "wasm32")]
-const KIND_TICK: u32 = 1;
-#[cfg(target_arch = "wasm32")]
-const KIND_DRAW_TRIANGLE: u32 = 20;
 
-// A fixed clip-space triangle with per-vertex color. Laid out to match
-// the substrate's VertexBufferLayout: (pos: vec2<f32>, color: vec3<f32>),
-// 20 bytes per vertex, 60 bytes total.
+// A fixed clip-space triangle with per-vertex color. Typed as
+// DrawTriangle so the vertex layout is the same type the substrate
+// decodes against; bytemuck handles the &T-to-bytes cast at send time.
 #[cfg(target_arch = "wasm32")]
-static TRIANGLE: [f32; 15] = [
-    // pos x, pos y,   r,   g,   b
-    0.0, 0.5, 1.0, 0.0, 0.0, //
-    -0.5, -0.5, 0.0, 1.0, 0.0, //
-    0.5, -0.5, 0.0, 0.0, 1.0, //
-];
+static TRIANGLE: DrawTriangle = DrawTriangle {
+    verts: [
+        Vertex {
+            x: 0.0,
+            y: 0.5,
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+        },
+        Vertex {
+            x: -0.5,
+            y: -0.5,
+            r: 0.0,
+            g: 1.0,
+            b: 0.0,
+        },
+        Vertex {
+            x: 0.5,
+            y: -0.5,
+            r: 0.0,
+            g: 0.0,
+            b: 1.0,
+        },
+    ],
+};
 
 #[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "aether")]
@@ -37,15 +60,15 @@ unsafe extern "C" {
 
 /// # Safety
 /// Host contract: `ptr` points to a `count`-item payload for `kind` within
-/// guest linear memory. For milestone 3b we do not read the inbound
-/// payload; the tick's single-item body is unused.
+/// guest linear memory. For this milestone we do not read the inbound
+/// payload; the tick's empty body is unused.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn receive(kind: u32, _ptr: u32, _count: u32) -> u32 {
     #[cfg(target_arch = "wasm32")]
     unsafe {
         if kind == KIND_TICK {
-            let ptr = TRIANGLE.as_ptr() as u32;
-            let len = size_of_val(&TRIANGLE) as u32;
+            let ptr = &TRIANGLE as *const DrawTriangle as u32;
+            let len = core::mem::size_of::<DrawTriangle>() as u32;
             // count = number of triangles in this payload (one).
             send_mail(RENDER_SINK, KIND_DRAW_TRIANGLE, ptr, len, 1);
         }

--- a/crates/aether-mail/Cargo.toml
+++ b/crates/aether-mail/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aether-mail"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+bytemuck = { version = "1.19", features = ["derive"] }
+postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -1,0 +1,227 @@
+// aether-mail: shared machinery for the mail typing system described in
+// ADR-0005. No concrete kinds live here — each actor owns its kinds in
+// its own crate (substrate in `aether-substrate-mail`, components in
+// `{component}-mail` crates as they define their own).
+//
+// Two payload tiers:
+//   - POD: #[repr(C)] types implementing `bytemuck::NoUninit` /
+//     `AnyBitPattern`. Encoded as their native byte layout; decoded
+//     zero-copy to `&T` or `&[T]`. Used for vertex streams, fixed-layout
+//     structs, anything where throughput or zero-copy matters.
+//   - Structural: `serde::Serialize + DeserializeOwned` types. Encoded
+//     with postcard (Rust-native, varint-compact, no_std-friendly).
+//     Used for small control messages with Option/Vec/enum shape.
+//
+// A type picks one tier — not both — as part of its contract.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Identifies a mail kind by a stable, namespaced string name (e.g.
+/// `"aether.tick"`, `"hello.npc_health"`). The name is resolved to a
+/// runtime `u32` id by the substrate's kind registry at init; see
+/// ADR-0005 for the resolution flow.
+pub trait Kind {
+    const NAME: &'static str;
+}
+
+/// Reason a decode failed. Encoding is infallible for the tiers we
+/// support, so there is no corresponding `EncodeError`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Byte length is not compatible with the target layout (wrong size
+    /// for POD single, or not a multiple of element size for POD slice).
+    SizeMismatch { expected: usize, actual: usize },
+    /// Alignment of the input slice is incompatible with the target type.
+    Alignment,
+    /// Postcard decode failed for a structural payload.
+    Postcard(postcard::Error),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::SizeMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "mail payload size mismatch: expected {expected}, got {actual}"
+                )
+            }
+            DecodeError::Alignment => f.write_str("mail payload alignment mismatch"),
+            DecodeError::Postcard(e) => write!(f, "postcard decode failed: {e}"),
+        }
+    }
+}
+
+impl From<bytemuck::PodCastError> for DecodeError {
+    fn from(err: bytemuck::PodCastError) -> Self {
+        use bytemuck::PodCastError::*;
+        match err {
+            SizeMismatch | OutputSliceWouldHaveSlop => DecodeError::SizeMismatch {
+                expected: 0,
+                actual: 0,
+            },
+            TargetAlignmentGreaterAndInputNotAligned => DecodeError::Alignment,
+            AlignmentMismatch => DecodeError::Alignment,
+        }
+    }
+}
+
+impl From<postcard::Error> for DecodeError {
+    fn from(err: postcard::Error) -> Self {
+        DecodeError::Postcard(err)
+    }
+}
+
+/// Encode a single POD value to its native byte layout.
+pub fn encode<T: Kind + bytemuck::NoUninit>(value: &T) -> Vec<u8> {
+    bytemuck::bytes_of(value).to_vec()
+}
+
+/// Encode a slice of POD values as a contiguous byte buffer. The
+/// substrate's `count` field is `items.len()` when using this helper.
+pub fn encode_slice<T: Kind + bytemuck::NoUninit>(items: &[T]) -> Vec<u8> {
+    bytemuck::cast_slice(items).to_vec()
+}
+
+/// Decode a single POD value. The input must match `size_of::<T>()`
+/// exactly and meet `T`'s alignment requirement.
+pub fn decode<T: Kind + bytemuck::AnyBitPattern + Copy>(bytes: &[u8]) -> Result<T, DecodeError> {
+    if bytes.len() != core::mem::size_of::<T>() {
+        return Err(DecodeError::SizeMismatch {
+            expected: core::mem::size_of::<T>(),
+            actual: bytes.len(),
+        });
+    }
+    // `pod_read_unaligned` sidesteps the alignment requirement, which is
+    // the common shape on wire buffers pulled out of a Vec<u8>.
+    Ok(bytemuck::pod_read_unaligned(bytes))
+}
+
+/// Decode a POD slice in place. Zero-copy: the returned slice borrows
+/// from `bytes`. Input length must be a multiple of `size_of::<T>()`
+/// and aligned for `T`.
+pub fn decode_slice<T: Kind + bytemuck::AnyBitPattern>(bytes: &[u8]) -> Result<&[T], DecodeError> {
+    bytemuck::try_cast_slice(bytes).map_err(DecodeError::from)
+}
+
+/// Encode a structural value via postcard.
+pub fn encode_struct<T: Kind + serde::Serialize>(value: &T) -> Vec<u8> {
+    postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
+}
+
+/// Decode a structural value via postcard. Returns owned `T`.
+pub fn decode_struct<T: Kind + serde::de::DeserializeOwned>(
+    bytes: &[u8],
+) -> Result<T, DecodeError> {
+    postcard::from_bytes(bytes).map_err(DecodeError::from)
+}
+
+/// Marker payload for signal-only kinds with no bytes on the wire.
+/// Implementors need nothing but a `Kind` impl; use `encode_empty` on
+/// the sender side and ignore the payload on the receiver side.
+pub fn encode_empty<T: Kind>() -> Vec<u8> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytemuck::{Pod, Zeroable};
+    use serde::{Deserialize, Serialize};
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
+    struct TestPod {
+        a: u32,
+        b: f32,
+    }
+    impl Kind for TestPod {
+        const NAME: &'static str = "test.pod";
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
+    struct Vertex {
+        x: f32,
+        y: f32,
+    }
+    impl Kind for Vertex {
+        const NAME: &'static str = "test.vertex";
+    }
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        tag: u32,
+        label: alloc::string::String,
+    }
+    impl Kind for TestStruct {
+        const NAME: &'static str = "test.struct";
+    }
+
+    struct Signal;
+    impl Kind for Signal {
+        const NAME: &'static str = "test.signal";
+    }
+
+    #[test]
+    fn pod_roundtrip_single() {
+        let v = TestPod { a: 42, b: 1.5 };
+        let bytes = encode(&v);
+        assert_eq!(bytes.len(), 8);
+        let back: TestPod = decode(&bytes).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn pod_roundtrip_slice_is_zero_copy() {
+        let verts = [Vertex { x: 0.0, y: 0.5 }, Vertex { x: 1.0, y: -0.5 }];
+        let bytes = encode_slice(&verts);
+        assert_eq!(bytes.len(), 16);
+        // Alignment-preserving slice: we built `bytes` from `&[Vertex]`
+        // so it's aligned; use try_cast_slice for the real test.
+        let decoded: &[Vertex] = decode_slice(&bytes).unwrap();
+        assert_eq!(decoded, &verts);
+    }
+
+    #[test]
+    fn pod_decode_size_mismatch_rejected() {
+        let bytes = [0u8; 7]; // TestPod is 8 bytes
+        let err = decode::<TestPod>(&bytes).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::SizeMismatch {
+                expected: 8,
+                actual: 7
+            }
+        ));
+    }
+
+    #[test]
+    fn struct_roundtrip() {
+        let v = TestStruct {
+            tag: 7,
+            label: alloc::string::String::from("hello"),
+        };
+        let bytes = encode_struct(&v);
+        let back: TestStruct = decode_struct(&bytes).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn struct_decode_malformed_rejected() {
+        // A deliberately truncated payload — postcard will reject.
+        let err = decode_struct::<TestStruct>(&[0x00]).unwrap_err();
+        assert!(matches!(err, DecodeError::Postcard(_)));
+    }
+
+    #[test]
+    fn empty_kind_encodes_to_zero_bytes() {
+        assert!(encode_empty::<Signal>().is_empty());
+        assert_eq!(Signal::NAME, "test.signal");
+    }
+}

--- a/crates/aether-substrate-mail/Cargo.toml
+++ b/crates/aether-substrate-mail/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "aether-substrate-mail"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+aether-mail = { path = "../aether-mail" }
+bytemuck = { version = "1.19", features = ["derive"] }

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -1,0 +1,133 @@
+// aether-substrate-mail: the substrate's own mail vocabulary. Imported
+// by any actor that wants to send mail to the substrate, receive mail
+// the substrate dispatches (tick, input), or consume the substrate's
+// sink kinds (draw_triangle). See ADR-0005.
+//
+// Kind ids are hardcoded u32 constants in this PR to keep the wire
+// stable across the crate migration. A follow-up PR replaces them with
+// registry-assigned ids at init, parallel to the existing mailbox-name
+// registry.
+
+#![no_std]
+
+use aether_mail::Kind;
+use bytemuck::{Pod, Zeroable};
+
+// Kind ids — hardcoded for now, resolved by name in a later PR.
+pub const KIND_TICK: u32 = 1;
+pub const KIND_KEY: u32 = 10;
+pub const KIND_MOUSE_BUTTON: u32 = 11;
+pub const KIND_MOUSE_MOVE: u32 = 12;
+pub const KIND_DRAW_TRIANGLE: u32 = 20;
+
+/// Per-frame signal from the substrate's frame loop. Empty payload for
+/// now; milestone 4 will add an elapsed-seconds field.
+pub struct Tick;
+impl Kind for Tick {
+    const NAME: &'static str = "aether.tick";
+}
+
+/// A single keyboard keypress, identified by `winit::keyboard::KeyCode
+/// as u32`. Dispatched on press only (not release, not repeat).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Key {
+    pub code: u32,
+}
+impl Kind for Key {
+    const NAME: &'static str = "aether.key";
+}
+
+/// A mouse-button press. No payload today — which button isn't tracked.
+pub struct MouseButton;
+impl Kind for MouseButton {
+    const NAME: &'static str = "aether.mouse_button";
+}
+
+/// Cursor position in window coordinates, as logical pixels cast to f32.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct MouseMove {
+    pub x: f32,
+    pub y: f32,
+}
+impl Kind for MouseMove {
+    const NAME: &'static str = "aether.mouse_move";
+}
+
+/// A single clip-space vertex with per-vertex color. Matches the
+/// substrate's `VertexBufferLayout`: `(pos: vec2<f32>, color: vec3<f32>)`,
+/// 20 bytes on the wire.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct Vertex {
+    pub x: f32,
+    pub y: f32,
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+/// A draw-triangle item. One `DrawTriangle` is three vertices; the mail
+/// `count` field is the number of triangles in the payload when
+/// sent as a slice.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct DrawTriangle {
+    pub verts: [Vertex; 3],
+}
+impl Kind for DrawTriangle {
+    const NAME: &'static str = "aether.draw_triangle";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_mail::{decode, decode_slice, encode, encode_slice};
+
+    #[test]
+    fn key_roundtrip() {
+        let k = Key { code: 42 };
+        let bytes = encode(&k);
+        assert_eq!(bytes.len(), 4);
+        let back: Key = decode(&bytes).unwrap();
+        assert_eq!(back, k);
+    }
+
+    #[test]
+    fn mouse_move_roundtrip() {
+        let m = MouseMove { x: 1.5, y: -3.25 };
+        let bytes = encode(&m);
+        assert_eq!(bytes.len(), 8);
+        let back: MouseMove = decode(&bytes).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn draw_triangle_slice_size() {
+        let v = Vertex {
+            x: 0.0,
+            y: 0.5,
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+        };
+        let tris = [
+            DrawTriangle { verts: [v, v, v] },
+            DrawTriangle { verts: [v, v, v] },
+        ];
+        let bytes = encode_slice(&tris);
+        assert_eq!(bytes.len(), 2 * 60);
+        let back: &[DrawTriangle] = decode_slice(&bytes).unwrap();
+        assert_eq!(back, &tris);
+    }
+
+    #[test]
+    fn kind_names_are_stable() {
+        assert_eq!(Tick::NAME, "aether.tick");
+        assert_eq!(Key::NAME, "aether.key");
+        assert_eq!(MouseButton::NAME, "aether.mouse_button");
+        assert_eq!(MouseMove::NAME, "aether.mouse_move");
+        assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
+    }
+}

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 build = "build.rs"
 
 [dependencies]
+aether-mail = { path = "../aether-mail" }
+aether-substrate-mail = { path = "../aether-substrate-mail" }
+bytemuck = "1.19"
 pollster = "0.4.0"
 wasmtime = "30"
 wgpu = "29.0.1"

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -16,9 +16,13 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use aether_mail::{encode, encode_empty};
 use aether_substrate::{
     Component, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
+};
+use aether_substrate_mail::{
+    KIND_KEY, KIND_MOUSE_BUTTON, KIND_MOUSE_MOVE, KIND_TICK, Key, MouseButton, MouseMove, Tick,
 };
 use render::Gpu;
 use wasmtime::{Engine, Linker, Module};
@@ -29,11 +33,6 @@ use winit::keyboard::PhysicalKey;
 use winit::window::{Window, WindowId};
 
 const HELLO_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/hello_component.wasm"));
-
-const KIND_TICK: u32 = 1;
-const KIND_KEY: u32 = 10;
-const KIND_MOUSE_BUTTON: u32 = 11;
-const KIND_MOUSE_MOVE: u32 = 12;
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;
@@ -77,8 +76,12 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::RedrawRequested => {
-                self.queue
-                    .push(Mail::new(self.component_mbox, KIND_TICK, vec![], 1));
+                self.queue.push(Mail::new(
+                    self.component_mbox,
+                    KIND_TICK,
+                    encode_empty::<Tick>(),
+                    1,
+                ));
                 self.queue.wait_idle();
                 let verts = std::mem::take(&mut *self.frame_vertices.lock().unwrap());
                 if let Some(gpu) = self.gpu.as_mut() {
@@ -107,7 +110,7 @@ impl ApplicationHandler for App {
                     self.queue.push(Mail::new(
                         self.component_mbox,
                         KIND_KEY,
-                        code.to_le_bytes().to_vec(),
+                        encode(&Key { code }),
                         1,
                     ));
                 }
@@ -116,13 +119,18 @@ impl ApplicationHandler for App {
                 state: ElementState::Pressed,
                 ..
             } => {
-                self.queue
-                    .push(Mail::new(self.component_mbox, KIND_MOUSE_BUTTON, vec![], 1));
+                self.queue.push(Mail::new(
+                    self.component_mbox,
+                    KIND_MOUSE_BUTTON,
+                    encode_empty::<MouseButton>(),
+                    1,
+                ));
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let mut payload = Vec::with_capacity(8);
-                payload.extend_from_slice(&(position.x as f32).to_le_bytes());
-                payload.extend_from_slice(&(position.y as f32).to_le_bytes());
+                let payload = encode(&MouseMove {
+                    x: position.x as f32,
+                    y: position.y as f32,
+                });
                 self.queue
                     .push(Mail::new(self.component_mbox, KIND_MOUSE_MOVE, payload, 1));
             }


### PR DESCRIPTION
## Summary

Implements the trait layer of the mail typing system from ADR-0005.

- New `aether-mail` crate: `Kind` trait (namespaced kind-name identity) plus two encode/decode tiers — POD via bytemuck (zero-copy slice decode) and structural via postcard (serde-driven, varint-compact).
- New `aether-substrate-mail` crate: the substrate's own kinds — `Tick`, `Key`, `MouseButton`, `MouseMove`, `Vertex`, `DrawTriangle` — as `#[repr(C)]` POD types with `Kind` impls and hardcoded `u32` kind id constants.
- Substrate `main.rs` and `aether-hello-component` now import kind ids and payload types from `aether-substrate-mail` instead of duplicating `u32` constants and hand-rolling byte layouts.

Wire format is unchanged — bytemuck encoding of `#[repr(C)]` structs produces the same bytes as the prior `to_le_bytes` construction on LE targets. Tests confirm round-trip correctness in both crates.

Kind ids remain hardcoded in this PR; the follow-up replaces them with a kind-name registry at init, parallel to the existing mailbox-name registry.

## Test plan

- [x] `cargo test --workspace` — all green (10 new tests in the two crates, existing tests unchanged)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manually run `cargo run --release -p aether-substrate` and confirm the triangle still renders (wire format is byte-identical but worth a visual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)