### PR TITLE
feat(hub): session registry + engine mail fan-out

### DIFF
--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -10,7 +10,8 @@
 use std::time::Duration;
 
 use aether_hub_protocol::{
-    EngineId, EngineToHub, FrameError, HubToEngine, MAX_FRAME_SIZE, Uuid, Welcome,
+    ClaudeAddress, EngineId, EngineMailFrame, EngineToHub, FrameError, HubToEngine, MAX_FRAME_SIZE,
+    Uuid, Welcome,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -18,6 +19,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use crate::registry::{EngineRecord, EngineRegistry};
+use crate::session::SessionRegistry;
 
 /// Cadence at which the hub sends `Heartbeat` to each engine.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -33,6 +35,7 @@ const MAIL_CHANNEL_CAPACITY: usize = 256;
 pub async fn handle_connection(
     stream: TcpStream,
     registry: EngineRegistry,
+    sessions: SessionRegistry,
 ) -> Result<(), FrameError> {
     let (mut reader, mut writer) = stream.into_split();
 
@@ -100,7 +103,7 @@ pub async fn handle_connection(
     // Reader loop: run until the engine goes silent, sends Goodbye, or
     // the socket errors. Removing the registry entry drops the only
     // remaining `mail_tx`, which lets the writer task complete.
-    let result = read_loop(&mut reader).await;
+    let result = read_loop(&mut reader, &sessions, engine_id).await;
 
     registry.remove(&engine_id);
     let _ = writer_task.await;
@@ -112,7 +115,11 @@ pub async fn handle_connection(
     result
 }
 
-async fn read_loop(reader: &mut tokio::net::tcp::OwnedReadHalf) -> Result<(), FrameError> {
+async fn read_loop(
+    reader: &mut tokio::net::tcp::OwnedReadHalf,
+    sessions: &SessionRegistry,
+    engine_id: EngineId,
+) -> Result<(), FrameError> {
     loop {
         let frame = match timeout(READ_TIMEOUT, read_frame_async::<_, EngineToHub>(reader)).await {
             Ok(r) => r?,
@@ -131,17 +138,62 @@ async fn read_loop(reader: &mut tokio::net::tcp::OwnedReadHalf) -> Result<(), Fr
                 )));
             }
             EngineToHub::Heartbeat => {}
-            EngineToHub::Mail(m) => {
-                // PR 2 wires this into session routing; for now
-                // acknowledge on the wire but drop the payload.
+            EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m).await,
+            EngineToHub::Goodbye(_) => return Ok(()),
+        }
+    }
+}
+
+/// Fan an `EngineToHub::Mail` frame out to the addressed session(s).
+/// Unknown / disconnected tokens are logged and dropped; the engine
+/// wire has no reply, so there's nowhere to surface "sessionGone" to
+/// today. `Broadcast` to an empty registry is a no-op — not an error.
+async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail: EngineMailFrame) {
+    let EngineMailFrame {
+        address,
+        kind_name,
+        payload,
+    } = mail;
+    match address {
+        ClaudeAddress::Session(token) => match sessions.get(&token) {
+            Some(record) => {
+                let frame = EngineMailFrame {
+                    address: ClaudeAddress::Session(token),
+                    kind_name,
+                    payload,
+                };
+                if record.mail_tx.send(frame).await.is_err() {
+                    eprintln!(
+                        "aether-hub: engine {} mail to session {} dropped: receiver closed",
+                        engine_id.0, token.0
+                    );
+                }
+            }
+            None => {
                 eprintln!(
-                    "aether-hub: engine mail (addr={:?}, kind={:?}, {} bytes) — routing not wired yet",
-                    m.address,
-                    m.kind_name,
-                    m.payload.len()
+                    "aether-hub: engine {} mail dropped: unknown/expired session token {}",
+                    engine_id.0, token.0
                 );
             }
-            EngineToHub::Goodbye(_) => return Ok(()),
+        },
+        ClaudeAddress::Broadcast => {
+            let records = sessions.list();
+            if records.is_empty() {
+                return;
+            }
+            for record in records {
+                let frame = EngineMailFrame {
+                    address: ClaudeAddress::Broadcast,
+                    kind_name: kind_name.clone(),
+                    payload: payload.clone(),
+                };
+                if record.mail_tx.send(frame).await.is_err() {
+                    eprintln!(
+                        "aether-hub: engine {} broadcast to session {} dropped: receiver closed",
+                        engine_id.0, record.token.0
+                    );
+                }
+            }
         }
     }
 }
@@ -176,4 +228,89 @@ where
     let bytes = aether_hub_protocol::encode_frame(msg);
     w.write_all(&bytes).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::SessionHandle;
+
+    fn engine_id(n: u128) -> EngineId {
+        EngineId(Uuid::from_u128(n))
+    }
+
+    fn mail(address: ClaudeAddress, payload: Vec<u8>) -> EngineMailFrame {
+        EngineMailFrame {
+            address,
+            kind_name: "aether.observation.ping".into(),
+            payload,
+        }
+    }
+
+    #[tokio::test]
+    async fn session_address_routes_to_that_session() {
+        let sessions = SessionRegistry::new();
+        let (a, mut rx_a) = SessionHandle::mint(&sessions);
+        let (_b, mut rx_b) = SessionHandle::mint(&sessions);
+
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Session(a.token), vec![1, 2, 3]),
+        )
+        .await;
+
+        let got = rx_a.try_recv().expect("frame for a");
+        assert_eq!(got.payload, vec![1, 2, 3]);
+        assert!(rx_b.try_recv().is_err(), "b should not have received");
+    }
+
+    #[tokio::test]
+    async fn session_address_with_unknown_token_is_dropped() {
+        let sessions = SessionRegistry::new();
+        let (_a, mut rx_a) = SessionHandle::mint(&sessions);
+
+        let nobody = aether_hub_protocol::SessionToken(Uuid::from_u128(0xdead));
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Session(nobody), vec![]),
+        )
+        .await;
+
+        assert!(rx_a.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn broadcast_fans_out_to_every_session() {
+        let sessions = SessionRegistry::new();
+        let (_a, mut rx_a) = SessionHandle::mint(&sessions);
+        let (_b, mut rx_b) = SessionHandle::mint(&sessions);
+        let (_c, mut rx_c) = SessionHandle::mint(&sessions);
+
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Broadcast, vec![42]),
+        )
+        .await;
+
+        for (name, rx) in [("a", &mut rx_a), ("b", &mut rx_b), ("c", &mut rx_c)] {
+            let got = rx.try_recv().unwrap_or_else(|_| panic!("{name} no frame"));
+            assert_eq!(got.payload, vec![42]);
+            assert_eq!(got.address, ClaudeAddress::Broadcast);
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_with_no_sessions_is_noop() {
+        let sessions = SessionRegistry::new();
+        // No panic, no error — just nothing happens.
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Broadcast, vec![]),
+        )
+        .await;
+    }
 }

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -11,6 +11,7 @@ mod encoder;
 mod engine;
 mod mcp;
 mod registry;
+mod session;
 
 pub use encoder::{EncodeError, encode_pod};
 
@@ -18,6 +19,7 @@ pub use engine::HEARTBEAT_INTERVAL;
 pub use engine::READ_TIMEOUT;
 pub use mcp::{DEFAULT_MCP_PORT, HubState, run_mcp_server};
 pub use registry::{EngineRecord, EngineRegistry};
+pub use session::{SESSION_CHANNEL_CAPACITY, SessionHandle, SessionRecord, SessionRegistry};
 
 /// Default port the hub binds for engine TCP clients. ADR-0006 V0 fixes
 /// this; `AETHER_ENGINE_PORT` overrides.
@@ -29,6 +31,7 @@ pub const DEFAULT_ENGINE_PORT: u16 = 8889;
 pub async fn run_engine_listener(
     addr: SocketAddr,
     registry: EngineRegistry,
+    sessions: SessionRegistry,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     let bound = listener.local_addr()?;
@@ -37,8 +40,9 @@ pub async fn run_engine_listener(
     loop {
         let (stream, peer) = listener.accept().await?;
         let registry = registry.clone();
+        let sessions = sessions.clone();
         tokio::spawn(async move {
-            if let Err(e) = engine::handle_connection(stream, registry).await {
+            if let Err(e) = engine::handle_connection(stream, registry, sessions).await {
                 eprintln!("aether-hub: engine {peer} dropped: {e}");
             }
         });

--- a/crates/aether-hub/src/main.rs
+++ b/crates/aether-hub/src/main.rs
@@ -5,8 +5,8 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use aether_hub::{
-    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, run_engine_listener,
-    run_mcp_server,
+    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, SessionRegistry,
+    run_engine_listener, run_mcp_server,
 };
 
 #[tokio::main]
@@ -17,9 +17,10 @@ async fn main() -> std::io::Result<()> {
     let mcp_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), mcp_port);
 
     let registry = EngineRegistry::new();
-    let state = HubState::new(registry.clone());
+    let sessions = SessionRegistry::new();
+    let state = HubState::new(registry.clone(), sessions.clone());
 
-    let engine_task = tokio::spawn(run_engine_listener(engine_addr, registry));
+    let engine_task = tokio::spawn(run_engine_listener(engine_addr, registry, sessions));
     let mcp_task = tokio::spawn(run_mcp_server(mcp_addr, state));
 
     tokio::select! {

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -12,7 +12,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aether_hub_protocol::{
-    EngineId, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken, Uuid,
+    EngineId, EngineMailFrame, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken,
+    Uuid,
 };
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -25,9 +26,11 @@ use rmcp::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc};
 
 use crate::encoder::encode_pod;
 use crate::registry::{EngineRecord, EngineRegistry};
+use crate::session::{SessionHandle, SessionRegistry};
 
 /// Default port the hub binds for MCP clients. Overridable via
 /// `AETHER_MCP_PORT`.
@@ -37,27 +40,39 @@ pub const DEFAULT_MCP_PORT: u16 = 8888;
 /// each per-session `Hub` instance.
 pub struct HubState {
     engines: EngineRegistry,
+    sessions: SessionRegistry,
 }
 
 impl HubState {
-    pub fn new(engines: EngineRegistry) -> Arc<Self> {
-        Arc::new(Self { engines })
+    pub fn new(engines: EngineRegistry, sessions: SessionRegistry) -> Arc<Self> {
+        Arc::new(Self { engines, sessions })
     }
 }
 
-/// Per-session rmcp service. `ToolRouter<Self>` is built once in
-/// `new`; state is shared via `Arc<HubState>`.
+/// Per-session rmcp service. rmcp calls the factory once per MCP
+/// session and may clone the result for concurrent tool dispatch;
+/// `session` is an `Arc<SessionHandle>` so the registry entry only
+/// goes away when the last clone drops.
 #[derive(Clone)]
 pub struct Hub {
     state: Arc<HubState>,
     tool_router: ToolRouter<Self>,
+    session: Arc<SessionHandle>,
+    /// Drain for this session's inbound observation mail. PR 3 wires
+    /// the `receive_mail` tool to it; wrapping in an `Arc<Mutex<_>>`
+    /// lets clones share the same receiver.
+    #[allow(dead_code)]
+    inbound: Arc<Mutex<mpsc::Receiver<EngineMailFrame>>>,
 }
 
 impl Hub {
     pub fn new(state: Arc<HubState>) -> Self {
+        let (session, rx) = SessionHandle::mint(&state.sessions);
         Self {
             state,
             tool_router: Self::tool_router(),
+            session: Arc::new(session),
+            inbound: Arc::new(Mutex::new(rx)),
         }
     }
 }
@@ -134,7 +149,7 @@ impl Hub {
     ) -> Result<String, McpError> {
         let mut statuses = Vec::with_capacity(args.mails.len());
         for (i, spec) in args.mails.into_iter().enumerate() {
-            let result = deliver_one(spec, &self.state.engines).await;
+            let result = deliver_one(spec, &self.state.engines, self.session.token).await;
             let status = match result {
                 Ok(()) => "delivered".into(),
                 Err(e) => format!("error: {e}"),
@@ -205,7 +220,11 @@ impl ServerHandler for Hub {
 /// and push to the engine's mail channel. Returns a human-readable
 /// error string rather than `Err` so the batch driver can emit it as
 /// a per-mail status without losing sibling success.
-async fn deliver_one(spec: MailSpec, engines: &EngineRegistry) -> Result<(), String> {
+async fn deliver_one(
+    spec: MailSpec,
+    engines: &EngineRegistry,
+    sender: SessionToken,
+) -> Result<(), String> {
     let uuid = Uuid::parse_str(&spec.engine_id)
         .map_err(|e| format!("engine_id is not a valid UUID: {e}"))?;
     let id = EngineId(uuid);
@@ -220,7 +239,7 @@ async fn deliver_one(spec: MailSpec, engines: &EngineRegistry) -> Result<(), Str
         kind_name: spec.kind_name,
         payload,
         count: spec.count,
-        sender: SessionToken::NIL,
+        sender,
     });
     record
         .mail_tx
@@ -329,7 +348,7 @@ mod tests {
         let (b, _rx_b) = record(2);
         engines.insert(a);
         engines.insert(b);
-        let state = HubState::new(engines);
+        let state = HubState::new(engines, SessionRegistry::new());
         let hub = Hub::new(state);
 
         let json = hub.list_engines().await.unwrap();
@@ -362,12 +381,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_mail_stamps_sender_with_session_token() {
+        let engines = EngineRegistry::new();
+        let sessions = SessionRegistry::new();
+        let (rec, mut rx) = record(100);
+        let id = rec.id;
+        engines.insert(rec);
+        let hub = Hub::new(HubState::new(engines, sessions));
+        let expected = hub.session.token;
+
+        let statuses = run(
+            &hub,
+            vec![spec(id.0.to_string(), "aether.tick", None, Some(vec![]))],
+        )
+        .await;
+        assert_eq!(statuses[0].status, "delivered");
+
+        let HubToEngine::Mail(m) = rx.try_recv().unwrap() else {
+            panic!()
+        };
+        assert_eq!(m.sender, expected);
+        assert_ne!(m.sender, SessionToken::NIL);
+    }
+
+    #[tokio::test]
+    async fn two_hubs_mint_distinct_session_tokens() {
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let a = Hub::new(Arc::clone(&state));
+        let b = Hub::new(Arc::clone(&state));
+        assert_ne!(a.session.token, b.session.token);
+        // Both live in the registry.
+        assert_eq!(state.sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn dropping_hub_deregisters_session() {
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+        assert!(state.sessions.get(&token).is_some());
+        drop(hub);
+        assert!(state.sessions.get(&token).is_none());
+    }
+
+    #[tokio::test]
     async fn send_mail_payload_bytes_passthrough() {
         let engines = EngineRegistry::new();
         let (rec, mut rx) = record(7);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let statuses = run(
             &hub,
@@ -414,7 +477,7 @@ mod tests {
         let (rec, mut rx) = record_with_kinds(3, kinds);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let statuses = run(
             &hub,
@@ -449,7 +512,7 @@ mod tests {
         let (rec, mut rx) = record_with_kinds(4, kinds);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let statuses = run(
             &hub,
@@ -470,7 +533,7 @@ mod tests {
         let (rec, mut rx) = record(5);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let good = spec(id.0.to_string(), "aether.tick", None, Some(vec![]));
         let bad = spec(
@@ -499,7 +562,7 @@ mod tests {
         let (rec, _rx) = record(6);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let both = MailSpec {
             engine_id: id.0.to_string(),
@@ -525,7 +588,7 @@ mod tests {
         let (rec, _rx) = record_with_kinds(9, kinds);
         let id = rec.id;
         engines.insert(rec);
-        let hub = Hub::new(HubState::new(engines));
+        let hub = Hub::new(HubState::new(engines, SessionRegistry::new()));
 
         let statuses = run(
             &hub,
@@ -558,7 +621,7 @@ mod tests {
         let (rec, _rx) = record_with_kinds(11, kinds.clone());
         let id = rec.id;
         engines.insert(rec);
-        let state = HubState::new(engines);
+        let state = HubState::new(engines, SessionRegistry::new());
         let hub = Hub::new(state);
 
         let args = DescribeKindsArgs {
@@ -571,7 +634,7 @@ mod tests {
 
     #[tokio::test]
     async fn describe_kinds_unknown_engine_errors() {
-        let state = HubState::new(EngineRegistry::new());
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
         let hub = Hub::new(state);
         let args = DescribeKindsArgs {
             engine_id: Uuid::from_u128(1).to_string(),

--- a/crates/aether-hub/src/session.rs
+++ b/crates/aether-hub/src/session.rs
@@ -1,0 +1,138 @@
+// Session registry for Claude MCP sessions. ADR-0008 PR 2.
+//
+// Mirror of `EngineRegistry` on the Claude side of the hub: each
+// attached MCP session gets a `SessionToken` minted by the hub, an
+// mpsc queue for inbound observation mail from engines, and a
+// `SessionHandle` that deregisters on drop. The `Hub` service
+// instance rmcp builds per session holds an `Arc<SessionHandle>`, so
+// when the session ends (last Hub clone drops) the registry entry is
+// removed automatically.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use aether_hub_protocol::{EngineMailFrame, SessionToken, Uuid};
+use tokio::sync::mpsc;
+
+/// Bound on the per-session inbound observation queue. Back-pressure
+/// shape: if a Claude session isn't draining fast enough, engine mail
+/// senders await space on the channel.
+pub const SESSION_CHANNEL_CAPACITY: usize = 256;
+
+/// One entry in the hub's session table. `mail_tx` is how the engine
+/// connection handlers push observation mail at a specific session
+/// (via `ClaudeAddress::Session(token)`) or at all sessions (via
+/// `ClaudeAddress::Broadcast`, which iterates the registry).
+#[derive(Clone, Debug)]
+pub struct SessionRecord {
+    pub token: SessionToken,
+    pub mail_tx: mpsc::Sender<EngineMailFrame>,
+}
+
+/// Thread-safe map of live MCP sessions. Cheap to clone; all clones
+/// share the same underlying table.
+#[derive(Clone, Default)]
+pub struct SessionRegistry {
+    inner: Arc<Mutex<HashMap<SessionToken, SessionRecord>>>,
+}
+
+impl SessionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, record: SessionRecord) {
+        self.inner.lock().unwrap().insert(record.token, record);
+    }
+
+    pub fn remove(&self, token: &SessionToken) {
+        self.inner.lock().unwrap().remove(token);
+    }
+
+    pub fn get(&self, token: &SessionToken) -> Option<SessionRecord> {
+        self.inner.lock().unwrap().get(token).cloned()
+    }
+
+    pub fn list(&self) -> Vec<SessionRecord> {
+        self.inner.lock().unwrap().values().cloned().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().unwrap().is_empty()
+    }
+}
+
+/// Holder that owns a session's presence in the registry. Dropping
+/// the handle (when the `Hub` service — and every clone of it — is
+/// dropped by rmcp at end-of-session) removes the entry.
+pub struct SessionHandle {
+    pub token: SessionToken,
+    sessions: SessionRegistry,
+}
+
+impl SessionHandle {
+    /// Mint a fresh token, insert a `SessionRecord` with a bounded
+    /// mpsc, and hand back both the handle and the receiver. The
+    /// receiver drains inbound observation mail for this session —
+    /// PR 3 wires it to the `receive_mail` MCP tool.
+    pub fn mint(sessions: &SessionRegistry) -> (Self, mpsc::Receiver<EngineMailFrame>) {
+        let token = SessionToken(Uuid::new_v4());
+        let (tx, rx) = mpsc::channel(SESSION_CHANNEL_CAPACITY);
+        sessions.insert(SessionRecord { token, mail_tx: tx });
+        (
+            Self {
+                token,
+                sessions: sessions.clone(),
+            },
+            rx,
+        )
+    }
+}
+
+impl Drop for SessionHandle {
+    fn drop(&mut self) {
+        self.sessions.remove(&self.token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_inserts_and_drop_removes() {
+        let sessions = SessionRegistry::new();
+        assert!(sessions.is_empty());
+
+        let (handle, _rx) = SessionHandle::mint(&sessions);
+        let token = handle.token;
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions.get(&token).is_some());
+
+        drop(handle);
+        assert!(sessions.is_empty());
+        assert!(sessions.get(&token).is_none());
+    }
+
+    #[test]
+    fn list_sees_every_live_session() {
+        let sessions = SessionRegistry::new();
+        let (h1, _rx1) = SessionHandle::mint(&sessions);
+        let (h2, _rx2) = SessionHandle::mint(&sessions);
+        let (h3, _rx3) = SessionHandle::mint(&sessions);
+
+        let list = sessions.list();
+        assert_eq!(list.len(), 3);
+
+        drop(h2);
+        let list = sessions.list();
+        assert_eq!(list.len(), 2);
+        let tokens: Vec<_> = list.iter().map(|r| r.token).collect();
+        assert!(tokens.contains(&h1.token));
+        assert!(tokens.contains(&h3.token));
+    }
+}

--- a/crates/aether-hub/tests/engine_handshake.rs
+++ b/crates/aether-hub/tests/engine_handshake.rs
@@ -4,23 +4,27 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
-use aether_hub::{EngineRegistry, run_engine_listener};
+use aether_hub::{EngineRegistry, SessionRegistry, run_engine_listener};
 use aether_hub_protocol::{EngineToHub, Goodbye, Hello, HubToEngine, encode_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
-async fn spawn_hub() -> (SocketAddr, EngineRegistry) {
+async fn spawn_hub() -> (SocketAddr, EngineRegistry, SessionRegistry) {
     let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
         .await
         .unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
     let registry = EngineRegistry::new();
-    let reg_clone = registry.clone();
-    tokio::spawn(run_engine_listener(addr, reg_clone));
+    let sessions = SessionRegistry::new();
+    tokio::spawn(run_engine_listener(
+        addr,
+        registry.clone(),
+        sessions.clone(),
+    ));
     // Give the listener a beat to bind.
     tokio::time::sleep(Duration::from_millis(50)).await;
-    (addr, registry)
+    (addr, registry, sessions)
 }
 
 async fn connect(addr: SocketAddr) -> TcpStream {
@@ -53,7 +57,7 @@ fn hello(name: &str) -> EngineToHub {
 
 #[tokio::test]
 async fn handshake_assigns_engine_id_and_registers() {
-    let (addr, registry) = spawn_hub().await;
+    let (addr, registry, _sessions) = spawn_hub().await;
     let mut stream = connect(addr).await;
 
     write_frame_async(&mut stream, &hello("test")).await;
@@ -73,7 +77,7 @@ async fn handshake_assigns_engine_id_and_registers() {
 
 #[tokio::test]
 async fn goodbye_deregisters() {
-    let (addr, registry) = spawn_hub().await;
+    let (addr, registry, _sessions) = spawn_hub().await;
     let mut stream = connect(addr).await;
 
     write_frame_async(&mut stream, &hello("bye")).await;
@@ -100,7 +104,7 @@ async fn goodbye_deregisters() {
 
 #[tokio::test]
 async fn non_hello_first_frame_is_rejected() {
-    let (addr, registry) = spawn_hub().await;
+    let (addr, registry, _sessions) = spawn_hub().await;
     let mut stream = connect(addr).await;
 
     write_frame_async(&mut stream, &EngineToHub::Heartbeat).await;
@@ -116,7 +120,7 @@ async fn non_hello_first_frame_is_rejected() {
 async fn hub_sends_periodic_heartbeats() {
     // This test relies on HEARTBEAT_INTERVAL being short enough that a
     // heartbeat arrives within a few seconds.
-    let (addr, _registry) = spawn_hub().await;
+    let (addr, _registry, _sessions) = spawn_hub().await;
     let mut stream = connect(addr).await;
     write_frame_async(&mut stream, &hello("hb")).await;
     let _: HubToEngine = read_frame_async(&mut stream).await;
@@ -139,7 +143,7 @@ async fn hub_sends_periodic_heartbeats() {
 
 #[tokio::test]
 async fn silent_engine_is_reaped() {
-    let (addr, registry) = spawn_hub().await;
+    let (addr, registry, _sessions) = spawn_hub().await;
     let mut stream = connect(addr).await;
     write_frame_async(&mut stream, &hello("silent")).await;
     let _: HubToEngine = read_frame_async(&mut stream).await;


### PR DESCRIPTION
## Summary

ADR-0008 PR 2 of 5 — the hub learns session identity and routes engine-originated mail.

- New `session.rs` module: `SessionRegistry` keyed by hub-minted `SessionToken`, `SessionRecord` with an inbound mpsc queue, and `SessionHandle` with drop-deregistration so entries only live as long as the last `Hub` clone.
- `Hub::new` mints a fresh token per MCP session. `send_mail` now stamps outbound `MailFrame.sender` with the caller's token instead of `SessionToken::NIL` — engines can reply-to-sender by echoing the token back.
- `engine.rs::read_loop` routes `EngineToHub::Mail`:
  - `Session(token)` → deliver to that session's queue, or log-and-drop if token is unknown/expired.
  - `Broadcast` → fan out to every attached session. Empty registry is a no-op.
- The inbound receiver is parked on `Hub` under `#[allow(dead_code)]`; PR 3 wires the `receive_mail` tool to drain it.

## Test plan

- [x] `cargo build` clean.
- [x] `cargo test` — 78 passing. New tests:
  - `session::tests::{mint_inserts_and_drop_removes, list_sees_every_live_session}`
  - `engine::tests::{session_address_routes_to_that_session, session_address_with_unknown_token_is_dropped, broadcast_fans_out_to_every_session, broadcast_with_no_sessions_is_noop}`
  - `mcp::tests::{send_mail_stamps_sender_with_session_token, two_hubs_mint_distinct_session_tokens, dropping_hub_deregisters_session}`
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.

## Notes

- `SESSION_CHANNEL_CAPACITY` is 256 (matches the engine side). Without PR 3, a session that never drains will eventually back-pressure `send` calls from `route_engine_mail` — acceptable since no engine is emitting observation mail yet.
- `HubState::new` and `run_engine_listener` grew a `SessionRegistry` parameter; all call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)