### PR TITLE
feat(substrate): thread sender + hub.claude.broadcast sink

### DIFF
--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -11,6 +11,8 @@
 
 use std::sync::Arc;
 
+use aether_hub_protocol::SessionToken;
+
 use crate::mail::{Mail, MailKind, MailboxId};
 use crate::queue::MailQueue;
 use crate::registry::{MailboxEntry, Registry};
@@ -28,7 +30,9 @@ impl SubstrateCtx {
     pub fn send(&self, recipient: MailboxId, kind: MailKind, payload: Vec<u8>, count: u32) {
         match self.registry.entry(recipient) {
             Some(MailboxEntry::Sink(handler)) => {
-                handler(&payload, count);
+                let kind_name = self.registry.kind_name(kind).unwrap_or("");
+                // Component-originated mail has no Claude-side sender.
+                handler(kind_name, SessionToken::NIL, &payload, count);
             }
             Some(MailboxEntry::Component) => {
                 self.queue.push(Mail::new(recipient, kind, payload, count));

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -1,22 +1,28 @@
 // Substrate-side hub client. Dials an `aether-hub`, performs the
-// Hello/Welcome handshake, then runs two background threads:
+// Hello/Welcome handshake, then runs three background threads:
 //
 //   - a reader that blocks on `HubToEngine` frames and funnels inbound
 //     `Mail` into the scheduler's `MailQueue` after resolving the
 //     recipient and kind against the local `Registry`,
-//   - a heartbeat writer that sends `EngineToHub::Heartbeat` on a fixed
-//     cadence so the hub doesn't reap this connection.
+//   - a writer that drains a `std::sync::mpsc::Receiver<EngineToHub>`
+//     and serialises its frames onto the TCP stream,
+//   - a heartbeat thread that pushes `EngineToHub::Heartbeat` onto the
+//     writer's channel on a fixed cadence.
 //
-// Graceful shutdown is deliberately V0-minimal: when the substrate
-// process exits, the OS closes the TCP socket and both threads drop
-// out of their respective read/write calls. Per ADR-0006's "substrate
-// stays sync" note, this module avoids `tokio` and uses the sync
-// framing helpers from `aether-hub-protocol`.
+// Two threads writing to the same socket would race, so heartbeats and
+// outbound mail frames both go through the single writer. The writer
+// exits when the channel closes (when the HubClient drops) or when the
+// socket errors; that in turn lets the OS close the socket and drop
+// the reader/heartbeat threads.
+//
+// Per ADR-0006's "substrate stays sync" note, this module avoids
+// `tokio` and uses the sync framing helpers from `aether-hub-protocol`.
 
 use std::io;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::process;
-use std::sync::Arc;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -33,19 +39,65 @@ use crate::registry::Registry;
 /// tick doesn't trip reaping.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Shared outbound handle for the substrate side of the hub wire.
+/// Registered once at `HubClient::connect` time. Sinks and other
+/// components of the substrate hold an `Arc<HubOutbound>` and call
+/// `send` without caring whether a hub connection is live — if it
+/// isn't, the send silently drops. This lets the broadcast sink be
+/// registered unconditionally, before (or without) a hub connection.
+pub struct HubOutbound {
+    tx: OnceLock<Sender<EngineToHub>>,
+}
+
+impl HubOutbound {
+    /// Fresh unwired handle. No frames are actually sent until a
+    /// `HubClient::connect` attaches its writer channel via `attach`.
+    pub fn disconnected() -> Arc<Self> {
+        Arc::new(Self {
+            tx: OnceLock::new(),
+        })
+    }
+
+    fn attach(&self, tx: Sender<EngineToHub>) {
+        if self.tx.set(tx).is_err() {
+            eprintln!("aether-substrate: HubOutbound attached twice — ignoring second attach");
+        }
+    }
+
+    /// Push a frame onto the writer's channel. Returns `true` if the
+    /// frame was enqueued; `false` if no hub is attached or the writer
+    /// has exited.
+    pub fn send(&self, frame: EngineToHub) -> bool {
+        match self.tx.get() {
+            Some(tx) => tx.send(frame).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Whether this handle has a live outbound channel.
+    pub fn is_connected(&self) -> bool {
+        self.tx.get().is_some()
+    }
+}
+
 /// Live hub connection. Threads are retained so their join handles
-/// aren't dropped; they exit when the TCP socket closes.
+/// aren't dropped; they exit when the TCP socket closes or the
+/// outbound channel is torn down.
 pub struct HubClient {
     pub engine_id: EngineId,
     _reader: JoinHandle<()>,
+    _writer: JoinHandle<()>,
     _heartbeat: JoinHandle<()>,
 }
 
 impl HubClient {
     /// Dial `addr`, send `Hello`, receive `Welcome`, and spawn the
-    /// reader + heartbeat threads. Inbound `Mail` is resolved and
-    /// pushed onto `queue`; unknown recipient or kind names are logged
-    /// and dropped.
+    /// reader / writer / heartbeat threads. Inbound `Mail` is resolved
+    /// and pushed onto `queue`; unknown recipient or kind names are
+    /// logged and dropped.
+    ///
+    /// `outbound` is populated on success so any sink registered
+    /// against it starts forwarding immediately.
     pub fn connect<A: ToSocketAddrs>(
         addr: A,
         name: impl Into<String>,
@@ -53,6 +105,7 @@ impl HubClient {
         kinds: Vec<KindDescriptor>,
         registry: Arc<Registry>,
         queue: Arc<MailQueue>,
+        outbound: Arc<HubOutbound>,
     ) -> io::Result<Self> {
         let mut stream = TcpStream::connect(addr)?;
         let hello = EngineToHub::Hello(Hello {
@@ -76,14 +129,19 @@ impl HubClient {
         };
         eprintln!("aether-substrate: hub registered as engine {}", engine_id.0);
 
+        let (tx, rx) = mpsc::channel::<EngineToHub>();
         let reader_stream = stream.try_clone()?;
-        let heartbeat_stream = stream;
+        let writer_stream = stream;
         let _reader = thread::spawn(move || run_reader(reader_stream, registry, queue));
-        let _heartbeat = thread::spawn(move || run_heartbeat(heartbeat_stream));
+        let _writer = thread::spawn(move || run_writer(writer_stream, rx));
+        let heartbeat_tx = tx.clone();
+        let _heartbeat = thread::spawn(move || run_heartbeat(heartbeat_tx));
+        outbound.attach(tx);
 
         Ok(Self {
             engine_id,
             _reader,
+            _writer,
             _heartbeat,
         })
     }
@@ -109,10 +167,19 @@ fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<MailQue
     }
 }
 
-fn run_heartbeat(mut stream: TcpStream) {
+fn run_writer(mut stream: TcpStream, rx: mpsc::Receiver<EngineToHub>) {
+    while let Ok(frame) = rx.recv() {
+        if let Err(e) = write_frame(&mut stream, &frame) {
+            eprintln!("aether-substrate: hub write error: {e}");
+            return;
+        }
+    }
+}
+
+fn run_heartbeat(tx: Sender<EngineToHub>) {
     loop {
         thread::sleep(HEARTBEAT_INTERVAL);
-        if write_frame(&mut stream, &EngineToHub::Heartbeat).is_err() {
+        if tx.send(EngineToHub::Heartbeat).is_err() {
             return;
         }
     }
@@ -133,7 +200,7 @@ fn dispatch_mail(frame: MailFrame, registry: &Registry, queue: &MailQueue) {
         );
         return;
     };
-    queue.push(Mail::new(recipient, kind, frame.payload, frame.count));
+    queue.push(Mail::new(recipient, kind, frame.payload, frame.count).with_sender(frame.sender));
 }
 
 fn unix_now() -> u64 {

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -18,8 +18,14 @@ pub mod scheduler;
 
 pub use component::Component;
 pub use ctx::SubstrateCtx;
-pub use hub_client::HubClient;
+pub use hub_client::{HubClient, HubOutbound};
 pub use mail::{Mail, MailKind, MailboxId};
 pub use queue::MailQueue;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;
+
+/// Well-known mailbox name for fan-out to every attached Claude
+/// session (ADR-0008). A component or substrate-owned sink sends to
+/// this name the same way it sends to any local sink; the forwarder
+/// translates to `EngineToHub::Mail { address: Broadcast, ... }`.
+pub const HUB_CLAUDE_BROADCAST: &str = "hub.claude.broadcast";

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -1,6 +1,8 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
+use aether_hub_protocol::SessionToken;
+
 /// Addressing token for any mailbox — component or substrate-owned sink.
 /// Opaque `u32` newtype so it can't be accidentally mixed with wasmtime
 /// indices or raw integers.
@@ -14,13 +16,16 @@ pub type MailKind = u32;
 
 /// The transport envelope. `payload` is the exact byte layout the kind
 /// implies; `count` is the number of items the layout implies, where
-/// applicable.
+/// applicable. `sender` is the hub-minted session token for mail that
+/// came in over the hub wire (ADR-0008); substrate-generated mail
+/// leaves it as `SessionToken::NIL`.
 #[derive(Debug)]
 pub struct Mail {
     pub recipient: MailboxId,
     pub kind: MailKind,
     pub payload: Vec<u8>,
     pub count: u32,
+    pub sender: SessionToken,
 }
 
 impl Mail {
@@ -30,6 +35,15 @@ impl Mail {
             kind,
             payload,
             count,
+            sender: SessionToken::NIL,
         }
+    }
+
+    /// Attach a Claude session token as the sender. Used by the hub
+    /// client when forwarding `HubToEngine::Mail`; other mail paths
+    /// leave the default `NIL`.
+    pub fn with_sender(mut self, sender: SessionToken) -> Self {
+        self.sender = sender;
+        self
     }
 }

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -16,10 +16,12 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
 use aether_substrate::{
-    Component, HubClient, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    Component, HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, MailQueue, Registry, Scheduler,
+    SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
 use aether_substrate_mail::{DrawTriangle, Key, MouseButton, MouseMove, Tick};
@@ -170,11 +172,36 @@ fn main() -> wasmtime::Result<()> {
     let tris_for_sink = Arc::clone(&triangles_rendered);
     let sink_mbox = registry.register_sink(
         "render",
-        Arc::new(move |bytes: &[u8], count: u32| {
+        Arc::new(move |_kind: &str, _sender, bytes: &[u8], count: u32| {
             verts_for_sink.lock().unwrap().extend_from_slice(bytes);
             tris_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
         }),
     );
+
+    // Reserved well-known sink: mail sent here is forwarded to every
+    // attached Claude session via the hub. If no hub is connected, the
+    // outbound handle is disconnected and the sink silently drops —
+    // the component doesn't have to care either way.
+    let outbound = HubOutbound::disconnected();
+    {
+        let outbound = Arc::clone(&outbound);
+        registry.register_sink(
+            HUB_CLAUDE_BROADCAST,
+            Arc::new(move |kind_name: &str, _sender, bytes: &[u8], _count: u32| {
+                if kind_name.is_empty() {
+                    eprintln!(
+                        "aether-substrate: {HUB_CLAUDE_BROADCAST} received mail with unregistered kind — dropping"
+                    );
+                    return;
+                }
+                outbound.send(EngineToHub::Mail(EngineMailFrame {
+                    address: ClaudeAddress::Broadcast,
+                    kind_name: kind_name.to_owned(),
+                    payload: bytes.to_vec(),
+                }));
+            }),
+        );
+    }
 
     // Mailbox contract: component=0, render sink=1. The component
     // hardcodes 1 as its send_mail recipient; assert here so a mismatch
@@ -216,6 +243,7 @@ fn main() -> wasmtime::Result<()> {
             aether_substrate_mail::descriptors::all(),
             Arc::clone(&registry),
             Arc::clone(&queue),
+            Arc::clone(&outbound),
         ) {
             Ok(c) => Some(c),
             Err(e) => {

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -7,12 +7,18 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use aether_hub_protocol::SessionToken;
+
 use crate::mail::MailboxId;
 
 /// Handler invoked when mail is delivered to a substrate-owned sink.
-/// Called on a scheduler worker thread; must be `Send + Sync`. Argument
-/// is the payload bytes; second argument is the kind-implied count.
-pub type SinkHandler = Arc<dyn Fn(&[u8], u32) + Send + Sync + 'static>;
+/// Called on a scheduler worker thread; must be `Send + Sync`.
+/// Arguments: kind name (resolved by the dispatcher so sinks don't
+/// need a reverse lookup), the originating Claude session token for
+/// hub-inbound mail (or `SessionToken::NIL` for substrate-local mail)
+/// per ADR-0008's reply-to-sender primitive, payload bytes, and the
+/// kind-implied count.
+pub type SinkHandler = Arc<dyn Fn(&str, SessionToken, &[u8], u32) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -27,6 +33,11 @@ pub struct Registry {
     by_name: HashMap<String, MailboxId>,
     entries: Vec<MailboxEntry>,
     kind_by_name: HashMap<String, u32>,
+    /// Parallel index: `kind_names[id]` is the canonical name the kind
+    /// was first registered with. Kept in sync with `kind_by_name` so
+    /// `kind_name(id)` is O(1); used by `SinkHandler` dispatch to hand
+    /// sinks the name without forcing them to keep their own map.
+    kind_names: Vec<String>,
 }
 
 impl Registry {
@@ -35,6 +46,7 @@ impl Registry {
             by_name: HashMap::new(),
             entries: Vec::new(),
             kind_by_name: HashMap::new(),
+            kind_names: Vec::new(),
         }
     }
 
@@ -78,13 +90,21 @@ impl Registry {
         if let Some(&id) = self.kind_by_name.get(&name) {
             return id;
         }
-        let id = self.kind_by_name.len() as u32;
+        let id = self.kind_names.len() as u32;
+        self.kind_names.push(name.clone());
         self.kind_by_name.insert(name, id);
         id
     }
 
     pub fn kind_id(&self, name: &str) -> Option<u32> {
         self.kind_by_name.get(name).copied()
+    }
+
+    /// Reverse of `kind_id`: name for a given id, or `None` if the id
+    /// is out of range. Used by the scheduler to hand sink handlers a
+    /// kind name without them keeping their own map.
+    pub fn kind_name(&self, id: u32) -> Option<&str> {
+        self.kind_names.get(id as usize).map(|s| s.as_str())
     }
 
     pub fn len(&self) -> usize {
@@ -124,15 +144,15 @@ mod tests {
         let c2 = Arc::clone(&counter);
         let id = r.register_sink(
             "heartbeat",
-            Arc::new(move |_bytes, count| {
+            Arc::new(move |_kind, _sender, _bytes, count| {
                 c2.fetch_add(count, Ordering::SeqCst);
             }),
         );
         let Some(MailboxEntry::Sink(h)) = r.entry(id) else {
             panic!("expected sink")
         };
-        h(&[], 7);
-        h(&[], 3);
+        h("aether.tick", SessionToken::NIL, &[], 7);
+        h("aether.tick", SessionToken::NIL, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 
@@ -140,7 +160,7 @@ mod tests {
     fn mailbox_ids_are_dense_and_sequential() {
         let mut r = Registry::new();
         let a = r.register_component("a");
-        let b = r.register_sink("b", Arc::new(|_, _| {}));
+        let b = r.register_sink("b", Arc::new(|_, _, _, _| {}));
         let c = r.register_component("c");
         assert_eq!(a, MailboxId(0));
         assert_eq!(b, MailboxId(1));
@@ -189,5 +209,15 @@ mod tests {
         let id = r.register_kind("aether.tick");
         assert_eq!(r.kind_id("aether.tick"), Some(id));
         assert!(r.kind_id("absent").is_none());
+    }
+
+    #[test]
+    fn kind_name_reverse_lookup() {
+        let mut r = Registry::new();
+        let a = r.register_kind("aether.tick");
+        let b = r.register_kind("aether.key");
+        assert_eq!(r.kind_name(a), Some("aether.tick"));
+        assert_eq!(r.kind_name(b), Some("aether.key"));
+        assert!(r.kind_name(999).is_none());
     }
 }

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -90,7 +90,8 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
         let recipient = mail.recipient;
         match ctx.registry.entry(recipient) {
             Some(MailboxEntry::Sink(handler)) => {
-                handler(&mail.payload, mail.count);
+                let kind_name = ctx.registry.kind_name(mail.kind).unwrap_or("");
+                handler(kind_name, mail.sender, &mail.payload, mail.count);
             }
             Some(MailboxEntry::Component) => match ctx.components.get(&recipient) {
                 Some(lock) => {

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -50,7 +50,7 @@ fn tick_roundtrip_component_to_sink() {
     let c2 = Arc::clone(&counter);
     let sink_mbox = registry.register_sink(
         "heartbeat",
-        Arc::new(move |_bytes, count| {
+        Arc::new(move |_kind, _sender, _bytes, count| {
             c2.fetch_add(count, Ordering::SeqCst);
         }),
     );

--- a/crates/aether-substrate/tests/hub_client.rs
+++ b/crates/aether-substrate/tests/hub_client.rs
@@ -11,10 +11,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use aether_hub_protocol::{
-    EngineId, EngineToHub, Goodbye, HubToEngine, MailFrame, SessionToken, Uuid, Welcome,
-    read_frame, write_frame,
+    ClaudeAddress, EngineId, EngineMailFrame, EngineToHub, Goodbye, HubToEngine, MailFrame,
+    SessionToken, Uuid, Welcome, read_frame, write_frame,
 };
-use aether_substrate::{HubClient, MailQueue, Registry, Scheduler};
+use aether_substrate::{HubClient, HubOutbound, MailQueue, Registry, Scheduler};
 
 /// Start a mock hub on a random port. Returns the bound address and a
 /// `TcpStream` for the single connection it will accept.
@@ -42,7 +42,18 @@ fn handshake_exchanges_hello_and_welcome() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "test-engine", "0.0.0", vec![], registry, queue).unwrap()
+        move || {
+            HubClient::connect(
+                addr,
+                "test-engine",
+                "0.0.0",
+                vec![],
+                registry,
+                queue,
+                HubOutbound::disconnected(),
+            )
+            .unwrap()
+        }
     });
 
     // Server side of the handshake.
@@ -80,6 +91,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     struct Seen {
         count_sum: u32,
         payload_lens: Vec<usize>,
+        senders: Vec<SessionToken>,
     }
     let seen = Arc::new((Mutex::new(Seen::default()), Condvar::new()));
     let seen_for_sink = Arc::clone(&seen);
@@ -87,13 +99,16 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let mut registry = Registry::new();
     let recipient = registry.register_sink(
         "hello",
-        Arc::new(move |bytes: &[u8], count: u32| {
-            let (lock, cv) = &*seen_for_sink;
-            let mut s = lock.lock().unwrap();
-            s.count_sum += count;
-            s.payload_lens.push(bytes.len());
-            cv.notify_all();
-        }),
+        Arc::new(
+            move |_kind: &str, sender: SessionToken, bytes: &[u8], count: u32| {
+                let (lock, cv) = &*seen_for_sink;
+                let mut s = lock.lock().unwrap();
+                s.count_sum += count;
+                s.payload_lens.push(bytes.len());
+                s.senders.push(sender);
+                cv.notify_all();
+            },
+        ),
     );
     registry.register_kind("aether.tick");
     let registry = Arc::new(registry);
@@ -104,7 +119,18 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "t", "0", vec![], registry, queue).unwrap()
+        move || {
+            HubClient::connect(
+                addr,
+                "t",
+                "0",
+                vec![],
+                registry,
+                queue,
+                HubOutbound::disconnected(),
+            )
+            .unwrap()
+        }
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
@@ -118,14 +144,17 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     .unwrap();
     let _client = client_handle.join().unwrap();
 
-    // A known kind, an unknown kind (should drop), then another known.
+    // A known kind with a populated sender, an unknown kind (should
+    // drop), then another known with NIL. The sender on the first
+    // frame must survive the wire → reader → queue → sink path.
+    let alice = SessionToken(Uuid::from_u128(0xa11ce));
     for frame in [
         MailFrame {
             recipient_name: "hello".into(),
             kind_name: "aether.tick".into(),
             payload: vec![1, 2, 3],
             count: 7,
-            sender: SessionToken::NIL,
+            sender: alice,
         },
         MailFrame {
             recipient_name: "hello".into(),
@@ -160,6 +189,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     }
     assert_eq!(s.count_sum, 8);
     assert_eq!(s.payload_lens, vec![3, 1]);
+    assert_eq!(s.senders, vec![alice, SessionToken::NIL]);
     assert_eq!(recipient.0, 0);
 
     drop(stream);
@@ -174,7 +204,18 @@ fn client_sends_periodic_heartbeats() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "hb", "0", vec![], registry, queue).unwrap()
+        move || {
+            HubClient::connect(
+                addr,
+                "hb",
+                "0",
+                vec![],
+                registry,
+                queue,
+                HubOutbound::disconnected(),
+            )
+            .unwrap()
+        }
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
@@ -213,7 +254,18 @@ fn goodbye_stops_reader_thread() {
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
-        move || HubClient::connect(addr, "bye", "0", vec![], registry, queue).unwrap()
+        move || {
+            HubClient::connect(
+                addr,
+                "bye",
+                "0",
+                vec![],
+                registry,
+                queue,
+                HubOutbound::disconnected(),
+            )
+            .unwrap()
+        }
     });
 
     let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
@@ -238,4 +290,83 @@ fn goodbye_stops_reader_thread() {
     // Give the reader a beat to process Goodbye and exit.
     thread::sleep(Duration::from_millis(100));
     drop(stream);
+}
+
+#[test]
+fn outbound_sends_reach_the_hub_wire() {
+    // HubOutbound attached at connect time; subsequent sends show up
+    // on the server's read side as postcard-framed EngineToHub::Mail.
+    let (addr, conn_rx) = accept_one();
+    let outbound = HubOutbound::disconnected();
+    assert!(!outbound.is_connected());
+
+    let registry = Arc::new(Registry::new());
+    let queue = Arc::new(MailQueue::new());
+
+    let connect_outbound = Arc::clone(&outbound);
+    let client_handle = thread::spawn({
+        let registry = Arc::clone(&registry);
+        let queue = Arc::clone(&queue);
+        move || {
+            HubClient::connect(
+                addr,
+                "outbound-test",
+                "0",
+                vec![],
+                registry,
+                queue,
+                connect_outbound,
+            )
+            .unwrap()
+        }
+    });
+
+    let mut stream = conn_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    let _hello: EngineToHub = read_frame(&mut stream).unwrap();
+    write_frame(
+        &mut stream,
+        &HubToEngine::Welcome(Welcome {
+            engine_id: canned_engine_id(),
+        }),
+    )
+    .unwrap();
+    let _client = client_handle.join().unwrap();
+
+    assert!(outbound.is_connected());
+
+    // Drive a broadcast out through the outbound handle.
+    assert!(outbound.send(EngineToHub::Mail(EngineMailFrame {
+        address: ClaudeAddress::Broadcast,
+        kind_name: "aether.observation.ping".into(),
+        payload: vec![1, 2, 3],
+    })));
+
+    // Read it back on the server side. Heartbeats may arrive too —
+    // skip over them until we see the Mail frame.
+    let observed = loop {
+        let frame: EngineToHub = read_frame(&mut stream).unwrap();
+        match frame {
+            EngineToHub::Mail(m) => break m,
+            EngineToHub::Heartbeat => continue,
+            other => panic!("unexpected frame {other:?}"),
+        }
+    };
+    assert_eq!(observed.address, ClaudeAddress::Broadcast);
+    assert_eq!(observed.kind_name, "aether.observation.ping");
+    assert_eq!(observed.payload, vec![1, 2, 3]);
+
+    drop(stream);
+}
+
+#[test]
+fn outbound_send_without_attach_is_noop() {
+    let outbound = HubOutbound::disconnected();
+    assert!(!outbound.is_connected());
+    // No attach ever happened; send returns false and doesn't panic.
+    let ok = outbound.send(EngineToHub::Mail(EngineMailFrame {
+        address: ClaudeAddress::Broadcast,
+        kind_name: "aether.tick".into(),
+        payload: vec![],
+    }));
+    assert!(!ok);
 }


### PR DESCRIPTION
## Summary

ADR-0008 PR 4 of 5 — the substrate side of the observation path. Lights the broadcast direction end-to-end; reply-to-sender via a WASM host fn is deferred to a follow-on.

- `Mail` grows `sender: SessionToken` and a `with_sender` builder. `hub_client::dispatch_mail` populates it from `MailFrame.sender`; substrate-generated mail defaults to `SessionToken::NIL`.
- `SinkHandler` signature becomes `Fn(&str, SessionToken, &[u8], u32)`. The dispatcher resolves the kind name (via a new `Registry::kind_name(id)`) so sinks don't keep their own reverse map, and now receives the session token so future reply-to-sender sinks can use it directly.
- `HubClient` refactored: one writer thread drains an `mpsc::Receiver<EngineToHub>`; heartbeats push to that channel instead of writing the socket directly. Needed so outbound observation mail and heartbeats don't race on the wire.
- New `HubOutbound { OnceLock<Sender<EngineToHub>> }`. Registered unconditionally; `HubClient::connect` attaches on success. Sends without a hub are a no-op — lets the broadcast sink be registered before any attempt to connect.
- Reserved well-known sink `"hub.claude.broadcast"` (exported as `HUB_CLAUDE_BROADCAST`): forwards mail to the hub with `ClaudeAddress::Broadcast`.

## Test plan

- [x] `cargo build` clean.
- [x] `cargo test` — all green. New/updated coverage:
  - `registry::tests::kind_name_reverse_lookup`
  - `tests/hub_client::inbound_mail_lands_in_queue_after_resolution` now asserts `sender` survives wire → reader → queue → sink
  - `tests/hub_client::outbound_sends_reach_the_hub_wire` end-to-end: `HubOutbound::send` → mock server reads `EngineToHub::Mail`
  - `tests/hub_client::outbound_send_without_attach_is_noop`
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.

## Notes

- Component-facing changes are intentionally minimal: no new host fn, no WASM ABI change. A component can send to `"hub.claude.broadcast"` today via `resolve_mailbox` + the existing `send_mail` host fn. Reply-to-sender for components needs a new host fn (`current_sender()` or similar); left to a follow-on so this PR stays focused on plumbing.
- `HubClient::connect` grew a seventh parameter (`Arc<HubOutbound>`). All call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)