### PR TITLE
feat(substrate): emit kind descriptors at hub handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
 name = "aether-substrate-mail"
 version = "0.1.0"
 dependencies = [
+ "aether-hub-protocol",
  "aether-mail",
  "bytemuck",
 ]

--- a/crates/aether-substrate-mail/Cargo.toml
+++ b/crates/aether-substrate-mail/Cargo.toml
@@ -3,6 +3,13 @@ name = "aether-substrate-mail"
 version.workspace = true
 edition.workspace = true
 
+[features]
+# Emit wire-compatible descriptors for the ADR-0007 schema-driven hub
+# boundary. Off by default so WASM guests don't drag in hub-protocol.
+# Native binaries (aether-substrate) enable it.
+descriptors = ["dep:aether-hub-protocol"]
+
 [dependencies]
 aether-mail = { path = "../aether-mail" }
+aether-hub-protocol = { path = "../aether-hub-protocol", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -1,0 +1,118 @@
+// Wire descriptors for the substrate's kinds. Consumed by the native
+// substrate binary and shipped to the hub at `Hello` per ADR-0007 so
+// the hub can encode agent-supplied params for each kind.
+//
+// Adding a kind to `lib.rs` means adding a matching entry here; the
+// coupling is deliberate — each descriptor re-states the `#[repr(C)]`
+// field order the encoder will walk on the hub side, so drift between
+// the struct layout and the descriptor is caught when we next look at
+// this file.
+
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive};
+use aether_mail::Kind;
+
+use crate::{DrawTriangle, Key, MouseButton, MouseMove, Tick};
+
+/// Every kind the substrate exposes, in the order the `Registry` will
+/// register them. Caller ignores the order — names are the contract.
+pub fn all() -> Vec<KindDescriptor> {
+    vec![
+        signal(Tick::NAME),
+        pod(Key::NAME, vec![scalar("code", PodPrimitive::U32)]),
+        signal(MouseButton::NAME),
+        pod(
+            MouseMove::NAME,
+            vec![
+                scalar("x", PodPrimitive::F32),
+                scalar("y", PodPrimitive::F32),
+            ],
+        ),
+        // DrawTriangle nests Vertex; V0 descriptors don't model nested
+        // structs, so this kind stays opaque and clients use the raw
+        // payload_bytes path.
+        opaque(DrawTriangle::NAME),
+    ]
+}
+
+fn signal(name: &str) -> KindDescriptor {
+    KindDescriptor {
+        name: name.to_string(),
+        encoding: KindEncoding::Signal,
+    }
+}
+
+fn pod(name: &str, fields: Vec<PodField>) -> KindDescriptor {
+    KindDescriptor {
+        name: name.to_string(),
+        encoding: KindEncoding::Pod { fields },
+    }
+}
+
+fn opaque(name: &str) -> KindDescriptor {
+    KindDescriptor {
+        name: name.to_string(),
+        encoding: KindEncoding::Opaque,
+    }
+}
+
+fn scalar(name: &str, ty: PodPrimitive) -> PodField {
+    PodField {
+        name: name.to_string(),
+        ty: PodFieldType::Scalar(ty),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn covers_every_substrate_kind() {
+        let descs = all();
+        let names: Vec<&str> = descs.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&Tick::NAME));
+        assert!(names.contains(&Key::NAME));
+        assert!(names.contains(&MouseButton::NAME));
+        assert!(names.contains(&MouseMove::NAME));
+        assert!(names.contains(&DrawTriangle::NAME));
+    }
+
+    #[test]
+    fn key_fields_match_struct_layout() {
+        let descs = all();
+        let key = descs.iter().find(|d| d.name == Key::NAME).unwrap();
+        let KindEncoding::Pod { fields } = &key.encoding else {
+            panic!("expected Pod")
+        };
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "code");
+        assert_eq!(fields[0].ty, PodFieldType::Scalar(PodPrimitive::U32));
+    }
+
+    #[test]
+    fn mouse_move_fields_match_struct_layout() {
+        let descs = all();
+        let mm = descs.iter().find(|d| d.name == MouseMove::NAME).unwrap();
+        let KindEncoding::Pod { fields } = &mm.encoding else {
+            panic!("expected Pod")
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name, "x");
+        assert_eq!(fields[1].name, "y");
+        assert!(matches!(
+            fields[0].ty,
+            PodFieldType::Scalar(PodPrimitive::F32)
+        ));
+    }
+
+    #[test]
+    fn draw_triangle_is_opaque() {
+        let descs = all();
+        let dt = descs.iter().find(|d| d.name == DrawTriangle::NAME).unwrap();
+        assert_eq!(dt.encoding, KindEncoding::Opaque);
+    }
+}

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -10,6 +10,12 @@
 
 #![no_std]
 
+#[cfg(feature = "descriptors")]
+extern crate alloc;
+
+#[cfg(feature = "descriptors")]
+pub mod descriptors;
+
 use aether_mail::Kind;
 use bytemuck::{Pod, Zeroable};
 

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [dependencies]
 aether-hub-protocol = { path = "../aether-hub-protocol" }
 aether-mail = { path = "../aether-mail" }
-aether-substrate-mail = { path = "../aether-substrate-mail" }
+aether-substrate-mail = { path = "../aether-substrate-mail", features = ["descriptors"] }
 bytemuck = "1.19"
 pollster = "0.4.0"
 wasmtime = "30"

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -21,7 +21,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aether_hub_protocol::{
-    EngineId, EngineToHub, Hello, HubToEngine, MailFrame, read_frame, write_frame,
+    EngineId, EngineToHub, Hello, HubToEngine, KindDescriptor, MailFrame, read_frame, write_frame,
 };
 
 use crate::mail::Mail;
@@ -50,6 +50,7 @@ impl HubClient {
         addr: A,
         name: impl Into<String>,
         version: impl Into<String>,
+        kinds: Vec<KindDescriptor>,
         registry: Arc<Registry>,
         queue: Arc<MailQueue>,
     ) -> io::Result<Self> {
@@ -59,9 +60,7 @@ impl HubClient {
             pid: process::id(),
             started_unix: unix_now(),
             version: version.into(),
-            // PR 2 of the ADR-0007 arc replaces this with descriptors
-            // collected from aether-substrate-mail.
-            kinds: vec![],
+            kinds,
         });
         write_frame(&mut stream, &hello).map_err(io::Error::other)?;
 

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -213,6 +213,7 @@ fn main() -> wasmtime::Result<()> {
             url.as_str(),
             "hello-triangle",
             env!("CARGO_PKG_VERSION"),
+            aether_substrate_mail::descriptors::all(),
             Arc::clone(&registry),
             Arc::clone(&queue),
         ) {

--- a/crates/aether-substrate/tests/hub_client.rs
+++ b/crates/aether-substrate/tests/hub_client.rs
@@ -41,7 +41,7 @@ fn handshake_exchanges_hello_and_welcome() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "test-engine", "0.0.0", registry, queue).unwrap()
+        move || HubClient::connect(addr, "test-engine", "0.0.0", vec![], registry, queue).unwrap()
     });
 
     // Server side of the handshake.
@@ -103,7 +103,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "t", "0", registry, queue).unwrap()
+        move || HubClient::connect(addr, "t", "0", vec![], registry, queue).unwrap()
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
@@ -170,7 +170,7 @@ fn client_sends_periodic_heartbeats() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "hb", "0", registry, queue).unwrap()
+        move || HubClient::connect(addr, "hb", "0", vec![], registry, queue).unwrap()
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
@@ -209,7 +209,7 @@ fn goodbye_stops_reader_thread() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "bye", "0", registry, queue).unwrap()
+        move || HubClient::connect(addr, "bye", "0", vec![], registry, queue).unwrap()
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();


### PR DESCRIPTION
## Summary

PR 2 of the ADR-0007 arc. Substrate now ships real kind descriptors in `Hello.kinds`:

- `aether-substrate-mail` grows a `descriptors::all()` manifest behind a new off-by-default `descriptors` feature (keeps hub-protocol out of the WASM guest build).
- Native substrate binary enables the feature and passes the manifest through `HubClient::connect(..., kinds, ...)`.
- Mappings: `Tick`/`MouseButton` → `Signal`, `Key`/`MouseMove` → `Pod { fields }`, `DrawTriangle` → `Opaque` (nested `Vertex` struct; V0 descriptors don't model nesting, so it falls through to `payload_bytes` per ADR-0007).

Hub still ignores the field — PR 3 caches it per engine and exposes `describe_kinds`.

## Test plan

- [x] 4 new unit tests in `substrate-mail::descriptors` (covers-every-kind, Key fields match layout, MouseMove fields match layout, DrawTriangle opaque)
- [x] `cargo test --workspace` passes
- [x] `cargo check -p aether-substrate-mail --no-default-features` passes — WASM guest chain doesn't pull hub-protocol
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)