### PR TITLE
feat(substrate): component-origin sender handles (ADR-0017)

### DIFF
--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -8,7 +8,7 @@ use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::Mail;
-use crate::sender_table::SENDER_NONE;
+use crate::sender_table::{SENDER_NONE, SenderEntry};
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -98,16 +98,22 @@ impl Component {
     /// currently informational; host-visible errors propagate as
     /// `wasmtime::Error`).
     ///
-    /// ADR-0013: when the mail carries a non-NIL `SessionToken`
-    /// (hub-originated mail), a fresh sender handle is allocated from
-    /// the per-instance `SenderTable`. Component-originated mail and
-    /// broadcast-origin mail pass `SENDER_NONE` so the guest cannot
-    /// `reply_mail` against a meaningless target.
+    /// ADR-0013 + ADR-0017: a fresh sender handle is allocated from
+    /// the per-instance `SenderTable` for every inbound that has a
+    /// meaningful reply target — a Claude session (non-NIL
+    /// `SessionToken`) or another component (`from_component`
+    /// populated by `SubstrateCtx::send`). Broadcast-origin and
+    /// system-generated mail pass `SENDER_NONE` so the guest's
+    /// `mail.sender()` accessor returns `None`.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
-        let handle = if mail.sender == SessionToken::NIL {
-            SENDER_NONE
+        let entry = if mail.sender != SessionToken::NIL {
+            Some(SenderEntry::Session(mail.sender))
         } else {
-            self.store.data_mut().sender_table.allocate(mail.sender)
+            mail.from_component.map(SenderEntry::Component)
+        };
+        let handle = match entry {
+            Some(e) => self.store.data_mut().sender_table.allocate(e),
+            None => SENDER_NONE,
         };
         self.memory
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
@@ -463,11 +469,11 @@ mod tests {
     }
 
     #[test]
-    fn deliver_with_real_token_allocates_handle() {
+    fn deliver_with_real_token_allocates_session_handle() {
         use aether_hub_protocol::{SessionToken, Uuid};
 
         use crate::mail::{Mail as SubstrateMail, MailboxId as M};
-        use crate::sender_table::SENDER_NONE;
+        use crate::sender_table::{SENDER_NONE, SenderEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xaaaa));
@@ -477,8 +483,50 @@ mod tests {
         assert_ne!(observed, SENDER_NONE);
         assert_eq!(
             component.store.data().sender_table.resolve(observed),
-            Some(token),
+            Some(SenderEntry::Session(token)),
         );
+    }
+
+    #[test]
+    fn deliver_with_from_component_allocates_component_handle() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::sender_table::{SENDER_NONE, SenderEntry};
+
+        let mut component = instantiate(WAT_STORES_SENDER);
+        // ADR-0017: component-origin mail (no session token, but a
+        // populated `from_component`) gets a Component-variant handle.
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_origin(M(7));
+        component.deliver(&mail).expect("deliver");
+        let observed = component.read_u32(500);
+        assert_ne!(observed, SENDER_NONE);
+        assert_eq!(
+            component.store.data().sender_table.resolve(observed),
+            Some(SenderEntry::Component(M(7))),
+        );
+    }
+
+    #[test]
+    fn deliver_session_takes_priority_over_component_origin() {
+        // If both a session token and a from_component are set (which
+        // can happen if hub-originated mail somehow gets re-routed
+        // through SubstrateCtx::send), the Session variant wins. The
+        // session is the more specific reply target.
+        use aether_hub_protocol::{SessionToken, Uuid};
+
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::sender_table::SenderEntry;
+
+        let mut component = instantiate(WAT_STORES_SENDER);
+        let token = SessionToken(Uuid::from_u128(0xbbbb));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1)
+            .with_sender(token)
+            .with_origin(M(99));
+        component.deliver(&mail).expect("deliver");
+        let observed = component.read_u32(500);
+        match component.store.data().sender_table.resolve(observed) {
+            Some(SenderEntry::Session(t)) => assert_eq!(t, token),
+            other => panic!("expected Session, got {other:?}"),
+        }
     }
 
     fn plane_ctx_for_reply() -> (
@@ -545,5 +593,83 @@ mod tests {
         let mail = SubstrateMail::new(M(0), 0, vec![], 1);
         component.deliver(&mail).expect("deliver");
         assert!(rx.try_recv().is_err(), "no frame should have been sent");
+    }
+
+    /// ADR-0017 component-reply path. Builds a ctx whose registry
+    /// has both a fake originating-component mailbox (id 1, name
+    /// "caller") and a "test.pong" kind. When `WAT_REPLIES` calls
+    /// `reply_mail` with the Component-variant handle the substrate
+    /// allocated, the reply lands on the local `MailQueue` —
+    /// outbound stays empty.
+    fn plane_ctx_with_caller_mailbox() -> (
+        SubstrateCtx,
+        std::sync::mpsc::Receiver<aether_hub_protocol::EngineToHub>,
+        Arc<MailQueue>,
+        crate::mail::MailboxId,
+    ) {
+        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+
+        use crate::hub_client::HubOutbound;
+        use crate::mail::MailboxId as M;
+
+        let (outbound, rx) = HubOutbound::test_channel();
+        let registry = Arc::new(Registry::new());
+        let caller = registry.register_component("caller");
+        registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: "test.pong".into(),
+                encoding: KindEncoding::Signal,
+            })
+            .expect("register kind");
+        let queue = Arc::new(MailQueue::new());
+        let ctx = SubstrateCtx::new(M(0), registry, Arc::clone(&queue), outbound);
+        (ctx, rx, queue, caller)
+    }
+
+    #[test]
+    fn reply_mail_to_component_enqueues_on_mailqueue() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+
+        let (ctx, rx_outbound, queue, caller) = plane_ctx_with_caller_mailbox();
+        let mut component = instantiate_with_ctx(WAT_REPLIES, ctx);
+
+        // Inbound mail from "caller" — substrate allocates a
+        // Component-variant handle. The guest's reply_mail call
+        // routes through SubstrateCtx::send to the local queue.
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_origin(caller);
+        component.deliver(&mail).expect("deliver");
+
+        // Outbound stayed quiet — no hub frame for component replies.
+        assert!(
+            rx_outbound.try_recv().is_err(),
+            "component reply must not hit HubOutbound"
+        );
+        // The local queue picked up the reply addressed to caller.
+        let queued = queue.try_pop().expect("reply enqueued");
+        assert_eq!(queued.recipient, caller);
+        assert_eq!(queued.kind, 0);
+    }
+
+    #[test]
+    fn reply_mail_to_dropped_component_silently_discards() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+
+        let (ctx, rx_outbound, queue, caller) = plane_ctx_with_caller_mailbox();
+        // Drop the caller before the reply lands. SubstrateCtx::send
+        // logs and discards rather than panicking — the inbound flow
+        // still completes successfully from the receiving guest's
+        // perspective.
+        ctx.registry.drop_mailbox(caller).expect("drop caller");
+        let mut component = instantiate_with_ctx(WAT_REPLIES, ctx);
+
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_origin(caller);
+        component.deliver(&mail).expect("deliver");
+
+        assert!(rx_outbound.try_recv().is_err());
+        // Queue stays empty — dropped mailbox path discards.
+        assert!(
+            queue.try_pop().is_none(),
+            "reply to dropped mailbox must not enqueue"
+        );
     }
 }

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -41,10 +41,14 @@ pub struct SubstrateCtx {
     /// `HubOutbound::disconnected` when no hub is attached — sends
     /// silently drop, matching the broadcast semantics.
     pub outbound: Arc<HubOutbound>,
-    /// ADR-0013: handle→token map populated by `Component::deliver`
-    /// whenever an inbound Claude-originated mail is dispatched. The
-    /// guest receives the `u32` handle as the 4th param on its
-    /// `receive` shim and can pass it back to `reply_mail`.
+    /// ADR-0013 + ADR-0017: handle→entry map populated by
+    /// `Component::deliver` whenever an inbound mail has a meaningful
+    /// reply target — a Claude session (`SenderEntry::Session`) or
+    /// another component (`SenderEntry::Component`). The guest
+    /// receives an opaque `u32` handle as the 4th param on its
+    /// `receive` shim and passes it back to `reply_mail`; the
+    /// substrate routes either over `HubOutbound` or back through
+    /// `MailQueue` based on the variant.
     pub sender_table: SenderTable,
     /// Set by the `save_state` host fn during `on_replace`. The
     /// substrate extracts it after hooks return via
@@ -103,7 +107,13 @@ impl SubstrateCtx {
                 );
             }
             Some(MailboxEntry::Component) => {
-                self.queue.push(Mail::new(recipient, kind, payload, count));
+                // ADR-0017: component-to-component mail carries the
+                // sender's mailbox id so `Component::deliver` can
+                // allocate a Component-variant `SenderEntry`. The
+                // receiving guest gets a reply-capable handle that
+                // routes back through the local queue.
+                self.queue
+                    .push(Mail::new(recipient, kind, payload, count).with_origin(self.sender));
             }
             Some(MailboxEntry::Dropped) => {
                 eprintln!(

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -9,6 +9,7 @@ use wasmtime::{Caller, Linker};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::MailboxId;
+use crate::sender_table::SenderEntry;
 
 /// Returned by `resolve_kind` / `resolve_mailbox` when the requested
 /// name has not been registered. Guests use this as a "lookup failed"
@@ -151,12 +152,16 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         },
     )?;
 
-    // ADR-0013 §3: `reply_mail` addresses a specific Claude session
-    // using a per-instance handle the guest received as the 4th param
-    // on its `receive` shim. Two routes diverge here versus `send_mail`:
-    // the recipient is a `SessionToken` rather than a `MailboxId`, and
-    // the frame goes straight out over `HubOutbound` rather than
-    // through the registry's sink handlers.
+    // ADR-0013 + ADR-0017: `reply_mail` addresses the originator of
+    // the inbound mail whose sender handle the guest received.
+    // Branches on the `SenderEntry` variant:
+    //   - Session: ship as a `ClaudeAddress::Session` frame through
+    //     `HubOutbound` (same route as ADR-0013's original design).
+    //   - Component: enqueue on the local `MailQueue` via
+    //     `SubstrateCtx::send`. Dropped-mailbox discard is handled
+    //     there already, so a component that vanished between the
+    //     request and the reply silently drops — the same contract
+    //     as any other send to a dropped mailbox.
     linker.func_wrap(
         "aether",
         "reply_mail",
@@ -165,7 +170,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
          kind: u32,
          ptr: u32,
          len: u32,
-         _count: u32|
+         count: u32|
          -> u32 {
             let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
                 Some(m) => m,
@@ -180,19 +185,33 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
             let payload = data[start..end].to_vec();
 
             let ctx = caller.data();
-            let Some(token) = ctx.sender_table.resolve(sender) else {
+            let Some(entry) = ctx.sender_table.resolve(sender) else {
                 return REPLY_UNKNOWN_HANDLE;
             };
-            let Some(kind_name) = ctx.registry.kind_name(kind) else {
-                return REPLY_KIND_NOT_FOUND;
-            };
-            let origin = ctx.registry.mailbox_name(ctx.sender);
-            ctx.outbound.send(EngineToHub::Mail(EngineMailFrame {
-                address: ClaudeAddress::Session(token),
-                kind_name,
-                payload,
-                origin,
-            }));
+            match entry {
+                SenderEntry::Session(token) => {
+                    let Some(kind_name) = ctx.registry.kind_name(kind) else {
+                        return REPLY_KIND_NOT_FOUND;
+                    };
+                    let origin = ctx.registry.mailbox_name(ctx.sender);
+                    ctx.outbound.send(EngineToHub::Mail(EngineMailFrame {
+                        address: ClaudeAddress::Session(token),
+                        kind_name,
+                        payload,
+                        origin,
+                    }));
+                }
+                SenderEntry::Component(mbox) => {
+                    // Validate the kind id cheaply — the guest might
+                    // have passed a bogus one and we'd rather return
+                    // a meaningful status than silently enqueue mail
+                    // that the receiver can't decode.
+                    if ctx.registry.kind_name(kind).is_none() {
+                        return REPLY_KIND_NOT_FOUND;
+                    }
+                    ctx.send(mbox, kind, payload, count);
+                }
+            }
             REPLY_OK
         },
     )?;

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -16,9 +16,18 @@ pub type MailKind = u32;
 
 /// The transport envelope. `payload` is the exact byte layout the kind
 /// implies; `count` is the number of items the layout implies, where
-/// applicable. `sender` is the hub-minted session token for mail that
-/// came in over the hub wire (ADR-0008); substrate-generated mail
-/// leaves it as `SessionToken::NIL`.
+/// applicable.
+///
+/// Origin attribution is carried in two mutually-exclusive fields:
+/// - `sender` is the hub-minted session token for mail that came in
+///   over the hub wire (ADR-0008). Non-NIL means "originated from a
+///   Claude session."
+/// - `from_component` is the `MailboxId` of the originating component
+///   for mail enqueued by `SubstrateCtx::send` (ADR-0017). `Some`
+///   means "originated from another component on this substrate."
+///
+/// Both being absent (NIL + None) means broadcast-origin or
+/// system-generated mail with no meaningful reply target.
 #[derive(Debug)]
 pub struct Mail {
     pub recipient: MailboxId,
@@ -26,6 +35,7 @@ pub struct Mail {
     pub payload: Vec<u8>,
     pub count: u32,
     pub sender: SessionToken,
+    pub from_component: Option<MailboxId>,
 }
 
 impl Mail {
@@ -36,6 +46,7 @@ impl Mail {
             payload,
             count,
             sender: SessionToken::NIL,
+            from_component: None,
         }
     }
 
@@ -44,6 +55,15 @@ impl Mail {
     /// leave the default `NIL`.
     pub fn with_sender(mut self, sender: SessionToken) -> Self {
         self.sender = sender;
+        self
+    }
+
+    /// Attach the originating component's mailbox id. Set by
+    /// `SubstrateCtx::send` when enqueueing component-to-component
+    /// mail (ADR-0017) so `Component::deliver` can allocate a
+    /// `SenderEntry::Component` handle for the receiving guest.
+    pub fn with_origin(mut self, origin: MailboxId) -> Self {
+        self.from_component = Some(origin);
         self
     }
 }

--- a/crates/aether-substrate/src/queue.rs
+++ b/crates/aether-substrate/src/queue.rs
@@ -60,6 +60,15 @@ impl MailQueue {
         }
     }
 
+    /// Test-only: non-blocking pop. Returns `None` immediately if the
+    /// queue is empty rather than parking on `pending_cv`. Used by
+    /// substrate tests that need to assert on queue state without
+    /// running a worker.
+    #[cfg(test)]
+    pub(crate) fn try_pop(&self) -> Option<Mail> {
+        self.pending.lock().unwrap().pop_front()
+    }
+
     pub(crate) fn pop_blocking(&self) -> Option<Mail> {
         let mut q = self.pending.lock().unwrap();
         loop {

--- a/crates/aether-substrate/src/sender_table.rs
+++ b/crates/aether-substrate/src/sender_table.rs
@@ -1,12 +1,17 @@
 // Per-component-instance mapping from guest-visible sender handles
-// (opaque `u32`) to the real `SessionToken` the substrate received
-// over the hub wire (ADR-0008). Handles are allocated when an inbound
-// Claude-originated mail is dispatched to a component and resolved
-// when the guest calls `reply_mail` to answer it.
+// (opaque `u32`) to the substrate-internal identity of whoever
+// originated an inbound mail. Handles are allocated when a component
+// receives non-broadcast mail and resolved when the guest calls
+// `reply_mail` to answer it.
 //
-// ADR-0013 §1: handles are monotonically increasing per instance.
-// Exhaustion at 2³² dispatches is out of scope for V0; when it
-// becomes real, the handle becomes a generational index.
+// ADR-0013 covered session origins; ADR-0017 widened the table so
+// component-originated mail also produces a handle — a component can
+// now reply to a runtime-discovered peer without knowing its name at
+// init, using the same `ctx.reply` API regardless of who called.
+//
+// Handles are monotonically increasing per instance. Exhaustion at
+// 2³² dispatches is out of scope for V0; when it becomes real, the
+// handle becomes a generational index.
 //
 // The table lives on `SubstrateCtx` rather than `Component` because
 // the host fn touches it via `Caller::data_mut()`. Putting it there
@@ -17,16 +22,30 @@ use std::collections::HashMap;
 
 use aether_hub_protocol::SessionToken;
 
+use crate::mail::MailboxId;
+
 /// Sentinel passed to the guest's `receive` shim when the inbound
-/// mail has no meaningful reply target (component-originated mail, or
-/// broadcast origin — ADR-0013 §1). A `reply_mail` call with this
-/// handle fails with the "unknown handle" status.
+/// mail has no meaningful reply target (broadcast origin — ADR-0013
+/// §1). A `reply_mail` call with this handle fails with the "unknown
+/// handle" status.
 pub const SENDER_NONE: u32 = u32::MAX;
 
-/// Maintains the handle→token map for one component instance.
+/// What a sender handle resolves to on the substrate side. The guest
+/// sees only the opaque `u32` — the variant is purely host-side so
+/// `reply_mail` can pick the right outbound route.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SenderEntry {
+    /// Reply routes over `HubOutbound` as a session-addressed frame.
+    Session(SessionToken),
+    /// Reply routes through the local `MailQueue` as ordinary
+    /// component-to-component mail.
+    Component(MailboxId),
+}
+
+/// Maintains the handle→entry map for one component instance.
 #[derive(Debug, Default)]
 pub struct SenderTable {
-    entries: HashMap<u32, SessionToken>,
+    entries: HashMap<u32, SenderEntry>,
     next: u32,
 }
 
@@ -35,9 +54,9 @@ impl SenderTable {
         Self::default()
     }
 
-    /// Allocate a fresh handle bound to `token`. The returned handle
+    /// Allocate a fresh handle bound to `entry`. The returned handle
     /// is never `SENDER_NONE` — wraps past it silently.
-    pub fn allocate(&mut self, token: SessionToken) -> u32 {
+    pub fn allocate(&mut self, entry: SenderEntry) -> u32 {
         // Skip the sentinel. In practice `next` never hits `u32::MAX`
         // before the instance is replaced/dropped; this is hygiene.
         if self.next == SENDER_NONE {
@@ -45,14 +64,13 @@ impl SenderTable {
         }
         let handle = self.next;
         self.next = self.next.wrapping_add(1);
-        self.entries.insert(handle, token);
+        self.entries.insert(handle, entry);
         handle
     }
 
-    /// Look up the token for a guest-supplied handle. Returns `None`
-    /// for `SENDER_NONE`, for handles that were never allocated, and
-    /// (once implemented) for handles whose session is known-gone.
-    pub fn resolve(&self, handle: u32) -> Option<SessionToken> {
+    /// Look up the entry for a guest-supplied handle. Returns `None`
+    /// for `SENDER_NONE` and for handles that were never allocated.
+    pub fn resolve(&self, handle: u32) -> Option<SenderEntry> {
         if handle == SENDER_NONE {
             return None;
         }
@@ -71,13 +89,16 @@ mod tests {
     }
 
     #[test]
-    fn allocate_increments_and_roundtrips() {
+    fn allocate_session_and_component_handles_roundtrip() {
         let mut t = SenderTable::new();
-        let h0 = t.allocate(token(1));
-        let h1 = t.allocate(token(2));
-        assert_ne!(h0, h1);
-        assert_eq!(t.resolve(h0), Some(token(1)));
-        assert_eq!(t.resolve(h1), Some(token(2)));
+        let h_sess = t.allocate(SenderEntry::Session(token(1)));
+        let h_comp = t.allocate(SenderEntry::Component(MailboxId(42)));
+        assert_ne!(h_sess, h_comp);
+        assert_eq!(t.resolve(h_sess), Some(SenderEntry::Session(token(1))));
+        assert_eq!(
+            t.resolve(h_comp),
+            Some(SenderEntry::Component(MailboxId(42))),
+        );
     }
 
     #[test]
@@ -89,7 +110,7 @@ mod tests {
     #[test]
     fn resolve_unknown_handle_is_none() {
         let mut t = SenderTable::new();
-        let _ = t.allocate(token(7));
+        let _ = t.allocate(SenderEntry::Session(token(7)));
         assert!(t.resolve(9999).is_none());
     }
 
@@ -97,7 +118,7 @@ mod tests {
     fn allocate_skips_sentinel_on_wrap() {
         let mut t = SenderTable::new();
         t.next = SENDER_NONE;
-        let h = t.allocate(token(3));
+        let h = t.allocate(SenderEntry::Session(token(3)));
         // First handle after the wrap is 0 — the sentinel is never
         // handed out.
         assert_eq!(h, 0);

--- a/docs/adr/0017-component-sender-handles.md
+++ b/docs/adr/0017-component-sender-handles.md
@@ -1,7 +1,8 @@
 # ADR-0017: Extend `Sender` handles to component-origin mail
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-17
+- **Accepted:** 2026-04-17
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Implements ADR-0017. Component-to-component mail now produces a \`Sender\` handle on receive, so a component can answer a runtime-discovered peer using the same \`ctx.reply\` API as session-origin mail.
- No SDK changes — \`Sender\` stays opaque, the \`export!\` macro stays unchanged, the new variant lives entirely on the substrate side.
- \`SenderTable\` entries widen from \`SessionToken\` to a \`SenderEntry\` enum (\`Session(SessionToken) | Component(MailboxId)\`); \`Mail\` grows \`from_component: Option<MailboxId>\`; \`SubstrateCtx::send\` populates it; \`Component::deliver\` picks the variant; \`reply_mail\` branches on it.
- Flips ADR-0017 to **Accepted**.

## Test plan
- [x] \`cargo test --workspace\` — new tests: SenderTable holds both variants, deliver allocates Component handle for component-origin mail, deliver gives Session priority when both fields populated, reply with Component handle enqueues on MailQueue without touching outbound, reply to dropped component silently discards.
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] Live-hub: would need a second component crate to exercise — called out in ADR §Follow-up. The mechanism is tested via WAT modules; a real round-trip awaits a second component port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)