### PR TITLE
feat(hub): symmetric receive_mail decode (ADR-0020)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Claude drives a running engine through MCP — the concrete form of the "Claude-
 - `mcp__aether-hub__list_engines` — connected engines (UUID + name/pid/version + `spawned` flag: `true` if the hub launched the process, `false` if it connected externally).
 - `mcp__aether-hub__describe_kinds(engine_id)` — the kind vocabulary the engine declared at handshake, with enough structural detail to build params.
 - `mcp__aether-hub__send_mail(mails)` — batched, best-effort. Each item takes either `params` (hub encodes via the kind's descriptor) or `payload_bytes` (raw escape hatch for `Opaque` kinds). Response is a per-item status array; one failure doesn't abort siblings.
-- `mcp__aether-hub__receive_mail(max?)` — non-blocking drain of observation mail the engine pushed to this session. Each item carries `engine_id`, `kind_name`, `payload_bytes`, and a `broadcast` flag (`true` means fan-out to every attached session, `false` means targeted reply-to-sender).
+- `mcp__aether-hub__receive_mail(max?)` — non-blocking drain of observation mail the engine pushed to this session. Each item carries `engine_id`, `kind_name`, structured `params` (decoded against the engine's kind descriptor — symmetric to `send_mail`, ADR-0020), `payload_bytes` (always populated; primarily a fallback when `params` is null), an optional `decode_error` populated when decode failed, and a `broadcast` flag (`true` means fan-out to every attached session, `false` means targeted reply-to-sender). Read `params` first; fall back to `payload_bytes` only if it's null.
 - `mcp__aether-hub__spawn_substrate(binary_path, args?, env?, timeout_ms?)` — launches a substrate binary as a child of the hub with `AETHER_HUB_URL` injected. Blocks until `Hello` handshake; returns `engine_id` + `pid`. The hub owns the child for its lifetime.
 - `mcp__aether-hub__terminate_substrate(engine_id, grace_ms?)` — SIGTERM → grace (default 2s) → SIGKILL. Errors on externally connected engines (the hub only terminates children it owns).
 
@@ -33,7 +33,7 @@ The observation path (ADR-0008) goes the other way: engines emit to the well-kno
 
 Input streams (tick, key, mouse_move, mouse_button) are publish/subscribe (ADR-0021): the substrate boots with empty subscriber sets and drops every input event until something subscribes. To wire a freshly-loaded component into the platform's event stream, mail `aether.control.subscribe_input` with `{ "stream": "Tick" | "Key" | "MouseMove" | "MouseButton", "mailbox": <id from load_result> }`. Multiple components may subscribe to the same stream; the substrate fans out to every subscriber. `aether.control.unsubscribe_input` removes one. Both reply via `aether.control.subscribe_input_result`. Subscriptions are auto-cleared when a component is dropped and preserved across `replace_component` (the mailbox id is stable).
 
-Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), and ADR-0021 (input stream subscriptions).
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), and ADR-0021 (input stream subscriptions).
 
 ## Commands
 

--- a/crates/aether-hub/src/decoder.rs
+++ b/crates/aether-hub/src/decoder.rs
@@ -128,8 +128,6 @@ fn decode_value(
     }
 }
 
-// ---- cast-shaped path ------------------------------------------------
-
 fn decode_cast_struct(
     cur: &mut Cursor<'_>,
     fields: &[NamedField],
@@ -240,8 +238,6 @@ fn align_of_primitive(p: Primitive) -> usize {
         Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
     }
 }
-
-// ---- postcard path ---------------------------------------------------
 
 fn decode_postcard(
     cur: &mut Cursor<'_>,
@@ -424,8 +420,6 @@ fn decode_enum_body(
     }
 }
 
-// ---- varint / zigzag -------------------------------------------------
-
 /// Postcard 1.x varint: 7 bits per byte, MSB set means continue. Cap at
 /// 10 bytes — anything longer is overflow for u64.
 fn read_varint_u64(cur: &mut Cursor<'_>, path: &str) -> Result<u64, DecodeError> {
@@ -445,8 +439,6 @@ fn read_varint_u64(cur: &mut Cursor<'_>, path: &str) -> Result<u64, DecodeError>
 fn unzigzag(n: u64) -> i64 {
     ((n >> 1) as i64) ^ -((n & 1) as i64)
 }
-
-// ---- helpers ---------------------------------------------------------
 
 /// JSON numbers can't represent NaN/infinity. The encoder accepts
 /// arbitrary `f64`s; on decode we coerce non-finite to `null` so the

--- a/crates/aether-hub/src/decoder.rs
+++ b/crates/aether-hub/src/decoder.rs
@@ -1,0 +1,860 @@
+// `decode_schema`: wire bytes + `SchemaType` descriptor → serde_json
+// value the agent can read directly. Mirror of `encoder::encode_schema`
+// — same two paths, picked the same way:
+//
+// 1. Cast-shaped (`Struct { repr_c: true }` and the recursive tree
+//    under it): walk `#[repr(C)]` byte layout, lift each scalar / fixed
+//    array into JSON. Encoder pads to alignment between fields and
+//    rounds total size to the largest field alignment; the decoder does
+//    the same skips.
+//
+// 2. Postcard (everything else): consume the postcard 1.x wire format
+//    directly — varints, zigzag, length-prefixed strings/vecs/bytes,
+//    externally-tagged enums.
+//
+// We decode the bytes directly rather than going through serde's
+// deserializer because the descriptor is structural (not a typed
+// schema), and the encoder writes bytes directly for the same reason.
+// Round-trip tests against the encoder pin the wire format from both
+// sides.
+
+use std::fmt;
+
+use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaType};
+use serde_json::{Map, Value};
+
+#[derive(Debug)]
+pub enum DecodeError {
+    Truncated {
+        path: String,
+        needed: usize,
+        had: usize,
+    },
+    TrailingBytes {
+        path: String,
+        remaining: usize,
+    },
+    InvalidBool {
+        path: String,
+        byte: u8,
+    },
+    InvalidUtf8 {
+        path: String,
+    },
+    VarintOverflow {
+        path: String,
+    },
+    UnknownEnumDiscriminant {
+        path: String,
+        discriminant: u32,
+    },
+    /// Schema arm the hub decoder can't handle in this position. Mirror
+    /// of the encoder's same variant — fires for non-cast leaf types
+    /// inside a cast-shaped parent.
+    UnsupportedSchema(&'static str),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::Truncated { path, needed, had } => {
+                write!(f, "truncated at {path}: needed {needed} bytes, had {had}")
+            }
+            DecodeError::TrailingBytes { path, remaining } => write!(
+                f,
+                "trailing bytes after decoding {path}: {remaining} unread"
+            ),
+            DecodeError::InvalidBool { path, byte } => {
+                write!(f, "invalid bool at {path}: 0x{byte:02x} not 0 or 1")
+            }
+            DecodeError::InvalidUtf8 { path } => write!(f, "invalid utf-8 in string at {path}"),
+            DecodeError::VarintOverflow { path } => {
+                write!(f, "varint at {path} exceeds 10 bytes (overflow)")
+            }
+            DecodeError::UnknownEnumDiscriminant { path, discriminant } => write!(
+                f,
+                "enum at {path} has no variant for discriminant {discriminant}"
+            ),
+            DecodeError::UnsupportedSchema(shape) => {
+                write!(f, "schema arm not supported by hub decoder: {shape}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+/// ADR-0020: decode `bytes` against a `SchemaType` descriptor into a
+/// JSON value symmetric to what `encode_schema` would accept.
+/// Dispatches on the schema's wire shape (same split as the encoder):
+///
+/// - `Unit` → `null` (empty payload).
+/// - `Struct { repr_c: true }` (and the recursive cast-shaped tree
+///   under it) → walk the `#[repr(C)]` byte layout.
+/// - Everything else → consume postcard 1.x wire format.
+///
+/// Trailing bytes are an error (the encoder writes exactly the right
+/// number of bytes; extras mean schema/payload drift the agent should
+/// see).
+pub fn decode_schema(bytes: &[u8], schema: &SchemaType) -> Result<Value, DecodeError> {
+    let mut cur = Cursor::new(bytes);
+    let value = decode_value(&mut cur, schema, "$")?;
+    if cur.remaining() != 0 {
+        return Err(DecodeError::TrailingBytes {
+            path: "$".into(),
+            remaining: cur.remaining(),
+        });
+    }
+    Ok(value)
+}
+
+fn decode_value(
+    cur: &mut Cursor<'_>,
+    schema: &SchemaType,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    match schema {
+        SchemaType::Unit => Ok(Value::Null),
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => {
+            let obj = decode_cast_struct(cur, fields, path)?;
+            let max_align = struct_alignment(fields)?;
+            cur.skip_pad_to(max_align);
+            Ok(Value::Object(obj))
+        }
+        _ => decode_postcard(cur, schema, path),
+    }
+}
+
+// ---- cast-shaped path ------------------------------------------------
+
+fn decode_cast_struct(
+    cur: &mut Cursor<'_>,
+    fields: &[NamedField],
+    path: &str,
+) -> Result<Map<String, Value>, DecodeError> {
+    let mut out = Map::with_capacity(fields.len());
+    for field in fields {
+        let field_path = format!("{path}.{}", field.name);
+        let value = decode_cast_field(cur, &field.ty, &field_path)?;
+        out.insert(field.name.clone(), value);
+    }
+    Ok(out)
+}
+
+fn decode_cast_field(
+    cur: &mut Cursor<'_>,
+    ty: &SchemaType,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    match ty {
+        SchemaType::Scalar(p) => {
+            let a = align_of_primitive(*p);
+            cur.skip_pad_to(a);
+            read_primitive_cast(cur, *p, path)
+        }
+        SchemaType::Array { element, len } => {
+            let elem_align = alignment_of_schema(element)?;
+            cur.skip_pad_to(elem_align);
+            let mut arr = Vec::with_capacity(*len as usize);
+            for i in 0..*len {
+                let elem_path = format!("{path}[{i}]");
+                arr.push(decode_cast_field(cur, element, &elem_path)?);
+            }
+            Ok(Value::Array(arr))
+        }
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => {
+            let nested_align = alignment_of_schema(ty)?;
+            cur.skip_pad_to(nested_align);
+            let obj = decode_cast_struct(cur, fields, path)?;
+            let inner_max = struct_alignment(fields)?;
+            cur.skip_pad_to(inner_max);
+            Ok(Value::Object(obj))
+        }
+        SchemaType::Struct { repr_c: false, .. } => Err(DecodeError::UnsupportedSchema(
+            "Struct { repr_c: false } in cast-shaped parent",
+        )),
+        SchemaType::Bool
+        | SchemaType::String
+        | SchemaType::Bytes
+        | SchemaType::Option(_)
+        | SchemaType::Vec(_)
+        | SchemaType::Enum { .. }
+        | SchemaType::Unit => Err(DecodeError::UnsupportedSchema(
+            "non-cast field inside cast-shaped struct",
+        )),
+    }
+}
+
+fn read_primitive_cast(
+    cur: &mut Cursor<'_>,
+    p: Primitive,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    match p {
+        Primitive::U8 => Ok(Value::from(u8::from_le_bytes(cur.take::<1>(path)?))),
+        Primitive::U16 => Ok(Value::from(u16::from_le_bytes(cur.take::<2>(path)?))),
+        Primitive::U32 => Ok(Value::from(u32::from_le_bytes(cur.take::<4>(path)?))),
+        Primitive::U64 => Ok(Value::from(u64::from_le_bytes(cur.take::<8>(path)?))),
+        Primitive::I8 => Ok(Value::from(i8::from_le_bytes(cur.take::<1>(path)?))),
+        Primitive::I16 => Ok(Value::from(i16::from_le_bytes(cur.take::<2>(path)?))),
+        Primitive::I32 => Ok(Value::from(i32::from_le_bytes(cur.take::<4>(path)?))),
+        Primitive::I64 => Ok(Value::from(i64::from_le_bytes(cur.take::<8>(path)?))),
+        Primitive::F32 => Ok(json_f64(f32::from_le_bytes(cur.take::<4>(path)?) as f64)),
+        Primitive::F64 => Ok(json_f64(f64::from_le_bytes(cur.take::<8>(path)?))),
+    }
+}
+
+fn struct_alignment(fields: &[NamedField]) -> Result<usize, DecodeError> {
+    let mut a = 1usize;
+    for f in fields {
+        a = a.max(alignment_of_schema(&f.ty)?);
+    }
+    Ok(a)
+}
+
+fn alignment_of_schema(ty: &SchemaType) -> Result<usize, DecodeError> {
+    match ty {
+        SchemaType::Scalar(p) => Ok(align_of_primitive(*p)),
+        SchemaType::Array { element, .. } => alignment_of_schema(element),
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        } => struct_alignment(fields),
+        _ => Err(DecodeError::UnsupportedSchema(
+            "alignment query on non-cast schema",
+        )),
+    }
+}
+
+fn align_of_primitive(p: Primitive) -> usize {
+    match p {
+        Primitive::U8 | Primitive::I8 => 1,
+        Primitive::U16 | Primitive::I16 => 2,
+        Primitive::U32 | Primitive::I32 | Primitive::F32 => 4,
+        Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
+    }
+}
+
+// ---- postcard path ---------------------------------------------------
+
+fn decode_postcard(
+    cur: &mut Cursor<'_>,
+    schema: &SchemaType,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    match schema {
+        SchemaType::Unit => Ok(Value::Null),
+        SchemaType::Bool => {
+            let [b] = cur.take::<1>(path)?;
+            match b {
+                0 => Ok(Value::Bool(false)),
+                1 => Ok(Value::Bool(true)),
+                _ => Err(DecodeError::InvalidBool {
+                    path: path.into(),
+                    byte: b,
+                }),
+            }
+        }
+        SchemaType::Scalar(p) => read_primitive_postcard(cur, *p, path),
+        SchemaType::String => {
+            let len = read_varint_u64(cur, path)? as usize;
+            let bytes = cur.take_slice(len, path)?;
+            let s = std::str::from_utf8(bytes)
+                .map_err(|_| DecodeError::InvalidUtf8 { path: path.into() })?;
+            Ok(Value::String(s.into()))
+        }
+        SchemaType::Bytes => {
+            let len = read_varint_u64(cur, path)? as usize;
+            let bytes = cur.take_slice(len, path)?;
+            // Mirror encoder input shape: array of byte values.
+            let arr = bytes.iter().map(|b| Value::from(*b)).collect();
+            Ok(Value::Array(arr))
+        }
+        SchemaType::Option(inner) => {
+            let [tag] = cur.take::<1>(path)?;
+            match tag {
+                0 => Ok(Value::Null),
+                1 => decode_postcard(cur, inner, path),
+                _ => Err(DecodeError::InvalidBool {
+                    path: path.into(),
+                    byte: tag,
+                }),
+            }
+        }
+        SchemaType::Vec(inner) => {
+            let len = read_varint_u64(cur, path)? as usize;
+            let mut arr = Vec::with_capacity(len);
+            for i in 0..len {
+                let elem_path = format!("{path}[{i}]");
+                arr.push(decode_postcard(cur, inner, &elem_path)?);
+            }
+            Ok(Value::Array(arr))
+        }
+        SchemaType::Array { element, len } => {
+            let mut arr = Vec::with_capacity(*len as usize);
+            for i in 0..*len {
+                let elem_path = format!("{path}[{i}]");
+                arr.push(decode_postcard(cur, element, &elem_path)?);
+            }
+            Ok(Value::Array(arr))
+        }
+        SchemaType::Struct { fields, .. } => {
+            // Postcard struct: concatenated field bytes in declaration
+            // order.
+            let mut obj = Map::with_capacity(fields.len());
+            for field in fields {
+                let field_path = format!("{path}.{}", field.name);
+                let value = decode_postcard(cur, &field.ty, &field_path)?;
+                obj.insert(field.name.clone(), value);
+            }
+            Ok(Value::Object(obj))
+        }
+        SchemaType::Enum { variants } => {
+            let disc = read_varint_u64(cur, path)? as u32;
+            let variant = variants
+                .iter()
+                .find(|v| variant_discriminant(v) == disc)
+                .ok_or_else(|| DecodeError::UnknownEnumDiscriminant {
+                    path: path.into(),
+                    discriminant: disc,
+                })?;
+            decode_enum_body(cur, variant, path)
+        }
+    }
+}
+
+fn read_primitive_postcard(
+    cur: &mut Cursor<'_>,
+    p: Primitive,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    match p {
+        Primitive::U8 => Ok(Value::from(cur.take::<1>(path)?[0])),
+        Primitive::U16 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(n as u16))
+        }
+        Primitive::U32 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(n as u32))
+        }
+        Primitive::U64 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(n))
+        }
+        Primitive::I8 => Ok(Value::from(cur.take::<1>(path)?[0] as i8)),
+        Primitive::I16 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(unzigzag(n) as i16))
+        }
+        Primitive::I32 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(unzigzag(n) as i32))
+        }
+        Primitive::I64 => {
+            let n = read_varint_u64(cur, path)?;
+            Ok(Value::from(unzigzag(n)))
+        }
+        Primitive::F32 => Ok(json_f64(f32::from_le_bytes(cur.take::<4>(path)?) as f64)),
+        Primitive::F64 => Ok(json_f64(f64::from_le_bytes(cur.take::<8>(path)?))),
+    }
+}
+
+fn variant_discriminant(v: &EnumVariant) -> u32 {
+    match v {
+        EnumVariant::Unit { discriminant, .. }
+        | EnumVariant::Tuple { discriminant, .. }
+        | EnumVariant::Struct { discriminant, .. } => *discriminant,
+    }
+}
+
+fn variant_name(v: &EnumVariant) -> &str {
+    match v {
+        EnumVariant::Unit { name, .. }
+        | EnumVariant::Tuple { name, .. }
+        | EnumVariant::Struct { name, .. } => name.as_str(),
+    }
+}
+
+fn decode_enum_body(
+    cur: &mut Cursor<'_>,
+    variant: &EnumVariant,
+    path: &str,
+) -> Result<Value, DecodeError> {
+    let name = variant_name(variant).to_owned();
+    match variant {
+        EnumVariant::Unit { .. } => {
+            // Unit variant: bare-string tag, no body. Symmetric to the
+            // encoder accepting `"Variant"`.
+            Ok(Value::String(name))
+        }
+        EnumVariant::Tuple { fields, .. } => {
+            let body = if fields.len() == 1 {
+                let nested_path = format!("{path}::{name}.0");
+                decode_postcard(cur, &fields[0], &nested_path)?
+            } else {
+                let mut arr = Vec::with_capacity(fields.len());
+                for (i, ty) in fields.iter().enumerate() {
+                    let nested = format!("{path}::{name}.{i}");
+                    arr.push(decode_postcard(cur, ty, &nested)?);
+                }
+                Value::Array(arr)
+            };
+            let mut obj = Map::with_capacity(1);
+            obj.insert(name, body);
+            Ok(Value::Object(obj))
+        }
+        EnumVariant::Struct { fields, .. } => {
+            let mut body = Map::with_capacity(fields.len());
+            for field in fields {
+                let nested = format!("{path}::{name}.{}", field.name);
+                let v = decode_postcard(cur, &field.ty, &nested)?;
+                body.insert(field.name.clone(), v);
+            }
+            let mut obj = Map::with_capacity(1);
+            obj.insert(name, Value::Object(body));
+            Ok(Value::Object(obj))
+        }
+    }
+}
+
+// ---- varint / zigzag -------------------------------------------------
+
+/// Postcard 1.x varint: 7 bits per byte, MSB set means continue. Cap at
+/// 10 bytes — anything longer is overflow for u64.
+fn read_varint_u64(cur: &mut Cursor<'_>, path: &str) -> Result<u64, DecodeError> {
+    let mut n: u64 = 0;
+    let mut shift = 0u32;
+    for _ in 0..10 {
+        let [b] = cur.take::<1>(path)?;
+        n |= ((b & 0x7f) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Ok(n);
+        }
+        shift += 7;
+    }
+    Err(DecodeError::VarintOverflow { path: path.into() })
+}
+
+fn unzigzag(n: u64) -> i64 {
+    ((n >> 1) as i64) ^ -((n & 1) as i64)
+}
+
+// ---- helpers ---------------------------------------------------------
+
+/// JSON numbers can't represent NaN/infinity. The encoder accepts
+/// arbitrary `f64`s; on decode we coerce non-finite to `null` so the
+/// JSON value remains valid. Round-trip semantics: finite floats round
+/// trip exactly; NaN/inf bytes decode to null (loud, not silent).
+fn json_f64(n: f64) -> Value {
+    serde_json::Number::from_f64(n)
+        .map(Value::Number)
+        .unwrap_or(Value::Null)
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn take<const N: usize>(&mut self, path: &str) -> Result<[u8; N], DecodeError> {
+        if self.remaining() < N {
+            return Err(DecodeError::Truncated {
+                path: path.into(),
+                needed: N,
+                had: self.remaining(),
+            });
+        }
+        let mut out = [0u8; N];
+        out.copy_from_slice(&self.bytes[self.pos..self.pos + N]);
+        self.pos += N;
+        Ok(out)
+    }
+
+    fn take_slice(&mut self, n: usize, path: &str) -> Result<&'a [u8], DecodeError> {
+        if self.remaining() < n {
+            return Err(DecodeError::Truncated {
+                path: path.into(),
+                needed: n,
+                had: self.remaining(),
+            });
+        }
+        let slice = &self.bytes[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    /// Advance past zero-padding so `pos` lands on a multiple of `align`.
+    /// Mirror of `encoder::pad_to`. Padding bytes are not validated as
+    /// zero — the encoder writes zeros, but a third-party encoder might
+    /// not, and the descriptor wins either way.
+    fn skip_pad_to(&mut self, align: usize) {
+        while !self.pos.is_multiple_of(align) && self.pos < self.bytes.len() {
+            self.pos += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder::encode_schema;
+    use serde_json::json;
+
+    fn scalar(name: &str, ty: Primitive) -> NamedField {
+        NamedField {
+            name: name.into(),
+            ty: SchemaType::Scalar(ty),
+        }
+    }
+
+    fn cast_struct(fields: Vec<NamedField>) -> SchemaType {
+        SchemaType::Struct {
+            fields,
+            repr_c: true,
+        }
+    }
+
+    fn pc_struct(fields: Vec<NamedField>) -> SchemaType {
+        SchemaType::Struct {
+            fields,
+            repr_c: false,
+        }
+    }
+
+    /// Encode → decode → assert equal. The single most load-bearing
+    /// invariant: every kind shape the encoder accepts, the decoder
+    /// inverts.
+    fn roundtrip(value: Value, schema: &SchemaType) {
+        let bytes = encode_schema(&value, schema)
+            .unwrap_or_else(|e| panic!("encode failed for {value:?}: {e}"));
+        let back = decode_schema(&bytes, schema)
+            .unwrap_or_else(|e| panic!("decode failed for {value:?}: {e}"));
+        assert_eq!(back, value, "round-trip mismatch for {value:?}");
+    }
+
+    #[test]
+    fn unit_decodes_null() {
+        let v = decode_schema(&[], &SchemaType::Unit).unwrap();
+        assert_eq!(v, Value::Null);
+    }
+
+    #[test]
+    fn unit_rejects_trailing_bytes() {
+        let err = decode_schema(&[1, 2, 3], &SchemaType::Unit).unwrap_err();
+        assert!(matches!(err, DecodeError::TrailingBytes { .. }));
+    }
+
+    // Cast-shaped path
+
+    #[test]
+    fn cast_single_u32() {
+        roundtrip(
+            json!({"code": 42u32}),
+            &cast_struct(vec![scalar("code", Primitive::U32)]),
+        );
+    }
+
+    #[test]
+    fn cast_two_f32_fields() {
+        roundtrip(
+            json!({"x": 1.5, "y": -3.25}),
+            &cast_struct(vec![
+                scalar("x", Primitive::F32),
+                scalar("y", Primitive::F32),
+            ]),
+        );
+    }
+
+    #[test]
+    fn cast_padding_between_u8_and_u32() {
+        roundtrip(
+            json!({"a": 7u8, "b": 0x0102_0304u32}),
+            &cast_struct(vec![
+                scalar("a", Primitive::U8),
+                scalar("b", Primitive::U32),
+            ]),
+        );
+    }
+
+    #[test]
+    fn cast_trailing_padding_for_u64_then_u8() {
+        // Encoder pads to 16 bytes; decoder must skip the trailing 7
+        // zeros before checking for trailing bytes.
+        roundtrip(
+            json!({"a": 1u64, "b": 2u8}),
+            &cast_struct(vec![
+                scalar("a", Primitive::U64),
+                scalar("b", Primitive::U8),
+            ]),
+        );
+    }
+
+    #[test]
+    fn cast_fixed_array_field() {
+        roundtrip(
+            json!({"xs": [1u8, 2, 3, 4]}),
+            &cast_struct(vec![NamedField {
+                name: "xs".into(),
+                ty: SchemaType::Array {
+                    element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                    len: 4,
+                },
+            }]),
+        );
+    }
+
+    #[test]
+    fn cast_signed_negative_roundtrip() {
+        roundtrip(
+            json!({"n": -1}),
+            &cast_struct(vec![scalar("n", Primitive::I32)]),
+        );
+    }
+
+    #[test]
+    fn cast_nested_struct_drawtriangle_layout() {
+        // Mirror of the encoder test by the same name. The DrawTriangle
+        // shape is the load-bearing cast-nested case in the codebase.
+        let vertex = SchemaType::Struct {
+            repr_c: true,
+            fields: vec![
+                scalar("x", Primitive::F32),
+                scalar("y", Primitive::F32),
+                scalar("r", Primitive::F32),
+                scalar("g", Primitive::F32),
+                scalar("b", Primitive::F32),
+            ],
+        };
+        let triangle = cast_struct(vec![NamedField {
+            name: "verts".into(),
+            ty: SchemaType::Array {
+                element: Box::new(vertex),
+                len: 3,
+            },
+        }]);
+        let v = json!({"x": 0.0, "y": 0.5, "r": 1.0, "g": 0.0, "b": 0.0});
+        roundtrip(json!({"verts": [v.clone(), v.clone(), v]}), &triangle);
+    }
+
+    #[test]
+    fn cast_truncated_payload_errors() {
+        // 4-byte u32 expected, only 2 bytes provided.
+        let schema = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let err = decode_schema(&[1, 2], &schema).unwrap_err();
+        assert!(matches!(err, DecodeError::Truncated { .. }));
+    }
+
+    // Postcard path — primitives
+
+    #[test]
+    fn postcard_bool_field() {
+        roundtrip(
+            json!({"flag": true}),
+            &pc_struct(vec![NamedField {
+                name: "flag".into(),
+                ty: SchemaType::Bool,
+            }]),
+        );
+        roundtrip(
+            json!({"flag": false}),
+            &pc_struct(vec![NamedField {
+                name: "flag".into(),
+                ty: SchemaType::Bool,
+            }]),
+        );
+    }
+
+    #[test]
+    fn postcard_invalid_bool_byte_errors() {
+        let schema = pc_struct(vec![NamedField {
+            name: "flag".into(),
+            ty: SchemaType::Bool,
+        }]);
+        let err = decode_schema(&[2], &schema).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidBool { .. }));
+    }
+
+    #[test]
+    fn postcard_string_field() {
+        roundtrip(
+            json!({"body": "hello world"}),
+            &pc_struct(vec![NamedField {
+                name: "body".into(),
+                ty: SchemaType::String,
+            }]),
+        );
+    }
+
+    #[test]
+    fn postcard_string_invalid_utf8_errors() {
+        let schema = pc_struct(vec![NamedField {
+            name: "body".into(),
+            ty: SchemaType::String,
+        }]);
+        // varint length 2, then two invalid utf-8 bytes.
+        let err = decode_schema(&[2, 0xff, 0xfe], &schema).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidUtf8 { .. }));
+    }
+
+    #[test]
+    fn postcard_bytes_field() {
+        roundtrip(
+            json!({"blob": [1u8, 2, 3, 4, 5]}),
+            &pc_struct(vec![NamedField {
+                name: "blob".into(),
+                ty: SchemaType::Bytes,
+            }]),
+        );
+    }
+
+    #[test]
+    fn postcard_option_some_and_none() {
+        let schema = pc_struct(vec![NamedField {
+            name: "name".into(),
+            ty: SchemaType::Option(Box::new(SchemaType::String)),
+        }]);
+        roundtrip(json!({"name": "Aether"}), &schema);
+        roundtrip(json!({"name": null}), &schema);
+    }
+
+    #[test]
+    fn postcard_vec_of_strings() {
+        let schema = pc_struct(vec![NamedField {
+            name: "tags".into(),
+            ty: SchemaType::Vec(Box::new(SchemaType::String)),
+        }]);
+        roundtrip(json!({"tags": ["alpha", "beta", "gamma"]}), &schema);
+    }
+
+    #[test]
+    fn postcard_vec_of_nested_structs() {
+        let inner = pc_struct(vec![scalar("seq", Primitive::U32)]);
+        let schema = pc_struct(vec![NamedField {
+            name: "items".into(),
+            ty: SchemaType::Vec(Box::new(inner)),
+        }]);
+        roundtrip(
+            json!({"items": [{"seq": 1u32}, {"seq": 256u32}, {"seq": 0xDEADu32}]}),
+            &schema,
+        );
+    }
+
+    fn sum_schema() -> SchemaType {
+        SchemaType::Enum {
+            variants: vec![
+                EnumVariant::Unit {
+                    name: "Pending".into(),
+                    discriminant: 0,
+                },
+                EnumVariant::Tuple {
+                    name: "Ok".into(),
+                    discriminant: 1,
+                    fields: vec![SchemaType::Scalar(Primitive::U64)],
+                },
+                EnumVariant::Struct {
+                    name: "Err".into(),
+                    discriminant: 2,
+                    fields: vec![NamedField {
+                        name: "reason".into(),
+                        ty: SchemaType::String,
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn postcard_enum_unit_variant_decodes_as_string_tag() {
+        roundtrip(json!("Pending"), &sum_schema());
+    }
+
+    #[test]
+    fn postcard_enum_tuple_single_field_decodes_unwrapped() {
+        // Encoder accepts both `{"Ok": 42}` and `{"Ok": [42]}` for
+        // single-field tuples; decoder normalizes to the unwrapped
+        // form so round-trip from `{"Ok": 42}` is byte-equal.
+        roundtrip(json!({"Ok": 42u64}), &sum_schema());
+    }
+
+    #[test]
+    fn postcard_enum_struct_variant() {
+        roundtrip(json!({"Err": {"reason": "kind conflict"}}), &sum_schema());
+    }
+
+    #[test]
+    fn postcard_enum_unknown_discriminant_errors() {
+        // discriminant 99 isn't in the schema.
+        let schema = sum_schema();
+        let err = decode_schema(&[99], &schema).unwrap_err();
+        assert!(matches!(err, DecodeError::UnknownEnumDiscriminant { .. }));
+    }
+
+    #[test]
+    fn varint_decodes_at_byte_boundaries() {
+        for n in [0u64, 127, 128, 16383, 16384, u32::MAX as u64, u64::MAX] {
+            let bytes = postcard::to_allocvec(&n).unwrap();
+            let mut cur = Cursor::new(&bytes);
+            let back = read_varint_u64(&mut cur, "$").unwrap();
+            assert_eq!(back, n, "varint decode mismatch for {n}");
+        }
+    }
+
+    #[test]
+    fn varint_overflow_errors() {
+        // 11 continuation bytes — exceeds u64.
+        let bytes = vec![0xff; 11];
+        let mut cur = Cursor::new(&bytes);
+        let err = read_varint_u64(&mut cur, "$").unwrap_err();
+        assert!(matches!(err, DecodeError::VarintOverflow { .. }));
+    }
+
+    #[test]
+    fn zigzag_decodes_to_signed() {
+        for n in [0i64, -1, 1, -128, 127, i32::MIN as i64, i32::MAX as i64] {
+            let bytes = postcard::to_allocvec(&n).unwrap();
+            let mut cur = Cursor::new(&bytes);
+            let raw = read_varint_u64(&mut cur, "$").unwrap();
+            assert_eq!(unzigzag(raw), n, "zigzag mismatch for {n}");
+        }
+    }
+
+    #[test]
+    fn nan_and_infinity_decode_to_null() {
+        // Encoder writes raw f64 bytes; decoder coerces non-finite to
+        // null so the JSON value is always valid.
+        let schema = pc_struct(vec![scalar("x", Primitive::F64)]);
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&f64::NAN.to_le_bytes());
+        let v = decode_schema(&bytes, &schema).unwrap();
+        assert_eq!(v, json!({"x": null}));
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&f64::INFINITY.to_le_bytes());
+        let v = decode_schema(&bytes, &schema).unwrap();
+        assert_eq!(v, json!({"x": null}));
+    }
+
+    #[test]
+    fn finite_f64_roundtrips_exactly() {
+        let schema = pc_struct(vec![scalar("x", Primitive::F64)]);
+        for n in [0.0, 1.5, -123.456, f64::MIN_POSITIVE, f64::MAX] {
+            roundtrip(json!({"x": n}), &schema);
+        }
+    }
+}

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 
 use tokio::net::TcpListener;
 
+mod decoder;
 mod encoder;
 mod engine;
 mod mcp;
@@ -14,6 +15,7 @@ mod registry;
 mod session;
 mod spawn;
 
+pub use decoder::{DecodeError, decode_schema};
 pub use encoder::{EncodeError, encode_schema};
 
 pub use engine::HEARTBEAT_INTERVAL;

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -29,6 +29,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc};
 
+use crate::decoder::decode_schema;
 use crate::encoder::encode_schema;
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
@@ -222,8 +223,21 @@ pub struct ReceivedMail {
     pub engine_id: String,
     /// Kind name the engine declared at handshake.
     pub kind_name: String,
-    /// Raw payload bytes. Decode against the engine's kind descriptor
-    /// (via `describe_kinds`) if you need structured fields.
+    /// Structured value decoded against the engine's kind descriptor —
+    /// the symmetric counterpart to `send_mail`'s `params` field
+    /// (ADR-0020). `null` if the hub couldn't decode (no descriptor for
+    /// this kind, or decode failed), in which case `decode_error` is
+    /// populated and the agent falls back to `payload_bytes`.
+    pub params: Option<serde_json::Value>,
+    /// Decode failure reason. Populated only when `params` is `null`
+    /// because the hub's decoder rejected the payload (e.g. schema
+    /// drift, truncation, unknown kind). Always paired with intact
+    /// `payload_bytes` for an escape-hatch decode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decode_error: Option<String>,
+    /// Raw payload bytes. Always populated. Prefer `params`; reach for
+    /// `payload_bytes` only when `params` is `null` (decode failed) or
+    /// when the agent genuinely needs the wire bytes.
     pub payload_bytes: Vec<u8>,
     /// `true` if this mail was addressed to every attached session;
     /// `false` if it was a reply targeted at this session specifically.
@@ -281,7 +295,7 @@ impl Hub {
     }
 
     #[tool(
-        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, the raw payload bytes, a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false), and an optional `origin` — the substrate-local mailbox name of the emitting component (absent for substrate-core pushes with no sending mailbox). Non-blocking: returns an empty array if nothing is queued."
+        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, structured `params` decoded against the engine's kind descriptor (ADR-0020 — symmetric to `send_mail`), the raw `payload_bytes` (always populated; primarily a fallback when `params` is null), an optional `decode_error` explaining why decode failed when `params` is null, a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false), and an optional `origin` — the substrate-local mailbox name of the emitting component (absent for substrate-core pushes with no sending mailbox). Non-blocking: returns an empty array if nothing is queued."
     )]
     async fn receive_mail(
         &self,
@@ -292,13 +306,19 @@ impl Hub {
         let mut out = Vec::new();
         while out.len() < cap {
             match rx.try_recv() {
-                Ok(m) => out.push(ReceivedMail {
-                    engine_id: m.engine_id.0.to_string(),
-                    kind_name: m.kind_name,
-                    payload_bytes: m.payload,
-                    broadcast: m.broadcast,
-                    origin: m.origin,
-                }),
+                Ok(m) => {
+                    let (params, decode_error) =
+                        decode_inbound(&m.engine_id, &m.kind_name, &m.payload, &self.state.engines);
+                    out.push(ReceivedMail {
+                        engine_id: m.engine_id.0.to_string(),
+                        kind_name: m.kind_name,
+                        params,
+                        decode_error,
+                        payload_bytes: m.payload,
+                        broadcast: m.broadcast,
+                        origin: m.origin,
+                    });
+                }
                 Err(_) => break,
             }
         }
@@ -477,6 +497,42 @@ fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, St
 
 fn find_kind<'a>(record: &'a EngineRecord, name: &str) -> Option<&'a KindDescriptor> {
     record.kinds.iter().find(|k| k.name == name)
+}
+
+/// Decode an inbound observation payload against the originating
+/// engine's kind descriptor (ADR-0020). Returns the structured `params`
+/// on success; on any failure (engine no longer in the registry, kind
+/// not declared, decode error) returns `(None, Some(reason))` so the
+/// agent sees both the bytes and a human-readable explanation. Lookup
+/// failures are treated as decode failures rather than tool errors —
+/// the rest of the batch should still drain.
+fn decode_inbound(
+    engine_id: &EngineId,
+    kind_name: &str,
+    payload: &[u8],
+    engines: &EngineRegistry,
+) -> (Option<serde_json::Value>, Option<String>) {
+    let Some(record) = engines.get(engine_id) else {
+        return (
+            None,
+            Some(format!(
+                "engine {} no longer connected; cannot resolve schema",
+                engine_id.0
+            )),
+        );
+    };
+    let Some(desc) = find_kind(&record, kind_name) else {
+        return (
+            None,
+            Some(format!(
+                "kind {kind_name:?} has no descriptor on this engine"
+            )),
+        );
+    };
+    match decode_schema(payload, &desc.schema) {
+        Ok(v) => (Some(v), None),
+        Err(e) => (None, Some(e.to_string())),
+    }
 }
 
 /// Bind an axum server on `addr` exposing the MCP tool surface at
@@ -899,6 +955,193 @@ mod tests {
         assert_eq!(second.len(), 2);
         let rest = drain(&hub, None).await;
         assert_eq!(rest.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn receive_mail_decodes_params_against_descriptor() {
+        // FrameStats-shaped: cast struct with two u64 fields. The
+        // engine ships raw cast bytes; the hub looks up the descriptor
+        // and lifts them into structured `params`.
+        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaType};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![KindDescriptor {
+            name: "aether.observation.frame_stats".into(),
+            schema: SchemaType::Struct {
+                repr_c: true,
+                fields: vec![
+                    NamedField {
+                        name: "frame".into(),
+                        ty: SchemaType::Scalar(Primitive::U64),
+                    },
+                    NamedField {
+                        name: "triangles".into(),
+                        ty: SchemaType::Scalar(Primitive::U64),
+                    },
+                ],
+            },
+        }];
+        let (rec, _rx) = record_with_kinds(33, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&120u64.to_le_bytes());
+        payload.extend_from_slice(&7u64.to_le_bytes());
+        push_queued(
+            &state.sessions,
+            token,
+            QueuedMail {
+                engine_id: id,
+                kind_name: "aether.observation.frame_stats".into(),
+                payload,
+                broadcast: true,
+                origin: None,
+            },
+        )
+        .await;
+
+        let got = drain(&hub, None).await;
+        assert_eq!(got.len(), 1);
+        let item = &got[0];
+        assert_eq!(
+            item.params,
+            Some(serde_json::json!({"frame": 120u64, "triangles": 7u64}))
+        );
+        assert!(item.decode_error.is_none());
+        // payload_bytes still populated alongside params (escape hatch).
+        assert_eq!(item.payload_bytes.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn receive_mail_decode_failure_populates_error() {
+        // Descriptor declares 8-byte u64; hub gets only 2 bytes.
+        // Decoder must surface a Truncated error in `decode_error` and
+        // leave `params` null without dropping the item.
+        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaType};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![KindDescriptor {
+            name: "demo.short".into(),
+            schema: SchemaType::Struct {
+                repr_c: true,
+                fields: vec![NamedField {
+                    name: "n".into(),
+                    ty: SchemaType::Scalar(Primitive::U64),
+                }],
+            },
+        }];
+        let (rec, _rx) = record_with_kinds(34, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        push_queued(
+            &state.sessions,
+            token,
+            QueuedMail {
+                engine_id: id,
+                kind_name: "demo.short".into(),
+                payload: vec![1, 2],
+                broadcast: false,
+                origin: None,
+            },
+        )
+        .await;
+
+        let got = drain(&hub, None).await;
+        assert_eq!(got.len(), 1);
+        let item = &got[0];
+        assert!(item.params.is_none());
+        let err = item
+            .decode_error
+            .as_deref()
+            .expect("decode error populated");
+        assert!(err.contains("truncated"), "got: {err}");
+        assert_eq!(item.payload_bytes, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn receive_mail_unknown_kind_falls_back_to_bytes() {
+        // Engine sent a kind it never declared at handshake (or the
+        // descriptor was lost). Decode reports the missing descriptor;
+        // bytes survive for the agent to inspect.
+        let engines = EngineRegistry::new();
+        let (rec, _rx) = record_with_kinds(35, vec![]);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        push_queued(
+            &state.sessions,
+            token,
+            QueuedMail {
+                engine_id: id,
+                kind_name: "demo.unknown".into(),
+                payload: vec![9, 9, 9],
+                broadcast: false,
+                origin: None,
+            },
+        )
+        .await;
+
+        let got = drain(&hub, None).await;
+        assert_eq!(got.len(), 1);
+        assert!(got[0].params.is_none());
+        let err = got[0].decode_error.as_deref().unwrap();
+        assert!(err.contains("no descriptor"), "got: {err}");
+        assert_eq!(got[0].payload_bytes, vec![9, 9, 9]);
+    }
+
+    #[tokio::test]
+    async fn receive_mail_unit_kind_decodes_to_null_params() {
+        use aether_hub_protocol::{KindDescriptor, SchemaType};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![KindDescriptor {
+            name: "aether.observation.ping".into(),
+            schema: SchemaType::Unit,
+        }];
+        let (rec, _rx) = record_with_kinds(36, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let token = hub.session.token;
+
+        push_queued(
+            &state.sessions,
+            token,
+            QueuedMail {
+                engine_id: id,
+                kind_name: "aether.observation.ping".into(),
+                payload: vec![],
+                broadcast: false,
+                origin: None,
+            },
+        )
+        .await;
+
+        // Read raw JSON rather than going through `drain` — `Option<Value>`
+        // collapses `Some(Null)` and `None` over deserialization, so the
+        // distinction between "decoded to null" and "no value" is only
+        // observable in the wire form. The MCP client sees the wire form.
+        let json = hub
+            .receive_mail(Parameters(ReceiveMailArgs { max: None }))
+            .await
+            .unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let item = &raw.as_array().unwrap()[0];
+        assert_eq!(item.get("params"), Some(&serde_json::Value::Null));
+        // decode_error skipped on success thanks to `skip_serializing_if`.
+        assert!(item.get("decode_error").is_none());
     }
 
     #[tokio::test]

--- a/docs/adr/0020-symmetric-receive-mail-decode.md
+++ b/docs/adr/0020-symmetric-receive-mail-decode.md
@@ -1,6 +1,6 @@
 # ADR-0020: Symmetric receive_mail decode
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-17
 
 ## Context


### PR DESCRIPTION
## Summary

- Add `decoder::decode_schema(bytes, &SchemaType) -> Result<Value, DecodeError>` mirroring `encoder::encode_schema` — same cast-shaped vs postcard split, same field-by-field walker, same error vocabulary.
- Wire it into the `receive_mail` MCP tool: each item gains a `params` field (decoded against the originating engine's `KindDescriptor`) and a `decode_error` field (populated on failure). `payload_bytes` is always populated and remains the escape hatch.
- Flip ADR-0020 from Proposed to Accepted.
- Update CLAUDE.md to document the new shape.

This closes the ADR-0019 ergonomics loop: send by params, receive by params. Reply-to-sender results (`load_result`, `subscribe_input_result`, etc.) and observation broadcasts (`frame_stats`) become first-class JSON.

## Test plan

- [x] 27 decoder unit tests (round-trip every kind shape against the encoder; cover all primitives, cast structs with padding/nested arrays, strings/bytes/options/vecs, all enum variant shapes, plus failure modes — truncation, invalid bool, invalid UTF-8, varint overflow, unknown enum discriminant)
- [x] 4 new mcp tests (cast-shaped decode, decode failure populates `decode_error`, unknown kind falls back to bytes, Unit kind decodes to `null` over the wire)
- [x] `cargo test` — 98 passing in aether-hub (was 90); zero regressions across the workspace
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [ ] End-to-end smoke against a live substrate (verify `frame_stats` and `subscribe_input_result` arrive with structured `params`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)