### PR TITLE
docs(adr): flip 0008/0009/0010/0011 to accepted

### DIFF
--- a/docs/adr/0008-engine-to-claude-mail.md
+++ b/docs/adr/0008-engine-to-claude-mail.md
@@ -1,6 +1,6 @@
 # ADR-0008: Engine-to-Claude mail (observation path)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
 
 ## Context

--- a/docs/adr/0009-hub-supervised-substrate-spawn.md
+++ b/docs/adr/0009-hub-supervised-substrate-spawn.md
@@ -1,6 +1,6 @@
 # ADR-0009: Hub-supervised substrate spawn
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
 
 ## Context

--- a/docs/adr/0010-runtime-component-loading.md
+++ b/docs/adr/0010-runtime-component-loading.md
@@ -1,6 +1,6 @@
 # ADR-0010: Runtime component loading and replacement
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
 
 ## Context

--- a/docs/adr/0011-origin-attribution-on-observation-mail.md
+++ b/docs/adr/0011-origin-attribution-on-observation-mail.md
@@ -1,6 +1,6 @@
 # ADR-0011: Origin attribution on observation mail
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
 
 ## Context


### PR DESCRIPTION
## Summary

All four ADRs are fully shipped; flipping Status from Proposed → Accepted.

- **ADR-0008** — engine-to-Claude mail (observation path). ADR-0006/7/8 arc merged.
- **ADR-0009** — hub-supervised substrate spawn. `spawn_substrate` / `terminate_substrate` MCP tools live.
- **ADR-0010** — runtime component loading. Seven-PR arc merged: control vocabulary, `load_component` / `drop_component` / `replace_component`, runtime-mutable registry + scheduler table, empty componentless boot, `resolve_mailbox` host fn, `KindsChanged` cache refresh.
- **ADR-0011** — origin attribution on observation mail. `EngineMailFrame` + `ReceivedMail` carry `origin: Option<String>` end-to-end.

No content changes — Status line only.

## Test plan

- [x] `grep -r "Status" docs/adr/` — only TEMPLATE.md still lists "Proposed" (as the valid-values enum line, intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)