### PR TITLE
feat(protocol): add observation-path wire types

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -215,11 +215,13 @@ mod tests {
 
     #[test]
     fn mail_frame_roundtrip() {
+        let sender = SessionToken(Uuid::from_u128(0xa_b_c_d));
         let msg = HubToEngine::Mail(MailFrame {
             recipient_name: "hello".into(),
             kind_name: "aether.tick".into(),
             payload: vec![],
             count: 1,
+            sender,
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();
@@ -229,7 +231,45 @@ mod tests {
                 assert_eq!(m.recipient_name, "hello");
                 assert_eq!(m.kind_name, "aether.tick");
                 assert_eq!(m.count, 1);
+                assert_eq!(m.sender, sender);
             }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn engine_mail_frame_session_roundtrip() {
+        let token = SessionToken(Uuid::from_u128(0x1));
+        let msg = EngineToHub::Mail(EngineMailFrame {
+            address: ClaudeAddress::Session(token),
+            kind_name: "aether.observation.ping".into(),
+            payload: vec![1, 2, 3],
+        });
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            EngineToHub::Mail(m) => {
+                assert_eq!(m.address, ClaudeAddress::Session(token));
+                assert_eq!(m.kind_name, "aether.observation.ping");
+                assert_eq!(m.payload, vec![1, 2, 3]);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn engine_mail_frame_broadcast_roundtrip() {
+        let msg = EngineToHub::Mail(EngineMailFrame {
+            address: ClaudeAddress::Broadcast,
+            kind_name: "aether.observation.world".into(),
+            payload: vec![],
+        });
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            EngineToHub::Mail(m) => assert_eq!(m.address, ClaudeAddress::Broadcast),
             _ => panic!("wrong variant"),
         }
     }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -11,6 +11,20 @@ use uuid::Uuid;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EngineId(pub Uuid);
 
+/// Hub-minted routing handle for a Claude MCP session. The engine
+/// treats it as opaque bytes: it only echoes tokens the hub handed it
+/// on inbound mail back as the address on a reply. The hub validates
+/// on receipt; unknown/expired tokens produce an undeliverable status
+/// (per ADR-0008).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionToken(pub Uuid);
+
+impl SessionToken {
+    /// Placeholder used before session tracking lands at the hub.
+    /// Always treated as expired by the hub's validator.
+    pub const NIL: SessionToken = SessionToken(Uuid::nil());
+}
+
 /// First frame the engine sends after the TCP connection is open.
 /// The hub replies with a `Welcome` carrying the assigned `EngineId`.
 ///
@@ -96,13 +110,38 @@ pub struct Welcome {
 
 /// A piece of mail routed by the hub to an engine. Kind and recipient
 /// are carried by name; the engine resolves them against its local
-/// registry (per ADR-0005's kind registry).
+/// registry (per ADR-0005's kind registry). `sender` is the hub's
+/// routing handle for the originating Claude session — components
+/// that want to reply-to-sender echo it back on an outbound
+/// `EngineMailFrame` (ADR-0008).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MailFrame {
     pub recipient_name: String,
     pub kind_name: String,
     pub payload: Vec<u8>,
     pub count: u32,
+    pub sender: SessionToken,
+}
+
+/// A piece of mail the engine is sending to one or more Claude
+/// sessions through the hub. The hub owns session routing, so the
+/// engine addresses by `ClaudeAddress` rather than by session id or
+/// recipient name (ADR-0008).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EngineMailFrame {
+    pub address: ClaudeAddress,
+    pub kind_name: String,
+    pub payload: Vec<u8>,
+}
+
+/// How an engine-originated mail is addressed at the hub. `Session`
+/// targets the specific MCP session whose token the engine is echoing
+/// from an earlier inbound mail; `Broadcast` fan-outs to every
+/// currently attached session.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClaudeAddress {
+    Session(SessionToken),
+    Broadcast,
 }
 
 /// Optional clean-shutdown marker. Either side may send it; receipt is
@@ -113,12 +152,14 @@ pub struct Goodbye {
     pub reason: String,
 }
 
-/// Frames an engine sends to the hub. V0 omits engine-originated mail
-/// and replies — those land when pub-sub lands.
+/// Frames an engine sends to the hub. `Mail` is the observation path
+/// (ADR-0008): engine-originated mail addressed to a Claude session
+/// or broadcast to all sessions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EngineToHub {
     Hello(Hello),
     Heartbeat,
+    Mail(EngineMailFrame),
     Goodbye(Goodbye),
 }
 

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -131,6 +131,16 @@ async fn read_loop(reader: &mut tokio::net::tcp::OwnedReadHalf) -> Result<(), Fr
                 )));
             }
             EngineToHub::Heartbeat => {}
+            EngineToHub::Mail(m) => {
+                // PR 2 wires this into session routing; for now
+                // acknowledge on the wire but drop the payload.
+                eprintln!(
+                    "aether-hub: engine mail (addr={:?}, kind={:?}, {} bytes) — routing not wired yet",
+                    m.address,
+                    m.kind_name,
+                    m.payload.len()
+                );
+            }
             EngineToHub::Goodbye(_) => return Ok(()),
         }
     }

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -11,7 +11,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aether_hub_protocol::{EngineId, HubToEngine, KindDescriptor, KindEncoding, MailFrame, Uuid};
+use aether_hub_protocol::{
+    EngineId, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken, Uuid,
+};
 use rmcp::{
     ErrorData as McpError, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -218,6 +220,7 @@ async fn deliver_one(spec: MailSpec, engines: &EngineRegistry) -> Result<(), Str
         kind_name: spec.kind_name,
         payload,
         count: spec.count,
+        sender: SessionToken::NIL,
     });
     record
         .mail_tx

--- a/crates/aether-substrate/tests/hub_client.rs
+++ b/crates/aether-substrate/tests/hub_client.rs
@@ -11,7 +11,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use aether_hub_protocol::{
-    EngineId, EngineToHub, Goodbye, HubToEngine, MailFrame, Uuid, Welcome, read_frame, write_frame,
+    EngineId, EngineToHub, Goodbye, HubToEngine, MailFrame, SessionToken, Uuid, Welcome,
+    read_frame, write_frame,
 };
 use aether_substrate::{HubClient, MailQueue, Registry, Scheduler};
 
@@ -124,18 +125,21 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             kind_name: "aether.tick".into(),
             payload: vec![1, 2, 3],
             count: 7,
+            sender: SessionToken::NIL,
         },
         MailFrame {
             recipient_name: "hello".into(),
             kind_name: "not.registered".into(),
             payload: vec![],
             count: 1,
+            sender: SessionToken::NIL,
         },
         MailFrame {
             recipient_name: "hello".into(),
             kind_name: "aether.tick".into(),
             payload: vec![9],
             count: 1,
+            sender: SessionToken::NIL,
         },
     ] {
         write_frame(&mut stream, &HubToEngine::Mail(frame)).unwrap();


### PR DESCRIPTION
## Summary

ADR-0008 PR 1 of 5 — wire format only, no routing yet.

- `SessionToken` wraps a UUID; opaque to engines (they only echo tokens the hub handed them).
- `ClaudeAddress { Session(SessionToken) | Broadcast }` is how engines address Claudes.
- `EngineMailFrame` + new `EngineToHub::Mail` variant carry engine-originated mail.
- `sender: SessionToken` on the existing `MailFrame` so components can reply-to-sender.

Hub's `send_mail` populates `sender` with `SessionToken::NIL` for now — PR 2 mints real tokens. Incoming `EngineToHub::Mail` frames are logged and dropped at the hub's read loop until PR 2 wires routing.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — all existing tests pass; 2 new protocol roundtrips (`engine_mail_frame_session_roundtrip`, `engine_mail_frame_broadcast_roundtrip`) cover the new frame variant and both address shapes; `mail_frame_roundtrip` extended to assert `sender` survives the wire.
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)