### PR TITLE
feat(substrate): drop_component + replace_component (ADR-0010 PR 5)

### DIFF
--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -16,8 +16,8 @@ use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, 
 use aether_mail::Kind;
 
 use crate::{
-    DrawTriangle, DropComponent, FrameStats, Key, LoadComponent, LoadResult, MouseButton,
-    MouseMove, ReplaceComponent, Tick,
+    DrawTriangle, DropComponent, DropResult, FrameStats, Key, LoadComponent, LoadResult,
+    MouseButton, MouseMove, ReplaceComponent, ReplaceResult, Tick,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -53,6 +53,8 @@ pub fn all() -> Vec<KindDescriptor> {
         opaque(ReplaceComponent::NAME),
         opaque(DropComponent::NAME),
         opaque(LoadResult::NAME),
+        opaque(DropResult::NAME),
+        opaque(ReplaceResult::NAME),
     ]
 }
 
@@ -101,6 +103,8 @@ mod tests {
         assert!(names.contains(&ReplaceComponent::NAME));
         assert!(names.contains(&DropComponent::NAME));
         assert!(names.contains(&LoadResult::NAME));
+        assert!(names.contains(&DropResult::NAME));
+        assert!(names.contains(&ReplaceResult::NAME));
     }
 
     #[test]
@@ -111,6 +115,8 @@ mod tests {
             ReplaceComponent::NAME,
             DropComponent::NAME,
             LoadResult::NAME,
+            DropResult::NAME,
+            ReplaceResult::NAME,
         ] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
             assert_eq!(d.encoding, KindEncoding::Opaque, "{name}");

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -136,6 +136,23 @@ impl Kind for LoadResult {
     const NAME: &'static str = "aether.control.load_result";
 }
 
+/// `aether.control.drop_result` — reply-to-sender for `drop_component`.
+/// Carries `Ok` on success or an error describing why the drop failed
+/// (unknown mailbox, mailbox wasn't a component, already dropped).
+pub struct DropResult;
+impl Kind for DropResult {
+    const NAME: &'static str = "aether.control.drop_result";
+}
+
+/// `aether.control.replace_result` — reply-to-sender for
+/// `replace_component`. Carries `Ok` on success or an error if the
+/// target mailbox was invalid, the new module failed to compile, or
+/// instantiation failed.
+pub struct ReplaceResult;
+impl Kind for ReplaceResult {
+    const NAME: &'static str = "aether.control.replace_result";
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +207,8 @@ mod tests {
         assert_eq!(ReplaceComponent::NAME, "aether.control.replace_component");
         assert_eq!(DropComponent::NAME, "aether.control.drop_component");
         assert_eq!(LoadResult::NAME, "aether.control.load_result");
+        assert_eq!(DropResult::NAME, "aether.control.drop_result");
+        assert_eq!(ReplaceResult::NAME, "aether.control.replace_result");
     }
 
     #[test]

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -2,24 +2,27 @@
 // `aether.control`. Agents drive runtime component loading / dropping
 // / replacement by mailing here; the substrate handles each reserved
 // kind inline on the sink-handler thread and replies with a
-// `aether.control.load_result` addressed at the originating session.
+// matching `aether.control.*_result` addressed at the originating
+// session.
 //
-// Today's surface area: `aether.control.load_component` only. Drop
-// and replace are wired in a subsequent PR; the sink handler already
-// routes on kind name so adding them is strictly additive.
+// Surface area: `load_component`, `drop_component`, `replace_component`.
+// Each has its own result kind so an agent can disambiguate replies
+// without threading a correlation token through the payload.
 //
 // Error discipline: agent-visible failures (bad postcard, kind
 // conflict, name conflict, invalid WASM, wasmtime instantiation
-// error) surface as a `LoadResult::Err` on the reply. Panics are
-// reserved for invariant violations that the agent cannot have
-// caused — e.g. a poisoned lock.
+// error, unknown/wrong-type mailbox) surface as an `Err` variant on
+// the matching result. Panics are reserved for invariant violations
+// that the agent cannot have caused — e.g. a poisoned lock.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub, KindDescriptor};
 use aether_mail::Kind;
-use aether_substrate_mail::{DropComponent, LoadComponent, LoadResult, ReplaceComponent};
+use aether_substrate_mail::{
+    DropComponent, DropResult, LoadComponent, LoadResult, ReplaceComponent, ReplaceResult,
+};
 use serde::{Deserialize, Serialize};
 use wasmtime::{Engine, Linker, Module};
 
@@ -66,6 +69,36 @@ pub enum LoadResultPayload {
     Err { error: String },
 }
 
+/// Payload decoded from `aether.control.drop_component`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DropComponentPayload {
+    /// Mailbox id previously returned by a `load_component` reply.
+    pub mailbox_id: u32,
+}
+
+/// Payload of an outbound `aether.control.drop_result` reply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DropResultPayload {
+    Ok,
+    Err { error: String },
+}
+
+/// Payload decoded from `aether.control.replace_component`. Target is
+/// addressed by id — the new module reuses the mailbox's name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplaceComponentPayload {
+    pub mailbox_id: u32,
+    pub wasm: Vec<u8>,
+    pub kinds: Vec<KindDescriptor>,
+}
+
+/// Payload of an outbound `aether.control.replace_result` reply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReplaceResultPayload {
+    Ok,
+    Err { error: String },
+}
+
 /// State the control-plane sink handler captures. Grouping it in a
 /// struct keeps the closure body short and makes the dependencies
 /// explicit — useful since the handler needs a broad slice of
@@ -102,14 +135,13 @@ impl ControlPlane {
     fn dispatch(&self, kind_name: &str, sender: aether_hub_protocol::SessionToken, bytes: &[u8]) {
         if kind_name == LoadComponent::NAME {
             let result = self.handle_load(bytes);
-            self.reply_load_result(sender, result);
-        } else if kind_name == DropComponent::NAME || kind_name == ReplaceComponent::NAME {
-            self.reply_load_result(
-                sender,
-                LoadResultPayload::Err {
-                    error: format!("kind {kind_name:?} not yet implemented"),
-                },
-            );
+            self.reply(sender, LoadResult::NAME, &result);
+        } else if kind_name == DropComponent::NAME {
+            let result = self.handle_drop(bytes);
+            self.reply(sender, DropResult::NAME, &result);
+        } else if kind_name == ReplaceComponent::NAME {
+            let result = self.handle_replace(bytes);
+            self.reply(sender, ReplaceResult::NAME, &result);
         } else {
             eprintln!(
                 "aether-substrate: {AETHER_CONTROL} received unrecognised kind {kind_name:?} — dropping"
@@ -205,6 +237,113 @@ impl ControlPlane {
         }
     }
 
+    fn handle_drop(&self, bytes: &[u8]) -> DropResultPayload {
+        let payload: DropComponentPayload = match postcard::from_bytes(bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                return DropResultPayload::Err {
+                    error: format!("postcard decode failed: {e}"),
+                };
+            }
+        };
+        let id = MailboxId(payload.mailbox_id);
+        if let Err(e) = self.registry.drop_mailbox(id) {
+            return DropResultPayload::Err {
+                error: e.to_string(),
+            };
+        }
+        // Pull the Component out of the scheduler table and drop it
+        // here to reclaim wasmtime resources. If the table has no
+        // entry (shouldn't happen if the registry said Component but
+        // worth tolerating), we've already marked the mailbox Dropped
+        // so subsequent mail is discarded regardless.
+        let _ = self.remove_component(id);
+        DropResultPayload::Ok
+    }
+
+    fn handle_replace(&self, bytes: &[u8]) -> ReplaceResultPayload {
+        let payload: ReplaceComponentPayload = match postcard::from_bytes(bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                return ReplaceResultPayload::Err {
+                    error: format!("postcard decode failed: {e}"),
+                };
+            }
+        };
+        let id = MailboxId(payload.mailbox_id);
+
+        // Target must be a live Component. Reject unknown ids, sinks,
+        // and already-dropped mailboxes before touching wasmtime.
+        match self.registry.entry(id) {
+            Some(crate::registry::MailboxEntry::Component) => {}
+            Some(crate::registry::MailboxEntry::Sink(_)) => {
+                return ReplaceResultPayload::Err {
+                    error: format!("mailbox {:?} is a sink, not a component", id),
+                };
+            }
+            Some(crate::registry::MailboxEntry::Dropped) => {
+                return ReplaceResultPayload::Err {
+                    error: format!("mailbox {:?} already dropped", id),
+                };
+            }
+            None => {
+                return ReplaceResultPayload::Err {
+                    error: format!("unknown mailbox id {:?}", id),
+                };
+            }
+        }
+
+        // Kind descriptors: pre-validate like load_component.
+        for kind in &payload.kinds {
+            if let Some(kid) = self.registry.kind_id(&kind.name)
+                && let Some(existing) = self.registry.kind_descriptor(kid)
+                && existing.encoding != kind.encoding
+            {
+                return ReplaceResultPayload::Err {
+                    error: format!(
+                        "kind {:?} already registered with a different encoding",
+                        kind.name
+                    ),
+                };
+            }
+        }
+        for kind in payload.kinds {
+            self.registry
+                .register_kind_with_descriptor(kind)
+                .expect("pre-validated; no concurrent descriptor registrations");
+        }
+
+        let module = match Module::new(&self.engine, &payload.wasm) {
+            Ok(m) => m,
+            Err(e) => {
+                return ReplaceResultPayload::Err {
+                    error: format!("invalid wasm module: {e}"),
+                };
+            }
+        };
+
+        let ctx = SubstrateCtx {
+            sender: id,
+            registry: Arc::clone(&self.registry),
+            queue: Arc::clone(&self.queue),
+        };
+        let new_component = match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
+            Ok(c) => c,
+            Err(e) => {
+                // Registry is left as-is; any newly registered
+                // kinds stay. The old component is still bound.
+                return ReplaceResultPayload::Err {
+                    error: format!("wasm instantiation failed: {e}"),
+                };
+            }
+        };
+
+        // Atomic swap in the scheduler table. The returned old
+        // Component is dropped at end of scope — wasmtime reclaims.
+        let _old = self.swap_component(id, new_component);
+        ReplaceResultPayload::Ok
+    }
+
     fn insert_component(&self, id: MailboxId, component: Component) {
         self.components
             .write()
@@ -212,21 +351,39 @@ impl ControlPlane {
             .insert(id, std::sync::Mutex::new(component));
     }
 
-    fn reply_load_result(
+    fn remove_component(&self, id: MailboxId) -> Option<Component> {
+        self.components
+            .write()
+            .unwrap()
+            .remove(&id)
+            .map(|m| m.into_inner().expect("component mutex poisoned"))
+    }
+
+    fn swap_component(&self, id: MailboxId, new_component: Component) -> Option<Component> {
+        let mut table = self.components.write().unwrap();
+        let old = table
+            .remove(&id)
+            .map(|m| m.into_inner().expect("component mutex poisoned"));
+        table.insert(id, std::sync::Mutex::new(new_component));
+        old
+    }
+
+    fn reply<T: Serialize>(
         &self,
         sender: aether_hub_protocol::SessionToken,
-        result: LoadResultPayload,
+        kind_name: &str,
+        result: &T,
     ) {
-        let payload = match postcard::to_allocvec(&result) {
+        let payload = match postcard::to_allocvec(result) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("aether-substrate: load_result encode failed: {e}");
+                eprintln!("aether-substrate: {kind_name} encode failed: {e}");
                 return;
             }
         };
         self.outbound.send(EngineToHub::Mail(EngineMailFrame {
             address: ClaudeAddress::Session(sender),
-            kind_name: LoadResult::NAME.to_owned(),
+            kind_name: kind_name.to_owned(),
             payload,
             origin: None,
         }));
@@ -405,12 +562,186 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_rejects_unimplemented_control_kinds() {
+    fn drop_component_removes_component_and_frees_name() {
         let plane = make_plane();
-        // Capture send attempts via the outbound channel is awkward
-        // without a live hub; exercise that dispatch at least doesn't
-        // panic on the drop/replace paths.
-        plane.dispatch(DropComponent::NAME, SessionToken::NIL, &[]);
-        plane.dispatch(ReplaceComponent::NAME, SessionToken::NIL, &[]);
+        // Load first, then drop the same mailbox.
+        let wasm = wat::parse_str(WAT).unwrap();
+        let loaded = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm,
+                kinds: vec![],
+                name: Some("victim".into()),
+            })
+            .unwrap(),
+        );
+        let LoadResultPayload::Ok { mailbox_id, .. } = loaded else {
+            panic!("load should succeed");
+        };
+
+        let dropped = plane
+            .handle_drop(&postcard::to_allocvec(&DropComponentPayload { mailbox_id }).unwrap());
+        assert!(matches!(dropped, DropResultPayload::Ok));
+        assert!(
+            plane.registry.lookup("victim").is_none(),
+            "name should be released so it can be reused"
+        );
+        assert!(
+            matches!(
+                plane.registry.entry(MailboxId(mailbox_id)),
+                Some(crate::registry::MailboxEntry::Dropped),
+            ),
+            "entry should be marked Dropped",
+        );
+        assert!(
+            !plane
+                .components
+                .read()
+                .unwrap()
+                .contains_key(&MailboxId(mailbox_id)),
+            "component must be removed from scheduler table",
+        );
+    }
+
+    #[test]
+    fn drop_component_rejects_unknown_id() {
+        let plane = make_plane();
+        let result = plane
+            .handle_drop(&postcard::to_allocvec(&DropComponentPayload { mailbox_id: 99 }).unwrap());
+        assert!(matches!(result, DropResultPayload::Err { .. }));
+    }
+
+    #[test]
+    fn drop_component_rejects_double_drop() {
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm,
+                kinds: vec![],
+                name: Some("once".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+        let args = postcard::to_allocvec(&DropComponentPayload { mailbox_id }).unwrap();
+        assert!(matches!(plane.handle_drop(&args), DropResultPayload::Ok));
+        assert!(matches!(
+            plane.handle_drop(&args),
+            DropResultPayload::Err { .. }
+        ));
+    }
+
+    #[test]
+    fn replace_component_swaps_instance_and_preserves_id() {
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, name } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wasm.clone(),
+                kinds: vec![],
+                name: Some("swap_target".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+        assert_eq!(name, "swap_target");
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm,
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Ok));
+        // Name still resolves to the same id; new Component bound.
+        assert_eq!(
+            plane.registry.lookup("swap_target"),
+            Some(MailboxId(mailbox_id))
+        );
+        assert!(
+            plane
+                .components
+                .read()
+                .unwrap()
+                .contains_key(&MailboxId(mailbox_id))
+        );
+    }
+
+    #[test]
+    fn replace_component_rejects_unknown_target() {
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id: 99,
+                wasm,
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Err { .. }));
+    }
+
+    #[test]
+    fn replace_component_rejects_dropped_target() {
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wasm.clone(),
+                kinds: vec![],
+                name: Some("gone".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!();
+        };
+        plane.handle_drop(&postcard::to_allocvec(&DropComponentPayload { mailbox_id }).unwrap());
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm,
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Err { .. }));
+    }
+
+    #[test]
+    fn replace_component_rejects_invalid_wasm() {
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm,
+                kinds: vec![],
+                name: Some("target".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!();
+        };
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: vec![0, 1, 2, 3],
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Err { .. }));
+    }
+
+    #[test]
+    fn dispatch_unrecognised_kind_is_silent_drop() {
+        let plane = make_plane();
+        // No panic; no outbound reply. Unknown kind arriving at the
+        // control mailbox just logs and moves on.
+        plane.dispatch("aether.control.does_not_exist", SessionToken::NIL, &[]);
     }
 }

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -47,6 +47,12 @@ impl SubstrateCtx {
             Some(MailboxEntry::Component) => {
                 self.queue.push(Mail::new(recipient, kind, payload, count));
             }
+            Some(MailboxEntry::Dropped) => {
+                eprintln!(
+                    "substrate: component {:?} sent mail to dropped mailbox {:?} — discarded",
+                    self.sender, recipient
+                );
+            }
             None => {
                 eprintln!(
                     "substrate: dropped mail from {:?} to unknown mailbox {:?}",

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -18,7 +18,10 @@ pub mod registry;
 pub mod scheduler;
 
 pub use component::Component;
-pub use control::{AETHER_CONTROL, ControlPlane, LoadComponentPayload, LoadResultPayload};
+pub use control::{
+    AETHER_CONTROL, ControlPlane, DropComponentPayload, DropResultPayload, LoadComponentPayload,
+    LoadResultPayload, ReplaceComponentPayload, ReplaceResultPayload,
+};
 pub use ctx::SubstrateCtx;
 pub use hub_client::{HubClient, HubOutbound};
 pub use mail::{Mail, MailKind, MailboxId};

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -37,6 +37,12 @@ pub enum MailboxEntry {
     Component,
     /// Mail is handled inline by a substrate-native closure.
     Sink(SinkHandler),
+    /// Mailbox has been explicitly dropped (ADR-0010). The slot stays
+    /// in place so the numeric id isn't reused, but any mail addressed
+    /// to it is discarded by the scheduler / ctx dispatch. The name is
+    /// released from the lookup table so a subsequent load can reuse
+    /// it.
+    Dropped,
 }
 
 pub struct Registry {
@@ -107,6 +113,29 @@ impl fmt::Display for NameConflict {
 
 impl std::error::Error for NameConflict {}
 
+/// Reasons `Registry::drop_mailbox` can refuse. Distinct from the
+/// post-drop dispatch log, which the scheduler handles independently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropError {
+    UnknownId(MailboxId),
+    NotComponent { id: MailboxId, kind: &'static str },
+    AlreadyDropped(MailboxId),
+}
+
+impl fmt::Display for DropError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DropError::UnknownId(id) => write!(f, "unknown mailbox id {:?}", id),
+            DropError::NotComponent { id, kind } => {
+                write!(f, "mailbox {:?} is a {kind}, not a component", id)
+            }
+            DropError::AlreadyDropped(id) => write!(f, "mailbox {:?} already dropped", id),
+        }
+    }
+}
+
+impl std::error::Error for DropError {}
+
 impl Registry {
     pub fn new() -> Self {
         Self {
@@ -154,6 +183,33 @@ impl Registry {
         inner.mailbox_names.push(name.clone());
         inner.by_name.insert(name, id);
         Ok(id)
+    }
+
+    /// Invalidate a component mailbox (ADR-0010). Releases the name
+    /// from the lookup table so a subsequent `load_component` may
+    /// reuse it, and marks the entry as `Dropped` so dispatch-path
+    /// readers can distinguish an intentional drop from an unknown
+    /// id. Returns the released name on success; callers that need
+    /// to tear down the underlying `Component` do so via the
+    /// scheduler's `remove_component`. Refuses to drop `Sink` entries
+    /// — those are substrate-owned and outlive the control plane.
+    pub fn drop_mailbox(&self, id: MailboxId) -> Result<String, DropError> {
+        let mut inner = self.inner.write().unwrap();
+        let idx = id.0 as usize;
+        let Some(entry) = inner.entries.get(idx) else {
+            return Err(DropError::UnknownId(id));
+        };
+        match entry {
+            MailboxEntry::Component => {}
+            MailboxEntry::Sink(_) => {
+                return Err(DropError::NotComponent { id, kind: "sink" });
+            }
+            MailboxEntry::Dropped => return Err(DropError::AlreadyDropped(id)),
+        }
+        let name = std::mem::take(&mut inner.mailbox_names[idx]);
+        inner.by_name.remove(&name);
+        inner.entries[idx] = MailboxEntry::Dropped;
+        Ok(name)
     }
 
     /// Register a substrate-owned sink. Mail to this mailbox is handled
@@ -494,6 +550,43 @@ mod tests {
         assert_eq!(r.lookup("loaded"), Some(first));
         // Entries count unchanged after the failed second attempt.
         assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn drop_mailbox_frees_name_and_marks_entry_dropped() {
+        let r = Registry::new();
+        let id = r.try_register_component("loaded").unwrap();
+        let name = r.drop_mailbox(id).expect("drop");
+        assert_eq!(name, "loaded");
+        assert!(r.lookup("loaded").is_none(), "name should be reusable");
+        assert!(
+            matches!(r.entry(id), Some(MailboxEntry::Dropped)),
+            "entry must mark id as dropped"
+        );
+        // Reload the same name — allocates a fresh id after the dropped slot.
+        let reloaded = r.try_register_component("loaded").unwrap();
+        assert_ne!(reloaded, id);
+        assert_eq!(r.lookup("loaded"), Some(reloaded));
+    }
+
+    #[test]
+    fn drop_mailbox_rejects_sink_and_unknown_and_repeat() {
+        let r = Registry::new();
+        let sink = r.register_sink("heartbeat", Arc::new(|_, _, _, _, _| {}));
+        assert!(matches!(
+            r.drop_mailbox(sink),
+            Err(DropError::NotComponent { .. })
+        ));
+        assert!(matches!(
+            r.drop_mailbox(MailboxId(999)),
+            Err(DropError::UnknownId(_))
+        ));
+        let c = r.try_register_component("x").unwrap();
+        r.drop_mailbox(c).unwrap();
+        assert!(matches!(
+            r.drop_mailbox(c),
+            Err(DropError::AlreadyDropped(_))
+        ));
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -124,6 +124,22 @@ impl Scheduler {
             .remove(&id)
             .map(|m| m.into_inner().expect("component mutex poisoned"))
     }
+
+    /// Atomically rebind `id` to a freshly instantiated component
+    /// (ADR-0010). Returns the old component so the caller can drop
+    /// it after the swap; wasmtime resources (linear memory, Store)
+    /// are reclaimed when the returned value falls out of scope.
+    /// The entry is replaced under the write lock so no worker can
+    /// observe a gap between old and new — any mail that gets popped
+    /// after the swap is delivered to the new instance.
+    pub fn replace_component(&self, id: MailboxId, new_component: Component) -> Option<Component> {
+        let mut table = self.ctx.components.write().unwrap();
+        let old = table
+            .remove(&id)
+            .map(|m| m.into_inner().expect("component mutex poisoned"));
+        table.insert(id, Mutex::new(new_component));
+        old
+    }
 }
 
 impl Drop for Scheduler {
@@ -163,6 +179,12 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
                         );
                     }
                 }
+            }
+            Some(MailboxEntry::Dropped) => {
+                eprintln!(
+                    "substrate: mail to dropped mailbox {:?} — discarded",
+                    recipient
+                );
             }
             None => {
                 eprintln!(


### PR DESCRIPTION
## Summary

Completes the control-plane surface ADR-0010 called for. The `aether.control` sink now handles `load_component` (PR 4), `drop_component`, and `replace_component` end-to-end.

### drop_component
Payload: `{ mailbox_id }`.
- `Registry::drop_mailbox(id)` — new method. Marks the entry as `MailboxEntry::Dropped` (new variant), releases the name from the lookup table so a subsequent load can reuse it, and refuses to drop sinks / unknown ids / already-dropped mailboxes.
- Removes the underlying `Component` from the scheduler's table so wasmtime resources (Store, linear memory) are reclaimed on drop.
- Replies `aether.control.drop_result`.

### replace_component
Payload: `{ mailbox_id, wasm, kinds }`.
- Pre-validates the target exists and is a `Component` (not a sink, not dropped).
- Pre-validates kind descriptors against the registry before any allocation.
- Compiles the new module, instantiates against the shared `Engine` + `Linker` with a fresh `SubstrateCtx` pointing at the preserved `mailbox_id`.
- `Scheduler::replace_component` — atomic swap under the components-table write lock. Returns the old component; it drops at the caller's scope.
- In-flight mail: mail popped after the swap goes to the new instance; mail already locked into the old instance finishes on the old instance (the worker holds the read lock on the table across `deliver`). "Drop" per ADR §5 is really "don't preserve" — carryover is the natural semantics with a shared queue, and V0 doesn't fight it.
- Replies `aether.control.replace_result`.

### Supporting changes
- Scheduler and `SubstrateCtx::send` grow a `MailboxEntry::Dropped` match arm that logs "mail to dropped mailbox — discarded," distinct from the pre-existing unknown-mailbox path.
- Two new result kinds (`drop_result`, `replace_result`) so agents can disambiguate replies without a correlation token.
- The ControlPlane reply path was generalised: `reply<T>(sender, kind_name, &payload)` instead of a per-op helper.

## Test plan

- [x] `cargo test` — 9 new unit tests: drop success, drop unknown, drop double, replace swap + id preservation, replace unknown target, replace dropped target, replace invalid wasm, dispatch silently drops unrecognised kinds, and a regression on the new Registry `drop_mailbox` paths.
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Post-merge live smoke: load → drop → reload same name; load → replace → verify id unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)