### PR TITLE
feat(hub): add aether-hub binary with engine TCP listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-hub"
+version = "0.1.0"
+dependencies = [
+ "aether-hub-protocol",
+ "postcard",
+ "serde",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "aether-hub-protocol"
 version = "0.1.0"
 dependencies = [
@@ -905,8 +916,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1303,6 +1327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1946,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "range-alloc"
@@ -2177,6 +2228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2309,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2372,6 +2443,33 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2514,6 +2612,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2546,6 +2645,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2617,12 +2725,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2636,6 +2766,18 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2759,7 +2901,7 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -2912,7 +3054,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap",
- "wit-parser",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -3558,6 +3700,70 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
 
 [[package]]
 name = "wit-parser"
@@ -3575,6 +3781,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/aether-substrate",
     "crates/aether-substrate-mail",
     "crates/aether-hello-component",
+    "crates/aether-hub",
     "crates/aether-hub-protocol",
     "crates/aether-mail",
     "crates/aether-mail-spike-host",

--- a/crates/aether-hub/Cargo.toml
+++ b/crates/aether-hub/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aether-hub"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+aether-hub-protocol = { path = "../aether-hub-protocol" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "signal"] }
+uuid = { version = "1", features = ["v4"] }
+postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -1,0 +1,168 @@
+// Per-engine connection handler. Owns the lifecycle for one accepted
+// TCP socket: handshake → registered mail loop → teardown.
+//
+// Concurrency shape: the reader runs on the connection task; a writer
+// task owns the write half of the split stream and drains an mpsc fed
+// by both the heartbeat ticker and (later) MCP tool handlers. If the
+// reader exits, it drops `mail_tx`, which closes the writer, which
+// closes the write half — no explicit abort needed.
+
+use std::time::Duration;
+
+use aether_hub_protocol::{
+    EngineId, EngineToHub, FrameError, HubToEngine, MAX_FRAME_SIZE, Uuid, Welcome,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+use crate::registry::{EngineRecord, EngineRegistry};
+
+/// Cadence at which the hub sends `Heartbeat` to each engine.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Maximum time the hub will wait for any frame from the engine before
+/// declaring the connection dead. Three missed heartbeats.
+pub const READ_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Bound on the per-engine outbound mail queue. Back-pressure: if the
+/// writer falls behind, senders (MCP tool handlers) will await space.
+const MAIL_CHANNEL_CAPACITY: usize = 256;
+
+pub async fn handle_connection(
+    stream: TcpStream,
+    registry: EngineRegistry,
+) -> Result<(), FrameError> {
+    let (mut reader, mut writer) = stream.into_split();
+
+    // Handshake: first frame must be Hello.
+    let first: EngineToHub = read_frame_async(&mut reader).await?;
+    let hello = match first {
+        EngineToHub::Hello(h) => h,
+        other => {
+            return Err(FrameError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("expected Hello, got {other:?}"),
+            )));
+        }
+    };
+
+    let engine_id = EngineId(Uuid::new_v4());
+    let welcome = HubToEngine::Welcome(Welcome { engine_id });
+    write_frame_async(&mut writer, &welcome).await?;
+
+    eprintln!(
+        "aether-hub: engine registered id={} name={} pid={} version={}",
+        engine_id.0, hello.name, hello.pid, hello.version
+    );
+
+    let (mail_tx, mut mail_rx) = mpsc::channel::<HubToEngine>(MAIL_CHANNEL_CAPACITY);
+    registry.insert(EngineRecord {
+        id: engine_id,
+        name: hello.name.clone(),
+        pid: hello.pid,
+        version: hello.version.clone(),
+        mail_tx,
+    });
+
+    // Writer task: drains the mpsc into the socket and injects
+    // periodic heartbeats. Owning the heartbeat here (instead of a
+    // separate task) means the reader dropping `mail_tx` is sufficient
+    // to tear both down — no abort dance.
+    let writer_task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+        // First tick fires immediately; skip it so the engine doesn't
+        // see a hub-heartbeat before it's read our Welcome.
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                msg = mail_rx.recv() => match msg {
+                    Some(m) => {
+                        if let Err(e) = write_frame_async(&mut writer, &m).await {
+                            eprintln!("aether-hub: write failed: {e}");
+                            break;
+                        }
+                    }
+                    None => break,
+                },
+                _ = interval.tick() => {
+                    if let Err(e) = write_frame_async(&mut writer, &HubToEngine::Heartbeat).await {
+                        eprintln!("aether-hub: heartbeat write failed: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Reader loop: run until the engine goes silent, sends Goodbye, or
+    // the socket errors. Removing the registry entry drops the only
+    // remaining `mail_tx`, which lets the writer task complete.
+    let result = read_loop(&mut reader).await;
+
+    registry.remove(&engine_id);
+    let _ = writer_task.await;
+
+    match &result {
+        Ok(()) => eprintln!("aether-hub: engine {} goodbye", engine_id.0),
+        Err(e) => eprintln!("aether-hub: engine {} dropped: {e}", engine_id.0),
+    }
+    result
+}
+
+async fn read_loop(reader: &mut tokio::net::tcp::OwnedReadHalf) -> Result<(), FrameError> {
+    loop {
+        let frame = match timeout(READ_TIMEOUT, read_frame_async::<_, EngineToHub>(reader)).await {
+            Ok(r) => r?,
+            Err(_) => {
+                return Err(FrameError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "engine heartbeat timeout",
+                )));
+            }
+        };
+        match frame {
+            EngineToHub::Hello(_) => {
+                return Err(FrameError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "duplicate Hello",
+                )));
+            }
+            EngineToHub::Heartbeat => {}
+            EngineToHub::Goodbye(_) => return Ok(()),
+        }
+    }
+}
+
+/// Async analogue of `aether_hub_protocol::read_frame`. Keeps the
+/// protocol crate tokio-free; the substrate client will grow a
+/// symmetrical helper next PR.
+async fn read_frame_async<R, T>(r: &mut R) -> Result<T, FrameError>
+where
+    R: AsyncReadExt + Unpin,
+    T: serde::de::DeserializeOwned,
+{
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        return Err(FrameError::FrameTooLarge {
+            size: len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await?;
+    Ok(postcard::from_bytes(&buf)?)
+}
+
+async fn write_frame_async<W, T>(w: &mut W, msg: &T) -> Result<(), FrameError>
+where
+    W: AsyncWriteExt + Unpin,
+    T: serde::Serialize,
+{
+    let bytes = aether_hub_protocol::encode_frame(msg);
+    w.write_all(&bytes).await?;
+    Ok(())
+}

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -1,0 +1,41 @@
+// aether-hub: central broker between Claude MCP clients and engine
+// processes. This crate owns the engine-facing TCP listener, handshake,
+// and heartbeat/reaping per ADR-0006. The Claude-facing rmcp transport
+// and MCP tool surface land in a follow-up PR.
+
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+
+mod engine;
+mod registry;
+
+pub use engine::HEARTBEAT_INTERVAL;
+pub use engine::READ_TIMEOUT;
+pub use registry::{EngineRecord, EngineRegistry};
+
+/// Default port the hub binds for engine TCP clients. ADR-0006 V0 fixes
+/// this; `AETHER_ENGINE_PORT` overrides.
+pub const DEFAULT_ENGINE_PORT: u16 = 8889;
+
+/// Run the engine listener loop on `addr`, dispatching each accepted
+/// connection to a per-connection task. Returns on listener error only;
+/// individual connection failures are logged and isolated.
+pub async fn run_engine_listener(
+    addr: SocketAddr,
+    registry: EngineRegistry,
+) -> std::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    let bound = listener.local_addr()?;
+    eprintln!("aether-hub: engine listener bound on {bound}");
+
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let registry = registry.clone();
+        tokio::spawn(async move {
+            if let Err(e) = engine::handle_connection(stream, registry).await {
+                eprintln!("aether-hub: engine {peer} dropped: {e}");
+            }
+        });
+    }
+}

--- a/crates/aether-hub/src/main.rs
+++ b/crates/aether-hub/src/main.rs
@@ -1,0 +1,32 @@
+// Thin binary entry point: parse port from env, spin up the engine
+// listener, wait for Ctrl-C. The Claude-facing rmcp transport lands in
+// PR 4; until then the hub is engine-only.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use aether_hub::{DEFAULT_ENGINE_PORT, EngineRegistry, run_engine_listener};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let port: u16 = std::env::var("AETHER_ENGINE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ENGINE_PORT);
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+
+    let registry = EngineRegistry::new();
+    let listener = tokio::spawn(run_engine_listener(addr, registry));
+
+    tokio::select! {
+        r = listener => {
+            if let Ok(Err(e)) = r {
+                eprintln!("aether-hub: listener error: {e}");
+                return Err(e);
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!("aether-hub: shutting down");
+        }
+    }
+    Ok(())
+}

--- a/crates/aether-hub/src/registry.rs
+++ b/crates/aether-hub/src/registry.rs
@@ -1,0 +1,55 @@
+// Shared engine registry. Keyed by hub-assigned `EngineId`; entries
+// carry display metadata and a mail channel the Claude-facing tools
+// will push `HubToEngine::Mail` frames into (PR 4).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use aether_hub_protocol::{EngineId, HubToEngine};
+use tokio::sync::mpsc;
+
+/// One entry in the hub's engine table. The `mail_tx` side is how any
+/// other task (including the MCP tool handlers, once they land) pushes
+/// frames at this engine — the per-connection writer task drains the
+/// receiver.
+#[derive(Clone, Debug)]
+pub struct EngineRecord {
+    pub id: EngineId,
+    pub name: String,
+    pub pid: u32,
+    pub version: String,
+    pub mail_tx: mpsc::Sender<HubToEngine>,
+}
+
+/// Thread-safe map of live engines. Cheap to clone; all clones share
+/// the same underlying table.
+#[derive(Clone, Default)]
+pub struct EngineRegistry {
+    inner: Arc<Mutex<HashMap<EngineId, EngineRecord>>>,
+}
+
+impl EngineRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, record: EngineRecord) {
+        self.inner.lock().unwrap().insert(record.id, record);
+    }
+
+    pub fn remove(&self, id: &EngineId) {
+        self.inner.lock().unwrap().remove(id);
+    }
+
+    pub fn list(&self) -> Vec<EngineRecord> {
+        self.inner.lock().unwrap().values().cloned().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().unwrap().is_empty()
+    }
+}

--- a/crates/aether-hub/tests/engine_handshake.rs
+++ b/crates/aether-hub/tests/engine_handshake.rs
@@ -1,0 +1,156 @@
+// Integration tests for the engine-facing TCP listener. Each test
+// binds port 0 so they can run in parallel.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use aether_hub::{EngineRegistry, run_engine_listener};
+use aether_hub_protocol::{EngineToHub, Goodbye, Hello, HubToEngine, encode_frame};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+async fn spawn_hub() -> (SocketAddr, EngineRegistry) {
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let registry = EngineRegistry::new();
+    let reg_clone = registry.clone();
+    tokio::spawn(run_engine_listener(addr, reg_clone));
+    // Give the listener a beat to bind.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, registry)
+}
+
+async fn connect(addr: SocketAddr) -> TcpStream {
+    TcpStream::connect(addr).await.unwrap()
+}
+
+async fn read_frame_async<T: serde::de::DeserializeOwned>(r: &mut TcpStream) -> T {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf).await.unwrap();
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await.unwrap();
+    postcard::from_bytes(&buf).unwrap()
+}
+
+async fn write_frame_async<T: serde::Serialize>(w: &mut TcpStream, msg: &T) {
+    let bytes = encode_frame(msg);
+    w.write_all(&bytes).await.unwrap();
+}
+
+fn hello(name: &str) -> EngineToHub {
+    EngineToHub::Hello(Hello {
+        name: name.into(),
+        pid: 1,
+        started_unix: 0,
+        version: "test".into(),
+    })
+}
+
+#[tokio::test]
+async fn handshake_assigns_engine_id_and_registers() {
+    let (addr, registry) = spawn_hub().await;
+    let mut stream = connect(addr).await;
+
+    write_frame_async(&mut stream, &hello("test")).await;
+    let reply: HubToEngine = read_frame_async(&mut stream).await;
+    let engine_id = match reply {
+        HubToEngine::Welcome(w) => w.engine_id,
+        other => panic!("expected Welcome, got {other:?}"),
+    };
+
+    // Registration is visible to the rest of the hub.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let engines = registry.list();
+    assert_eq!(engines.len(), 1);
+    assert_eq!(engines[0].id, engine_id);
+    assert_eq!(engines[0].name, "test");
+}
+
+#[tokio::test]
+async fn goodbye_deregisters() {
+    let (addr, registry) = spawn_hub().await;
+    let mut stream = connect(addr).await;
+
+    write_frame_async(&mut stream, &hello("bye")).await;
+    let _: HubToEngine = read_frame_async(&mut stream).await;
+    assert_eq!(registry.len(), 1);
+
+    write_frame_async(
+        &mut stream,
+        &EngineToHub::Goodbye(Goodbye {
+            reason: "test done".into(),
+        }),
+    )
+    .await;
+
+    // Give the hub a moment to tear down.
+    for _ in 0..50 {
+        if registry.is_empty() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("engine still registered after Goodbye");
+}
+
+#[tokio::test]
+async fn non_hello_first_frame_is_rejected() {
+    let (addr, registry) = spawn_hub().await;
+    let mut stream = connect(addr).await;
+
+    write_frame_async(&mut stream, &EngineToHub::Heartbeat).await;
+
+    // Hub drops the connection; a subsequent read yields EOF.
+    let mut buf = [0u8; 1];
+    let n = stream.read(&mut buf).await.unwrap_or(0);
+    assert_eq!(n, 0, "expected EOF after bad first frame");
+    assert!(registry.is_empty());
+}
+
+#[tokio::test]
+async fn hub_sends_periodic_heartbeats() {
+    // This test relies on HEARTBEAT_INTERVAL being short enough that a
+    // heartbeat arrives within a few seconds.
+    let (addr, _registry) = spawn_hub().await;
+    let mut stream = connect(addr).await;
+    write_frame_async(&mut stream, &hello("hb")).await;
+    let _: HubToEngine = read_frame_async(&mut stream).await;
+
+    // Keep sending heartbeats so the hub doesn't reap us, and wait for
+    // a heartbeat from the hub side.
+    let got_heartbeat = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            // Keepalive so the hub's read timeout doesn't fire.
+            write_frame_async(&mut stream, &EngineToHub::Heartbeat).await;
+            let frame: HubToEngine = read_frame_async(&mut stream).await;
+            if matches!(frame, HubToEngine::Heartbeat) {
+                return true;
+            }
+        }
+    })
+    .await;
+    assert!(got_heartbeat.unwrap());
+}
+
+#[tokio::test]
+async fn silent_engine_is_reaped() {
+    let (addr, registry) = spawn_hub().await;
+    let mut stream = connect(addr).await;
+    write_frame_async(&mut stream, &hello("silent")).await;
+    let _: HubToEngine = read_frame_async(&mut stream).await;
+    assert_eq!(registry.len(), 1);
+
+    // Don't send any more frames; hub reads should time out.
+    // READ_TIMEOUT is 15s. Wait up to 20s.
+    for _ in 0..200 {
+        if registry.is_empty() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("silent engine was not reaped");
+}


### PR DESCRIPTION
## Summary

- New `aether-hub` binary crate: engine-facing side of the hub per ADR-0006.
- TCP listener on `127.0.0.1:AETHER_ENGINE_PORT` (default 8889). Hello/Welcome handshake assigns a fresh UUID; per-engine writer task drains an mpsc and injects 5s heartbeats; 15s read timeout reaps silent engines.
- Shared `EngineRegistry` keyed by `EngineId` that the rmcp tool surface will plug into in PR 4.

PR 2 of 4 in the ADR-0006 arc (protocol → hub → substrate client → MCP tools). No substrate or MCP code yet — the hub is runnable but has no Claude-facing transport and no substrate connects to it.

## Test plan

- [x] `cargo test -p aether-hub` — 5 integration tests green (handshake/registration, Goodbye cleanup, non-Hello rejection, heartbeat cadence, silent-engine reaping)
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Manual smoke: `cargo run -p aether-hub` binds, logs, and shuts down on Ctrl-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)