### PR TITLE
feat(hello): echoer/caller examples + smoke loader (ADR-0017)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,9 @@ name = "aether-hello-component"
 version = "0.1.0"
 dependencies = [
  "aether-component",
+ "aether-mail",
  "aether-substrate-mail",
+ "bytemuck",
 ]
 
 [[package]]

--- a/crates/aether-hello-component/Cargo.toml
+++ b/crates/aether-hello-component/Cargo.toml
@@ -9,3 +9,19 @@ crate-type = ["cdylib"]
 [dependencies]
 aether-component = { path = "../aether-component" }
 aether-substrate-mail = { path = "../aether-substrate-mail" }
+
+# Examples for the ADR-0017 (component-to-component reply) smoke
+# test. Each is a standalone wasm cdylib loaded via the substrate's
+# `load_component` control plane — paired so caller sends
+# `demo.request` to "echoer" and observes the reply.
+[dev-dependencies]
+aether-mail = { path = "../aether-mail" }
+bytemuck = { version = "1", features = ["derive"] }
+
+[[example]]
+name = "echoer"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "caller"
+crate-type = ["cdylib"]

--- a/crates/aether-hello-component/examples/caller.rs
+++ b/crates/aether-hello-component/examples/caller.rs
@@ -1,0 +1,71 @@
+// Smoke-test component for ADR-0017 (component-origin sender
+// handles). On every `aether.tick`, sends `demo.request { seq }` to
+// the component registered as `"echoer"`. When the reply
+// `demo.response { seq }` arrives — via the Component-variant
+// sender handle the substrate allocated — broadcasts
+// `demo.observation { seq }` to `hub.claude.broadcast` so the round
+// trip is visible to the driving Claude session.
+
+use aether_component::{Component, Ctx, InitCtx, KindId, Mail, Sink};
+use aether_mail::Kind;
+use aether_substrate_mail::Tick;
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Request {
+    pub seq: u32,
+}
+impl Kind for Request {
+    const NAME: &'static str = "demo.request";
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Response {
+    pub seq: u32,
+}
+impl Kind for Response {
+    const NAME: &'static str = "demo.response";
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Observation {
+    pub seq: u32,
+}
+impl Kind for Observation {
+    const NAME: &'static str = "demo.observation";
+}
+
+pub struct Caller {
+    tick: KindId<Tick>,
+    response: KindId<Response>,
+    request: Sink<Request>,
+    observe: Sink<Observation>,
+    next_seq: u32,
+}
+
+impl Component for Caller {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        Caller {
+            tick: ctx.resolve::<Tick>(),
+            response: ctx.resolve::<Response>(),
+            request: ctx.resolve_sink::<Request>("echoer"),
+            observe: ctx.resolve_sink::<Observation>("hub.claude.broadcast"),
+            next_seq: 0,
+        }
+    }
+
+    fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>) {
+        if self.tick.matches(mail.kind()) {
+            let seq = self.next_seq;
+            self.next_seq = self.next_seq.wrapping_add(1);
+            ctx.send(&self.request, &Request { seq });
+        } else if let Some(resp) = mail.decode(self.response) {
+            ctx.send(&self.observe, &Observation { seq: resp.seq });
+        }
+    }
+}
+
+aether_component::export!(Caller);

--- a/crates/aether-hello-component/examples/echoer.rs
+++ b/crates/aether-hello-component/examples/echoer.rs
@@ -1,0 +1,51 @@
+// Smoke-test component for ADR-0017 (component-origin sender
+// handles). Receives `demo.request { seq: u32 }` and replies with
+// `demo.pong { seq: u32 }` to whatever component sent it, using
+// `ctx.reply` and the Component-variant handle the substrate
+// allocates for intra-substrate mail.
+
+use aether_component::{Component, Ctx, InitCtx, KindId, Mail};
+use aether_mail::Kind;
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Request {
+    pub seq: u32,
+}
+impl Kind for Request {
+    const NAME: &'static str = "demo.request";
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct Response {
+    pub seq: u32,
+}
+impl Kind for Response {
+    const NAME: &'static str = "demo.response";
+}
+
+pub struct Echoer {
+    request: KindId<Request>,
+    response: KindId<Response>,
+}
+
+impl Component for Echoer {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        Echoer {
+            request: ctx.resolve::<Request>(),
+            response: ctx.resolve::<Response>(),
+        }
+    }
+
+    fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>) {
+        if let Some(req) = mail.decode(self.request)
+            && let Some(sender) = mail.sender()
+        {
+            ctx.reply(sender, self.response, &Response { seq: req.seq });
+        }
+    }
+}
+
+aether_component::export!(Echoer);

--- a/crates/aether-substrate/examples/smoke_017_load.rs
+++ b/crates/aether-substrate/examples/smoke_017_load.rs
@@ -1,0 +1,54 @@
+// One-shot helper for the ADR-0017 component-to-component smoke
+// test. Builds a LoadComponentPayload for the echoer or caller
+// example shipped with `aether-hello-component`, declaring the
+// three demo kinds (Pod { seq: u32 }) inline so the substrate
+// registers them at load time.
+//
+// Usage:
+//   cargo build -p aether-hello-component --target wasm32-unknown-unknown \
+//       --release --examples
+//   smoke_017_load echoer target/wasm32-unknown-unknown/release/examples/echoer.wasm echoer
+//   smoke_017_load caller target/wasm32-unknown-unknown/release/examples/caller.wasm caller
+
+use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive};
+use aether_substrate::LoadComponentPayload;
+
+fn seq_pod(name: &str) -> KindDescriptor {
+    KindDescriptor {
+        name: name.to_string(),
+        encoding: KindEncoding::Pod {
+            fields: vec![PodField {
+                name: "seq".to_string(),
+                ty: PodFieldType::Scalar(PodPrimitive::U32),
+            }],
+        },
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let [_, role, wasm_path, name] = args.as_slice() else {
+        eprintln!("usage: smoke_017_load <echoer|caller> <wasm-path> <name>");
+        std::process::exit(1);
+    };
+
+    let wasm = std::fs::read(wasm_path).expect("read wasm");
+    let kinds = match role.as_str() {
+        "echoer" => vec![seq_pod("demo.request"), seq_pod("demo.response")],
+        "caller" => vec![
+            seq_pod("demo.request"),
+            seq_pod("demo.response"),
+            seq_pod("demo.observation"),
+        ],
+        other => panic!("unknown role {other:?} (expected echoer or caller)"),
+    };
+
+    let payload = LoadComponentPayload {
+        wasm,
+        kinds,
+        name: Some(name.clone()),
+    };
+    let bytes = postcard::to_allocvec(&payload).expect("encode");
+    let json: Vec<String> = bytes.iter().map(|b| b.to_string()).collect();
+    println!("[{}]", json.join(","));
+}


### PR DESCRIPTION
## Summary
- Adds two cdylib examples to `aether-hello-component` that exercise the component-to-component sender path end-to-end:
  - `examples/echoer.rs` — receives `demo.request`, replies `demo.response` via `ctx.reply` (component-variant sender handle).
  - `examples/caller.rs` — on tick, sends `demo.request` to `"echoer"`; on `demo.response`, broadcasts `demo.observation` to `hub.claude.broadcast` so the round trip is visible to the driving Claude session.
- Cargo's per-example `crate-type = ["cdylib"]` lets these ship as standalone wasm artifacts alongside the hello lib without polluting the workspace with extra crates.
- Adds `aether-substrate/examples/smoke_017_load.rs` — one-shot helper that builds a `LoadComponentPayload` with the three demo kinds (Pod `{ seq: u32 }`) declared inline, since the MCP `send_mail` tool needs raw postcard bytes for the control plane.

**Depends on #78** (ADR-0017 impl). After #78 merges this PR's diff collapses to just the example additions.

## How to run the smoke
```
cargo build -p aether-hello-component --target wasm32-unknown-unknown --release --examples
cargo build --release -p aether-hub -p aether-substrate
./target/release/aether-hub &  # or via your MCP harness
# Then via MCP: spawn_substrate → load echoer → load caller → send aether.tick
# to caller → drain receive_mail for demo.observation
```

## Test plan
- [x] `cargo build -p aether-hello-component --target wasm32-unknown-unknown --release --examples` (echoer.wasm 17.6KB, caller.wasm 18.1KB)
- [x] `cargo test --workspace`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo fmt --all -- --check`
- [x] Live-hub smoke: tick → caller → echoer → reply → observation with matching seq, monotonic across ticks; drop echoer → caller's send to dropped mailbox silently discards, no observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)