### PR TITLE
feat(hello): ping/pong round-trip via reply-to-sender

### DIFF
--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -1,21 +1,11 @@
-// First real aether component, now written against the ADR-0014
-// `Component` trait. On each tick it emits a fixed clip-space
-// triangle to the substrate's render sink.
-//
-// What the Component trait + export! macro replace compared to the
-// ADR-0012 shape this file used to carry:
-//   - hand-written `#[unsafe(no_mangle)] pub unsafe extern "C" fn
-//     init/receive` → `export!(Hello)` emits the shims.
-//   - `static mut Option<KindId<Tick>>` / `static mut Option<Sink<...>>`
-//     → fields on `Hello`, populated during `init`.
-//   - `unsafe` blocks around every access to the statics → none;
-//     `&mut self` in `receive` is ordinary safe Rust.
-//
-// Behavioral parity: resolves Tick and the "render" sink at init,
-// sends the triangle whenever a tick arrives. Nothing else.
+// First real aether component. On each tick it emits a fixed
+// clip-space triangle to the substrate's render sink. It also
+// answers ADR-0013 `aether.ping` mail with a matching `aether.pong`
+// back to the originating Claude session — a minimal round-trip
+// smoke test proving reply-to-sender works end-to-end over the hub.
 
 use aether_component::{Component, Ctx, InitCtx, KindId, Mail, Sink};
-use aether_substrate_mail::{DrawTriangle, Tick, Vertex};
+use aether_substrate_mail::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
     verts: [
@@ -45,6 +35,8 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
 
 pub struct Hello {
     tick: KindId<Tick>,
+    ping: KindId<Ping>,
+    pong: KindId<Pong>,
     render: Sink<DrawTriangle>,
 }
 
@@ -52,6 +44,8 @@ impl Component for Hello {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Hello {
             tick: ctx.resolve::<Tick>(),
+            ping: ctx.resolve::<Ping>(),
+            pong: ctx.resolve::<Pong>(),
             render: ctx.resolve_sink::<DrawTriangle>("render"),
         }
     }
@@ -59,6 +53,14 @@ impl Component for Hello {
     fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>) {
         if self.tick.matches(mail.kind()) {
             ctx.send(&self.render, &TRIANGLE);
+        } else if let Some(ping) = mail.decode(self.ping)
+            && let Some(sender) = mail.sender()
+        {
+            // Echo the sequence number so the caller can pair request
+            // and reply when multiple pings are in flight. No sender
+            // (component-origin or broadcast) silently drops the ping
+            // — there's nothing to reply to.
+            ctx.reply(sender, self.pong, &Pong { seq: ping.seq });
         }
     }
 }

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -17,7 +17,7 @@ use aether_mail::Kind;
 
 use crate::{
     DrawTriangle, DropComponent, DropResult, FrameStats, Key, LoadComponent, LoadResult,
-    MouseButton, MouseMove, ReplaceComponent, ReplaceResult, Tick,
+    MouseButton, MouseMove, Ping, Pong, ReplaceComponent, ReplaceResult, Tick,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -45,6 +45,11 @@ pub fn all() -> Vec<KindDescriptor> {
                 scalar("triangles", PodPrimitive::U64),
             ],
         ),
+        // ADR-0013 smoke-test vocabulary. Both Pod so the MCP
+        // `send_mail` tool can encode ping from params; Pong comes
+        // back as bytes on the reply path.
+        pod(Ping::NAME, vec![scalar("seq", PodPrimitive::U32)]),
+        pod(Pong::NAME, vec![scalar("seq", PodPrimitive::U32)]),
         // ADR-0010 control-plane kinds. Variable-length payloads that
         // don't fit the Pod model — the substrate handler decodes via
         // postcard against its own wire types. Agents that use the MCP
@@ -99,6 +104,8 @@ mod tests {
         assert!(names.contains(&MouseButton::NAME));
         assert!(names.contains(&MouseMove::NAME));
         assert!(names.contains(&DrawTriangle::NAME));
+        assert!(names.contains(&Ping::NAME));
+        assert!(names.contains(&Pong::NAME));
         assert!(names.contains(&LoadComponent::NAME));
         assert!(names.contains(&ReplaceComponent::NAME));
         assert!(names.contains(&DropComponent::NAME));

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -79,6 +79,31 @@ impl Kind for DrawTriangle {
     const NAME: &'static str = "aether.draw_triangle";
 }
 
+/// Request addressed to a component that supports the ADR-0013
+/// reply-to-sender smoke path. The component answers with `Pong`
+/// carrying the same `seq`; the round trip proves that a Claude
+/// session → component → session reply actually works end-to-end.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Ping {
+    pub seq: u32,
+}
+impl Kind for Ping {
+    const NAME: &'static str = "aether.ping";
+}
+
+/// Reply-to-sender counterpart to `Ping`. The `seq` is the incoming
+/// `Ping.seq` echoed back so the caller can match requests against
+/// replies when multiple are in flight.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Pong {
+    pub seq: u32,
+}
+impl Kind for Pong {
+    const NAME: &'static str = "aether.pong";
+}
+
 /// Periodic observation emitted by the substrate's frame loop when a
 /// hub is attached (ADR-0008). The substrate pushes one of these at
 /// `LOG_EVERY_FRAMES` cadence to the `hub.claude.broadcast` sink, so
@@ -203,6 +228,8 @@ mod tests {
         assert_eq!(MouseMove::NAME, "aether.mouse_move");
         assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
         assert_eq!(FrameStats::NAME, "aether.observation.frame_stats");
+        assert_eq!(Ping::NAME, "aether.ping");
+        assert_eq!(Pong::NAME, "aether.pong");
         assert_eq!(LoadComponent::NAME, "aether.control.load_component");
         assert_eq!(ReplaceComponent::NAME, "aether.control.replace_component");
         assert_eq!(DropComponent::NAME, "aether.control.drop_component");


### PR DESCRIPTION
## Summary
- Live-hub smoke test for ADR-0013. Adds \`Ping { seq: u32 }\` / \`Pong { seq: u32 }\` to \`aether-substrate-mail\` and wires hello to echo: on inbound \`aether.ping\` with a real sender, reply with \`aether.pong\` carrying the same \`seq\`.
- Both kinds are Pod with one u32 field, so the MCP \`send_mail\` tool's schema-driven encoding (ADR-0007) can build a ping straight from params — no \`payload_bytes\` escape hatch needed.
- Follow-up item from ADR-0013 §Follow-up: \"Port the receive-side of aether-hello-component to read sender for a trivial round-trip smoke test (Claude sends aether.ping, component replies with aether.pong).\"

## Test plan
- [x] \`cargo test --workspace\`
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo build -p aether-hello-component --target wasm32-unknown-unknown --release\` (18,132 bytes — still well under the 1 MiB frame cap)
- [ ] Live-hub: \`spawn_substrate\` → \`load_component\` hello → \`send_mail aether.ping { seq: N }\` → \`receive_mail\` drains \`aether.pong\` with matching seq addressed back to this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)