### PR TITLE
docs(adr): flip 0012, 0014, 0015 to Accepted

### DIFF
--- a/docs/adr/0012-guest-component-sdk.md
+++ b/docs/adr/0012-guest-component-sdk.md
@@ -1,7 +1,8 @@
 # ADR-0012: Guest-side component SDK
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
+- **Accepted:** 2026-04-14
 
 ## Context
 

--- a/docs/adr/0014-component-trait-and-associated-types.md
+++ b/docs/adr/0014-component-trait-and-associated-types.md
@@ -1,7 +1,8 @@
 # ADR-0014: Component trait and associated types
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
+- **Accepted:** 2026-04-15
 
 ## Context
 

--- a/docs/adr/0015-component-lifecycle-hooks.md
+++ b/docs/adr/0015-component-lifecycle-hooks.md
@@ -1,7 +1,8 @@
 # ADR-0015: Component lifecycle hooks
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
+- **Accepted:** 2026-04-15
 
 ## Context
 


### PR DESCRIPTION
Housekeeping — three ADRs shipped but the status flips were missed. Accepted dates match the actual merge dates of the shipping PRs:

- ADR-0012 (guest-component SDK) — PR #68, 2026-04-14
- ADR-0014 (Component trait) — PR #69, 2026-04-15
- ADR-0015 (lifecycle hooks) — PRs #70 + #71, 2026-04-15

After this merges, the only \`Proposed\` ADR in the tree is 0017 (correctly — not implemented yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)