### PR TITLE
chore(hub-protocol): drop legacy KindEncoding/Pod types (ADR-0019 PR 6)

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -136,20 +136,17 @@ mod tests {
             kinds: vec![
                 KindDescriptor {
                     name: "aether.tick".into(),
-                    encoding: KindEncoding::Signal,
+                    schema: SchemaType::Unit,
                 },
                 KindDescriptor {
                     name: "aether.key".into(),
-                    encoding: KindEncoding::Pod {
-                        fields: vec![PodField {
+                    schema: SchemaType::Struct {
+                        repr_c: true,
+                        fields: vec![NamedField {
                             name: "code".into(),
-                            ty: PodFieldType::Scalar(PodPrimitive::U32),
+                            ty: SchemaType::Scalar(Primitive::U32),
                         }],
                     },
-                },
-                KindDescriptor {
-                    name: "aether.draw_triangle".into(),
-                    encoding: KindEncoding::Opaque,
                 },
             ],
         });
@@ -160,43 +157,13 @@ mod tests {
         let EngineToHub::Hello(h) = back else {
             panic!("wrong variant")
         };
-        assert_eq!(h.kinds.len(), 3);
-        assert_eq!(h.kinds[0].encoding, KindEncoding::Signal);
-        let KindEncoding::Pod { fields } = &h.kinds[1].encoding else {
-            panic!("expected Pod")
+        assert_eq!(h.kinds.len(), 2);
+        assert_eq!(h.kinds[0].schema, SchemaType::Unit);
+        let SchemaType::Struct { fields, .. } = &h.kinds[1].schema else {
+            panic!("expected Struct")
         };
         assert_eq!(fields[0].name, "code");
-        assert_eq!(fields[0].ty, PodFieldType::Scalar(PodPrimitive::U32));
-        assert_eq!(h.kinds[2].encoding, KindEncoding::Opaque);
-    }
-
-    #[test]
-    fn pod_field_array_roundtrip() {
-        let desc = KindDescriptor {
-            name: "aether.mouse_move".into(),
-            encoding: KindEncoding::Pod {
-                fields: vec![
-                    PodField {
-                        name: "x".into(),
-                        ty: PodFieldType::Scalar(PodPrimitive::F32),
-                    },
-                    PodField {
-                        name: "y".into(),
-                        ty: PodFieldType::Scalar(PodPrimitive::F32),
-                    },
-                    PodField {
-                        name: "pad".into(),
-                        ty: PodFieldType::Array {
-                            element: PodPrimitive::U8,
-                            len: 4,
-                        },
-                    },
-                ],
-            },
-        };
-        let bytes = postcard::to_allocvec(&desc).unwrap();
-        let back: KindDescriptor = postcard::from_bytes(&bytes).unwrap();
-        assert_eq!(back, desc);
+        assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
     }
 
     #[test]
@@ -285,11 +252,11 @@ mod tests {
         let msg = EngineToHub::KindsChanged(vec![
             KindDescriptor {
                 name: "aether.tick".into(),
-                encoding: KindEncoding::Signal,
+                schema: SchemaType::Unit,
             },
             KindDescriptor {
                 name: "physics.contact".into(),
-                encoding: KindEncoding::Opaque,
+                schema: SchemaType::Bytes,
             },
         ]);
         let mut buf = Vec::new();
@@ -369,17 +336,16 @@ mod tests {
         assert!(matches!(err, FrameError::Postcard(_)));
     }
 
-    // ADR-0019 — schema descriptor roundtrips. The new `KindEncoding::Schema`
-    // arm and its `SchemaType` vocabulary need to survive postcard encode/
-    // decode end-to-end, including nested types and every enum variant shape.
-    // These tests pin the wire format so consumers (hub encoder, substrate
-    // decoder, derive macro) can rely on it across the migration PRs.
+    // ADR-0019 — schema descriptor roundtrips. The `SchemaType` vocabulary
+    // must survive postcard encode/decode end-to-end including nested types
+    // and every enum variant shape. These tests pin the wire format so
+    // consumers (hub encoder, substrate decoder, derive macro) can rely on it.
 
     #[test]
     fn schema_unit_and_scalar_roundtrip() {
         let desc = KindDescriptor {
             name: "demo.tick".into(),
-            encoding: KindEncoding::Schema(SchemaType::Unit),
+            schema: SchemaType::Unit,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -389,7 +355,7 @@ mod tests {
 
         let desc = KindDescriptor {
             name: "demo.seq".into(),
-            encoding: KindEncoding::Schema(SchemaType::Scalar(Primitive::U32)),
+            schema: SchemaType::Scalar(Primitive::U32),
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -427,7 +393,7 @@ mod tests {
         };
         let desc = KindDescriptor {
             name: "demo.draw_triangle".into(),
-            encoding: KindEncoding::Schema(triangle),
+            schema: triangle,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -459,7 +425,7 @@ mod tests {
         };
         let desc = KindDescriptor {
             name: "demo.load_component".into(),
-            encoding: KindEncoding::Schema(load),
+            schema: load,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -495,7 +461,7 @@ mod tests {
         };
         let desc = KindDescriptor {
             name: "demo.load_result".into(),
-            encoding: KindEncoding::Schema(result),
+            schema: result,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -516,13 +482,13 @@ mod tests {
             version: "0".into(),
             kinds: vec![KindDescriptor {
                 name: "demo.note".into(),
-                encoding: KindEncoding::Schema(SchemaType::Struct {
+                schema: SchemaType::Struct {
                     repr_c: false,
                     fields: vec![NamedField {
                         name: "body".into(),
                         ty: SchemaType::String,
                     }],
-                }),
+                },
             }],
         });
         let mut buf = Vec::new();
@@ -532,39 +498,11 @@ mod tests {
             panic!("wrong variant")
         };
         assert_eq!(h.kinds.len(), 1);
-        let KindEncoding::Schema(SchemaType::Struct { repr_c, fields }) = &h.kinds[0].encoding
-        else {
-            panic!("expected Schema(Struct)")
+        let SchemaType::Struct { repr_c, fields } = &h.kinds[0].schema else {
+            panic!("expected Struct")
         };
         assert!(!*repr_c);
         assert_eq!(fields[0].name, "body");
         assert_eq!(fields[0].ty, SchemaType::String);
-    }
-
-    #[test]
-    fn legacy_pod_arms_still_roundtrip() {
-        // The migration plan keeps Signal/Pod/Opaque alive during the
-        // intermediate PRs. A regression here means existing consumers
-        // would break before the cleanup PR can land.
-        for encoding in [
-            KindEncoding::Signal,
-            KindEncoding::Opaque,
-            KindEncoding::Pod {
-                fields: vec![PodField {
-                    name: "code".into(),
-                    ty: PodFieldType::Scalar(PodPrimitive::U32),
-                }],
-            },
-        ] {
-            let desc = KindDescriptor {
-                name: "demo.legacy".into(),
-                encoding: encoding.clone(),
-            };
-            let bytes = postcard::to_allocvec(&desc).unwrap();
-            assert_eq!(
-                postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
-                desc
-            );
-        }
     }
 }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -42,73 +42,13 @@ pub struct Hello {
     pub kinds: Vec<KindDescriptor>,
 }
 
-/// One entry in `Hello.kinds`: a kind-name plus a wire-describable
-/// encoding. Per ADR-0007 the hub uses these to encode agent-supplied
-/// params into the exact bytes the engine expects.
+/// One entry in `Hello.kinds`: a kind-name plus its schema. The hub
+/// uses the schema to encode agent-supplied params into the exact
+/// bytes the engine expects (cast-shaped or postcard, ADR-0019).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindDescriptor {
     pub name: String,
-    pub encoding: KindEncoding,
-}
-
-/// How the hub can materialize bytes for a given kind.
-///
-/// - `Signal`: empty payload. `params` must be absent or empty.
-/// - `Pod`: `#[repr(C)]` struct; hub encodes an ordered field list of
-///   scalars and fixed-size scalar arrays matching Rust's layout.
-/// - `Opaque`: the hub can't encode this from params. Clients must
-///   supply raw bytes. V0 structural (postcard) kinds land here.
-/// - `Schema`: ADR-0019 unified vocabulary covering scalars, strings,
-///   vecs, options, enums, and nested structs. The `repr_c` flag on
-///   `SchemaType::Struct` opts a struct into the cast-shaped wire
-///   format (today's `Pod` bytes); everything else is postcard.
-///
-/// `Signal`/`Pod`/`Opaque` are kept here through the migration so
-/// `aether-hub`, `aether-substrate`, and the smoke binaries can move
-/// over one PR at a time. The cleanup PR deletes them along with
-/// `PodField`/`PodFieldType`/`PodPrimitive`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum KindEncoding {
-    Signal,
-    Pod { fields: Vec<PodField> },
-    Opaque,
-    Schema(SchemaType),
-}
-
-/// One field in a POD kind. Field order matches the Rust struct's
-/// declaration order; the hub walks the list writing bytes with the
-/// same alignment/padding the `#[repr(C)]` layout implies.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PodField {
-    pub name: String,
-    pub ty: PodFieldType,
-}
-
-/// A POD field is either a scalar or a fixed-length array of one
-/// scalar primitive. Nested structs are deliberately out of scope for
-/// V0 (ADR-0007) — a kind with nested-struct fields uses
-/// `KindEncoding::Opaque` and the `payload_bytes` escape hatch.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PodFieldType {
-    Scalar(PodPrimitive),
-    Array { element: PodPrimitive, len: u32 },
-}
-
-/// POD primitive types the hub can encode. Matches the Rust primitive
-/// set that's trivially `bytemuck::Pod`. Names are the canonical Rust
-/// spelling so tooling can parse them without a lookup.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PodPrimitive {
-    U8,
-    U16,
-    U32,
-    U64,
-    I8,
-    I16,
-    I32,
-    I64,
-    F32,
-    F64,
+    pub schema: SchemaType,
 }
 
 /// ADR-0019 schema type vocabulary. Describes the structure of a mail
@@ -175,10 +115,10 @@ pub enum EnumVariant {
     },
 }
 
-/// Scalar primitives addressable by `SchemaType::Scalar`. Same set as
-/// `PodPrimitive` (which is parallel for the legacy `Pod` arm during
-/// migration); kept as its own type so `Schema` can outlive `Pod` once
-/// the cleanup PR removes the legacy arm.
+/// Scalar primitives addressable by `SchemaType::Scalar`. Matches the
+/// Rust primitive set that's trivially `bytemuck::Pod` so cast-shaped
+/// structs can express their leaf types; `bool` is `SchemaType::Bool`,
+/// not a `Primitive` (the cast path doesn't accept `bool` fields).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Primitive {
     U8,

--- a/crates/aether-hub/src/encoder.rs
+++ b/crates/aether-hub/src/encoder.rs
@@ -1,35 +1,29 @@
-// POD encoder: serde_json params + KindDescriptor field list → bytes
-// matching the Rust `#[repr(C)]` layout the engine expects.
+// `encode_schema`: serde_json params + `SchemaType` descriptor → wire
+// bytes the substrate's decode path is happy with. Pure function; no
+// hub state, no async.
 //
-// Pure function; no hub state, no async.
+// Two wire shapes, picked per descriptor:
 //
-// Layout rules implemented:
-//   - Scalar fields emit LE bytes at an offset padded up to the
-//     primitive's natural alignment (1/2/4/8).
-//   - Array fields emit elements contiguously; the start is padded to
-//     the element's alignment, elements don't re-pad between each
-//     other (matches `[T; N]` layout).
-//   - After all fields, trailing zeros bring total size up to a
-//     multiple of the largest field alignment (Rust `#[repr(C)]`
-//     struct size rule).
+// 1. Cast-shaped (`Struct { repr_c: true }` and the recursive tree
+//    under it): `#[repr(C)]` byte layout. Scalars and fixed arrays
+//    laid out at the alignment they'd occupy in a Rust struct;
+//    trailing padding rounds total size to the largest field
+//    alignment. Substrate decode is `bytemuck::cast`.
 //
-// ADR-0019 PR 4 added `encode_schema`, the `SchemaType`-driven sibling
-// of `encode_pod` for `KindEncoding::Schema(...)` kinds. PR 5 wired
-// the postcard path through it for postcard-shaped schemas (`String`,
-// `Bytes`, `Vec`, `Option`, `Enum`, `Struct { repr_c: false }`).
+// 2. Postcard (everything else): postcard 1.x wire format, written
+//    directly:
+//      - bool: 1 byte (0 or 1)
+//      - u8/i8: 1 byte
+//      - u16..u64: LEB128 varint
+//      - i16..i64: zigzag-then-LEB128
+//      - f32/f64: little-endian
+//      - String / &[u8] (Bytes): varint length + bytes
+//      - Vec<T>: varint length + concatenated encoded elements
+//      - [T; N]: concatenated encoded elements (no length prefix)
+//      - Option<T>: 1-byte tag (0 or 1), then T if Some
+//      - enum: varint discriminant, then variant body
+//      - struct: concatenated field bytes in declaration order
 //
-// Wire format for the postcard path follows postcard 1.x exactly:
-//   - bool: 1 byte (0 or 1)
-//   - u8/i8: 1 byte
-//   - u16..u64: LEB128 varint
-//   - i16..i64: zigzag-then-LEB128
-//   - f32/f64: little-endian
-//   - String / &[u8] (Bytes): varint length + bytes
-//   - Vec<T>: varint length + concatenated encoded elements
-//   - [T; N]: concatenated encoded elements (no length prefix)
-//   - Option<T>: 1-byte tag (0 or 1), then T if Some
-//   - enum: varint discriminant, then variant body in declaration order
-//   - struct: concatenated field bytes in declaration order
 // We write the bytes directly rather than going through a serde
 // serializer because the JSON-driven encoding is structural — matching
 // postcard's wire format byte-for-byte is the contract, not "calling
@@ -37,9 +31,7 @@
 
 use std::fmt;
 
-use aether_hub_protocol::{
-    EnumVariant, NamedField, PodField, PodFieldType, PodPrimitive, Primitive, SchemaType,
-};
+use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -97,75 +89,21 @@ impl fmt::Display for EncodeError {
 
 impl std::error::Error for EncodeError {}
 
-/// Encode `params` into the byte layout implied by `fields`. Params
-/// is expected to be a JSON object; keys not present in the
-/// descriptor are rejected so typos don't silently drop data.
-pub fn encode_pod(params: &Value, fields: &[PodField]) -> Result<Vec<u8>, EncodeError> {
-    let obj = params.as_object().ok_or(EncodeError::NotAnObject)?;
-
-    for key in obj.keys() {
-        if !fields.iter().any(|f| &f.name == key) {
-            return Err(EncodeError::UnexpectedField(key.clone()));
-        }
-    }
-
-    let mut out = Vec::new();
-    let mut max_align = 1usize;
-
-    for field in fields {
-        let value = obj
-            .get(&field.name)
-            .ok_or_else(|| EncodeError::MissingField(field.name.clone()))?;
-        match &field.ty {
-            PodFieldType::Scalar(p) => {
-                let a = align_of(*p);
-                pad_to(&mut out, a);
-                write_primitive(&mut out, *p, value, &field.name)?;
-                max_align = max_align.max(a);
-            }
-            PodFieldType::Array { element, len } => {
-                let a = align_of(*element);
-                pad_to(&mut out, a);
-                let arr = value.as_array().ok_or_else(|| EncodeError::TypeMismatch {
-                    field: field.name.clone(),
-                    expected: "array",
-                })?;
-                if arr.len() != *len as usize {
-                    return Err(EncodeError::ArrayLengthMismatch {
-                        field: field.name.clone(),
-                        expected: *len,
-                        got: arr.len(),
-                    });
-                }
-                for (i, v) in arr.iter().enumerate() {
-                    let elem_name = format!("{}[{}]", field.name, i);
-                    write_primitive(&mut out, *element, v, &elem_name)?;
-                }
-                max_align = max_align.max(a);
-            }
-        }
-    }
-
-    pad_to(&mut out, max_align);
-    Ok(out)
-}
-
 /// ADR-0019: encode `params` against a `SchemaType` descriptor.
 /// Dispatches on the schema's wire shape:
 ///
 /// - `Unit` → empty payload.
 /// - `Struct { repr_c: true }` (and the recursive cast-shaped tree
 ///   under it) → `#[repr(C)]` byte layout, decodable by
-///   `bytemuck::cast` on the substrate side. Same wire bytes as
-///   `encode_pod` for the same logical shape.
+///   `bytemuck::cast` on the substrate side.
 /// - Everything else → postcard wire format, written directly per the
 ///   format described at the top of this file.
 pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, EncodeError> {
     match schema {
         SchemaType::Unit => {
-            // Empty payload. Match `encode_pod`'s behavior of accepting
-            // an empty object or null; reject explicit non-empty input
-            // so a typo doesn't get silently swallowed.
+            // Empty payload. Accept an empty object or null; reject
+            // explicit non-empty input so a typo doesn't get silently
+            // swallowed.
             if let Some(obj) = params.as_object()
                 && !obj.is_empty()
             {
@@ -637,9 +575,8 @@ fn align_of_primitive(p: Primitive) -> usize {
     }
 }
 
-/// `Primitive`-flavored sibling of `write_primitive`. Same wire bytes
-/// — both enums describe the same set of types — but the duplication
-/// stays here until `PodPrimitive` goes away in the cleanup PR.
+/// Write one `Primitive` scalar into `out` at the cast-shaped wire
+/// layout (LE bytes, no padding — the caller pre-pads to alignment).
 fn write_primitive_schema(
     out: &mut Vec<u8>,
     p: Primitive,
@@ -709,78 +646,6 @@ fn pad_to(out: &mut Vec<u8>, align: usize) {
     }
 }
 
-fn align_of(p: PodPrimitive) -> usize {
-    match p {
-        PodPrimitive::U8 | PodPrimitive::I8 => 1,
-        PodPrimitive::U16 | PodPrimitive::I16 => 2,
-        PodPrimitive::U32 | PodPrimitive::I32 | PodPrimitive::F32 => 4,
-        PodPrimitive::U64 | PodPrimitive::I64 | PodPrimitive::F64 => 8,
-    }
-}
-
-fn write_primitive(
-    out: &mut Vec<u8>,
-    p: PodPrimitive,
-    v: &Value,
-    name: &str,
-) -> Result<(), EncodeError> {
-    match p {
-        PodPrimitive::U8 => {
-            let n = as_unsigned(v, name, "u8")?;
-            let n: u8 = n.try_into().map_err(|_| oor(name, "u8"))?;
-            out.push(n);
-        }
-        PodPrimitive::U16 => {
-            let n = as_unsigned(v, name, "u16")?;
-            let n: u16 = n.try_into().map_err(|_| oor(name, "u16"))?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::U32 => {
-            let n = as_unsigned(v, name, "u32")?;
-            let n: u32 = n.try_into().map_err(|_| oor(name, "u32"))?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::U64 => {
-            let n = as_unsigned(v, name, "u64")?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::I8 => {
-            let n = as_signed(v, name, "i8")?;
-            let n: i8 = n.try_into().map_err(|_| oor(name, "i8"))?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::I16 => {
-            let n = as_signed(v, name, "i16")?;
-            let n: i16 = n.try_into().map_err(|_| oor(name, "i16"))?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::I32 => {
-            let n = as_signed(v, name, "i32")?;
-            let n: i32 = n.try_into().map_err(|_| oor(name, "i32"))?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::I64 => {
-            let n = as_signed(v, name, "i64")?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-        PodPrimitive::F32 => {
-            let n = v.as_f64().ok_or_else(|| EncodeError::TypeMismatch {
-                field: name.to_owned(),
-                expected: "f32",
-            })?;
-            out.extend_from_slice(&(n as f32).to_le_bytes());
-        }
-        PodPrimitive::F64 => {
-            let n = v.as_f64().ok_or_else(|| EncodeError::TypeMismatch {
-                field: name.to_owned(),
-                expected: "f64",
-            })?;
-            out.extend_from_slice(&n.to_le_bytes());
-        }
-    }
-    Ok(())
-}
-
 fn as_unsigned(v: &Value, name: &str, expected: &'static str) -> Result<u64, EncodeError> {
     v.as_u64().ok_or_else(|| EncodeError::TypeMismatch {
         field: name.to_owned(),
@@ -807,34 +672,48 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn scalar(name: &str, ty: PodPrimitive) -> PodField {
-        PodField {
+    fn scalar(name: &str, ty: Primitive) -> NamedField {
+        NamedField {
             name: name.into(),
-            ty: PodFieldType::Scalar(ty),
+            ty: SchemaType::Scalar(ty),
         }
     }
 
-    fn array(name: &str, element: PodPrimitive, len: u32) -> PodField {
-        PodField {
-            name: name.into(),
-            ty: PodFieldType::Array { element, len },
+    fn cast_struct(fields: Vec<NamedField>) -> SchemaType {
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
         }
     }
 
     #[test]
-    fn key_u32_field() {
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let bytes = encode_pod(&json!({"code": 42}), fields).unwrap();
+    fn unit_encodes_empty_payload() {
+        let bytes = encode_schema(&json!({}), &SchemaType::Unit).unwrap();
+        assert!(bytes.is_empty());
+        let bytes = encode_schema(&json!(null), &SchemaType::Unit).unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn unit_rejects_non_empty_object() {
+        let err = encode_schema(&json!({"x": 1}), &SchemaType::Unit).unwrap_err();
+        assert!(matches!(err, EncodeError::UnexpectedField(_)));
+    }
+
+    #[test]
+    fn cast_struct_single_u32_field() {
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let bytes = encode_schema(&json!({"code": 42}), &schema).unwrap();
         assert_eq!(bytes, vec![42, 0, 0, 0]);
     }
 
     #[test]
-    fn mouse_move_two_f32() {
-        let fields = &[
-            scalar("x", PodPrimitive::F32),
-            scalar("y", PodPrimitive::F32),
-        ];
-        let bytes = encode_pod(&json!({"x": 1.5, "y": -3.25}), fields).unwrap();
+    fn cast_struct_two_f32_fields() {
+        let schema = cast_struct(vec![
+            scalar("x", Primitive::F32),
+            scalar("y", Primitive::F32),
+        ]);
+        let bytes = encode_schema(&json!({"x": 1.5, "y": -3.25}), &schema).unwrap();
         let mut expected = Vec::new();
         expected.extend_from_slice(&1.5f32.to_le_bytes());
         expected.extend_from_slice(&(-3.25f32).to_le_bytes());
@@ -842,58 +721,26 @@ mod tests {
     }
 
     #[test]
-    fn bytemuck_roundtrip_for_key_shape() {
-        // Re-decoding our bytes via bytemuck::cast (as the engine
-        // would) is the load-bearing proof of layout correctness.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
-        struct Key {
-            code: u32,
-        }
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let bytes = encode_pod(&json!({"code": 0xdead_beefu32}), fields).unwrap();
-        let back: Key = bytemuck::cast_slice(&bytes)[0];
-        assert_eq!(back, Key { code: 0xdead_beef });
-    }
-
-    #[test]
-    fn bytemuck_roundtrip_for_mousemove_shape() {
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
-        struct MouseMove {
-            x: f32,
-            y: f32,
-        }
-        let fields = &[
-            scalar("x", PodPrimitive::F32),
-            scalar("y", PodPrimitive::F32),
-        ];
-        let bytes = encode_pod(&json!({"x": 10.5, "y": 20.0}), fields).unwrap();
-        let back: MouseMove = bytemuck::cast_slice(&bytes)[0];
-        assert_eq!(back, MouseMove { x: 10.5, y: 20.0 });
-    }
-
-    #[test]
-    fn pads_between_u8_and_u32() {
+    fn cast_struct_pads_between_u8_and_u32() {
         // #[repr(C)] { a: u8, b: u32 } is 8 bytes: a at 0, 3 bytes of
         // padding, b at 4.
-        let fields = &[
-            scalar("a", PodPrimitive::U8),
-            scalar("b", PodPrimitive::U32),
-        ];
-        let bytes = encode_pod(&json!({"a": 7, "b": 0x0102_0304u32}), fields).unwrap();
+        let schema = cast_struct(vec![
+            scalar("a", Primitive::U8),
+            scalar("b", Primitive::U32),
+        ]);
+        let bytes = encode_schema(&json!({"a": 7, "b": 0x0102_0304u32}), &schema).unwrap();
         assert_eq!(bytes, vec![7, 0, 0, 0, 4, 3, 2, 1]);
     }
 
     #[test]
-    fn trailing_padding_for_u64_then_u8() {
+    fn cast_struct_trailing_padding_for_u64_then_u8() {
         // { a: u64, b: u8 } — 9 bytes of content, rounded to 16 by
         // trailing padding for align-8.
-        let fields = &[
-            scalar("a", PodPrimitive::U64),
-            scalar("b", PodPrimitive::U8),
-        ];
-        let bytes = encode_pod(&json!({"a": 1u64, "b": 2}), fields).unwrap();
+        let schema = cast_struct(vec![
+            scalar("a", Primitive::U64),
+            scalar("b", Primitive::U8),
+        ]);
+        let bytes = encode_schema(&json!({"a": 1u64, "b": 2}), &schema).unwrap();
         assert_eq!(bytes.len(), 16);
         assert_eq!(&bytes[0..8], &1u64.to_le_bytes());
         assert_eq!(bytes[8], 2);
@@ -901,44 +748,79 @@ mod tests {
     }
 
     #[test]
-    fn fixed_array_field() {
-        let fields = &[array("xs", PodPrimitive::U8, 4)];
-        let bytes = encode_pod(&json!({"xs": [1, 2, 3, 4]}), fields).unwrap();
+    fn cast_struct_fixed_array_field() {
+        let schema = cast_struct(vec![NamedField {
+            name: "xs".into(),
+            ty: SchemaType::Array {
+                element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                len: 4,
+            },
+        }]);
+        let bytes = encode_schema(&json!({"xs": [1, 2, 3, 4]}), &schema).unwrap();
         assert_eq!(bytes, vec![1, 2, 3, 4]);
     }
 
     #[test]
-    fn missing_field_errors() {
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let err = encode_pod(&json!({}), fields).unwrap_err();
+    fn cast_struct_signed_negative_roundtrip() {
+        // i32 in cast layout = LE bytes; -1 = 0xffffffff.
+        let schema = cast_struct(vec![scalar("n", Primitive::I32)]);
+        let bytes = encode_schema(&json!({"n": -1}), &schema).unwrap();
+        assert_eq!(bytes, vec![0xff, 0xff, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn cast_struct_bytemuck_roundtrip_for_key_shape() {
+        // Re-decoding our bytes via bytemuck::cast (as the engine
+        // would) is the load-bearing proof of layout correctness.
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
+        struct Key {
+            code: u32,
+        }
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let bytes = encode_schema(&json!({"code": 0xdead_beefu32}), &schema).unwrap();
+        let back: Key = bytemuck::cast_slice(&bytes)[0];
+        assert_eq!(back, Key { code: 0xdead_beef });
+    }
+
+    #[test]
+    fn cast_struct_missing_field_errors() {
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!({}), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::MissingField(n) if n == "code"));
     }
 
     #[test]
-    fn unexpected_field_errors() {
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let err = encode_pod(&json!({"code": 1, "extra": 2}), fields).unwrap_err();
+    fn cast_struct_unexpected_field_errors() {
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!({"code": 1, "extra": 2}), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::UnexpectedField(n) if n == "extra"));
     }
 
     #[test]
-    fn type_mismatch_errors() {
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let err = encode_pod(&json!({"code": "not-a-number"}), fields).unwrap_err();
+    fn cast_struct_type_mismatch_errors() {
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!({"code": "not-a-number"}), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::TypeMismatch { .. }));
     }
 
     #[test]
-    fn out_of_range_errors() {
-        let fields = &[scalar("b", PodPrimitive::U8)];
-        let err = encode_pod(&json!({"b": 300}), fields).unwrap_err();
+    fn cast_struct_out_of_range_errors() {
+        let schema = cast_struct(vec![scalar("b", Primitive::U8)]);
+        let err = encode_schema(&json!({"b": 300}), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::OutOfRange { .. }));
     }
 
     #[test]
-    fn array_length_mismatch_errors() {
-        let fields = &[array("xs", PodPrimitive::U8, 4)];
-        let err = encode_pod(&json!({"xs": [1, 2, 3]}), fields).unwrap_err();
+    fn cast_struct_array_length_mismatch_errors() {
+        let schema = cast_struct(vec![NamedField {
+            name: "xs".into(),
+            ty: SchemaType::Array {
+                element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                len: 4,
+            },
+        }]);
+        let err = encode_schema(&json!({"xs": [1, 2, 3]}), &schema).unwrap_err();
         assert!(matches!(
             err,
             EncodeError::ArrayLengthMismatch {
@@ -950,132 +832,27 @@ mod tests {
     }
 
     #[test]
-    fn non_object_params_errors() {
-        let fields = &[scalar("code", PodPrimitive::U32)];
-        let err = encode_pod(&json!([1, 2, 3]), fields).unwrap_err();
+    fn cast_struct_non_object_params_errors() {
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let err = encode_schema(&json!([1, 2, 3]), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::NotAnObject));
     }
 
     #[test]
-    fn signed_negative_roundtrip() {
-        let fields = &[scalar("n", PodPrimitive::I32)];
-        let bytes = encode_pod(&json!({"n": -1}), fields).unwrap();
-        assert_eq!(bytes, vec![0xff, 0xff, 0xff, 0xff]);
-    }
-
-    // ADR-0019 PR 4 — `encode_schema` must produce byte-identical
-    // output to `encode_pod` for cast-shaped kinds. PR 5 will retire
-    // `encode_pod` once consumers migrate; until then both encoders
-    // coexist and a regression in either path is caught here.
-
-    fn schema_scalar(name: &str, ty: Primitive) -> NamedField {
-        NamedField {
-            name: name.into(),
-            ty: SchemaType::Scalar(ty),
-        }
-    }
-
-    fn schema_struct(fields: Vec<NamedField>) -> SchemaType {
-        SchemaType::Struct {
-            fields,
-            repr_c: true,
-        }
-    }
-
-    #[test]
-    fn schema_unit_encodes_empty_payload() {
-        let bytes = encode_schema(&json!({}), &SchemaType::Unit).unwrap();
-        assert!(bytes.is_empty());
-        let bytes = encode_schema(&json!(null), &SchemaType::Unit).unwrap();
-        assert!(bytes.is_empty());
-    }
-
-    #[test]
-    fn schema_unit_rejects_non_empty_object() {
-        let err = encode_schema(&json!({"x": 1}), &SchemaType::Unit).unwrap_err();
-        assert!(matches!(err, EncodeError::UnexpectedField(_)));
-    }
-
-    #[test]
-    fn schema_struct_matches_encode_pod_for_key() {
-        // Single u32 — the simplest cast struct.
-        let pod_bytes = encode_pod(
-            &json!({"code": 0xdead_beefu32}),
-            &[scalar("code", PodPrimitive::U32)],
-        )
-        .unwrap();
-        let schema_bytes = encode_schema(
-            &json!({"code": 0xdead_beefu32}),
-            &schema_struct(vec![schema_scalar("code", Primitive::U32)]),
-        )
-        .unwrap();
-        assert_eq!(pod_bytes, schema_bytes);
-    }
-
-    #[test]
-    fn schema_struct_matches_encode_pod_for_mousemove() {
-        // Two f32 — the same shape Pod encoder tests use.
-        let pod_bytes = encode_pod(
-            &json!({"x": 10.5, "y": 20.0}),
-            &[
-                scalar("x", PodPrimitive::F32),
-                scalar("y", PodPrimitive::F32),
-            ],
-        )
-        .unwrap();
-        let schema_bytes = encode_schema(
-            &json!({"x": 10.5, "y": 20.0}),
-            &schema_struct(vec![
-                schema_scalar("x", Primitive::F32),
-                schema_scalar("y", Primitive::F32),
-            ]),
-        )
-        .unwrap();
-        assert_eq!(pod_bytes, schema_bytes);
-    }
-
-    #[test]
-    fn schema_struct_pads_between_u8_and_u32_like_pod() {
-        // The padding-rule test from `encode_pod` ported to schema —
-        // alignment behavior must match for binary compatibility.
-        let pod_bytes = encode_pod(
-            &json!({"a": 7, "b": 0x0102_0304u32}),
-            &[
-                scalar("a", PodPrimitive::U8),
-                scalar("b", PodPrimitive::U32),
-            ],
-        )
-        .unwrap();
-        let schema_bytes = encode_schema(
-            &json!({"a": 7, "b": 0x0102_0304u32}),
-            &schema_struct(vec![
-                schema_scalar("a", Primitive::U8),
-                schema_scalar("b", Primitive::U32),
-            ]),
-        )
-        .unwrap();
-        assert_eq!(pod_bytes, schema_bytes);
-        assert_eq!(schema_bytes, vec![7, 0, 0, 0, 4, 3, 2, 1]);
-    }
-
-    #[test]
-    fn schema_nested_struct_matches_drawtriangle_layout() {
+    fn cast_nested_struct_drawtriangle_layout() {
         // DrawTriangle's shape: { verts: [Vertex; 3] } where Vertex is
         // 5 f32s. Cast wire format = 60 bytes, no internal padding.
-        // Pod descriptors couldn't model nested structs so this had to
-        // be Opaque before — proving the schema path matches the cast
-        // layout end-to-end is the key property of PR 4.
         let vertex = SchemaType::Struct {
             repr_c: true,
             fields: vec![
-                schema_scalar("x", Primitive::F32),
-                schema_scalar("y", Primitive::F32),
-                schema_scalar("r", Primitive::F32),
-                schema_scalar("g", Primitive::F32),
-                schema_scalar("b", Primitive::F32),
+                scalar("x", Primitive::F32),
+                scalar("y", Primitive::F32),
+                scalar("r", Primitive::F32),
+                scalar("g", Primitive::F32),
+                scalar("b", Primitive::F32),
             ],
         };
-        let triangle = schema_struct(vec![NamedField {
+        let triangle = cast_struct(vec![NamedField {
             name: "verts".into(),
             ty: SchemaType::Array {
                 element: Box::new(vertex),
@@ -1087,7 +864,6 @@ mod tests {
         let bytes = encode_schema(&params, &triangle).unwrap();
         assert_eq!(bytes.len(), 60);
 
-        // Roundtrip via bytemuck — same proof shape as the Pod tests.
         #[repr(C)]
         #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
         struct Vertex {
@@ -1118,25 +894,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn schema_struct_rejects_unexpected_field() {
-        let schema = schema_struct(vec![schema_scalar("code", Primitive::U32)]);
-        let err = encode_schema(&json!({"code": 1, "extra": 2}), &schema).unwrap_err();
-        assert!(matches!(err, EncodeError::UnexpectedField(n) if n == "extra"));
-    }
-
-    #[test]
-    fn schema_struct_rejects_missing_field() {
-        let schema = schema_struct(vec![schema_scalar("code", Primitive::U32)]);
-        let err = encode_schema(&json!({}), &schema).unwrap_err();
-        assert!(matches!(err, EncodeError::MissingField(n) if n == "code"));
-    }
-
-    // ADR-0019 PR 5 — postcard path. Each test asserts that
-    // `encode_schema` produces byte-identical output to
-    // `postcard::to_allocvec` on an equivalent typed value. That's the
-    // load-bearing property: if these match, the substrate decode
-    // (via `postcard::from_bytes`) sees the same value the agent sent.
+    // Postcard path. Each test asserts byte-identity with
+    // `postcard::to_allocvec` on an equivalent typed value — if these
+    // match, the substrate decode (via `postcard::from_bytes`) sees
+    // the same value the agent sent.
 
     use serde::{Deserialize, Serialize};
 

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -14,7 +14,7 @@ mod registry;
 mod session;
 mod spawn;
 
-pub use encoder::{EncodeError, encode_pod};
+pub use encoder::{EncodeError, encode_schema};
 
 pub use engine::HEARTBEAT_INTERVAL;
 pub use engine::READ_TIMEOUT;

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_hub_protocol::{
-    EngineId, HubToEngine, KindDescriptor, KindEncoding, MailFrame, SessionToken, Uuid,
+    EngineId, HubToEngine, KindDescriptor, MailFrame, SchemaType, SessionToken, Uuid,
 };
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -29,7 +29,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc};
 
-use crate::encoder::{encode_pod, encode_schema};
+use crate::encoder::encode_schema;
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
 use crate::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnOpts};
@@ -458,48 +458,25 @@ async fn deliver_one(
         .map_err(|_| "engine disconnected".to_owned())
 }
 
-/// Decide which encoding path a mail goes through based on the
-/// kind's descriptor. ADR-0019 PR 5 removed the `payload_bytes`
-/// escape hatch — every mail must come through `params`, and the
-/// hub picks cast vs postcard from the schema.
+/// Decide the wire bytes for a mail by looking up the kind's
+/// descriptor and feeding `params` through `encode_schema`. ADR-0019:
+/// every kind has a schema; absent params is only legal when the
+/// schema is `Unit`.
 fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, String> {
     let desc = find_kind(record, &spec.kind_name)
         .ok_or_else(|| format!("kind {:?} has no descriptor on this engine", spec.kind_name))?;
-    match (&spec.params, &desc.encoding) {
-        // Empty-payload shortcut: no params for a kind whose schema
-        // is empty (Signal or Schema(Unit)) — both legal.
-        (None, KindEncoding::Signal) => Ok(Vec::new()),
-        (None, KindEncoding::Schema(aether_hub_protocol::SchemaType::Unit)) => Ok(Vec::new()),
+    match (&spec.params, &desc.schema) {
+        (None, SchemaType::Unit) => Ok(Vec::new()),
         (None, _) => Err(format!(
-            "kind {:?} requires `params` (no `payload_bytes` escape hatch — ADR-0019)",
+            "kind {:?} requires `params` (only Unit kinds may omit them)",
             spec.kind_name
         )),
-        (Some(p), KindEncoding::Signal) => {
-            if !is_empty_params(p) {
-                return Err(format!(
-                    "kind {:?} is Signal; params must be absent or empty",
-                    spec.kind_name
-                ));
-            }
-            Ok(Vec::new())
-        }
-        (Some(p), KindEncoding::Pod { fields }) => encode_pod(p, fields).map_err(|e| e.to_string()),
-        (Some(_), KindEncoding::Opaque) => Err(format!(
-            "kind {:?} is Opaque — no encoder available, and `payload_bytes` was removed in ADR-0019 PR 5. Engine must publish a real Schema for this kind.",
-            spec.kind_name
-        )),
-        (Some(p), KindEncoding::Schema(schema)) => {
-            encode_schema(p, schema).map_err(|e| e.to_string())
-        }
+        (Some(p), schema) => encode_schema(p, schema).map_err(|e| e.to_string()),
     }
 }
 
 fn find_kind<'a>(record: &'a EngineRecord, name: &str) -> Option<&'a KindDescriptor> {
     record.kinds.iter().find(|k| k.name == name)
-}
-
-fn is_empty_params(v: &serde_json::Value) -> bool {
-    v.is_null() || v.as_object().is_some_and(|o| o.is_empty())
 }
 
 /// Bind an axum server on `addr` exposing the MCP tool surface at
@@ -547,9 +524,7 @@ mod tests {
         // unreachable from `send_mail`.
         let tick = aether_hub_protocol::KindDescriptor {
             name: "aether.tick".into(),
-            encoding: aether_hub_protocol::KindEncoding::Schema(
-                aether_hub_protocol::SchemaType::Unit,
-            ),
+            schema: aether_hub_protocol::SchemaType::Unit,
         };
         record_with_kinds(id_u128, vec![tick])
     }
@@ -646,22 +621,21 @@ mod tests {
 
     #[tokio::test]
     async fn send_mail_params_encodes_via_descriptor() {
-        use aether_hub_protocol::{
-            KindDescriptor, KindEncoding, PodField, PodFieldType, PodPrimitive,
-        };
+        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaType};
 
         let engines = EngineRegistry::new();
         let kinds = vec![KindDescriptor {
             name: "aether.mouse_move".into(),
-            encoding: KindEncoding::Pod {
+            schema: SchemaType::Struct {
+                repr_c: true,
                 fields: vec![
-                    PodField {
+                    NamedField {
                         name: "x".into(),
-                        ty: PodFieldType::Scalar(PodPrimitive::F32),
+                        ty: SchemaType::Scalar(Primitive::F32),
                     },
-                    PodField {
+                    NamedField {
                         name: "y".into(),
-                        ty: PodFieldType::Scalar(PodPrimitive::F32),
+                        ty: SchemaType::Scalar(Primitive::F32),
                     },
                 ],
             },
@@ -692,13 +666,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_mail_signal_no_params() {
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+    async fn send_mail_unit_kind_no_params() {
+        use aether_hub_protocol::{KindDescriptor, SchemaType};
 
         let engines = EngineRegistry::new();
         let kinds = vec![KindDescriptor {
             name: "aether.tick".into(),
-            encoding: KindEncoding::Signal,
+            schema: SchemaType::Unit,
         }];
         let (rec, mut rx) = record_with_kinds(4, kinds);
         let id = rec.id;
@@ -739,18 +713,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_mail_opaque_kind_rejects_with_helpful_error() {
-        // ADR-0019 PR 5: `payload_bytes` is gone. If a kind is still
-        // Opaque (foreign engine, V0 holdover), agents have no way to
-        // send it — the error message should make the cause explicit.
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
-
+    async fn send_mail_unknown_kind_errors() {
+        // ADR-0019 cleanup: there's no fallback path for kinds without
+        // a descriptor — an agent gets a clear "no descriptor" error.
         let engines = EngineRegistry::new();
-        let kinds = vec![KindDescriptor {
-            name: "hello.opaque".into(),
-            encoding: KindEncoding::Opaque,
-        }];
-        let (rec, _rx) = record_with_kinds(9, kinds);
+        let (rec, _rx) = record_with_kinds(9, vec![]);
         let id = rec.id;
         engines.insert(rec);
         let hub = Hub::new(test_state(engines, SessionRegistry::new()));
@@ -759,13 +726,13 @@ mod tests {
             &hub,
             vec![spec(
                 id.0.to_string(),
-                "hello.opaque",
+                "hello.unknown",
                 Some(serde_json::json!({})),
             )],
         )
         .await;
         assert!(
-            statuses[0].status.contains("Opaque"),
+            statuses[0].status.contains("no descriptor"),
             "got: {}",
             statuses[0].status
         );
@@ -773,16 +740,32 @@ mod tests {
 
     #[tokio::test]
     async fn describe_kinds_returns_descriptors() {
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaType};
 
         let kinds = vec![
             KindDescriptor {
                 name: "aether.tick".into(),
-                encoding: KindEncoding::Signal,
+                schema: SchemaType::Unit,
             },
             KindDescriptor {
-                name: "hello.custom".into(),
-                encoding: KindEncoding::Opaque,
+                name: "hello.note".into(),
+                schema: SchemaType::Struct {
+                    repr_c: false,
+                    fields: vec![NamedField {
+                        name: "body".into(),
+                        ty: SchemaType::String,
+                    }],
+                },
+            },
+            KindDescriptor {
+                name: "hello.cast".into(),
+                schema: SchemaType::Struct {
+                    repr_c: true,
+                    fields: vec![NamedField {
+                        name: "n".into(),
+                        ty: SchemaType::Scalar(Primitive::U32),
+                    }],
+                },
             },
         ];
         let engines = EngineRegistry::new();

--- a/crates/aether-hub/src/registry.rs
+++ b/crates/aether-hub/src/registry.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn update_kinds_replaces_cached_descriptors() {
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+        use aether_hub_protocol::{KindDescriptor, SchemaType};
         let reg = EngineRegistry::new();
         let r = record(3);
         let id = r.id;
@@ -186,7 +186,7 @@ mod tests {
 
         let new_kinds = vec![KindDescriptor {
             name: "physics.contact".into(),
-            encoding: KindEncoding::Opaque,
+            schema: SchemaType::Bytes,
         }];
         reg.update_kinds(&id, new_kinds.clone());
         assert_eq!(reg.get(&id).unwrap().kinds, new_kinds);

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -14,7 +14,7 @@ use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use aether_hub_protocol::{KindDescriptor, KindEncoding};
+use aether_hub_protocol::KindDescriptor;
 use aether_mail::{Kind, Schema};
 
 use crate::{
@@ -54,7 +54,7 @@ pub fn all() -> Vec<KindDescriptor> {
 fn schema<K: Kind + Schema>() -> KindDescriptor {
     KindDescriptor {
         name: K::NAME.to_string(),
-        encoding: KindEncoding::Schema(K::schema()),
+        schema: K::schema(),
     }
 }
 
@@ -84,11 +84,10 @@ mod tests {
 
     #[test]
     fn control_kinds_are_postcard_schemas() {
-        // ADR-0019 PR 5: control-plane kinds are no longer `Opaque`.
-        // Each ships as `Schema(Struct{repr_c:false,..})` (LoadComponent,
-        // DropComponent, ReplaceComponent) or `Schema(Enum{..})` (the
-        // *Result variants). The hub builds them from agent params via
-        // the postcard encoder.
+        // ADR-0019: control-plane kinds ship as `Struct{repr_c:false,..}`
+        // (LoadComponent, DropComponent, ReplaceComponent) or `Enum{..}`
+        // (the *Result variants). Hub builds them from agent params
+        // via the postcard encoder.
         let descs = all();
         for name in [
             LoadComponent::NAME,
@@ -96,39 +95,23 @@ mod tests {
             DropComponent::NAME,
         ] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
-            let KindEncoding::Schema(SchemaType::Struct { repr_c, .. }) = &d.encoding else {
-                panic!("{name} should be Schema(Struct), got {:?}", d.encoding);
+            let SchemaType::Struct { repr_c, .. } = &d.schema else {
+                panic!("{name} should be Struct, got {:?}", d.schema);
             };
             assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
         }
         for name in [LoadResult::NAME, DropResult::NAME, ReplaceResult::NAME] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
             assert!(
-                matches!(d.encoding, KindEncoding::Schema(SchemaType::Enum { .. })),
-                "{name} should be Schema(Enum), got {:?}",
-                d.encoding
+                matches!(d.schema, SchemaType::Enum { .. }),
+                "{name} should be Enum, got {:?}",
+                d.schema
             );
         }
     }
 
     #[test]
-    fn no_kinds_are_opaque() {
-        // The whole point of PR 5: every kind in the substrate's
-        // descriptor list is hub-encodable. A regression here means
-        // an agent would lose the ability to send some kind via
-        // `send_mail`.
-        let descs = all();
-        for d in &descs {
-            assert!(
-                !matches!(d.encoding, KindEncoding::Opaque),
-                "kind {:?} is still Opaque",
-                d.name
-            );
-        }
-    }
-
-    #[test]
-    fn cast_kinds_emit_schema_struct_with_repr_c() {
+    fn cast_kinds_emit_struct_with_repr_c() {
         let descs = all();
         for name in [
             Key::NAME,
@@ -139,23 +122,19 @@ mod tests {
             Pong::NAME,
         ] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
-            let KindEncoding::Schema(SchemaType::Struct { repr_c, .. }) = &d.encoding else {
-                panic!("expected Schema(Struct) for {name}, got {:?}", d.encoding);
+            let SchemaType::Struct { repr_c, .. } = &d.schema else {
+                panic!("expected Struct for {name}, got {:?}", d.schema);
             };
             assert!(*repr_c, "{name} should be cast-shaped");
         }
     }
 
     #[test]
-    fn signal_kinds_emit_schema_unit() {
+    fn signal_kinds_emit_unit() {
         let descs = all();
         for name in [Tick::NAME, MouseButton::NAME] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
-            assert_eq!(
-                d.encoding,
-                KindEncoding::Schema(SchemaType::Unit),
-                "{name} should be Schema(Unit)"
-            );
+            assert_eq!(d.schema, SchemaType::Unit, "{name} should be Unit");
         }
     }
 
@@ -163,8 +142,8 @@ mod tests {
     fn key_field_layout() {
         let descs = all();
         let key = descs.iter().find(|d| d.name == Key::NAME).unwrap();
-        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &key.encoding else {
-            panic!("expected Schema(Struct)")
+        let SchemaType::Struct { fields, .. } = &key.schema else {
+            panic!("expected Struct")
         };
         assert_eq!(fields.len(), 1);
         assert_eq!(fields[0].name, "code");
@@ -175,8 +154,8 @@ mod tests {
     fn mouse_move_field_layout() {
         let descs = all();
         let mm = descs.iter().find(|d| d.name == MouseMove::NAME).unwrap();
-        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &mm.encoding else {
-            panic!("expected Schema(Struct)")
+        let SchemaType::Struct { fields, .. } = &mm.schema else {
+            panic!("expected Struct")
         };
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "x");
@@ -187,12 +166,10 @@ mod tests {
 
     #[test]
     fn draw_triangle_recurses_into_vertex() {
-        // The cast wire format previously couldn't describe nested
-        // structs (DrawTriangle was Opaque). The Schema arm fixes that.
         let descs = all();
         let dt = descs.iter().find(|d| d.name == DrawTriangle::NAME).unwrap();
-        let KindEncoding::Schema(SchemaType::Struct { fields, repr_c }) = &dt.encoding else {
-            panic!("expected Schema(Struct)")
+        let SchemaType::Struct { fields, repr_c } = &dt.schema else {
+            panic!("expected Struct")
         };
         assert!(*repr_c);
         assert_eq!(fields.len(), 1);
@@ -216,8 +193,8 @@ mod tests {
     fn frame_stats_field_layout() {
         let descs = all();
         let fs = descs.iter().find(|d| d.name == FrameStats::NAME).unwrap();
-        let KindEncoding::Schema(SchemaType::Struct { fields, .. }) = &fs.encoding else {
-            panic!("expected Schema(Struct)")
+        let SchemaType::Struct { fields, .. } = &fs.schema else {
+            panic!("expected Struct")
         };
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "frame");

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -533,7 +533,7 @@ mod tests {
         SubstrateCtx,
         std::sync::mpsc::Receiver<aether_hub_protocol::EngineToHub>,
     ) {
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+        use aether_hub_protocol::{KindDescriptor, SchemaType};
 
         use crate::hub_client::HubOutbound;
         use crate::mail::MailboxId as M;
@@ -544,7 +544,7 @@ mod tests {
         registry
             .register_kind_with_descriptor(KindDescriptor {
                 name: "test.pong".into(),
-                encoding: KindEncoding::Signal,
+                schema: SchemaType::Unit,
             })
             .expect("register kind");
         let ctx = SubstrateCtx::new(M(0), registry, Arc::new(MailQueue::new()), outbound);
@@ -607,7 +607,7 @@ mod tests {
         Arc<MailQueue>,
         crate::mail::MailboxId,
     ) {
-        use aether_hub_protocol::{KindDescriptor, KindEncoding};
+        use aether_hub_protocol::{KindDescriptor, SchemaType};
 
         use crate::hub_client::HubOutbound;
         use crate::mail::MailboxId as M;
@@ -618,7 +618,7 @@ mod tests {
         registry
             .register_kind_with_descriptor(KindDescriptor {
                 name: "test.pong".into(),
-                encoding: KindEncoding::Signal,
+                schema: SchemaType::Unit,
             })
             .expect("register kind");
         let queue = Arc::new(MailQueue::new());

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -27,8 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use aether_hub_protocol::{
-    ClaudeAddress, EngineMailFrame, EngineToHub, KindDescriptor, KindEncoding, NamedField,
-    Primitive, SchemaType,
+    ClaudeAddress, EngineMailFrame, EngineToHub, KindDescriptor, NamedField, Primitive, SchemaType,
 };
 use aether_mail::Kind;
 use aether_substrate_mail::{
@@ -59,8 +58,8 @@ pub const AETHER_CONTROL: &str = "aether.control";
 /// kinds, so a runtime-registered kind is indistinguishable from a
 /// boot-registered one on the wire.
 fn lift_load_kind(k: &LoadKind) -> KindDescriptor {
-    let encoding = match &k.encoding {
-        LoadKindEncoding::Signal => KindEncoding::Schema(SchemaType::Unit),
+    let schema = match &k.encoding {
+        LoadKindEncoding::Signal => SchemaType::Unit,
         LoadKindEncoding::Pod { fields } => {
             let named = fields
                 .iter()
@@ -69,15 +68,15 @@ fn lift_load_kind(k: &LoadKind) -> KindDescriptor {
                     ty: lift_load_field_type(f.primitive, f.array_len),
                 })
                 .collect();
-            KindEncoding::Schema(SchemaType::Struct {
+            SchemaType::Struct {
                 fields: named,
                 repr_c: true,
-            })
+            }
         }
     };
     KindDescriptor {
         name: k.name.clone(),
-        encoding,
+        schema,
     }
 }
 
@@ -175,7 +174,7 @@ impl ControlPlane {
         for kind in &descriptors {
             if let Some(id) = self.registry.kind_id(&kind.name)
                 && let Some(existing) = self.registry.kind_descriptor(id)
-                && existing.encoding != kind.encoding
+                && existing.schema != kind.schema
             {
                 return LoadResult::Err {
                     error: format!(
@@ -312,7 +311,7 @@ impl ControlPlane {
         for kind in &descriptors {
             if let Some(kid) = self.registry.kind_id(&kind.name)
                 && let Some(existing) = self.registry.kind_descriptor(kid)
-                && existing.encoding != kind.encoding
+                && existing.schema != kind.schema
             {
                 return ReplaceResult::Err {
                     error: format!(
@@ -459,7 +458,7 @@ impl ControlPlane {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_hub_protocol::{KindEncoding, SessionToken};
+    use aether_hub_protocol::SessionToken;
 
     #[test]
     fn load_payload_roundtrip() {
@@ -669,13 +668,13 @@ mod tests {
             .registry
             .register_kind_with_descriptor(KindDescriptor {
                 name: "shared".into(),
-                encoding: KindEncoding::Schema(SchemaType::Struct {
+                schema: SchemaType::Struct {
                     fields: vec![NamedField {
                         name: "n".into(),
                         ty: SchemaType::Scalar(Primitive::U32),
                     }],
                     repr_c: true,
-                }),
+                },
             })
             .unwrap();
         let wasm = wat::parse_str(WAT).unwrap();

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
-use aether_hub_protocol::{KindDescriptor, KindEncoding, SessionToken};
+use aether_hub_protocol::{KindDescriptor, SchemaType, SessionToken};
 
 use crate::mail::MailboxId;
 
@@ -79,8 +79,8 @@ struct Inner {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KindConflict {
     pub name: String,
-    pub existing: KindEncoding,
-    pub requested: KindEncoding,
+    pub existing: SchemaType,
+    pub requested: SchemaType,
 }
 
 impl fmt::Display for KindConflict {
@@ -247,25 +247,25 @@ impl Registry {
             .cloned()
     }
 
-    /// Register a mail kind by name, defaulting to an `Opaque`
-    /// descriptor. Idempotent — re-registering a name returns the id
-    /// it was first assigned, regardless of whether the first call
-    /// supplied a descriptor. Kept as a convenience for tests and
-    /// substrate-internal registrations that don't need the hub to
-    /// encode params; production init should prefer
-    /// `register_kind_with_descriptor` so the descriptor stored here
-    /// matches the one shipped to the hub at `Hello`.
+    /// Register a mail kind by name, defaulting the schema to `Bytes`
+    /// (raw byte payload, no agent-encodable structure). Idempotent —
+    /// re-registering a name returns the id it was first assigned,
+    /// regardless of whether the first call supplied a descriptor.
+    /// Kept as a convenience for tests and substrate-internal
+    /// registrations that don't need the hub to encode params;
+    /// production init should prefer `register_kind_with_descriptor`
+    /// so the descriptor stored here matches the type definition.
     pub fn register_kind(&self, name: impl Into<String>) -> u32 {
         let name = name.into();
         let descriptor = KindDescriptor {
             name: name.clone(),
-            encoding: KindEncoding::Opaque,
+            schema: SchemaType::Bytes,
         };
         // Name-only registration never conflicts: if the name is new
-        // we store Opaque; if it exists we return the existing id and
-        // leave its descriptor untouched.
+        // we store the default schema; if it exists we return the
+        // existing id and leave the stored descriptor untouched.
         self.register_kind_internal(name, descriptor, /*reject_conflict=*/ false)
-            .expect("Opaque default cannot produce a conflict")
+            .expect("Bytes default cannot produce a conflict")
     }
 
     /// Register a mail kind along with the descriptor the hub will
@@ -295,11 +295,11 @@ impl Registry {
         let mut inner = self.inner.write().unwrap();
         if let Some(&id) = inner.kind_by_name.get(&name) {
             let existing = &inner.kind_descriptors[id as usize];
-            if reject_conflict && existing.encoding != descriptor.encoding {
+            if reject_conflict && existing.schema != descriptor.schema {
                 return Err(KindConflict {
                     name,
-                    existing: existing.encoding.clone(),
-                    requested: descriptor.encoding,
+                    existing: existing.schema.clone(),
+                    requested: descriptor.schema,
                 });
             }
             return Ok(id);
@@ -470,80 +470,82 @@ mod tests {
         assert!(r.kind_name(999).is_none());
     }
 
-    fn opaque_desc(name: &str) -> KindDescriptor {
+    fn unit_desc(name: &str) -> KindDescriptor {
         KindDescriptor {
             name: name.to_string(),
-            encoding: KindEncoding::Opaque,
+            schema: SchemaType::Unit,
         }
     }
 
-    fn pod_desc(name: &str) -> KindDescriptor {
-        use aether_hub_protocol::{PodField, PodFieldType, PodPrimitive};
+    fn cast_struct_desc(name: &str) -> KindDescriptor {
+        use aether_hub_protocol::{NamedField, Primitive};
         KindDescriptor {
             name: name.to_string(),
-            encoding: KindEncoding::Pod {
-                fields: vec![PodField {
+            schema: SchemaType::Struct {
+                repr_c: true,
+                fields: vec![NamedField {
                     name: "x".to_string(),
-                    ty: PodFieldType::Scalar(PodPrimitive::U32),
+                    ty: SchemaType::Scalar(Primitive::U32),
                 }],
             },
         }
     }
 
     #[test]
-    fn register_kind_with_descriptor_stores_encoding() {
+    fn register_kind_with_descriptor_stores_schema() {
         let r = Registry::new();
         let id = r
-            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
             .expect("fresh name");
         let stored = r.kind_descriptor(id).expect("descriptor present");
-        assert_eq!(stored.encoding, pod_desc("aether.foo").encoding);
+        assert_eq!(stored.schema, cast_struct_desc("aether.foo").schema);
     }
 
     #[test]
     fn register_kind_with_descriptor_is_idempotent_on_match() {
         let r = Registry::new();
         let first = r
-            .register_kind_with_descriptor(pod_desc("aether.foo"))
+            .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
             .expect("first");
         let second = r
-            .register_kind_with_descriptor(pod_desc("aether.foo"))
-            .expect("same encoding should succeed");
+            .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
+            .expect("same schema should succeed");
         assert_eq!(first, second);
     }
 
     #[test]
     fn register_kind_with_descriptor_rejects_conflict() {
         let r = Registry::new();
-        r.register_kind_with_descriptor(opaque_desc("aether.foo"))
+        r.register_kind_with_descriptor(unit_desc("aether.foo"))
             .expect("first");
         let err = r
-            .register_kind_with_descriptor(pod_desc("aether.foo"))
-            .expect_err("different encoding should conflict");
+            .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
+            .expect_err("different schema should conflict");
         assert_eq!(err.name, "aether.foo");
-        assert_eq!(err.existing, KindEncoding::Opaque);
-        assert!(matches!(err.requested, KindEncoding::Pod { .. }));
+        assert_eq!(err.existing, SchemaType::Unit);
+        assert!(matches!(err.requested, SchemaType::Struct { .. }));
     }
 
     #[test]
-    fn register_kind_defaults_to_opaque() {
+    fn register_kind_defaults_to_bytes() {
         let r = Registry::new();
         let id = r.register_kind("aether.bar");
         let stored = r.kind_descriptor(id).expect("descriptor present");
-        assert_eq!(stored.encoding, KindEncoding::Opaque);
+        assert_eq!(stored.schema, SchemaType::Bytes);
     }
 
     #[test]
-    fn name_only_register_after_with_descriptor_preserves_stored_encoding() {
-        // The legacy name-only path must not clobber a real descriptor
-        // that was recorded first — tests frequently call `register_kind`
-        // after main.rs has already registered via `register_kind_with_descriptor`.
+    fn name_only_register_after_with_descriptor_preserves_stored_schema() {
+        // The name-only path must not clobber a real descriptor that
+        // was recorded first — tests frequently call `register_kind`
+        // after main.rs has already registered via
+        // `register_kind_with_descriptor`.
         let r = Registry::new();
-        r.register_kind_with_descriptor(pod_desc("aether.foo"))
+        r.register_kind_with_descriptor(cast_struct_desc("aether.foo"))
             .expect("first");
         let _ = r.register_kind("aether.foo");
         let stored = r.kind_descriptor(0).expect("descriptor present");
-        assert!(matches!(stored.encoding, KindEncoding::Pod { .. }));
+        assert!(matches!(stored.schema, SchemaType::Struct { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Final cleanup. Now that PRs 1-5 migrated every kind to schema-described and removed the `payload_bytes` escape hatch, the legacy types that existed only to bridge the migration go away.

## What's removed

- **`KindEncoding` enum** collapses entirely. `KindDescriptor` now carries `schema: SchemaType` directly; the single-purpose wrapper was dead weight.
- **`PodField` / `PodFieldType` / `PodPrimitive`** deleted from `aether-hub-protocol`.
- **`encode_pod` + pod-flavored helpers** (`align_of`, `write_primitive`) deleted from `aether-hub`. `encode_schema` is the only encoder. Tests rewritten to assert exact bytes against the schema path rather than cross-comparing two encoders.

## Behavioral note

Substrate's `Registry::register_kind(name)` (no-descriptor convenience) now defaults to `SchemaType::Bytes` instead of `Opaque` — matches its actual semantic ("raw byte payload, no agent-encodable structure"). Test-only path; production init goes through `register_kind_with_descriptor`.

## Net diff

10 files, +305/-705. Mostly mechanical rename (`encoding:` → `schema:`, `KindEncoding::Schema(s)` → `s`).

## Test plan

- [x] `cargo test --workspace` — every crate green
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No remaining references to `KindEncoding` / `PodField` / `PodFieldType` / `PodPrimitive` / `encode_pod` anywhere in `crates/` (verified by grep)