### PR TITLE
feat(substrate): publish/subscribe routing for input streams (ADR-0021)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ Prefer `params` over `payload_bytes` when the kind is describable — the hub do
 
 The observation path (ADR-0008) goes the other way: engines emit to the well-known sink `"hub.claude.broadcast"` and the hub fans out to every attached session. The live substrate binary pushes `aether.observation.frame_stats` there every 120 frames — a good smoke test for `receive_mail`. Reply-to-sender from a WASM component is plumbed at the wire level but not yet exposed as a host fn.
 
-Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), and ADR-0009 (hub-supervised substrate spawn).
+Input streams (tick, key, mouse_move, mouse_button) are publish/subscribe (ADR-0021): the substrate boots with empty subscriber sets and drops every input event until something subscribes. To wire a freshly-loaded component into the platform's event stream, mail `aether.control.subscribe_input` with `{ "stream": "Tick" | "Key" | "MouseMove" | "MouseButton", "mailbox": <id from load_result> }`. Multiple components may subscribe to the same stream; the substrate fans out to every subscriber. `aether.control.unsubscribe_input` removes one. Both reply via `aether.control.subscribe_input_result`. Subscriptions are auto-cleared when a component is dropped and preserved across `replace_component` (the mailbox id is stable).
+
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), and ADR-0021 (input stream subscriptions).
 
 ## Commands
 

--- a/crates/aether-substrate-mail/src/descriptors.rs
+++ b/crates/aether-substrate-mail/src/descriptors.rs
@@ -19,7 +19,8 @@ use aether_mail::{Kind, Schema};
 
 use crate::{
     DrawTriangle, DropComponent, DropResult, FrameStats, Key, LoadComponent, LoadResult,
-    MouseButton, MouseMove, Ping, Pong, ReplaceComponent, ReplaceResult, Tick,
+    MouseButton, MouseMove, Ping, Pong, ReplaceComponent, ReplaceResult, SubscribeInput,
+    SubscribeInputResult, Tick, UnsubscribeInput,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -48,6 +49,10 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<LoadResult>(),
         schema::<DropResult>(),
         schema::<ReplaceResult>(),
+        // ADR-0021 publish/subscribe routing for input streams.
+        schema::<SubscribeInput>(),
+        schema::<UnsubscribeInput>(),
+        schema::<SubscribeInputResult>(),
     ]
 }
 
@@ -80,6 +85,9 @@ mod tests {
         assert!(names.contains(&LoadResult::NAME));
         assert!(names.contains(&DropResult::NAME));
         assert!(names.contains(&ReplaceResult::NAME));
+        assert!(names.contains(&SubscribeInput::NAME));
+        assert!(names.contains(&UnsubscribeInput::NAME));
+        assert!(names.contains(&SubscribeInputResult::NAME));
     }
 
     #[test]

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -263,6 +263,69 @@ mod control_plane {
         F32,
         F64,
     }
+
+    // ADR-0021 publish/subscribe routing for substrate input streams.
+    // Closed enum over streams the platform layer publishes; a
+    // SubscribeInput names one and a mailbox to receive it. Reserved
+    // kind names `aether.control.subscribe_input` /
+    // `aether.control.unsubscribe_input` / `aether.control.subscribe_input_result`
+    // match the namespace used for load/drop/replace; the substrate
+    // handles them inline and replies via reply-to-sender.
+
+    /// A substrate-published input stream (ADR-0021). Closed set —
+    /// adding a platform event (e.g. `Resize`) is an additive variant
+    /// plus a publisher change on the substrate side.
+    #[derive(
+        aether_mail::Schema,
+        Serialize,
+        Deserialize,
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+    )]
+    pub enum InputStream {
+        Tick,
+        Key,
+        MouseMove,
+        MouseButton,
+    }
+
+    /// `aether.control.subscribe_input` — add `mailbox` to the
+    /// subscriber set for `stream`. Idempotent: subscribing a mailbox
+    /// already in the set is still `Ok` (subscriptions are a set, not
+    /// a counter). Reply: `SubscribeInputResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.control.subscribe_input")]
+    pub struct SubscribeInput {
+        pub stream: InputStream,
+        pub mailbox: u32,
+    }
+
+    /// `aether.control.unsubscribe_input` — remove `mailbox` from the
+    /// subscriber set for `stream`. Idempotent: unsubscribing a mailbox
+    /// that isn't subscribed is still `Ok`. Reply:
+    /// `SubscribeInputResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.control.unsubscribe_input")]
+    pub struct UnsubscribeInput {
+        pub stream: InputStream,
+        pub mailbox: u32,
+    }
+
+    /// Reply to both subscribe and unsubscribe (ADR-0021 §2). Only
+    /// failure mode: the target mailbox id doesn't name a live
+    /// component (unknown, a sink, or already dropped).
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.control.subscribe_input_result")]
+    pub enum SubscribeInputResult {
+        Ok,
+        Err { error: String },
+    }
 }
 
 #[cfg(test)]
@@ -323,6 +386,12 @@ mod tests {
         assert_eq!(LoadResult::NAME, "aether.control.load_result");
         assert_eq!(DropResult::NAME, "aether.control.drop_result");
         assert_eq!(ReplaceResult::NAME, "aether.control.replace_result");
+        assert_eq!(SubscribeInput::NAME, "aether.control.subscribe_input");
+        assert_eq!(UnsubscribeInput::NAME, "aether.control.unsubscribe_input");
+        assert_eq!(
+            SubscribeInputResult::NAME,
+            "aether.control.subscribe_input_result"
+        );
     }
 
     #[test]

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -32,7 +32,8 @@ use aether_hub_protocol::{
 use aether_mail::Kind;
 use aether_substrate_mail::{
     DropComponent, DropResult, LoadComponent, LoadKind, LoadKindEncoding, LoadKindPrimitive,
-    LoadResult, ReplaceComponent, ReplaceResult,
+    LoadResult, ReplaceComponent, ReplaceResult, SubscribeInput, SubscribeInputResult,
+    UnsubscribeInput,
 };
 use serde::Serialize;
 use wasmtime::{Engine, Linker, Module};
@@ -40,6 +41,7 @@ use wasmtime::{Engine, Linker, Module};
 use crate::component::Component;
 use crate::ctx::SubstrateCtx;
 use crate::hub_client::HubOutbound;
+use crate::input::{self, InputSubscribers};
 use crate::mail::MailboxId;
 use crate::queue::MailQueue;
 use crate::registry::{Registry, SinkHandler};
@@ -91,6 +93,24 @@ fn lift_load_field_type(primitive: LoadKindPrimitive, array_len: Option<u32>) ->
     }
 }
 
+/// Shared validation for `subscribe_input` / `unsubscribe_input`: the
+/// mailbox id must name a live component. Sinks are rejected because
+/// they handle mail inline and have no business receiving fan-out
+/// input events; dropped mailboxes are rejected so callers don't
+/// unsubscribe with a stale id and think the op succeeded.
+fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
+    match registry.entry(id) {
+        Some(crate::registry::MailboxEntry::Component) => Ok(()),
+        Some(crate::registry::MailboxEntry::Sink(_)) => {
+            Err(format!("mailbox {:?} is a sink, not a component", id))
+        }
+        Some(crate::registry::MailboxEntry::Dropped) => {
+            Err(format!("mailbox {:?} already dropped", id))
+        }
+        None => Err(format!("unknown mailbox id {:?}", id)),
+    }
+}
+
 fn lift_primitive(p: LoadKindPrimitive) -> Primitive {
     match p {
         LoadKindPrimitive::U8 => Primitive::U8,
@@ -117,6 +137,11 @@ pub struct ControlPlane {
     pub queue: Arc<MailQueue>,
     pub outbound: Arc<HubOutbound>,
     pub components: ComponentTable,
+    /// ADR-0021 per-stream subscriber sets, shared with the platform
+    /// thread. The control plane mutates this table on subscribe /
+    /// unsubscribe / drop; the platform thread reads it to fan out
+    /// each published event.
+    pub input_subscribers: InputSubscribers,
     /// Monotonic counter for default component names. Only consulted
     /// when the load payload omits `name`.
     pub default_name_counter: Arc<AtomicU64>,
@@ -149,6 +174,12 @@ impl ControlPlane {
         } else if kind_name == ReplaceComponent::NAME {
             let result = self.handle_replace(bytes);
             self.reply(sender, ReplaceResult::NAME, &result);
+        } else if kind_name == SubscribeInput::NAME {
+            let result = self.handle_subscribe(bytes);
+            self.reply(sender, SubscribeInputResult::NAME, &result);
+        } else if kind_name == UnsubscribeInput::NAME {
+            let result = self.handle_unsubscribe(bytes);
+            self.reply(sender, SubscribeInputResult::NAME, &result);
         } else {
             eprintln!(
                 "aether-substrate: {AETHER_CONTROL} received unrecognised kind {kind_name:?} — dropping"
@@ -262,6 +293,15 @@ impl ControlPlane {
                 error: e.to_string(),
             };
         }
+        // ADR-0021 §4: clear this mailbox from every input subscriber
+        // set. Done after the registry marks the mailbox `Dropped` so
+        // the invariant "every subscriber id references a live mailbox"
+        // holds across the short window before `remove_component`
+        // finishes — any mail the platform thread publishes in that
+        // window is already discarded by the scheduler's `Dropped`
+        // arm, so fan-out to a soon-to-be-empty subscriber set is
+        // harmless.
+        input::remove_from_all(&self.input_subscribers, id);
         // Pull the Component out of the scheduler table, fire the
         // ADR-0015 `on_drop` hook on it, then let it drop at end of
         // scope so wasmtime reclaims linear memory. The mailbox was
@@ -272,6 +312,59 @@ impl ControlPlane {
             component.on_drop();
         }
         DropResult::Ok
+    }
+
+    fn handle_subscribe(&self, bytes: &[u8]) -> SubscribeInputResult {
+        let payload: SubscribeInput = match postcard::from_bytes(bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                return SubscribeInputResult::Err {
+                    error: format!("postcard decode failed: {e}"),
+                };
+            }
+        };
+        let id = MailboxId(payload.mailbox);
+        if let Err(e) = validate_subscriber_mailbox(&self.registry, id) {
+            return SubscribeInputResult::Err { error: e };
+        }
+        self.input_subscribers
+            .write()
+            .unwrap()
+            .entry(payload.stream)
+            .or_default()
+            .insert(id);
+        SubscribeInputResult::Ok
+    }
+
+    fn handle_unsubscribe(&self, bytes: &[u8]) -> SubscribeInputResult {
+        let payload: UnsubscribeInput = match postcard::from_bytes(bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                return SubscribeInputResult::Err {
+                    error: format!("postcard decode failed: {e}"),
+                };
+            }
+        };
+        let id = MailboxId(payload.mailbox);
+        // Unsubscribe is idempotent on "not currently subscribed" but
+        // still validates the mailbox: an unknown or sink id is a
+        // clear programming error, not something to swallow. A dropped
+        // mailbox has already had its subscriptions cleared by
+        // handle_drop, but accepting one here would mask a caller bug
+        // where they unsubscribe using a stale id. Err is the right
+        // answer in both cases.
+        if let Err(e) = validate_subscriber_mailbox(&self.registry, id) {
+            return SubscribeInputResult::Err { error: e };
+        }
+        if let Some(set) = self
+            .input_subscribers
+            .write()
+            .unwrap()
+            .get_mut(&payload.stream)
+        {
+            set.remove(&id);
+        }
+        SubscribeInputResult::Ok
     }
 
     fn handle_replace(&self, bytes: &[u8]) -> ReplaceResult {
@@ -606,6 +699,7 @@ mod tests {
             queue,
             outbound,
             components,
+            input_subscribers: input::new_subscribers(),
             default_name_counter: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -1115,5 +1209,243 @@ mod tests {
         let mut new = cell.lock().unwrap();
         assert_eq!(new.read_u32(396), 0);
         assert_eq!(new.read_u32(400), 0);
+    }
+
+    // ADR-0021: per-stream subscribe / unsubscribe, drop cleanup,
+    // replace-preserves-subscriptions. `make_plane` already threads an
+    // empty `InputSubscribers` into the handler, so these tests only
+    // need to load a component and exercise the subscribe surface.
+
+    use aether_substrate_mail::{
+        InputStream, SubscribeInput, SubscribeInputResult, UnsubscribeInput,
+    };
+
+    fn subs(plane: &ControlPlane, stream: InputStream) -> std::collections::BTreeSet<MailboxId> {
+        plane
+            .input_subscribers
+            .read()
+            .unwrap()
+            .get(&stream)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn load_blank(plane: &ControlPlane, name: &str) -> u32 {
+        let wasm = wat::parse_str(WAT).unwrap();
+        let result = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponent {
+                wasm,
+                kinds: vec![],
+                name: Some(name.into()),
+            })
+            .unwrap(),
+        );
+        let LoadResult::Ok { mailbox_id, .. } = result else {
+            panic!("load should succeed: {result:?}");
+        };
+        mailbox_id
+    }
+
+    fn do_subscribe(
+        plane: &ControlPlane,
+        mailbox: u32,
+        stream: InputStream,
+    ) -> SubscribeInputResult {
+        plane.handle_subscribe(&postcard::to_allocvec(&SubscribeInput { stream, mailbox }).unwrap())
+    }
+
+    fn do_unsubscribe(
+        plane: &ControlPlane,
+        mailbox: u32,
+        stream: InputStream,
+    ) -> SubscribeInputResult {
+        plane.handle_unsubscribe(
+            &postcard::to_allocvec(&UnsubscribeInput { stream, mailbox }).unwrap(),
+        )
+    }
+
+    #[test]
+    fn subscribe_adds_mailbox_to_stream_set() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        assert!(matches!(
+            do_subscribe(&plane, id, InputStream::Tick),
+            SubscribeInputResult::Ok
+        ));
+        let set = subs(&plane, InputStream::Tick);
+        assert!(set.contains(&MailboxId(id)));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn subscribe_is_idempotent() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        for _ in 0..3 {
+            assert!(matches!(
+                do_subscribe(&plane, id, InputStream::Key),
+                SubscribeInputResult::Ok
+            ));
+        }
+        assert_eq!(subs(&plane, InputStream::Key).len(), 1);
+    }
+
+    #[test]
+    fn subscribe_two_components_fan_out_to_both() {
+        let plane = make_plane();
+        let a = load_blank(&plane, "a");
+        let b = load_blank(&plane, "b");
+        assert!(matches!(
+            do_subscribe(&plane, a, InputStream::Tick),
+            SubscribeInputResult::Ok
+        ));
+        assert!(matches!(
+            do_subscribe(&plane, b, InputStream::Tick),
+            SubscribeInputResult::Ok
+        ));
+        let set = subs(&plane, InputStream::Tick);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&MailboxId(a)));
+        assert!(set.contains(&MailboxId(b)));
+    }
+
+    #[test]
+    fn unsubscribe_removes_from_set() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        do_subscribe(&plane, id, InputStream::MouseMove);
+        assert!(matches!(
+            do_unsubscribe(&plane, id, InputStream::MouseMove),
+            SubscribeInputResult::Ok
+        ));
+        assert!(subs(&plane, InputStream::MouseMove).is_empty());
+    }
+
+    #[test]
+    fn unsubscribe_not_subscribed_is_ok() {
+        // ADR-0021 §2: unsubscribe of a non-subscriber is `Ok`, not
+        // `Err`. The mailbox must still be a live component though.
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        assert!(matches!(
+            do_unsubscribe(&plane, id, InputStream::Tick),
+            SubscribeInputResult::Ok
+        ));
+    }
+
+    #[test]
+    fn subscribe_unknown_mailbox_is_err() {
+        let plane = make_plane();
+        assert!(matches!(
+            do_subscribe(&plane, 9999, InputStream::Tick),
+            SubscribeInputResult::Err { .. }
+        ));
+    }
+
+    #[test]
+    fn subscribe_sink_mailbox_is_err() {
+        // Sinks are substrate-owned and don't make sense as input
+        // subscribers; the handler rejects.
+        let plane = make_plane();
+        let sink = plane
+            .registry
+            .register_sink("some.sink", Arc::new(|_, _, _, _, _| {}));
+        assert!(matches!(
+            do_subscribe(&plane, sink.0, InputStream::Tick),
+            SubscribeInputResult::Err { .. }
+        ));
+    }
+
+    #[test]
+    fn subscribe_dropped_mailbox_is_err() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "victim");
+        plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
+        assert!(matches!(
+            do_subscribe(&plane, id, InputStream::Tick),
+            SubscribeInputResult::Err { .. }
+        ));
+    }
+
+    #[test]
+    fn drop_component_removes_from_every_subscriber_set() {
+        // ADR-0021 §4: dropping a component clears its id from every
+        // stream's subscriber set, not just the ones currently held.
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        do_subscribe(&plane, id, InputStream::Tick);
+        do_subscribe(&plane, id, InputStream::Key);
+        do_subscribe(&plane, id, InputStream::MouseButton);
+        let dropped =
+            plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
+        assert!(matches!(dropped, DropResult::Ok));
+        for s in [
+            InputStream::Tick,
+            InputStream::Key,
+            InputStream::MouseMove,
+            InputStream::MouseButton,
+        ] {
+            assert!(
+                !subs(&plane, s).contains(&MailboxId(id)),
+                "stream {s:?} still contains dropped id"
+            );
+        }
+    }
+
+    #[test]
+    fn replace_component_preserves_subscriptions() {
+        // ADR-0021 §4: replace keeps the mailbox id, and subscriptions
+        // are keyed by mailbox, so the new instance inherits them.
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        do_subscribe(&plane, id, InputStream::Tick);
+        do_subscribe(&plane, id, InputStream::Key);
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponent {
+                mailbox_id: id,
+                wasm: wat::parse_str(WAT).unwrap(),
+                kinds: vec![],
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResult::Ok));
+        assert!(subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
+        assert!(subs(&plane, InputStream::Key).contains(&MailboxId(id)));
+    }
+
+    #[test]
+    fn subscribe_malformed_payload_is_err() {
+        let plane = make_plane();
+        let result = plane.handle_subscribe(&[0xFF; 4]);
+        assert!(matches!(result, SubscribeInputResult::Err { .. }));
+    }
+
+    #[test]
+    fn subscribe_dispatch_replies_with_result_kind() {
+        // Dispatch goes through `dispatch()` so a SubscribeInputResult
+        // is sent via reply-to-sender. We can't easily observe the
+        // outbound here without a richer fake, but at least confirm
+        // the dispatch path doesn't panic on the two kinds.
+        let plane = make_plane();
+        let id = load_blank(&plane, "listener");
+        plane.dispatch(
+            SubscribeInput::NAME,
+            SessionToken::NIL,
+            &postcard::to_allocvec(&SubscribeInput {
+                stream: InputStream::Tick,
+                mailbox: id,
+            })
+            .unwrap(),
+        );
+        plane.dispatch(
+            UnsubscribeInput::NAME,
+            SessionToken::NIL,
+            &postcard::to_allocvec(&UnsubscribeInput {
+                stream: InputStream::Tick,
+                mailbox: id,
+            })
+            .unwrap(),
+        );
+        assert!(!subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
     }
 }

--- a/crates/aether-substrate/src/input.rs
+++ b/crates/aether-substrate/src/input.rs
@@ -1,0 +1,53 @@
+// ADR-0021 publish/subscribe routing for substrate input streams.
+//
+// `InputSubscribers` is the shared table between the platform thread
+// (which publishes `aether.tick`, `aether.key`, `aether.mouse_move`,
+// and `aether.mouse_button`) and the control-plane handler (which
+// mutates subscriber sets on `subscribe_input` / `unsubscribe_input`
+// and on component drop). Readers take a shared lock per published
+// event; writers take an exclusive lock on subscribe / unsubscribe /
+// drop. `BTreeSet` rather than `Vec` so subscriber order is
+// deterministic across runs and duplicate subscribe is naturally
+// idempotent.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::{Arc, RwLock};
+
+use aether_substrate_mail::InputStream;
+
+use crate::mail::MailboxId;
+
+/// Per-stream subscriber sets. One entry per `InputStream`; absent
+/// entries are treated the same as empty sets, which lets subscribe
+/// lazily initialise an entry without a boot-time prepass.
+pub type InputSubscribers = Arc<RwLock<HashMap<InputStream, BTreeSet<MailboxId>>>>;
+
+/// Build an empty subscriber table. Callers clone the returned `Arc`
+/// into both the control plane (mutator) and the platform thread
+/// (reader).
+pub fn new_subscribers() -> InputSubscribers {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Snapshot of the subscribers for a single stream, returned as a
+/// `Vec` so the caller can drop the read lock before dispatching. The
+/// platform thread calls this once per platform event; the copy is
+/// cheap (small sets, integer elements).
+pub fn subscribers_for(table: &InputSubscribers, stream: InputStream) -> Vec<MailboxId> {
+    table
+        .read()
+        .unwrap()
+        .get(&stream)
+        .map(|set| set.iter().copied().collect())
+        .unwrap_or_default()
+}
+
+/// Remove `id` from every stream's subscriber set. Invoked by the
+/// control plane on successful `drop_component` so the invariant
+/// "every subscriber id references a live mailbox" holds.
+pub fn remove_from_all(table: &InputSubscribers, id: MailboxId) {
+    let mut guard = table.write().unwrap();
+    for set in guard.values_mut() {
+        set.remove(&id);
+    }
+}

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -12,6 +12,7 @@ pub mod control;
 pub mod ctx;
 pub mod host_fns;
 pub mod hub_client;
+pub mod input;
 pub mod mail;
 pub mod queue;
 pub mod registry;
@@ -20,6 +21,7 @@ pub mod sender_table;
 
 pub use component::Component;
 pub use control::{AETHER_CONTROL, ControlPlane};
+pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 // ADR-0019 PR 5: control-plane payload types now live as schema kinds
 // in `aether-substrate-mail` (LoadComponent, LoadResult, etc.).
 // Re-exports of the old `*Payload` structs are gone — consumers

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -6,7 +6,7 @@ use aether_hub_protocol::SessionToken;
 /// Addressing token for any mailbox — component or substrate-owned sink.
 /// Opaque `u32` newtype so it can't be accidentally mixed with wasmtime
 /// indices or raw integers.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct MailboxId(pub u32);
 
 /// Host/guest contract tag for the payload layout. The substrate and the

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -5,13 +5,12 @@
 // screen; until a component is loaded and explicitly mailed, the
 // window clears to its default and no triangles are drawn.
 //
-// Keyboard/mouse/tick events from winit target the substrate's
-// optional `default_component` mailbox. It's `None` at boot and stays
-// `None` until something (a future CLI flag, an `aether.control.*`
-// message, or a load handler extension) wires one up. For the current
-// "test component in isolation" workflow, agents drive components via
-// direct mail to the id returned by `load_component`, not via the
-// window's input stream.
+// Keyboard/mouse/tick events from winit are published per-stream
+// (ADR-0021): the substrate consults an `InputSubscribers` table —
+// shared with the control-plane handler — and enqueues one copy of
+// the event per currently-subscribed mailbox. Empty subscriber sets
+// drop the event at the source. Subscriptions are managed via
+// `aether.control.subscribe_input` / `aether.control.unsubscribe_input`.
 
 mod render;
 
@@ -25,11 +24,12 @@ use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
 use aether_substrate::{
-    HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, MailQueue, Registry, Scheduler, SubstrateCtx,
-    host_fns,
+    HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, MailQueue, Registry, Scheduler,
+    SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
+    subscribers_for,
 };
-use aether_substrate_mail::{FrameStats, Key, MouseButton, MouseMove, Tick};
+use aether_substrate_mail::{FrameStats, InputStream, Key, MouseButton, MouseMove, Tick};
 use render::Gpu;
 use wasmtime::{Engine, Linker};
 use winit::application::ApplicationHandler;
@@ -43,10 +43,11 @@ const LOG_EVERY_FRAMES: u64 = 120;
 
 struct App {
     queue: Arc<MailQueue>,
-    /// Mailbox that receives `aether.tick`, `aether.key`, and mouse
-    /// events while the window has focus. `None` means "substrate
-    /// boots componentless"; input events are dropped silently.
-    default_component: Option<MailboxId>,
+    /// ADR-0021 per-stream subscribers. Shared with the control plane
+    /// so subscribe / unsubscribe / drop write through the same table
+    /// the platform thread reads on each event. Empty sets — the
+    /// boot state — mean the event is dropped at the source.
+    input_subscribers: InputSubscribers,
     broadcast_mbox: MailboxId,
     kind_tick: u32,
     kind_key: u32,
@@ -116,7 +117,8 @@ impl ApplicationHandler for App {
                 if self.occluded {
                     return;
                 }
-                if let Some(mbox) = self.default_component {
+                let tick_subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+                for mbox in tick_subs {
                     self.queue
                         .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
                 }
@@ -151,23 +153,30 @@ impl ApplicationHandler for App {
             WindowEvent::KeyboardInput {
                 event: key_event, ..
             } => {
-                if let Some(mbox) = self.default_component
-                    && key_event.state == ElementState::Pressed
-                    && !key_event.repeat
-                {
-                    let code: u32 = match key_event.physical_key {
-                        PhysicalKey::Code(k) => k as u32,
-                        PhysicalKey::Unidentified(_) => 0,
-                    };
-                    self.queue
-                        .push(Mail::new(mbox, self.kind_key, encode(&Key { code }), 1));
+                if key_event.state == ElementState::Pressed && !key_event.repeat {
+                    let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
+                    if !subs.is_empty() {
+                        let code: u32 = match key_event.physical_key {
+                            PhysicalKey::Code(k) => k as u32,
+                            PhysicalKey::Unidentified(_) => 0,
+                        };
+                        for mbox in subs {
+                            self.queue.push(Mail::new(
+                                mbox,
+                                self.kind_key,
+                                encode(&Key { code }),
+                                1,
+                            ));
+                        }
+                    }
                 }
             }
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 ..
             } => {
-                if let Some(mbox) = self.default_component {
+                let subs = subscribers_for(&self.input_subscribers, InputStream::MouseButton);
+                for mbox in subs {
                     self.queue.push(Mail::new(
                         mbox,
                         self.kind_mouse_button,
@@ -177,13 +186,16 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                if let Some(mbox) = self.default_component {
+                let subs = subscribers_for(&self.input_subscribers, InputStream::MouseMove);
+                if !subs.is_empty() {
                     let payload = encode(&MouseMove {
                         x: position.x as f32,
                         y: position.y as f32,
                     });
-                    self.queue
-                        .push(Mail::new(mbox, self.kind_mouse_move, payload, 1));
+                    for mbox in subs {
+                        self.queue
+                            .push(Mail::new(mbox, self.kind_mouse_move, payload.clone(), 1));
+                    }
                 }
             }
             _ => {}
@@ -282,6 +294,11 @@ fn main() -> wasmtime::Result<()> {
         WORKERS,
     );
 
+    // ADR-0021 subscriber table, shared with the control plane so
+    // subscribe / unsubscribe / drop write through the same `Arc`
+    // the platform thread reads when publishing events.
+    let input_subscribers = aether_substrate::new_subscribers();
+
     // Wire the ADR-0010 control plane. Registered after the scheduler
     // exists so the handler can capture the runtime component table
     // directly rather than an `Arc<Scheduler>` (which would cycle back
@@ -294,6 +311,7 @@ fn main() -> wasmtime::Result<()> {
             queue: Arc::clone(&queue),
             outbound: Arc::clone(&outbound),
             components: scheduler.components().clone(),
+            input_subscribers: Arc::clone(&input_subscribers),
             default_name_counter: Arc::new(AtomicU64::new(0)),
         };
         registry.register_sink(
@@ -335,7 +353,7 @@ fn main() -> wasmtime::Result<()> {
 
     let mut app = App {
         queue,
-        default_component: None,
+        input_subscribers,
         broadcast_mbox,
         kind_tick,
         kind_key,

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -152,22 +152,16 @@ impl ApplicationHandler for App {
             }
             WindowEvent::KeyboardInput {
                 event: key_event, ..
-            } => {
-                if key_event.state == ElementState::Pressed && !key_event.repeat {
-                    let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
-                    if !subs.is_empty() {
-                        let code: u32 = match key_event.physical_key {
-                            PhysicalKey::Code(k) => k as u32,
-                            PhysicalKey::Unidentified(_) => 0,
-                        };
-                        for mbox in subs {
-                            self.queue.push(Mail::new(
-                                mbox,
-                                self.kind_key,
-                                encode(&Key { code }),
-                                1,
-                            ));
-                        }
+            } if key_event.state == ElementState::Pressed && !key_event.repeat => {
+                let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
+                if !subs.is_empty() {
+                    let code: u32 = match key_event.physical_key {
+                        PhysicalKey::Code(k) => k as u32,
+                        PhysicalKey::Unidentified(_) => 0,
+                    };
+                    for mbox in subs {
+                        self.queue
+                            .push(Mail::new(mbox, self.kind_key, encode(&Key { code }), 1));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adds `InputStream` enum + `SubscribeInput`/`UnsubscribeInput`/`SubscribeInputResult` reserved kinds in `aether-substrate-mail`.
- New `input` module in `aether-substrate` with a shared `InputSubscribers` table; `ControlPlane` mutates it via `handle_subscribe` / `handle_unsubscribe` and clears entries on `handle_drop`.
- `App::default_component` removed; the platform thread fans each `aether.tick` / `aether.key` / `aether.mouse_move` / `aether.mouse_button` event out to every subscriber. Empty sets drop the event at the source.
- Validation rejects unknown / sink / dropped mailbox ids; duplicate subscribe and unsubscribe-of-non-subscriber are idempotent `Ok` per ADR-0021 §2.
- Drop clears the mailbox from every stream; replace preserves subscriptions because the mailbox id is stable (per ADR-0010 §5).
- CLAUDE.md MCP harness section documents the load → subscribe sequence.

## Test plan

- [x] `cargo test --workspace` (12 new control-plane tests + existing suites)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manual: load a component via `load_component`, subscribe Tick + Key, observe the substrate dispatches both streams to the component's mailbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)