### PR TITLE
feat(hub): receive_mail tool drains observation queue

### DIFF
--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use crate::registry::{EngineRecord, EngineRegistry};
-use crate::session::SessionRegistry;
+use crate::session::{QueuedMail, SessionRegistry};
 
 /// Cadence at which the hub sends `Heartbeat` to each engine.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -157,12 +157,13 @@ async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail
     match address {
         ClaudeAddress::Session(token) => match sessions.get(&token) {
             Some(record) => {
-                let frame = EngineMailFrame {
-                    address: ClaudeAddress::Session(token),
+                let queued = QueuedMail {
+                    engine_id,
                     kind_name,
                     payload,
+                    broadcast: false,
                 };
-                if record.mail_tx.send(frame).await.is_err() {
+                if record.mail_tx.send(queued).await.is_err() {
                     eprintln!(
                         "aether-hub: engine {} mail to session {} dropped: receiver closed",
                         engine_id.0, token.0
@@ -182,12 +183,13 @@ async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail
                 return;
             }
             for record in records {
-                let frame = EngineMailFrame {
-                    address: ClaudeAddress::Broadcast,
+                let queued = QueuedMail {
+                    engine_id,
                     kind_name: kind_name.clone(),
                     payload: payload.clone(),
+                    broadcast: true,
                 };
-                if record.mail_tx.send(frame).await.is_err() {
+                if record.mail_tx.send(queued).await.is_err() {
                     eprintln!(
                         "aether-hub: engine {} broadcast to session {} dropped: receiver closed",
                         engine_id.0, record.token.0
@@ -262,6 +264,8 @@ mod tests {
 
         let got = rx_a.try_recv().expect("frame for a");
         assert_eq!(got.payload, vec![1, 2, 3]);
+        assert_eq!(got.engine_id, engine_id(1));
+        assert!(!got.broadcast, "session address should not set broadcast");
         assert!(rx_b.try_recv().is_err(), "b should not have received");
     }
 
@@ -298,7 +302,8 @@ mod tests {
         for (name, rx) in [("a", &mut rx_a), ("b", &mut rx_b), ("c", &mut rx_c)] {
             let got = rx.try_recv().unwrap_or_else(|_| panic!("{name} no frame"));
             assert_eq!(got.payload, vec![42]);
-            assert_eq!(got.address, ClaudeAddress::Broadcast);
+            assert!(got.broadcast, "{name}: broadcast flag should be set");
+            assert_eq!(got.engine_id, engine_id(1));
         }
     }
 

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -19,7 +19,9 @@ pub use engine::HEARTBEAT_INTERVAL;
 pub use engine::READ_TIMEOUT;
 pub use mcp::{DEFAULT_MCP_PORT, HubState, run_mcp_server};
 pub use registry::{EngineRecord, EngineRegistry};
-pub use session::{SESSION_CHANNEL_CAPACITY, SessionHandle, SessionRecord, SessionRegistry};
+pub use session::{
+    QueuedMail, SESSION_CHANNEL_CAPACITY, SessionHandle, SessionRecord, SessionRegistry,
+};
 
 /// Default port the hub binds for engine TCP clients. ADR-0006 V0 fixes
 /// this; `AETHER_ENGINE_PORT` overrides.

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -12,8 +12,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aether_hub_protocol::{
-    EngineId, EngineMailFrame, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken,
-    Uuid,
+    EngineId, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken, Uuid,
 };
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -30,7 +29,7 @@ use tokio::sync::{Mutex, mpsc};
 
 use crate::encoder::encode_pod;
 use crate::registry::{EngineRecord, EngineRegistry};
-use crate::session::{SessionHandle, SessionRegistry};
+use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
 
 /// Default port the hub binds for MCP clients. Overridable via
 /// `AETHER_MCP_PORT`.
@@ -58,11 +57,10 @@ pub struct Hub {
     state: Arc<HubState>,
     tool_router: ToolRouter<Self>,
     session: Arc<SessionHandle>,
-    /// Drain for this session's inbound observation mail. PR 3 wires
-    /// the `receive_mail` tool to it; wrapping in an `Arc<Mutex<_>>`
-    /// lets clones share the same receiver.
-    #[allow(dead_code)]
-    inbound: Arc<Mutex<mpsc::Receiver<EngineMailFrame>>>,
+    /// Drain for this session's inbound observation mail. `receive_mail`
+    /// pulls from it non-blocking; wrapping in an `Arc<Mutex<_>>` lets
+    /// rmcp's per-tool-call clones share the same receiver.
+    inbound: Arc<Mutex<mpsc::Receiver<QueuedMail>>>,
 }
 
 impl Hub {
@@ -138,6 +136,28 @@ pub struct EngineInfo {
     pub version: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReceiveMailArgs {
+    /// Maximum number of items to return in this call. `None` drains
+    /// everything currently queued. Defaults to unlimited.
+    #[serde(default)]
+    pub max: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ReceivedMail {
+    /// Hub-assigned UUID of the engine that sent this mail.
+    pub engine_id: String,
+    /// Kind name the engine declared at handshake.
+    pub kind_name: String,
+    /// Raw payload bytes. Decode against the engine's kind descriptor
+    /// (via `describe_kinds`) if you need structured fields.
+    pub payload_bytes: Vec<u8>,
+    /// `true` if this mail was addressed to every attached session;
+    /// `false` if it was a reply targeted at this session specifically.
+    pub broadcast: bool,
+}
+
 #[tool_router]
 impl Hub {
     #[tool(
@@ -181,6 +201,30 @@ impl Hub {
         };
         serde_json::to_string(&record.kinds)
             .map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, the raw payload bytes, and a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false). Non-blocking: returns an empty array if nothing is queued."
+    )]
+    async fn receive_mail(
+        &self,
+        Parameters(args): Parameters<ReceiveMailArgs>,
+    ) -> Result<String, McpError> {
+        let cap = args.max.map(|n| n as usize).unwrap_or(usize::MAX);
+        let mut rx = self.inbound.lock().await;
+        let mut out = Vec::new();
+        while out.len() < cap {
+            match rx.try_recv() {
+                Ok(m) => out.push(ReceivedMail {
+                    engine_id: m.engine_id.0.to_string(),
+                    kind_name: m.kind_name,
+                    payload_bytes: m.payload,
+                    broadcast: m.broadcast,
+                }),
+                Err(_) => break,
+            }
+        }
+        serde_json::to_string(&out).map_err(|e| McpError::internal_error(e.to_string(), None))
     }
 
     #[tool(description = "List all engines currently connected to the hub.")]
@@ -641,5 +685,116 @@ mod tests {
         };
         let err = hub.describe_kinds(Parameters(args)).await.unwrap_err();
         assert!(format!("{err:?}").contains("unknown engine_id"));
+    }
+
+    async fn push_queued(sessions: &SessionRegistry, token: SessionToken, mail: QueuedMail) {
+        sessions
+            .get(&token)
+            .expect("session")
+            .mail_tx
+            .send(mail)
+            .await
+            .expect("send");
+    }
+
+    fn queued(engine: u128, kind: &str, payload: Vec<u8>, broadcast: bool) -> QueuedMail {
+        QueuedMail {
+            engine_id: EngineId(Uuid::from_u128(engine)),
+            kind_name: kind.into(),
+            payload,
+            broadcast,
+        }
+    }
+
+    async fn drain(hub: &Hub, max: Option<u32>) -> Vec<ReceivedMail> {
+        let json = hub
+            .receive_mail(Parameters(ReceiveMailArgs { max }))
+            .await
+            .unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[tokio::test]
+    async fn receive_mail_empty_queue_returns_empty_array() {
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(state);
+        let got = drain(&hub, None).await;
+        assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn receive_mail_drains_everything_by_default() {
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        push_queued(
+            &state.sessions,
+            token,
+            queued(7, "aether.observation.ping", vec![1, 2], false),
+        )
+        .await;
+        push_queued(
+            &state.sessions,
+            token,
+            queued(7, "aether.observation.world", vec![9], true),
+        )
+        .await;
+
+        let got = drain(&hub, None).await;
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].kind_name, "aether.observation.ping");
+        assert_eq!(got[0].payload_bytes, vec![1, 2]);
+        assert!(!got[0].broadcast);
+        assert_eq!(got[0].engine_id, Uuid::from_u128(7).to_string());
+        assert!(got[1].broadcast);
+
+        // Queue is now empty.
+        let got = drain(&hub, None).await;
+        assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn receive_mail_respects_max() {
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+        for i in 0..5u8 {
+            push_queued(
+                &state.sessions,
+                token,
+                queued(1, "aether.tick", vec![i], false),
+            )
+            .await;
+        }
+
+        let first = drain(&hub, Some(2)).await;
+        assert_eq!(first.len(), 2);
+        let second = drain(&hub, Some(2)).await;
+        assert_eq!(second.len(), 2);
+        let rest = drain(&hub, None).await;
+        assert_eq!(rest.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn receive_mail_scoped_to_own_session() {
+        // Push into session A's queue; session B's drain should see nothing.
+        let state = HubState::new(EngineRegistry::new(), SessionRegistry::new());
+        let hub_a = Hub::new(Arc::clone(&state));
+        let hub_b = Hub::new(Arc::clone(&state));
+
+        push_queued(
+            &state.sessions,
+            hub_a.session.token,
+            queued(1, "aether.tick", vec![42], false),
+        )
+        .await;
+
+        let got_b = drain(&hub_b, None).await;
+        assert!(got_b.is_empty());
+
+        let got_a = drain(&hub_a, None).await;
+        assert_eq!(got_a.len(), 1);
+        assert_eq!(got_a[0].payload_bytes, vec![42]);
     }
 }

--- a/crates/aether-hub/src/session.rs
+++ b/crates/aether-hub/src/session.rs
@@ -11,13 +11,25 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use aether_hub_protocol::{EngineMailFrame, SessionToken, Uuid};
+use aether_hub_protocol::{EngineId, SessionToken, Uuid};
 use tokio::sync::mpsc;
 
 /// Bound on the per-session inbound observation queue. Back-pressure
 /// shape: if a Claude session isn't draining fast enough, engine mail
 /// senders await space on the channel.
 pub const SESSION_CHANNEL_CAPACITY: usize = 256;
+
+/// Observation mail queued for a specific Claude session. Wraps the
+/// wire-level `EngineMailFrame` with the hub-known engine id and a
+/// flag so the draining session can tell broadcasts apart from
+/// targeted replies when it pulls via `receive_mail`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueuedMail {
+    pub engine_id: EngineId,
+    pub kind_name: String,
+    pub payload: Vec<u8>,
+    pub broadcast: bool,
+}
 
 /// One entry in the hub's session table. `mail_tx` is how the engine
 /// connection handlers push observation mail at a specific session
@@ -26,7 +38,7 @@ pub const SESSION_CHANNEL_CAPACITY: usize = 256;
 #[derive(Clone, Debug)]
 pub struct SessionRecord {
     pub token: SessionToken,
-    pub mail_tx: mpsc::Sender<EngineMailFrame>,
+    pub mail_tx: mpsc::Sender<QueuedMail>,
 }
 
 /// Thread-safe map of live MCP sessions. Cheap to clone; all clones
@@ -79,7 +91,7 @@ impl SessionHandle {
     /// mpsc, and hand back both the handle and the receiver. The
     /// receiver drains inbound observation mail for this session —
     /// PR 3 wires it to the `receive_mail` MCP tool.
-    pub fn mint(sessions: &SessionRegistry) -> (Self, mpsc::Receiver<EngineMailFrame>) {
+    pub fn mint(sessions: &SessionRegistry) -> (Self, mpsc::Receiver<QueuedMail>) {
         let token = SessionToken(Uuid::new_v4());
         let (tx, rx) = mpsc::channel(SESSION_CHANNEL_CAPACITY);
         sessions.insert(SessionRecord { token, mail_tx: tx });


### PR DESCRIPTION
## Summary

ADR-0008 PR 3 of 5 — first end-to-end moment for the observation path.

- New `QueuedMail` type wraps the wire `EngineMailFrame` with the originating `engine_id` and a `broadcast` flag. The raw wire frame no longer reaches the MCP surface; each session's inbound mpsc now carries `QueuedMail`.
- `route_engine_mail` populates `broadcast: false` for `Session` addresses and `broadcast: true` for `Broadcast` fan-outs.
- New `receive_mail(max?)` MCP tool: non-blocking drain of the caller's inbound queue, returns a JSON array of `ReceivedMail { engine_id, kind_name, payload_bytes, broadcast }`. Scoped to the caller's session by construction — the receiver lives on `Hub`, so no other session can see it.
- Drain-all with optional `max`. Polling shape; rmcp notifications / Claude Code Channels are parked (see ADR-0008 follow-ups).

## Test plan

- [x] `cargo build` clean.
- [x] `cargo test` — 82 passing. New tests:
  - `mcp::tests::receive_mail_empty_queue_returns_empty_array`
  - `mcp::tests::receive_mail_drains_everything_by_default`
  - `mcp::tests::receive_mail_respects_max`
  - `mcp::tests::receive_mail_scoped_to_own_session`
  - Existing routing tests updated to assert the new `engine_id` and `broadcast` fields on `QueuedMail`.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.

## Notes

- Payload bytes are returned as a JSON array of numbers (symmetric with how `send_mail` accepts `payload_bytes`). Base64 is a follow-on if large payloads prove clumsy.
- Non-blocking was a deliberate choice: a blocking/long-polling variant with a `wait_ms` is a strict upgrade if agents want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)