### PR TITLE
feat(protocol): add KindDescriptor wire types and extend Hello

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -109,6 +109,7 @@ mod tests {
             pid: 8910,
             started_unix: 1_712_345_678,
             version: "0.1.0".into(),
+            kinds: vec![],
         });
 
         let mut buf = Vec::new();
@@ -123,6 +124,79 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn hello_with_kinds_roundtrip() {
+        let hello = EngineToHub::Hello(Hello {
+            name: "hello-triangle".into(),
+            pid: 1,
+            started_unix: 0,
+            version: "0".into(),
+            kinds: vec![
+                KindDescriptor {
+                    name: "aether.tick".into(),
+                    encoding: KindEncoding::Signal,
+                },
+                KindDescriptor {
+                    name: "aether.key".into(),
+                    encoding: KindEncoding::Pod {
+                        fields: vec![PodField {
+                            name: "code".into(),
+                            ty: PodFieldType::Scalar(PodPrimitive::U32),
+                        }],
+                    },
+                },
+                KindDescriptor {
+                    name: "aether.draw_triangle".into(),
+                    encoding: KindEncoding::Opaque,
+                },
+            ],
+        });
+
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &hello).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        let EngineToHub::Hello(h) = back else {
+            panic!("wrong variant")
+        };
+        assert_eq!(h.kinds.len(), 3);
+        assert_eq!(h.kinds[0].encoding, KindEncoding::Signal);
+        let KindEncoding::Pod { fields } = &h.kinds[1].encoding else {
+            panic!("expected Pod")
+        };
+        assert_eq!(fields[0].name, "code");
+        assert_eq!(fields[0].ty, PodFieldType::Scalar(PodPrimitive::U32));
+        assert_eq!(h.kinds[2].encoding, KindEncoding::Opaque);
+    }
+
+    #[test]
+    fn pod_field_array_roundtrip() {
+        let desc = KindDescriptor {
+            name: "aether.mouse_move".into(),
+            encoding: KindEncoding::Pod {
+                fields: vec![
+                    PodField {
+                        name: "x".into(),
+                        ty: PodFieldType::Scalar(PodPrimitive::F32),
+                    },
+                    PodField {
+                        name: "y".into(),
+                        ty: PodFieldType::Scalar(PodPrimitive::F32),
+                    },
+                    PodField {
+                        name: "pad".into(),
+                        ty: PodFieldType::Array {
+                            element: PodPrimitive::U8,
+                            len: 4,
+                        },
+                    },
+                ],
+            },
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        let back: KindDescriptor = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(back, desc);
     }
 
     #[test]
@@ -178,6 +252,7 @@ mod tests {
             pid: 1,
             started_unix: 0,
             version: "0".into(),
+            kinds: vec![],
         });
         let b = EngineToHub::Heartbeat;
         let c = EngineToHub::Goodbye(Goodbye {

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -13,12 +13,78 @@ pub struct EngineId(pub Uuid);
 
 /// First frame the engine sends after the TCP connection is open.
 /// The hub replies with a `Welcome` carrying the assigned `EngineId`.
+///
+/// `kinds` declares every mail kind this engine's registry knows about
+/// along with enough structural detail for the hub to encode agent-
+/// supplied params for that kind (ADR-0007). Engines that don't want
+/// schema-driven encoding can send an empty `kinds` and only the raw
+/// `payload_bytes` path will work for their clients.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Hello {
     pub name: String,
     pub pid: u32,
     pub started_unix: u64,
     pub version: String,
+    pub kinds: Vec<KindDescriptor>,
+}
+
+/// One entry in `Hello.kinds`: a kind-name plus a wire-describable
+/// encoding. Per ADR-0007 the hub uses these to encode agent-supplied
+/// params into the exact bytes the engine expects.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KindDescriptor {
+    pub name: String,
+    pub encoding: KindEncoding,
+}
+
+/// How the hub can materialize bytes for a given kind.
+///
+/// - `Signal`: empty payload. `params` must be absent or empty.
+/// - `Pod`: `#[repr(C)]` struct; hub encodes an ordered field list of
+///   scalars and fixed-size scalar arrays matching Rust's layout.
+/// - `Opaque`: the hub can't encode this from params. Clients must
+///   supply raw bytes. V0 structural (postcard) kinds land here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KindEncoding {
+    Signal,
+    Pod { fields: Vec<PodField> },
+    Opaque,
+}
+
+/// One field in a POD kind. Field order matches the Rust struct's
+/// declaration order; the hub walks the list writing bytes with the
+/// same alignment/padding the `#[repr(C)]` layout implies.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PodField {
+    pub name: String,
+    pub ty: PodFieldType,
+}
+
+/// A POD field is either a scalar or a fixed-length array of one
+/// scalar primitive. Nested structs are deliberately out of scope for
+/// V0 (ADR-0007) — a kind with nested-struct fields uses
+/// `KindEncoding::Opaque` and the `payload_bytes` escape hatch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PodFieldType {
+    Scalar(PodPrimitive),
+    Array { element: PodPrimitive, len: u32 },
+}
+
+/// POD primitive types the hub can encode. Matches the Rust primitive
+/// set that's trivially `bytemuck::Pod`. Names are the canonical Rust
+/// spelling so tooling can parse them without a lookup.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PodPrimitive {
+    U8,
+    U16,
+    U32,
+    U64,
+    I8,
+    I16,
+    I32,
+    I64,
+    F32,
+    F64,
 }
 
 /// Hub's reply to `Hello`. Carries the `EngineId` the engine should

--- a/crates/aether-hub/tests/engine_handshake.rs
+++ b/crates/aether-hub/tests/engine_handshake.rs
@@ -47,6 +47,7 @@ fn hello(name: &str) -> EngineToHub {
         pid: 1,
         started_unix: 0,
         version: "test".into(),
+        kinds: vec![],
     })
 }
 

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -59,6 +59,9 @@ impl HubClient {
             pid: process::id(),
             started_unix: unix_now(),
             version: version.into(),
+            // PR 2 of the ADR-0007 arc replaces this with descriptors
+            // collected from aether-substrate-mail.
+            kinds: vec![],
         });
         write_frame(&mut stream, &hello).map_err(io::Error::other)?;
 


### PR DESCRIPTION
## Summary

PR 1 of the ADR-0007 implementation arc. Pure wire-type addition:

- New types in `aether-hub-protocol`: `KindDescriptor`, `KindEncoding` (`Signal | Pod { fields } | Opaque`), `PodField`, `PodFieldType` (`Scalar | Array`), `PodPrimitive` (U8/…/F64).
- `Hello` grows `kinds: Vec<KindDescriptor>`. Existing callers pass an empty vec; PR 2 wires substrate-mail into the real list.
- Nested-struct descriptors are deliberately out of scope for V0 — any kind with a nested struct uses `Opaque` and the `payload_bytes` escape hatch.

No behavior change yet — hub still only forwards `payload_bytes`. PR 2 starts emitting real descriptors, PR 3 caches them on the hub + adds `describe_kinds`, PR 4 adds the POD encoder, PR 5 flips `send_mail` to plural + schema-driven.

## Test plan

- [x] New unit tests: `hello_with_kinds_roundtrip`, `pod_field_array_roundtrip`
- [x] `cargo test --workspace` passes (existing Hello callers updated to pass `kinds: vec![]`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)