### PR TITLE
feat(substrate): drain in-flight mail before component swap (ADR-0022)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ The observation path (ADR-0008) goes the other way: engines emit to the well-kno
 
 Input streams (tick, key, mouse_move, mouse_button) are publish/subscribe (ADR-0021): the substrate boots with empty subscriber sets and drops every input event until something subscribes. To wire a freshly-loaded component into the platform's event stream, mail `aether.control.subscribe_input` with `{ "stream": "Tick" | "Key" | "MouseMove" | "MouseButton", "mailbox": <id from load_result> }`. Multiple components may subscribe to the same stream; the substrate fans out to every subscriber. `aether.control.unsubscribe_input` removes one. Both reply via `aether.control.subscribe_input_result`. Subscriptions are auto-cleared when a component is dropped and preserved across `replace_component` (the mailbox id is stable).
 
-Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), and ADR-0021 (input stream subscriptions).
+`aether.control.replace_component` is freeze-drain-swap (ADR-0022): the substrate freezes the target mailbox, waits for in-flight `deliver` calls on the old instance to complete, then swaps. If the drain exceeds `drain_timeout_ms` (default 5000, per-replace overridable) the reply is `Err { error: "drain timeout ..." }` and the old instance stays bound — a loud failure rather than silent dropped mail. Mail that arrives during the freeze is parked and flushed through whichever instance ends up bound (new on success, old on timeout).
+
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), ADR-0021 (input stream subscriptions), and ADR-0022 (drain-on-swap for replace_component).
 
 ## Commands
 

--- a/crates/aether-substrate-mail/src/lib.rs
+++ b/crates/aether-substrate-mail/src/lib.rs
@@ -191,9 +191,11 @@ mod control_plane {
     }
 
     /// `aether.control.replace_component` — atomically rebind a target
-    /// mailbox id to a freshly instantiated component. In-flight mail
-    /// queued on the old instance at the moment of swap is dropped
-    /// (V0 policy; drain is an additive follow-up). Reply:
+    /// mailbox id to a freshly instantiated component. ADR-0022: the
+    /// substrate freezes the target, drains in-flight mail through
+    /// the old instance, then swaps. If the drain exceeds
+    /// `drain_timeout_ms` (default 5000) the replace fails with
+    /// `ReplaceResult::Err` and the old instance stays bound. Reply:
     /// `ReplaceResult`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.replace_component")]
@@ -201,6 +203,7 @@ mod control_plane {
         pub mailbox_id: u32,
         pub wasm: Vec<u8>,
         pub kinds: Vec<LoadKind>,
+        pub drain_timeout_ms: Option<u32>,
     }
 
     /// Reply to `ReplaceComponent`. Same shape as `DropResult` —

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -24,7 +24,9 @@
 // that the agent cannot have caused — e.g. a poisoned lock.
 
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use aether_hub_protocol::{
     ClaudeAddress, EngineMailFrame, EngineToHub, KindDescriptor, NamedField, Primitive, SchemaType,
@@ -52,6 +54,56 @@ use crate::scheduler::ComponentTable;
 /// a component. Kept as a constant so substrate init, tests, and any
 /// future tooling share one spelling.
 pub const AETHER_CONTROL: &str = "aether.control";
+
+/// ADR-0022 default ceiling on the freeze-drain phase of
+/// `replace_component`. Per-replace overridable via
+/// `ReplaceComponent::drain_timeout_ms`.
+pub const DEFAULT_DRAIN_TIMEOUT_MS: u32 = 5_000;
+
+/// Spin-sleep cadence for `drain_pending`. Short enough that the
+/// usual sub-millisecond drain returns within a single sleep, long
+/// enough that the polling thread doesn't burn a core when a
+/// component has a slow `deliver`.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_micros(200);
+
+/// Block until the entry's `pending` count reaches zero or `timeout`
+/// elapses. Returns `true` if the drain completed, `false` on
+/// timeout. Polled rather than condvar-driven to keep
+/// `ComponentEntry` lock-free on the hot dispatch path.
+fn drain_pending(entry: &crate::scheduler::ComponentEntry, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if entry.pending.load(Ordering::Acquire) == 0 {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return entry.pending.load(Ordering::Acquire) == 0;
+        }
+        std::thread::sleep(DRAIN_POLL_INTERVAL);
+    }
+}
+
+/// Deliver every parked mail through `target`. The caller must hold
+/// the components-table write lock so workers can't dispatch
+/// concurrently to either `entry.component` or `target` — that's
+/// what makes the per-component serialization invariant hold across
+/// the flush. Parked mail was already counted off the shared
+/// queue's outstanding tally when it was parked (see
+/// `worker_loop`), so we don't touch it here.
+fn flush_parked_to(
+    entry: &crate::scheduler::ComponentEntry,
+    target: &Mutex<Component>,
+    _queue: &MailQueue,
+) {
+    let mut parked = entry.parked.lock().unwrap();
+    if parked.is_empty() {
+        return;
+    }
+    let mut comp = target.lock().unwrap();
+    while let Some(mail) = parked.pop_front() {
+        comp.deliver(&mail).expect("component.deliver failed");
+    }
+}
 
 /// Translate a `LoadKind` (the flat, agent-shippable descriptor) into
 /// the recursive `KindDescriptor` the registry stores. `Signal`
@@ -383,6 +435,9 @@ impl ControlPlane {
             }
         };
         let id = MailboxId(payload.mailbox_id);
+        let drain_timeout = Duration::from_millis(
+            payload.drain_timeout_ms.unwrap_or(DEFAULT_DRAIN_TIMEOUT_MS) as u64,
+        );
 
         // Target must be a live Component. Reject unknown ids, sinks,
         // and already-dropped mailboxes before touching wasmtime.
@@ -435,6 +490,41 @@ impl ControlPlane {
             }
         };
 
+        // ADR-0022 freeze-drain: clone the Arc out of the table under
+        // a brief read lock so we can flip `frozen` and poll `pending`
+        // without holding any table-level lock. New mail that arrives
+        // during the freeze parks on this entry's `parked` deque;
+        // workers finishing in-flight `deliver` calls drive `pending`
+        // to zero.
+        let old_entry = match self.components.read().unwrap().get(&id).map(Arc::clone) {
+            Some(e) => e,
+            None => {
+                // Registered as a Component above but no entry bound
+                // — happens if instantiation lost the race with a
+                // concurrent drop. Treat as a stale id.
+                return ReplaceResult::Err {
+                    error: format!("mailbox {:?} has no bound component", id),
+                };
+            }
+        };
+        old_entry.frozen.store(true, Ordering::Release);
+        if !drain_pending(&old_entry, drain_timeout) {
+            // Drain timeout: old instance stays bound. Unfreeze and
+            // flush parked through the old component so accumulated
+            // mail isn't dropped on the floor. Holding the write lock
+            // here keeps workers from racing on the parked flush.
+            let table = self.components.write().unwrap();
+            flush_parked_to(&old_entry, &old_entry.component, &self.queue);
+            old_entry.frozen.store(false, Ordering::Release);
+            drop(table);
+            return ReplaceResult::Err {
+                error: format!(
+                    "drain timeout after {}ms; old instance still bound",
+                    drain_timeout.as_millis()
+                ),
+            };
+        }
+
         // ADR-0015 §3 + ADR-0016 §4: hooks run on the old instance
         // under the write lock before instantiation. Take the lock
         // now, invoke hooks, extract any saved state, then keep the
@@ -443,19 +533,21 @@ impl ControlPlane {
         // fails, `on_drop` will have already fired on the old
         // instance even though it stays live.
         let mut table = self.components.write().unwrap();
-        let mut saved = None;
-        if let Some(cell) = table.get(&id) {
-            let mut old = cell.lock().unwrap();
-            old.on_replace();
-            // ADR-0016 §4 step 2: save failures abort the replace
-            // before `on_drop` fires, so the old instance is still
-            // fully alive. Check the error slot before continuing.
-            if let Some(err) = old.take_save_error() {
-                return ReplaceResult::Err { error: err };
-            }
-            saved = old.take_saved_state();
-            old.on_drop();
+        let mut old_component = old_entry.component.lock().unwrap();
+        old_component.on_replace();
+        // ADR-0016 §4 step 2: save failures abort the replace
+        // before `on_drop` fires, so the old instance is still
+        // fully alive. Check the error slot before continuing.
+        if let Some(err) = old_component.take_save_error() {
+            drop(old_component);
+            flush_parked_to(&old_entry, &old_entry.component, &self.queue);
+            old_entry.frozen.store(false, Ordering::Release);
+            drop(table);
+            return ReplaceResult::Err { error: err };
         }
+        let saved = old_component.take_saved_state();
+        old_component.on_drop();
+        drop(old_component);
 
         let ctx = SubstrateCtx::new(
             id,
@@ -470,7 +562,11 @@ impl ControlPlane {
                     // Registry is left as-is; any newly registered
                     // kinds stay. The old component is still bound
                     // (on_replace + on_drop already fired — see wart
-                    // above); the bundle is discarded.
+                    // above); the bundle is discarded. Parked mail
+                    // flushes through the still-bound old instance.
+                    flush_parked_to(&old_entry, &old_entry.component, &self.queue);
+                    old_entry.frozen.store(false, Ordering::Release);
+                    drop(table);
                     return ReplaceResult::Err {
                         error: format!("wasm instantiation failed: {e}"),
                     };
@@ -485,37 +581,41 @@ impl ControlPlane {
         if let Some(bundle) = saved
             && let Err(e) = new_component.call_on_rehydrate(&bundle)
         {
+            flush_parked_to(&old_entry, &old_entry.component, &self.queue);
+            old_entry.frozen.store(false, Ordering::Release);
+            drop(table);
             return ReplaceResult::Err {
                 error: format!("on_rehydrate failed: {e}"),
             };
         }
 
-        // Atomic swap in-place under the already-held write lock.
-        // The returned old Component drops at end of scope; wasmtime
-        // reclaims linear memory + Store.
-        let _old = table
-            .remove(&id)
-            .map(|m| m.into_inner().expect("component mutex poisoned"));
-        table.insert(id, std::sync::Mutex::new(new_component));
+        // Build the new entry. Frozen defaults to false so workers
+        // dispatch normally as soon as the table swap is visible.
+        let new_entry = Arc::new(crate::scheduler::ComponentEntry::new(new_component));
+        // ADR-0022 §3: parked mail collected during the freeze flushes
+        // to the new instance before the table flips, so it's
+        // delivered before any post-swap mail and the agent's
+        // happens-before edge holds.
+        flush_parked_to(&old_entry, &new_entry.component, &self.queue);
+        table.insert(id, Arc::clone(&new_entry));
         drop(table);
+        // The old `Arc<ComponentEntry>` (and its wasmtime instance)
+        // drops when `old_entry` falls out of scope at function exit.
 
         self.announce_kinds();
         ReplaceResult::Ok
     }
 
     fn insert_component(&self, id: MailboxId, component: Component) {
-        self.components
-            .write()
-            .unwrap()
-            .insert(id, std::sync::Mutex::new(component));
+        self.components.write().unwrap().insert(
+            id,
+            Arc::new(crate::scheduler::ComponentEntry::new(component)),
+        );
     }
 
     fn remove_component(&self, id: MailboxId) -> Option<Component> {
-        self.components
-            .write()
-            .unwrap()
-            .remove(&id)
-            .map(|m| m.into_inner().expect("component mutex poisoned"))
+        let entry = self.components.write().unwrap().remove(&id)?;
+        Some(crate::scheduler::extract_component(entry))
     }
 
     /// Ship the complete current kind vocabulary to the hub so its
@@ -557,7 +657,9 @@ impl ControlPlane {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mail::Mail;
     use aether_hub_protocol::SessionToken;
+    use std::sync::atomic::AtomicU32;
 
     #[test]
     fn load_payload_roundtrip() {
@@ -910,6 +1012,7 @@ mod tests {
                 mailbox_id,
                 wasm,
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -937,6 +1040,7 @@ mod tests {
                 mailbox_id: 99,
                 wasm,
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -963,6 +1067,7 @@ mod tests {
                 mailbox_id,
                 wasm,
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -988,6 +1093,7 @@ mod tests {
                 mailbox_id,
                 wasm: vec![0, 1, 2, 3],
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1066,6 +1172,7 @@ mod tests {
                 mailbox_id,
                 wasm: wasm_new,
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1102,6 +1209,7 @@ mod tests {
                 mailbox_id,
                 wasm: wat::parse_str(WAT_REHYDRATES).unwrap(),
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1112,7 +1220,7 @@ mod tests {
         // offset 400.
         let table = plane.components.read().unwrap();
         let cell = table.get(&MailboxId(mailbox_id)).expect("present");
-        let mut new = cell.lock().unwrap();
+        let mut new = cell.component.lock().unwrap();
         assert_eq!(new.read_u32(396), 7);
         assert_eq!(new.read_bytes(400, 4), vec![0xDE, 0xAD, 0xBE, 0xEF],);
     }
@@ -1138,6 +1246,7 @@ mod tests {
                 mailbox_id,
                 wasm: wat::parse_str(WAT).unwrap(),
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1177,6 +1286,7 @@ mod tests {
                 mailbox_id,
                 wasm: wat::parse_str(WAT).unwrap(),
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1206,13 +1316,14 @@ mod tests {
                 mailbox_id,
                 wasm: wat::parse_str(WAT_REHYDRATES).unwrap(),
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
         assert!(matches!(result, ReplaceResult::Ok));
         let table = plane.components.read().unwrap();
         let cell = table.get(&MailboxId(mailbox_id)).expect("present");
-        let mut new = cell.lock().unwrap();
+        let mut new = cell.component.lock().unwrap();
         assert_eq!(new.read_u32(396), 0);
         assert_eq!(new.read_u32(400), 0);
     }
@@ -1411,6 +1522,7 @@ mod tests {
                 mailbox_id: id,
                 wasm: wat::parse_str(WAT).unwrap(),
                 kinds: vec![],
+                drain_timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1454,4 +1566,262 @@ mod tests {
         );
         assert!(!subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
     }
+
+    // ADR-0022 freeze-drain-swap. The first three tests poke
+    // `pending` / `parked` directly to exercise the drain and flush
+    // paths without spinning up a worker pool — the drain logic is
+    // expressed against the entry's atomics, so the entry is the
+    // right level to test it at.
+
+    #[test]
+    fn drain_pending_returns_true_when_count_drops_in_time() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "drainable");
+        let entry = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        entry.pending.store(2, Ordering::SeqCst);
+        let entry_for_drainer = Arc::clone(&entry);
+        let drainer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            entry_for_drainer.pending.store(0, Ordering::SeqCst);
+        });
+        assert!(super::drain_pending(&entry, Duration::from_millis(500)));
+        drainer.join().unwrap();
+    }
+
+    #[test]
+    fn replace_drain_timeout_keeps_old_bound() {
+        let plane = make_plane();
+        let id = load_blank(&plane, "victim");
+        let entry_before = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        // Pin pending above zero so drain never completes within the
+        // tight per-replace timeout.
+        entry_before.pending.store(1, Ordering::SeqCst);
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponent {
+                mailbox_id: id,
+                wasm: wat::parse_str(WAT).unwrap(),
+                kinds: vec![],
+                drain_timeout_ms: Some(20),
+            })
+            .unwrap(),
+        );
+        let ReplaceResult::Err { error } = result else {
+            panic!("expected timeout, got {result:?}");
+        };
+        assert!(
+            error.contains("drain timeout"),
+            "unexpected error message: {error}"
+        );
+
+        // Same Arc still bound — no swap happened.
+        let entry_after = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        assert!(Arc::ptr_eq(&entry_before, &entry_after));
+        // Frozen flag cleared so future mail flows through again.
+        assert!(!entry_after.frozen.load(Ordering::SeqCst));
+
+        // Reset pending so the entry drops cleanly when the table
+        // releases it (no real worker to decrement on our behalf).
+        entry_after.pending.store(0, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn replace_flushes_parked_mail_to_new_instance() {
+        // Old + new components both forward `receive` to a counter
+        // sink. After parking N mails on the entry and triggering a
+        // successful replace, the counter records exactly the parked
+        // ticks — proving the new instance is the one that handled
+        // them post-swap.
+        let plane = make_plane();
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_for_sink = Arc::clone(&counter);
+        let sink_id = plane.registry.register_sink(
+            "drain-flush-sink",
+            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+                counter_for_sink.fetch_add(count, Ordering::SeqCst);
+            }),
+        );
+
+        let LoadResult::Ok { mailbox_id: id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponent {
+                wasm: wat::parse_str(WAT_FORWARDS_TO_SINK).unwrap(),
+                kinds: vec![],
+                name: Some("flusher".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load failed");
+        };
+
+        let entry = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        // Park three mails directly on the entry. Real workers would
+        // do this when frozen=true; here we simulate the post-park
+        // state without standing up a worker pool. We do NOT touch
+        // queue.outstanding — these mails are off-queue from the
+        // pool's perspective.
+        entry.frozen.store(true, Ordering::SeqCst);
+        let kind_id = 0; // sink_id payload is unused; kind is irrelevant.
+        let _ = kind_id;
+        for n in 1..=3u32 {
+            entry.parked.lock().unwrap().push_back(Mail {
+                recipient: MailboxId(id),
+                kind: 0,
+                payload: vec![sink_id.0 as u8],
+                count: n,
+                sender: SessionToken::NIL,
+                from_component: None,
+            });
+        }
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponent {
+                mailbox_id: id,
+                wasm: wat::parse_str(WAT_FORWARDS_TO_SINK).unwrap(),
+                kinds: vec![],
+                drain_timeout_ms: Some(500),
+            })
+            .unwrap(),
+        );
+        assert!(matches!(result, ReplaceResult::Ok), "got {result:?}");
+
+        // Three parked ticks (counts 1, 2, 3) flushed to the new
+        // instance, which forwarded each to the sink.
+        assert_eq!(counter.load(Ordering::SeqCst), 1 + 2 + 3);
+
+        // New entry is bound now, parked is empty, frozen cleared.
+        let entry_after = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        assert!(!Arc::ptr_eq(&entry, &entry_after));
+        assert!(entry_after.parked.lock().unwrap().is_empty());
+        assert!(!entry_after.frozen.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn replace_drain_timeout_flushes_parked_to_old() {
+        // Pending stays >0 (a forever in-flight deliver), so the
+        // replace times out. Parked mail must still be delivered —
+        // through the old instance, since the swap didn't happen.
+        let plane = make_plane();
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_for_sink = Arc::clone(&counter);
+        let sink_id = plane.registry.register_sink(
+            "drain-timeout-sink",
+            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+                counter_for_sink.fetch_add(count, Ordering::SeqCst);
+            }),
+        );
+
+        let LoadResult::Ok { mailbox_id: id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponent {
+                wasm: wat::parse_str(WAT_FORWARDS_TO_SINK).unwrap(),
+                kinds: vec![],
+                name: Some("survivor".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load failed");
+        };
+
+        let entry = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        entry.pending.store(1, Ordering::SeqCst);
+        entry.frozen.store(true, Ordering::SeqCst);
+        for n in 1..=2u32 {
+            entry.parked.lock().unwrap().push_back(Mail {
+                recipient: MailboxId(id),
+                kind: 0,
+                payload: vec![sink_id.0 as u8],
+                count: n,
+                sender: SessionToken::NIL,
+                from_component: None,
+            });
+        }
+
+        let result = plane.handle_replace(
+            &postcard::to_allocvec(&ReplaceComponent {
+                mailbox_id: id,
+                wasm: wat::parse_str(WAT_FORWARDS_TO_SINK).unwrap(),
+                kinds: vec![],
+                drain_timeout_ms: Some(20),
+            })
+            .unwrap(),
+        );
+        let ReplaceResult::Err { error } = result else {
+            panic!("expected timeout, got {result:?}");
+        };
+        assert!(error.contains("drain timeout"), "{error}");
+
+        // Old instance handled the parked counts (1 + 2 = 3).
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+
+        // Same entry still bound; parked empty, frozen cleared.
+        let entry_after = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(id))
+            .unwrap()
+            .clone();
+        assert!(Arc::ptr_eq(&entry, &entry_after));
+        assert!(entry_after.parked.lock().unwrap().is_empty());
+        assert!(!entry_after.frozen.load(Ordering::SeqCst));
+
+        // Reset for clean drop.
+        entry_after.pending.store(0, Ordering::SeqCst);
+    }
+
+    /// Component that, on each `receive`, forwards a `send_mail` to
+    /// the sink mailbox encoded in the first payload byte. Used by
+    /// the drain-flush tests so we can observe whether the new (or
+    /// old) instance handled each parked mail.
+    const WAT_FORWARDS_TO_SINK: &str = r#"
+        (module
+            (import "aether" "send_mail"
+                (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "receive")
+                (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+                (result i32)
+                (drop (call $send_mail
+                    (i32.load8_u (local.get $ptr))
+                    (i32.const 0)
+                    (i32.const 0)
+                    (i32.const 0)
+                    (local.get $count)))
+                i32.const 0))
+    "#;
 }

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -19,21 +19,55 @@
 // take the shared lock (one per dispatch); writes are rare and held
 // briefly (insert/remove). The per-component `Mutex` serialises
 // deliver calls for a single component as before.
+//
+// ADR-0022 layers freeze-drain semantics on top of the table:
+// `replace_component` flips a per-entry `frozen` flag so workers park
+// new mail on the entry instead of dispatching, then waits for the
+// per-entry `pending` count of in-flight `deliver` calls to reach
+// zero before swapping. The swap step (and the parked-mail flush) is
+// driven by `ControlPlane::handle_replace`; this module just owns
+// the per-entry state and the worker dispatch path that respects it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
 
 use crate::component::Component;
-use crate::mail::MailboxId;
+use crate::mail::{Mail, MailboxId};
 use crate::queue::MailQueue;
 use crate::registry::{MailboxEntry, Registry};
 
+/// Per-mailbox scheduler state. Beyond the wasmtime instance itself we
+/// track ADR-0022's freeze-drain bookkeeping: `pending` counts mail
+/// currently being delivered to this component, `frozen` halts dispatch
+/// for replace's quiescence window, and `parked` holds mail popped
+/// while frozen so it can be replayed against whichever component is
+/// bound after the swap (new instance on success, old on timeout).
+pub struct ComponentEntry {
+    pub component: Mutex<Component>,
+    pub pending: AtomicU32,
+    pub frozen: AtomicBool,
+    pub parked: Mutex<VecDeque<Mail>>,
+}
+
+impl ComponentEntry {
+    pub fn new(component: Component) -> Self {
+        Self {
+            component: Mutex::new(component),
+            pending: AtomicU32::new(0),
+            frozen: AtomicBool::new(false),
+            parked: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
 /// Shared, runtime-mutable table of bound components. Cloned into the
 /// scheduler's workers and into the ADR-0010 load handler so both read
-/// and write through the same `RwLock`. The inner `Mutex<Component>`
-/// still serialises deliver calls per-component.
-pub type ComponentTable = Arc<RwLock<HashMap<MailboxId, Mutex<Component>>>>;
+/// and write through the same `RwLock`. Values are `Arc`-shared so the
+/// freeze-drain path in `replace_component` can hold a long-lived
+/// reference to one entry without keeping the table read lock open.
+pub type ComponentTable = Arc<RwLock<HashMap<MailboxId, Arc<ComponentEntry>>>>;
 
 /// Owned by the scheduler, shared with every worker. Separate from the
 /// public `Scheduler` handle so workers can keep running even while the
@@ -64,7 +98,7 @@ impl Scheduler {
         let components: ComponentTable = Arc::new(RwLock::new(
             components
                 .into_iter()
-                .map(|(id, c)| (id, Mutex::new(c)))
+                .map(|(id, c)| (id, Arc::new(ComponentEntry::new(c))))
                 .collect(),
         ));
         let ctx = Arc::new(WorkerContext {
@@ -102,13 +136,13 @@ impl Scheduler {
     /// the load handler once instantiation succeeds and the mailbox
     /// id has been assigned. Silently replaces any existing component
     /// at `id` — replacement is an ADR-0010 primitive in its own
-    /// right, wired in a later PR.
+    /// right, handled by `ControlPlane::handle_replace` (ADR-0022).
     pub fn add_component(&self, id: MailboxId, component: Component) {
         self.ctx
             .components
             .write()
             .unwrap()
-            .insert(id, Mutex::new(component));
+            .insert(id, Arc::new(ComponentEntry::new(component)));
     }
 
     /// Remove and return the component bound to `id`, if any. The
@@ -122,24 +156,23 @@ impl Scheduler {
             .write()
             .unwrap()
             .remove(&id)
-            .map(|m| m.into_inner().expect("component mutex poisoned"))
+            .map(extract_component)
     }
+}
 
-    /// Atomically rebind `id` to a freshly instantiated component
-    /// (ADR-0010). Returns the old component so the caller can drop
-    /// it after the swap; wasmtime resources (linear memory, Store)
-    /// are reclaimed when the returned value falls out of scope.
-    /// The entry is replaced under the write lock so no worker can
-    /// observe a gap between old and new — any mail that gets popped
-    /// after the swap is delivered to the new instance.
-    pub fn replace_component(&self, id: MailboxId, new_component: Component) -> Option<Component> {
-        let mut table = self.ctx.components.write().unwrap();
-        let old = table
-            .remove(&id)
-            .map(|m| m.into_inner().expect("component mutex poisoned"));
-        table.insert(id, Mutex::new(new_component));
-        old
-    }
+/// Pull the wasmtime instance out of a removed entry. Panics if any
+/// other `Arc` clone is still live (e.g. a worker holding a reference
+/// across a deliver that's about to return). The control plane only
+/// removes entries after either (a) `drop_component` marked the
+/// mailbox `Dropped` so workers refuse new dispatches, or (b) the
+/// freeze-drain path of `handle_replace` confirmed `pending == 0`,
+/// so no worker should be holding a clone in either case.
+pub(crate) fn extract_component(entry: Arc<ComponentEntry>) -> Component {
+    Arc::into_inner(entry)
+        .expect("component entry still referenced by a worker")
+        .component
+        .into_inner()
+        .expect("component mutex poisoned")
 }
 
 impl Drop for Scheduler {
@@ -165,11 +198,30 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
                 handler(&kind_name, None, mail.sender, &mail.payload, mail.count);
             }
             Some(MailboxEntry::Component) => {
-                let components = ctx.components.read().unwrap();
-                match components.get(&recipient) {
-                    Some(lock) => {
-                        let mut c = lock.lock().unwrap();
-                        c.deliver(&mail).expect("component.deliver failed");
+                let entry = ctx
+                    .components
+                    .read()
+                    .unwrap()
+                    .get(&recipient)
+                    .map(Arc::clone);
+                match entry {
+                    Some(entry) => {
+                        // ADR-0022 freeze-drain: while frozen, mail is
+                        // parked on the entry without entering the
+                        // pending count. handle_replace flushes the
+                        // parked queue under the write lock once the
+                        // swap (or timeout) resolves.
+                        if entry.frozen.load(Ordering::Acquire) {
+                            entry.parked.lock().unwrap().push_back(mail);
+                            ctx.queue.mark_completed();
+                            continue;
+                        }
+                        entry.pending.fetch_add(1, Ordering::AcqRel);
+                        {
+                            let mut c = entry.component.lock().unwrap();
+                            c.deliver(&mail).expect("component.deliver failed");
+                        }
+                        entry.pending.fetch_sub(1, Ordering::AcqRel);
                     }
                     None => {
                         eprintln!(

--- a/docs/adr/0010-runtime-component-loading.md
+++ b/docs/adr/0010-runtime-component-loading.md
@@ -67,6 +67,8 @@ External senders see no addressing change. Mail in flight on the wire that hasn'
 
 In-flight mail policy is **drop**, not drain. Drain is more semantically clean but adds protocol — quiesce signal, flush ack, then swap. V0 picks drop; if a real workload needs drain, it's an additive `drain: bool` flag on the replace mail.
 
+> **Superseded by ADR-0022.** The drop policy was loose-but-harmless while components were stateless renderers; ADR-0016 (state migration) and ADR-0013 (reply-to-sender) made it actively wrong. ADR-0022 replaces step 3 with a freeze-drain-swap: the substrate quiesces the recipient, waits for in-flight `deliver` calls to complete, then swaps. See ADR-0022 for the actual semantics in shipping code.
+
 ### 6. State migration is out of scope
 
 The new component starts fresh. WASM linear memory from the old instance is not transferred. If a component needs persistent state across swaps, it's the component's responsibility to externalize it (e.g., write to a sidecar mailbox another component owns, or to a future persistence service). When state migration becomes a concrete need, it gets its own ADR.

--- a/docs/adr/0015-component-lifecycle-hooks.md
+++ b/docs/adr/0015-component-lifecycle-hooks.md
@@ -92,6 +92,8 @@ For `replace_component(target, new_bytes)`:
 
 This ordering is the subject of follow-up bikeshed: `on_replace` + `on_drop` firing back-to-back is redundant if the state migration already captured everything. Keeping both firing is the honest answer — `on_drop` is for universal cleanup; `on_replace` is the migration-specific moment. Overrides don't have to implement both.
 
+> **Updated by ADR-0022.** Steps 1–6 above describe what happens *during* the swap; ADR-0022 prepends two phases — freeze (flip a per-entry flag so workers park new mail instead of dispatching) and drain (wait for in-flight `deliver` calls on the old instance to complete) — before step 1 takes the write lock. Mail parked during the freeze flushes through whichever instance ends up bound (new on success, old on timeout) before the write lock releases. The ordering of hooks 2–5 is unchanged.
+
 ### 4. What stays parked
 
 - **`on_tick` as a first-class hook.** Continues to come in via `receive` as `aether.tick` mail. Revisit when the pattern-matching cost is visible.

--- a/docs/adr/0022-drain-on-swap.md
+++ b/docs/adr/0022-drain-on-swap.md
@@ -1,6 +1,6 @@
 # ADR-0022: Drain in-flight mail before component swap
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-17
 
 ## Context


### PR DESCRIPTION
## Summary

- Implements ADR-0022. `replace_component` is now freeze-drain-swap: workers park new mail on a per-entry `frozen` flag, the substrate waits for in-flight `deliver` calls (per-entry `pending` AtomicU32) to drain, then takes the write lock and runs the existing swap flow. Parked mail flushes through whichever instance ends up bound — new on success, old on timeout or instantiate/rehydrate failure.
- Drain bound by the additive `drain_timeout_ms: Option<u32>` field on `ReplaceComponent` (default 5000ms). On timeout the replace returns `Err { error: "drain timeout ..." }` and the old instance stays bound — loud failure mode replacing the previous silent dropped-mail behavior.
- Closes the ADR-0019 / ADR-0016 / ADR-0013 invariant: the snapshot a new instance rehydrates from reflects every mail the old instance saw; reply-to-sender requests issued before a replace get their reply from the old instance.
- ADR-0022 flipped to Accepted; ADR-0010 §5 and ADR-0015 §3 cross-referenced to point at ADR-0022 for actual swap semantics. CLAUDE.md updated.

## Test plan

- [x] `cargo test --workspace` — full suite green (4 new lib tests added)
- [x] New tests cover drain success (`drain_pending_returns_true_when_count_drops_in_time`), drain timeout keeps old bound (`replace_drain_timeout_keeps_old_bound`), parked mail flushed to new instance on success (`replace_flushes_parked_mail_to_new_instance`), parked mail flushed to old instance on timeout (`replace_drain_timeout_flushes_parked_to_old`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live smoke against a substrate built from this branch: `describe_kinds` shows the new `drain_timeout_ms` field on `aether.control.replace_component`; replace with both explicit (`5000`) and `null` (default) returns `Ok` end-to-end via the hub's MCP tool surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)