### PR TITLE
feat(substrate): wire on_replace / on_drop hooks (ADR-0015 PR 2)

### DIFF
--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -11,12 +11,17 @@ use crate::mail::Mail;
 const MAIL_OFFSET: u32 = 1024;
 
 /// Contract with the guest: it exports a `receive(kind, ptr, count) -> u32`
-/// entrypoint and a `memory` named `memory`. Matches the spike's contract;
-/// generalization (component lifecycle, richer ABI) is deferred.
+/// entrypoint and a `memory` named `memory`. ADR-0015 adds optional
+/// `on_replace`, `on_drop`, and `on_rehydrate` exports; the substrate
+/// calls them at the right lifecycle moments when present and silently
+/// skips when absent (no-op trait defaults compile down to no symbol
+/// under LTO, so components that don't override stay backwards-compat).
 pub struct Component {
     store: Store<SubstrateCtx>,
     memory: Memory,
     receive: TypedFunc<(u32, u32, u32), u32>,
+    on_replace: Option<TypedFunc<(), u32>>,
+    on_drop: Option<TypedFunc<(), u32>>,
 }
 
 impl Component {
@@ -43,10 +48,24 @@ impl Component {
             init.call(&mut store, ())?;
         }
 
+        // ADR-0015 hook exports are optional. A component whose
+        // `Component::on_replace` / `on_drop` are the default no-ops
+        // still emits the symbol via `export!`, but a raw-FFI guest
+        // without the macro won't. Either way: look it up, store
+        // `None` if missing.
+        let on_replace = instance
+            .get_typed_func::<(), u32>(&mut store, "on_replace")
+            .ok();
+        let on_drop = instance
+            .get_typed_func::<(), u32>(&mut store, "on_drop")
+            .ok();
+
         Ok(Self {
             store,
             memory,
             receive,
+            on_replace,
+            on_drop,
         })
     }
 
@@ -59,5 +78,139 @@ impl Component {
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
         self.receive
             .call(&mut self.store, (mail.kind, MAIL_OFFSET, mail.count))
+    }
+
+    /// Invoke the guest's `on_replace` hook if it exports one.
+    /// Wasmtime traps (guest panics, unreachable) are caught and
+    /// logged rather than propagated — per ADR-0015, a panicking
+    /// hook must not stall teardown.
+    pub fn on_replace(&mut self) {
+        if let Some(f) = self.on_replace.clone()
+            && let Err(e) = f.call(&mut self.store, ())
+        {
+            eprintln!("substrate: on_replace hook trapped: {e}");
+        }
+    }
+
+    /// Invoke the guest's `on_drop` hook if it exports one. Same trap
+    /// containment as `on_replace`.
+    pub fn on_drop(&mut self) {
+        if let Some(f) = self.on_drop.clone()
+            && let Err(e) = f.call(&mut self.store, ())
+        {
+            eprintln!("substrate: on_drop hook trapped: {e}");
+        }
+    }
+
+    /// Read a `u32` from guest linear memory at `offset`. Test-only
+    /// accessor: the production mail path writes at `MAIL_OFFSET`
+    /// and the guest interprets the bytes — nothing in non-test
+    /// code reads guest memory directly.
+    #[cfg(test)]
+    pub fn read_u32(&mut self, offset: usize) -> u32 {
+        let mut buf = [0u8; 4];
+        self.memory
+            .read(&mut self.store, offset, &mut buf)
+            .expect("test memory read");
+        u32::from_le_bytes(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use wasmtime::{Engine, Linker};
+
+    use super::*;
+    use crate::mail::MailboxId;
+    use crate::queue::MailQueue;
+    use crate::registry::Registry;
+
+    fn ctx() -> SubstrateCtx {
+        SubstrateCtx {
+            sender: MailboxId(0),
+            registry: Arc::new(Registry::new()),
+            queue: Arc::new(MailQueue::new()),
+        }
+    }
+
+    fn instantiate(wat: &str) -> Component {
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        crate::host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(wat).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate")
+    }
+
+    /// WAT where `on_drop` writes 0x22 to offset 204 and `on_replace`
+    /// writes 0x11 to offset 200 — same pattern as `control.rs` test
+    /// shape but kept local so component tests stay standalone.
+    const WAT_HOOKS: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                i32.const 200
+                i32.const 0x11
+                i32.store
+                i32.const 0)
+            (func (export "on_drop") (result i32)
+                i32.const 204
+                i32.const 0x22
+                i32.store
+                i32.const 0))
+    "#;
+
+    const WAT_NO_HOOKS: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0))
+    "#;
+
+    const WAT_TRAP_ON_DROP: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_drop") (result i32)
+                unreachable))
+    "#;
+
+    #[test]
+    fn on_drop_invokes_export_and_writes_marker() {
+        let mut component = instantiate(WAT_HOOKS);
+        // Pre-condition: memory is zero-initialised.
+        assert_eq!(component.read_u32(204), 0);
+        component.on_drop();
+        assert_eq!(component.read_u32(204), 0x22);
+    }
+
+    #[test]
+    fn on_replace_invokes_export_and_writes_marker() {
+        let mut component = instantiate(WAT_HOOKS);
+        assert_eq!(component.read_u32(200), 0);
+        component.on_replace();
+        assert_eq!(component.read_u32(200), 0x11);
+    }
+
+    #[test]
+    fn on_drop_on_component_without_export_is_noop() {
+        let mut component = instantiate(WAT_NO_HOOKS);
+        // Just needs to not panic. No marker to check.
+        component.on_drop();
+        component.on_replace();
+    }
+
+    #[test]
+    fn on_drop_trap_is_contained() {
+        let mut component = instantiate(WAT_TRAP_ON_DROP);
+        // `unreachable` in WASM traps; substrate must log and
+        // continue rather than propagate. Reaching the line after
+        // the call is the whole assertion.
+        component.on_drop();
     }
 }

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -253,12 +253,15 @@ impl ControlPlane {
                 error: e.to_string(),
             };
         }
-        // Pull the Component out of the scheduler table and drop it
-        // here to reclaim wasmtime resources. If the table has no
-        // entry (shouldn't happen if the registry said Component but
-        // worth tolerating), we've already marked the mailbox Dropped
-        // so subsequent mail is discarded regardless.
-        let _ = self.remove_component(id);
+        // Pull the Component out of the scheduler table, fire the
+        // ADR-0015 `on_drop` hook on it, then let it drop at end of
+        // scope so wasmtime reclaims linear memory. The mailbox was
+        // already marked `Dropped` above, so any mail racing in
+        // parallel will be discarded regardless of when the hook
+        // runs.
+        if let Some(mut component) = self.remove_component(id) {
+            component.on_drop();
+        }
         DropResultPayload::Ok
     }
 
@@ -323,6 +326,19 @@ impl ControlPlane {
             }
         };
 
+        // ADR-0015 §3: hooks run on the old instance under the write
+        // lock before instantiation. Take the lock now, invoke hooks,
+        // then keep the lock while we instantiate + swap so no mail
+        // races in. Wart named in ADR-0015: if instantiation below
+        // fails, `on_drop` will have already fired on the old
+        // instance even though it stays live.
+        let mut table = self.components.write().unwrap();
+        if let Some(cell) = table.get(&id) {
+            let mut old = cell.lock().unwrap();
+            old.on_replace();
+            old.on_drop();
+        }
+
         let ctx = SubstrateCtx {
             sender: id,
             registry: Arc::clone(&self.registry),
@@ -332,16 +348,23 @@ impl ControlPlane {
             Ok(c) => c,
             Err(e) => {
                 // Registry is left as-is; any newly registered
-                // kinds stay. The old component is still bound.
+                // kinds stay. The old component is still bound (hooks
+                // already fired — see wart above).
                 return ReplaceResultPayload::Err {
                     error: format!("wasm instantiation failed: {e}"),
                 };
             }
         };
 
-        // Atomic swap in the scheduler table. The returned old
-        // Component is dropped at end of scope — wasmtime reclaims.
-        let _old = self.swap_component(id, new_component);
+        // Atomic swap in-place under the already-held write lock.
+        // The returned old Component drops at end of scope; wasmtime
+        // reclaims linear memory + Store.
+        let _old = table
+            .remove(&id)
+            .map(|m| m.into_inner().expect("component mutex poisoned"));
+        table.insert(id, std::sync::Mutex::new(new_component));
+        drop(table);
+
         self.announce_kinds();
         ReplaceResultPayload::Ok
     }
@@ -359,15 +382,6 @@ impl ControlPlane {
             .unwrap()
             .remove(&id)
             .map(|m| m.into_inner().expect("component mutex poisoned"))
-    }
-
-    fn swap_component(&self, id: MailboxId, new_component: Component) -> Option<Component> {
-        let mut table = self.components.write().unwrap();
-        let old = table
-            .remove(&id)
-            .map(|m| m.into_inner().expect("component mutex poisoned"));
-        table.insert(id, std::sync::Mutex::new(new_component));
-        old
     }
 
     /// Ship the complete current kind vocabulary to the hub so its
@@ -452,6 +466,38 @@ mod tests {
             (memory (export "memory") 1)
             (func (export "receive") (param i32 i32 i32) (result i32)
                 i32.const 0))
+    "#;
+
+    /// WAT with lifecycle hooks. Each hook writes a marker to a
+    /// distinct offset in linear memory so tests can observe which
+    /// hook fired. `on_replace` writes 0x11 at offset 200;
+    /// `on_drop` writes 0x22 at offset 204.
+    const WAT_HOOKS: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                i32.const 200
+                i32.const 0x11
+                i32.store
+                i32.const 0)
+            (func (export "on_drop") (result i32)
+                i32.const 204
+                i32.const 0x22
+                i32.store
+                i32.const 0))
+    "#;
+
+    /// WAT where `on_drop` traps via `unreachable`. Used to verify
+    /// that a panicking hook does not stall teardown.
+    const WAT_TRAPS_ON_DROP: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_drop") (result i32)
+                unreachable))
     "#;
 
     fn make_plane() -> ControlPlane {
@@ -751,6 +797,84 @@ mod tests {
             .unwrap(),
         );
         assert!(matches!(result, ReplaceResultPayload::Err { .. }));
+    }
+
+    #[test]
+    fn drop_component_with_hooks_completes_ok() {
+        // WAT_HOOKS exports on_drop. handle_drop should fire it and
+        // complete without error; the marker write is exercised in
+        // component::tests::on_drop_invokes_export_and_writes_marker.
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT_HOOKS).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm,
+                kinds: vec![],
+                name: Some("hooked".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+        let dropped = plane
+            .handle_drop(&postcard::to_allocvec(&DropComponentPayload { mailbox_id }).unwrap());
+        assert!(matches!(dropped, DropResultPayload::Ok));
+    }
+
+    #[test]
+    fn drop_component_with_trapping_on_drop_still_ok() {
+        // ADR-0015 trap containment: a panicking hook must not stall
+        // teardown. The handler logs and returns Ok regardless.
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT_TRAPS_ON_DROP).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm,
+                kinds: vec![],
+                name: Some("crasher".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+        let dropped = plane
+            .handle_drop(&postcard::to_allocvec(&DropComponentPayload { mailbox_id }).unwrap());
+        assert!(matches!(dropped, DropResultPayload::Ok));
+        // Mailbox still marked Dropped; component still removed.
+        assert!(matches!(
+            plane.registry.entry(MailboxId(mailbox_id)),
+            Some(crate::registry::MailboxEntry::Dropped),
+        ));
+    }
+
+    #[test]
+    fn replace_component_fires_hooks_on_old_instance() {
+        // handle_replace takes the write lock, fires on_replace +
+        // on_drop on the old component, instantiates the new one,
+        // and swaps under the same lock. Success means both hooks
+        // completed without stalling the replace.
+        let plane = make_plane();
+        let wasm_old = wat::parse_str(WAT_HOOKS).unwrap();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wasm_old,
+                kinds: vec![],
+                name: Some("swap_me".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+        let wasm_new = wat::parse_str(WAT).unwrap();
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: wasm_new,
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Ok));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Substrate side of ADR-0015. Now that the guest SDK emits `on_replace` / `on_drop` exports (PR 1, merged), the scheduler actually calls them at the right lifecycle moments.

### `Component` additions

- Caches optional `TypedFunc<(), u32>` handles for `on_replace` / `on_drop` at instantiate time via `get_typed_func(...).ok()`. Components that don't export hooks store `None`; call sites silently skip.
- `on_replace()` / `on_drop()` methods call the handle and catch wasmtime traps. Per ADR-0015's "hook-panic containment", a guest `unreachable` or panic logs to stderr and returns — teardown continues.
- Test-only `read_u32(offset)` for observing hook side effects.

### `ControlPlane` call sites

- **`handle_drop`**: pulls the component out of the table, fires `on_drop`, then lets RAII reclaim wasmtime resources. Mailbox is marked `Dropped` before the hook runs, so racing mail is discarded regardless.
- **`handle_replace`**: takes the components write lock, fires `on_replace` + `on_drop` on the still-bound old instance, instantiates the new, atomic-swaps under the same lock. ADR-0015 §3's named wart (instantiation failure after hooks already fired) is preserved deliberately — documented in comments.

### Tests (7 new)

Component-level (`component::tests`):
- `on_drop_invokes_export_and_writes_marker`
- `on_replace_invokes_export_and_writes_marker`
- `on_drop_on_component_without_export_is_noop`
- `on_drop_trap_is_contained`

Control-plane-level (`control::tests`):
- `drop_component_with_hooks_completes_ok`
- `drop_component_with_trapping_on_drop_still_ok`
- `replace_component_fires_hooks_on_old_instance`

### Hello

No guest-side changes; the defaulted hooks compile to empty wasm bodies that just return 0.

## Verification

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all existing + 7 new pass
- [x] `cargo fmt --all -- --check`

## Follow-up

ADR-0015's `on_rehydrate` is committed on the trait surface but not yet wired on the substrate side — there's nowhere for the state bundle to come from until ADR-0016 lands. PR 3+ of the arc is ADR-0016 (persistent state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)