### PR TITLE
docs(adr): propose component SDK, reply, trait, hooks, state (ADR-0012..0016)

### DIFF
--- a/docs/adr/0012-guest-component-sdk.md
+++ b/docs/adr/0012-guest-component-sdk.md
@@ -1,0 +1,114 @@
+# ADR-0012: Guest-side component SDK
+
+- **Status:** Proposed
+- **Date:** 2026-04-14
+
+## Context
+
+`aether-hello-component` is the first real component and exposes exactly what it takes to write one today:
+
+- Two `#[unsafe(no_mangle)] pub unsafe extern "C" fn` exports (`init`, `receive`) with raw `u32` ptr/len/count parameters.
+- A hand-rolled `#[link(wasm_import_module = "aether")] unsafe extern "C"` block declaring `send_mail`, `resolve_kind`, `resolve_mailbox`.
+- `unsafe` wrappers that do `name.as_ptr() as u32` and `name.len() as u32` casts.
+- `static mut` slots with `u32::MAX` sentinels for every cached kind and mailbox id, plus an explicit sentinel check at every send site.
+- Pointer math at send time (`&payload as *const T as u32`, `size_of::<T>() as u32`).
+- `#[cfg(target_arch = "wasm32")]` guards around every body so the crate still type-checks for `cargo test --workspace` on the host, where the `aether` module isn't linkable and pointer casts would truncate.
+
+Everything in that list is boilerplate a component author has to get right. Nothing in it is part of what the component is trying to *do*. ADR-0002 said "Claude is just another mail sender"; the guest ergonomics right now push the opposite direction — components look like raw WASM shims, not mail peers.
+
+ADR-0010 makes the pain worse in two ways. First, components are now something agents produce routinely (load, iterate, replace), so the per-component boilerplate multiplies. Second, the `static mut` + sentinel pattern was tolerable when the one component was written once by a human; when Claude generates components, a forgotten sentinel check lands silently as mail to mailbox 0.
+
+Forces at play:
+
+- **Unsafe should be a substrate concern, not a component concern.** The substrate is the trust boundary; it already wraps raw wasmtime APIs in a typed `SubstrateCtx`. The guest surface deserves the same treatment. A component doing `ptr as u32` is not expressing anything the author wanted to express.
+- **Typed sends are already possible.** `aether-substrate-mail` defines `#[repr(C)]` payload types with `Kind` impls. The guest does `bytemuck`-style casts by hand; a `ctx.send(sink, &payload)` that does them under the hood is a pure ergonomics win — no new wire behavior.
+- **Host-target compilability is a real constraint.** Components live in the workspace and `cargo test --workspace` runs on the host. Today that's handled by `cfg(target_arch = "wasm32")` sprinkled per item. A shim crate that provides a stub `aether` module on non-wasm targets moves that concern out of every component.
+- **Dispatch is the open design question.** Send ergonomics are largely mechanical. Receive is where design choices bite: enum-over-all-kinds vs per-kind handler fns vs a trait with a single `receive`. Each has real tradeoffs and none is obviously right before a second real component exists.
+- **The SDK is additive.** It sits on top of the existing FFI. The raw `extern` surface stays — nothing in the substrate or host side changes. A component written against the raw FFI today continues to work; new components pick up the SDK.
+
+## Decision
+
+Add a new crate `aether-component`: a guest-side safe wrapper over the substrate's host-function ABI. Components depend on it instead of writing raw `extern "C"` blocks and `static mut` caches.
+
+Scope of this ADR is the **send side** and the **init/resolve side**, plus the plumbing that removes per-component `cfg` noise. The **receive-side dispatch shape** is deliberately left open — see §4.
+
+### 1. Crate shape
+
+`aether-component` is a new crate in the workspace:
+
+- `no_std`-compatible (guests are `no_std`-adjacent; the FFI contract has no allocator dependency).
+- Provides a stub `aether` module on non-wasm targets so components compile for `cargo test --workspace` without per-item `cfg` guards. Stub impls panic-or-return-sentinel; components can still be unit-tested for pure logic on the host, they just can't call the FFI there.
+- Depends on `aether-mail` (for the `Kind` trait) and nothing substrate-side. A guest component that depends on `aether-component` does **not** pull in substrate or hub code.
+
+The raw `extern "C"` block lives in `aether-component` and is the only place in a guest component tree that writes `unsafe extern`.
+
+### 2. Init and resolved handles
+
+The SDK replaces `static mut u32` caches with two typed handles:
+
+- `KindId<K: Kind>` — returned by `resolve::<K>()`. Internally a `u32`; externally a phantom-typed wrapper. A `KindId<Tick>` cannot be passed where a `KindId<DrawTriangle>` is expected.
+- `Sink<K: Kind>` — returned by `resolve_sink::<K>(name)`. Wraps the mailbox id plus the kind id for sends to that sink. `Sink<DrawTriangle>` is the only thing the `render` target needs: the author named it once, and the type system remembers which kind it accepts.
+
+Resolution happens inside an SDK-owned `init` shim. The component author writes a `fn init(ctx: &mut InitCtx) -> State`; the SDK's `#[no_mangle] extern "C" fn init` calls it and stores the returned `State` in a `OnceCell` (or equivalent single-slot container). The `u32::MAX` sentinel pattern goes away because a failed resolve in `init` panics loudly instead of being silently tolerated until first send.
+
+### 3. Typed send
+
+`ctx.send(sink, &payload)` where `sink: &Sink<K>` and `payload: &K::Payload`. The SDK does the `as *const T as u32` cast, the `size_of::<T>() as u32` length, and the `count = 1` case internally. Multi-item sends get a `ctx.send_many(sink, slice)` variant.
+
+Payload types remain defined in `aether-substrate-mail` (or wherever the kind is declared); the SDK doesn't own wire layout, it just knows how to hand a `&T` to the host. `T: bytemuck::Pod` is the bound — same as today, just enforced at the send call rather than implicit in the `as u32` cast.
+
+### 4. Receive dispatch — deferred shape
+
+The receive side has three plausible shapes:
+
+- **Single `receive` method on a `Component` trait.** User matches on kind id or kind name themselves. Simplest; leaks the raw switch to every component.
+- **Macro-generated match over per-kind handler fns.** `#[aether_component::on(Tick)] fn on_tick(state, msg)`. Clean per-kind, but macros carry their own ergonomic debt and the dispatch table has to be assembled somewhere.
+- **Enum of all inbound kinds.** `enum Inbound { Tick(Tick), ... }` with the SDK decoding into it. Requires the component to declare its inbound set up front; plays well with exhaustiveness checking.
+
+Each has real costs and the current one-component evidence doesn't pick a winner. This ADR commits only to: **a receive shim that decodes kind id → typed reference and hands it to a user function whose exact shape is decided when the second component lands.** Until then, the SDK exposes the simplest version (trait with a single `receive(&mut self, ctx, kind_id, bytes)`) and the hello component uses it. Revisiting happens the first time a component has more than two inbound kinds or needs per-kind state machines — at which point the choice is informed, not speculative.
+
+### 5. What stays out of scope
+
+- **Reply-to-sender.** ADR-0008's token flow is plumbed at the wire level but the host fn doesn't exist yet. When it lands, `Sink<K>` gains a `reply` constructor; no SDK-shape change.
+- **Allocator / heap-allocated payloads.** `#[repr(C)] Pod` is the whole wire vocabulary today. Dynamic payloads (strings, `Vec`, variable-length structs) cross into ADR-0007's `Opaque` territory and a separate encoding story.
+- **Lifecycle hooks beyond init/receive.** No `on_drop`, no `on_replace`. Replace semantics (ADR-0010 §5) drop the old instance's linear memory; there's nowhere honest to run drop code.
+- **Capability subsetting.** Today every component gets every host fn. A capability-gated SDK (component opts into `send` but not `resolve_mailbox`, say) is a future direction; the raw host surface would need to grow gates first.
+
+## Consequences
+
+### Positive
+
+- **Removes `unsafe` from component authorship.** The only `unsafe` is inside `aether-component`. Components become ordinary Rust crates that happen to compile to WASM.
+- **Sentinel-check footgun disappears.** Failed resolves surface at `init` time, loudly, instead of becoming a silent "mail to mailbox 0" at first send.
+- **Type errors catch kind/sink mixups.** Passing a `Sink<DrawTriangle>` where a `Sink<Tick>` is needed is a compile error. Today it's a runtime bad-dispatch.
+- **`cfg(target_arch = "wasm32")` goes away from components.** The SDK owns the host/wasm split; components read like ordinary code.
+- **Claude-generated components get smaller and safer.** ADR-0010 made component authoring a routine Claude activity; the SDK cuts the surface area Claude has to get right by an order of magnitude.
+
+### Negative
+
+- **New crate to maintain.** `aether-component` becomes part of the public guest API surface. Breaking it breaks every component. The bar for changing it has to be set accordingly.
+- **Host/wasm stub duplicates the extern surface.** The stub exists only to keep `cargo test --workspace` green; every host fn added to the substrate now needs a matching stub. Small cost per fn, but it's per-fn forever.
+- **Receive-side decision is deferred, not avoided.** The simplest trait works for one component; the second component will force the choice. Deferring is a bet that the forcing case will be more informative than the current one — probably true, not free.
+- **Raw FFI still works.** A component can bypass the SDK and write `extern "C"` directly. Fine for now; if it becomes a maintenance problem, the raw surface can be moved behind a feature flag or renamed.
+
+### Neutral
+
+- **No wire change.** This is a pure guest ergonomics ADR. Substrate, hub, and protocol crates are untouched.
+- **`aether-mail` stays a shared dep.** `Kind` continues to live there; the SDK consumes it, components consume it transitively.
+- **`aether-substrate-mail` is still the payload home.** The SDK doesn't pull payload types down into itself — payload ownership stays where the substrate and guest both need to agree.
+
+## Alternatives considered
+
+- **Macro-only SDK (no runtime types).** A single `component!` macro generates the whole `init`/`receive`/`extern` block from a declarative spec. Rejected for now: macro-only hides the types, which makes IDE experience worse and forecloses hand-written hybrids. The trait+types SDK can grow a macro sugar layer later if the boilerplate pressure returns.
+- **Fold the SDK into `aether-mail`.** One crate, guest and host both consume it. Rejected: `aether-mail` is pure vocabulary (`Kind` trait, nothing else); `aether-component` carries an FFI. Different trust domains, different dep graphs. Mixing them invites substrate-side code to accidentally depend on guest shims.
+- **Generate the SDK from substrate host-fn definitions.** A build script reads the `Linker::func_wrap` calls and emits matching guest stubs. Rejected: the host side is small enough (three fns) that hand-written stays readable, and code generation adds a build-time coupling between substrate and SDK that's a net loss until the host surface has a dozen entries.
+- **Keep the raw FFI, just add typed helpers.** No new crate; add a `safe_send<T>` free function in `aether-substrate-mail`. Rejected: doesn't remove the `#[unsafe(no_mangle)] extern "C" fn init/receive`, doesn't remove the `static mut` caches, doesn't remove the `cfg` guards. Half-measure.
+- **Cap'n-proto-style IDL for component boundary.** Define components in a schema language; generate both guest and substrate sides. Rejected at V0: enormous plumbing for a surface that has four verbs (init, receive, send, resolve). If the boundary grows complex enough to justify IDL, revisit then.
+
+## Follow-up work
+
+- `aether-component` crate with `Component` trait, `InitCtx`, `Ctx`, `Sink<K>`, `KindId<K>`, `resolve` / `resolve_sink` helpers, and the `#[no_mangle]` shim for `init`/`receive`.
+- Host-target stub `aether` module so non-wasm builds compile without per-item `cfg`.
+- Port `aether-hello-component` to the SDK as the proof — diff size is the headline measurement for whether the ergonomics moved.
+- Document the guest-side `Cargo.toml` shape (`crate-type = ["cdylib"]`, opt levels, the SDK dep) in the component author's README.
+- **Parked, not committed:** macro sugar for `on(Kind)` handlers, enum-based inbound dispatch, reply-to-sender, non-Pod payload encoding, lifecycle hooks beyond init/receive, capability subsetting, IDL-driven boundary.

--- a/docs/adr/0013-reply-to-sender-host-fn.md
+++ b/docs/adr/0013-reply-to-sender-host-fn.md
@@ -1,0 +1,113 @@
+# ADR-0013: Reply-to-sender host fn
+
+- **Status:** Proposed
+- **Date:** 2026-04-14
+
+## Context
+
+ADR-0008 shipped engine→Claude mail with two addressing modes on the wire: `ClaudeAddress::Broadcast` and `ClaudeAddress::Session(SessionToken)`. The broadcast path is exposed today — guests send to the reserved `"hub.claude.broadcast"` mailbox and the hub fans out. The session-token path is plumbed end-to-end on the wire but the **host fn** that lets a WASM component send one is still missing.
+
+Concretely, today's flow:
+
+- Hub → engine frames carry a `sender: SessionToken` on every `HubToEngine::Mail`.
+- The substrate's receive path has the token (it comes in on the wire).
+- The guest-facing `receive(kind, ptr, count)` shim does not pass it through.
+- The guest-facing `send_mail(recipient, kind, ptr, len, count)` only addresses mailboxes by `MailboxId` — there's no way to name a session.
+
+Result: a component can observe-to-all, but it cannot answer "here's the thing the Claude who just messaged me asked for." Reply-to-sender was named in ADR-0008 as the **common case** — targeted responses to the originating session, not broadcasts. Making it the uncommon case inverts the cost model and invites races when multiple Claudes are driving.
+
+Forces at play:
+
+- **Tokens are opaque bytes by design (ADR-0008).** The engine never synthesizes tokens; it only echoes ones the hub gave it. Any guest-facing API must preserve that property — the guest must not be able to fabricate a token.
+- **The guest has no allocator.** Passing the raw token bytes in and back out works with guest linear memory, but lifetimes get awkward (the inbound mail dispatch doesn't own a buffer the guest can hold past the receive call).
+- **A guest-local handle is the natural shape.** The substrate mints a small integer per inbound mail, hands it to the guest, and translates back to the real `SessionToken` on the send side. The guest stores `u32`s, not bytes.
+- **Handle lifetime is bounded by the session.** ADR-0008 already says reply-to-sender mail can fail with `sessionGone`. A handle that outlives its underlying token fails the same way on use — no new failure mode.
+- **The SDK surface is the real consumer.** ADR-0012 deferred reply-to-sender from the SDK on the grounds the host fn didn't exist. Landing it unblocks `Sink::reply_to(sender)` in `aether-component`.
+
+## Decision
+
+Add one host fn and one parameter to the receive shim. Introduce a guest-side `SenderHandle` (opaque `u32`) that the guest receives on inbound mail and can pass to a new `reply_mail` host fn to target the originating session.
+
+### 1. Substrate-side sender table
+
+The substrate maintains a per-instance table mapping `SenderHandle (u32) → SessionToken`. Entries are:
+
+- **Allocated** when an inbound `HubToEngine::Mail` is dispatched to a component. A fresh handle is minted; the `SessionToken` is stashed.
+- **Looked up** when the guest calls `reply_mail` with that handle.
+- **Expired** on a "session gone" status from the hub (per ADR-0008), or on component replace/drop (per ADR-0010).
+
+Handles are monotonically increasing `u32`s per component instance. Exhaustion at 2³² inbound mails-per-instance is not a real problem for V0; if it becomes one, the handle becomes a generational index.
+
+Broadcast-origin mail (inbound mail where `sender` was `Broadcast`) has no meaningful reply target. For those, the handle is `SENDER_NONE` (`u32::MAX`). A `reply_mail` call with `SENDER_NONE` fails with a status.
+
+### 2. Extended receive shim
+
+The `receive` export grows a `sender` parameter:
+
+```
+fn receive(kind: u32, ptr: u32, count: u32, sender: u32) -> u32;
+```
+
+This is a breaking change to the guest ABI, but the only existing guest (`aether-hello-component`) is in this repo and doesn't read inbound mail beyond the empty-tick case. The SDK (ADR-0012) absorbs the change so component authors don't see it directly.
+
+### 3. New `reply_mail` host fn
+
+```
+fn reply_mail(sender: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+```
+
+Semantics:
+
+- `sender` is a handle previously handed to the guest via `receive`.
+- Resolves to a `SessionToken`; builds `EngineToHub::Mail { address: ClaudeAddress::Session(token), kind_name, payload, origin }` and routes it through the outbound path.
+- Returns status codes: `0` success, `1` unknown handle, `2` session gone, `3` memory OOB, `4` kind not found. (Parallels the existing `send_mail` status surface.)
+- `origin` is resolved the same way ADR-0011 resolves it for broadcast sends — from the calling mailbox's registered name.
+
+The existing `send_mail` is **not** overloaded to accept sender handles. Addressing a `MailboxId` and addressing a session are conceptually different — the first stays on the substrate, the second crosses the hub boundary. Keeping two fns makes the capability distinction visible at the call site.
+
+### 4. Guest-facing SDK shape (pointers forward into ADR-0012)
+
+In `aether-component`:
+
+- `Sender` — opaque wrapper around the `u32` handle. Not `Copy`; single-use semantics are *not* enforced, but cloning is deliberate.
+- On inbound mail dispatch, the SDK surfaces a `&Sender` (or `Option<&Sender>` — `None` for broadcast-origin mail) alongside the typed payload.
+- `ctx.reply(&sender, &payload)` wraps `reply_mail` with the same typed-send ergonomics as `ctx.send`.
+
+A component that wants to remember a sender across receives can `sender.clone()` and stash it. The handle may expire before it's used again; the eventual reply attempt is the failure surface.
+
+## Consequences
+
+### Positive
+
+- **Closes ADR-0008's stated common case.** Reply-to-sender is the routine interaction pattern; making it available to components turns request/response into a natural mail exchange.
+- **Opaque to the guest.** The guest holds a `u32` handle, not a byte blob. Can't synthesize, can't introspect, can't forge.
+- **Clean lifecycle story.** Replace/drop invalidates the table along with everything else (ADR-0010). Session disconnect invalidates individual handles with a specific status. No new "what happens when" edge case beyond what ADR-0008 already named.
+- **Composes cleanly with ADR-0012.** The SDK's `Sink<K>` abstraction extends naturally to `Sender` — same typed-send body, different destination.
+
+### Negative
+
+- **Receive shim ABI change.** The fourth parameter breaks existing guests. Mitigated by the SDK landing simultaneously; the raw-FFI path for components that skip the SDK breaks but has one user today.
+- **Per-instance sender table is a new substrate responsibility.** The component host already owns linker/ctx/registry; this adds a table. Small, but it's another thing to evict on replace/drop and to bound in size.
+- **Handle exhaustion is theoretically possible.** 2³² inbound mails on a single instance is astronomical for V0; naming it is just hygiene.
+
+### Neutral
+
+- **Broadcast remains addressed by well-known name.** `"hub.claude.broadcast"` is still the broadcast target; reply uses the handle. Two different shapes for two different intents — the asymmetry is honest.
+- **Origin attribution (ADR-0011) applies symmetrically.** Reply mail carries the calling mailbox's name as `origin`, same rule as broadcast.
+- **Token format stays hub-internal.** Nothing about this ADR couples to how the hub mints tokens.
+
+## Alternatives considered
+
+- **Pass raw token bytes to the guest.** Guest reads the bytes into its own memory, passes them back verbatim. Rejected: lifetime and copy semantics are awkward; the handle indirection is strictly simpler and preserves the "opaque to guest" property better.
+- **Overload `send_mail` with a discriminated recipient.** `send_mail(kind: RecipientKind, id: u32, ...)` where `RecipientKind` is `Mailbox | Session`. Rejected: one more branch on every send, and the capability distinction goes invisible. Two fns is cheaper and clearer.
+- **Auto-expose the last sender as an implicit context.** `reply(kind, ptr, len, count)` that targets whatever triggered the current receive. Rejected: forecloses stashing senders for later replies, and ties reply semantics to receive scoping rather than to an explicit handle.
+- **Signed tokens all the way to the guest.** Hub signs, guest holds signed blob, guest echoes it. Rejected: the per-instance handle indirection is cheaper and achieves the same unforgeability property at the trust boundary we actually have (substrate↔hub is trusted; guest↔substrate is the only place forgery could happen).
+
+## Follow-up work
+
+- Substrate: per-instance `SenderTable`, allocation on inbound dispatch, expiry hooks on replace/drop/session-gone.
+- Wire-through on the receive shim ABI: fourth param `sender: u32`, `SENDER_NONE` sentinel for broadcast-origin.
+- New `reply_mail` host fn in `aether-substrate/src/host_fns.rs` with full status codes.
+- `Sender` type and `ctx.reply` in `aether-component` (blocked on ADR-0012 landing).
+- Port the receive-side of `aether-hello-component` to read sender for a trivial round-trip smoke test (Claude sends `aether.ping`, component replies with `aether.pong`).
+- **Parked, not committed:** generational sender handles, multi-reply semantics (one sender, N replies over time — already works; naming it if constraints emerge), cross-instance sender migration on replace (tied to ADR-0016).

--- a/docs/adr/0014-component-trait-and-associated-types.md
+++ b/docs/adr/0014-component-trait-and-associated-types.md
@@ -1,0 +1,147 @@
+# ADR-0014: Component trait and associated types
+
+- **Status:** Proposed
+- **Date:** 2026-04-14
+
+## Context
+
+ADR-0012 introduced `aether-component` as a guest-side SDK, committed to typed `Sink<K>` and `KindId<K>` handles for the send side, and **explicitly deferred** the receive-side dispatch shape. The stated reason: one real component (`aether-hello-component`) doesn't distinguish between plausible trait shapes, and the forcing case was expected to appear with the second component.
+
+That deferral was pragmatic but it left a hole: without a committed trait, the SDK's `init` / `receive` shim has no stable signature to call into, which means components today still write their own `#[unsafe(no_mangle)] pub unsafe extern "C" fn init` and pretend the SDK only exists for send helpers. The ergonomic win ADR-0012 promised can't be collected without a receive-side contract.
+
+Two external pressures also pulled the decision forward:
+
+- **ADR-0013 changes the receive shim ABI** (adds a `sender` parameter). If the guest writes the shim by hand, every component breaks when reply-to-sender lands. If the SDK owns the shim, the change lands once.
+- **ADR-0016 (persistent state, proposed)** needs somewhere to put "state the component owns across a replace." The natural home is an associated `State` type on a component trait. Without a trait, state ownership has to be reinvented per component.
+
+Forces at play:
+
+- **One user of the trait is not two.** The trait this ADR commits to is the one that works for `aether-hello-component` today and leaves explicit extension points for the known near-future uses (reply, hooks, state). Generalizing beyond that is speculative.
+- **State ownership has to live somewhere.** The component needs a place to keep cached kind ids, cached sink handles, and whatever domain state it cares about. Putting it on `self` via a trait implementor is the Rust-idiomatic answer.
+- **The SDK must own `#[no_mangle]`.** If components write their own exports, ABI changes (ADR-0013's `sender` param, future fn-signature evolution) cascade. If the SDK writes them, it's one place to evolve.
+- **Macros are glue, not the core.** A trait + a small `export!` macro keeps the types visible and the generated code minimal. A macro-DSL component definition hides types and costs IDE experience.
+- **Dispatch stays simple for now.** A single `receive` method that sees `(kind_id, bytes, sender)` is honest about what WASM actually gives us. Per-kind routing can be a layer on top without a trait change.
+
+## Decision
+
+Commit to a `Component` trait in `aether-component` with one associated type and three methods. Commit to `InitCtx` and `Ctx` as the context objects passed to those methods. Commit to an `export!` macro as the only supported way to bind a `Component` impl into the `#[no_mangle]` init/receive exports.
+
+### 1. The trait
+
+```rust
+pub trait Component: Sized + 'static {
+    fn init(ctx: &mut InitCtx<'_>) -> Self;
+
+    fn receive(
+        &mut self,
+        ctx: &mut Ctx<'_>,
+        mail: Mail<'_>,
+    );
+}
+```
+
+- `Self` **is** the component's state. Cached kind ids, cached sink handles, and any domain fields live on `self`. No separate `State` associated type; pulling state out of `Self` adds a layer without use.
+- `init` returns `Self` and is called exactly once by the SDK-owned shim, before any `receive`. Resolution of kinds and sinks happens here through `InitCtx`.
+- `receive` gets `&mut self` plus the inbound mail. No return value: sends happen through `ctx` during the call.
+
+### 2. `Mail<'_>` — the inbound
+
+```rust
+pub struct Mail<'a> {
+    pub kind: UntypedKindId,
+    pub bytes: &'a [u8],
+    pub sender: Option<Sender>,   // None when originating address was Broadcast
+}
+
+impl<'a> Mail<'a> {
+    pub fn decode<K: Kind>(&self, kind_id: KindId<K>) -> Option<&'a K::Payload>;
+}
+```
+
+- `bytes` is a view into a substrate-owned buffer valid for the duration of the `receive` call. Holding a reference past return is not supported; the bound makes this a compile error.
+- `decode::<K>` performs a kind-id match and a `bytemuck`-style cast. Mismatch returns `None` instead of panicking — components routinely branch on kind.
+- `sender` is the ADR-0013 reply handle. `None` for broadcast-origin mail.
+
+Per-kind dispatch remains the component's responsibility: a `match mail.kind` against the cached `KindId<K>` values, with `mail.decode(self.kind_tick)?` inside each arm. A macro sugar on top is possible later; the trait doesn't depend on it.
+
+### 3. `InitCtx<'_>` and `Ctx<'_>`
+
+Both are opaque handles holding whatever the SDK needs internally (today: nothing state-ful; tomorrow: logging, timing, sender table hooks).
+
+`InitCtx` surface — init-only capabilities:
+
+```rust
+impl InitCtx<'_> {
+    pub fn resolve<K: Kind>(&self) -> KindId<K>;
+    pub fn resolve_sink<K: Kind>(&self, name: &str) -> Sink<K>;
+}
+```
+
+`Ctx` surface — per-receive capabilities:
+
+```rust
+impl Ctx<'_> {
+    pub fn send<K: Kind>(&self, sink: &Sink<K>, payload: &K::Payload);
+    pub fn send_many<K: Kind>(&self, sink: &Sink<K>, payload: &[K::Payload]);
+    pub fn reply<K: Kind>(&self, sender: &Sender, payload: &K::Payload);  // ADR-0013
+}
+```
+
+The `InitCtx` / `Ctx` split is deliberate: resolution is only valid during init (it mutates substrate-side caches), sending is only valid during receive (there's nowhere meaningful to send *from* during init — the component isn't wired into the dispatch path yet). Splitting the types makes these invariants type-checked.
+
+### 4. The `export!` macro
+
+```rust
+aether_component::export!(MyComponent);
+```
+
+Generates:
+
+- `#[no_mangle] extern "C" fn init() -> u32` — calls `MyComponent::init`, stores the returned `Self` in a `OnceCell`.
+- `#[no_mangle] extern "C" fn receive(kind: u32, ptr: u32, count: u32, sender: u32) -> u32` — builds `Ctx` and `Mail`, calls `MyComponent::receive` on the stored instance.
+- A static backing store for the `MyComponent` instance.
+
+The macro is the **only** supported wiring. Components don't write `#[no_mangle]`. ABI changes (like ADR-0013's `sender` param) land in the macro, not in user code.
+
+### 5. What this ADR doesn't commit to
+
+- **Lifecycle hooks beyond init/receive.** `on_drop`, `on_replace`, state-migration hooks — all are ADR-0015's territory. Additive trait methods with default impls, so this ADR's shape doesn't churn.
+- **Typed per-kind dispatch.** No `#[on(Kind)]` macro. The `mail.decode` pattern is what the SDK ships with; a macro layer is purely additive.
+- **Async receive.** WASM components are single-threaded per instance today; async is not needed yet and would complicate the shim contract.
+
+## Consequences
+
+### Positive
+
+- **Unblocks ADR-0012's promise.** Components stop writing `#[no_mangle]` and `unsafe extern`; the `unsafe` surface collapses into `aether-component`.
+- **ABI changes land once.** Adding `sender` (ADR-0013), adding hooks (ADR-0015), rehydration plumbing (ADR-0016) — all happen in the SDK, not per-component.
+- **State has a natural home.** `self` is the component's state. No parallel "state slot" concept to invent later.
+- **Type-level separation of init vs receive capabilities.** `InitCtx` and `Ctx` make the "when can I do what" rules compile-time, not convention.
+
+### Negative
+
+- **`Sized + 'static` bounds lock in one implementation shape.** Components that want to be generic over some trait object won't work without boxing. Fine for V0; a limitation to name.
+- **`OnceCell` backing store is macro-hidden state.** If the macro is ever replaced, the store migrates with it. The cost is small (one static) but it's indirection added for ergonomics.
+- **`match mail.kind` is hand-written per component.** Not elegant; the simplest honest shape. Sugar can come later.
+
+### Neutral
+
+- **No associated `State` type.** `Self` is the state. Trait implementors who want an explicit split can use a wrapper type.
+- **No async.** Present-day WASM is fine with sync; revisit when component-model adoption or wasmtime async changes pressure it.
+- **Macro is small.** ~50 lines of generated code per component, all mechanical. Readable in `cargo expand` if debugging ever needs it.
+
+## Alternatives considered
+
+- **Trait with `type State` associated type.** `fn init() -> Self::State; fn receive(state: &mut Self::State, ...)`. Rejected: adds a type-level indirection for zero benefit over `Self`-is-state. Worth the simpler shape.
+- **Free-function exports with attribute macros.** `#[aether_component::init] fn init() -> State { ... }`. Rejected: attribute-macro flow makes the state threading invisible and the macro carries more logic than `export!(Type)` does.
+- **Stateless `fn receive` + externalized state container.** SDK owns an arena; component references it by key. Rejected: reinvents `&mut self`. The `Self`-based shape is idiomatic Rust and works.
+- **Enum-of-all-kinds `Mail` instead of `Mail { kind, bytes }`.** `enum Mail { Tick(Tick), DrawTriangle(DrawTriangle), ... }`. Rejected: forces the component to declare its full inbound universe up front, which doesn't match the substrate's "kinds resolved by name at init" model. A component that loads with a new inbound kind shouldn't need a trait-level enum change.
+- **Async receive via `Future`.** Rejected as premature: no pressure yet, and the WASM runtime story for async is still component-model-dependent.
+
+## Follow-up work
+
+- `Component` trait, `InitCtx`, `Ctx`, `Mail`, `KindId<K>`, `Sink<K>`, `Sender` in `aether-component`.
+- `export!` macro (decl macro or `proc-macro` — decl is likely enough) emitting `init` / `receive` shims.
+- Port `aether-hello-component` to the trait as the measurement of "did the ergonomics move." Diff size and `unsafe` count are the headline numbers.
+- Update substrate's documented ABI contract so the `receive(kind, ptr, count, sender)` signature is the canonical shape (ADR-0013 lands the fourth param).
+- **Parked, not committed:** per-kind dispatch sugar (`#[on(Kind)]`), async receive, multi-instance-per-crate exports (one `export!` per component crate is the rule), component-local logging/metrics surface on `Ctx`.

--- a/docs/adr/0015-component-lifecycle-hooks.md
+++ b/docs/adr/0015-component-lifecycle-hooks.md
@@ -1,0 +1,137 @@
+# ADR-0015: Component lifecycle hooks
+
+- **Status:** Proposed
+- **Date:** 2026-04-14
+
+## Context
+
+ADR-0014 commits to a `Component` trait with two methods: `init` and `receive`. That's enough to run; it's not enough for a component to participate in its own lifecycle.
+
+Three concrete pressures have surfaced:
+
+- **Replace loses state (ADR-0010 §6).** The old instance's linear memory is dropped; the new instance starts fresh. ADR-0016 picks this up from the persistence angle, but *something* has to be the component-visible hook for "save yourself before the swap" and "here's what you were."
+- **Drop is silent.** A component that owns external resources — open handles to a mailbox it spawned, cached work in flight, anything observable — can't run cleanup before it's torn down. Today "torn down" means the substrate drops the `Store` and the linear memory goes with it. Fine for pure-compute components; wrong for anything with externally visible state.
+- **Tick / frame is a de-facto hook.** The substrate emits `aether.tick` on the main loop, and components handle it in `receive`. This works, but it conflates "I got a message" with "time passed." Components that care about the *distinction* (schedulers, animation, debouncing) have to pattern-match a kind id.
+
+None of these are blockers for "run a component and see it do a thing." All three are blockers for *iteration at speed*: the exact workflow ADR-0010 was designed to unlock.
+
+Forces at play:
+
+- **Hooks must be additive.** Every hook added to the trait is a default-impl method so existing components don't break. ADR-0014 ships `init` + `receive`; this ADR adds methods without touching those.
+- **Hooks must be substrate-driven, not component-synthesized.** A component can't decide to run its own `on_replace` — the substrate is the one doing the replacing. The trait surface has to be what the substrate calls at the right moment.
+- **Hooks must be cheap when unused.** A component that doesn't override `on_drop` shouldn't pay for it. Default impls are zero-cost; the substrate's call site does an unconditional virtual/trait call, but it's once per lifecycle event, not per mail.
+- **State migration is a separate concern (ADR-0016).** This ADR commits to the **hook shapes** — what gets called and when. What goes across the hook (serialized bytes, structured state, nothing) is ADR-0016's decision. Keeping them separate means the lifecycle surface can land without state serialization landing.
+- **`aether.tick` staying as mail is fine.** The tick hook is cheap to add but not urgent. This ADR commits to the hooks actually needed for the replace-and-drop story and names the rest.
+
+## Decision
+
+Extend the `Component` trait (ADR-0014) with three additional lifecycle methods, all defaulted, all substrate-invoked at well-defined moments.
+
+### 1. Trait additions
+
+```rust
+pub trait Component: Sized + 'static {
+    fn init(ctx: &mut InitCtx<'_>) -> Self;
+    fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>);
+
+    // NEW — all with default no-op impls.
+
+    /// Called once, on the old instance, immediately before a
+    /// replace_component swap. The default impl does nothing.
+    /// Override to emit state that the new instance can consume
+    /// (see ADR-0016 for the serialization contract).
+    fn on_replace(&mut self, ctx: &mut DropCtx<'_>) {}
+
+    /// Called once, on the instance being dropped, immediately before
+    /// the substrate tears down linear memory. For both drop_component
+    /// and the old instance of replace_component. The default impl does
+    /// nothing. Override for cleanup (sending "goodbye" mail, flushing
+    /// work to a sibling component, logging).
+    fn on_drop(&mut self, ctx: &mut DropCtx<'_>) {}
+
+    /// Called after init on a freshly-instantiated component that is
+    /// replacing an older instance, if the substrate has state from
+    /// the old instance for us. The default impl ignores prior state.
+    /// Components that persist across replace override this to rehydrate.
+    /// Signature is ADR-0016's problem; shape committed here so the hook
+    /// exists.
+    fn on_rehydrate(&mut self, ctx: &mut Ctx<'_>, prior: PriorState<'_>) {
+        let _ = prior;
+    }
+}
+```
+
+`PriorState<'_>` is opaque to this ADR — its internal shape is ADR-0016. The hook exists; what flows through it is decided there.
+
+### 2. `DropCtx<'_>`
+
+A narrowed context for shutdown hooks. Like `Ctx` but:
+
+- `send` is still available (outgoing mail during shutdown is valid and useful — "I'm going away, here's the last thing I observed").
+- No `reply` — sender handles invalidate on teardown; a reply attempt during `on_drop` can't be honored cleanly.
+- No resolve — resolution only makes sense at init. Drop-time resolution would be a new capability with no use case.
+
+The type separation mirrors the `InitCtx`/`Ctx` split from ADR-0014: capability fences are types.
+
+### 3. Substrate call order
+
+For `drop_component(target)`:
+1. Scheduler takes the write lock.
+2. `on_drop(&mut self, DropCtx)` runs on the target instance.
+3. Outbound mail sent during `on_drop` is queued normally.
+4. Instance is dropped; mailbox entry marked `Dropped`.
+
+For `replace_component(target, new_bytes)`:
+1. Scheduler takes the write lock.
+2. `on_replace(&mut self, DropCtx)` runs on the old instance. ADR-0016 decides what state exits through this call.
+3. `on_drop(&mut self, DropCtx)` runs on the old instance. (Both hooks fire: `on_replace` is the migration-specific hook, `on_drop` is the universal shutdown hook.)
+4. New instance is instantiated; its `init` runs.
+5. If ADR-0016's state bundle is present, `on_rehydrate(&mut self, Ctx, prior)` runs on the new instance.
+6. Mailbox is atomically rebound to the new instance.
+
+This ordering is the subject of follow-up bikeshed: `on_replace` + `on_drop` firing back-to-back is redundant if the state migration already captured everything. Keeping both firing is the honest answer — `on_drop` is for universal cleanup; `on_replace` is the migration-specific moment. Overrides don't have to implement both.
+
+### 4. What stays parked
+
+- **`on_tick` as a first-class hook.** Continues to come in via `receive` as `aether.tick` mail. Revisit when the pattern-matching cost is visible.
+- **`on_pause` / `on_resume`.** No pause concept exists yet.
+- **`on_error`.** Component-visible error channel is a larger surface (what counts as an error? who reports it?). Out of scope.
+- **Async hooks.** Same stance as ADR-0014: sync until pressure.
+
+## Consequences
+
+### Positive
+
+- **Makes replace and drop non-destructive to externally-visible state.** Components that own handles, in-flight work, or observability contracts can clean up before teardown.
+- **Unblocks ADR-0016.** The hook shape for state migration is committed; the data shape is ADR-0016's problem but has a home to flow through.
+- **Additive to ADR-0014.** Existing components don't break. `aether-hello-component` doesn't implement any of these and stays green.
+- **Capability fencing stays typed.** `DropCtx` vs `Ctx` enforces shutdown-only semantics at compile time.
+
+### Negative
+
+- **Trait surface grows.** Three defaulted methods added, but three more things a component author has to know exist. Mitigated by all being opt-in no-ops.
+- **`on_replace` + `on_drop` call order is judgment-y.** The rule is defensible but not the only option; either could fire first. Picked "on_replace first" because it's the migration-specific semantic and `on_drop` is the universal cleanup — migration happens, then cleanup.
+- **Hooks must not panic mid-teardown.** A component that panics in `on_drop` can't be cleanly torn down. The substrate needs to catch and log rather than propagate. Same constraint as `on_replace` and `on_rehydrate` — the substrate treats hook panic as "hook opted out, continue teardown."
+
+### Neutral
+
+- **No runtime cost for unused hooks.** Default impls are empty; the call happens but does nothing.
+- **ADR-0016 can land without an ABI change.** The hooks are trait-level; what `PriorState<'_>` contains is internal to `aether-component`.
+- **Component author's concept count grows slowly.** ADR-0014 introduced `init`/`receive`. ADR-0015 adds three hooks with obvious names. Nothing subtle.
+
+## Alternatives considered
+
+- **Single `on_lifecycle(event)` method.** Variant-based dispatch. Rejected: conflates three very different semantics into one method that components have to `match` on. Separate methods are more Rust-idiomatic and each can have a distinct `Ctx` type.
+- **No `on_replace`; rely on `on_drop` + `on_rehydrate` alone.** The migration state would exit through `on_drop`. Rejected: `on_drop` is the universal shutdown path; making it also the migration serialization path overloads it. `on_replace` is where migration-specific logic belongs.
+- **Hooks as separate trait implementations (`DropHook for MyComponent`).** Opt-in via additional `impl` blocks. Rejected: makes `export!` macro-logic harder (it has to detect which traits are implemented to wire the right shim path), and multi-trait lifecycle is a shape that pays off only if hooks multiply dramatically.
+- **Hooks as mail kinds (`aether.lifecycle.replace`, etc.).** Rejected: lifecycle events aren't observations or commands; they're control flow. The substrate driving them directly as trait methods is clearer and avoids confusing "component is being dropped" with "component received a drop message."
+- **`on_tick` committed in this ADR.** Rejected: the existing `aether.tick` mail path works and no component has expressed pattern-matching pain. Add when the pain is real.
+
+## Follow-up work
+
+- Trait extensions on `Component` in `aether-component`: `on_replace`, `on_drop`, `on_rehydrate` with default no-op impls.
+- `DropCtx<'_>` type in `aether-component`. Subset of `Ctx` capabilities.
+- Substrate `Scheduler::remove_component` grows a hook-call step before drop.
+- Substrate `Scheduler::replace_component` grows hook-call steps in the order §3 describes.
+- Hook-panic containment: the substrate wraps each hook call, logs panics, and continues teardown.
+- **Parked, not committed:** `on_tick`, `on_pause` / `on_resume`, `on_error`, async hooks, lifecycle-as-mail-kinds alternative.

--- a/docs/adr/0016-persistent-state-across-hot-reload.md
+++ b/docs/adr/0016-persistent-state-across-hot-reload.md
@@ -1,0 +1,158 @@
+# ADR-0016: Persistent component state across hot reload
+
+- **Status:** Proposed
+- **Date:** 2026-04-14
+
+## Context
+
+ADR-0010 §6 explicitly parked state migration: "The new component starts fresh. WASM linear memory from the old instance is not transferred. If a component needs persistent state across swaps, it's the component's responsibility to externalize it." That was the right call for the runtime-loading PR arc — state migration is its own design problem and would have bloated ADR-0010 past its scope.
+
+It's also the wall the harness hits the moment components do anything beyond emit draws. A physics component accumulating rigid-body state, a dialogue component tracking a tree position, an input-mapping component remembering bindings — all of them become unusable under `replace_component` because "iterate the code, swap it in" silently becomes "wipe the world and start over."
+
+The user's framing: *"as it stands reloading a component drops its memory and starts over. Until this is solved we cannot do serious work."* That's the commit-worthy signal — the parked item has become the active one.
+
+Forces at play:
+
+- **WASM linear memory is not directly transferable.** The old instance's memory is tied to its `Store`; it goes away when the `Store` does. Pointer values, internal references, allocator state are all meaningless to the new instance. Migration has to happen through a **serialization step** where the old component's state is reduced to bytes and the new component rebuilds from them.
+- **Schema evolution is the real hazard.** The point of hot-reload is to change the component's code. If the `State` shape changed between old and new versions, naive byte-copy migration silently corrupts. Version-tagging the state payload is the minimum honest defense.
+- **Not every component wants this.** A pure render component with no state doesn't need a migration path; paying for one would be pure overhead. The mechanism has to be opt-in.
+- **Atomicity matters.** If a save step succeeds but the rehydrate step fails, what's the state of the mailbox? "Old gone, new broken" is worse than "nothing happened." The replace has to either complete with state transferred or roll back.
+- **This is not a persistence system.** State survives *within a running substrate session* across `replace_component`. It does **not** survive substrate shutdown, crash, or spawn/terminate cycles. Cross-session persistence is a different ADR if it ever happens.
+- **ADR-0015 gave us the hooks.** `on_replace` (old instance, pre-drop) and `on_rehydrate` (new instance, post-init) are the anchor points. This ADR fills in what flows through them.
+
+## Decision
+
+Introduce opt-in state migration on `replace_component`. The old instance serializes its migration payload into a substrate-owned byte buffer during `on_replace`; the substrate hands that buffer to the new instance during `on_rehydrate`. The payload is versioned, opaque to the substrate, and bounded in size.
+
+### 1. State bundle shape
+
+A **state bundle** is:
+
+```rust
+pub struct StateBundle {
+    pub schema_version: u32,   // component-defined; the substrate does not interpret it
+    pub bytes: Vec<u8>,        // component-defined layout
+}
+```
+
+The substrate treats both fields as opaque. The component owns versioning (what version means, when to bump it, how to migrate).
+
+### 2. Save side — `on_replace`
+
+During `replace_component`, after the scheduler takes the write lock and before the old instance is dropped, the substrate calls the old instance's `on_replace` hook (ADR-0015). The hook can call a new `DropCtx` method:
+
+```rust
+impl DropCtx<'_> {
+    pub fn save_state(&mut self, version: u32, bytes: &[u8]);
+}
+```
+
+- `save_state` may be called zero or one times per `on_replace`. A second call overwrites.
+- If `on_replace` returns without calling `save_state`, no bundle is produced and the new instance will not see `on_rehydrate` — it only sees `init`.
+- Bytes are copied into a substrate-owned buffer immediately. The component's linear memory is freed normally when the instance drops.
+- Size is capped at the same `MAX_FRAME_SIZE` (1 MiB, ADR-0006). A component that tries to save more fails `on_replace`; the replace is aborted, old instance remains live. This is conservative and revisitable.
+
+On the host-fn side: `save_state` translates to a new `aether::save_state(version: u32, ptr: u32, len: u32) -> u32` host fn. Status codes mirror the existing envelope.
+
+### 3. Load side — `on_rehydrate`
+
+The new instance's shim calls `init` first (ADR-0014). Then, if a bundle exists:
+
+```rust
+pub trait Component {
+    fn on_rehydrate(&mut self, ctx: &mut Ctx<'_>, prior: PriorState<'_>) {
+        let _ = prior;  // default: ignore
+    }
+}
+
+pub struct PriorState<'a> {
+    pub schema_version: u32,
+    pub bytes: &'a [u8],
+}
+```
+
+- `PriorState<'_>` is a view into a substrate-owned buffer valid only for the duration of the `on_rehydrate` call. Holding past return is a lifetime error.
+- A component that doesn't override `on_rehydrate` silently discards the bundle. Compatible with ADR-0015's "default hook is no-op."
+- Version mismatch (prior.schema_version doesn't match what the component expects) is **the component's problem**. The substrate doesn't interpret. A component override typically branches:
+
+```rust
+fn on_rehydrate(&mut self, ctx: &mut Ctx<'_>, prior: PriorState<'_>) {
+    match prior.schema_version {
+        1 => self.rehydrate_v1(prior.bytes),
+        2 => self.rehydrate_v2(prior.bytes),
+        _ => {}  // unknown version; continue with init defaults
+    }
+}
+```
+
+Host-fn-wise: the new instance receives the bundle via a new `aether::load_state(buf_ptr: u32, buf_len: u32) -> u32` host fn called from within the SDK's `on_rehydrate` shim. Returns `0` for "no prior state," `len` for success, `u32::MAX` for "buffer too small." The SDK hides this plumbing — component authors only see `PriorState`.
+
+### 4. Atomicity
+
+The replace sequence under this ADR:
+
+1. Scheduler takes write lock.
+2. Old `on_replace` runs. If it calls `save_state`, bundle is captured; if the bundle exceeds `MAX_FRAME_SIZE`, abort.
+3. Old `on_drop` runs (ADR-0015).
+4. New instance instantiated. `init` runs.
+5. New `on_rehydrate` runs if a bundle exists.
+6. Mailbox atomically rebound.
+
+Failure at steps 4 or 5 (instantiate error, WASM trap in `init`/`on_rehydrate`) aborts the replace: old instance stays live, new instance is dropped, mailbox binding unchanged, bundle discarded. Step 3's `on_drop` ran already — this is a wart. `on_drop` running on an instance that ends up not being replaced is observable but not incorrect (the instance *is* being replaced from its own perspective; the rollback is a substrate concern). Revisit if this becomes surprising in practice.
+
+### 5. Interaction with `drop_component`
+
+`drop_component` does not trigger state saving. `on_replace` only fires for `replace_component`. A component dropped with `drop_component` has no successor to hand state to; running a save would be burning cycles for a buffer with no reader.
+
+If a component wants its state preserved across *arbitrary* drops (with the expectation that a later load rehydrates from it), that's a different shape — a persistence sidecar component, or a `persist_state` primitive that stashes the bundle under the component's name. Named as a future direction, not committed.
+
+### 6. What this ADR does not do
+
+- **No serialization framework.** Bytes in, bytes out. The component picks postcard, bincode, hand-rolled, whatever. The substrate is indifferent.
+- **No cross-session persistence.** Substrate shutdown drops the bundle with everything else.
+- **No automatic schema migration.** The version tag is the only schema-awareness baked in; the component owns migration logic.
+- **No state at `drop_component`-time.** Only at `replace_component`-time.
+- **No partial / streaming migration.** The bundle is handed across in one shot.
+
+## Consequences
+
+### Positive
+
+- **Unblocks iterative development of stateful components.** Replace a physics component; the world doesn't reset. This is the workflow ADR-0010 was aiming at.
+- **Opt-in — no cost for stateless components.** `aether-hello-component` and every pure-render component stay green with zero new code.
+- **Versioning is explicit.** `schema_version` lives on the bundle, not in the bytes. Components are forced to think about it.
+- **Composes cleanly with ADR-0015.** The hook names and call sites were already committed; this ADR fills in the payload story without trait shape churn.
+- **Serialization is the component's choice.** Postcard, custom, whatever. No framework lock-in.
+
+### Negative
+
+- **Migration code is a component burden.** Every stateful component writes `rehydrate_v1`, `rehydrate_v2`, etc. No magic; schema evolution is hard work and this ADR does nothing to make it easier beyond handing a version tag.
+- **Version tag is trust-me.** If a component bumps its schema but forgets to bump the version, old-format bytes get handed to new-format logic. This is the footgun; only discipline prevents it.
+- **1 MiB cap is tight for rich state.** A physics component with thousands of bodies, or a UI state with many widgets, can exceed this. Cap is revisitable; chunked/streamed migration is a parked direction.
+- **`on_drop`-ran-then-rolled-back is a wart.** The ordering of the call sequence means a replace that fails at instantiation has already fired `on_drop` on the old instance. Not incorrect, but a sharp edge that probably bites someone.
+- **Atomicity failure modes are rare but real.** A new instance whose `on_rehydrate` panics gets rolled back; the bundle is discarded; the *old* instance is still there with its `on_drop` already fired. Needs clear logging so the failure is visible.
+
+### Neutral
+
+- **Bytes are not validated.** The substrate copies them verbatim. A component that corrupts its own state on save gets corrupted state on load. Fine — the component is the one who cares.
+- **In-flight mail policy unchanged.** ADR-0010 §5's "drop on swap" still holds. A component mid-replace loses queued mail; state migration doesn't change that.
+- **`StateBundle` is internal.** Never crosses the hub wire, never reaches Claude. Component authors see `save_state` / `PriorState`; nothing else.
+
+## Alternatives considered
+
+- **Push state via mail to a persistence component.** Old component emits `aether.state.save` mail before replace; a long-lived persistence component holds it; new component pulls it. Rejected for V0: relies on a sidecar being present, introduces N-way ordering problems (save before replace? at what mail-queue position?), and the substrate-owned slot is strictly simpler. The sidecar model stays available for components that want cross-drop or cross-session persistence.
+- **Transfer WASM linear memory directly.** Copy the old `Store`'s memory into the new `Store`. Rejected: pointer values and allocator internals make this incorrect across code changes. Works only for byte-identical code, which defeats the purpose.
+- **Substrate-provided serialization framework.** Bake in serde/postcard/bincode as the required format. Rejected: picks winners, couples the substrate to a particular ecosystem, forecloses components that want something else. Bytes-in/bytes-out is the escape hatch.
+- **Automatic migration via schema descriptors.** Register a schema per version; substrate runs automated transforms. Rejected as enormous scope for questionable payoff — schema migration in general-purpose form is a research problem; hand-rolled migration in component code is the pragmatic path.
+- **Tag the bundle with component identity, enforce match.** Substrate refuses to hand a bundle from component A to replacement B if names differ. Rejected: replace_component is already keyed by `MailboxId`, which the substrate owns; the component has no identity beyond that. Cross-name migration is not a meaningful operation at this level.
+- **No version tag — just bytes.** Rejected: every nontrivial use of the system will want versioning, so bake it in at the shape level so components get it right by default.
+
+## Follow-up work
+
+- Substrate: per-mailbox state bundle slot, wiring in the `replace_component` sequence per §4. Cleared on `drop_component` and on spawn teardown.
+- New host fns: `aether::save_state(version, ptr, len) -> u32` and `aether::load_state(buf_ptr, buf_len) -> u32`.
+- SDK additions in `aether-component`: `DropCtx::save_state(version, &[u8])`, `PriorState<'_>`, `on_rehydrate` default impl.
+- `StateBundle` internal type in the substrate; never crosses the hub.
+- Port a test component (new or adapted `hello`) to demonstrate a counter that survives `replace_component`. Smoke test: send N ticks → replace → send M more → observation mail shows counter = N+M.
+- Documentation: schema-version discipline in the component-author guide, including a worked example of `rehydrate_v1` → `rehydrate_v2`.
+- **Parked, not committed:** cross-session persistence, persistence-sidecar pattern, chunked/streaming migration for state >1 MiB, substrate-provided serialization framework, automatic schema migration, `drop_component` state preservation, transferring in-flight mail across the swap (ADR-0010's drain-on-swap), state bundle compression.


### PR DESCRIPTION
## Summary

Five-ADR arc defining how components are authored on top of ADR-0010's runtime-component substrate. All proposed; implementation is follow-up work.

- **ADR-0012 — Guest-side component SDK.** New `aether-component` crate. Typed `Sink<K>` / `KindId<K>` handles, `ctx.send(sink, &payload)`. Replaces the raw `extern "C"` + `static mut u32` + sentinel pattern. Receive-dispatch shape deliberately deferred to 0014.
- **ADR-0013 — Reply-to-sender host fn.** Exposes ADR-0008's `SessionToken` to the guest via an opaque per-instance `u32` handle. Adds `reply_mail` host fn and a fourth `sender: u32` param on the receive shim. The SDK absorbs the ABI change so components don't see it.
- **ADR-0014 — `Component` trait and associated types.** `init` / `receive`, `Self`-is-state, typed `InitCtx` / `Ctx` capability split, `Mail<'_>` for inbound, `export!` macro owns every `#[no_mangle]` in the guest.
- **ADR-0015 — Component lifecycle hooks.** Additive `on_replace`, `on_drop`, `on_rehydrate` with a narrowed `DropCtx`. Substrate call order for drop and replace committed. All default to no-ops.
- **ADR-0016 — Persistent state across hot reload.** Opt-in migration on `replace_component`. Old instance calls `ctx.save_state(version, bytes)`; new instance receives `PriorState<'_>` in `on_rehydrate`. Substrate-owned buffer, component-owned schema versioning, 1 MiB cap. Unblocks iteration on stateful components.

Dependency chain: `0012 → 0014 → 0015 → 0016`. `0013` is topically independent but its shim-ABI change lands with the SDK.

## Why one PR

Tight narrative arc — each ADR references the next, and reviewing them together catches cross-ADR inconsistencies (capability fencing, hook ordering, state-bundle lifetime) that split PRs would lose. No implementation yet; "sits waiting" while any one is debated costs nothing.

## Test plan

- [x] CI pass (docs-only — `clippy` / `test` should skip, thanks to #66).
- [x] Reviewer can walk the arc and flag any cross-ADR wording drift before acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)