### PR TITLE
feat(substrate): persistent state across hot reload (ADR-0016)

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -13,17 +13,17 @@
 //   - ADR-0015: Additive lifecycle hooks on the `Component` trait
 //     (`on_replace`, `on_drop`, `on_rehydrate`, all defaulted), plus
 //     the narrowed `DropCtx<'_>` capability type. `export!` emits the
-//     matching `#[no_mangle]` shims; the substrate-side wiring that
-//     actually invokes them lands in a follow-up. Components that
-//     don't override stay green; components that do can be written
-//     against the hooks today, behavior activates the moment substrate
-//     catches up.
+//     matching `#[no_mangle]` shims and the substrate invokes them at
+//     `drop_component` and `replace_component` call sites. Components
+//     that don't override stay green; hook traps are contained so a
+//     panicking hook doesn't stall teardown.
+//   - ADR-0016: Persistent state across hot reload. `DropCtx::save_state`
+//     lets `on_replace` deposit a version-tagged byte bundle; the
+//     substrate hands it to the new instance via `on_rehydrate` with
+//     a populated `PriorState<'_>`. Opt-in — components that don't
+//     override either hook migrate nothing.
 //
 // Still deferred:
-//   - Persistent state across hot reload (ADR-0016). `PriorState<'_>`
-//     is part of the `on_rehydrate` signature this ADR commits to, but
-//     the substrate-owned state bundle, the `save_state` host fn, and
-//     the call sites that actually populate it are ADR-0016's problem.
 //   - Reply-to-sender (ADR-0013). `Mail::sender()` is present as
 //     `Option<&Sender>` and always returns `None` today; once 0013
 //     lands on the substrate side, the `export!` macro will flip to
@@ -213,10 +213,9 @@ pub trait Component: Sized + 'static {
 
     /// Called once on the old instance, immediately before a
     /// `replace_component` swap (ADR-0015 §3). Default is no-op;
-    /// override to emit state that the new instance can consume via
-    /// `on_rehydrate`. The state-bundle serialization contract is
-    /// ADR-0016's problem — this hook exists here so state can flow
-    /// through it once that lands.
+    /// override to serialize state (via `DropCtx::save_state`) that
+    /// the new instance can consume through `on_rehydrate`, or to
+    /// emit farewell mail. ADR-0016 §2 governs the save-bundle shape.
     fn on_replace(&mut self, ctx: &mut DropCtx<'_>) {
         let _ = ctx;
     }
@@ -232,10 +231,11 @@ pub trait Component: Sized + 'static {
     }
 
     /// Called after `init` on a freshly-instantiated component that
-    /// is replacing an older instance, if and only if the substrate
-    /// has state from the old instance for us. Default ignores the
-    /// prior state; components that persist across replace override
-    /// to rehydrate. ADR-0016 fills in the state-bundle shape.
+    /// is replacing an older instance, if and only if the predecessor
+    /// produced a state bundle via `DropCtx::save_state` (ADR-0016 §3).
+    /// Default ignores the prior state; components that persist
+    /// across replace override to rehydrate and typically branch on
+    /// `prior.schema_version()`.
     fn on_rehydrate(&mut self, ctx: &mut Ctx<'_>, prior: PriorState<'_>) {
         let _ = ctx;
         let _ = prior;
@@ -316,12 +316,15 @@ pub struct Sender {
 /// - `send` / `send_many` still work — outbound mail during shutdown
 ///   is a valid and useful pattern ("I'm going away, here's the last
 ///   thing I observed").
+/// - `save_state` is only meaningful in `on_replace` — it deposits a
+///   version-tagged byte bundle the substrate hands to the new
+///   instance via `on_rehydrate`. Calling it from `on_drop` is
+///   technically accepted by the host fn, but the bytes are then
+///   discarded (ADR-0016 §5 — plain drops have no successor).
 /// - No `reply` — sender handles invalidate on teardown; a reply
 ///   attempt during `on_drop` cannot be honored.
 /// - No `resolve` — resolution belongs at init. There is no use case
 ///   for resolving at teardown.
-/// - Exposes `save_state` once ADR-0016 lands — state serialization
-///   is the defining reason `on_replace` has its own context.
 pub struct DropCtx<'a> {
     _borrow: PhantomData<&'a ()>,
 }
@@ -344,12 +347,36 @@ impl DropCtx<'_> {
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
     }
+
+    /// Deposit a migration bundle for the substrate to hand to the
+    /// replacement instance via `on_rehydrate`. `version` is
+    /// component-defined (the substrate doesn't interpret it); bytes
+    /// are copied into a substrate-owned buffer immediately, so the
+    /// caller is free to drop the slice on return.
+    ///
+    /// Panics if the substrate rejects the call — today that's only
+    /// the 1 MiB cap being exceeded or an internal OOB, both of
+    /// which are component bugs. ADR-0015's trap containment ensures
+    /// the panic doesn't stall teardown on the substrate side.
+    ///
+    /// May be called zero or one times per `on_replace`; a second
+    /// call overwrites. Calling from `on_drop` is legal but the
+    /// bundle is discarded on plain drops — `drop_component` has no
+    /// successor to hand it to (ADR-0016 §5).
+    pub fn save_state(&mut self, version: u32, bytes: &[u8]) {
+        let status =
+            unsafe { raw::save_state(version, bytes.as_ptr().addr() as u32, bytes.len() as u32) };
+        if status != 0 {
+            panic!("aether-component: save_state failed (status {status})");
+        }
+    }
 }
 
 /// Opaque view of a prior state bundle handed to `on_rehydrate` by
-/// the substrate. Today the substrate never produces one, so
-/// `on_rehydrate` is never called — the type exists on the surface
-/// so ADR-0016 can populate it without changing the trait shape.
+/// the substrate. Populated when the predecessor called
+/// `DropCtx::save_state` during its own `on_replace`; empty otherwise
+/// (and in that case `on_rehydrate` is not called at all — ADR-0016
+/// §3).
 ///
 /// The lifetime `'a` ties `bytes()` back to the call; holding a
 /// reference past return is a compile error.
@@ -380,7 +407,6 @@ impl<'a> PriorState<'a> {
     }
 
     /// Bytes the previous instance saved via `DropCtx::save_state`.
-    /// Empty today; non-empty once ADR-0016 is wired end-to-end.
     pub fn bytes(&self) -> &'a [u8] {
         if self.len == 0 {
             &[]
@@ -618,8 +644,7 @@ macro_rules! export {
         /// Called by the substrate after `init` on a freshly
         /// instantiated replacement, with `(version, ptr, len)`
         /// describing the prior-state bundle the old instance
-        /// produced via `DropCtx::save_state` (ADR-0016 wires this
-        /// end-to-end; today the substrate never calls it).
+        /// produced via `DropCtx::save_state`.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn on_rehydrate(version: u32, ptr: u32, len: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -15,6 +15,7 @@ unsafe extern "C" {
     pub fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
     pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
     pub fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u32;
+    pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
 }
 
 /// # Safety
@@ -39,4 +40,12 @@ pub unsafe fn resolve_kind(_name_ptr: u32, _name_len: u32) -> u32 {
 #[cfg(not(target_arch = "wasm32"))]
 pub unsafe fn resolve_mailbox(_name_ptr: u32, _name_len: u32) -> u32 {
     panic!("aether-component: resolve_mailbox called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::save_state` import. Always
+/// panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn save_state(_version: u32, _ptr: u32, _len: u32) -> u32 {
+    panic!("aether-component: save_state called on non-wasm target");
 }

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -5,10 +5,18 @@
 
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
-use crate::ctx::SubstrateCtx;
+use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::Mail;
 
 const MAIL_OFFSET: u32 = 1024;
+
+/// Offset the substrate writes prior-state bytes to before calling
+/// `on_rehydrate` (ADR-0016 §3). Deliberately separated from
+/// `MAIL_OFFSET` so the two scratch regions don't overlap in the
+/// worst-case size. The lifetimes are also disjoint in practice —
+/// rehydrate runs once, post-init, before any mail arrives — but the
+/// offset split keeps out-of-bounds checks obvious.
+const STATE_OFFSET: u32 = 8192;
 
 /// Contract with the guest: it exports a `receive(kind, ptr, count) -> u32`
 /// entrypoint and a `memory` named `memory`. ADR-0015 adds optional
@@ -22,6 +30,7 @@ pub struct Component {
     receive: TypedFunc<(u32, u32, u32), u32>,
     on_replace: Option<TypedFunc<(), u32>>,
     on_drop: Option<TypedFunc<(), u32>>,
+    on_rehydrate: Option<TypedFunc<(u32, u32, u32), u32>>,
 }
 
 impl Component {
@@ -59,6 +68,13 @@ impl Component {
         let on_drop = instance
             .get_typed_func::<(), u32>(&mut store, "on_drop")
             .ok();
+        // ADR-0016: `on_rehydrate` takes `(version, ptr, len)` — the
+        // substrate writes bytes into the new instance's memory at
+        // `STATE_OFFSET`, then calls the shim with `(version,
+        // STATE_OFFSET, len)`.
+        let on_rehydrate = instance
+            .get_typed_func::<(u32, u32, u32), u32>(&mut store, "on_rehydrate")
+            .ok();
 
         Ok(Self {
             store,
@@ -66,6 +82,7 @@ impl Component {
             receive,
             on_replace,
             on_drop,
+            on_rehydrate,
         })
     }
 
@@ -102,6 +119,47 @@ impl Component {
         }
     }
 
+    /// Extract the state bundle the guest deposited via `save_state`
+    /// during `on_replace`. Returns `None` if `save_state` was never
+    /// called (component doesn't implement migration, or the hook is
+    /// a no-op). Called by the control plane *after* `on_replace` /
+    /// `on_drop` run on the old instance — the bundle has to outlive
+    /// the store.
+    pub fn take_saved_state(&mut self) -> Option<StateBundle> {
+        self.store.data_mut().saved_state.take()
+    }
+
+    /// Extract a failure recorded by `save_state` (size cap, OOB).
+    /// `None` on clean saves and on components that didn't attempt a
+    /// save. Checked by the control plane to decide whether to abort
+    /// the replace (ADR-0016 §4).
+    pub fn take_save_error(&mut self) -> Option<String> {
+        self.store.data_mut().save_state_error.take()
+    }
+
+    /// Write the prior-state bytes into the new instance's linear
+    /// memory at `STATE_OFFSET` and invoke `on_rehydrate(version,
+    /// STATE_OFFSET, len)`. Returns `Ok(())` if the instance doesn't
+    /// export `on_rehydrate` (ADR-0016 §3: the bundle is silently
+    /// discarded when no handler claims it).
+    ///
+    /// ADR-0016 §4 specifies that a trap here aborts the replace, so
+    /// errors are propagated rather than contained (unlike
+    /// `on_replace` / `on_drop`). A memory write failure — the bundle
+    /// doesn't fit in the current pages — propagates too.
+    pub fn call_on_rehydrate(&mut self, bundle: &StateBundle) -> wasmtime::Result<()> {
+        let Some(f) = self.on_rehydrate.clone() else {
+            return Ok(());
+        };
+        self.memory
+            .write(&mut self.store, STATE_OFFSET as usize, &bundle.bytes)?;
+        f.call(
+            &mut self.store,
+            (bundle.version, STATE_OFFSET, bundle.bytes.len() as u32),
+        )?;
+        Ok(())
+    }
+
     /// Read a `u32` from guest linear memory at `offset`. Test-only
     /// accessor: the production mail path writes at `MAIL_OFFSET`
     /// and the guest interprets the bytes — nothing in non-test
@@ -113,6 +171,18 @@ impl Component {
             .read(&mut self.store, offset, &mut buf)
             .expect("test memory read");
         u32::from_le_bytes(buf)
+    }
+
+    /// Read `len` bytes from guest linear memory starting at `offset`.
+    /// Test-only accessor for verifying that a rehydrate hook copied
+    /// bytes to a known marker offset.
+    #[cfg(test)]
+    pub fn read_bytes(&mut self, offset: usize, len: usize) -> Vec<u8> {
+        let mut buf = vec![0u8; len];
+        self.memory
+            .read(&mut self.store, offset, &mut buf)
+            .expect("test memory read");
+        buf
     }
 }
 
@@ -128,11 +198,11 @@ mod tests {
     use crate::registry::Registry;
 
     fn ctx() -> SubstrateCtx {
-        SubstrateCtx {
-            sender: MailboxId(0),
-            registry: Arc::new(Registry::new()),
-            queue: Arc::new(MailQueue::new()),
-        }
+        SubstrateCtx::new(
+            MailboxId(0),
+            Arc::new(Registry::new()),
+            Arc::new(MailQueue::new()),
+        )
     }
 
     fn instantiate(wat: &str) -> Component {
@@ -180,6 +250,64 @@ mod tests {
                 unreachable))
     "#;
 
+    /// ADR-0016 save-side: `on_replace` calls `save_state` with a
+    /// version and 4 bytes at offset 300 (`0xDE 0xAD 0xBE 0xEF`).
+    const WAT_SAVES_STATE: &str = r#"
+        (module
+            (import "aether" "save_state"
+                (func $save_state (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 300) "\de\ad\be\ef")
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                (drop (call $save_state
+                    (i32.const 7)    ;; version
+                    (i32.const 300)  ;; ptr
+                    (i32.const 4)))  ;; len
+                i32.const 0))
+    "#;
+
+    /// ADR-0016 save-side: `on_replace` attempts a save larger than
+    /// the 1 MiB cap. The host fn records the error on the ctx and
+    /// returns status 3 (too-large). The guest drops the return.
+    const WAT_SAVES_TOO_LARGE: &str = r#"
+        (module
+            (import "aether" "save_state"
+                (func $save_state (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                (drop (call $save_state
+                    (i32.const 1)            ;; version
+                    (i32.const 0)            ;; ptr
+                    (i32.const 0x00200000))) ;; 2 MiB — over the cap
+                i32.const 0))
+    "#;
+
+    /// ADR-0016 load-side: `on_rehydrate(version, ptr, len)` copies
+    /// `len` bytes from `ptr` to offset 400 and writes `version` at
+    /// offset 396. Bulk-memory (`memory.copy`) is on by default in
+    /// wasmtime; no feature flag needed.
+    const WAT_REHYDRATES: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
+                ;; *(u32*)396 = version
+                i32.const 396
+                local.get 0
+                i32.store
+                ;; memcpy(dst=400, src=ptr, n=len)
+                i32.const 400
+                local.get 1
+                local.get 2
+                memory.copy
+                i32.const 0))
+    "#;
+
     #[test]
     fn on_drop_invokes_export_and_writes_marker() {
         let mut component = instantiate(WAT_HOOKS);
@@ -212,5 +340,61 @@ mod tests {
         // continue rather than propagate. Reaching the line after
         // the call is the whole assertion.
         component.on_drop();
+    }
+
+    #[test]
+    fn on_replace_save_state_populates_bundle() {
+        let mut component = instantiate(WAT_SAVES_STATE);
+        assert!(component.take_saved_state().is_none());
+        component.on_replace();
+        let bundle = component.take_saved_state().expect("bundle saved");
+        assert_eq!(bundle.version, 7);
+        assert_eq!(bundle.bytes, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        // take_saved_state is destructive.
+        assert!(component.take_saved_state().is_none());
+    }
+
+    #[test]
+    fn on_replace_save_state_without_export_leaves_bundle_empty() {
+        let mut component = instantiate(WAT_NO_HOOKS);
+        component.on_replace();
+        assert!(component.take_saved_state().is_none());
+        assert!(component.take_save_error().is_none());
+    }
+
+    #[test]
+    fn save_state_over_cap_records_error_and_no_bundle() {
+        let mut component = instantiate(WAT_SAVES_TOO_LARGE);
+        component.on_replace();
+        let err = component.take_save_error().expect("error recorded");
+        assert!(err.contains("exceeds"), "got: {err}");
+        assert!(component.take_saved_state().is_none());
+    }
+
+    #[test]
+    fn call_on_rehydrate_writes_bytes_and_invokes_hook() {
+        let mut component = instantiate(WAT_REHYDRATES);
+        let bundle = StateBundle {
+            version: 0x2A,
+            bytes: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+        };
+        component.call_on_rehydrate(&bundle).expect("rehydrate ok");
+        // Hook copied the version to offset 396 and the bytes to 400.
+        assert_eq!(component.read_u32(396), 0x2A);
+        assert_eq!(
+            component.read_bytes(400, 5),
+            vec![0x01, 0x02, 0x03, 0x04, 0x05],
+        );
+    }
+
+    #[test]
+    fn call_on_rehydrate_without_export_is_noop() {
+        let mut component = instantiate(WAT_NO_HOOKS);
+        let bundle = StateBundle {
+            version: 1,
+            bytes: vec![9, 9, 9],
+        };
+        // Silently discards the bundle per ADR-0016 §3.
+        component.call_on_rehydrate(&bundle).expect("noop ok");
     }
 }

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -210,11 +210,7 @@ impl ControlPlane {
             }
         };
 
-        let ctx = SubstrateCtx {
-            sender: mailbox,
-            registry: Arc::clone(&self.registry),
-            queue: Arc::clone(&self.queue),
-        };
+        let ctx = SubstrateCtx::new(mailbox, Arc::clone(&self.registry), Arc::clone(&self.queue));
         let component = match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
             Ok(c) => c,
             Err(e) => {
@@ -326,35 +322,55 @@ impl ControlPlane {
             }
         };
 
-        // ADR-0015 §3: hooks run on the old instance under the write
-        // lock before instantiation. Take the lock now, invoke hooks,
-        // then keep the lock while we instantiate + swap so no mail
+        // ADR-0015 §3 + ADR-0016 §4: hooks run on the old instance
+        // under the write lock before instantiation. Take the lock
+        // now, invoke hooks, extract any saved state, then keep the
+        // lock while we instantiate + rehydrate + swap so no mail
         // races in. Wart named in ADR-0015: if instantiation below
         // fails, `on_drop` will have already fired on the old
         // instance even though it stays live.
         let mut table = self.components.write().unwrap();
+        let mut saved = None;
         if let Some(cell) = table.get(&id) {
             let mut old = cell.lock().unwrap();
             old.on_replace();
+            // ADR-0016 §4 step 2: save failures abort the replace
+            // before `on_drop` fires, so the old instance is still
+            // fully alive. Check the error slot before continuing.
+            if let Some(err) = old.take_save_error() {
+                return ReplaceResultPayload::Err { error: err };
+            }
+            saved = old.take_saved_state();
             old.on_drop();
         }
 
-        let ctx = SubstrateCtx {
-            sender: id,
-            registry: Arc::clone(&self.registry),
-            queue: Arc::clone(&self.queue),
-        };
-        let new_component = match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
-            Ok(c) => c,
-            Err(e) => {
-                // Registry is left as-is; any newly registered
-                // kinds stay. The old component is still bound (hooks
-                // already fired — see wart above).
-                return ReplaceResultPayload::Err {
-                    error: format!("wasm instantiation failed: {e}"),
-                };
-            }
-        };
+        let ctx = SubstrateCtx::new(id, Arc::clone(&self.registry), Arc::clone(&self.queue));
+        let mut new_component =
+            match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
+                Ok(c) => c,
+                Err(e) => {
+                    // Registry is left as-is; any newly registered
+                    // kinds stay. The old component is still bound
+                    // (on_replace + on_drop already fired — see wart
+                    // above); the bundle is discarded.
+                    return ReplaceResultPayload::Err {
+                        error: format!("wasm instantiation failed: {e}"),
+                    };
+                }
+            };
+
+        // ADR-0016 §4 step 5: rehydrate the new instance if the old
+        // one produced a bundle. A trap or memory-write failure here
+        // aborts the replace: drop the new instance, keep the old
+        // in the table. `on_drop` on the old already fired — that's
+        // the documented ordering wart.
+        if let Some(bundle) = saved
+            && let Err(e) = new_component.call_on_rehydrate(&bundle)
+        {
+            return ReplaceResultPayload::Err {
+                error: format!("on_rehydrate failed: {e}"),
+            };
+        }
 
         // Atomic swap in-place under the already-held write lock.
         // The returned old Component drops at end of scope; wasmtime
@@ -498,6 +514,61 @@ mod tests {
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
+    "#;
+
+    /// ADR-0016 save side: `on_replace` saves 4 bytes of 0xDEADBEEF
+    /// with schema version 7.
+    const WAT_SAVES_STATE: &str = r#"
+        (module
+            (import "aether" "save_state"
+                (func $save_state (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 300) "\de\ad\be\ef")
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                (drop (call $save_state
+                    (i32.const 7)
+                    (i32.const 300)
+                    (i32.const 4)))
+                i32.const 0))
+    "#;
+
+    /// ADR-0016 save side: attempts a 2 MiB save, which the substrate
+    /// rejects over the 1 MiB cap. `save_state` returns status 3 and
+    /// the ctx error slot is populated.
+    const WAT_SAVES_TOO_LARGE: &str = r#"
+        (module
+            (import "aether" "save_state"
+                (func $save_state (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_replace") (result i32)
+                (drop (call $save_state
+                    (i32.const 1)
+                    (i32.const 0)
+                    (i32.const 0x00200000)))
+                i32.const 0))
+    "#;
+
+    /// ADR-0016 load side: `on_rehydrate` copies the bundle bytes to
+    /// offset 400 and stores the version at offset 396. Used to prove
+    /// migration end-to-end when paired with `WAT_SAVES_STATE`.
+    const WAT_REHYDRATES: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32) (result i32)
+                i32.const 0)
+            (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
+                i32.const 396
+                local.get 0
+                i32.store
+                i32.const 400
+                local.get 1
+                local.get 2
+                memory.copy
+                i32.const 0))
     "#;
 
     fn make_plane() -> ControlPlane {
@@ -883,5 +954,142 @@ mod tests {
         // No panic; no outbound reply. Unknown kind arriving at the
         // control mailbox just logs and moves on.
         plane.dispatch("aether.control.does_not_exist", SessionToken::NIL, &[]);
+    }
+
+    #[test]
+    fn replace_migrates_state_from_old_to_new() {
+        // The full ADR-0016 path: load an old instance that saves on
+        // replace, replace with a new instance that rehydrates, and
+        // observe that the new instance's memory received the bundle.
+        let plane = make_plane();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wat::parse_str(WAT_SAVES_STATE).unwrap(),
+                kinds: vec![],
+                name: Some("stateful".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: wat::parse_str(WAT_REHYDRATES).unwrap(),
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Ok), "got {result:?}");
+
+        // Peek into the new component's memory — rehydrate should
+        // have written version 7 at offset 396 and 0xDEADBEEF at
+        // offset 400.
+        let table = plane.components.read().unwrap();
+        let cell = table.get(&MailboxId(mailbox_id)).expect("present");
+        let mut new = cell.lock().unwrap();
+        assert_eq!(new.read_u32(396), 7);
+        assert_eq!(new.read_bytes(400, 4), vec![0xDE, 0xAD, 0xBE, 0xEF],);
+    }
+
+    #[test]
+    fn replace_aborts_when_save_state_over_cap() {
+        // Old instance requests a save larger than 1 MiB; substrate
+        // rejects, `handle_replace` surfaces the error, old stays live.
+        let plane = make_plane();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wat::parse_str(WAT_SAVES_TOO_LARGE).unwrap(),
+                kinds: vec![],
+                name: Some("greedy".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: wat::parse_str(WAT).unwrap(),
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        let ReplaceResultPayload::Err { error } = result else {
+            panic!("expected replace to fail, got {result:?}");
+        };
+        assert!(error.contains("exceeds"), "got: {error}");
+        // Old instance is still bound; name still resolves to its id.
+        assert_eq!(plane.registry.lookup("greedy"), Some(MailboxId(mailbox_id)));
+        assert!(
+            plane
+                .components
+                .read()
+                .unwrap()
+                .contains_key(&MailboxId(mailbox_id))
+        );
+    }
+
+    #[test]
+    fn replace_without_rehydrate_hook_discards_bundle() {
+        // Old saves, new doesn't implement on_rehydrate — the bundle
+        // is silently discarded (ADR-0016 §3). Replace succeeds.
+        let plane = make_plane();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wat::parse_str(WAT_SAVES_STATE).unwrap(),
+                kinds: vec![],
+                name: Some("orphan_save".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: wat::parse_str(WAT).unwrap(),
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Ok), "got {result:?}");
+    }
+
+    #[test]
+    fn replace_with_no_save_does_not_invoke_rehydrate() {
+        // Old doesn't save; new has on_rehydrate but it must not
+        // fire — ADR-0016 §3 says rehydrate only runs if a bundle
+        // exists. The new instance's rehydrate marker offsets should
+        // stay zero.
+        let plane = make_plane();
+        let LoadResultPayload::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponentPayload {
+                wasm: wat::parse_str(WAT).unwrap(),
+                kinds: vec![],
+                name: Some("stateless_old".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponentPayload {
+                mailbox_id,
+                wasm: wat::parse_str(WAT_REHYDRATES).unwrap(),
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResultPayload::Ok));
+        let table = plane.components.read().unwrap();
+        let cell = table.get(&MailboxId(mailbox_id)).expect("present");
+        let mut new = cell.lock().unwrap();
+        assert_eq!(new.read_u32(396), 0);
+        assert_eq!(new.read_u32(400), 0);
     }
 }

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -17,13 +17,49 @@ use crate::mail::{Mail, MailKind, MailboxId};
 use crate::queue::MailQueue;
 use crate::registry::{MailboxEntry, Registry};
 
+/// ADR-0016 §3: opt-in state migration payload. The substrate owns the
+/// buffer from the moment `save_state` is called on the old instance
+/// until the bundle is handed to the new instance via `on_rehydrate`
+/// (or discarded if no successor consumes it). Both fields are opaque
+/// to the substrate — the component owns versioning and the byte layout.
+#[derive(Debug, Clone)]
+pub struct StateBundle {
+    pub version: u32,
+    pub bytes: Vec<u8>,
+}
+
 pub struct SubstrateCtx {
     pub sender: MailboxId,
     pub registry: Arc<Registry>,
     pub queue: Arc<MailQueue>,
+    /// Set by the `save_state` host fn during `on_replace`. The
+    /// substrate extracts it after hooks return via
+    /// `Component::take_saved_state`. Never read by the guest —
+    /// rehydration reads from a scratch offset written by the
+    /// substrate, not from here.
+    pub saved_state: Option<StateBundle>,
+    /// Set by the `save_state` host fn when it rejects a call (1 MiB
+    /// cap exceeded, OOB pointer). ADR-0016 §4: a failing save aborts
+    /// the replace; the substrate checks this after `on_replace` and
+    /// surfaces the message back up the control plane.
+    pub save_state_error: Option<String>,
 }
 
 impl SubstrateCtx {
+    /// Build a fresh ctx with empty state-migration slots. Using this
+    /// over the struct literal keeps the `saved_state` /
+    /// `save_state_error` fields private to the migration wiring —
+    /// callers should never set them directly.
+    pub fn new(sender: MailboxId, registry: Arc<Registry>, queue: Arc<MailQueue>) -> Self {
+        SubstrateCtx {
+            sender,
+            registry,
+            queue,
+            saved_state: None,
+            save_state_error: None,
+        }
+    }
+
     /// Dispatch mail. If the recipient is a sink, the handler runs inline
     /// on the caller's thread. If it's a component, the mail is enqueued
     /// for a worker to deliver. Unknown recipients are dropped.

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -6,7 +6,7 @@
 
 use wasmtime::{Caller, Linker};
 
-use crate::ctx::SubstrateCtx;
+use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::MailboxId;
 
 /// Returned by `resolve_kind` / `resolve_mailbox` when the requested
@@ -14,6 +14,21 @@ use crate::mail::MailboxId;
 /// sentinel.
 pub const KIND_NOT_FOUND: u32 = u32::MAX;
 pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
+
+/// ADR-0016 §2: maximum size of a single state bundle. A `save_state`
+/// call with `len > MAX_STATE_BUNDLE_BYTES` is rejected (status 3) and
+/// the failure is recorded on the ctx so the substrate can abort the
+/// replace. 1 MiB is conservative and matches ADR-0006's `MAX_FRAME_SIZE`
+/// — revisitable once a real component actually hits the cap.
+pub const MAX_STATE_BUNDLE_BYTES: usize = 1 << 20;
+
+/// Status codes returned by the `save_state` host fn. 0 is success —
+/// non-zero values let the SDK distinguish component bugs (OOB, no
+/// memory) from policy rejection (over the size cap).
+pub const SAVE_STATE_OK: u32 = 0;
+pub const SAVE_STATE_NO_MEMORY: u32 = 1;
+pub const SAVE_STATE_OOB: u32 = 2;
+pub const SAVE_STATE_TOO_LARGE: u32 = 3;
 
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
@@ -82,6 +97,46 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // `hub.claude.broadcast`, `aether.control`) without hardcoding
     // numeric ids — ADR-0010's empty boot removed the fixed boot
     // order that such hardcoding used to depend on.
+    // ADR-0016 §2: save_state buffers the component's migration payload
+    // into a substrate-owned slot on the store ctx. The guest passes a
+    // `version` (opaque to the substrate) and a `(ptr, len)` pair
+    // pointing at its own linear memory. Bytes are copied out so the
+    // old instance can drop its memory normally; the substrate later
+    // hands them to the new instance via `on_rehydrate`.
+    //
+    // Size cap is enforced before the guest memory is read — an
+    // oversized request records an error and aborts without touching
+    // memory. A subsequent `save_state` in the same `on_replace` call
+    // overwrites; this matches ADR-0016 §2's "zero or one times" clause
+    // for the success path and doesn't change behavior on error.
+    linker.func_wrap(
+        "aether",
+        "save_state",
+        |mut caller: Caller<'_, SubstrateCtx>, version: u32, ptr: u32, len: u32| -> u32 {
+            if len as usize > MAX_STATE_BUNDLE_BYTES {
+                caller.data_mut().save_state_error = Some(format!(
+                    "save_state: bundle size {} exceeds {} byte cap",
+                    len, MAX_STATE_BUNDLE_BYTES,
+                ));
+                return SAVE_STATE_TOO_LARGE;
+            }
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return SAVE_STATE_NO_MEMORY,
+            };
+            let data = memory.data(&caller);
+            let start = ptr as usize;
+            let end = match start.checked_add(len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return SAVE_STATE_OOB,
+            };
+            let bytes = data[start..end].to_vec();
+            let ctx = caller.data_mut();
+            ctx.saved_state = Some(StateBundle { version, bytes });
+            SAVE_STATE_OK
+        },
+    )?;
+
     linker.func_wrap(
         "aether",
         "resolve_mailbox",

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -61,11 +61,7 @@ fn tick_roundtrip_component_to_sink() {
     let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
     host_fns::register(&mut linker).expect("register host fns");
 
-    let ctx = SubstrateCtx {
-        sender: component_mbox,
-        registry: Arc::clone(&registry),
-        queue: Arc::clone(&queue),
-    };
+    let ctx = SubstrateCtx::new(component_mbox, Arc::clone(&registry), Arc::clone(&queue));
     let component = Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
 
     let mut components = std::collections::HashMap::new();

--- a/docs/adr/0016-persistent-state-across-hot-reload.md
+++ b/docs/adr/0016-persistent-state-across-hot-reload.md
@@ -1,7 +1,8 @@
 # ADR-0016: Persistent component state across hot reload
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
+- **Accepted:** 2026-04-17
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Implements ADR-0016 — the blocker called out as *"until this is solved we cannot do serious work."* A component that overrides `on_replace` can now deposit a version-tagged byte bundle via `DropCtx::save_state`, and the substrate hands it to the replacement instance through `on_rehydrate`.
- Adds `aether::save_state(version, ptr, len) -> u32` host fn (status codes: 0 ok / 1 no-memory / 2 OOB / 3 too-large), with a 1 MiB cap matching `MAX_FRAME_SIZE`.
- Wires the full ADR-0016 §4 sequence into `handle_replace`: on_replace → check save-error (abort pre-drop, old stays live) → take bundle → on_drop → instantiate new → `call_on_rehydrate` (writes bytes to `STATE_OFFSET=8192`, calls hook, propagates traps to abort the replace) → atomic swap, all under the components write lock.
- Flips ADR-0016 to **Accepted**.

## Test plan
- [x] `cargo test --workspace` — new tests: save populates bundle, no-save leaves it empty, cap rejection records error, rehydrate writes bytes at hook-chosen offsets, save-then-rehydrate roundtrip end-to-end, cap violation aborts the replace, save-without-rehydrate-export silently discards, rehydrate-without-bundle is not invoked.
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Live-hub smoke: port a counter-style stateful component and verify it survives `replace_component` (follow-up — called out in ADR §Follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)