### PR TITLE
feat(substrate): reply-to-sender host fn (ADR-0013)

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -22,14 +22,11 @@
 //     substrate hands it to the new instance via `on_rehydrate` with
 //     a populated `PriorState<'_>`. Opt-in — components that don't
 //     override either hook migrate nothing.
-//
-// Still deferred:
-//   - Reply-to-sender (ADR-0013). `Mail::sender()` is present as
-//     `Option<&Sender>` and always returns `None` today; once 0013
-//     lands on the substrate side, the `export!` macro will flip to
-//     the 4-param receive ABI and the field will start carrying a
-//     handle. Component authors won't see the ABI change — it lands
-//     inside the macro.
+//   - ADR-0013: Reply-to-sender. `Mail::sender()` returns `Some(Sender)`
+//     for mail that came from a Claude session; `Ctx::reply` takes a
+//     `Sender` and a typed `KindId<K>` to answer the originating
+//     session. The 4-param `receive(kind, ptr, count, sender)` ABI is
+//     absorbed by the `export!` macro so component authors don't see it.
 
 #![no_std]
 
@@ -299,15 +296,63 @@ impl Ctx<'_> {
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
     }
+
+    /// Reply to the Claude session that originated the inbound mail
+    /// (ADR-0013). `sender` came from `mail.sender()` on the current
+    /// receive — pass it back as the routing handle. The kind is
+    /// supplied as a typed `KindId<K>` so the same compile-time
+    /// matching the rest of the SDK uses applies here too.
+    ///
+    /// Status of the underlying host call is dropped; reply is
+    /// fire-and-forget on the guest side. If the session is gone the
+    /// hub silently discards the frame.
+    pub fn reply<K: Kind + bytemuck::NoUninit>(
+        &self,
+        sender: Sender,
+        kind: KindId<K>,
+        payload: &K,
+    ) {
+        let bytes = bytemuck::bytes_of(payload);
+        unsafe {
+            raw::reply_mail(
+                sender.raw,
+                kind.raw,
+                bytes.as_ptr().addr() as u32,
+                bytes.len() as u32,
+                1,
+            );
+        }
+    }
 }
 
-/// Reply-to-sender handle. Placeholder until ADR-0013 lands — today
-/// nothing on the substrate side produces a non-`None` sender, so
-/// `Mail::sender()` always returns `None`. Kept on the surface so
-/// consumers structure their receive bodies around
-/// `Option<&Sender>` from day one.
+/// Sentinel the substrate passes as the `sender` parameter on the
+/// `receive` shim when there is no meaningful reply target — for
+/// component-originated mail (no Claude session involved) and for
+/// broadcast-origin mail. `Mail::sender()` returns `None` in this
+/// case; `Sender` is only constructable via the `Mail` accessor.
+pub const SENDER_NONE: u32 = u32::MAX;
+
+/// Opaque per-instance handle identifying the originating Claude
+/// session of an inbound mail. Hand it back to `Ctx::reply` to send
+/// a session-targeted response.
+///
+/// `Copy` because the handle is a `u32` underneath; cloning is free.
+/// Cloning is also fine for stashing across receives — the substrate
+/// guarantees the handle stays valid until the originating session
+/// disconnects (in which case the eventual reply silently drops on
+/// the hub side; ADR-0013 §1's session-gone status is not yet
+/// detected synchronously).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Sender {
-    _priv: (),
+    raw: u32,
+}
+
+impl Sender {
+    /// Raw handle value. Exposed for components that need to call a
+    /// host fn the SDK doesn't yet wrap.
+    pub fn raw(self) -> u32 {
+        self.raw
+    }
 }
 
 /// Narrowed capability handle for shutdown hooks (`on_replace`,
@@ -417,7 +462,7 @@ impl<'a> PriorState<'a> {
 }
 
 /// Inbound mail, as received by `Component::receive`. Wraps the raw
-/// `(kind, ptr, count)` FFI parameters with typed decode helpers.
+/// `(kind, ptr, count, sender)` FFI parameters with typed decode helpers.
 ///
 /// The lifetime `'a` ties the returned references back to the receive
 /// call; holding a decoded `&K` past the return of `receive` is a
@@ -432,6 +477,7 @@ pub struct Mail<'a> {
     // no-op; on 64-bit hosts it lets us unit-test with real pointers.
     ptr: usize,
     count: u32,
+    sender: u32,
     _borrow: PhantomData<&'a [u8]>,
 }
 
@@ -439,11 +485,12 @@ impl<'a> Mail<'a> {
     /// Not part of the public API; called only by `export!`. The FFI
     /// delivers `ptr` as a wasm32 offset (`u32`); this widens it.
     #[doc(hidden)]
-    pub unsafe fn __from_raw(kind: u32, ptr: u32, count: u32) -> Self {
+    pub unsafe fn __from_raw(kind: u32, ptr: u32, count: u32, sender: u32) -> Self {
         Mail {
             kind,
             ptr: ptr as usize,
             count,
+            sender,
             _borrow: PhantomData,
         }
     }
@@ -452,11 +499,12 @@ impl<'a> Mail<'a> {
     /// from a host pointer go through here so 64-bit addresses survive.
     #[doc(hidden)]
     #[cfg(test)]
-    unsafe fn __from_ptr_test(kind: u32, ptr: usize, count: u32) -> Self {
+    unsafe fn __from_ptr_test(kind: u32, ptr: usize, count: u32, sender: u32) -> Self {
         Mail {
             kind,
             ptr,
             count,
+            sender,
             _borrow: PhantomData,
         }
     }
@@ -474,10 +522,16 @@ impl<'a> Mail<'a> {
         self.count
     }
 
-    /// Reply handle for the session that originated this mail.
-    /// Always `None` today; ADR-0013 will start returning `Some`.
-    pub fn sender(&self) -> Option<&Sender> {
-        None
+    /// Reply handle for the session that originated this mail. `None`
+    /// for component-to-component mail and broadcast-origin mail;
+    /// `Some(Sender)` when the inbound came from a Claude session and
+    /// can be answered via `Ctx::reply`.
+    pub fn sender(&self) -> Option<Sender> {
+        if self.sender == SENDER_NONE {
+            None
+        } else {
+            Some(Sender { raw: self.sender })
+        }
     }
 
     /// Decode as a single owned `K`. Returns `None` if the kind does
@@ -601,15 +655,18 @@ macro_rules! export {
         }
 
         /// # Safety
-        /// Called by the substrate with `(kind, ptr, count)` matching
-        /// the FFI contract in `aether-substrate/src/host_fns.rs`.
+        /// Called by the substrate with `(kind, ptr, count, sender)`
+        /// matching the FFI contract in
+        /// `aether-substrate/src/host_fns.rs`. `sender` is the per-
+        /// instance reply-to handle (ADR-0013) or `SENDER_NONE` for
+        /// mail with no meaningful reply target.
         #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn receive(kind: u32, ptr: u32, count: u32) -> u32 {
+        pub unsafe extern "C" fn receive(kind: u32, ptr: u32, count: u32, sender: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
             let mut ctx = $crate::Ctx::__new();
-            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, count) };
+            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, count, sender) };
             <$component as $crate::Component>::receive(instance, &mut ctx, mail);
             0
         }
@@ -735,7 +792,7 @@ mod tests {
         // has to arrange for that address to point at valid bytes.
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, SENDER_NONE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -748,7 +805,7 @@ mod tests {
     fn mail_decode_wrong_kind_returns_none() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, SENDER_NONE) };
         let wrong: KindId<FakePod> = KindId {
             raw: 8,
             _k: PhantomData,
@@ -760,7 +817,7 @@ mod tests {
     fn mail_decode_wrong_count_returns_none() {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, SENDER_NONE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -773,7 +830,7 @@ mod tests {
     fn mail_decode_slice_roundtrip() {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, SENDER_NONE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -783,9 +840,16 @@ mod tests {
     }
 
     #[test]
-    fn mail_sender_is_always_none_today() {
-        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0) };
+    fn mail_sender_none_for_sentinel_handle() {
+        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, SENDER_NONE) };
         assert!(mail.sender().is_none());
+    }
+
+    #[test]
+    fn mail_sender_some_for_real_handle() {
+        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, 42) };
+        let s = mail.sender().expect("non-sentinel handle yields Some");
+        assert_eq!(s.raw(), 42);
     }
 
     #[test]

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -13,6 +13,7 @@
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
     pub fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    pub fn reply_mail(sender: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
     pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
     pub fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u32;
     pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
@@ -24,6 +25,14 @@ unsafe extern "C" {
 #[cfg(not(target_arch = "wasm32"))]
 pub unsafe fn send_mail(_recipient: u32, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-component: send_mail called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::reply_mail` import. Always
+/// panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn reply_mail(_sender: u32, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
+    panic!("aether-component: reply_mail called on non-wasm target");
 }
 
 /// # Safety

--- a/crates/aether-substrate/examples/encode_load.rs
+++ b/crates/aether-substrate/examples/encode_load.rs
@@ -28,7 +28,7 @@ use aether_substrate::{
 const WAT: &str = r#"
     (module
         (memory (export "memory") 1)
-        (func (export "receive") (param i32 i32 i32) (result i32)
+        (func (export "receive") (param i32 i32 i32 i32) (result i32)
             i32.const 0))
 "#;
 

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -3,10 +3,12 @@
 // static-offset convention (mail payload written at `MAIL_OFFSET`) to
 // match the spike; a guest-side allocator is future work per issue #18.
 
+use aether_hub_protocol::SessionToken;
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::Mail;
+use crate::sender_table::SENDER_NONE;
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -18,16 +20,20 @@ const MAIL_OFFSET: u32 = 1024;
 /// offset split keeps out-of-bounds checks obvious.
 const STATE_OFFSET: u32 = 8192;
 
-/// Contract with the guest: it exports a `receive(kind, ptr, count) -> u32`
-/// entrypoint and a `memory` named `memory`. ADR-0015 adds optional
-/// `on_replace`, `on_drop`, and `on_rehydrate` exports; the substrate
-/// calls them at the right lifecycle moments when present and silently
-/// skips when absent (no-op trait defaults compile down to no symbol
-/// under LTO, so components that don't override stay backwards-compat).
+/// Contract with the guest: it exports a
+/// `receive(kind, ptr, count, sender) -> u32` entrypoint and a `memory`
+/// named `memory`. ADR-0013 widened the receive ABI with a fourth
+/// `sender: u32` parameter — a per-instance handle the guest can pass
+/// back to `reply_mail`, or `SENDER_NONE` for component-originated
+/// mail. ADR-0015 adds optional `on_replace`, `on_drop`, and
+/// `on_rehydrate` exports; the substrate calls them at the right
+/// lifecycle moments when present and silently skips when absent
+/// (no-op trait defaults compile down to no symbol under LTO, so
+/// components that don't override stay backwards-compat).
 pub struct Component {
     store: Store<SubstrateCtx>,
     memory: Memory,
-    receive: TypedFunc<(u32, u32, u32), u32>,
+    receive: TypedFunc<(u32, u32, u32, u32), u32>,
     on_replace: Option<TypedFunc<(), u32>>,
     on_drop: Option<TypedFunc<(), u32>>,
     on_rehydrate: Option<TypedFunc<(u32, u32, u32), u32>>,
@@ -48,7 +54,8 @@ impl Component {
         let memory = instance
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
-        let receive = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "receive")?;
+        let receive =
+            instance.get_typed_func::<(u32, u32, u32, u32), u32>(&mut store, "receive")?;
 
         // Optional `init() -> u32` export: called once before the first
         // `receive`, used for one-shot bootstrap like resolving kind
@@ -90,11 +97,24 @@ impl Component {
     /// `receive`. Returns the guest's return value (contract is
     /// currently informational; host-visible errors propagate as
     /// `wasmtime::Error`).
+    ///
+    /// ADR-0013: when the mail carries a non-NIL `SessionToken`
+    /// (hub-originated mail), a fresh sender handle is allocated from
+    /// the per-instance `SenderTable`. Component-originated mail and
+    /// broadcast-origin mail pass `SENDER_NONE` so the guest cannot
+    /// `reply_mail` against a meaningless target.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
+        let handle = if mail.sender == SessionToken::NIL {
+            SENDER_NONE
+        } else {
+            self.store.data_mut().sender_table.allocate(mail.sender)
+        };
         self.memory
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
-        self.receive
-            .call(&mut self.store, (mail.kind, MAIL_OFFSET, mail.count))
+        self.receive.call(
+            &mut self.store,
+            (mail.kind, MAIL_OFFSET, mail.count, handle),
+        )
     }
 
     /// Invoke the guest's `on_replace` hook if it exports one.
@@ -193,6 +213,7 @@ mod tests {
     use wasmtime::{Engine, Linker};
 
     use super::*;
+    use crate::hub_client::HubOutbound;
     use crate::mail::MailboxId;
     use crate::queue::MailQueue;
     use crate::registry::Registry;
@@ -202,6 +223,7 @@ mod tests {
             MailboxId(0),
             Arc::new(Registry::new()),
             Arc::new(MailQueue::new()),
+            HubOutbound::disconnected(),
         )
     }
 
@@ -220,7 +242,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -237,14 +259,14 @@ mod tests {
     const WAT_NO_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
     const WAT_TRAP_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -258,7 +280,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -276,7 +298,7 @@ mod tests {
             (import "aether" "save_state"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -293,7 +315,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
                 ;; *(u32*)396 = version
@@ -305,6 +327,36 @@ mod tests {
                 local.get 1
                 local.get 2
                 memory.copy
+                i32.const 0))
+    "#;
+
+    /// ADR-0013: `receive` stores the sender handle at offset 500 so
+    /// the test can observe what the substrate passed through.
+    const WAT_STORES_SENDER: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+                i32.const 500
+                local.get 3
+                i32.store
+                i32.const 0))
+    "#;
+
+    /// ADR-0013: `receive` echoes a reply back to the sender under
+    /// whatever kind id the caller registered. Payload is empty —
+    /// the round-trip is the observable behavior.
+    const WAT_REPLIES: &str = r#"
+        (module
+            (import "aether" "reply_mail"
+                (func $reply_mail (param i32 i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+                (drop (call $reply_mail
+                    (local.get 3) ;; sender handle from receive param
+                    (i32.const 0) ;; kind id 0 — registered in the test
+                    (i32.const 0) ;; ptr
+                    (i32.const 0) ;; len
+                    (i32.const 1))) ;; count
                 i32.const 0))
     "#;
 
@@ -396,5 +448,102 @@ mod tests {
         };
         // Silently discards the bundle per ADR-0016 §3.
         component.call_on_rehydrate(&bundle).expect("noop ok");
+    }
+
+    #[test]
+    fn deliver_with_nil_sender_passes_sender_none() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::sender_table::SENDER_NONE;
+
+        let mut component = instantiate(WAT_STORES_SENDER);
+        // Mail::new defaults sender to SessionToken::NIL.
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1);
+        component.deliver(&mail).expect("deliver");
+        assert_eq!(component.read_u32(500), SENDER_NONE);
+    }
+
+    #[test]
+    fn deliver_with_real_token_allocates_handle() {
+        use aether_hub_protocol::{SessionToken, Uuid};
+
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::sender_table::SENDER_NONE;
+
+        let mut component = instantiate(WAT_STORES_SENDER);
+        let token = SessionToken(Uuid::from_u128(0xaaaa));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(token);
+        component.deliver(&mail).expect("deliver");
+        let observed = component.read_u32(500);
+        assert_ne!(observed, SENDER_NONE);
+        assert_eq!(
+            component.store.data().sender_table.resolve(observed),
+            Some(token),
+        );
+    }
+
+    fn plane_ctx_for_reply() -> (
+        SubstrateCtx,
+        std::sync::mpsc::Receiver<aether_hub_protocol::EngineToHub>,
+    ) {
+        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+
+        use crate::hub_client::HubOutbound;
+        use crate::mail::MailboxId as M;
+
+        let (outbound, rx) = HubOutbound::test_channel();
+        let registry = Arc::new(Registry::new());
+        // Kind id 0 is what `WAT_REPLIES` passes to reply_mail.
+        registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: "test.pong".into(),
+                encoding: KindEncoding::Signal,
+            })
+            .expect("register kind");
+        let ctx = SubstrateCtx::new(M(0), registry, Arc::new(MailQueue::new()), outbound);
+        (ctx, rx)
+    }
+
+    fn instantiate_with_ctx(wat: &str, ctx: SubstrateCtx) -> Component {
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        crate::host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(wat).unwrap();
+        let module = Module::new(&engine, &wasm).unwrap();
+        Component::instantiate(&engine, &linker, &module, ctx).unwrap()
+    }
+
+    #[test]
+    fn reply_mail_emits_session_addressed_frame() {
+        use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
+
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+
+        let (ctx, rx) = plane_ctx_for_reply();
+        let mut component = instantiate_with_ctx(WAT_REPLIES, ctx);
+
+        let token = SessionToken(Uuid::from_u128(0xbeef));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(token);
+        component.deliver(&mail).expect("deliver");
+
+        let frame = rx.try_recv().expect("outbound frame queued");
+        let EngineToHub::Mail(mail_frame) = frame else {
+            panic!("expected EngineToHub::Mail, got {frame:?}");
+        };
+        assert_eq!(mail_frame.address, ClaudeAddress::Session(token));
+        assert_eq!(mail_frame.kind_name, "test.pong");
+    }
+
+    #[test]
+    fn reply_mail_with_unknown_handle_sends_no_frame() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+
+        let (ctx, rx) = plane_ctx_for_reply();
+        let mut component = instantiate_with_ctx(WAT_REPLIES, ctx);
+
+        // NIL sender → SENDER_NONE reaches the guest → reply_mail
+        // returns REPLY_UNKNOWN_HANDLE and outbound stays quiet.
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1);
+        component.deliver(&mail).expect("deliver");
+        assert!(rx.try_recv().is_err(), "no frame should have been sent");
     }
 }

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -210,7 +210,12 @@ impl ControlPlane {
             }
         };
 
-        let ctx = SubstrateCtx::new(mailbox, Arc::clone(&self.registry), Arc::clone(&self.queue));
+        let ctx = SubstrateCtx::new(
+            mailbox,
+            Arc::clone(&self.registry),
+            Arc::clone(&self.queue),
+            Arc::clone(&self.outbound),
+        );
         let component = match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
             Ok(c) => c,
             Err(e) => {
@@ -344,7 +349,12 @@ impl ControlPlane {
             old.on_drop();
         }
 
-        let ctx = SubstrateCtx::new(id, Arc::clone(&self.registry), Arc::clone(&self.queue));
+        let ctx = SubstrateCtx::new(
+            id,
+            Arc::clone(&self.registry),
+            Arc::clone(&self.queue),
+            Arc::clone(&self.outbound),
+        );
         let mut new_component =
             match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
                 Ok(c) => c,
@@ -475,12 +485,12 @@ mod tests {
     }
 
     /// Minimal WAT module satisfying the substrate's component
-    /// contract: exports `memory`, a `receive(i32,i32,i32) -> i32`
+    /// contract: exports `memory`, a `receive(i32,i32,i32,i32) -> i32`
     /// that returns 0, and no `init`.
     const WAT: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
@@ -491,7 +501,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -510,7 +520,7 @@ mod tests {
     const WAT_TRAPS_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -524,7 +534,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -542,7 +552,7 @@ mod tests {
             (import "aether" "save_state"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -558,7 +568,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32) (result i32)
+            (func (export "receive") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
                 i32.const 396

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -13,9 +13,11 @@ use std::sync::Arc;
 
 use aether_hub_protocol::SessionToken;
 
+use crate::hub_client::HubOutbound;
 use crate::mail::{Mail, MailKind, MailboxId};
 use crate::queue::MailQueue;
 use crate::registry::{MailboxEntry, Registry};
+use crate::sender_table::SenderTable;
 
 /// ADR-0016 §3: opt-in state migration payload. The substrate owns the
 /// buffer from the moment `save_state` is called on the old instance
@@ -32,6 +34,18 @@ pub struct SubstrateCtx {
     pub sender: MailboxId,
     pub registry: Arc<Registry>,
     pub queue: Arc<MailQueue>,
+    /// ADR-0013: direct outbound handle so the `reply_mail` host fn
+    /// can address a specific Claude session without routing through
+    /// a well-known sink. Broadcast still goes through
+    /// `hub.claude.broadcast`; reply is the session-targeted twin.
+    /// `HubOutbound::disconnected` when no hub is attached — sends
+    /// silently drop, matching the broadcast semantics.
+    pub outbound: Arc<HubOutbound>,
+    /// ADR-0013: handle→token map populated by `Component::deliver`
+    /// whenever an inbound Claude-originated mail is dispatched. The
+    /// guest receives the `u32` handle as the 4th param on its
+    /// `receive` shim and can pass it back to `reply_mail`.
+    pub sender_table: SenderTable,
     /// Set by the `save_state` host fn during `on_replace`. The
     /// substrate extracts it after hooks return via
     /// `Component::take_saved_state`. Never read by the guest —
@@ -46,15 +60,23 @@ pub struct SubstrateCtx {
 }
 
 impl SubstrateCtx {
-    /// Build a fresh ctx with empty state-migration slots. Using this
-    /// over the struct literal keeps the `saved_state` /
-    /// `save_state_error` fields private to the migration wiring —
-    /// callers should never set them directly.
-    pub fn new(sender: MailboxId, registry: Arc<Registry>, queue: Arc<MailQueue>) -> Self {
+    /// Build a fresh ctx with empty state-migration slots and an
+    /// empty sender table. Using this over the struct literal keeps
+    /// the private fields (sender_table, saved_state,
+    /// save_state_error) internal to the wiring — callers should
+    /// never set them directly.
+    pub fn new(
+        sender: MailboxId,
+        registry: Arc<Registry>,
+        queue: Arc<MailQueue>,
+        outbound: Arc<HubOutbound>,
+    ) -> Self {
         SubstrateCtx {
             sender,
             registry,
             queue,
+            outbound,
+            sender_table: SenderTable::new(),
             saved_state: None,
             save_state_error: None,
         }

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -4,6 +4,7 @@
 // surface. Growth of this surface should be reviewed as deliberately
 // as any other architectural change.
 
+use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
 use wasmtime::{Caller, Linker};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
@@ -14,6 +15,19 @@ use crate::mail::MailboxId;
 /// sentinel.
 pub const KIND_NOT_FOUND: u32 = u32::MAX;
 pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
+
+/// Status codes returned by the `reply_mail` host fn (ADR-0013 §3).
+/// `0` is success; non-zero values distinguish call-site errors
+/// (unknown handle, OOB guest memory, unregistered kind) from each
+/// other so the SDK can surface a useful message. "Session gone" is
+/// a named status but not yet populated — V0 cannot synchronously
+/// detect that the hub has dropped a session; the outbound frame is
+/// queued and if the session is gone the hub discards it silently.
+pub const REPLY_OK: u32 = 0;
+pub const REPLY_UNKNOWN_HANDLE: u32 = 1;
+pub const REPLY_SESSION_GONE: u32 = 2;
+pub const REPLY_OOB: u32 = 3;
+pub const REPLY_KIND_NOT_FOUND: u32 = 4;
 
 /// ADR-0016 §2: maximum size of a single state bundle. A `save_state`
 /// call with `len > MAX_STATE_BUNDLE_BYTES` is rejected (status 3) and
@@ -134,6 +148,52 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
             let ctx = caller.data_mut();
             ctx.saved_state = Some(StateBundle { version, bytes });
             SAVE_STATE_OK
+        },
+    )?;
+
+    // ADR-0013 §3: `reply_mail` addresses a specific Claude session
+    // using a per-instance handle the guest received as the 4th param
+    // on its `receive` shim. Two routes diverge here versus `send_mail`:
+    // the recipient is a `SessionToken` rather than a `MailboxId`, and
+    // the frame goes straight out over `HubOutbound` rather than
+    // through the registry's sink handlers.
+    linker.func_wrap(
+        "aether",
+        "reply_mail",
+        |mut caller: Caller<'_, SubstrateCtx>,
+         sender: u32,
+         kind: u32,
+         ptr: u32,
+         len: u32,
+         _count: u32|
+         -> u32 {
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return REPLY_OOB,
+            };
+            let data = memory.data(&caller);
+            let start = ptr as usize;
+            let end = match start.checked_add(len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return REPLY_OOB,
+            };
+            let payload = data[start..end].to_vec();
+
+            let ctx = caller.data();
+            let Some(token) = ctx.sender_table.resolve(sender) else {
+                return REPLY_UNKNOWN_HANDLE;
+            };
+            let Some(kind_name) = ctx.registry.kind_name(kind) else {
+                return REPLY_KIND_NOT_FOUND;
+            };
+            let origin = ctx.registry.mailbox_name(ctx.sender);
+            ctx.outbound.send(EngineToHub::Mail(EngineMailFrame {
+                address: ClaudeAddress::Session(token),
+                kind_name,
+                payload,
+                origin,
+            }));
+            REPLY_OK
         },
     )?;
 

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -78,6 +78,20 @@ impl HubOutbound {
     pub fn is_connected(&self) -> bool {
         self.tx.get().is_some()
     }
+
+    /// Test helper: build an attached outbound paired with the
+    /// receiver end so tests can assert on the frames components
+    /// emit. Mirrors the channel `HubClient::connect` would attach
+    /// but skips the TCP machinery.
+    #[cfg(test)]
+    pub fn test_channel() -> (Arc<Self>, std::sync::mpsc::Receiver<EngineToHub>) {
+        let (tx, rx) = mpsc::channel::<EngineToHub>();
+        let outbound = Arc::new(Self {
+            tx: OnceLock::new(),
+        });
+        outbound.attach(tx);
+        (outbound, rx)
+    }
 }
 
 /// Live hub connection. Threads are retained so their join handles

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -16,6 +16,7 @@ pub mod mail;
 pub mod queue;
 pub mod registry;
 pub mod scheduler;
+pub mod sender_table;
 
 pub use component::Component;
 pub use control::{

--- a/crates/aether-substrate/src/sender_table.rs
+++ b/crates/aether-substrate/src/sender_table.rs
@@ -1,0 +1,106 @@
+// Per-component-instance mapping from guest-visible sender handles
+// (opaque `u32`) to the real `SessionToken` the substrate received
+// over the hub wire (ADR-0008). Handles are allocated when an inbound
+// Claude-originated mail is dispatched to a component and resolved
+// when the guest calls `reply_mail` to answer it.
+//
+// ADR-0013 §1: handles are monotonically increasing per instance.
+// Exhaustion at 2³² dispatches is out of scope for V0; when it
+// becomes real, the handle becomes a generational index.
+//
+// The table lives on `SubstrateCtx` rather than `Component` because
+// the host fn touches it via `Caller::data_mut()`. Putting it there
+// also means replace/drop on the component naturally clears it — the
+// old `Store<SubstrateCtx>` is dropped and the table with it.
+
+use std::collections::HashMap;
+
+use aether_hub_protocol::SessionToken;
+
+/// Sentinel passed to the guest's `receive` shim when the inbound
+/// mail has no meaningful reply target (component-originated mail, or
+/// broadcast origin — ADR-0013 §1). A `reply_mail` call with this
+/// handle fails with the "unknown handle" status.
+pub const SENDER_NONE: u32 = u32::MAX;
+
+/// Maintains the handle→token map for one component instance.
+#[derive(Debug, Default)]
+pub struct SenderTable {
+    entries: HashMap<u32, SessionToken>,
+    next: u32,
+}
+
+impl SenderTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a fresh handle bound to `token`. The returned handle
+    /// is never `SENDER_NONE` — wraps past it silently.
+    pub fn allocate(&mut self, token: SessionToken) -> u32 {
+        // Skip the sentinel. In practice `next` never hits `u32::MAX`
+        // before the instance is replaced/dropped; this is hygiene.
+        if self.next == SENDER_NONE {
+            self.next = 0;
+        }
+        let handle = self.next;
+        self.next = self.next.wrapping_add(1);
+        self.entries.insert(handle, token);
+        handle
+    }
+
+    /// Look up the token for a guest-supplied handle. Returns `None`
+    /// for `SENDER_NONE`, for handles that were never allocated, and
+    /// (once implemented) for handles whose session is known-gone.
+    pub fn resolve(&self, handle: u32) -> Option<SessionToken> {
+        if handle == SENDER_NONE {
+            return None;
+        }
+        self.entries.get(&handle).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_hub_protocol::Uuid;
+
+    use super::*;
+
+    fn token(byte: u8) -> SessionToken {
+        SessionToken(Uuid::from_bytes([byte; 16]))
+    }
+
+    #[test]
+    fn allocate_increments_and_roundtrips() {
+        let mut t = SenderTable::new();
+        let h0 = t.allocate(token(1));
+        let h1 = t.allocate(token(2));
+        assert_ne!(h0, h1);
+        assert_eq!(t.resolve(h0), Some(token(1)));
+        assert_eq!(t.resolve(h1), Some(token(2)));
+    }
+
+    #[test]
+    fn resolve_sentinel_is_none() {
+        let t = SenderTable::new();
+        assert!(t.resolve(SENDER_NONE).is_none());
+    }
+
+    #[test]
+    fn resolve_unknown_handle_is_none() {
+        let mut t = SenderTable::new();
+        let _ = t.allocate(token(7));
+        assert!(t.resolve(9999).is_none());
+    }
+
+    #[test]
+    fn allocate_skips_sentinel_on_wrap() {
+        let mut t = SenderTable::new();
+        t.next = SENDER_NONE;
+        let h = t.allocate(token(3));
+        // First handle after the wrap is 0 — the sentinel is never
+        // handed out.
+        assert_eq!(h, 0);
+        assert_ne!(h, SENDER_NONE);
+    }
+}

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use aether_substrate::{
-    Component, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    Component, HubOutbound, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
 use wasmtime::{Engine, Linker, Module};
@@ -27,7 +27,9 @@ const WAT: &str = r#"
   (import "aether" "send_mail"
     (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
-  (func (export "receive") (param $kind i32) (param $ptr i32) (param $count i32) (result i32)
+  (func (export "receive")
+    (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+    (result i32)
     ;; Forward a send_mail call to mailbox 1 (the sink in this test).
     ;; recipient=1, kind=99, ptr=0, len=0, count=<same as incoming count>.
     i32.const 1
@@ -61,7 +63,12 @@ fn tick_roundtrip_component_to_sink() {
     let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
     host_fns::register(&mut linker).expect("register host fns");
 
-    let ctx = SubstrateCtx::new(component_mbox, Arc::clone(&registry), Arc::clone(&queue));
+    let ctx = SubstrateCtx::new(
+        component_mbox,
+        Arc::clone(&registry),
+        Arc::clone(&queue),
+        HubOutbound::disconnected(),
+    );
     let component = Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
 
     let mut components = std::collections::HashMap::new();

--- a/docs/adr/0013-reply-to-sender-host-fn.md
+++ b/docs/adr/0013-reply-to-sender-host-fn.md
@@ -1,7 +1,8 @@
 # ADR-0013: Reply-to-sender host fn
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
+- **Accepted:** 2026-04-17
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Implements ADR-0013. A component can now answer the Claude session that sent it mail: `mail.sender()` returns `Some(Sender)` for hub-originated mail, and `ctx.reply(sender, kind_id, &payload)` emits a `ClaudeAddress::Session`-addressed frame back over `HubOutbound`.
- New per-instance `SenderTable` (monotonic `u32` handles, `SENDER_NONE = u32::MAX` sentinel) lives on `SubstrateCtx` so replace/drop discards it along with the old `Store`.
- Receive shim ABI widened to `(kind, ptr, count, sender) -> u32`. The `export!` macro absorbs the change; `aether-hello-component` compiles unchanged.
- `SubstrateCtx::new` now takes an `Arc<HubOutbound>` so `reply_mail` can emit session-addressed frames directly (sink handlers aren't shaped for session addressing).
- Flips ADR-0013 to **Accepted**.

## Test plan
- [x] `cargo test --workspace` — new tests: SenderTable alloc/resolve (including SENDER_NONE skip-on-wrap), deliver with NIL sender passes SENDER_NONE, deliver with real token allocates a handle that resolves back to the original session, reply_mail emits a session-addressed frame with the originating token via `HubOutbound::test_channel`, reply with an unknown handle returns `REPLY_UNKNOWN_HANDLE` and sends no frame, plus Mail::sender() branch in the guest SDK.
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Live-hub smoke: port \`aether-hello-component\` for a ping→pong round trip (called out as follow-up in ADR §Follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)