### PR TITLE
feat(substrate): resolve_mailbox host fn; hello uses it

### DIFF
--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -6,10 +6,10 @@
 // Per ADR-0005, kind ids are resolved by name at component init — the
 // substrate assigns them; the guest caches them in statics. Payload
 // types are imported from `aether-substrate-mail` so wire layout stays
-// in one place.
-//
-// Mailbox ids remain hardcoded (component=0, render sink=1); symbolic
-// mailbox resolution is still future work.
+// in one place. The render sink's mailbox id is resolved the same way
+// via `resolve_mailbox`; this matters under ADR-0010's empty boot,
+// where the substrate's mailbox allocation order is no longer fixed
+// and hardcoded ids would target the wrong sink.
 //
 // `#[cfg(target_arch = "wasm32")]` guards bodies so the crate still
 // compiles for the host target in `cargo test --workspace` (where the
@@ -21,15 +21,16 @@ use aether_mail::Kind;
 #[cfg(target_arch = "wasm32")]
 use aether_substrate_mail::{DrawTriangle, Tick, Vertex};
 
-#[cfg(target_arch = "wasm32")]
-const RENDER_SINK: u32 = 1;
-
-// `u32::MAX` sentinel matches the host's KIND_NOT_FOUND — if `init`
-// didn't run or a name is missing, the dispatch below simply no-ops.
+// `u32::MAX` sentinel matches the host's KIND_NOT_FOUND /
+// MAILBOX_NOT_FOUND — if `init` didn't run or a name is missing, the
+// dispatch below simply no-ops instead of sending to mailbox 0 or a
+// wrong kind id.
 #[cfg(target_arch = "wasm32")]
 static mut KIND_TICK: u32 = u32::MAX;
 #[cfg(target_arch = "wasm32")]
 static mut KIND_DRAW_TRIANGLE: u32 = u32::MAX;
+#[cfg(target_arch = "wasm32")]
+static mut RENDER_SINK: u32 = u32::MAX;
 
 // A fixed clip-space triangle with per-vertex color. Typed as
 // DrawTriangle so the vertex layout matches the substrate's decode
@@ -66,28 +67,35 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
 unsafe extern "C" {
     fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
     fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
+    fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u32;
 }
 
 #[cfg(target_arch = "wasm32")]
-unsafe fn resolve(name: &str) -> u32 {
+unsafe fn resolve_k(name: &str) -> u32 {
     unsafe { resolve_kind(name.as_ptr() as u32, name.len() as u32) }
 }
 
-/// Runs once before the first `receive`. Resolves each kind name this
-/// component cares about and caches the assigned id. Return value is
-/// currently informational.
+#[cfg(target_arch = "wasm32")]
+unsafe fn resolve_m(name: &str) -> u32 {
+    unsafe { resolve_mailbox(name.as_ptr() as u32, name.len() as u32) }
+}
+
+/// Runs once before the first `receive`. Resolves each kind name and
+/// the render-sink mailbox name this component cares about and caches
+/// the assigned ids. Return value is currently informational.
 ///
 /// # Safety
 /// Called by the substrate exactly once, before any `receive` call, on
 /// a thread that owns this component's linear memory. The body mutates
-/// the `KIND_*` statics — safe because there is no concurrent reader
+/// the resolution statics — safe because there is no concurrent reader
 /// until `init` returns.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn init() -> u32 {
     #[cfg(target_arch = "wasm32")]
     unsafe {
-        KIND_TICK = resolve(Tick::NAME);
-        KIND_DRAW_TRIANGLE = resolve(DrawTriangle::NAME);
+        KIND_TICK = resolve_k(Tick::NAME);
+        KIND_DRAW_TRIANGLE = resolve_k(DrawTriangle::NAME);
+        RENDER_SINK = resolve_m("render");
     }
     0
 }
@@ -100,7 +108,7 @@ pub unsafe extern "C" fn init() -> u32 {
 pub unsafe extern "C" fn receive(kind: u32, _ptr: u32, _count: u32) -> u32 {
     #[cfg(target_arch = "wasm32")]
     unsafe {
-        if kind == KIND_TICK {
+        if kind == KIND_TICK && RENDER_SINK != u32::MAX {
             let ptr = &TRIANGLE as *const DrawTriangle as u32;
             let len = core::mem::size_of::<DrawTriangle>() as u32;
             // count = number of triangles in this payload (one).

--- a/crates/aether-substrate/examples/encode_load.rs
+++ b/crates/aether-substrate/examples/encode_load.rs
@@ -4,12 +4,13 @@
 // `--decode <kind> <bytes>`.
 //
 // Usage:
-//   encode_load                         # encode LoadComponentPayload
-//   encode_load drop <id>               # encode DropComponentPayload
-//   encode_load replace <id> [name]     # encode ReplaceComponentPayload
-//   encode_load --decode load  <bytes>  # decode LoadResultPayload
-//   encode_load --decode drop  <bytes>  # decode DropResultPayload
-//   encode_load --decode repl  <bytes>  # decode ReplaceResultPayload
+//   encode_load                                    # encode a tiny WAT stub
+//   encode_load --wasm-file <path> [--name <n>]    # encode real WASM bytes
+//   encode_load drop <id>                          # encode DropComponentPayload
+//   encode_load replace <id>                       # encode ReplaceComponentPayload
+//   encode_load --decode load  <bytes>             # decode LoadResultPayload
+//   encode_load --decode drop  <bytes>             # decode DropResultPayload
+//   encode_load --decode repl  <bytes>             # decode ReplaceResultPayload
 //
 // `<bytes>` is a comma-separated decimal byte list (what MCP
 // `receive_mail` emits).
@@ -81,16 +82,45 @@ fn main() {
         }
     }
 
-    // Default: encode LoadComponentPayload.
-    let wasm = wat::parse_str(WAT).expect("compile WAT");
-    let payload = LoadComponentPayload {
-        wasm,
-        kinds: vec![KindDescriptor {
+    // Default: encode LoadComponentPayload. A `--wasm-file <path>`
+    // flag swaps the built-in WAT stub for an external module
+    // (e.g. the hello-component release build); `--name <n>` sets
+    // the mailbox name the substrate will register.
+    let mut wasm_path: Option<String> = None;
+    let mut name: Option<String> = Some("smoke".into());
+    let mut use_smoke_kind = true;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--wasm-file" => {
+                wasm_path = Some(args[i + 1].clone());
+                use_smoke_kind = false;
+                i += 2;
+            }
+            "--name" => {
+                name = Some(args[i + 1].clone());
+                i += 2;
+            }
+            other => panic!("unknown arg {other:?}"),
+        }
+    }
+    let wasm = match wasm_path {
+        Some(p) => std::fs::read(&p).unwrap_or_else(|e| panic!("read {p:?}: {e}")),
+        None => wat::parse_str(WAT).expect("compile WAT"),
+    };
+    let kinds = if use_smoke_kind {
+        vec![KindDescriptor {
             name: "smoke.ping".into(),
             encoding: KindEncoding::Signal,
-        }],
-        name: Some("smoke".into()),
+        }]
+    } else {
+        // Real components (like aether-hello-component) resolve the
+        // kinds they need by name via the `resolve_kind` host fn —
+        // substrate boot already registers Tick, Key, MouseButton,
+        // MouseMove, and DrawTriangle. No extra descriptors needed.
+        vec![]
     };
+    let payload = LoadComponentPayload { wasm, kinds, name };
     let bytes = postcard::to_allocvec(&payload).expect("encode");
     print_bytes(&bytes);
 }

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -9,9 +9,11 @@ use wasmtime::{Caller, Linker};
 use crate::ctx::SubstrateCtx;
 use crate::mail::MailboxId;
 
-/// Returned by `resolve_kind` when the requested name has not been
-/// registered. Guests use this as a "lookup failed" sentinel.
+/// Returned by `resolve_kind` / `resolve_mailbox` when the requested
+/// name has not been registered. Guests use this as a "lookup failed"
+/// sentinel.
 pub const KIND_NOT_FOUND: u32 = u32::MAX;
+pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
 
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
@@ -71,6 +73,39 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                 .registry
                 .kind_id(name)
                 .unwrap_or(KIND_NOT_FOUND)
+        },
+    )?;
+
+    // Symmetric to `resolve_kind`: lookup a mailbox by its registered
+    // name and return the `MailboxId`. Runtime-loaded components rely
+    // on this to reach substrate-owned sinks (`render`,
+    // `hub.claude.broadcast`, `aether.control`) without hardcoding
+    // numeric ids — ADR-0010's empty boot removed the fixed boot
+    // order that such hardcoding used to depend on.
+    linker.func_wrap(
+        "aether",
+        "resolve_mailbox",
+        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return MAILBOX_NOT_FOUND,
+            };
+            let data = memory.data(&caller);
+            let start = name_ptr as usize;
+            let end = match start.checked_add(name_len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return MAILBOX_NOT_FOUND,
+            };
+            let name = match std::str::from_utf8(&data[start..end]) {
+                Ok(s) => s,
+                Err(_) => return MAILBOX_NOT_FOUND,
+            };
+            caller
+                .data()
+                .registry
+                .lookup(name)
+                .map(|id| id.0)
+                .unwrap_or(MAILBOX_NOT_FOUND)
         },
     )?;
 


### PR DESCRIPTION
## Summary

Follow-up to the bug surfaced during PR #62's smoke test. Adds `aether::resolve_mailbox(name_ptr, name_len) -> u32` as a symmetric counterpart to the existing `resolve_kind`, so runtime-loaded components can reach substrate-owned sinks by name instead of hardcoded numeric ids.

- New host fn in `aether-substrate/src/host_fns.rs`. Returns `MAILBOX_NOT_FOUND = u32::MAX` on unknown name / missing memory export / non-UTF8 bytes — same sentinel shape as `KIND_NOT_FOUND`.
- `aether-hello-component` now resolves `"render"` in `init` and stashes the id in a static alongside `KIND_TICK` / `KIND_DRAW_TRIANGLE`. Dispatch no-ops if resolution fails (can't accidentally send to mailbox 0).
- Drops the `const RENDER_SINK: u32 = 1` that assumed the pre-ADR-0010 boot order.

Also folds in `encode_load.rs`'s `--wasm-file <path>` / `--name <name>` flags from the PR #62 smoke-test pass so the triangle flow can be exercised end-to-end without editing the example.

## Why this matters

Before: hello's hardcoded `RENDER_SINK = 1` targeted `hub.claude.broadcast` under ADR-0010's empty boot, so `DrawTriangle` mail fanned out as a Claude observation instead of reaching the GPU.

After: hello looks up `"render"` by name, gets whatever id the substrate assigned at boot, and its triangle reaches the render sink. Matches ADR-0005's "names are the contract" intent and generalizes to any future substrate-owned sink.

## Test plan

- [x] `cargo test` — existing tests still pass (hello's host-target build bypasses the wasm32-only dispatch body, so lib tests don't link the new extern).
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo build -p aether-hello-component --target wasm32-unknown-unknown --release` succeeds.
- [ ] Post-merge live smoke: load the real hello component via `aether.control.load_component`, mail `aether.tick`, watch `FrameStats.triangles` go up and the window render the RGB triangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)