### PR TITLE
feat(hub): spawn substrates as child processes (ADR-0009 PR 1)

### DIFF
--- a/crates/aether-hub/Cargo.toml
+++ b/crates/aether-hub/Cargo.toml
@@ -15,7 +15,7 @@ rmcp = { version = "0.8", features = [
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "signal", "process"] }
 tokio-util = "0.7"
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -20,6 +20,7 @@ use tokio::time::timeout;
 
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionRegistry};
+use crate::spawn::PendingSpawns;
 
 /// Cadence at which the hub sends `Heartbeat` to each engine.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -36,6 +37,7 @@ pub async fn handle_connection(
     stream: TcpStream,
     registry: EngineRegistry,
     sessions: SessionRegistry,
+    pending: PendingSpawns,
 ) -> Result<(), FrameError> {
     let (mut reader, mut writer) = stream.into_split();
 
@@ -55,9 +57,15 @@ pub async fn handle_connection(
     let welcome = HubToEngine::Welcome(Welcome { engine_id });
     write_frame_async(&mut writer, &welcome).await?;
 
+    // If this engine was spawned by the hub, fulfil the waiting spawn
+    // with the freshly minted engine id. A `false` return just means
+    // the engine was started externally — equally valid, different
+    // ownership.
+    let spawned = pending.fulfill(hello.pid, engine_id);
+
     eprintln!(
-        "aether-hub: engine registered id={} name={} pid={} version={}",
-        engine_id.0, hello.name, hello.pid, hello.version
+        "aether-hub: engine registered id={} name={} pid={} version={} spawned={}",
+        engine_id.0, hello.name, hello.pid, hello.version, spawned
     );
 
     let (mail_tx, mut mail_rx) = mpsc::channel::<HubToEngine>(MAIL_CHANNEL_CAPACITY);
@@ -68,6 +76,7 @@ pub async fn handle_connection(
         version: hello.version.clone(),
         kinds: hello.kinds,
         mail_tx,
+        spawned,
     });
 
     // Writer task: drains the mpsc into the socket and injects

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -12,6 +12,7 @@ mod engine;
 mod mcp;
 mod registry;
 mod session;
+mod spawn;
 
 pub use encoder::{EncodeError, encode_pod};
 
@@ -22,6 +23,7 @@ pub use registry::{EngineRecord, EngineRegistry};
 pub use session::{
     QueuedMail, SESSION_CHANNEL_CAPACITY, SessionHandle, SessionRecord, SessionRegistry,
 };
+pub use spawn::{DEFAULT_HANDSHAKE_TIMEOUT, PendingSpawns, SpawnError, SpawnOpts, spawn_substrate};
 
 /// Default port the hub binds for engine TCP clients. ADR-0006 V0 fixes
 /// this; `AETHER_ENGINE_PORT` overrides.
@@ -34,6 +36,7 @@ pub async fn run_engine_listener(
     addr: SocketAddr,
     registry: EngineRegistry,
     sessions: SessionRegistry,
+    pending: PendingSpawns,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     let bound = listener.local_addr()?;
@@ -43,8 +46,9 @@ pub async fn run_engine_listener(
         let (stream, peer) = listener.accept().await?;
         let registry = registry.clone();
         let sessions = sessions.clone();
+        let pending = pending.clone();
         tokio::spawn(async move {
-            if let Err(e) = engine::handle_connection(stream, registry, sessions).await {
+            if let Err(e) = engine::handle_connection(stream, registry, sessions, pending).await {
                 eprintln!("aether-hub: engine {peer} dropped: {e}");
             }
         });

--- a/crates/aether-hub/src/main.rs
+++ b/crates/aether-hub/src/main.rs
@@ -5,8 +5,8 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use aether_hub::{
-    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, SessionRegistry,
-    run_engine_listener, run_mcp_server,
+    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, PendingSpawns,
+    SessionRegistry, run_engine_listener, run_mcp_server,
 };
 
 #[tokio::main]
@@ -18,9 +18,15 @@ async fn main() -> std::io::Result<()> {
 
     let registry = EngineRegistry::new();
     let sessions = SessionRegistry::new();
+    let pending = PendingSpawns::new();
     let state = HubState::new(registry.clone(), sessions.clone());
 
-    let engine_task = tokio::spawn(run_engine_listener(engine_addr, registry, sessions));
+    let engine_task = tokio::spawn(run_engine_listener(
+        engine_addr,
+        registry,
+        sessions,
+        pending,
+    ));
     let mcp_task = tokio::spawn(run_mcp_server(mcp_addr, state));
 
     tokio::select! {

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -134,6 +134,9 @@ pub struct EngineInfo {
     pub name: String,
     pub pid: u32,
     pub version: String,
+    /// `true` if this engine was spawned by the hub (ADR-0009), `false`
+    /// if it connected externally.
+    pub spawned: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -227,7 +230,9 @@ impl Hub {
         serde_json::to_string(&out).map_err(|e| McpError::internal_error(e.to_string(), None))
     }
 
-    #[tool(description = "List all engines currently connected to the hub.")]
+    #[tool(
+        description = "List all engines currently connected to the hub. Each item reports the hub-assigned engine_id, the engine's self-declared name/pid/version, and a `spawned` flag: `true` if the hub launched this engine as a child process (ADR-0009), `false` if it connected externally."
+    )]
     async fn list_engines(&self) -> Result<String, McpError> {
         let engines: Vec<EngineInfo> = self
             .state
@@ -239,6 +244,7 @@ impl Hub {
                 name: r.name,
                 pid: r.pid,
                 version: r.version,
+                spawned: r.spawned,
             })
             .collect();
         serde_json::to_string(&engines).map_err(|e| McpError::internal_error(e.to_string(), None))
@@ -381,6 +387,7 @@ mod tests {
             version: "test".into(),
             kinds,
             mail_tx: tx,
+            spawned: false,
         };
         (rec, rx)
     }

--- a/crates/aether-hub/src/registry.rs
+++ b/crates/aether-hub/src/registry.rs
@@ -1,17 +1,24 @@
 // Shared engine registry. Keyed by hub-assigned `EngineId`; entries
 // carry display metadata and a mail channel the Claude-facing tools
-// will push `HubToEngine::Mail` frames into (PR 4).
+// push `HubToEngine::Mail` frames into.
+//
+// For engines spawned by the hub (ADR-0009), the registry also owns a
+// `tokio::process::Child` handle in a side map keyed by the same
+// `EngineId`. Removing the engine drops the child, which — with
+// `kill_on_drop(true)` — reaps the process. Externally connected
+// engines have no entry in the side map; their lifecycle is owned by
+// whoever launched them.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aether_hub_protocol::{EngineId, HubToEngine, KindDescriptor};
+use tokio::process::Child;
 use tokio::sync::mpsc;
 
-/// One entry in the hub's engine table. The `mail_tx` side is how any
-/// other task (including the MCP tool handlers, once they land) pushes
-/// frames at this engine — the per-connection writer task drains the
-/// receiver.
+/// One entry in the hub's engine table. `mail_tx` is how any other
+/// task (including MCP tool handlers) pushes frames at this engine —
+/// the per-connection writer task drains the receiver.
 #[derive(Clone, Debug)]
 pub struct EngineRecord {
     pub id: EngineId,
@@ -19,17 +26,30 @@ pub struct EngineRecord {
     pub pid: u32,
     pub version: String,
     /// Kind vocabulary the engine declared at Hello. Used by the MCP
-    /// tool surface for `describe_kinds` and, once PR 5 lands, for
-    /// schema-driven encoding on `send_mail`.
+    /// tool surface for `describe_kinds` and for schema-driven encoding
+    /// on `send_mail`.
     pub kinds: Vec<KindDescriptor>,
     pub mail_tx: mpsc::Sender<HubToEngine>,
+    /// `true` if this engine was spawned by the hub (ADR-0009).
+    /// `false` for externally connected substrates. Purely informational
+    /// — set by the engine handshake when a pending spawn is matched.
+    pub spawned: bool,
 }
 
 /// Thread-safe map of live engines. Cheap to clone; all clones share
 /// the same underlying table.
 #[derive(Clone, Default)]
 pub struct EngineRegistry {
-    inner: Arc<Mutex<HashMap<EngineId, EngineRecord>>>,
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Default)]
+struct Inner {
+    records: HashMap<EngineId, EngineRecord>,
+    /// Child processes the hub owns. Entry lifetime matches the
+    /// corresponding record — `remove` drops both together, which
+    /// kills the child via `kill_on_drop`.
+    spawned_children: HashMap<EngineId, Child>,
 }
 
 impl EngineRegistry {
@@ -38,26 +58,97 @@ impl EngineRegistry {
     }
 
     pub fn insert(&self, record: EngineRecord) {
-        self.inner.lock().unwrap().insert(record.id, record);
+        self.inner.lock().unwrap().records.insert(record.id, record);
+    }
+
+    /// Attach a spawned `Child` to an already-registered engine. Called
+    /// by `spawn_substrate` after handshake correlation completes.
+    /// Silently replaces any prior child for the same id (which will
+    /// never happen in practice but keeps the API total).
+    pub fn adopt_child(&self, id: EngineId, child: Child) {
+        self.inner
+            .lock()
+            .unwrap()
+            .spawned_children
+            .insert(id, child);
     }
 
     pub fn remove(&self, id: &EngineId) {
-        self.inner.lock().unwrap().remove(id);
+        let mut inner = self.inner.lock().unwrap();
+        inner.records.remove(id);
+        // Drop any adopted child alongside the record. `kill_on_drop`
+        // takes care of reaping if the process is still running.
+        inner.spawned_children.remove(id);
     }
 
     pub fn list(&self) -> Vec<EngineRecord> {
-        self.inner.lock().unwrap().values().cloned().collect()
+        self.inner
+            .lock()
+            .unwrap()
+            .records
+            .values()
+            .cloned()
+            .collect()
     }
 
     pub fn get(&self, id: &EngineId) -> Option<EngineRecord> {
-        self.inner.lock().unwrap().get(id).cloned()
+        self.inner.lock().unwrap().records.get(id).cloned()
     }
 
     pub fn len(&self) -> usize {
-        self.inner.lock().unwrap().len()
+        self.inner.lock().unwrap().records.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.lock().unwrap().is_empty()
+        self.inner.lock().unwrap().records.is_empty()
+    }
+
+    /// Test-only inspection of the child-handle side map. The production
+    /// flow never needs to know whether a child is adopted separately
+    /// from the `spawned: bool` on the record.
+    #[cfg(test)]
+    pub fn has_child(&self, id: &EngineId) -> bool {
+        self.inner.lock().unwrap().spawned_children.contains_key(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_hub_protocol::Uuid;
+
+    fn record(id_u128: u128) -> EngineRecord {
+        let (tx, _rx) = mpsc::channel(1);
+        EngineRecord {
+            id: EngineId(Uuid::from_u128(id_u128)),
+            name: "e".into(),
+            pid: 1,
+            version: "0".into(),
+            kinds: vec![],
+            mail_tx: tx,
+            spawned: false,
+        }
+    }
+
+    #[test]
+    fn insert_and_remove_roundtrip() {
+        let reg = EngineRegistry::new();
+        let r = record(1);
+        let id = r.id;
+        reg.insert(r);
+        assert!(reg.get(&id).is_some());
+        reg.remove(&id);
+        assert!(reg.get(&id).is_none());
+    }
+
+    #[test]
+    fn remove_without_child_is_harmless() {
+        let reg = EngineRegistry::new();
+        let r = record(2);
+        let id = r.id;
+        reg.insert(r);
+        assert!(!reg.has_child(&id));
+        reg.remove(&id);
+        assert!(reg.get(&id).is_none());
     }
 }

--- a/crates/aether-hub/src/spawn.rs
+++ b/crates/aether-hub/src/spawn.rs
@@ -1,0 +1,274 @@
+// Substrate spawn mechanism for ADR-0009 PR 1. The hub launches a
+// substrate binary as a child process with `AETHER_HUB_URL` injected,
+// then blocks until the substrate's `Hello` handshake comes back — at
+// which point the child is adopted into the engine registry so its
+// lifetime is tied to the connection.
+//
+// Correlation from PID → engine id: when the hub spawns, it registers
+// the child's PID against a pending-spawn entry. When `engine.rs`
+// processes a `Hello` frame whose PID matches, it fulfils the entry
+// with the freshly minted `EngineId`. PIDs are sufficient on localhost
+// where reuse windows are nanoseconds; token-based correlation is an
+// additive upgrade if that ever becomes a real hazard.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use aether_hub_protocol::EngineId;
+use tokio::process::Command;
+use tokio::sync::oneshot;
+
+use crate::registry::EngineRegistry;
+
+/// Default grace period the hub waits for a spawned substrate to
+/// complete its `Hello` handshake before declaring the spawn failed.
+pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Inputs to `spawn_substrate`. All fields except `binary_path` are
+/// optional; callers that want full control pass a populated struct.
+#[derive(Debug, Clone)]
+pub struct SpawnOpts {
+    pub binary_path: PathBuf,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub handshake_timeout: Duration,
+}
+
+impl SpawnOpts {
+    pub fn new(binary_path: impl Into<PathBuf>) -> Self {
+        Self {
+            binary_path: binary_path.into(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+        }
+    }
+}
+
+/// Failure modes for `spawn_substrate`. The `Child` has already been
+/// killed (or never existed) by the time the caller sees one of these.
+#[derive(Debug)]
+pub enum SpawnError {
+    /// OS-level failure launching the child.
+    Io(std::io::Error),
+    /// The spawned child exposed no PID. Only happens if the child was
+    /// already reaped before we could query it — effectively an early
+    /// exit.
+    MissingPid,
+    /// The substrate did not complete its `Hello` handshake inside the
+    /// configured window. Child killed.
+    HandshakeTimeout(Duration),
+    /// The pending-spawn entry was cancelled before fulfilment (should
+    /// not happen in normal operation — indicates a hub-internal bug).
+    HandshakeAbandoned,
+}
+
+impl fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SpawnError::Io(e) => write!(f, "io: {e}"),
+            SpawnError::MissingPid => write!(f, "spawned child reported no pid"),
+            SpawnError::HandshakeTimeout(d) => {
+                write!(f, "substrate did not handshake within {d:?}")
+            }
+            SpawnError::HandshakeAbandoned => write!(f, "handshake entry cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for SpawnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SpawnError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for SpawnError {
+    fn from(e: std::io::Error) -> Self {
+        SpawnError::Io(e)
+    }
+}
+
+/// Shared registry of spawns awaiting their matching `Hello`. Keyed by
+/// child PID. Cheap to clone; all clones share the same table.
+#[derive(Clone, Default)]
+pub struct PendingSpawns {
+    inner: Arc<Mutex<HashMap<u32, oneshot::Sender<EngineId>>>>,
+}
+
+impl PendingSpawns {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reserve a slot for a spawn about to happen. The returned receiver
+    /// fires when `fulfill(pid, engine_id)` is called by the engine
+    /// handshake path, or when the slot is cancelled.
+    pub fn register(&self, pid: u32) -> oneshot::Receiver<EngineId> {
+        let (tx, rx) = oneshot::channel();
+        let mut inner = self.inner.lock().unwrap();
+        // If a PID collision somehow occurs (shouldn't on localhost in
+        // a correlation window this tight), the older waiter gets its
+        // sender dropped — its wait resolves with RecvError and the
+        // caller maps it to HandshakeAbandoned.
+        inner.insert(pid, tx);
+        rx
+    }
+
+    /// Fulfil a pending spawn by PID. Returns true if a waiter was
+    /// matched (i.e. this engine is hub-spawned). External connections
+    /// that share a PID with no active spawn return false.
+    pub fn fulfill(&self, pid: u32, engine_id: EngineId) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        match inner.remove(&pid) {
+            Some(tx) => tx.send(engine_id).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Drop a pending entry without fulfilling it. Used on timeout /
+    /// error paths so the table doesn't accumulate stale waiters.
+    pub fn cancel(&self, pid: u32) {
+        self.inner.lock().unwrap().remove(&pid);
+    }
+
+    /// Number of outstanding waiters. Test-only.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+}
+
+/// Spawn a substrate binary as a child process, wait for its `Hello`
+/// handshake, and adopt the `Child` into the engine registry so the
+/// child's lifetime is tied to the engine record. Returns the freshly
+/// minted `EngineId` on success; on any failure the child is killed
+/// before returning.
+///
+/// `hub_engine_addr` is the address the child should dial to reach the
+/// hub — it's injected as `AETHER_HUB_URL` in the child's environment.
+pub async fn spawn_substrate(
+    opts: SpawnOpts,
+    hub_engine_addr: SocketAddr,
+    pending: &PendingSpawns,
+    engines: &EngineRegistry,
+) -> Result<EngineId, SpawnError> {
+    let mut cmd = Command::new(&opts.binary_path);
+    cmd.args(&opts.args);
+    for (k, v) in &opts.env {
+        cmd.env(k, v);
+    }
+    // Callers can override via `opts.env`, but the default we inject is
+    // the hub's engine listener address — the whole point of this API.
+    cmd.env("AETHER_HUB_URL", hub_engine_addr.to_string());
+    cmd.stdin(Stdio::null());
+    cmd.kill_on_drop(true);
+
+    let mut child = cmd.spawn()?;
+    let Some(pid) = child.id() else {
+        // Child already reaped before we could read the PID.
+        let _ = child.start_kill();
+        return Err(SpawnError::MissingPid);
+    };
+
+    let rx = pending.register(pid);
+
+    match tokio::time::timeout(opts.handshake_timeout, rx).await {
+        Ok(Ok(engine_id)) => {
+            engines.adopt_child(engine_id, child);
+            Ok(engine_id)
+        }
+        Ok(Err(_)) => {
+            pending.cancel(pid);
+            // Child drops here; kill_on_drop reaps it.
+            Err(SpawnError::HandshakeAbandoned)
+        }
+        Err(_) => {
+            pending.cancel(pid);
+            Err(SpawnError::HandshakeTimeout(opts.handshake_timeout))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_hub_protocol::Uuid;
+
+    fn engine_id(n: u128) -> EngineId {
+        EngineId(Uuid::from_u128(n))
+    }
+
+    #[tokio::test]
+    async fn register_then_fulfill_delivers_engine_id() {
+        let pending = PendingSpawns::new();
+        let rx = pending.register(1234);
+        assert_eq!(pending.len(), 1);
+
+        assert!(pending.fulfill(1234, engine_id(7)));
+        let got = rx.await.expect("fulfilled");
+        assert_eq!(got, engine_id(7));
+        assert_eq!(pending.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn fulfill_unknown_pid_returns_false() {
+        let pending = PendingSpawns::new();
+        assert!(!pending.fulfill(9999, engine_id(1)));
+    }
+
+    #[tokio::test]
+    async fn cancel_removes_waiter_and_receiver_resolves_err() {
+        let pending = PendingSpawns::new();
+        let rx = pending.register(42);
+        pending.cancel(42);
+        assert_eq!(pending.len(), 0);
+        rx.await.expect_err("receiver should see dropped sender");
+    }
+
+    #[tokio::test]
+    async fn duplicate_register_drops_older_waiter() {
+        let pending = PendingSpawns::new();
+        let rx_old = pending.register(100);
+        let _rx_new = pending.register(100);
+        assert_eq!(pending.len(), 1);
+        rx_old.await.expect_err("older waiter should be dropped");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn spawn_times_out_when_child_never_handshakes() {
+        // /bin/sh + sleep is present on macOS and every Linux we care
+        // about. We point AETHER_HUB_URL at an unreachable address so
+        // even if the child tried to dial back, it would fail — the
+        // shape we actually test is that the pending entry times out,
+        // the helper returns HandshakeTimeout, and no child leaks.
+        let pending = PendingSpawns::new();
+        let engines = EngineRegistry::new();
+        let opts = SpawnOpts {
+            binary_path: PathBuf::from("/bin/sh"),
+            args: vec!["-c".into(), "sleep 60".into()],
+            env: HashMap::new(),
+            handshake_timeout: Duration::from_millis(150),
+        };
+        let unreachable: SocketAddr = "127.0.0.1:1".parse().unwrap();
+
+        let start = std::time::Instant::now();
+        let err = spawn_substrate(opts, unreachable, &pending, &engines)
+            .await
+            .expect_err("expected timeout");
+        assert!(matches!(err, SpawnError::HandshakeTimeout(_)), "{err:?}");
+        // Sanity: the helper didn't block much past the configured
+        // timeout — if it did, we'd be leaking handles or awaits.
+        assert!(start.elapsed() < Duration::from_secs(2));
+
+        assert_eq!(pending.len(), 0, "pending entry should be cleaned up");
+    }
+}

--- a/crates/aether-hub/tests/engine_handshake.rs
+++ b/crates/aether-hub/tests/engine_handshake.rs
@@ -4,7 +4,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
-use aether_hub::{EngineRegistry, SessionRegistry, run_engine_listener};
+use aether_hub::{EngineRegistry, PendingSpawns, SessionRegistry, run_engine_listener};
 use aether_hub_protocol::{EngineToHub, Goodbye, Hello, HubToEngine, encode_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -17,10 +17,12 @@ async fn spawn_hub() -> (SocketAddr, EngineRegistry, SessionRegistry) {
     drop(listener);
     let registry = EngineRegistry::new();
     let sessions = SessionRegistry::new();
+    let pending = PendingSpawns::new();
     tokio::spawn(run_engine_listener(
         addr,
         registry.clone(),
         sessions.clone(),
+        pending,
     ));
     // Give the listener a beat to bind.
     tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
## Summary
Hub-internal spawn mechanism for ADR-0009, without yet exposing it via MCP. Sets up the scaffolding so PR 2 can add a thin MCP tool on top.

- **`spawn_substrate(opts, hub_addr, &pending, &engines)`**: launches a child process with `AETHER_HUB_URL` injected and `kill_on_drop(true)`, waits on handshake correlation, and adopts the `Child` into the engine registry on success.
- **PID-based handshake correlation**: the hub registers the child's PID into a `PendingSpawns` table; when the engine handshake sees a matching `Hello`, it fulfils the waiter with the freshly minted `EngineId`. On timeout the child is killed and the entry cleaned up.
- **Registry ownership of spawned children**: `EngineRegistry` grows an internal `HashMap<EngineId, Child>` side map. Removing an engine drops the child (which `kill_on_drop` reaps). Externally connected engines have no child entry — unchanged behavior.
- **`spawned: bool`** on `EngineRecord` and the MCP `list_engines` output, set `true` when a pending spawn is matched at handshake. Always `false` today (no MCP tool yet).

PR 2 will add `spawn_substrate` / `terminate_substrate` MCP tools on top of this surface.

## Test plan
- [x] `cargo test -p aether-hub` — 43 unit tests pass; 5 engine_handshake integration tests still green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] New `PendingSpawns` unit tests: register/fulfill, cancel, duplicate-register, unknown-PID.
- [x] New end-to-end timeout test: spawns `/bin/sh -c "sleep 60"` pointed at an unreachable hub address, verifies `HandshakeTimeout` fires within the configured window and `PendingSpawns` is cleaned up. The child is reaped by `kill_on_drop`.

## Decisions flagged in the ADR that this PR implements
- **PID correlation** (vs. token): shipped PID; simpler wire and sufficient for localhost V0. Token is additive if PID reuse ever bites.
- **Synchronous-feeling spawn**: `spawn_substrate` blocks until handshake with a configurable timeout.
- **Kill-on-drop + graceful teardown**: children die with the hub. Graceful SIGTERM vs SIGKILL is PR 3's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)