### PR TITLE
feat(hub-protocol): schema type vocabulary (ADR-0019 PR 1)

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -368,4 +368,203 @@ mod tests {
         let err = read_frame::<_, EngineToHub>(&mut Cursor::new(buf)).unwrap_err();
         assert!(matches!(err, FrameError::Postcard(_)));
     }
+
+    // ADR-0019 — schema descriptor roundtrips. The new `KindEncoding::Schema`
+    // arm and its `SchemaType` vocabulary need to survive postcard encode/
+    // decode end-to-end, including nested types and every enum variant shape.
+    // These tests pin the wire format so consumers (hub encoder, substrate
+    // decoder, derive macro) can rely on it across the migration PRs.
+
+    #[test]
+    fn schema_unit_and_scalar_roundtrip() {
+        let desc = KindDescriptor {
+            name: "demo.tick".into(),
+            encoding: KindEncoding::Schema(SchemaType::Unit),
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+
+        let desc = KindDescriptor {
+            name: "demo.seq".into(),
+            encoding: KindEncoding::Schema(SchemaType::Scalar(Primitive::U32)),
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_cast_eligible_struct_roundtrip() {
+        // `Struct { repr_c: true }` — vertex-shaped: scalars + fixed array
+        // of a nested cast-eligible struct.
+        let vertex = SchemaType::Struct {
+            repr_c: true,
+            fields: vec![
+                NamedField {
+                    name: "x".into(),
+                    ty: SchemaType::Scalar(Primitive::F32),
+                },
+                NamedField {
+                    name: "y".into(),
+                    ty: SchemaType::Scalar(Primitive::F32),
+                },
+            ],
+        };
+        let triangle = SchemaType::Struct {
+            repr_c: true,
+            fields: vec![NamedField {
+                name: "verts".into(),
+                ty: SchemaType::Array {
+                    element: Box::new(vertex),
+                    len: 3,
+                },
+            }],
+        };
+        let desc = KindDescriptor {
+            name: "demo.draw_triangle".into(),
+            encoding: KindEncoding::Schema(triangle),
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_postcard_struct_with_rich_fields_roundtrip() {
+        // `Struct { repr_c: false }` — control-plane-shaped: string,
+        // bytes, optional, nested vec.
+        let load = SchemaType::Struct {
+            repr_c: false,
+            fields: vec![
+                NamedField {
+                    name: "wasm".into(),
+                    ty: SchemaType::Bytes,
+                },
+                NamedField {
+                    name: "name".into(),
+                    ty: SchemaType::Option(Box::new(SchemaType::String)),
+                },
+                NamedField {
+                    name: "tags".into(),
+                    ty: SchemaType::Vec(Box::new(SchemaType::String)),
+                },
+            ],
+        };
+        let desc = KindDescriptor {
+            name: "demo.load_component".into(),
+            encoding: KindEncoding::Schema(load),
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_enum_with_all_variant_shapes_roundtrip() {
+        // Cover every `EnumVariant` arm in one descriptor: result-shaped
+        // sum (`Ok(payload) | Err { reason }`) plus a unit variant.
+        let result = SchemaType::Enum {
+            variants: vec![
+                EnumVariant::Unit {
+                    name: "Pending".into(),
+                    discriminant: 0,
+                },
+                EnumVariant::Tuple {
+                    name: "Ok".into(),
+                    discriminant: 1,
+                    fields: vec![SchemaType::Scalar(Primitive::U64)],
+                },
+                EnumVariant::Struct {
+                    name: "Err".into(),
+                    discriminant: 2,
+                    fields: vec![NamedField {
+                        name: "reason".into(),
+                        ty: SchemaType::String,
+                    }],
+                },
+            ],
+        };
+        let desc = KindDescriptor {
+            name: "demo.load_result".into(),
+            encoding: KindEncoding::Schema(result),
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_descriptor_survives_full_frame_roundtrip() {
+        // The schema arm has to survive a real `Hello` frame, not just a
+        // bare `KindDescriptor`. This catches enum-tag drift inside the
+        // outer `EngineToHub` envelope.
+        let hello = EngineToHub::Hello(Hello {
+            name: "schema-demo".into(),
+            pid: 1,
+            started_unix: 0,
+            version: "0".into(),
+            kinds: vec![KindDescriptor {
+                name: "demo.note".into(),
+                encoding: KindEncoding::Schema(SchemaType::Struct {
+                    repr_c: false,
+                    fields: vec![NamedField {
+                        name: "body".into(),
+                        ty: SchemaType::String,
+                    }],
+                }),
+            }],
+        });
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &hello).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        let EngineToHub::Hello(h) = back else {
+            panic!("wrong variant")
+        };
+        assert_eq!(h.kinds.len(), 1);
+        let KindEncoding::Schema(SchemaType::Struct { repr_c, fields }) = &h.kinds[0].encoding
+        else {
+            panic!("expected Schema(Struct)")
+        };
+        assert!(!*repr_c);
+        assert_eq!(fields[0].name, "body");
+        assert_eq!(fields[0].ty, SchemaType::String);
+    }
+
+    #[test]
+    fn legacy_pod_arms_still_roundtrip() {
+        // The migration plan keeps Signal/Pod/Opaque alive during the
+        // intermediate PRs. A regression here means existing consumers
+        // would break before the cleanup PR can land.
+        for encoding in [
+            KindEncoding::Signal,
+            KindEncoding::Opaque,
+            KindEncoding::Pod {
+                fields: vec![PodField {
+                    name: "code".into(),
+                    ty: PodFieldType::Scalar(PodPrimitive::U32),
+                }],
+            },
+        ] {
+            let desc = KindDescriptor {
+                name: "demo.legacy".into(),
+                encoding: encoding.clone(),
+            };
+            let bytes = postcard::to_allocvec(&desc).unwrap();
+            assert_eq!(
+                postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+                desc
+            );
+        }
+    }
 }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -58,11 +58,21 @@ pub struct KindDescriptor {
 ///   scalars and fixed-size scalar arrays matching Rust's layout.
 /// - `Opaque`: the hub can't encode this from params. Clients must
 ///   supply raw bytes. V0 structural (postcard) kinds land here.
+/// - `Schema`: ADR-0019 unified vocabulary covering scalars, strings,
+///   vecs, options, enums, and nested structs. The `repr_c` flag on
+///   `SchemaType::Struct` opts a struct into the cast-shaped wire
+///   format (today's `Pod` bytes); everything else is postcard.
+///
+/// `Signal`/`Pod`/`Opaque` are kept here through the migration so
+/// `aether-hub`, `aether-substrate`, and the smoke binaries can move
+/// over one PR at a time. The cleanup PR deletes them along with
+/// `PodField`/`PodFieldType`/`PodPrimitive`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KindEncoding {
     Signal,
     Pod { fields: Vec<PodField> },
     Opaque,
+    Schema(SchemaType),
 }
 
 /// One field in a POD kind. Field order matches the Rust struct's
@@ -89,6 +99,88 @@ pub enum PodFieldType {
 /// spelling so tooling can parse them without a lookup.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PodPrimitive {
+    U8,
+    U16,
+    U32,
+    U64,
+    I8,
+    I16,
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+/// ADR-0019 schema type vocabulary. Describes the structure of a mail
+/// kind's payload in enough detail for the hub to encode it from
+/// agent-supplied params and the substrate to decode it into a typed
+/// value. `Struct.repr_c = true` selects the cast-shaped wire format
+/// (raw `#[repr(C)]` bytes); everything else is postcard.
+///
+/// Restrictions on `repr_c = true` (enforced by the SDK derive, not
+/// the wire format): only legal when every field is itself
+/// cast-eligible — `Scalar`, `Array` of cast-eligible elements, or a
+/// nested `Struct { repr_c: true, .. }`. `String`, `Bytes`, `Vec`,
+/// `Option`, and `Enum` fields disqualify a struct from `repr_c`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SchemaType {
+    Unit,
+    Bool,
+    Scalar(Primitive),
+    String,
+    Bytes,
+    Option(Box<SchemaType>),
+    Vec(Box<SchemaType>),
+    Array {
+        element: Box<SchemaType>,
+        len: u32,
+    },
+    Struct {
+        fields: Vec<NamedField>,
+        repr_c: bool,
+    },
+    Enum {
+        variants: Vec<EnumVariant>,
+    },
+}
+
+/// One field inside a `SchemaType::Struct` or struct-shaped enum
+/// variant. Field order matches the Rust source order; for cast-shaped
+/// structs (`repr_c: true`) it also matches `#[repr(C)]` layout.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamedField {
+    pub name: String,
+    pub ty: SchemaType,
+}
+
+/// One variant of a `SchemaType::Enum`. Discriminants are explicit
+/// `u32`s so the wire encoding doesn't depend on declaration order —
+/// adding a variant later (without renumbering existing ones) is
+/// forward-compatible at the postcard level.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EnumVariant {
+    Unit {
+        name: String,
+        discriminant: u32,
+    },
+    Tuple {
+        name: String,
+        discriminant: u32,
+        fields: Vec<SchemaType>,
+    },
+    Struct {
+        name: String,
+        discriminant: u32,
+        fields: Vec<NamedField>,
+    },
+}
+
+/// Scalar primitives addressable by `SchemaType::Scalar`. Same set as
+/// `PodPrimitive` (which is parallel for the legacy `Pod` arm during
+/// migration); kept as its own type so `Schema` can outlive `Pod` once
+/// the cleanup PR removes the legacy arm.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Primitive {
     U8,
     U16,
     U32,

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -486,6 +486,13 @@ fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, St
                     "kind {:?} is Opaque; use payload_bytes",
                     spec.kind_name
                 )),
+                // ADR-0019 PR 1: type plumbed, encoder lands in PR 5.
+                // Until then, agents that hit a Schema kind get a clear
+                // error rather than silent corruption.
+                KindEncoding::Schema(_) => Err(format!(
+                    "kind {:?} uses Schema encoding; hub encoder not yet implemented (ADR-0019)",
+                    spec.kind_name
+                )),
             }
         }
         (None, None) => {


### PR DESCRIPTION
## Summary

First PR in the ADR-0019 implementation chain. Pure additive: introduces `KindEncoding::Schema(SchemaType)` alongside the existing `Signal`/`Pod`/`Opaque` arms, plus `SchemaType`, `NamedField`, `EnumVariant`, and `Primitive`. No consumer migrates yet — this just plumbs the wire format so subsequent PRs (derive macro, substrate-mail rewrite, hub encoder) have a stable type to build against.

The hub returns a clear "not yet implemented" error if an agent ever hits a `Schema` kind through `send_mail`; the actual encoder lands in PR 5.

## Test plan

- [x] `cargo test -p aether-hub-protocol` — 19 tests pass (5 new schema roundtrips + 1 legacy-arm regression check)
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

The new tests pin the postcard wire format for every `SchemaType` arm (unit, scalar, cast-eligible struct, postcard struct with string/bytes/option/vec, enum with all three variant shapes) and verify a full `Hello` frame survives roundtrip carrying a Schema descriptor. The legacy-arm test makes sure `Signal`/`Pod`/`Opaque` still encode unchanged so PRs 2-5 can migrate consumers without breaking the wire.