### PR TITLE
feat(hello,substrate): input_logger example + end-to-end subscribe smoke (ADR-0021)

### DIFF
--- a/crates/aether-hello-component/Cargo.toml
+++ b/crates/aether-hello-component/Cargo.toml
@@ -25,3 +25,10 @@ crate-type = ["cdylib"]
 [[example]]
 name = "caller"
 crate-type = ["cdylib"]
+
+# ADR-0021 input subscriptions smoke. Resolves all four substrate
+# input kinds and broadcasts a `demo.input_observed` per event so
+# `receive_mail` shows the dispatch landing.
+[[example]]
+name = "input_logger"
+crate-type = ["cdylib"]

--- a/crates/aether-hello-component/examples/input_logger.rs
+++ b/crates/aether-hello-component/examples/input_logger.rs
@@ -1,0 +1,82 @@
+// Smoke component for ADR-0021 input subscriptions. Resolves the
+// four substrate-published input kinds (Tick / Key / MouseMove /
+// MouseButton) and the `hub.claude.broadcast` sink, then on every
+// received input event emits a `demo.input_observed { stream, code }`
+// observation so the driving Claude session can see the dispatch
+// land via `receive_mail`.
+//
+// The component itself doesn't subscribe to anything — that's the
+// agent's job. From the harness:
+//
+//   1. `load_component` with this `.wasm` (or compile and use the
+//      built artifact at `target/wasm32-unknown-unknown/release/
+//      examples/input_logger.wasm`).
+//   2. `send_mail` `aether.control.subscribe_input` with
+//      `{ stream: "Key", mailbox: <id from load_result> }`.
+//   3. Press keys in the substrate window (or otherwise drive the
+//      platform layer).
+//   4. `receive_mail` — each press lands as a
+//      `demo.input_observed { stream: 1, code: <keycode> }`.
+//
+// `stream` is encoded as: 0=Tick, 1=Key, 2=MouseButton, 3=MouseMove.
+// `code` carries the keycode for Key, the rounded cursor `x` for
+// MouseMove, and `0` for the empty-payload kinds (Tick and
+// MouseButton).
+
+use aether_component::{Component, Ctx, InitCtx, KindId, Mail, Sink};
+use aether_mail::Kind;
+use aether_substrate_mail::{Key, MouseButton, MouseMove, Tick};
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct InputObserved {
+    pub stream: u32,
+    pub code: u32,
+}
+impl Kind for InputObserved {
+    const NAME: &'static str = "demo.input_observed";
+}
+
+pub struct InputLogger {
+    tick: KindId<Tick>,
+    key: KindId<Key>,
+    mouse_button: KindId<MouseButton>,
+    mouse_move: KindId<MouseMove>,
+    observe: Sink<InputObserved>,
+}
+
+impl Component for InputLogger {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        InputLogger {
+            tick: ctx.resolve::<Tick>(),
+            key: ctx.resolve::<Key>(),
+            mouse_button: ctx.resolve::<MouseButton>(),
+            mouse_move: ctx.resolve::<MouseMove>(),
+            observe: ctx.resolve_sink::<InputObserved>("hub.claude.broadcast"),
+        }
+    }
+
+    fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>) {
+        let observation = if self.tick.matches(mail.kind()) {
+            Some(InputObserved { stream: 0, code: 0 })
+        } else if self.mouse_button.matches(mail.kind()) {
+            Some(InputObserved { stream: 2, code: 0 })
+        } else if let Some(k) = mail.decode(self.key) {
+            Some(InputObserved {
+                stream: 1,
+                code: k.code,
+            })
+        } else {
+            mail.decode(self.mouse_move).map(|m| InputObserved {
+                stream: 3,
+                code: m.x as u32,
+            })
+        };
+        if let Some(obs) = observation {
+            ctx.send(&self.observe, &obs);
+        }
+    }
+}
+
+aether_component::export!(InputLogger);

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -130,6 +130,12 @@ fn lift_primitive(p: LoadKindPrimitive) -> Primitive {
 /// struct keeps the closure body short and makes the dependencies
 /// explicit — useful since the handler needs a broad slice of
 /// substrate state (wasmtime, registry, scheduler table, outbound).
+///
+/// `Clone` is cheap — every field is an `Arc` — and exists for tests
+/// that want to drive `dispatch` more than once (each call consumes
+/// the handler via `into_sink_handler`). Production has exactly one
+/// ControlPlane and never clones it.
+#[derive(Clone)]
 pub struct ControlPlane {
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<SubstrateCtx>>,

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -1,0 +1,254 @@
+// End-to-end smoke for ADR-0021 publish/subscribe routing. The test
+// stands up the same triple the substrate binary uses — Registry,
+// Scheduler, ControlPlane sharing one `InputSubscribers` table —
+// loads a WAT component via the control-plane sink handler,
+// subscribes it, then drives "platform events" by calling the same
+// `subscribers_for` helper that `App::window_event` uses and pushing
+// one mail per subscriber. The WAT guest forwards every `receive`
+// into a counting sink so the test can observe end-to-end delivery
+// without peeking guest memory.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use aether_hub_protocol::SessionToken;
+use aether_mail::Kind;
+use aether_substrate::{
+    AETHER_CONTROL, ControlPlane, HubOutbound, InputSubscribers, MailQueue, Registry, Scheduler,
+    SubstrateCtx, host_fns,
+    mail::{Mail, MailboxId},
+    new_subscribers, subscribers_for,
+};
+use aether_substrate_mail::{
+    DropComponent, InputStream, LoadComponent, SubscribeInput, Tick, UnsubscribeInput,
+};
+use wasmtime::{Engine, Linker};
+
+/// Minimal guest: forwards every `receive` to mailbox `1` (the
+/// counting sink the harness registers) with a fixed kind id and a
+/// count of 1. Byte-identical for Tick / Key / any other input kind
+/// — the test doesn't care about the payload shape, only that the
+/// dispatch arrived.
+const WAT: &str = r#"
+(module
+  (import "aether" "send_mail"
+    (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (func (export "receive")
+    (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+    (result i32)
+    (drop (call $send_mail
+        (i32.const 1) (i32.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))
+    i32.const 0))
+"#;
+
+struct Harness {
+    plane: ControlPlane,
+    queue: Arc<MailQueue>,
+    input_subscribers: InputSubscribers,
+    counter: Arc<AtomicU32>,
+    kind_tick: u32,
+    _scheduler: Scheduler,
+}
+
+fn make_harness() -> Harness {
+    let engine = Arc::new(Engine::default());
+    let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+    host_fns::register(&mut linker).expect("register host fns");
+    let linker = Arc::new(linker);
+
+    let registry = Arc::new(Registry::new());
+    for d in aether_substrate_mail::descriptors::all() {
+        registry
+            .register_kind_with_descriptor(d)
+            .expect("descriptor unique");
+    }
+    let kind_tick = registry.kind_id(Tick::NAME).expect("Tick registered");
+
+    // Mailbox id 0 is the counting sink — the WAT hard-codes `1` as
+    // the forwarding target, so we register the sink first at id 0,
+    // then correct the expectation below. Actually `register_sink`
+    // allocates ids in order; the first registration gets id 0, so
+    // we need the tally sink to land at id 1. Reserve id 0 with a
+    // placeholder control sink first.
+    let placeholder = registry.register_sink(
+        AETHER_CONTROL,
+        Arc::new(|_, _, _, _, _| { /* replaced below once plane exists */ }),
+    );
+    assert_eq!(placeholder.0, 0);
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let c2 = Arc::clone(&counter);
+    let sink_mbox = registry.register_sink(
+        "tally",
+        Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+            c2.fetch_add(count, Ordering::SeqCst);
+        }),
+    );
+    assert_eq!(sink_mbox.0, 1, "WAT hardcodes mailbox 1 as the sink");
+
+    let queue = Arc::new(MailQueue::new());
+    let scheduler = Scheduler::new(
+        Arc::clone(&registry),
+        Arc::clone(&queue),
+        std::collections::HashMap::new(),
+        2,
+    );
+
+    let input_subscribers = new_subscribers();
+    let plane = ControlPlane {
+        engine: Arc::clone(&engine),
+        linker: Arc::clone(&linker),
+        registry: Arc::clone(&registry),
+        queue: Arc::clone(&queue),
+        outbound: HubOutbound::disconnected(),
+        components: scheduler.components().clone(),
+        input_subscribers: Arc::clone(&input_subscribers),
+        default_name_counter: Arc::new(AtomicU64::new(0)),
+    };
+
+    Harness {
+        plane,
+        queue,
+        input_subscribers,
+        counter,
+        kind_tick,
+        _scheduler: scheduler,
+    }
+}
+
+/// Dispatch a single control-plane kind by going through the public
+/// sink-handler surface. `ControlPlane::into_sink_handler` consumes
+/// its receiver, so the harness clones the plane (`Arc`-cheap) for
+/// each call. Mirrors how main.rs wires the handler at boot.
+fn dispatch<K: serde::Serialize>(plane: &ControlPlane, kind_name: &str, payload: &K) {
+    let bytes = postcard::to_allocvec(payload).unwrap();
+    let handler = plane.clone().into_sink_handler();
+    handler(kind_name, None, SessionToken::NIL, &bytes, 0);
+}
+
+fn load_wat(plane: &ControlPlane, name: &str) -> u32 {
+    let before: std::collections::HashSet<u32> = plane
+        .components
+        .read()
+        .unwrap()
+        .keys()
+        .map(|m| m.0)
+        .collect();
+    dispatch(
+        plane,
+        LoadComponent::NAME,
+        &LoadComponent {
+            wasm: wat::parse_str(WAT).expect("compile WAT"),
+            kinds: vec![],
+            name: Some(name.into()),
+        },
+    );
+    let after: std::collections::HashSet<u32> = plane
+        .components
+        .read()
+        .unwrap()
+        .keys()
+        .map(|m| m.0)
+        .collect();
+    *after
+        .difference(&before)
+        .next()
+        .expect("load inserted a new component")
+}
+
+fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
+    dispatch(
+        plane,
+        SubscribeInput::NAME,
+        &SubscribeInput { stream, mailbox },
+    );
+}
+
+fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
+    dispatch(
+        plane,
+        UnsubscribeInput::NAME,
+        &UnsubscribeInput { stream, mailbox },
+    );
+}
+
+fn drop_component(plane: &ControlPlane, mailbox_id: u32) {
+    dispatch(plane, DropComponent::NAME, &DropComponent { mailbox_id });
+}
+
+/// Publish one Tick exactly as `App::window_event` does: snapshot the
+/// subscriber set, push one mail per subscriber, block until the
+/// scheduler drains.
+fn publish_tick(h: &Harness) {
+    for mbox in subscribers_for(&h.input_subscribers, InputStream::Tick) {
+        h.queue.push(Mail::new(mbox, h.kind_tick, vec![], 1));
+    }
+    h.queue.wait_idle();
+}
+
+#[test]
+fn empty_subscribers_means_no_delivery() {
+    let h = make_harness();
+    publish_tick(&h);
+    publish_tick(&h);
+    assert_eq!(h.counter.load(Ordering::SeqCst), 0);
+    assert!(subscribers_for(&h.input_subscribers, InputStream::Tick).is_empty());
+}
+
+#[test]
+fn subscribed_component_receives_published_ticks() {
+    let h = make_harness();
+    let id = load_wat(&h.plane, "listener");
+    subscribe(&h.plane, InputStream::Tick, id);
+    assert_eq!(
+        subscribers_for(&h.input_subscribers, InputStream::Tick),
+        vec![MailboxId(id)]
+    );
+    for _ in 0..3 {
+        publish_tick(&h);
+    }
+    assert_eq!(h.counter.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn two_subscribers_each_receive_every_tick() {
+    let h = make_harness();
+    let a = load_wat(&h.plane, "a");
+    let b = load_wat(&h.plane, "b");
+    subscribe(&h.plane, InputStream::Tick, a);
+    subscribe(&h.plane, InputStream::Tick, b);
+    publish_tick(&h);
+    publish_tick(&h);
+    // 2 subscribers × 2 ticks = 4 deliveries.
+    assert_eq!(h.counter.load(Ordering::SeqCst), 4);
+}
+
+#[test]
+fn unsubscribe_stops_delivery() {
+    let h = make_harness();
+    let id = load_wat(&h.plane, "listener");
+    subscribe(&h.plane, InputStream::Tick, id);
+    publish_tick(&h);
+    assert_eq!(h.counter.load(Ordering::SeqCst), 1);
+
+    unsubscribe(&h.plane, InputStream::Tick, id);
+    publish_tick(&h);
+    publish_tick(&h);
+    assert_eq!(h.counter.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn drop_clears_subscriptions() {
+    let h = make_harness();
+    let id = load_wat(&h.plane, "victim");
+    subscribe(&h.plane, InputStream::Tick, id);
+    publish_tick(&h);
+    assert_eq!(h.counter.load(Ordering::SeqCst), 1);
+
+    drop_component(&h.plane, id);
+    assert!(subscribers_for(&h.input_subscribers, InputStream::Tick).is_empty());
+    publish_tick(&h);
+    publish_tick(&h);
+    assert_eq!(h.counter.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary

- New `input_logger` example component (wasm32 cdylib): resolves all four substrate input kinds (Tick / Key / MouseMove / MouseButton) and broadcasts a `demo.input_observed { stream, code }` to `hub.claude.broadcast` per event. An agent loads it, sends `subscribe_input` for whichever streams they want, and watches the dispatch land via `receive_mail`.
- New host-side integration test `tests/input_subscriptions.rs`: stands up the full Registry + Scheduler + ControlPlane stack with a shared `InputSubscribers`, loads a WAT guest, drives subscribe / unsubscribe / drop through the public sink-handler surface, and publishes ticks via the same `subscribers_for` helper `App::window_event` uses. Five tests cover empty-set drop, single-subscriber delivery, two-subscriber fan-out, unsubscribe-stops-delivery, drop-clears-subscriptions.
- `#[derive(Clone)]` on `ControlPlane` so the test harness can hand a fresh sink handler per dispatch (`into_sink_handler` consumes its receiver). Cheap — every field is an `Arc`. Production wires exactly one plane and never clones.

## Test plan

- [x] `cargo test --workspace` (existing 76 control-plane unit tests + 5 new integration tests, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo build --example input_logger -p aether-hello-component --target wasm32-unknown-unknown --release` (18 KB cdylib, well under the 1 MiB frame cap)
- [x] Manual: spawn substrate, load `input_logger.wasm`, subscribe Tick + Key, observe `demo.input_observed` mail on `receive_mail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)