### PR TITLE
feat(hub): refresh describe_kinds cache after load (ADR-0010 PR 7)

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -281,6 +281,31 @@ mod tests {
     }
 
     #[test]
+    fn kinds_changed_roundtrip() {
+        let msg = EngineToHub::KindsChanged(vec![
+            KindDescriptor {
+                name: "aether.tick".into(),
+                encoding: KindEncoding::Signal,
+            },
+            KindDescriptor {
+                name: "physics.contact".into(),
+                encoding: KindEncoding::Opaque,
+            },
+        ]);
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            EngineToHub::KindsChanged(k) => {
+                assert_eq!(k.len(), 2);
+                assert_eq!(k[0].name, "aether.tick");
+                assert_eq!(k[1].name, "physics.contact");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
     fn heartbeat_both_directions() {
         for buf in [
             encode_frame(&EngineToHub::Heartbeat),

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -158,12 +158,17 @@ pub struct Goodbye {
 
 /// Frames an engine sends to the hub. `Mail` is the observation path
 /// (ADR-0008): engine-originated mail addressed to a Claude session
-/// or broadcast to all sessions.
+/// or broadcast to all sessions. `KindsChanged` (ADR-0010 §4) tells
+/// the hub to replace its cached descriptor list for this engine —
+/// needed after `aether.control.load_component` /
+/// `aether.control.replace_component` registers a new kind, which the
+/// hub would otherwise miss since its cache is pinned at `Hello`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EngineToHub {
     Hello(Hello),
     Heartbeat,
     Mail(EngineMailFrame),
+    KindsChanged(Vec<KindDescriptor>),
     Goodbye(Goodbye),
 }
 

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -112,7 +112,7 @@ pub async fn handle_connection(
     // Reader loop: run until the engine goes silent, sends Goodbye, or
     // the socket errors. Removing the registry entry drops the only
     // remaining `mail_tx`, which lets the writer task complete.
-    let result = read_loop(&mut reader, &sessions, engine_id).await;
+    let result = read_loop(&mut reader, &registry, &sessions, engine_id).await;
 
     registry.remove(&engine_id);
     let _ = writer_task.await;
@@ -126,6 +126,7 @@ pub async fn handle_connection(
 
 async fn read_loop(
     reader: &mut tokio::net::tcp::OwnedReadHalf,
+    registry: &EngineRegistry,
     sessions: &SessionRegistry,
     engine_id: EngineId,
 ) -> Result<(), FrameError> {
@@ -148,6 +149,7 @@ async fn read_loop(
             }
             EngineToHub::Heartbeat => {}
             EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m).await,
+            EngineToHub::KindsChanged(kinds) => registry.update_kinds(&engine_id, kinds),
             EngineToHub::Goodbye(_) => return Ok(()),
         }
     }

--- a/crates/aether-hub/src/registry.rs
+++ b/crates/aether-hub/src/registry.rs
@@ -93,6 +93,17 @@ impl EngineRegistry {
         inner.spawned_children.remove(id);
     }
 
+    /// Replace the cached kind descriptors for an engine. Called when
+    /// the substrate reports `EngineToHub::KindsChanged` post-load
+    /// (ADR-0010 §4) so subsequent `describe_kinds` calls see the
+    /// newly-registered vocabulary. No-op if the engine is unknown —
+    /// the engine may have dropped concurrently.
+    pub fn update_kinds(&self, id: &EngineId, kinds: Vec<KindDescriptor>) {
+        if let Some(record) = self.inner.lock().unwrap().records.get_mut(id) {
+            record.kinds = kinds;
+        }
+    }
+
     pub fn list(&self) -> Vec<EngineRecord> {
         self.inner
             .lock()
@@ -162,5 +173,29 @@ mod tests {
         assert!(!reg.has_child(&id));
         reg.remove(&id);
         assert!(reg.get(&id).is_none());
+    }
+
+    #[test]
+    fn update_kinds_replaces_cached_descriptors() {
+        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+        let reg = EngineRegistry::new();
+        let r = record(3);
+        let id = r.id;
+        reg.insert(r);
+        assert!(reg.get(&id).unwrap().kinds.is_empty());
+
+        let new_kinds = vec![KindDescriptor {
+            name: "physics.contact".into(),
+            encoding: KindEncoding::Opaque,
+        }];
+        reg.update_kinds(&id, new_kinds.clone());
+        assert_eq!(reg.get(&id).unwrap().kinds, new_kinds);
+    }
+
+    #[test]
+    fn update_kinds_for_unknown_engine_is_noop() {
+        let reg = EngineRegistry::new();
+        let unknown = EngineId(Uuid::from_u128(999));
+        reg.update_kinds(&unknown, vec![]);
     }
 }

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -230,6 +230,7 @@ impl ControlPlane {
         };
 
         self.insert_component(mailbox, component);
+        self.announce_kinds();
 
         LoadResultPayload::Ok {
             mailbox_id: mailbox.0,
@@ -341,6 +342,7 @@ impl ControlPlane {
         // Atomic swap in the scheduler table. The returned old
         // Component is dropped at end of scope — wasmtime reclaims.
         let _old = self.swap_component(id, new_component);
+        self.announce_kinds();
         ReplaceResultPayload::Ok
     }
 
@@ -366,6 +368,20 @@ impl ControlPlane {
             .map(|m| m.into_inner().expect("component mutex poisoned"));
         table.insert(id, std::sync::Mutex::new(new_component));
         old
+    }
+
+    /// Ship the complete current kind vocabulary to the hub so its
+    /// per-engine descriptor cache (ADR-0007) reflects kinds that were
+    /// registered at runtime (ADR-0010 §4). Called after a successful
+    /// load or replace; drop doesn't affect the vocabulary.
+    ///
+    /// The substrate is authoritative on what it has registered, so we
+    /// send the full list rather than a delta — simpler protocol, no
+    /// ordering hazard, trivial on the wire (descriptors are small).
+    /// If no hub is attached the outbound silently drops — harmless.
+    fn announce_kinds(&self) {
+        let kinds = self.registry.list_kind_descriptors();
+        self.outbound.send(EngineToHub::KindsChanged(kinds));
     }
 
     fn reply<T: Serialize>(

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -339,6 +339,13 @@ impl Registry {
             .cloned()
     }
 
+    /// Snapshot of every kind descriptor currently registered, in id
+    /// order. Used by the control plane to ship an authoritative view
+    /// to the hub after a runtime load or replace (ADR-0010 §4).
+    pub fn list_kind_descriptors(&self) -> Vec<KindDescriptor> {
+        self.inner.read().unwrap().kind_descriptors.clone()
+    }
+
     pub fn len(&self) -> usize {
         self.inner.read().unwrap().entries.len()
     }


### PR DESCRIPTION
## Summary

Final piece of the ADR-0010 arc. Closes ADR-0010 §4's open choice between push and pull for keeping the hub's per-engine descriptor cache in sync with the substrate after runtime `load_component` / `replace_component`.

**Decision: push.** Substrate emits `EngineToHub::KindsChanged(Vec<KindDescriptor>)` after every successful load or replace. Hub replaces its cached view for that engine.

### Why push over pull
- One new variant, one-way. Pull would need a request/response pair (new `HubToEngine` + new `EngineToHub` reply).
- Substrate already emits result frames from the same handler; adding `KindsChanged` alongside is a one-line helper call.
- `describe_kinds` stays a cache read with no round-trip.

### Changes
- `aether-hub-protocol`: new `EngineToHub::KindsChanged(Vec<KindDescriptor>)` variant + roundtrip test.
- `aether-hub`: read loop handles the variant via new `EngineRegistry::update_kinds(id, kinds)`. No-op if the engine is gone concurrently.
- `aether-substrate`: `Registry::list_kind_descriptors()` snapshot; `ControlPlane::announce_kinds()` helper called after load + replace success. Drop doesn't announce — it doesn't affect the vocabulary.
- Full list on the wire, not a delta — simpler, no ordering hazard, trivially small (descriptors compress well).

## Test plan

- [x] `cargo test` — new protocol roundtrip, new `update_kinds` registry tests (success + unknown-engine noop).
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [ ] Post-merge live smoke: load the hello component, `describe_kinds` should reflect any newly-registered kinds (for hello specifically that's still just the boot set since hello doesn't bring new kinds, but the mechanism is exercised — a follow-up load with a payload-declared kind will show the cache refreshing).

## That's the ADR-0010 arc done

All seven PRs (registry mutability → control vocab → scheduler mutability → load_component → drop+replace → empty boot → kinds refresh) are in. The only items explicitly parked inside ADR-0010 are drain-on-swap, signed bytes, state migration, and sandboxing — each named-and-deferred per the ADR text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)