### PR TITLE
feat(substrate-mail): migrate cast kinds to derive (ADR-0019 PR 3)

### DIFF
--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -5,17 +5,19 @@
 // force every consumer through the proc-macro toolchain even when they
 // just want the runtime traits.
 //
-// `Kind` always emits the `aether_mail::Kind` impl plus a
-// `CastEligible` impl that propagates each field's eligibility — this
-// is the compile-time machinery the `Schema` derive uses to decide
-// whether a struct can use the `#[repr(C)]`-shaped wire format. Enums
-// always get `CastEligible::ELIGIBLE = false`.
+// `Kind` emits only the `aether_mail::Kind` impl — a `const NAME` and
+// nothing else. Wasm guests that just want to address a kind by name
+// derive only this and stay free of hub-protocol entirely.
 //
-// `Schema` is opt-in. It emits an `aether_mail::Schema` impl that
-// returns the `aether_hub_protocol::SchemaType` describing the type's
-// payload. Components that never need to introspect their own kinds
-// (every wasm guest today) skip `Schema` and stay free of the
-// hub-protocol dep.
+// `Schema` is opt-in (typically gated on a `descriptors` feature so
+// it expands only in std consumers). It emits *both* the
+// `aether_mail::Schema` impl returning a `SchemaType` AND a
+// `CastEligible` impl whose `ELIGIBLE` const propagates each field's
+// eligibility against `#[repr(C)]` presence. Pairing them here means
+// types used as schema fields (helper structs like `Vertex`) get
+// `CastEligible` for free without needing a separate derive — the
+// Schema derive is the only place that needs eligibility, so it owns
+// the impl.
 //
 // Field-type handling is the trickiest part. For most field types we
 // delegate to `<FieldT as Schema>::schema()` and let the blanket impls
@@ -54,33 +56,15 @@ pub fn derive_schema(input: TokenStream) -> TokenStream {
 fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
     let kind_name = parse_kind_name(&input.attrs)?;
-
-    let cast_eligible_expr = match &input.data {
-        Data::Struct(_) => {
-            let fields = struct_fields(input)?;
-            let has_repr_c = struct_has_repr_c(&input.attrs);
-            cast_eligible_expr_for_struct(has_repr_c, &fields)
-        }
-        // Enums and unions are never cast-eligible — they need a tag
-        // discriminant + variable layout that `bytemuck::cast` can't
-        // express. The derive emits `false` and the schema lands as a
-        // postcard-encoded sum.
-        Data::Enum(_) => quote! { false },
-        Data::Union(u) => {
-            return Err(syn::Error::new_spanned(
-                u.union_token,
-                "Kind derive does not support unions",
-            ));
-        }
-    };
-
+    if let Data::Union(u) = &input.data {
+        return Err(syn::Error::new_spanned(
+            u.union_token,
+            "Kind derive does not support unions",
+        ));
+    }
     Ok(quote! {
         impl ::aether_mail::Kind for #name {
             const NAME: &'static str = #kind_name;
-        }
-
-        impl ::aether_mail::CastEligible for #name {
-            const ELIGIBLE: bool = #cast_eligible_expr;
         }
     })
 }
@@ -101,9 +85,16 @@ fn cast_eligible_expr_for_struct(has_repr_c: bool, fields: &[FieldInfo]) -> Toke
 
 fn expand_schema(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
-    let body = match &input.data {
-        Data::Struct(_) => expand_schema_struct(input)?,
-        Data::Enum(e) => expand_schema_enum(e)?,
+    let (body, cast_eligible_expr) = match &input.data {
+        Data::Struct(_) => {
+            let fields = struct_fields(input)?;
+            let has_repr_c = struct_has_repr_c(&input.attrs);
+            (
+                expand_schema_struct(&fields)?,
+                cast_eligible_expr_for_struct(has_repr_c, &fields),
+            )
+        }
+        Data::Enum(e) => (expand_schema_enum(e)?, quote! { false }),
         Data::Union(u) => {
             return Err(syn::Error::new_spanned(
                 u.union_token,
@@ -117,12 +108,14 @@ fn expand_schema(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 #body
             }
         }
+
+        impl ::aether_mail::CastEligible for #name {
+            const ELIGIBLE: bool = #cast_eligible_expr;
+        }
     })
 }
 
-fn expand_schema_struct(input: &DeriveInput) -> syn::Result<TokenStream2> {
-    let fields = struct_fields(input)?;
-
+fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
     if fields.is_empty() {
         return Ok(quote! { ::aether_hub_protocol::SchemaType::Unit });
     }

--- a/crates/aether-substrate-mail/Cargo.toml
+++ b/crates/aether-substrate-mail/Cargo.toml
@@ -7,9 +7,13 @@ edition.workspace = true
 # Emit wire-compatible descriptors for the ADR-0007 schema-driven hub
 # boundary. Off by default so WASM guests don't drag in hub-protocol.
 # Native binaries (aether-substrate) enable it.
-descriptors = ["dep:aether-hub-protocol"]
+descriptors = [
+    "dep:aether-hub-protocol",
+    "aether-mail/descriptors",
+    "aether-mail/derive",
+]
 
 [dependencies]
-aether-mail = { path = "../aether-mail" }
+aether-mail = { path = "../aether-mail", features = ["derive"] }
 aether-hub-protocol = { path = "../aether-hub-protocol", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -19,46 +19,57 @@ pub mod descriptors;
 use aether_mail::Kind;
 use bytemuck::{Pod, Zeroable};
 
+// ADR-0019 PR 3: every cast-shaped kind below moves to
+// `#[derive(Kind)]` (always) plus `#[derive(Schema)]` (gated on the
+// `descriptors` feature so wasm guests stay free of hub-protocol).
+// Wire format is unchanged in this PR — descriptors.rs still emits the
+// legacy `Pod`/`Signal`/`Opaque` arms. The `Schema` impls land here so
+// the substrate's dispatch path (PR 4) and the hub encoder (PR 5) have
+// something to call into without another round of boilerplate.
+
 /// Per-frame signal from the substrate's frame loop. Empty payload for
 /// now; milestone 4 will add an elapsed-seconds field.
+#[derive(aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.tick")]
 pub struct Tick;
-impl Kind for Tick {
-    const NAME: &'static str = "aether.tick";
-}
 
 /// A single keyboard keypress, identified by `winit::keyboard::KeyCode
 /// as u32`. Dispatched on press only (not release, not repeat).
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.key")]
 pub struct Key {
     pub code: u32,
 }
-impl Kind for Key {
-    const NAME: &'static str = "aether.key";
-}
 
 /// A mouse-button press. No payload today — which button isn't tracked.
+#[derive(aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.mouse_button")]
 pub struct MouseButton;
-impl Kind for MouseButton {
-    const NAME: &'static str = "aether.mouse_button";
-}
 
 /// Cursor position in window coordinates, as logical pixels cast to f32.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.mouse_move")]
 pub struct MouseMove {
     pub x: f32,
     pub y: f32,
 }
-impl Kind for MouseMove {
-    const NAME: &'static str = "aether.mouse_move";
-}
 
 /// A single clip-space vertex with per-vertex color. Matches the
 /// substrate's `VertexBufferLayout`: `(pos: vec2<f32>, color: vec3<f32>)`,
-/// 20 bytes on the wire.
+/// 20 bytes on the wire. Not a kind on its own — only addressable as
+/// the element type inside `DrawTriangle.verts`. The `Schema` derive
+/// is conditional so DrawTriangle's emitted schema can recurse into
+/// it under `descriptors`; without the feature, neither type emits
+/// schema or eligibility info.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
 pub struct Vertex {
     pub x: f32,
     pub y: f32,
@@ -71,12 +82,11 @@ pub struct Vertex {
 /// `count` field is the number of triangles in the payload when
 /// sent as a slice.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.draw_triangle")]
 pub struct DrawTriangle {
     pub verts: [Vertex; 3],
-}
-impl Kind for DrawTriangle {
-    const NAME: &'static str = "aether.draw_triangle";
 }
 
 /// Request addressed to a component that supports the ADR-0013
@@ -84,24 +94,22 @@ impl Kind for DrawTriangle {
 /// carrying the same `seq`; the round trip proves that a Claude
 /// session → component → session reply actually works end-to-end.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.ping")]
 pub struct Ping {
     pub seq: u32,
-}
-impl Kind for Ping {
-    const NAME: &'static str = "aether.ping";
 }
 
 /// Reply-to-sender counterpart to `Ping`. The `seq` is the incoming
 /// `Ping.seq` echoed back so the caller can match requests against
 /// replies when multiple are in flight.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.pong")]
 pub struct Pong {
     pub seq: u32,
-}
-impl Kind for Pong {
-    const NAME: &'static str = "aether.pong";
 }
 
 /// Periodic observation emitted by the substrate's frame loop when a
@@ -110,13 +118,12 @@ impl Kind for Pong {
 /// every attached Claude session learns how the engine is running
 /// without having to poll the engine directly.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, aether_mail::Kind)]
+#[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
+#[kind(name = "aether.observation.frame_stats")]
 pub struct FrameStats {
     pub frame: u64,
     pub triangles: u64,
-}
-impl Kind for FrameStats {
-    const NAME: &'static str = "aether.observation.frame_stats";
 }
 
 // Reserved control-plane vocabulary (ADR-0010). The substrate handles
@@ -248,5 +255,86 @@ mod tests {
         assert_eq!(bytes.len(), 16);
         let back: FrameStats = decode(&bytes).unwrap();
         assert_eq!(back, s);
+    }
+
+    // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
+    // (gated on `descriptors`). These tests pin the derive output so
+    // PR 5's switch-over of `descriptors.rs` from legacy `Pod`/`Signal`
+    // arms to `Schema(...)` doesn't drift on wire bytes for cast-shaped
+    // kinds.
+    #[cfg(feature = "descriptors")]
+    mod schema {
+        use super::*;
+        use aether_hub_protocol::{Primitive, SchemaType};
+        use aether_mail::{CastEligible, Schema};
+
+        #[test]
+        fn unit_kinds_emit_schema_unit() {
+            assert!(matches!(<Tick as Schema>::schema(), SchemaType::Unit));
+            assert!(matches!(
+                <MouseButton as Schema>::schema(),
+                SchemaType::Unit
+            ));
+        }
+
+        #[test]
+        fn cast_kinds_pick_repr_c_true() {
+            const { assert!(<Key as CastEligible>::ELIGIBLE) };
+            const { assert!(<MouseMove as CastEligible>::ELIGIBLE) };
+            const { assert!(<Vertex as CastEligible>::ELIGIBLE) };
+            const { assert!(<DrawTriangle as CastEligible>::ELIGIBLE) };
+            const { assert!(<Ping as CastEligible>::ELIGIBLE) };
+            const { assert!(<Pong as CastEligible>::ELIGIBLE) };
+            const { assert!(<FrameStats as CastEligible>::ELIGIBLE) };
+        }
+
+        #[test]
+        fn key_schema_is_one_u32_field() {
+            let SchemaType::Struct { repr_c, fields } = <Key as Schema>::schema() else {
+                panic!("expected Struct");
+            };
+            assert!(repr_c);
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "code");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+        }
+
+        #[test]
+        fn draw_triangle_schema_recurses_into_vertex() {
+            let SchemaType::Struct { repr_c, fields } = <DrawTriangle as Schema>::schema() else {
+                panic!("expected Struct");
+            };
+            assert!(repr_c);
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "verts");
+            let SchemaType::Array { element, len } = &fields[0].ty else {
+                panic!("expected Array");
+            };
+            assert_eq!(*len, 3);
+            let SchemaType::Struct {
+                repr_c: nested_repr,
+                fields: nested_fields,
+            } = element.as_ref()
+            else {
+                panic!("expected nested Struct");
+            };
+            assert!(*nested_repr);
+            assert_eq!(nested_fields.len(), 5);
+            assert_eq!(nested_fields[0].name, "x");
+            assert_eq!(nested_fields[4].name, "b");
+        }
+
+        #[test]
+        fn frame_stats_schema_is_two_u64_fields() {
+            let SchemaType::Struct { repr_c, fields } = <FrameStats as Schema>::schema() else {
+                panic!("expected Struct");
+            };
+            assert!(repr_c);
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "frame");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U64));
+            assert_eq!(fields[1].name, "triangles");
+            assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U64));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Third PR in the ADR-0019 chain. Replaces the hand-written `impl Kind` boilerplate on every cast-shaped substrate kind with `#[derive(aether_mail::Kind)]` + `cfg_attr`-gated `aether_mail::Schema`. Wire format is **unchanged** in this PR — `descriptors.rs` still emits legacy `Pod`/`Signal`/`Opaque` arms; PR 5 will switch it over alongside the hub encoder rewrite.

The `Schema` impls land here so PR 4 (substrate dispatch) and PR 5 (hub encoder) have something to call into without another round of mechanical boilerplate.

## Refactor inside `aether-mail-derive`

`CastEligible` emission moved from the `Kind` derive to the `Schema` derive. Motivation: helper structs like `Vertex` (only used as the element type of `DrawTriangle.verts`, not addressable as a kind on its own) need `Schema` for the recursion and `CastEligible` for the eligibility chain — but they shouldn't get a spurious `impl Kind`. Pairing `Schema` with `CastEligible` lets `Vertex` derive only `Schema` and get both.

## Test plan

- [x] `cargo test -p aether-substrate-mail --features descriptors` — 16 tests pass (5 new schema assertions covering unit kinds, cast eligibility on every cast kind, `Key` single-field, `DrawTriangle → [Vertex; 3]` recursion, `FrameStats` two-u64 shape)
- [x] `cargo test -p aether-mail-derive` — 7 derive tests still pass after the `CastEligible` move
- [x] `cargo test --workspace` clean
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Control-plane kinds (`LoadComponent`, `LoadResult`, etc.) keep their hand-written `impl Kind` and `Opaque` descriptors — they migrate in PR 5 alongside `payload_bytes` removal.