### PR TITLE
feat(component): derive(Kind/Schema) proc macros (ADR-0019 PR 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,22 @@ dependencies = [
 name = "aether-mail"
 version = "0.1.0"
 dependencies = [
+ "aether-hub-protocol",
+ "aether-mail-derive",
  "bytemuck",
  "postcard",
  "serde",
+]
+
+[[package]]
+name = "aether-mail-derive"
+version = "0.1.0"
+dependencies = [
+ "aether-hub-protocol",
+ "aether-mail",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/aether-hub",
     "crates/aether-hub-protocol",
     "crates/aether-mail",
+    "crates/aether-mail-derive",
     "crates/aether-mail-spike-host",
     "crates/aether-mail-spike-guest",
 ]

--- a/crates/aether-mail-derive/Cargo.toml
+++ b/crates/aether-mail-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "aether-mail-derive"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+# Tests need both the runtime traits and the macro re-exports, plus
+# the `descriptors` feature so `Schema` resolves.
+aether-mail = { path = "../aether-mail", features = ["derive", "descriptors"] }
+aether-hub-protocol = { path = "../aether-hub-protocol" }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -1,0 +1,321 @@
+// Proc-macro home for `#[derive(Kind)]` and `#[derive(Schema)]` per
+// ADR-0019. Kept separate from `aether-mail` because Rust requires
+// proc-macro crates to opt into `proc-macro = true` and forbids them
+// from exporting non-macro items; pairing them in the same crate would
+// force every consumer through the proc-macro toolchain even when they
+// just want the runtime traits.
+//
+// `Kind` always emits the `aether_mail::Kind` impl plus a
+// `CastEligible` impl that propagates each field's eligibility — this
+// is the compile-time machinery the `Schema` derive uses to decide
+// whether a struct can use the `#[repr(C)]`-shaped wire format. Enums
+// always get `CastEligible::ELIGIBLE = false`.
+//
+// `Schema` is opt-in. It emits an `aether_mail::Schema` impl that
+// returns the `aether_hub_protocol::SchemaType` describing the type's
+// payload. Components that never need to introspect their own kinds
+// (every wasm guest today) skip `Schema` and stay free of the
+// hub-protocol dep.
+//
+// Field-type handling is the trickiest part. For most field types we
+// delegate to `<FieldT as Schema>::schema()` and let the blanket impls
+// in `aether-mail` do the work. The one exception is `Vec<u8>` —
+// stable Rust forbids the specialization (`Vec<u8>` would overlap
+// `Vec<T>` because `u8: Schema`), so the derive pattern-matches the
+// field type's syntax and emits `SchemaType::Bytes` directly when it
+// sees `Vec<u8>`. Every other shape goes through the trait.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{
+    Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, GenericArgument, Lit, Meta,
+    PathArguments, Type, parse_macro_input, spanned::Spanned,
+};
+
+#[proc_macro_derive(Kind, attributes(kind))]
+pub fn derive_kind(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand_kind(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(Schema, attributes(kind))]
+pub fn derive_schema(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand_schema(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let kind_name = parse_kind_name(&input.attrs)?;
+
+    let cast_eligible_expr = match &input.data {
+        Data::Struct(_) => {
+            let fields = struct_fields(input)?;
+            let has_repr_c = struct_has_repr_c(&input.attrs);
+            cast_eligible_expr_for_struct(has_repr_c, &fields)
+        }
+        // Enums and unions are never cast-eligible — they need a tag
+        // discriminant + variable layout that `bytemuck::cast` can't
+        // express. The derive emits `false` and the schema lands as a
+        // postcard-encoded sum.
+        Data::Enum(_) => quote! { false },
+        Data::Union(u) => {
+            return Err(syn::Error::new_spanned(
+                u.union_token,
+                "Kind derive does not support unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl ::aether_mail::Kind for #name {
+            const NAME: &'static str = #kind_name;
+        }
+
+        impl ::aether_mail::CastEligible for #name {
+            const ELIGIBLE: bool = #cast_eligible_expr;
+        }
+    })
+}
+
+fn cast_eligible_expr_for_struct(has_repr_c: bool, fields: &[FieldInfo]) -> TokenStream2 {
+    if !has_repr_c {
+        return quote! { false };
+    }
+    if fields.is_empty() {
+        return quote! { true };
+    }
+    let parts = fields.iter().map(|f| {
+        let ty = &f.ty;
+        quote! { <#ty as ::aether_mail::CastEligible>::ELIGIBLE }
+    });
+    quote! { #(#parts)&&* }
+}
+
+fn expand_schema(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let body = match &input.data {
+        Data::Struct(_) => expand_schema_struct(input)?,
+        Data::Enum(e) => expand_schema_enum(e)?,
+        Data::Union(u) => {
+            return Err(syn::Error::new_spanned(
+                u.union_token,
+                "Schema derive does not support unions",
+            ));
+        }
+    };
+    Ok(quote! {
+        impl ::aether_mail::Schema for #name {
+            fn schema() -> ::aether_hub_protocol::SchemaType {
+                #body
+            }
+        }
+    })
+}
+
+fn expand_schema_struct(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let fields = struct_fields(input)?;
+
+    if fields.is_empty() {
+        return Ok(quote! { ::aether_hub_protocol::SchemaType::Unit });
+    }
+
+    let entries = fields.iter().enumerate().map(|(idx, f)| {
+        let name = match &f.ident {
+            Some(id) => id.to_string(),
+            // Tuple struct field — name positionally so the hub still
+            // has something to render in `describe_kinds`. Postcard
+            // doesn't care; field names are advisory metadata.
+            None => idx.to_string(),
+        };
+        let ty_expr = field_type_schema_expr(&f.ty);
+        quote! {
+            ::aether_hub_protocol::NamedField {
+                name: ::aether_mail::__derive_runtime::string_from(#name),
+                ty: #ty_expr,
+            }
+        }
+    });
+
+    Ok(quote! {
+        ::aether_hub_protocol::SchemaType::Struct {
+            fields: ::aether_mail::__derive_runtime::vec_from([ #( #entries ),* ]),
+            repr_c: <Self as ::aether_mail::CastEligible>::ELIGIBLE,
+        }
+    })
+}
+
+fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
+    let variant_entries = data.variants.iter().enumerate().map(|(idx, v)| {
+        let name = v.ident.to_string();
+        let discriminant = idx as u32;
+        match &v.fields {
+            Fields::Unit => quote! {
+                ::aether_hub_protocol::EnumVariant::Unit {
+                    name: ::aether_mail::__derive_runtime::string_from(#name),
+                    discriminant: #discriminant,
+                }
+            },
+            Fields::Unnamed(unnamed) => {
+                let field_exprs = unnamed
+                    .unnamed
+                    .iter()
+                    .map(|f| field_type_schema_expr(&f.ty));
+                quote! {
+                    ::aether_hub_protocol::EnumVariant::Tuple {
+                        name: ::aether_mail::__derive_runtime::string_from(#name),
+                        discriminant: #discriminant,
+                        fields: ::aether_mail::__derive_runtime::vec_from([ #( #field_exprs ),* ]),
+                    }
+                }
+            }
+            Fields::Named(named) => {
+                let field_exprs = named.named.iter().map(|f| {
+                    let fname = f.ident.as_ref().map(|i| i.to_string()).unwrap_or_default();
+                    let ty_expr = field_type_schema_expr(&f.ty);
+                    quote! {
+                        ::aether_hub_protocol::NamedField {
+                            name: ::aether_mail::__derive_runtime::string_from(#fname),
+                            ty: #ty_expr,
+                        }
+                    }
+                });
+                quote! {
+                    ::aether_hub_protocol::EnumVariant::Struct {
+                        name: ::aether_mail::__derive_runtime::string_from(#name),
+                        discriminant: #discriminant,
+                        fields: ::aether_mail::__derive_runtime::vec_from([ #( #field_exprs ),* ]),
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(quote! {
+        ::aether_hub_protocol::SchemaType::Enum {
+            variants: ::aether_mail::__derive_runtime::vec_from([ #( #variant_entries ),* ]),
+        }
+    })
+}
+
+// Pattern-match `Vec<u8>` at the field-type level so it lands as
+// `SchemaType::Bytes` rather than the generic `Vec(Scalar(U8))`. Every
+// other shape just delegates to the `Schema` trait.
+fn field_type_schema_expr(ty: &Type) -> TokenStream2 {
+    if is_vec_u8(ty) {
+        quote! { ::aether_hub_protocol::SchemaType::Bytes }
+    } else {
+        quote! { <#ty as ::aether_mail::Schema>::schema() }
+    }
+}
+
+fn is_vec_u8(ty: &Type) -> bool {
+    let Type::Path(tp) = ty else { return false };
+    let Some(seg) = tp.path.segments.last() else {
+        return false;
+    };
+    if seg.ident != "Vec" {
+        return false;
+    }
+    let PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return false;
+    };
+    let Some(GenericArgument::Type(Type::Path(inner))) = args.args.first() else {
+        return false;
+    };
+    inner.path.is_ident("u8")
+}
+
+// ----- attribute and shape helpers --------------------------------------
+
+fn parse_kind_name(attrs: &[Attribute]) -> syn::Result<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("kind") {
+            continue;
+        }
+        let mut found: Option<String> = None;
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("name") {
+                return Err(meta.error("expected `name = \"...\"`"));
+            }
+            let value = meta.value()?;
+            let expr: Expr = value.parse()?;
+            if let Expr::Lit(lit) = &expr
+                && let Lit::Str(s) = &lit.lit
+            {
+                found = Some(s.value());
+                return Ok(());
+            }
+            Err(meta.error("`name` must be a string literal"))
+        })?;
+        if let Some(name) = found {
+            return Ok(name);
+        }
+    }
+    Err(syn::Error::new(
+        attrs
+            .first()
+            .map(|a| a.span())
+            .unwrap_or_else(proc_macro2::Span::call_site),
+        "missing `#[kind(name = \"...\")]` attribute",
+    ))
+}
+
+fn struct_has_repr_c(attrs: &[Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        let Meta::List(list) = &attr.meta else {
+            continue;
+        };
+        let mut has_c = false;
+        let _ = list.parse_nested_meta(|meta| {
+            if meta.path.is_ident("C") {
+                has_c = true;
+            }
+            Ok(())
+        });
+        if has_c {
+            return true;
+        }
+    }
+    false
+}
+
+fn struct_fields(input: &DeriveInput) -> syn::Result<Vec<FieldInfo>> {
+    let Data::Struct(DataStruct { fields, .. }) = &input.data else {
+        return Err(syn::Error::new_spanned(&input.ident, "expected struct"));
+    };
+    Ok(match fields {
+        Fields::Named(named) => named
+            .named
+            .iter()
+            .map(|f| FieldInfo {
+                ident: f.ident.clone(),
+                ty: f.ty.clone(),
+            })
+            .collect(),
+        Fields::Unnamed(unnamed) => unnamed
+            .unnamed
+            .iter()
+            .map(|f| FieldInfo {
+                ident: None,
+                ty: f.ty.clone(),
+            })
+            .collect(),
+        Fields::Unit => Vec::new(),
+    })
+}
+
+struct FieldInfo {
+    ident: Option<syn::Ident>,
+    ty: Type,
+}

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -1,0 +1,214 @@
+// Integration tests for `#[derive(Kind)]` and `#[derive(Schema)]`. Run
+// with `cargo test -p aether-mail-derive`. The aether-mail dev-dep
+// has both `derive` and `descriptors` features enabled (Cargo.toml of
+// this crate), so the macros expand and the runtime traits resolve.
+//
+// Each test pins one slice of behavior:
+//   - `#[derive(Kind)]` sets `NAME` and `CastEligible::ELIGIBLE`
+//     correctly across `#[repr(C)]` / non-repr / nested-substructure
+//     cases.
+//   - `#[derive(Schema)]` produces the right `SchemaType` for unit,
+//     tuple, named-field, cast-eligible, postcard-shaped, and
+//     enum-shaped inputs.
+//   - The `Vec<u8>` field-level specialization lands as `Bytes`, not
+//     `Vec(Scalar(U8))`.
+
+use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaType};
+use aether_mail::{CastEligible, Kind, Schema};
+
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.tick")]
+struct Tick;
+
+#[repr(C)]
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.key")]
+struct Key {
+    code: u32,
+}
+
+#[repr(C)]
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.vertex")]
+struct Vertex {
+    x: f32,
+    y: f32,
+}
+
+#[repr(C)]
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.triangle")]
+struct Triangle {
+    verts: [Vertex; 3],
+}
+
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.note")]
+#[allow(dead_code)]
+struct Note {
+    body: String,
+    tags: Vec<String>,
+    optional: Option<u32>,
+    blob: Vec<u8>,
+}
+
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.tuple")]
+#[allow(dead_code)]
+struct TupleStruct(u32, bool);
+
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.result")]
+#[allow(dead_code)]
+enum Outcome {
+    Pending,
+    Ok(u64),
+    Err { reason: String },
+}
+
+#[test]
+fn unit_struct_emits_name_and_unit_schema() {
+    assert_eq!(<Tick as Kind>::NAME, "test.tick");
+    assert!(matches!(<Tick as Schema>::schema(), SchemaType::Unit));
+}
+
+#[test]
+fn cast_eligible_struct_picks_repr_c_true() {
+    assert_eq!(<Key as Kind>::NAME, "test.key");
+    const { assert!(<Key as CastEligible>::ELIGIBLE) };
+    let SchemaType::Struct { repr_c, fields } = <Key as Schema>::schema() else {
+        panic!("expected Struct schema");
+    };
+    assert!(repr_c);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "code");
+    assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+}
+
+#[test]
+fn cast_eligible_propagates_through_array_of_substruct() {
+    const { assert!(<Vertex as CastEligible>::ELIGIBLE) };
+    const { assert!(<Triangle as CastEligible>::ELIGIBLE) };
+    let SchemaType::Struct { repr_c, fields } = <Triangle as Schema>::schema() else {
+        panic!("expected Struct schema");
+    };
+    assert!(repr_c);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "verts");
+    let SchemaType::Array { element, len } = &fields[0].ty else {
+        panic!("expected Array");
+    };
+    assert_eq!(*len, 3);
+    let SchemaType::Struct {
+        repr_c: nested_repr,
+        fields: nested_fields,
+    } = element.as_ref()
+    else {
+        panic!("expected nested Struct");
+    };
+    assert!(*nested_repr);
+    assert_eq!(nested_fields.len(), 2);
+}
+
+#[test]
+fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
+    const { assert!(!<Note as CastEligible>::ELIGIBLE) };
+    let SchemaType::Struct { repr_c, fields } = <Note as Schema>::schema() else {
+        panic!("expected Struct schema");
+    };
+    assert!(!repr_c);
+    let by_name: std::collections::HashMap<&str, &SchemaType> =
+        fields.iter().map(|f| (f.name.as_str(), &f.ty)).collect();
+    assert_eq!(by_name["body"], &SchemaType::String);
+    assert!(matches!(by_name["tags"], SchemaType::Vec(inner) if **inner == SchemaType::String));
+    assert!(
+        matches!(by_name["optional"], SchemaType::Option(inner) if **inner == SchemaType::Scalar(Primitive::U32))
+    );
+    // Vec<u8> is the load-bearing specialization — must land as
+    // `Bytes`, not `Vec(Scalar(U8))`. Catching this regression is the
+    // point of having a dedicated assertion.
+    assert_eq!(by_name["blob"], &SchemaType::Bytes);
+}
+
+#[test]
+fn tuple_struct_names_fields_positionally() {
+    let SchemaType::Struct { fields, repr_c } = <TupleStruct as Schema>::schema() else {
+        panic!("expected Struct schema");
+    };
+    // No `#[repr(C)]` on the tuple struct → not cast eligible.
+    assert!(!repr_c);
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "0");
+    assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+    assert_eq!(fields[1].name, "1");
+    assert_eq!(fields[1].ty, SchemaType::Bool);
+}
+
+#[test]
+fn enum_emits_each_variant_shape_with_sequential_discriminants() {
+    assert_eq!(<Outcome as Kind>::NAME, "test.result");
+    const { assert!(!<Outcome as CastEligible>::ELIGIBLE) };
+    let SchemaType::Enum { variants } = <Outcome as Schema>::schema() else {
+        panic!("expected Enum schema");
+    };
+    assert_eq!(variants.len(), 3);
+
+    let EnumVariant::Unit { name, discriminant } = &variants[0] else {
+        panic!("expected Unit variant first");
+    };
+    assert_eq!(name, "Pending");
+    assert_eq!(*discriminant, 0);
+
+    let EnumVariant::Tuple {
+        name,
+        discriminant,
+        fields,
+    } = &variants[1]
+    else {
+        panic!("expected Tuple variant second");
+    };
+    assert_eq!(name, "Ok");
+    assert_eq!(*discriminant, 1);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0], SchemaType::Scalar(Primitive::U64));
+
+    let EnumVariant::Struct {
+        name,
+        discriminant,
+        fields,
+    } = &variants[2]
+    else {
+        panic!("expected Struct variant third");
+    };
+    assert_eq!(name, "Err");
+    assert_eq!(*discriminant, 2);
+    assert_eq!(
+        fields,
+        &vec![NamedField {
+            name: "reason".into(),
+            ty: SchemaType::String,
+        }]
+    );
+}
+
+#[test]
+fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
+    // A struct with `#[repr(C)]` but a non-eligible field type must
+    // still report `ELIGIBLE = false`. Catching this is what stops
+    // the substrate from misclassifying a postcard kind as cast-able.
+    #[repr(C)]
+    #[derive(aether_mail::Kind, aether_mail::Schema)]
+    #[kind(name = "test.repr_c_with_string")]
+    #[allow(dead_code)]
+    struct ReprCButStrung {
+        seq: u32,
+        // String isn't `CastEligible` (no impl), so the AND in the
+        // derive's emitted `ELIGIBLE` const evaluates to `false`.
+        label: String,
+    }
+    const { assert!(!<ReprCButStrung as CastEligible>::ELIGIBLE) };
+    let SchemaType::Struct { repr_c, .. } = <ReprCButStrung as Schema>::schema() else {
+        panic!("expected Struct");
+    };
+    assert!(!repr_c);
+}

--- a/crates/aether-mail/Cargo.toml
+++ b/crates/aether-mail/Cargo.toml
@@ -3,7 +3,19 @@ name = "aether-mail"
 version.workspace = true
 edition.workspace = true
 
+[features]
+# Pull in the hub-protocol descriptor types so the `Schema` trait and
+# its blanket impls become available. Off by default so wasm guests
+# stay free of std-bound deps.
+descriptors = ["dep:aether-hub-protocol"]
+# Re-export `#[derive(Kind)]` and `#[derive(Schema)]` from
+# `aether-mail-derive`. Off by default so guests that hand-write
+# `impl Kind for ...` don't pay the proc-macro compile cost.
+derive = ["dep:aether-mail-derive"]
+
 [dependencies]
+aether-hub-protocol = { path = "../aether-hub-protocol", optional = true }
+aether-mail-derive = { path = "../aether-mail-derive", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -29,6 +29,165 @@ pub trait Kind {
     const NAME: &'static str;
 }
 
+/// Compile-time predicate: can this type's payload travel across the
+/// wire as raw `#[repr(C)]` bytes (and decode by `bytemuck::cast`)?
+///
+/// Used by `#[derive(Kind)]` to compute `SchemaType::Struct.repr_c`
+/// at the consumer's compile time without losing recursion: a struct
+/// whose fields are all `CastEligible` is itself eligible *iff* it
+/// also carries `#[repr(C)]`. Anything containing a `String`, `Vec`,
+/// `Option`, enum, or non-`#[repr(C)]` substruct short-circuits to
+/// `false`, which forces the postcard wire path on the descriptor.
+pub trait CastEligible {
+    const ELIGIBLE: bool;
+}
+
+macro_rules! cast_eligible_primitive {
+    ($($t:ty),* $(,)?) => {
+        $( impl CastEligible for $t { const ELIGIBLE: bool = true; } )*
+    };
+}
+
+cast_eligible_primitive!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, bool);
+
+impl<T: CastEligible, const N: usize> CastEligible for [T; N] {
+    const ELIGIBLE: bool = T::ELIGIBLE;
+}
+
+// Variable-length and sum-shaped stdlib types are explicitly cast
+// *in*-eligible. The derive's emitted `ELIGIBLE` const ANDs every
+// field's value, so without these impls a `#[repr(C)]` struct
+// containing a `String` would fail to compile — the trait bound
+// on `<String as CastEligible>::ELIGIBLE` would be unsatisfied.
+// Listing them here is the price of not having stable Rust
+// specialization; new "definitely not eligible" types can be added
+// as the kind vocabulary reaches for them.
+impl CastEligible for alloc::string::String {
+    const ELIGIBLE: bool = false;
+}
+impl<T> CastEligible for alloc::vec::Vec<T> {
+    const ELIGIBLE: bool = false;
+}
+impl<T> CastEligible for Option<T> {
+    const ELIGIBLE: bool = false;
+}
+
+/// Re-exported derive macros from `aether-mail-derive`. Behind the
+/// `derive` feature so `cargo build` on a guest that hand-writes
+/// `impl Kind` doesn't pay the proc-macro compile cost.
+#[cfg(feature = "derive")]
+pub use aether_mail_derive::{Kind, Schema};
+
+/// ADR-0019 schema producer. The substrate (and tooling that builds
+/// hub descriptors) calls `T::schema()` to learn how a kind's payload
+/// is laid out. Wasm guests typically don't need this — they send and
+/// receive bytes — so the trait sits behind the `descriptors` feature.
+///
+/// Blanket impls cover the leaf types in the schema vocabulary
+/// (primitives, `String`, `[u8]`-shaped `Vec`s, fixed arrays,
+/// `Option`, generic `Vec`). User structs reach the trait via
+/// `#[derive(Schema)]`.
+#[cfg(feature = "descriptors")]
+pub use schema::Schema;
+
+/// Internal helpers the `#[derive(Schema)]` macro uses to construct
+/// `String` and `Vec` values without forcing every consumer crate to
+/// `extern crate alloc;`. Not part of the public API; the macro is the
+/// only intended caller.
+#[cfg(feature = "descriptors")]
+#[doc(hidden)]
+pub mod __derive_runtime {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    pub fn string_from(s: &str) -> String {
+        String::from(s)
+    }
+
+    pub fn vec_from<T, const N: usize>(arr: [T; N]) -> Vec<T> {
+        Vec::from(arr)
+    }
+}
+
+#[cfg(feature = "descriptors")]
+mod schema {
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use aether_hub_protocol::{Primitive, SchemaType};
+
+    /// Produces the `SchemaType` describing how this type lays out as
+    /// a mail payload. Implemented by `#[derive(Schema)]` on user
+    /// structs, and by blanket impl on the schema-vocabulary leaves.
+    pub trait Schema {
+        fn schema() -> SchemaType;
+    }
+
+    macro_rules! scalar {
+        ($t:ty, $p:ident) => {
+            impl Schema for $t {
+                fn schema() -> SchemaType {
+                    SchemaType::Scalar(Primitive::$p)
+                }
+            }
+        };
+    }
+
+    scalar!(u8, U8);
+    scalar!(u16, U16);
+    scalar!(u32, U32);
+    scalar!(u64, U64);
+    scalar!(i8, I8);
+    scalar!(i16, I16);
+    scalar!(i32, I32);
+    scalar!(i64, I64);
+    scalar!(f32, F32);
+    scalar!(f64, F64);
+
+    impl Schema for bool {
+        fn schema() -> SchemaType {
+            SchemaType::Bool
+        }
+    }
+
+    impl Schema for String {
+        fn schema() -> SchemaType {
+            SchemaType::String
+        }
+    }
+
+    // Generic `Vec<T>`. `Vec<u8>` is the canonical byte-buffer shape
+    // and the wire vocabulary has a `Bytes` arm to render it as
+    // base64/JSON-array params at the hub. We can't add a specialized
+    // `impl Schema for Vec<u8>` here because Rust's overlap rules
+    // forbid it without nightly specialization — so the derive macro
+    // pattern-matches `Vec<u8>` on field types and emits
+    // `SchemaType::Bytes` directly, bypassing this blanket. Standalone
+    // `Vec<u8>` outside a derived struct still routes through this
+    // impl and lands as `Vec(Scalar(U8))`.
+    impl<T: Schema> Schema for Vec<T> {
+        fn schema() -> SchemaType {
+            SchemaType::Vec(Box::new(T::schema()))
+        }
+    }
+
+    impl<T: Schema> Schema for Option<T> {
+        fn schema() -> SchemaType {
+            SchemaType::Option(Box::new(T::schema()))
+        }
+    }
+
+    impl<T: Schema, const N: usize> Schema for [T; N] {
+        fn schema() -> SchemaType {
+            SchemaType::Array {
+                element: Box::new(T::schema()),
+                len: N as u32,
+            }
+        }
+    }
+}
+
 /// Reason a decode failed. Encoding is infallible for the tiers we
 /// support, so there is no corresponding `EncodeError`.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Second PR in the ADR-0019 implementation chain. Introduces the `#[derive(Kind)]` and `#[derive(Schema)]` proc macros that PR 3 will use to migrate `aether-substrate-mail` off hand-written `impl Kind` boilerplate and the parallel hand-written descriptor table.

New crate `aether-mail-derive` (proc-macro). Re-exported from `aether-mail` behind a `derive` feature. The `Schema` trait and its blanket impls (primitives, `String`, `Vec<T>`, `Option<T>`, `[T; N]`) live behind a `descriptors` feature pulling in `aether-hub-protocol`. Wasm guests that only need `#[derive(Kind)]` stay free of both.

## Key choices

- **Auto-picked `repr_c`**: `#[derive(Kind)]` emits `impl CastEligible` whose `ELIGIBLE` const ANDs every field's eligibility against `#[repr(C)]` presence. `#[derive(Schema)]` reads that const into the emitted `SchemaType::Struct.repr_c`. Authors don't pick the wire format; the type's structure does.
- **Vec<u8> field-level specialization**: stable Rust forbids `impl Schema for Vec<u8>` overlapping `impl<T: Schema> Schema for Vec<T>` because `u8: Schema`. The derive pattern-matches `Vec<u8>` field types and emits `SchemaType::Bytes` directly, sidestepping the trait.
- **Explicit not-eligible impls** for `String`, `Vec<T>`, `Option<T>` — without specialization, the `<FieldT as CastEligible>::ELIGIBLE` const expression needs the bound to resolve. Listing the disqualified types is the cost.
- **No `#[derive(Schema)]` for unions** (compile error) — the wire format has no tagged-union vocabulary.

## Test plan

- [x] `cargo test -p aether-mail-derive` — 7 tests covering: unit struct, cast-eligible struct, cast-eligibility through nested arrays, postcard struct (with `Vec<u8>`→`Bytes` specialization, `Vec<String>`, `Option<u32>`), tuple struct, enum with all three variant shapes, and the `repr(C) + non-cast-field → ELIGIBLE = false` short-circuit.
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` clean (no existing consumer changes wire format)
- [x] `cargo fmt --check` clean