### PR TITLE
feat(substrate): control-kind vocabulary + descriptor-aware kinds (ADR-0010 PR 2)

### DIFF
--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -15,7 +15,10 @@ use alloc::vec::Vec;
 use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive};
 use aether_mail::Kind;
 
-use crate::{DrawTriangle, FrameStats, Key, MouseButton, MouseMove, Tick};
+use crate::{
+    DrawTriangle, DropComponent, FrameStats, Key, LoadComponent, LoadResult, MouseButton,
+    MouseMove, ReplaceComponent, Tick,
+};
 
 /// Every kind the substrate exposes, in the order the `Registry` will
 /// register them. Caller ignores the order — names are the contract.
@@ -42,6 +45,14 @@ pub fn all() -> Vec<KindDescriptor> {
                 scalar("triangles", PodPrimitive::U64),
             ],
         ),
+        // ADR-0010 control-plane kinds. Variable-length payloads that
+        // don't fit the Pod model — the substrate handler decodes via
+        // postcard against its own wire types. Agents that use the MCP
+        // `send_mail` tool supply these as raw `payload_bytes`.
+        opaque(LoadComponent::NAME),
+        opaque(ReplaceComponent::NAME),
+        opaque(DropComponent::NAME),
+        opaque(LoadResult::NAME),
     ]
 }
 
@@ -86,6 +97,24 @@ mod tests {
         assert!(names.contains(&MouseButton::NAME));
         assert!(names.contains(&MouseMove::NAME));
         assert!(names.contains(&DrawTriangle::NAME));
+        assert!(names.contains(&LoadComponent::NAME));
+        assert!(names.contains(&ReplaceComponent::NAME));
+        assert!(names.contains(&DropComponent::NAME));
+        assert!(names.contains(&LoadResult::NAME));
+    }
+
+    #[test]
+    fn control_kinds_are_opaque() {
+        let descs = all();
+        for name in [
+            LoadComponent::NAME,
+            ReplaceComponent::NAME,
+            DropComponent::NAME,
+            LoadResult::NAME,
+        ] {
+            let d = descs.iter().find(|d| d.name == name).unwrap();
+            assert_eq!(d.encoding, KindEncoding::Opaque, "{name}");
+        }
     }
 
     #[test]

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -94,6 +94,48 @@ impl Kind for FrameStats {
     const NAME: &'static str = "aether.observation.frame_stats";
 }
 
+// Reserved control-plane vocabulary (ADR-0010). The substrate handles
+// these kinds inline rather than dispatching to a component — the
+// namespace itself is the routing discriminator. Payloads are not Pod,
+// so each is `Opaque`: the substrate-side handler decodes via postcard
+// against substrate-internal types. Keeping them here (alongside the
+// engine-facing kinds) means the hub's `describe_kinds` surfaces them
+// uniformly and the init path registers them exactly once at boot.
+
+/// `aether.control.load_component` — request the substrate load a WASM
+/// component into a freshly allocated mailbox. Payload carries the WASM
+/// bytes, any new kinds the component intends to use, and an optional
+/// human-readable name. The substrate replies with `load_result`.
+pub struct LoadComponent;
+impl Kind for LoadComponent {
+    const NAME: &'static str = "aether.control.load_component";
+}
+
+/// `aether.control.replace_component` — atomically rebind a target
+/// mailbox id to a freshly instantiated component. Any mail queued on
+/// the old instance at the moment of swap is dropped (V0 policy; drain
+/// is an additive follow-up).
+pub struct ReplaceComponent;
+impl Kind for ReplaceComponent {
+    const NAME: &'static str = "aether.control.replace_component";
+}
+
+/// `aether.control.drop_component` — remove a component from the
+/// substrate and invalidate its mailbox id.
+pub struct DropComponent;
+impl Kind for DropComponent {
+    const NAME: &'static str = "aether.control.drop_component";
+}
+
+/// `aether.control.load_result` — reply-to-sender emitted by the
+/// substrate after handling `load_component`. Carries the assigned
+/// mailbox id on success or an error describing why the load failed
+/// (kind-descriptor conflict, invalid WASM, etc.).
+pub struct LoadResult;
+impl Kind for LoadResult {
+    const NAME: &'static str = "aether.control.load_result";
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,6 +186,10 @@ mod tests {
         assert_eq!(MouseMove::NAME, "aether.mouse_move");
         assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
         assert_eq!(FrameStats::NAME, "aether.observation.frame_stats");
+        assert_eq!(LoadComponent::NAME, "aether.control.load_component");
+        assert_eq!(ReplaceComponent::NAME, "aether.control.replace_component");
+        assert_eq!(DropComponent::NAME, "aether.control.drop_component");
+        assert_eq!(LoadResult::NAME, "aether.control.load_result");
     }
 
     #[test]

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -24,7 +24,7 @@ use aether_substrate::{
     SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
-use aether_substrate_mail::{DrawTriangle, FrameStats, Key, MouseButton, MouseMove, Tick};
+use aether_substrate_mail::{FrameStats, Key, MouseButton, MouseMove, Tick};
 use render::Gpu;
 use wasmtime::{Engine, Linker, Module};
 use winit::application::ApplicationHandler;
@@ -195,16 +195,28 @@ fn main() -> wasmtime::Result<()> {
     let registry = Arc::new(Registry::new());
     let component_mbox = registry.register_component("hello");
 
-    // Pre-register every substrate-owned kind by name so the component
-    // can resolve them during `init` via the `resolve_kind` host fn.
+    // Pre-register every substrate-owned kind with its descriptor so
+    // the Registry agrees with what the hub receives at `Hello` and
+    // ADR-0010's load-time conflict check has the right reference.
     // Ids are dense and assigned in the order below; not otherwise
     // meaningful — consumers always resolve by name.
-    let kind_tick = registry.register_kind(Tick::NAME);
-    let kind_key = registry.register_kind(Key::NAME);
-    let kind_mouse_button = registry.register_kind(MouseButton::NAME);
-    let kind_mouse_move = registry.register_kind(MouseMove::NAME);
-    registry.register_kind(DrawTriangle::NAME);
-    let kind_frame_stats = registry.register_kind(FrameStats::NAME);
+    let boot_descriptors = aether_substrate_mail::descriptors::all();
+    for d in &boot_descriptors {
+        registry
+            .register_kind_with_descriptor(d.clone())
+            .expect("duplicate kind in substrate init");
+    }
+    let kind_tick = registry.kind_id(Tick::NAME).expect("Tick registered");
+    let kind_key = registry.kind_id(Key::NAME).expect("Key registered");
+    let kind_mouse_button = registry
+        .kind_id(MouseButton::NAME)
+        .expect("MouseButton registered");
+    let kind_mouse_move = registry
+        .kind_id(MouseMove::NAME)
+        .expect("MouseMove registered");
+    let kind_frame_stats = registry
+        .kind_id(FrameStats::NAME)
+        .expect("FrameStats registered");
 
     let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(4096)));
     let triangles_rendered = Arc::new(AtomicU64::new(0));
@@ -289,7 +301,7 @@ fn main() -> wasmtime::Result<()> {
             url.as_str(),
             "hello-triangle",
             env!("CARGO_PKG_VERSION"),
-            aether_substrate_mail::descriptors::all(),
+            boot_descriptors.clone(),
             Arc::clone(&registry),
             Arc::clone(&queue),
             Arc::clone(&outbound),

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -8,9 +8,10 @@
 // /drop).
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{Arc, RwLock};
 
-use aether_hub_protocol::SessionToken;
+use aether_hub_protocol::{KindDescriptor, KindEncoding, SessionToken};
 
 use crate::mail::MailboxId;
 
@@ -56,7 +57,37 @@ struct Inner {
     /// `kind_name(id)` is O(1); used by `SinkHandler` dispatch to hand
     /// sinks the name without forcing them to keep their own map.
     kind_names: Vec<String>,
+    /// Parallel index: `kind_descriptors[id]` is the descriptor the
+    /// kind was first registered with. `register_kind` (name-only)
+    /// defaults to `Opaque`; ADR-0010's runtime loader supplies a real
+    /// descriptor via `register_kind_with_descriptor` and rejects
+    /// conflicts against this stored copy.
+    kind_descriptors: Vec<KindDescriptor>,
 }
+
+/// Rejected-load error returned when a runtime kind registration
+/// names an existing kind but supplies a different descriptor than the
+/// one first seen. Per ADR-0010, the load fails rather than silently
+/// reinterpreting; agents rename, evolve the existing descriptor, or
+/// restart the substrate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KindConflict {
+    pub name: String,
+    pub existing: KindEncoding,
+    pub requested: KindEncoding,
+}
+
+impl fmt::Display for KindConflict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "kind {:?} already registered with a different encoding (existing={:?}, requested={:?})",
+            self.name, self.existing, self.requested
+        )
+    }
+}
+
+impl std::error::Error for KindConflict {}
 
 impl Registry {
     pub fn new() -> Self {
@@ -119,19 +150,68 @@ impl Registry {
             .cloned()
     }
 
-    /// Register a mail kind by name. Idempotent — re-registering a name
-    /// returns the id it was first assigned. Ids are dense and assigned
-    /// in insertion order, per ADR-0005's kind-name registry.
+    /// Register a mail kind by name, defaulting to an `Opaque`
+    /// descriptor. Idempotent — re-registering a name returns the id
+    /// it was first assigned, regardless of whether the first call
+    /// supplied a descriptor. Kept as a convenience for tests and
+    /// substrate-internal registrations that don't need the hub to
+    /// encode params; production init should prefer
+    /// `register_kind_with_descriptor` so the descriptor stored here
+    /// matches the one shipped to the hub at `Hello`.
     pub fn register_kind(&self, name: impl Into<String>) -> u32 {
         let name = name.into();
+        let descriptor = KindDescriptor {
+            name: name.clone(),
+            encoding: KindEncoding::Opaque,
+        };
+        // Name-only registration never conflicts: if the name is new
+        // we store Opaque; if it exists we return the existing id and
+        // leave its descriptor untouched.
+        self.register_kind_internal(name, descriptor, /*reject_conflict=*/ false)
+            .expect("Opaque default cannot produce a conflict")
+    }
+
+    /// Register a mail kind along with the descriptor the hub will
+    /// use to encode agent-supplied params (ADR-0007). Per ADR-0010:
+    ///
+    /// - Fresh name → assign a new id, store the descriptor.
+    /// - Existing name with identical descriptor → return the id.
+    /// - Existing name with a different descriptor → `KindConflict`.
+    ///
+    /// Used by substrate boot (to agree with `descriptors::all()`) and
+    /// by the future `load_component` handler when a runtime-loaded
+    /// component brings its own kind vocabulary.
+    pub fn register_kind_with_descriptor(
+        &self,
+        descriptor: KindDescriptor,
+    ) -> Result<u32, KindConflict> {
+        let name = descriptor.name.clone();
+        self.register_kind_internal(name, descriptor, /*reject_conflict=*/ true)
+    }
+
+    fn register_kind_internal(
+        &self,
+        name: String,
+        descriptor: KindDescriptor,
+        reject_conflict: bool,
+    ) -> Result<u32, KindConflict> {
         let mut inner = self.inner.write().unwrap();
         if let Some(&id) = inner.kind_by_name.get(&name) {
-            return id;
+            let existing = &inner.kind_descriptors[id as usize];
+            if reject_conflict && existing.encoding != descriptor.encoding {
+                return Err(KindConflict {
+                    name,
+                    existing: existing.encoding.clone(),
+                    requested: descriptor.encoding,
+                });
+            }
+            return Ok(id);
         }
         let id = inner.kind_names.len() as u32;
         inner.kind_names.push(name.clone());
+        inner.kind_descriptors.push(descriptor);
         inner.kind_by_name.insert(name, id);
-        id
+        Ok(id)
     }
 
     pub fn kind_id(&self, name: &str) -> Option<u32> {
@@ -146,6 +226,18 @@ impl Registry {
             .read()
             .unwrap()
             .kind_names
+            .get(id as usize)
+            .cloned()
+    }
+
+    /// The descriptor stored for a given kind id, or `None` if the id
+    /// is out of range. Returned as an owned clone so callers don't
+    /// hold the read lock while inspecting the encoding.
+    pub fn kind_descriptor(&self, id: u32) -> Option<KindDescriptor> {
+        self.inner
+            .read()
+            .unwrap()
+            .kind_descriptors
             .get(id as usize)
             .cloned()
     }
@@ -272,6 +364,82 @@ mod tests {
         assert_eq!(r.kind_name(a).as_deref(), Some("aether.tick"));
         assert_eq!(r.kind_name(b).as_deref(), Some("aether.key"));
         assert!(r.kind_name(999).is_none());
+    }
+
+    fn opaque_desc(name: &str) -> KindDescriptor {
+        KindDescriptor {
+            name: name.to_string(),
+            encoding: KindEncoding::Opaque,
+        }
+    }
+
+    fn pod_desc(name: &str) -> KindDescriptor {
+        use aether_hub_protocol::{PodField, PodFieldType, PodPrimitive};
+        KindDescriptor {
+            name: name.to_string(),
+            encoding: KindEncoding::Pod {
+                fields: vec![PodField {
+                    name: "x".to_string(),
+                    ty: PodFieldType::Scalar(PodPrimitive::U32),
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn register_kind_with_descriptor_stores_encoding() {
+        let r = Registry::new();
+        let id = r
+            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .expect("fresh name");
+        let stored = r.kind_descriptor(id).expect("descriptor present");
+        assert_eq!(stored.encoding, pod_desc("aether.foo").encoding);
+    }
+
+    #[test]
+    fn register_kind_with_descriptor_is_idempotent_on_match() {
+        let r = Registry::new();
+        let first = r
+            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .expect("first");
+        let second = r
+            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .expect("same encoding should succeed");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn register_kind_with_descriptor_rejects_conflict() {
+        let r = Registry::new();
+        r.register_kind_with_descriptor(opaque_desc("aether.foo"))
+            .expect("first");
+        let err = r
+            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .expect_err("different encoding should conflict");
+        assert_eq!(err.name, "aether.foo");
+        assert_eq!(err.existing, KindEncoding::Opaque);
+        assert!(matches!(err.requested, KindEncoding::Pod { .. }));
+    }
+
+    #[test]
+    fn register_kind_defaults_to_opaque() {
+        let r = Registry::new();
+        let id = r.register_kind("aether.bar");
+        let stored = r.kind_descriptor(id).expect("descriptor present");
+        assert_eq!(stored.encoding, KindEncoding::Opaque);
+    }
+
+    #[test]
+    fn name_only_register_after_with_descriptor_preserves_stored_encoding() {
+        // The legacy name-only path must not clobber a real descriptor
+        // that was recorded first — tests frequently call `register_kind`
+        // after main.rs has already registered via `register_kind_with_descriptor`.
+        let r = Registry::new();
+        r.register_kind_with_descriptor(pod_desc("aether.foo"))
+            .expect("first");
+        let _ = r.register_kind("aether.foo");
+        let stored = r.kind_descriptor(0).expect("descriptor present");
+        assert!(matches!(stored.encoding, KindEncoding::Pod { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scaffolding PR 2 for ADR-0010. Two coupled changes:

1. **Control-kind vocabulary.** Adds the reserved `aether.control.*` namespace — `load_component`, `replace_component`, `drop_component`, `load_result` — as named kinds in `aether-substrate-mail`. All four are Opaque; the handler PR (PR 3) will decode payloads against substrate-internal postcard types.
2. **Descriptor-aware Registry.** The substrate `Registry` now stores a `KindDescriptor` per kind id. `register_kind_with_descriptor` returns `Result<u32, KindConflict>` and rejects registrations whose encoding disagrees with one already stored — the guardrail ADR-0010's load_component handler will use when a runtime-loaded component brings its own kind set. The existing name-only `register_kind` stays as a test/internal convenience (defaults to Opaque, never clobbers a real descriptor already stored).

Substrate boot now iterates `descriptors::all()` and calls `register_kind_with_descriptor` for each, so the Registry and the hub-shipped `Hello` descriptors are kept in sync by construction.

No runtime behavior change for today's single-component boot — the control kinds are registered but nothing dispatches on them yet.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] New unit tests cover: fresh/descriptor-matching/conflicting registrations, idempotency on match, name-only fallback preserving an existing descriptor.
- [ ] Post-merge: verify `describe_kinds` surfaces the four new control kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)