### PR TITLE
feat(mail): resolve kind ids via name registry at init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
 name = "aether-hello-component"
 version = "0.1.0"
 dependencies = [
+ "aether-mail",
  "aether-substrate-mail",
 ]
 

--- a/crates/aether-hello-component/Cargo.toml
+++ b/crates/aether-hello-component/Cargo.toml
@@ -7,4 +7,5 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+aether-mail = { path = "../aether-mail" }
 aether-substrate-mail = { path = "../aether-substrate-mail" }

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -1,30 +1,39 @@
 // First real aether component. On each tick the component emits a
-// triangle as KIND_DRAW_TRIANGLE mail to the substrate's render sink.
-// Positions are clip-space; the component has no camera/transform story
-// yet.
+// triangle as a draw-triangle mail to the substrate's render sink.
+// Positions are clip-space; the component has no camera/transform
+// story yet.
 //
-// Kind ids and payload types are imported from `aether-substrate-mail`
-// per ADR-0005 — the substrate's mail vocabulary is a crate components
-// depend on, not a duplicated wire constant.
+// Per ADR-0005, kind ids are resolved by name at component init — the
+// substrate assigns them; the guest caches them in statics. Payload
+// types are imported from `aether-substrate-mail` so wire layout stays
+// in one place.
 //
 // Mailbox ids remain hardcoded (component=0, render sink=1); symbolic
-// name resolution at component init is future work per ADR-0005's
-// kind-registry-at-init follow-up.
+// mailbox resolution is still future work.
 //
-// `#[cfg(target_arch = "wasm32")]` guards the bodies so the crate still
+// `#[cfg(target_arch = "wasm32")]` guards bodies so the crate still
 // compiles for the host target in `cargo test --workspace` (where the
-// `send_mail` import is not resolvable at link time, and where
-// `ptr as u32` would truncate a 64-bit host pointer).
+// `aether` imports aren't linkable and `ptr as u32` would truncate a
+// 64-bit host pointer).
 
 #[cfg(target_arch = "wasm32")]
-use aether_substrate_mail::{DrawTriangle, KIND_DRAW_TRIANGLE, KIND_TICK, Vertex};
+use aether_mail::Kind;
+#[cfg(target_arch = "wasm32")]
+use aether_substrate_mail::{DrawTriangle, Tick, Vertex};
 
 #[cfg(target_arch = "wasm32")]
 const RENDER_SINK: u32 = 1;
 
+// `u32::MAX` sentinel matches the host's KIND_NOT_FOUND — if `init`
+// didn't run or a name is missing, the dispatch below simply no-ops.
+#[cfg(target_arch = "wasm32")]
+static mut KIND_TICK: u32 = u32::MAX;
+#[cfg(target_arch = "wasm32")]
+static mut KIND_DRAW_TRIANGLE: u32 = u32::MAX;
+
 // A fixed clip-space triangle with per-vertex color. Typed as
-// DrawTriangle so the vertex layout is the same type the substrate
-// decodes against; bytemuck handles the &T-to-bytes cast at send time.
+// DrawTriangle so the vertex layout matches the substrate's decode
+// type; bytemuck handles the &T-to-bytes cast at send time.
 #[cfg(target_arch = "wasm32")]
 static TRIANGLE: DrawTriangle = DrawTriangle {
     verts: [
@@ -56,12 +65,37 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
     fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
+}
+
+#[cfg(target_arch = "wasm32")]
+unsafe fn resolve(name: &str) -> u32 {
+    unsafe { resolve_kind(name.as_ptr() as u32, name.len() as u32) }
+}
+
+/// Runs once before the first `receive`. Resolves each kind name this
+/// component cares about and caches the assigned id. Return value is
+/// currently informational.
+///
+/// # Safety
+/// Called by the substrate exactly once, before any `receive` call, on
+/// a thread that owns this component's linear memory. The body mutates
+/// the `KIND_*` statics — safe because there is no concurrent reader
+/// until `init` returns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn init() -> u32 {
+    #[cfg(target_arch = "wasm32")]
+    unsafe {
+        KIND_TICK = resolve(Tick::NAME);
+        KIND_DRAW_TRIANGLE = resolve(DrawTriangle::NAME);
+    }
+    0
 }
 
 /// # Safety
-/// Host contract: `ptr` points to a `count`-item payload for `kind` within
-/// guest linear memory. For this milestone we do not read the inbound
-/// payload; the tick's empty body is unused.
+/// Host contract: `ptr` points to a `count`-item payload for `kind`
+/// within guest linear memory. For this milestone we do not read the
+/// inbound payload; the tick's empty body is unused.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn receive(kind: u32, _ptr: u32, _count: u32) -> u32 {
     #[cfg(target_arch = "wasm32")]

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -3,22 +3,15 @@
 // the substrate dispatches (tick, input), or consume the substrate's
 // sink kinds (draw_triangle). See ADR-0005.
 //
-// Kind ids are hardcoded u32 constants in this PR to keep the wire
-// stable across the crate migration. A follow-up PR replaces them with
-// registry-assigned ids at init, parallel to the existing mailbox-name
-// registry.
+// Kind ids are assigned at substrate boot via `Registry::register_kind`
+// and resolved by name at component init via the `resolve_kind` host
+// function. Consumers never depend on the id's numeric value — only on
+// the `NAME` constants on the `Kind` impls below.
 
 #![no_std]
 
 use aether_mail::Kind;
 use bytemuck::{Pod, Zeroable};
-
-// Kind ids — hardcoded for now, resolved by name in a later PR.
-pub const KIND_TICK: u32 = 1;
-pub const KIND_KEY: u32 = 10;
-pub const KIND_MOUSE_BUTTON: u32 = 11;
-pub const KIND_MOUSE_MOVE: u32 = 12;
-pub const KIND_DRAW_TRIANGLE: u32 = 20;
 
 /// Per-frame signal from the substrate's frame loop. Empty payload for
 /// now; milestone 4 will add an elapsed-seconds field.

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -35,6 +35,14 @@ impl Component {
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
         let receive = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "receive")?;
+
+        // Optional `init() -> u32` export: called once before the first
+        // `receive`, used for one-shot bootstrap like resolving kind
+        // names to ids. Per ADR-0005's registry-at-init flow.
+        if let Ok(init) = instance.get_typed_func::<(), u32>(&mut store, "init") {
+            init.call(&mut store, ())?;
+        }
+
         Ok(Self {
             store,
             memory,

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -9,6 +9,10 @@ use wasmtime::{Caller, Linker};
 use crate::ctx::SubstrateCtx;
 use crate::mail::MailboxId;
 
+/// Returned by `resolve_kind` when the requested name has not been
+/// registered. Guests use this as a "lookup failed" sentinel.
+pub const KIND_NOT_FOUND: u32 = u32::MAX;
+
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
 /// function has been called on.
@@ -43,5 +47,32 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
             0
         },
     )?;
+
+    linker.func_wrap(
+        "aether",
+        "resolve_kind",
+        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return KIND_NOT_FOUND,
+            };
+            let data = memory.data(&caller);
+            let start = name_ptr as usize;
+            let end = match start.checked_add(name_len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return KIND_NOT_FOUND,
+            };
+            let name = match std::str::from_utf8(&data[start..end]) {
+                Ok(s) => s,
+                Err(_) => return KIND_NOT_FOUND,
+            };
+            caller
+                .data()
+                .registry
+                .kind_id(name)
+                .unwrap_or(KIND_NOT_FOUND)
+        },
+    )?;
+
     Ok(())
 }

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -16,14 +16,13 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
 use aether_substrate::{
     Component, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
-use aether_substrate_mail::{
-    KIND_KEY, KIND_MOUSE_BUTTON, KIND_MOUSE_MOVE, KIND_TICK, Key, MouseButton, MouseMove, Tick,
-};
+use aether_substrate_mail::{DrawTriangle, Key, MouseButton, MouseMove, Tick};
 use render::Gpu;
 use wasmtime::{Engine, Linker, Module};
 use winit::application::ApplicationHandler;
@@ -40,6 +39,10 @@ const LOG_EVERY_FRAMES: u64 = 120;
 struct App {
     queue: Arc<MailQueue>,
     component_mbox: MailboxId,
+    kind_tick: u32,
+    kind_key: u32,
+    kind_mouse_button: u32,
+    kind_mouse_move: u32,
     frame_vertices: Arc<Mutex<Vec<u8>>>,
     triangles_rendered: Arc<AtomicU64>,
     window: Option<Arc<Window>>,
@@ -78,7 +81,7 @@ impl ApplicationHandler for App {
             WindowEvent::RedrawRequested => {
                 self.queue.push(Mail::new(
                     self.component_mbox,
-                    KIND_TICK,
+                    self.kind_tick,
                     encode_empty::<Tick>(),
                     1,
                 ));
@@ -109,7 +112,7 @@ impl ApplicationHandler for App {
                     };
                     self.queue.push(Mail::new(
                         self.component_mbox,
-                        KIND_KEY,
+                        self.kind_key,
                         encode(&Key { code }),
                         1,
                     ));
@@ -121,7 +124,7 @@ impl ApplicationHandler for App {
             } => {
                 self.queue.push(Mail::new(
                     self.component_mbox,
-                    KIND_MOUSE_BUTTON,
+                    self.kind_mouse_button,
                     encode_empty::<MouseButton>(),
                     1,
                 ));
@@ -131,8 +134,12 @@ impl ApplicationHandler for App {
                     x: position.x as f32,
                     y: position.y as f32,
                 });
-                self.queue
-                    .push(Mail::new(self.component_mbox, KIND_MOUSE_MOVE, payload, 1));
+                self.queue.push(Mail::new(
+                    self.component_mbox,
+                    self.kind_mouse_move,
+                    payload,
+                    1,
+                ));
             }
             _ => {}
         }
@@ -145,6 +152,16 @@ fn main() -> wasmtime::Result<()> {
 
     let mut registry = Registry::new();
     let component_mbox = registry.register_component("hello");
+
+    // Pre-register every substrate-owned kind by name so the component
+    // can resolve them during `init` via the `resolve_kind` host fn.
+    // Ids are dense and assigned in the order below; not otherwise
+    // meaningful — consumers always resolve by name.
+    let kind_tick = registry.register_kind(Tick::NAME);
+    let kind_key = registry.register_kind(Key::NAME);
+    let kind_mouse_button = registry.register_kind(MouseButton::NAME);
+    let kind_mouse_move = registry.register_kind(MouseMove::NAME);
+    registry.register_kind(DrawTriangle::NAME);
 
     let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(4096)));
     let triangles_rendered = Arc::new(AtomicU64::new(0));
@@ -192,6 +209,10 @@ fn main() -> wasmtime::Result<()> {
     let mut app = App {
         queue,
         component_mbox,
+        kind_tick,
+        kind_key,
+        kind_mouse_button,
+        kind_mouse_move,
         frame_vertices,
         triangles_rendered: Arc::clone(&triangles_rendered),
         window: None,

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -1,7 +1,8 @@
-// Mailbox registry. Maps stable string names to `MailboxId`s and records
-// whether each mailbox is a WASM component or a substrate-owned sink.
-// Fixed at substrate boot for milestone 1; dynamic registration is a
-// later-milestone concern (issue #18).
+// Name registries. Two parallel tables: mailboxes (name → MailboxId,
+// tagged component-vs-sink) and kinds (name → u32 kind id, per
+// ADR-0005). Both are populated at substrate boot and frozen when the
+// registry is wrapped in Arc — readers see a stable snapshot and
+// contend on nothing. Post-boot dynamic registration is deferred.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -25,6 +26,7 @@ pub enum MailboxEntry {
 pub struct Registry {
     by_name: HashMap<String, MailboxId>,
     entries: Vec<MailboxEntry>,
+    kind_by_name: HashMap<String, u32>,
 }
 
 impl Registry {
@@ -32,6 +34,7 @@ impl Registry {
         Self {
             by_name: HashMap::new(),
             entries: Vec::new(),
+            kind_by_name: HashMap::new(),
         }
     }
 
@@ -65,6 +68,23 @@ impl Registry {
 
     pub fn entry(&self, id: MailboxId) -> Option<&MailboxEntry> {
         self.entries.get(id.0 as usize)
+    }
+
+    /// Register a mail kind by name. Idempotent — re-registering a name
+    /// returns the id it was first assigned. Ids are dense and assigned
+    /// in insertion order, per ADR-0005's kind-name registry.
+    pub fn register_kind(&mut self, name: impl Into<String>) -> u32 {
+        let name = name.into();
+        if let Some(&id) = self.kind_by_name.get(&name) {
+            return id;
+        }
+        let id = self.kind_by_name.len() as u32;
+        self.kind_by_name.insert(name, id);
+        id
+    }
+
+    pub fn kind_id(&self, name: &str) -> Option<u32> {
+        self.kind_by_name.get(name).copied()
     }
 
     pub fn len(&self) -> usize {
@@ -141,5 +161,33 @@ mod tests {
         let r = Registry::new();
         assert!(r.lookup("nope").is_none());
         assert!(r.entry(MailboxId(42)).is_none());
+    }
+
+    #[test]
+    fn kind_ids_are_dense_and_sequential() {
+        let mut r = Registry::new();
+        let a = r.register_kind("aether.tick");
+        let b = r.register_kind("aether.key");
+        let c = r.register_kind("hello.npc_health");
+        assert_eq!(a, 0);
+        assert_eq!(b, 1);
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn kind_registration_is_idempotent() {
+        let mut r = Registry::new();
+        let first = r.register_kind("aether.tick");
+        let second = r.register_kind("aether.tick");
+        assert_eq!(first, second);
+        assert_eq!(r.register_kind("aether.key"), 1);
+    }
+
+    #[test]
+    fn kind_id_lookup() {
+        let mut r = Registry::new();
+        let id = r.register_kind("aether.tick");
+        assert_eq!(r.kind_id("aether.tick"), Some(id));
+        assert!(r.kind_id("absent").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Completes ADR-0005's registry-at-init flow — the final of three PRs on the mail typing system.

- **Registry**: adds a parallel kind-name table alongside the existing mailbox-name table. `register_kind(name)` is idempotent; ids are dense and insertion-ordered.
- **Host fn**: new `resolve_kind(name_ptr, name_len) -> u32` looks up assigned ids from guest memory. Returns `u32::MAX` (re-exported as `KIND_NOT_FOUND`) on missing name or invalid UTF-8.
- **Component lifecycle**: `Component::instantiate` now calls an optional `init() -> u32` export once, before the first `receive`. Used for kind resolution; later will also cover mailbox-name resolution.
- **hello-component**: gains an `init` that resolves `Tick::NAME` and `DrawTriangle::NAME`, caching the ids in `static mut`. `receive` dispatches against the resolved tick id.
- **`aether-substrate-mail`**: hardcoded `KIND_TICK = 1` style constants are removed. Consumers resolve by name — ids are an implementation detail of the running substrate.

Kind ids are in-process only (there is no wire), so dropping the fixed numbers doesn't break compatibility with anything external.

## What's deferred

- **Guest-registered kinds**: components can't yet announce kinds they originate. Not needed until a second component or an MCP sender lands; then add `register_kind` as a host fn mirror of `resolve_kind`.
- **Mailbox-name resolution**: still hardcoded `component=0, render sink=1`. Parallel design to this PR; a natural follow-up.

## Test plan

- [x] `cargo test --workspace` — all green (3 new registry tests for kind name flow; existing e2e test unaffected since its WAT guest doesn't export `init`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean (added `# Safety` doc on the new `init` export)
- [x] `cargo fmt -- --check` — clean
- [x] Manually run `cargo run --release -p aether-substrate`: triangle should still render. `init` runs once on instantiation before the first tick; kind ids are now assigned in registration order (tick=0, key=1, mouse_button=2, mouse_move=3, draw_triangle=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)