### PR TITLE
feat(hub): encode_schema for cast kinds + descriptors switch (ADR-0019 PR 4)

### DIFF
--- a/crates/aether-hub/src/encoder.rs
+++ b/crates/aether-hub/src/encoder.rs
@@ -1,9 +1,7 @@
 // POD encoder: serde_json params + KindDescriptor field list → bytes
 // matching the Rust `#[repr(C)]` layout the engine expects.
 //
-// Pure function; no hub state, no async. PR 5 wires it into the MCP
-// `send_mail` tool; PR 4 ships the function standalone so the logic
-// can be exhaustively tested before it's reachable from a tool call.
+// Pure function; no hub state, no async.
 //
 // Layout rules implemented:
 //   - Scalar fields emit LE bytes at an offset padded up to the
@@ -15,13 +13,18 @@
 //     multiple of the largest field alignment (Rust `#[repr(C)]`
 //     struct size rule).
 //
-// Nested structs and unions are out of scope for V0 — the descriptor
-// format doesn't model them (per ADR-0007). Kinds that need them use
-// `KindEncoding::Opaque` and bypass this encoder.
+// ADR-0019 PR 4 added `encode_schema`, the `SchemaType`-driven sibling
+// of `encode_pod` for `KindEncoding::Schema(...)` kinds. It currently
+// covers the cast subset (`Unit`, top-level `Struct { repr_c: true }`
+// containing scalars/arrays/nested cast structs) — same wire bytes as
+// `encode_pod`. Postcard-shaped schemas (strings/vecs/options/enums)
+// land in PR 5; until then they error out with a clear message.
 
 use std::fmt;
 
-use aether_hub_protocol::{PodField, PodFieldType, PodPrimitive};
+use aether_hub_protocol::{
+    NamedField, PodField, PodFieldType, PodPrimitive, Primitive, SchemaType,
+};
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -42,6 +45,11 @@ pub enum EncodeError {
         expected: u32,
         got: usize,
     },
+    /// A `SchemaType` arm the hub can't yet encode. ADR-0019 PR 4 only
+    /// covers cast-shaped schemas; postcard-shaped ones (strings, vecs,
+    /// options, enums) land in PR 5. The variant carries a description
+    /// of the offending shape so the agent error is actionable.
+    UnsupportedSchema(&'static str),
 }
 
 impl fmt::Display for EncodeError {
@@ -64,6 +72,12 @@ impl fmt::Display for EncodeError {
                 f,
                 "field {field:?}: array length {got} != expected {expected}"
             ),
+            EncodeError::UnsupportedSchema(shape) => {
+                write!(
+                    f,
+                    "schema arm not yet supported by hub encoder: {shape} (ADR-0019 PR 5)"
+                )
+            }
         }
     }
 }
@@ -121,6 +135,255 @@ pub fn encode_pod(params: &Value, fields: &[PodField]) -> Result<Vec<u8>, Encode
 
     pad_to(&mut out, max_align);
     Ok(out)
+}
+
+/// ADR-0019: encode `params` against a `SchemaType` descriptor. Cast
+/// subset only in this PR — top-level `Unit`, top-level `Struct {
+/// repr_c: true }` containing scalars, fixed arrays, and nested
+/// `Struct { repr_c: true }`. Wire bytes match what `encode_pod`
+/// produces for the same logical shape, which is what the substrate
+/// already decodes via `bytemuck::cast` on the receive side.
+///
+/// Postcard-shaped schemas (`String`, `Bytes`, `Vec`, `Option`,
+/// `Enum`, or any `Struct { repr_c: false }`) return
+/// `EncodeError::UnsupportedSchema` until PR 5 wires the postcard
+/// path through this function.
+pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, EncodeError> {
+    match schema {
+        SchemaType::Unit => {
+            // Empty payload. Match `encode_pod`'s behavior of accepting
+            // an empty object or null; reject explicit non-empty input
+            // so a typo doesn't get silently swallowed.
+            if let Some(obj) = params.as_object()
+                && !obj.is_empty()
+            {
+                return Err(EncodeError::UnexpectedField(
+                    obj.keys().next().cloned().unwrap_or_default(),
+                ));
+            }
+            Ok(Vec::new())
+        }
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => {
+            let obj = params.as_object().ok_or(EncodeError::NotAnObject)?;
+            for key in obj.keys() {
+                if !fields.iter().any(|f| &f.name == key) {
+                    return Err(EncodeError::UnexpectedField(key.clone()));
+                }
+            }
+            let mut out = Vec::new();
+            let max_align = encode_struct_fields(&mut out, obj, fields)?;
+            pad_to(&mut out, max_align);
+            Ok(out)
+        }
+        SchemaType::Struct { repr_c: false, .. } => {
+            Err(EncodeError::UnsupportedSchema("Struct { repr_c: false }"))
+        }
+        SchemaType::Bool => Err(EncodeError::UnsupportedSchema("Bool top-level")),
+        SchemaType::Scalar(_) => Err(EncodeError::UnsupportedSchema("Scalar top-level")),
+        SchemaType::String => Err(EncodeError::UnsupportedSchema("String")),
+        SchemaType::Bytes => Err(EncodeError::UnsupportedSchema("Bytes")),
+        SchemaType::Option(_) => Err(EncodeError::UnsupportedSchema("Option")),
+        SchemaType::Vec(_) => Err(EncodeError::UnsupportedSchema("Vec")),
+        SchemaType::Array { .. } => Err(EncodeError::UnsupportedSchema("Array top-level")),
+        SchemaType::Enum { .. } => Err(EncodeError::UnsupportedSchema("Enum")),
+    }
+}
+
+/// Recursively walk a `repr_c: true` struct's fields, packing them
+/// into `out` with `#[repr(C)]` alignment rules. Returns the maximum
+/// field alignment so the caller can apply trailing padding.
+fn encode_struct_fields(
+    out: &mut Vec<u8>,
+    obj: &serde_json::Map<String, Value>,
+    fields: &[NamedField],
+) -> Result<usize, EncodeError> {
+    let mut max_align = 1usize;
+    for field in fields {
+        let value = obj
+            .get(&field.name)
+            .ok_or_else(|| EncodeError::MissingField(field.name.clone()))?;
+        let a = encode_field_value(out, &field.name, &field.ty, value)?;
+        max_align = max_align.max(a);
+    }
+    Ok(max_align)
+}
+
+/// Encode one field value into `out`. Returns the alignment requirement
+/// the field imposed (so the parent can track `max_align`). Recurses
+/// into nested cast structs; rejects any non-cast leaf type with
+/// `UnsupportedSchema`.
+fn encode_field_value(
+    out: &mut Vec<u8>,
+    name: &str,
+    ty: &SchemaType,
+    value: &Value,
+) -> Result<usize, EncodeError> {
+    match ty {
+        SchemaType::Scalar(p) => {
+            let a = align_of_primitive(*p);
+            pad_to(out, a);
+            write_primitive_schema(out, *p, value, name)?;
+            Ok(a)
+        }
+        SchemaType::Array { element, len } => {
+            let arr = value.as_array().ok_or_else(|| EncodeError::TypeMismatch {
+                field: name.to_owned(),
+                expected: "array",
+            })?;
+            if arr.len() != *len as usize {
+                return Err(EncodeError::ArrayLengthMismatch {
+                    field: name.to_owned(),
+                    expected: *len,
+                    got: arr.len(),
+                });
+            }
+            // Compute element alignment up-front and pad the start
+            // before the first element. Subsequent elements are
+            // contiguous (no per-element re-pad) — matches `[T; N]`
+            // layout under `#[repr(C)]`.
+            let elem_align = alignment_of_schema(element)?;
+            pad_to(out, elem_align);
+            for (i, v) in arr.iter().enumerate() {
+                let elem_name = format!("{name}[{i}]");
+                encode_field_value(out, &elem_name, element, v)?;
+            }
+            Ok(elem_align)
+        }
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => {
+            // Nested cast struct — pad to its alignment, encode in
+            // place, apply trailing padding so the next sibling field
+            // starts at the right offset.
+            let nested_align = alignment_of_schema(ty)?;
+            pad_to(out, nested_align);
+            let obj = value.as_object().ok_or_else(|| EncodeError::TypeMismatch {
+                field: name.to_owned(),
+                expected: "object",
+            })?;
+            for key in obj.keys() {
+                if !fields.iter().any(|f| &f.name == key) {
+                    return Err(EncodeError::UnexpectedField(format!("{name}.{key}")));
+                }
+            }
+            let inner_max = encode_struct_fields(out, obj, fields)?;
+            pad_to(out, inner_max);
+            Ok(nested_align)
+        }
+        SchemaType::Struct { repr_c: false, .. } => Err(EncodeError::UnsupportedSchema(
+            "Struct { repr_c: false } in cast-shaped parent",
+        )),
+        SchemaType::Bool
+        | SchemaType::String
+        | SchemaType::Bytes
+        | SchemaType::Option(_)
+        | SchemaType::Vec(_)
+        | SchemaType::Enum { .. }
+        | SchemaType::Unit => Err(EncodeError::UnsupportedSchema(
+            "non-cast field inside cast-shaped struct",
+        )),
+    }
+}
+
+/// Compute the `#[repr(C)]` alignment of a cast-shaped schema. Used to
+/// place fields at the right offsets without actually encoding them.
+fn alignment_of_schema(ty: &SchemaType) -> Result<usize, EncodeError> {
+    match ty {
+        SchemaType::Scalar(p) => Ok(align_of_primitive(*p)),
+        SchemaType::Array { element, .. } => alignment_of_schema(element),
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => {
+            let mut a = 1usize;
+            for f in fields {
+                a = a.max(alignment_of_schema(&f.ty)?);
+            }
+            Ok(a)
+        }
+        _ => Err(EncodeError::UnsupportedSchema(
+            "alignment query on non-cast schema",
+        )),
+    }
+}
+
+fn align_of_primitive(p: Primitive) -> usize {
+    match p {
+        Primitive::U8 | Primitive::I8 => 1,
+        Primitive::U16 | Primitive::I16 => 2,
+        Primitive::U32 | Primitive::I32 | Primitive::F32 => 4,
+        Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
+    }
+}
+
+/// `Primitive`-flavored sibling of `write_primitive`. Same wire bytes
+/// — both enums describe the same set of types — but the duplication
+/// stays here until `PodPrimitive` goes away in the cleanup PR.
+fn write_primitive_schema(
+    out: &mut Vec<u8>,
+    p: Primitive,
+    v: &Value,
+    name: &str,
+) -> Result<(), EncodeError> {
+    match p {
+        Primitive::U8 => {
+            let n = as_unsigned(v, name, "u8")?;
+            let n: u8 = n.try_into().map_err(|_| oor(name, "u8"))?;
+            out.push(n);
+        }
+        Primitive::U16 => {
+            let n = as_unsigned(v, name, "u16")?;
+            let n: u16 = n.try_into().map_err(|_| oor(name, "u16"))?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::U32 => {
+            let n = as_unsigned(v, name, "u32")?;
+            let n: u32 = n.try_into().map_err(|_| oor(name, "u32"))?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::U64 => {
+            let n = as_unsigned(v, name, "u64")?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::I8 => {
+            let n = as_signed(v, name, "i8")?;
+            let n: i8 = n.try_into().map_err(|_| oor(name, "i8"))?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::I16 => {
+            let n = as_signed(v, name, "i16")?;
+            let n: i16 = n.try_into().map_err(|_| oor(name, "i16"))?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::I32 => {
+            let n = as_signed(v, name, "i32")?;
+            let n: i32 = n.try_into().map_err(|_| oor(name, "i32"))?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::I64 => {
+            let n = as_signed(v, name, "i64")?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+        Primitive::F32 => {
+            let n = v.as_f64().ok_or_else(|| EncodeError::TypeMismatch {
+                field: name.to_owned(),
+                expected: "f32",
+            })?;
+            out.extend_from_slice(&(n as f32).to_le_bytes());
+        }
+        Primitive::F64 => {
+            let n = v.as_f64().ok_or_else(|| EncodeError::TypeMismatch {
+                field: name.to_owned(),
+                expected: "f64",
+            })?;
+            out.extend_from_slice(&n.to_le_bytes());
+        }
+    }
+    Ok(())
 }
 
 fn pad_to(out: &mut Vec<u8>, align: usize) {
@@ -381,5 +644,187 @@ mod tests {
         let fields = &[scalar("n", PodPrimitive::I32)];
         let bytes = encode_pod(&json!({"n": -1}), fields).unwrap();
         assert_eq!(bytes, vec![0xff, 0xff, 0xff, 0xff]);
+    }
+
+    // ADR-0019 PR 4 — `encode_schema` must produce byte-identical
+    // output to `encode_pod` for cast-shaped kinds. PR 5 will retire
+    // `encode_pod` once consumers migrate; until then both encoders
+    // coexist and a regression in either path is caught here.
+
+    fn schema_scalar(name: &str, ty: Primitive) -> NamedField {
+        NamedField {
+            name: name.into(),
+            ty: SchemaType::Scalar(ty),
+        }
+    }
+
+    fn schema_struct(fields: Vec<NamedField>) -> SchemaType {
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        }
+    }
+
+    #[test]
+    fn schema_unit_encodes_empty_payload() {
+        let bytes = encode_schema(&json!({}), &SchemaType::Unit).unwrap();
+        assert!(bytes.is_empty());
+        let bytes = encode_schema(&json!(null), &SchemaType::Unit).unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn schema_unit_rejects_non_empty_object() {
+        let err = encode_schema(&json!({"x": 1}), &SchemaType::Unit).unwrap_err();
+        assert!(matches!(err, EncodeError::UnexpectedField(_)));
+    }
+
+    #[test]
+    fn schema_struct_matches_encode_pod_for_key() {
+        // Single u32 — the simplest cast struct.
+        let pod_bytes = encode_pod(
+            &json!({"code": 0xdead_beefu32}),
+            &[scalar("code", PodPrimitive::U32)],
+        )
+        .unwrap();
+        let schema_bytes = encode_schema(
+            &json!({"code": 0xdead_beefu32}),
+            &schema_struct(vec![schema_scalar("code", Primitive::U32)]),
+        )
+        .unwrap();
+        assert_eq!(pod_bytes, schema_bytes);
+    }
+
+    #[test]
+    fn schema_struct_matches_encode_pod_for_mousemove() {
+        // Two f32 — the same shape Pod encoder tests use.
+        let pod_bytes = encode_pod(
+            &json!({"x": 10.5, "y": 20.0}),
+            &[
+                scalar("x", PodPrimitive::F32),
+                scalar("y", PodPrimitive::F32),
+            ],
+        )
+        .unwrap();
+        let schema_bytes = encode_schema(
+            &json!({"x": 10.5, "y": 20.0}),
+            &schema_struct(vec![
+                schema_scalar("x", Primitive::F32),
+                schema_scalar("y", Primitive::F32),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(pod_bytes, schema_bytes);
+    }
+
+    #[test]
+    fn schema_struct_pads_between_u8_and_u32_like_pod() {
+        // The padding-rule test from `encode_pod` ported to schema —
+        // alignment behavior must match for binary compatibility.
+        let pod_bytes = encode_pod(
+            &json!({"a": 7, "b": 0x0102_0304u32}),
+            &[
+                scalar("a", PodPrimitive::U8),
+                scalar("b", PodPrimitive::U32),
+            ],
+        )
+        .unwrap();
+        let schema_bytes = encode_schema(
+            &json!({"a": 7, "b": 0x0102_0304u32}),
+            &schema_struct(vec![
+                schema_scalar("a", Primitive::U8),
+                schema_scalar("b", Primitive::U32),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(pod_bytes, schema_bytes);
+        assert_eq!(schema_bytes, vec![7, 0, 0, 0, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn schema_nested_struct_matches_drawtriangle_layout() {
+        // DrawTriangle's shape: { verts: [Vertex; 3] } where Vertex is
+        // 5 f32s. Cast wire format = 60 bytes, no internal padding.
+        // Pod descriptors couldn't model nested structs so this had to
+        // be Opaque before — proving the schema path matches the cast
+        // layout end-to-end is the key property of PR 4.
+        let vertex = SchemaType::Struct {
+            repr_c: true,
+            fields: vec![
+                schema_scalar("x", Primitive::F32),
+                schema_scalar("y", Primitive::F32),
+                schema_scalar("r", Primitive::F32),
+                schema_scalar("g", Primitive::F32),
+                schema_scalar("b", Primitive::F32),
+            ],
+        };
+        let triangle = schema_struct(vec![NamedField {
+            name: "verts".into(),
+            ty: SchemaType::Array {
+                element: Box::new(vertex),
+                len: 3,
+            },
+        }]);
+        let v = json!({"x": 0.0, "y": 0.5, "r": 1.0, "g": 0.0, "b": 0.0});
+        let params = json!({"verts": [v, v, v]});
+        let bytes = encode_schema(&params, &triangle).unwrap();
+        assert_eq!(bytes.len(), 60);
+
+        // Roundtrip via bytemuck — same proof shape as the Pod tests.
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
+        struct Vertex {
+            x: f32,
+            y: f32,
+            r: f32,
+            g: f32,
+            b: f32,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
+        struct DrawTriangle {
+            verts: [Vertex; 3],
+        }
+        let back: DrawTriangle = bytemuck::cast_slice(&bytes)[0];
+        let v_struct = Vertex {
+            x: 0.0,
+            y: 0.5,
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+        };
+        assert_eq!(
+            back,
+            DrawTriangle {
+                verts: [v_struct, v_struct, v_struct]
+            }
+        );
+    }
+
+    #[test]
+    fn schema_postcard_struct_errors_until_pr5() {
+        let schema = SchemaType::Struct {
+            fields: vec![NamedField {
+                name: "label".into(),
+                ty: SchemaType::String,
+            }],
+            repr_c: false,
+        };
+        let err = encode_schema(&json!({"label": "x"}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::UnsupportedSchema(_)));
+    }
+
+    #[test]
+    fn schema_struct_rejects_unexpected_field() {
+        let schema = schema_struct(vec![schema_scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!({"code": 1, "extra": 2}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::UnexpectedField(n) if n == "extra"));
+    }
+
+    #[test]
+    fn schema_struct_rejects_missing_field() {
+        let schema = schema_struct(vec![schema_scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!({}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::MissingField(n) if n == "code"));
     }
 }

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -29,7 +29,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc};
 
-use crate::encoder::encode_pod;
+use crate::encoder::{encode_pod, encode_schema};
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
 use crate::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnOpts};
@@ -486,20 +486,27 @@ fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, St
                     "kind {:?} is Opaque; use payload_bytes",
                     spec.kind_name
                 )),
-                // ADR-0019 PR 1: type plumbed, encoder lands in PR 5.
-                // Until then, agents that hit a Schema kind get a clear
-                // error rather than silent corruption.
-                KindEncoding::Schema(_) => Err(format!(
-                    "kind {:?} uses Schema encoding; hub encoder not yet implemented (ADR-0019)",
-                    spec.kind_name
-                )),
+                // ADR-0019 PR 4: cast-shaped Schema kinds encode through
+                // `encode_schema`; postcard-shaped ones still error
+                // until PR 5 wires the postcard path.
+                KindEncoding::Schema(schema) => encode_schema(p, schema).map_err(|e| e.to_string()),
             }
         }
         (None, None) => {
-            // Neither given: permissible only if the descriptor says
-            // Signal. Anything else is ambiguous — fail loudly.
+            // Neither given: permissible only if the descriptor implies
+            // an empty payload — `KindEncoding::Signal` (legacy) or
+            // ADR-0019's `KindEncoding::Schema(SchemaType::Unit)`.
+            // Anything else is ambiguous — fail loudly.
             match find_kind(record, &spec.kind_name) {
                 Some(desc) if matches!(desc.encoding, KindEncoding::Signal) => Ok(Vec::new()),
+                Some(desc)
+                    if matches!(
+                        desc.encoding,
+                        KindEncoding::Schema(aether_hub_protocol::SchemaType::Unit)
+                    ) =>
+                {
+                    Ok(Vec::new())
+                }
                 _ => Err("missing params or payload_bytes".to_owned()),
             }
         }

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -2,18 +2,24 @@
 // substrate binary and shipped to the hub at `Hello` per ADR-0007 so
 // the hub can encode agent-supplied params for each kind.
 //
-// Adding a kind to `lib.rs` means adding a matching entry here; the
-// coupling is deliberate — each descriptor re-states the `#[repr(C)]`
-// field order the encoder will walk on the hub side, so drift between
-// the struct layout and the descriptor is caught when we next look at
-// this file.
+// ADR-0019 PR 4: cast-shaped kinds are now emitted as
+// `KindEncoding::Schema(T::schema())` — the bytes the hub produces are
+// identical to what the legacy `Pod`/`Signal` arms produced, but the
+// descriptor walks the type definition instead of restating its layout
+// here. Adding or renaming a field on a kind is a one-place change
+// (the struct itself); the schema is whatever the derive emits.
+//
+// Control-plane kinds (LoadComponent, ReplaceComponent, DropComponent,
+// LoadResult, DropResult, ReplaceResult) stay `Opaque` here. They
+// migrate in PR 5 along with the postcard encoder + `payload_bytes`
+// removal.
 
 use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use aether_hub_protocol::{KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive};
-use aether_mail::Kind;
+use aether_hub_protocol::{KindDescriptor, KindEncoding};
+use aether_mail::{Kind, Schema};
 
 use crate::{
     DrawTriangle, DropComponent, DropResult, FrameStats, Key, LoadComponent, LoadResult,
@@ -24,36 +30,20 @@ use crate::{
 /// register them. Caller ignores the order — names are the contract.
 pub fn all() -> Vec<KindDescriptor> {
     vec![
-        signal(Tick::NAME),
-        pod(Key::NAME, vec![scalar("code", PodPrimitive::U32)]),
-        signal(MouseButton::NAME),
-        pod(
-            MouseMove::NAME,
-            vec![
-                scalar("x", PodPrimitive::F32),
-                scalar("y", PodPrimitive::F32),
-            ],
-        ),
-        // DrawTriangle nests Vertex; V0 descriptors don't model nested
-        // structs, so this kind stays opaque and clients use the raw
-        // payload_bytes path.
-        opaque(DrawTriangle::NAME),
-        pod(
-            FrameStats::NAME,
-            vec![
-                scalar("frame", PodPrimitive::U64),
-                scalar("triangles", PodPrimitive::U64),
-            ],
-        ),
-        // ADR-0013 smoke-test vocabulary. Both Pod so the MCP
-        // `send_mail` tool can encode ping from params; Pong comes
-        // back as bytes on the reply path.
-        pod(Ping::NAME, vec![scalar("seq", PodPrimitive::U32)]),
-        pod(Pong::NAME, vec![scalar("seq", PodPrimitive::U32)]),
-        // ADR-0010 control-plane kinds. Variable-length payloads that
-        // don't fit the Pod model — the substrate handler decodes via
-        // postcard against its own wire types. Agents that use the MCP
-        // `send_mail` tool supply these as raw `payload_bytes`.
+        schema::<Tick>(),
+        schema::<Key>(),
+        schema::<MouseButton>(),
+        schema::<MouseMove>(),
+        // DrawTriangle's schema recurses into Vertex; the cast wire
+        // format keeps today's bytes (the hub encoder treats the
+        // nested `Struct { repr_c: true }` exactly like a flat Pod).
+        schema::<DrawTriangle>(),
+        schema::<FrameStats>(),
+        // ADR-0013 smoke-test vocabulary.
+        schema::<Ping>(),
+        schema::<Pong>(),
+        // ADR-0010 control-plane kinds — still Opaque; PR 5 turns
+        // them into real schemas alongside dropping `payload_bytes`.
         opaque(LoadComponent::NAME),
         opaque(ReplaceComponent::NAME),
         opaque(DropComponent::NAME),
@@ -63,17 +53,10 @@ pub fn all() -> Vec<KindDescriptor> {
     ]
 }
 
-fn signal(name: &str) -> KindDescriptor {
+fn schema<K: Kind + Schema>() -> KindDescriptor {
     KindDescriptor {
-        name: name.to_string(),
-        encoding: KindEncoding::Signal,
-    }
-}
-
-fn pod(name: &str, fields: Vec<PodField>) -> KindDescriptor {
-    KindDescriptor {
-        name: name.to_string(),
-        encoding: KindEncoding::Pod { fields },
+        name: K::NAME.to_string(),
+        encoding: KindEncoding::Schema(K::schema()),
     }
 }
 
@@ -84,16 +67,10 @@ fn opaque(name: &str) -> KindDescriptor {
     }
 }
 
-fn scalar(name: &str, ty: PodPrimitive) -> PodField {
-    PodField {
-        name: name.to_string(),
-        ty: PodFieldType::Scalar(ty),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_hub_protocol::{Primitive, SchemaType};
 
     #[test]
     fn covers_every_substrate_kind() {
@@ -116,6 +93,8 @@ mod tests {
 
     #[test]
     fn control_kinds_are_opaque() {
+        // PR 5 turns these into Schema kinds. Until then, agents must
+        // supply `payload_bytes` for the control plane.
         let descs = all();
         for name in [
             LoadComponent::NAME,
@@ -131,53 +110,100 @@ mod tests {
     }
 
     #[test]
-    fn key_fields_match_struct_layout() {
+    fn cast_kinds_emit_schema_struct_with_repr_c() {
         let descs = all();
-        let key = descs.iter().find(|d| d.name == Key::NAME).unwrap();
-        let KindEncoding::Pod { fields } = &key.encoding else {
-            panic!("expected Pod")
-        };
-        assert_eq!(fields.len(), 1);
-        assert_eq!(fields[0].name, "code");
-        assert_eq!(fields[0].ty, PodFieldType::Scalar(PodPrimitive::U32));
+        for name in [
+            Key::NAME,
+            MouseMove::NAME,
+            DrawTriangle::NAME,
+            FrameStats::NAME,
+            Ping::NAME,
+            Pong::NAME,
+        ] {
+            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let KindEncoding::Schema(SchemaType::Struct { repr_c, .. }) = &d.encoding else {
+                panic!("expected Schema(Struct) for {name}, got {:?}", d.encoding);
+            };
+            assert!(*repr_c, "{name} should be cast-shaped");
+        }
     }
 
     #[test]
-    fn mouse_move_fields_match_struct_layout() {
+    fn signal_kinds_emit_schema_unit() {
+        let descs = all();
+        for name in [Tick::NAME, MouseButton::NAME] {
+            let d = descs.iter().find(|d| d.name == name).unwrap();
+            assert_eq!(
+                d.encoding,
+                KindEncoding::Schema(SchemaType::Unit),
+                "{name} should be Schema(Unit)"
+            );
+        }
+    }
+
+    #[test]
+    fn key_field_layout() {
+        let descs = all();
+        let key = descs.iter().find(|d| d.name == Key::NAME).unwrap();
+        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &key.encoding else {
+            panic!("expected Schema(Struct)")
+        };
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "code");
+        assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+    }
+
+    #[test]
+    fn mouse_move_field_layout() {
         let descs = all();
         let mm = descs.iter().find(|d| d.name == MouseMove::NAME).unwrap();
-        let KindEncoding::Pod { fields } = &mm.encoding else {
-            panic!("expected Pod")
+        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &mm.encoding else {
+            panic!("expected Schema(Struct)")
         };
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "x");
         assert_eq!(fields[1].name, "y");
-        assert!(matches!(
-            fields[0].ty,
-            PodFieldType::Scalar(PodPrimitive::F32)
-        ));
+        assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::F32));
+        assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::F32));
     }
 
     #[test]
-    fn draw_triangle_is_opaque() {
+    fn draw_triangle_recurses_into_vertex() {
+        // The cast wire format previously couldn't describe nested
+        // structs (DrawTriangle was Opaque). The Schema arm fixes that.
         let descs = all();
         let dt = descs.iter().find(|d| d.name == DrawTriangle::NAME).unwrap();
-        assert_eq!(dt.encoding, KindEncoding::Opaque);
+        let KindEncoding::Schema(SchemaType::Struct { fields, repr_c }) = &dt.encoding else {
+            panic!("expected Schema(Struct)")
+        };
+        assert!(*repr_c);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "verts");
+        let SchemaType::Array { element, len } = &fields[0].ty else {
+            panic!("expected Array");
+        };
+        assert_eq!(*len, 3);
+        let SchemaType::Struct {
+            repr_c: nested_repr,
+            fields: nested_fields,
+        } = element.as_ref()
+        else {
+            panic!("expected nested Struct");
+        };
+        assert!(*nested_repr);
+        assert_eq!(nested_fields.len(), 5);
     }
 
     #[test]
-    fn frame_stats_fields_match_struct_layout() {
+    fn frame_stats_field_layout() {
         let descs = all();
         let fs = descs.iter().find(|d| d.name == FrameStats::NAME).unwrap();
-        let KindEncoding::Pod { fields } = &fs.encoding else {
-            panic!("expected Pod")
+        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &fs.encoding else {
+            panic!("expected Schema(Struct)")
         };
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "frame");
         assert_eq!(fields[1].name, "triangles");
-        assert!(matches!(
-            fields[0].ty,
-            PodFieldType::Scalar(PodPrimitive::U64)
-        ));
+        assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U64));
     }
 }


### PR DESCRIPTION
## Summary

Fourth PR in the ADR-0019 chain. Hub encoder learns `KindEncoding::Schema(...)` for the cast subset, and `aether-substrate-mail/descriptors.rs` switches every cast kind from `Pod`/`Signal` to `Schema`. Wire bytes are byte-identical for the cast path — agents see no behavior change for kinds that were already encodable; the substrate's `bytemuck::cast` decode keeps working.

## Notable shape change

`DrawTriangle` moves from `Opaque` (because the legacy descriptor format couldn't model nested structs) to a real `Schema(Struct { repr_c: true, fields: [Array { Vertex, 3 }] })`. The hub can now build it from `params` — no more `payload_bytes` workaround for triangle frames.

## What's deferred to PR 5

- Postcard-shaped schemas (`String`, `Bytes`, `Vec`, `Option`, `Enum`, `Struct { repr_c: false }`) return `EncodeError::UnsupportedSchema` until PR 5 wires the postcard path.
- Control-plane kinds (LoadComponent, ReplaceComponent, DropComponent, LoadResult, DropResult, ReplaceResult) stay `Opaque` — they migrate alongside dropping `payload_bytes` from `send_mail`.

## Reframed scope vs. the original ADR plan

The ADR's original PR 4 was \"dual-path dispatch in `Component::deliver`\" — but `Component::deliver` doesn't actually decode payloads (it just hands raw bytes to the wasm guest). The substrate's built-in handlers (renderer, control plane) already pick their decode strategy per kind. The real prep work for PR 5 is the hub-side `encode_schema` + the descriptor switch, which is what this PR delivers.

## Test plan

- [x] `cargo test -p aether-hub` — 62 tests (10 new): byte-identity between `encode_pod` and `encode_schema` for Key u32, MouseMove two-f32, u8/u32 padding; full DrawTriangle 60-byte slab roundtripping through `bytemuck::cast`; postcard schemas error cleanly; missing/unexpected-field errors; Unit empty-payload behavior
- [x] `cargo test -p aether-substrate-mail --features descriptors` — 18 tests (5 new): every cast kind emits `Schema(Struct{repr_c:true,..})`, signal kinds emit `Schema(Unit)`, control-plane kinds still `Opaque`, DrawTriangle recurses correctly
- [x] `cargo test --workspace` clean
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean