### PR TITLE
feat(hub): add aether-hub-protocol wire types and framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-hub-protocol"
+version = "0.1.0"
+dependencies = [
+ "postcard",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "aether-mail"
 version = "0.1.0"
 dependencies = [
@@ -2506,6 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/aether-substrate",
     "crates/aether-substrate-mail",
     "crates/aether-hello-component",
+    "crates/aether-hub-protocol",
     "crates/aether-mail",
     "crates/aether-mail-spike-host",
     "crates/aether-mail-spike-guest",

--- a/crates/aether-hub-protocol/Cargo.toml
+++ b/crates/aether-hub-protocol/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aether-hub-protocol"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+uuid = { version = "1", default-features = false, features = ["serde"] }

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -1,0 +1,225 @@
+// aether-hub-protocol: engine ↔ hub wire types and framing per ADR-0006.
+//
+// Uni-directional mail flow for V0: frames go Claude → hub → engine.
+// Engines send only lifecycle frames (Hello, Heartbeat, Goodbye) —
+// engine-originated mail and replies are parked.
+//
+// Framing: each frame on the TCP stream is a 4-byte little-endian
+// length prefix followed by the postcard-encoded message. Two enum
+// types (`EngineToHub`, `HubToEngine`) enforce direction at the type
+// level.
+
+use std::fmt;
+use std::io::{self, Read, Write};
+
+use serde::{Serialize, de::DeserializeOwned};
+
+pub use uuid::Uuid;
+
+mod types;
+pub use types::*;
+
+/// Maximum accepted frame body size. Bounded so a malformed length
+/// prefix cannot drive a reader into an OOM. 16 MiB is comfortably
+/// larger than any expected mail payload on the hub wire (vertex
+/// streams travel through the render sink, not the hub).
+pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+/// Errors from the framing helpers. Wraps I/O and postcard decode
+/// errors; adds its own variant for an oversize length prefix.
+#[derive(Debug)]
+pub enum FrameError {
+    Io(io::Error),
+    Postcard(postcard::Error),
+    FrameTooLarge { size: usize, max: usize },
+}
+
+impl fmt::Display for FrameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrameError::Io(e) => write!(f, "hub protocol io: {e}"),
+            FrameError::Postcard(e) => write!(f, "hub protocol decode: {e}"),
+            FrameError::FrameTooLarge { size, max } => {
+                write!(f, "hub protocol frame too large: {size} > {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+impl From<io::Error> for FrameError {
+    fn from(e: io::Error) -> Self {
+        FrameError::Io(e)
+    }
+}
+
+impl From<postcard::Error> for FrameError {
+    fn from(e: postcard::Error) -> Self {
+        FrameError::Postcard(e)
+    }
+}
+
+/// Encode a message into its framed wire representation (4-byte LE
+/// length prefix + postcard body). Infallible — postcard encoding of
+/// `alloc::Vec` is infallible for the types in this crate.
+pub fn encode_frame<T: Serialize>(msg: &T) -> Vec<u8> {
+    let body = postcard::to_allocvec(msg).expect("postcard encode to Vec is infallible");
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Synchronous read of one framed message. Blocks until a complete
+/// frame is consumed from `r`. Async callers should inline the
+/// length+body reads on their own async stream rather than calling
+/// this on a blocking wrapper.
+pub fn read_frame<R: Read, T: DeserializeOwned>(r: &mut R) -> Result<T, FrameError> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        return Err(FrameError::FrameTooLarge {
+            size: len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(postcard::from_bytes(&buf)?)
+}
+
+/// Synchronous write of one framed message.
+pub fn write_frame<W: Write, T: Serialize>(w: &mut W, msg: &T) -> Result<(), FrameError> {
+    let bytes = encode_frame(msg);
+    w.write_all(&bytes)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn hello_roundtrip() {
+        let hello = EngineToHub::Hello(Hello {
+            name: "hello-triangle".into(),
+            pid: 8910,
+            started_unix: 1_712_345_678,
+            version: "0.1.0".into(),
+        });
+
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &hello).unwrap();
+
+        let mut r = Cursor::new(buf);
+        let back: EngineToHub = read_frame(&mut r).unwrap();
+        match back {
+            EngineToHub::Hello(h) => {
+                assert_eq!(h.name, "hello-triangle");
+                assert_eq!(h.pid, 8910);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn welcome_roundtrip() {
+        let id = EngineId(Uuid::from_u128(0x1234_5678_9abc_def0_1234_5678_9abc_def0));
+        let msg = HubToEngine::Welcome(Welcome { engine_id: id });
+
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: HubToEngine = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            HubToEngine::Welcome(w) => assert_eq!(w.engine_id, id),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn mail_frame_roundtrip() {
+        let msg = HubToEngine::Mail(MailFrame {
+            recipient_name: "hello".into(),
+            kind_name: "aether.tick".into(),
+            payload: vec![],
+            count: 1,
+        });
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: HubToEngine = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            HubToEngine::Mail(m) => {
+                assert_eq!(m.recipient_name, "hello");
+                assert_eq!(m.kind_name, "aether.tick");
+                assert_eq!(m.count, 1);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn heartbeat_both_directions() {
+        for buf in [
+            encode_frame(&EngineToHub::Heartbeat),
+            encode_frame(&HubToEngine::Heartbeat),
+        ] {
+            // Smallest possible frame: 4 byte prefix + 1 byte postcard tag.
+            assert_eq!(buf.len(), 5);
+        }
+    }
+
+    #[test]
+    fn multiple_frames_back_to_back() {
+        let a = EngineToHub::Hello(Hello {
+            name: "a".into(),
+            pid: 1,
+            started_unix: 0,
+            version: "0".into(),
+        });
+        let b = EngineToHub::Heartbeat;
+        let c = EngineToHub::Goodbye(Goodbye {
+            reason: "done".into(),
+        });
+
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &a).unwrap();
+        write_frame(&mut buf, &b).unwrap();
+        write_frame(&mut buf, &c).unwrap();
+
+        let mut r = Cursor::new(buf);
+        let _: EngineToHub = read_frame(&mut r).unwrap();
+        let _: EngineToHub = read_frame(&mut r).unwrap();
+        let _: EngineToHub = read_frame(&mut r).unwrap();
+    }
+
+    #[test]
+    fn frame_too_large_rejected() {
+        // Hand-craft a length prefix claiming 100 MiB.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(100 * 1024 * 1024u32).to_le_bytes());
+        let err = read_frame::<_, EngineToHub>(&mut Cursor::new(buf)).unwrap_err();
+        assert!(matches!(err, FrameError::FrameTooLarge { .. }));
+    }
+
+    #[test]
+    fn truncated_body_returns_io_error() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&100u32.to_le_bytes()); // claim 100 bytes
+        buf.extend_from_slice(&[0u8; 10]); // only 10 bytes
+        let err = read_frame::<_, EngineToHub>(&mut Cursor::new(buf)).unwrap_err();
+        assert!(matches!(err, FrameError::Io(_)));
+    }
+
+    #[test]
+    fn malformed_body_returns_postcard_error() {
+        // Length=1, body byte that doesn't match any EngineToHub variant tag.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.push(0xff);
+        let err = read_frame::<_, EngineToHub>(&mut Cursor::new(buf)).unwrap_err();
+        assert!(matches!(err, FrameError::Postcard(_)));
+    }
+}

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -1,0 +1,66 @@
+// Wire types for the engine ↔ hub protocol. Direction is enforced by
+// the top-level enums `EngineToHub` / `HubToEngine`; the bodies are
+// plain structs so they're ergonomic to construct and pattern-match.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Hub-assigned stable identity for an engine connection. Fresh per
+/// connect; not preserved across reconnects (resume-with-id is a V1
+/// concern per ADR-0006).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EngineId(pub Uuid);
+
+/// First frame the engine sends after the TCP connection is open.
+/// The hub replies with a `Welcome` carrying the assigned `EngineId`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Hello {
+    pub name: String,
+    pub pid: u32,
+    pub started_unix: u64,
+    pub version: String,
+}
+
+/// Hub's reply to `Hello`. Carries the `EngineId` the engine should
+/// treat as its identity for the rest of this connection.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Welcome {
+    pub engine_id: EngineId,
+}
+
+/// A piece of mail routed by the hub to an engine. Kind and recipient
+/// are carried by name; the engine resolves them against its local
+/// registry (per ADR-0005's kind registry).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailFrame {
+    pub recipient_name: String,
+    pub kind_name: String,
+    pub payload: Vec<u8>,
+    pub count: u32,
+}
+
+/// Optional clean-shutdown marker. Either side may send it; receipt is
+/// a signal that a subsequent TCP close is intentional rather than a
+/// crash.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Goodbye {
+    pub reason: String,
+}
+
+/// Frames an engine sends to the hub. V0 omits engine-originated mail
+/// and replies — those land when pub-sub lands.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EngineToHub {
+    Hello(Hello),
+    Heartbeat,
+    Goodbye(Goodbye),
+}
+
+/// Frames the hub sends to an engine.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HubToEngine {
+    Welcome(Welcome),
+    Heartbeat,
+    Mail(MailFrame),
+    Goodbye(Goodbye),
+}


### PR DESCRIPTION
## Summary

PR 1 of the ADR-0006 implementation arc. Foundational crate both the hub binary and the substrate TCP client will depend on.

- **Direction-enforced enums**: `EngineToHub { Hello, Heartbeat, Goodbye }` and `HubToEngine { Welcome, Heartbeat, Mail, Goodbye }`. Type system catches sending the wrong frame in the wrong direction.
- **Wire types**: `Hello { name, pid, started_unix, version }`, `Welcome { engine_id: EngineId }`, `MailFrame { recipient_name, kind_name, payload, count }`, `Goodbye { reason }`. `EngineId` wraps `Uuid`.
- **Framing**: 4-byte LE length prefix + postcard body. 16 MiB max frame size prevents OOM from a malformed length. `encode_frame` is infallible; `read_frame`/`write_frame` are sync helpers for the substrate side. Async callers (the hub) inline their own length+body reads.
- **Uni-directional mail**: V0 is Claude → hub → engine only. Engine-originated mail is parked per the ADR.

## Test plan

- [x] `cargo test -p aether-hub-protocol` — 8 tests: roundtrip each frame type, heartbeats in both directions, multi-frame stream, size cap, truncated body, malformed body
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] No dependencies on substrate, mail, or hub binary yet — this crate stands alone

## Follow-ups

- PR 2: `aether-hub` binary with engine TCP listener, handshake, heartbeat reaping
- PR 3: Substrate TCP client that dials the hub
- PR 4: MCP tool surface (`send_mail`, `list_engines`) via rmcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)