### PR TITLE
feat(hub): stamp origin on observation mail (ADR-0011)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "aether-hub-protocol",
  "axum",
  "bytemuck",
+ "libc",
  "postcard",
  "rmcp",
  "schemars",

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -244,6 +244,7 @@ mod tests {
             address: ClaudeAddress::Session(token),
             kind_name: "aether.observation.ping".into(),
             payload: vec![1, 2, 3],
+            origin: Some("physics".into()),
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();
@@ -253,6 +254,7 @@ mod tests {
                 assert_eq!(m.address, ClaudeAddress::Session(token));
                 assert_eq!(m.kind_name, "aether.observation.ping");
                 assert_eq!(m.payload, vec![1, 2, 3]);
+                assert_eq!(m.origin.as_deref(), Some("physics"));
             }
             _ => panic!("wrong variant"),
         }
@@ -264,12 +266,16 @@ mod tests {
             address: ClaudeAddress::Broadcast,
             kind_name: "aether.observation.world".into(),
             payload: vec![],
+            origin: None,
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();
         let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
         match back {
-            EngineToHub::Mail(m) => assert_eq!(m.address, ClaudeAddress::Broadcast),
+            EngineToHub::Mail(m) => {
+                assert_eq!(m.address, ClaudeAddress::Broadcast);
+                assert!(m.origin.is_none());
+            }
             _ => panic!("wrong variant"),
         }
     }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -126,12 +126,16 @@ pub struct MailFrame {
 /// A piece of mail the engine is sending to one or more Claude
 /// sessions through the hub. The hub owns session routing, so the
 /// engine addresses by `ClaudeAddress` rather than by session id or
-/// recipient name (ADR-0008).
+/// recipient name (ADR-0008). `origin` is the substrate-local mailbox
+/// name of the emitting component (ADR-0011); `None` for substrate
+/// core pushes that have no sending mailbox. The hub forwards it
+/// verbatim and does not validate.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineMailFrame {
     pub address: ClaudeAddress,
     pub kind_name: String,
     pub payload: Vec<u8>,
+    pub origin: Option<String>,
 }
 
 /// How an engine-originated mail is addressed at the hub. `Session`

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -162,6 +162,7 @@ async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail
         address,
         kind_name,
         payload,
+        origin,
     } = mail;
     match address {
         ClaudeAddress::Session(token) => match sessions.get(&token) {
@@ -171,6 +172,7 @@ async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail
                     kind_name,
                     payload,
                     broadcast: false,
+                    origin,
                 };
                 if record.mail_tx.send(queued).await.is_err() {
                     eprintln!(
@@ -197,6 +199,7 @@ async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail
                     kind_name: kind_name.clone(),
                     payload: payload.clone(),
                     broadcast: true,
+                    origin: origin.clone(),
                 };
                 if record.mail_tx.send(queued).await.is_err() {
                     eprintln!(
@@ -255,6 +258,16 @@ mod tests {
             address,
             kind_name: "aether.observation.ping".into(),
             payload,
+            origin: None,
+        }
+    }
+
+    fn mail_with_origin(address: ClaudeAddress, payload: Vec<u8>, origin: &str) -> EngineMailFrame {
+        EngineMailFrame {
+            address,
+            kind_name: "aether.observation.ping".into(),
+            payload,
+            origin: Some(origin.into()),
         }
     }
 
@@ -267,7 +280,7 @@ mod tests {
         route_engine_mail(
             &sessions,
             engine_id(1),
-            mail(ClaudeAddress::Session(a.token), vec![1, 2, 3]),
+            mail_with_origin(ClaudeAddress::Session(a.token), vec![1, 2, 3], "physics"),
         )
         .await;
 
@@ -275,6 +288,7 @@ mod tests {
         assert_eq!(got.payload, vec![1, 2, 3]);
         assert_eq!(got.engine_id, engine_id(1));
         assert!(!got.broadcast, "session address should not set broadcast");
+        assert_eq!(got.origin.as_deref(), Some("physics"));
         assert!(rx_b.try_recv().is_err(), "b should not have received");
     }
 
@@ -304,7 +318,7 @@ mod tests {
         route_engine_mail(
             &sessions,
             engine_id(1),
-            mail(ClaudeAddress::Broadcast, vec![42]),
+            mail_with_origin(ClaudeAddress::Broadcast, vec![42], "render"),
         )
         .await;
 
@@ -313,6 +327,7 @@ mod tests {
             assert_eq!(got.payload, vec![42]);
             assert!(got.broadcast, "{name}: broadcast flag should be set");
             assert_eq!(got.engine_id, engine_id(1));
+            assert_eq!(got.origin.as_deref(), Some("render"), "{name}: origin");
         }
     }
 

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -228,6 +228,11 @@ pub struct ReceivedMail {
     /// `true` if this mail was addressed to every attached session;
     /// `false` if it was a reply targeted at this session specifically.
     pub broadcast: bool,
+    /// Substrate-attested name of the emitting mailbox (ADR-0011).
+    /// Distinguishes components that share a kind. `None` for mail
+    /// pushed by substrate core (e.g. the frame loop's `FrameStats`),
+    /// which has no sending mailbox.
+    pub origin: Option<String>,
 }
 
 #[tool_router]
@@ -276,7 +281,7 @@ impl Hub {
     }
 
     #[tool(
-        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, the raw payload bytes, and a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false). Non-blocking: returns an empty array if nothing is queued."
+        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, the raw payload bytes, a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false), and an optional `origin` — the substrate-local mailbox name of the emitting component (absent for substrate-core pushes with no sending mailbox). Non-blocking: returns an empty array if nothing is queued."
     )]
     async fn receive_mail(
         &self,
@@ -292,6 +297,7 @@ impl Hub {
                     kind_name: m.kind_name,
                     payload_bytes: m.payload,
                     broadcast: m.broadcast,
+                    origin: m.origin,
                 }),
                 Err(_) => break,
             }
@@ -877,6 +883,7 @@ mod tests {
             kind_name: kind.into(),
             payload,
             broadcast,
+            origin: None,
         }
     }
 
@@ -921,11 +928,28 @@ mod tests {
         assert_eq!(got[0].payload_bytes, vec![1, 2]);
         assert!(!got[0].broadcast);
         assert_eq!(got[0].engine_id, Uuid::from_u128(7).to_string());
+        assert!(got[0].origin.is_none());
         assert!(got[1].broadcast);
+        assert!(got[1].origin.is_none());
 
         // Queue is now empty.
         let got = drain(&hub, None).await;
         assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn receive_mail_surfaces_origin() {
+        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        let mut with_origin = queued(3, "aether.observation.frame_stats", vec![], true);
+        with_origin.origin = Some("render".into());
+        push_queued(&state.sessions, token, with_origin).await;
+
+        let got = drain(&hub, None).await;
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].origin.as_deref(), Some("render"));
     }
 
     #[tokio::test]

--- a/crates/aether-hub/src/session.rs
+++ b/crates/aether-hub/src/session.rs
@@ -29,6 +29,11 @@ pub struct QueuedMail {
     pub kind_name: String,
     pub payload: Vec<u8>,
     pub broadcast: bool,
+    /// Substrate-attested origin — the mailbox name of the emitting
+    /// component, forwarded verbatim from `EngineMailFrame::origin`
+    /// (ADR-0011). `None` for substrate-core pushes with no sending
+    /// mailbox.
+    pub origin: Option<String>,
 }
 
 /// One entry in the hub's session table. `mail_tx` is how the engine

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -31,8 +31,12 @@ impl SubstrateCtx {
         match self.registry.entry(recipient) {
             Some(MailboxEntry::Sink(handler)) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or("");
-                // Component-originated mail has no Claude-side sender.
-                handler(kind_name, SessionToken::NIL, &payload, count);
+                // Component-originated mail: the sender is this ctx's
+                // mailbox, so its registry name is the `origin` any
+                // sink cares about (ADR-0011). Claude-side session is
+                // `NIL` — component sends never have a reply-to target.
+                let origin = self.registry.mailbox_name(self.sender);
+                handler(kind_name, origin, SessionToken::NIL, &payload, count);
             }
             Some(MailboxEntry::Component) => {
                 self.queue.push(Mail::new(recipient, kind, payload, count));

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -213,10 +213,12 @@ fn main() -> wasmtime::Result<()> {
     let tris_for_sink = Arc::clone(&triangles_rendered);
     let sink_mbox = registry.register_sink(
         "render",
-        Arc::new(move |_kind: &str, _sender, bytes: &[u8], count: u32| {
-            verts_for_sink.lock().unwrap().extend_from_slice(bytes);
-            tris_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
-        }),
+        Arc::new(
+            move |_kind: &str, _origin: Option<&str>, _sender, bytes: &[u8], count: u32| {
+                verts_for_sink.lock().unwrap().extend_from_slice(bytes);
+                tris_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
+            },
+        ),
     );
 
     // Reserved well-known sink: mail sent here is forwarded to every
@@ -228,19 +230,26 @@ fn main() -> wasmtime::Result<()> {
         let outbound = Arc::clone(&outbound);
         registry.register_sink(
             HUB_CLAUDE_BROADCAST,
-            Arc::new(move |kind_name: &str, _sender, bytes: &[u8], _count: u32| {
-                if kind_name.is_empty() {
-                    eprintln!(
-                        "aether-substrate: {HUB_CLAUDE_BROADCAST} received mail with unregistered kind — dropping"
-                    );
-                    return;
-                }
-                outbound.send(EngineToHub::Mail(EngineMailFrame {
-                    address: ClaudeAddress::Broadcast,
-                    kind_name: kind_name.to_owned(),
-                    payload: bytes.to_vec(),
-                }));
-            }),
+            Arc::new(
+                move |kind_name: &str,
+                      origin: Option<&str>,
+                      _sender,
+                      bytes: &[u8],
+                      _count: u32| {
+                    if kind_name.is_empty() {
+                        eprintln!(
+                            "aether-substrate: {HUB_CLAUDE_BROADCAST} received mail with unregistered kind — dropping"
+                        );
+                        return;
+                    }
+                    outbound.send(EngineToHub::Mail(EngineMailFrame {
+                        address: ClaudeAddress::Broadcast,
+                        kind_name: kind_name.to_owned(),
+                        payload: bytes.to_vec(),
+                        origin: origin.map(str::to_owned),
+                    }));
+                },
+            ),
         )
     };
 

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -14,11 +14,14 @@ use crate::mail::MailboxId;
 /// Handler invoked when mail is delivered to a substrate-owned sink.
 /// Called on a scheduler worker thread; must be `Send + Sync`.
 /// Arguments: kind name (resolved by the dispatcher so sinks don't
-/// need a reverse lookup), the originating Claude session token for
-/// hub-inbound mail (or `SessionToken::NIL` for substrate-local mail)
-/// per ADR-0008's reply-to-sender primitive, payload bytes, and the
-/// kind-implied count.
-pub type SinkHandler = Arc<dyn Fn(&str, SessionToken, &[u8], u32) + Send + Sync + 'static>;
+/// need a reverse lookup), the sending mailbox's registered name if
+/// the mail came from a component (`None` for substrate-core pushes
+/// with no sending mailbox, per ADR-0011), the originating Claude
+/// session token for hub-inbound mail (or `SessionToken::NIL` for
+/// substrate-local mail) per ADR-0008's reply-to-sender primitive,
+/// payload bytes, and the kind-implied count.
+pub type SinkHandler =
+    Arc<dyn Fn(&str, Option<&str>, SessionToken, &[u8], u32) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -32,6 +35,10 @@ pub enum MailboxEntry {
 pub struct Registry {
     by_name: HashMap<String, MailboxId>,
     entries: Vec<MailboxEntry>,
+    /// Parallel index: `mailbox_names[id]` is the name the mailbox was
+    /// registered with. Enables the `MailboxId` → name reverse lookup
+    /// used to stamp `origin` on observation mail (ADR-0011).
+    mailbox_names: Vec<String>,
     kind_by_name: HashMap<String, u32>,
     /// Parallel index: `kind_names[id]` is the canonical name the kind
     /// was first registered with. Kept in sync with `kind_by_name` so
@@ -45,6 +52,7 @@ impl Registry {
         Self {
             by_name: HashMap::new(),
             entries: Vec::new(),
+            mailbox_names: Vec::new(),
             kind_by_name: HashMap::new(),
             kind_names: Vec::new(),
         }
@@ -57,6 +65,7 @@ impl Registry {
         }
         let id = MailboxId(self.entries.len() as u32);
         self.entries.push(entry);
+        self.mailbox_names.push(name.clone());
         self.by_name.insert(name, id);
         id
     }
@@ -80,6 +89,13 @@ impl Registry {
 
     pub fn entry(&self, id: MailboxId) -> Option<&MailboxEntry> {
         self.entries.get(id.0 as usize)
+    }
+
+    /// Reverse of `lookup`: name for a given mailbox id, or `None` if
+    /// the id is out of range. Used by the sink dispatch path to stamp
+    /// `origin` on observation mail (ADR-0011).
+    pub fn mailbox_name(&self, id: MailboxId) -> Option<&str> {
+        self.mailbox_names.get(id.0 as usize).map(|s| s.as_str())
     }
 
     /// Register a mail kind by name. Idempotent — re-registering a name
@@ -144,15 +160,15 @@ mod tests {
         let c2 = Arc::clone(&counter);
         let id = r.register_sink(
             "heartbeat",
-            Arc::new(move |_kind, _sender, _bytes, count| {
+            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
                 c2.fetch_add(count, Ordering::SeqCst);
             }),
         );
         let Some(MailboxEntry::Sink(h)) = r.entry(id) else {
             panic!("expected sink")
         };
-        h("aether.tick", SessionToken::NIL, &[], 7);
-        h("aether.tick", SessionToken::NIL, &[], 3);
+        h("aether.tick", None, SessionToken::NIL, &[], 7);
+        h("aether.tick", Some("physics"), SessionToken::NIL, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 
@@ -160,7 +176,7 @@ mod tests {
     fn mailbox_ids_are_dense_and_sequential() {
         let mut r = Registry::new();
         let a = r.register_component("a");
-        let b = r.register_sink("b", Arc::new(|_, _, _, _| {}));
+        let b = r.register_sink("b", Arc::new(|_, _, _, _, _| {}));
         let c = r.register_component("c");
         assert_eq!(a, MailboxId(0));
         assert_eq!(b, MailboxId(1));
@@ -209,6 +225,16 @@ mod tests {
         let id = r.register_kind("aether.tick");
         assert_eq!(r.kind_id("aether.tick"), Some(id));
         assert!(r.kind_id("absent").is_none());
+    }
+
+    #[test]
+    fn mailbox_name_reverse_lookup() {
+        let mut r = Registry::new();
+        let a = r.register_component("physics");
+        let b = r.register_sink("hub.claude.broadcast", Arc::new(|_, _, _, _, _| {}));
+        assert_eq!(r.mailbox_name(a), Some("physics"));
+        assert_eq!(r.mailbox_name(b), Some("hub.claude.broadcast"));
+        assert!(r.mailbox_name(MailboxId(999)).is_none());
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -91,7 +91,12 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
         match ctx.registry.entry(recipient) {
             Some(MailboxEntry::Sink(handler)) => {
                 let kind_name = ctx.registry.kind_name(mail.kind).unwrap_or("");
-                handler(kind_name, mail.sender, &mail.payload, mail.count);
+                // Mail reaching a sink through the scheduler queue
+                // came from substrate core (e.g. the frame loop's
+                // FrameStats push) and has no sending mailbox; per
+                // ADR-0011 origin is `None`. Components reach sinks
+                // inline via `SubstrateCtx::send`, not this path.
+                handler(kind_name, None, mail.sender, &mail.payload, mail.count);
             }
             Some(MailboxEntry::Component) => match ctx.components.get(&recipient) {
                 Some(lock) => {

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -50,7 +50,7 @@ fn tick_roundtrip_component_to_sink() {
     let c2 = Arc::clone(&counter);
     let sink_mbox = registry.register_sink(
         "heartbeat",
-        Arc::new(move |_kind, _sender, _bytes, count| {
+        Arc::new(move |_kind, _origin, _sender, _bytes, count| {
             c2.fetch_add(count, Ordering::SeqCst);
         }),
     );

--- a/crates/aether-substrate/tests/hub_client.rs
+++ b/crates/aether-substrate/tests/hub_client.rs
@@ -100,7 +100,11 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let recipient = registry.register_sink(
         "hello",
         Arc::new(
-            move |_kind: &str, sender: SessionToken, bytes: &[u8], count: u32| {
+            move |_kind: &str,
+                  _origin: Option<&str>,
+                  sender: SessionToken,
+                  bytes: &[u8],
+                  count: u32| {
                 let (lock, cv) = &*seen_for_sink;
                 let mut s = lock.lock().unwrap();
                 s.count_sum += count;
@@ -339,6 +343,7 @@ fn outbound_sends_reach_the_hub_wire() {
         address: ClaudeAddress::Broadcast,
         kind_name: "aether.observation.ping".into(),
         payload: vec![1, 2, 3],
+        origin: Some("physics".into()),
     })));
 
     // Read it back on the server side. Heartbeats may arrive too —
@@ -354,6 +359,7 @@ fn outbound_sends_reach_the_hub_wire() {
     assert_eq!(observed.address, ClaudeAddress::Broadcast);
     assert_eq!(observed.kind_name, "aether.observation.ping");
     assert_eq!(observed.payload, vec![1, 2, 3]);
+    assert_eq!(observed.origin.as_deref(), Some("physics"));
 
     drop(stream);
 }
@@ -367,6 +373,7 @@ fn outbound_send_without_attach_is_noop() {
         address: ClaudeAddress::Broadcast,
         kind_name: "aether.tick".into(),
         payload: vec![],
+        origin: None,
     }));
     assert!(!ok);
 }


### PR DESCRIPTION
## Summary

Implements ADR-0011 end-to-end: observation mail now carries an optional `origin` — the substrate-local mailbox name of the emitting component — all the way from the substrate through the hub to the MCP `receive_mail` tool output.

- `EngineMailFrame` in `aether-hub-protocol` grows `origin: Option<String>`; `QueuedMail` and `ReceivedMail` mirror the field.
- Substrate `SinkHandler` grows an `Option<&str>` origin argument. `SubstrateCtx::send` resolves it via a new `Registry::mailbox_name` reverse lookup (components always have a sender). The scheduler worker loop always passes `None` — any mail reaching a sink via the queue came from substrate core and has no sending mailbox.
- The well-known `hub.claude.broadcast` sink stamps the resolved name onto the outbound `EngineMailFrame`.
- Hub is a transparent passthrough: it neither validates nor normalizes `origin`.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Smoke test end-to-end once merged: restart hub, spawn substrate, drain `receive_mail` and confirm the live FrameStats broadcast carries `origin: null` (substrate-core push) while any component-sourced broadcast surfaces the component name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)