### PR TITLE
feat(substrate): emit FrameStats observation to broadcast sink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,18 @@ Early-stage Rust project (edition 2024). Vision: a game engine where Claude sits
 
 ## MCP harness
 
-Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. Starting `cargo run -p aether-hub` and `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate` exposes three tools to a Claude Code session pointed at the project-scoped `.mcp.json`:
+Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. Starting `cargo run -p aether-hub` and `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate` exposes four tools to a Claude Code session pointed at the project-scoped `.mcp.json`:
 
 - `mcp__aether-hub__list_engines` — connected engines (UUID + name/pid/version).
 - `mcp__aether-hub__describe_kinds(engine_id)` — the kind vocabulary the engine declared at handshake, with enough structural detail to build params.
 - `mcp__aether-hub__send_mail(mails)` — batched, best-effort. Each item takes either `params` (hub encodes via the kind's descriptor) or `payload_bytes` (raw escape hatch for `Opaque` kinds). Response is a per-item status array; one failure doesn't abort siblings.
+- `mcp__aether-hub__receive_mail(max?)` — non-blocking drain of observation mail the engine pushed to this session. Each item carries `engine_id`, `kind_name`, `payload_bytes`, and a `broadcast` flag (`true` means fan-out to every attached session, `false` means targeted reply-to-sender).
 
 Prefer `params` over `payload_bytes` when the kind is describable — the hub does the `#[repr(C)]` byte packing so agents don't. When verifying substrate behavior end-to-end, reach for this before running a new test binary.
 
-Design detail lives in ADR-0006 (wire + topology) and ADR-0007 (schema-driven encoding).
+The observation path (ADR-0008) goes the other way: engines emit to the well-known sink `"hub.claude.broadcast"` and the hub fans out to every attached session. The live substrate binary pushes `aether.observation.frame_stats` there every 120 frames — a good smoke test for `receive_mail`. Reply-to-sender from a WASM component is plumbed at the wire level but not yet exposed as a host fn.
+
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), and ADR-0008 (observation path).
 
 ## Commands
 

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive};
 use aether_mail::Kind;
 
-use crate::{DrawTriangle, Key, MouseButton, MouseMove, Tick};
+use crate::{DrawTriangle, FrameStats, Key, MouseButton, MouseMove, Tick};
 
 /// Every kind the substrate exposes, in the order the `Registry` will
 /// register them. Caller ignores the order — names are the contract.
@@ -35,6 +35,13 @@ pub fn all() -> Vec<KindDescriptor> {
         // structs, so this kind stays opaque and clients use the raw
         // payload_bytes path.
         opaque(DrawTriangle::NAME),
+        pod(
+            FrameStats::NAME,
+            vec![
+                scalar("frame", PodPrimitive::U64),
+                scalar("triangles", PodPrimitive::U64),
+            ],
+        ),
     ]
 }
 
@@ -114,5 +121,21 @@ mod tests {
         let descs = all();
         let dt = descs.iter().find(|d| d.name == DrawTriangle::NAME).unwrap();
         assert_eq!(dt.encoding, KindEncoding::Opaque);
+    }
+
+    #[test]
+    fn frame_stats_fields_match_struct_layout() {
+        let descs = all();
+        let fs = descs.iter().find(|d| d.name == FrameStats::NAME).unwrap();
+        let KindEncoding::Pod { fields } = &fs.encoding else {
+            panic!("expected Pod")
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name, "frame");
+        assert_eq!(fields[1].name, "triangles");
+        assert!(matches!(
+            fields[0].ty,
+            PodFieldType::Scalar(PodPrimitive::U64)
+        ));
     }
 }

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -79,6 +79,21 @@ impl Kind for DrawTriangle {
     const NAME: &'static str = "aether.draw_triangle";
 }
 
+/// Periodic observation emitted by the substrate's frame loop when a
+/// hub is attached (ADR-0008). The substrate pushes one of these at
+/// `LOG_EVERY_FRAMES` cadence to the `hub.claude.broadcast` sink, so
+/// every attached Claude session learns how the engine is running
+/// without having to poll the engine directly.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct FrameStats {
+    pub frame: u64,
+    pub triangles: u64,
+}
+impl Kind for FrameStats {
+    const NAME: &'static str = "aether.observation.frame_stats";
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +143,18 @@ mod tests {
         assert_eq!(MouseButton::NAME, "aether.mouse_button");
         assert_eq!(MouseMove::NAME, "aether.mouse_move");
         assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
+        assert_eq!(FrameStats::NAME, "aether.observation.frame_stats");
+    }
+
+    #[test]
+    fn frame_stats_roundtrip() {
+        let s = FrameStats {
+            frame: 120,
+            triangles: 240,
+        };
+        let bytes = encode(&s);
+        assert_eq!(bytes.len(), 16);
+        let back: FrameStats = decode(&bytes).unwrap();
+        assert_eq!(back, s);
     }
 }

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -24,7 +24,7 @@ use aether_substrate::{
     SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
-use aether_substrate_mail::{DrawTriangle, Key, MouseButton, MouseMove, Tick};
+use aether_substrate_mail::{DrawTriangle, FrameStats, Key, MouseButton, MouseMove, Tick};
 use render::Gpu;
 use wasmtime::{Engine, Linker, Module};
 use winit::application::ApplicationHandler;
@@ -41,10 +41,12 @@ const LOG_EVERY_FRAMES: u64 = 120;
 struct App {
     queue: Arc<MailQueue>,
     component_mbox: MailboxId,
+    broadcast_mbox: MailboxId,
     kind_tick: u32,
     kind_key: u32,
     kind_mouse_button: u32,
     kind_mouse_move: u32,
+    kind_frame_stats: u32,
     frame_vertices: Arc<Mutex<Vec<u8>>>,
     triangles_rendered: Arc<AtomicU64>,
     window: Option<Arc<Window>>,
@@ -94,11 +96,22 @@ impl ApplicationHandler for App {
                 }
                 self.frame += 1;
                 if self.frame.is_multiple_of(LOG_EVERY_FRAMES) {
+                    let triangles = self.triangles_rendered.load(Ordering::Relaxed);
                     eprintln!(
                         "  frame {:>5}  triangles_rendered={}",
-                        self.frame,
-                        self.triangles_rendered.load(Ordering::Relaxed),
+                        self.frame, triangles,
                     );
+                    // Emit an observation to every attached Claude
+                    // session. No-op when no hub is connected.
+                    self.queue.push(Mail::new(
+                        self.broadcast_mbox,
+                        self.kind_frame_stats,
+                        encode(&FrameStats {
+                            frame: self.frame,
+                            triangles,
+                        }),
+                        1,
+                    ));
                 }
                 if let Some(w) = &self.window {
                     w.request_redraw();
@@ -164,6 +177,7 @@ fn main() -> wasmtime::Result<()> {
     let kind_mouse_button = registry.register_kind(MouseButton::NAME);
     let kind_mouse_move = registry.register_kind(MouseMove::NAME);
     registry.register_kind(DrawTriangle::NAME);
+    let kind_frame_stats = registry.register_kind(FrameStats::NAME);
 
     let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(4096)));
     let triangles_rendered = Arc::new(AtomicU64::new(0));
@@ -183,7 +197,7 @@ fn main() -> wasmtime::Result<()> {
     // outbound handle is disconnected and the sink silently drops —
     // the component doesn't have to care either way.
     let outbound = HubOutbound::disconnected();
-    {
+    let broadcast_mbox = {
         let outbound = Arc::clone(&outbound);
         registry.register_sink(
             HUB_CLAUDE_BROADCAST,
@@ -200,8 +214,8 @@ fn main() -> wasmtime::Result<()> {
                     payload: bytes.to_vec(),
                 }));
             }),
-        );
-    }
+        )
+    };
 
     // Mailbox contract: component=0, render sink=1. The component
     // hardcodes 1 as its send_mail recipient; assert here so a mismatch
@@ -264,10 +278,12 @@ fn main() -> wasmtime::Result<()> {
     let mut app = App {
         queue,
         component_mbox,
+        broadcast_mbox,
         kind_tick,
         kind_key,
         kind_mouse_button,
         kind_mouse_move,
+        kind_frame_stats,
         frame_vertices,
         triangles_rendered: Arc::clone(&triangles_rendered),
         window: None,


### PR DESCRIPTION
## Summary

ADR-0008 PR 5 of 5 — closes the observation path arc with a concrete kind that lights every layer.

- New POD kind `FrameStats { frame: u64, triangles: u64 }` in `aether-substrate-mail`, with a matching `Pod` descriptor so Claude receives decoded params via the existing `describe_kinds` surface.
- Substrate's frame loop pushes one `FrameStats` mail to the `hub.claude.broadcast` sink every `LOG_EVERY_FRAMES` (120) frames — piggybacks on the existing "log every N frames" cadence. The sink forwards to the hub, the hub fans out to every attached Claude session, sessions drain via `receive_mail`. No-op when no hub is attached.
- CLAUDE.md MCP-harness section updated: names `receive_mail` as the fourth tool, documents the `broadcast` flag, points at the `hub.claude.broadcast` sink and ADR-0008.

## Test plan

- [x] `cargo build` clean.
- [x] `cargo test` — all green. New tests:
  - `aether_substrate_mail::tests::frame_stats_roundtrip`
  - `aether_substrate_mail::descriptors::tests::frame_stats_fields_match_struct_layout`
  - (`kind_names_are_stable` extended to cover `FrameStats::NAME`)
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] **Manual end-to-end smoke** (requires a display):
  1. Terminal A: `cargo run -p aether-hub`
  2. Terminal B: `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate`
  3. Restart Claude Code session so the MCP tools re-register against the new hub build.
  4. Call `list_engines` → copy engine id.
  5. Call `describe_kinds(engine_id)` → expect `aether.observation.frame_stats` with `{frame: U64, triangles: U64}`.
  6. Wait ~2s for the substrate to tick past 120 frames, then call `receive_mail({})` → expect one or more `{engine_id, kind_name: "aether.observation.frame_stats", payload_bytes: [...], broadcast: true}` items. Decoding `payload_bytes` as two little-endian `u64`s gives you the frame counter and triangle count.

## Notes

- If the substrate window isn't rendering frames (e.g. unfocused on some platforms), `FrameStats` won't tick. Focus the window if observations stop arriving.
- Reply-to-sender from a WASM component is still deferred; broadcast is the live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)