### PR TITLE
feat(hub,substrate): substrate log capture + engine_logs MCP tool (ADR-0023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Early-stage Rust project (edition 2024). Vision: a game engine where Claude sits
 
 ## MCP harness
 
-Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. Starting `cargo run -p aether-hub` (and either letting the hub spawn substrates via `spawn_substrate`, or running `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate` by hand) exposes six tools to a Claude Code session pointed at the project-scoped `.mcp.json`:
+Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. Starting `cargo run -p aether-hub` (and either letting the hub spawn substrates via `spawn_substrate`, or running `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate` by hand) exposes seven tools to a Claude Code session pointed at the project-scoped `.mcp.json`:
 
 - `mcp__aether-hub__list_engines` — connected engines (UUID + name/pid/version + `spawned` flag: `true` if the hub launched the process, `false` if it connected externally).
 - `mcp__aether-hub__describe_kinds(engine_id)` — the kind vocabulary the engine declared at handshake, with enough structural detail to build params.
@@ -26,6 +26,7 @@ Claude drives a running engine through MCP — the concrete form of the "Claude-
 - `mcp__aether-hub__receive_mail(max?)` — non-blocking drain of observation mail the engine pushed to this session. Each item carries `engine_id`, `kind_name`, structured `params` (decoded against the engine's kind descriptor — symmetric to `send_mail`, ADR-0020), `payload_bytes` (always populated; primarily a fallback when `params` is null), an optional `decode_error` populated when decode failed, and a `broadcast` flag (`true` means fan-out to every attached session, `false` means targeted reply-to-sender). Read `params` first; fall back to `payload_bytes` only if it's null.
 - `mcp__aether-hub__spawn_substrate(binary_path, args?, env?, timeout_ms?)` — launches a substrate binary as a child of the hub with `AETHER_HUB_URL` injected. Blocks until `Hello` handshake; returns `engine_id` + `pid`. The hub owns the child for its lifetime.
 - `mcp__aether-hub__terminate_substrate(engine_id, grace_ms?)` — SIGTERM → grace (default 2s) → SIGKILL. Errors on externally connected engines (the hub only terminates children it owns).
+- `mcp__aether-hub__engine_logs(engine_id, max?, level?, since?)` — drain captured substrate `tracing` events for an engine (ADR-0023). Cursor-based polling: pass back the previous response's `next_since` to receive only new entries. `level` filters server-side (`"trace"|"debug"|"info"|"warn"|"error"`, default `"trace"`); `max` defaults to 100 / clamped to 1000. `truncated_before` flags hub-side ring eviction so a slow poller knows it missed a window. The buffer survives engine exit, so post-mortem polls work after a substrate crash. Substrate-side filter: `AETHER_LOG_FILTER` (standard `EnvFilter` syntax, e.g. `AETHER_LOG_FILTER=aether_substrate=debug,wgpu=warn`) overrides the INFO+ default.
 
 Prefer `params` over `payload_bytes` when the kind is describable — the hub does the `#[repr(C)]` byte packing so agents don't. When verifying substrate behavior end-to-end, reach for this before running a new test binary.
 
@@ -35,7 +36,7 @@ Input streams (tick, key, mouse_move, mouse_button) are publish/subscribe (ADR-0
 
 `aether.control.replace_component` is freeze-drain-swap (ADR-0022): the substrate freezes the target mailbox, waits for in-flight `deliver` calls on the old instance to complete, then swaps. If the drain exceeds `drain_timeout_ms` (default 5000, per-replace overridable) the reply is `Err { error: "drain timeout ..." }` and the old instance stays bound — a loud failure rather than silent dropped mail. Mail that arrives during the freeze is parked and flushed through whichever instance ends up bound (new on success, old on timeout).
 
-Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), ADR-0021 (input stream subscriptions), and ADR-0022 (drain-on-swap for replace_component).
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), ADR-0021 (input stream subscriptions), ADR-0022 (drain-on-swap for replace_component), and ADR-0023 (substrate log capture + engine_logs).
 
 ## Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,8 @@ dependencies = [
  "pollster",
  "postcard",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "wasmtime",
  "wat",
  "wgpu",
@@ -143,6 +145,15 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1593,6 +1604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1781,6 +1807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2496,6 +2531,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,6 +3071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,6 +3284,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3274,6 +3374,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -273,6 +273,46 @@ mod tests {
     }
 
     #[test]
+    fn log_batch_roundtrip() {
+        let msg = EngineToHub::LogBatch(vec![
+            LogEntry {
+                timestamp_unix_ms: 1_713_379_200_123,
+                level: LogLevel::Error,
+                target: "aether_substrate::component".into(),
+                message: "trap in deliver: unreachable".into(),
+                sequence: 47,
+            },
+            LogEntry {
+                timestamp_unix_ms: 1_713_379_200_456,
+                level: LogLevel::Info,
+                target: "aether_substrate::scheduler".into(),
+                message: "boot complete".into(),
+                sequence: 48,
+            },
+        ]);
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).unwrap();
+        let back: EngineToHub = read_frame(&mut Cursor::new(buf)).unwrap();
+        match back {
+            EngineToHub::LogBatch(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].sequence, 47);
+                assert_eq!(entries[0].level, LogLevel::Error);
+                assert_eq!(entries[1].target, "aether_substrate::scheduler");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn log_level_ordering() {
+        assert!(LogLevel::Error > LogLevel::Warn);
+        assert!(LogLevel::Warn > LogLevel::Info);
+        assert!(LogLevel::Info > LogLevel::Debug);
+        assert!(LogLevel::Debug > LogLevel::Trace);
+    }
+
+    #[test]
     fn heartbeat_both_directions() {
         for buf in [
             encode_frame(&EngineToHub::Heartbeat),

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -188,6 +188,34 @@ pub struct Goodbye {
     pub reason: String,
 }
 
+/// One captured log entry forwarded from an engine to the hub
+/// (ADR-0023). Sequence is monotonic per substrate boot starting at 0
+/// — agents poll `engine_logs` with `since: <last>` to consume
+/// incrementally without re-receiving entries. `message` is the
+/// already-formatted event text (tracing's structured fields are
+/// flattened into it); per-line cap is enforced at capture time
+/// (>16 KiB truncated with a `...[truncated]` marker).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogEntry {
+    pub timestamp_unix_ms: u64,
+    pub level: LogLevel,
+    pub target: String,
+    pub message: String,
+    pub sequence: u64,
+}
+
+/// Severity for `LogEntry`. Mirrors `tracing::Level`. Ordered
+/// most-verbose to least-verbose so a min-level filter can be
+/// expressed as `entry.level >= min`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
 /// Frames an engine sends to the hub. `Mail` is the observation path
 /// (ADR-0008): engine-originated mail addressed to a Claude session
 /// or broadcast to all sessions. `KindsChanged` (ADR-0010 §4) tells
@@ -195,12 +223,16 @@ pub struct Goodbye {
 /// needed after `aether.control.load_component` /
 /// `aether.control.replace_component` registers a new kind, which the
 /// hub would otherwise miss since its cache is pinned at `Hello`.
+/// `LogBatch` (ADR-0023) carries captured log entries from the
+/// substrate's tracing layer; the hub appends them to a per-engine
+/// ring buffer served via the `engine_logs` MCP tool.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EngineToHub {
     Hello(Hello),
     Heartbeat,
     Mail(EngineMailFrame),
     KindsChanged(Vec<KindDescriptor>),
+    LogBatch(Vec<LogEntry>),
     Goodbye(Goodbye),
 }
 

--- a/crates/aether-hub/src/engine.rs
+++ b/crates/aether-hub/src/engine.rs
@@ -18,6 +18,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+use crate::log_store::LogStore;
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionRegistry};
 use crate::spawn::PendingSpawns;
@@ -38,6 +39,7 @@ pub async fn handle_connection(
     registry: EngineRegistry,
     sessions: SessionRegistry,
     pending: PendingSpawns,
+    logs: LogStore,
 ) -> Result<(), FrameError> {
     let (mut reader, mut writer) = stream.into_split();
 
@@ -112,7 +114,7 @@ pub async fn handle_connection(
     // Reader loop: run until the engine goes silent, sends Goodbye, or
     // the socket errors. Removing the registry entry drops the only
     // remaining `mail_tx`, which lets the writer task complete.
-    let result = read_loop(&mut reader, &registry, &sessions, engine_id).await;
+    let result = read_loop(&mut reader, &registry, &sessions, &logs, engine_id).await;
 
     registry.remove(&engine_id);
     let _ = writer_task.await;
@@ -128,6 +130,7 @@ async fn read_loop(
     reader: &mut tokio::net::tcp::OwnedReadHalf,
     registry: &EngineRegistry,
     sessions: &SessionRegistry,
+    logs: &LogStore,
     engine_id: EngineId,
 ) -> Result<(), FrameError> {
     loop {
@@ -150,6 +153,7 @@ async fn read_loop(
             EngineToHub::Heartbeat => {}
             EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m).await,
             EngineToHub::KindsChanged(kinds) => registry.update_kinds(&engine_id, kinds),
+            EngineToHub::LogBatch(entries) => logs.append(engine_id, entries),
             EngineToHub::Goodbye(_) => return Ok(()),
         }
     }

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -10,6 +10,7 @@ use tokio::net::TcpListener;
 mod decoder;
 mod encoder;
 mod engine;
+mod log_store;
 mod mcp;
 mod registry;
 mod session;
@@ -20,6 +21,7 @@ pub use encoder::{EncodeError, encode_schema};
 
 pub use engine::HEARTBEAT_INTERVAL;
 pub use engine::READ_TIMEOUT;
+pub use log_store::{LogStore, ReadResult as LogReadResult};
 pub use mcp::{DEFAULT_MCP_PORT, HubState, run_mcp_server};
 pub use registry::{EngineRecord, EngineRegistry};
 pub use session::{
@@ -42,6 +44,7 @@ pub async fn run_engine_listener(
     registry: EngineRegistry,
     sessions: SessionRegistry,
     pending: PendingSpawns,
+    logs: LogStore,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     let bound = listener.local_addr()?;
@@ -52,8 +55,11 @@ pub async fn run_engine_listener(
         let registry = registry.clone();
         let sessions = sessions.clone();
         let pending = pending.clone();
+        let logs = logs.clone();
         tokio::spawn(async move {
-            if let Err(e) = engine::handle_connection(stream, registry, sessions, pending).await {
+            if let Err(e) =
+                engine::handle_connection(stream, registry, sessions, pending, logs).await
+            {
                 eprintln!("aether-hub: engine {peer} dropped: {e}");
             }
         });

--- a/crates/aether-hub/src/log_store.rs
+++ b/crates/aether-hub/src/log_store.rs
@@ -1,0 +1,297 @@
+// ADR-0023 hub-side log buffer. One bounded ring per `EngineId`,
+// fed by `EngineToHub::LogBatch` frames and drained by the
+// `engine_logs` MCP tool. The buffer survives engine exit until hub
+// shutdown — post-mortem ("why did the substrate crash?") is the
+// most valuable case for these logs, so the engine record going away
+// must not take its history with it.
+//
+// Eviction is silent at append time; readers learn about it from
+// `truncated_before` on the response (the smallest sequence still
+// present is compared to `since` to surface a gap).
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use aether_hub_protocol::{EngineId, LogEntry, LogLevel};
+
+/// Default cap on entries per engine. Quoted in ADR-0023.
+pub const DEFAULT_RING_ENTRIES: usize = 2_000;
+/// Default cap on bytes per engine (variable-length parts only).
+pub const DEFAULT_RING_BYTES: usize = 2 * 1024 * 1024;
+
+/// Hard ceiling the MCP tool will honour. Caller-supplied `max`
+/// values above this clamp down silently.
+pub const TOOL_MAX_ENTRIES: usize = 1_000;
+/// Default `max` when the caller omits it.
+pub const TOOL_DEFAULT_ENTRIES: usize = 100;
+
+/// Shared, thread-safe per-engine log store. Cheap to clone — all
+/// clones share the same map.
+#[derive(Clone, Default)]
+pub struct LogStore {
+    inner: Arc<Mutex<HashMap<EngineId, Buffer>>>,
+}
+
+struct Buffer {
+    entries: VecDeque<LogEntry>,
+    current_bytes: usize,
+    cap_entries: usize,
+    cap_bytes: usize,
+    /// Smallest sequence ever evicted. `None` if the buffer has never
+    /// dropped an entry; the reader uses this to fill `truncated_before`.
+    earliest_evicted: Option<u64>,
+}
+
+impl Buffer {
+    fn new(cap_entries: usize, cap_bytes: usize) -> Self {
+        Self {
+            entries: VecDeque::new(),
+            current_bytes: 0,
+            cap_entries,
+            cap_bytes,
+            earliest_evicted: None,
+        }
+    }
+
+    fn append(&mut self, entry: LogEntry) {
+        self.current_bytes = self.current_bytes.saturating_add(entry_size(&entry));
+        self.entries.push_back(entry);
+        while self.entries.len() > self.cap_entries || self.current_bytes > self.cap_bytes {
+            let Some(dropped) = self.entries.pop_front() else {
+                break;
+            };
+            self.current_bytes = self.current_bytes.saturating_sub(entry_size(&dropped));
+            // First eviction: remember the boundary. Subsequent
+            // evictions advance it to the latest dropped sequence so
+            // readers see "anything below this sequence is gone."
+            self.earliest_evicted = Some(dropped.sequence);
+        }
+    }
+}
+
+fn entry_size(entry: &LogEntry) -> usize {
+    entry.target.len() + entry.message.len()
+}
+
+impl LogStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a batch of entries to the per-engine buffer, creating
+    /// the buffer on first use. Per ADR-0023 the buffer outlives the
+    /// engine record; this method does not consult the engine
+    /// registry.
+    pub fn append(&self, engine_id: EngineId, entries: Vec<LogEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+        let mut inner = self.inner.lock().unwrap();
+        let buf = inner
+            .entry(engine_id)
+            .or_insert_with(|| Buffer::new(DEFAULT_RING_ENTRIES, DEFAULT_RING_BYTES));
+        for entry in entries {
+            buf.append(entry);
+        }
+    }
+
+    /// Read back at most `max` entries with `sequence > since` and
+    /// `level >= min_level`. Returns the slice plus `next_since`
+    /// (the highest sequence in the slice, or `since` unchanged if
+    /// the slice is empty) and `truncated_before` (the first
+    /// surviving sequence above `since` if the buffer has evicted
+    /// anything the caller hadn't seen).
+    pub fn read(
+        &self,
+        engine_id: EngineId,
+        max: usize,
+        min_level: LogLevel,
+        since: u64,
+    ) -> ReadResult {
+        let inner = self.inner.lock().unwrap();
+        let Some(buf) = inner.get(&engine_id) else {
+            return ReadResult {
+                entries: Vec::new(),
+                next_since: since,
+                truncated_before: None,
+            };
+        };
+        let truncated_before = buf.earliest_evicted.filter(|&seq| seq >= since).map(|_| {
+            // Surface the lowest sequence still present — the
+            // gap the caller is missing starts above `since` and
+            // ends just below this. Empty buffer post-eviction
+            // shouldn't happen in practice but is handled safely.
+            buf.entries.front().map(|e| e.sequence).unwrap_or(0)
+        });
+        let max = max.min(TOOL_MAX_ENTRIES);
+        let mut out: Vec<LogEntry> = Vec::with_capacity(max.min(buf.entries.len()));
+        for e in &buf.entries {
+            if e.sequence <= since {
+                continue;
+            }
+            if e.level < min_level {
+                continue;
+            }
+            out.push(e.clone());
+            if out.len() >= max {
+                break;
+            }
+        }
+        let next_since = out.last().map(|e| e.sequence).unwrap_or(since);
+        ReadResult {
+            entries: out,
+            next_since,
+            truncated_before,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn buffer_len(&self, engine_id: EngineId) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(&engine_id)
+            .map(|b| b.entries.len())
+            .unwrap_or(0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadResult {
+    pub entries: Vec<LogEntry>,
+    pub next_since: u64,
+    pub truncated_before: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_hub_protocol::Uuid;
+
+    fn id(n: u128) -> EngineId {
+        EngineId(Uuid::from_u128(n))
+    }
+
+    fn entry(seq: u64, level: LogLevel, msg: &str) -> LogEntry {
+        LogEntry {
+            timestamp_unix_ms: seq,
+            level,
+            target: "t".into(),
+            message: msg.into(),
+            sequence: seq,
+        }
+    }
+
+    #[test]
+    fn append_and_read_basic() {
+        let store = LogStore::new();
+        let e = id(1);
+        store.append(
+            e,
+            vec![
+                entry(0, LogLevel::Info, "a"),
+                entry(1, LogLevel::Error, "b"),
+            ],
+        );
+        let r = store.read(e, 100, LogLevel::Trace, 0);
+        // since=0 is exclusive: only sequence > 0 returned.
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].sequence, 1);
+        assert_eq!(r.next_since, 1);
+        assert!(r.truncated_before.is_none());
+    }
+
+    #[test]
+    fn since_zero_includes_all_when_starting_below_zero() {
+        // u64 has no negative range; the convention is that callers
+        // start with since=0 only after consulting next_since once.
+        // For pure first-poll, callers omit since (server defaults to
+        // u64::MAX_PRE = absent → we treat omitted as "from start").
+        // Verified at the MCP layer (default is None → 0 means
+        // "after seq 0"); document the boundary here.
+        let store = LogStore::new();
+        let e = id(1);
+        store.append(e, vec![entry(0, LogLevel::Info, "first")]);
+        let r = store.read(e, 100, LogLevel::Trace, 0);
+        // sequence 0 is NOT > 0, so excluded.
+        assert!(r.entries.is_empty());
+    }
+
+    #[test]
+    fn level_filter_drops_below_min() {
+        let store = LogStore::new();
+        let e = id(1);
+        store.append(
+            e,
+            vec![
+                entry(1, LogLevel::Debug, "d"),
+                entry(2, LogLevel::Info, "i"),
+                entry(3, LogLevel::Error, "e"),
+            ],
+        );
+        let r = store.read(e, 100, LogLevel::Info, 0);
+        assert_eq!(r.entries.len(), 2);
+        assert_eq!(r.entries[0].sequence, 2);
+        assert_eq!(r.entries[1].sequence, 3);
+    }
+
+    #[test]
+    fn max_clamps_returned_count() {
+        let store = LogStore::new();
+        let e = id(1);
+        for i in 1..=10 {
+            store.append(e, vec![entry(i, LogLevel::Info, "x")]);
+        }
+        let r = store.read(e, 3, LogLevel::Trace, 0);
+        assert_eq!(r.entries.len(), 3);
+        assert_eq!(r.next_since, 3);
+    }
+
+    #[test]
+    fn eviction_surfaces_truncated_before() {
+        let store = LogStore::new();
+        let e = id(1);
+        // Tight cap by injecting raw — use the public API by writing
+        // many entries past the default cap is too noisy; insert a
+        // tiny custom buffer manually.
+        {
+            let mut inner = store.inner.lock().unwrap();
+            inner.insert(e, Buffer::new(3, 1024));
+        }
+        for i in 1..=5 {
+            store.append(e, vec![entry(i, LogLevel::Info, "x")]);
+        }
+        // Buffer holds the last 3: seqs 3,4,5. Earliest evicted is 2.
+        assert_eq!(store.buffer_len(e), 3);
+        let r = store.read(e, 100, LogLevel::Trace, 0);
+        assert_eq!(r.entries.len(), 3);
+        // truncated_before flags the gap above since=0.
+        assert!(r.truncated_before.is_some());
+    }
+
+    #[test]
+    fn truncated_before_clears_once_caller_catches_up() {
+        let store = LogStore::new();
+        let e = id(1);
+        {
+            let mut inner = store.inner.lock().unwrap();
+            inner.insert(e, Buffer::new(3, 1024));
+        }
+        for i in 1..=5 {
+            store.append(e, vec![entry(i, LogLevel::Info, "x")]);
+        }
+        // since=10 is above any evicted sequence (latest evicted: 2).
+        let r = store.read(e, 100, LogLevel::Trace, 10);
+        assert!(r.entries.is_empty());
+        assert!(r.truncated_before.is_none());
+    }
+
+    #[test]
+    fn unknown_engine_returns_empty() {
+        let store = LogStore::new();
+        let r = store.read(id(99), 100, LogLevel::Trace, 0);
+        assert!(r.entries.is_empty());
+        assert_eq!(r.next_since, 0);
+        assert!(r.truncated_before.is_none());
+    }
+}

--- a/crates/aether-hub/src/main.rs
+++ b/crates/aether-hub/src/main.rs
@@ -5,7 +5,7 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use aether_hub::{
-    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, PendingSpawns,
+    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, LogStore, PendingSpawns,
     SessionRegistry, run_engine_listener, run_mcp_server,
 };
 
@@ -19,10 +19,12 @@ async fn main() -> std::io::Result<()> {
     let registry = EngineRegistry::new();
     let sessions = SessionRegistry::new();
     let pending = PendingSpawns::new();
+    let logs = LogStore::new();
     let state = HubState::new(
         registry.clone(),
         sessions.clone(),
         pending.clone(),
+        logs.clone(),
         engine_addr,
     );
 
@@ -31,6 +33,7 @@ async fn main() -> std::io::Result<()> {
         registry,
         sessions,
         pending,
+        logs,
     ));
     let mcp_task = tokio::spawn(run_mcp_server(mcp_addr, state));
 

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_hub_protocol::{
-    EngineId, HubToEngine, KindDescriptor, MailFrame, SchemaType, SessionToken, Uuid,
+    EngineId, HubToEngine, KindDescriptor, LogLevel, MailFrame, SchemaType, SessionToken, Uuid,
 };
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -31,6 +31,7 @@ use tokio::sync::{Mutex, mpsc};
 
 use crate::decoder::decode_schema;
 use crate::encoder::encode_schema;
+use crate::log_store::{LogStore, TOOL_DEFAULT_ENTRIES, TOOL_MAX_ENTRIES};
 use crate::registry::{EngineRecord, EngineRegistry};
 use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
 use crate::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnOpts};
@@ -45,6 +46,9 @@ pub struct HubState {
     engines: EngineRegistry,
     sessions: SessionRegistry,
     pending_spawns: PendingSpawns,
+    /// ADR-0023 per-engine log buffers. Outlives engine records so
+    /// post-mortem `engine_logs` polls succeed after a substrate exit.
+    logs: LogStore,
     /// Address of the hub's engine TCP listener. Injected as
     /// `AETHER_HUB_URL` into spawned substrates so they dial back to
     /// this hub instance.
@@ -56,12 +60,14 @@ impl HubState {
         engines: EngineRegistry,
         sessions: SessionRegistry,
         pending_spawns: PendingSpawns,
+        logs: LogStore,
         hub_engine_addr: SocketAddr,
     ) -> Arc<Self> {
         Arc::new(Self {
             engines,
             sessions,
             pending_spawns,
+            logs,
             hub_engine_addr,
         })
     }
@@ -147,6 +153,16 @@ fn one() -> u32 {
     1
 }
 
+fn log_level_to_str(level: LogLevel) -> &'static str {
+    match level {
+        LogLevel::Trace => "trace",
+        LogLevel::Debug => "debug",
+        LogLevel::Info => "info",
+        LogLevel::Warn => "warn",
+        LogLevel::Error => "error",
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EngineInfo {
     pub engine_id: String,
@@ -207,6 +223,54 @@ pub struct TerminateResult {
     /// Exit code if the child exited normally; `null` if it was killed
     /// by a signal (the common case when `sigkilled` is true).
     pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EngineLogsArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Maximum entries to return. Defaults to 100; clamped to 1000.
+    #[serde(default)]
+    pub max: Option<u32>,
+    /// Minimum log level (`"trace"|"debug"|"info"|"warn"|"error"`).
+    /// Defaults to `"trace"` (every captured entry).
+    #[serde(default)]
+    pub level: Option<String>,
+    /// Cursor: only entries with `sequence > since` are returned.
+    /// Pass back the previous response's `next_since` to poll
+    /// incrementally without re-receiving.
+    #[serde(default)]
+    pub since: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EngineLogsResponse {
+    pub engine_id: String,
+    pub entries: Vec<EngineLogEntry>,
+    /// Highest `sequence` returned in `entries`, or the request's
+    /// `since` value if the response is empty. Use as the next
+    /// `since` for incremental polling.
+    pub next_since: u64,
+    /// Set when the hub-side ring evicted entries the caller hadn't
+    /// seen — `Some(seq)` means the gap above the request's `since`
+    /// extends up to (but not including) `seq`. Treat as a signal to
+    /// poll more often or accept the loss.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated_before: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EngineLogEntry {
+    pub timestamp_unix_ms: u64,
+    /// Lowercase level: `"trace"|"debug"|"info"|"warn"|"error"`.
+    pub level: String,
+    /// Module path the event was emitted from
+    /// (e.g. `"aether_substrate::scheduler"`).
+    pub target: String,
+    /// Already-formatted event text. Tracing's structured fields are
+    /// flattened into this string by the substrate's capture layer.
+    pub message: String,
+    pub sequence: u64,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -411,6 +475,56 @@ impl Hub {
     }
 
     #[tool(
+        description = "Drain captured substrate log entries for an engine (ADR-0023). Cursor-based polling: pass back `next_since` from the previous response to receive only new entries. `level` (default `\"trace\"`) filters server-side. `max` defaults to 100, clamped to 1000. `truncated_before` is set when the hub-side ring evicted entries the caller hadn't seen — treat it as a signal to poll more often or accept the gap. Buffer survives engine exit until hub shutdown, so post-mortem polls work after the substrate has crashed."
+    )]
+    async fn engine_logs(
+        &self,
+        Parameters(args): Parameters<EngineLogsArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let min_level = match args.level.as_deref() {
+            None | Some("trace") => LogLevel::Trace,
+            Some("debug") => LogLevel::Debug,
+            Some("info") => LogLevel::Info,
+            Some("warn") => LogLevel::Warn,
+            Some("error") => LogLevel::Error,
+            Some(other) => {
+                return Err(McpError::invalid_params(
+                    format!("level {other:?} is not one of trace|debug|info|warn|error",),
+                    None,
+                ));
+            }
+        };
+        let max = args
+            .max
+            .map(|n| n as usize)
+            .unwrap_or(TOOL_DEFAULT_ENTRIES)
+            .min(TOOL_MAX_ENTRIES);
+        let since = args.since.unwrap_or(0);
+        let result = self.state.logs.read(id, max, min_level, since);
+        let response = EngineLogsResponse {
+            engine_id: args.engine_id,
+            entries: result
+                .entries
+                .into_iter()
+                .map(|e| EngineLogEntry {
+                    timestamp_unix_ms: e.timestamp_unix_ms,
+                    level: log_level_to_str(e.level).to_owned(),
+                    target: e.target,
+                    message: e.message,
+                    sequence: e.sequence,
+                })
+                .collect(),
+            next_since: result.next_since,
+            truncated_before: result.truncated_before,
+        };
+        serde_json::to_string(&response).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
         description = "List all engines currently connected to the hub. Each item reports the hub-assigned engine_id, the engine's self-declared name/pid/version, and a `spawned` flag: `true` if the hub launched this engine as a child process (ADR-0009), `false` if it connected externally."
     )]
     async fn list_engines(&self) -> Result<String, McpError> {
@@ -568,6 +682,7 @@ mod tests {
             engines,
             sessions,
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:0".parse().unwrap(),
         )
     }
@@ -1172,6 +1287,7 @@ mod tests {
             EngineRegistry::new(),
             SessionRegistry::new(),
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:1".parse().unwrap(),
         );
         let hub = Hub::new(state);
@@ -1195,6 +1311,7 @@ mod tests {
             EngineRegistry::new(),
             SessionRegistry::new(),
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:1".parse().unwrap(),
         );
         let hub = Hub::new(state);
@@ -1219,6 +1336,7 @@ mod tests {
             engines,
             SessionRegistry::new(),
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:1".parse().unwrap(),
         );
         let hub = Hub::new(state);
@@ -1258,6 +1376,7 @@ mod tests {
             engines.clone(),
             SessionRegistry::new(),
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:1".parse().unwrap(),
         );
         let hub = Hub::new(state);
@@ -1286,6 +1405,7 @@ mod tests {
             EngineRegistry::new(),
             SessionRegistry::new(),
             PendingSpawns::new(),
+            LogStore::new(),
             "127.0.0.1:1".parse().unwrap(),
         );
         let hub = Hub::new(state);

--- a/crates/aether-hub/tests/engine_handshake.rs
+++ b/crates/aether-hub/tests/engine_handshake.rs
@@ -4,7 +4,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
-use aether_hub::{EngineRegistry, PendingSpawns, SessionRegistry, run_engine_listener};
+use aether_hub::{EngineRegistry, LogStore, PendingSpawns, SessionRegistry, run_engine_listener};
 use aether_hub_protocol::{EngineToHub, Goodbye, Hello, HubToEngine, encode_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -23,6 +23,7 @@ async fn spawn_hub() -> (SocketAddr, EngineRegistry, SessionRegistry) {
         registry.clone(),
         sessions.clone(),
         pending,
+        LogStore::new(),
     ));
     // Give the listener a beat to bind.
     tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/aether-hub/tests/engine_logs.rs
+++ b/crates/aether-hub/tests/engine_logs.rs
@@ -1,0 +1,179 @@
+// Integration test for ADR-0023: substrate emits a `LogBatch` frame,
+// the hub appends it to its per-engine ring, and `LogStore::read`
+// (the same code path the `engine_logs` MCP tool drives) returns the
+// expected entries with cursor + level filter behaviour.
+//
+// Walks one end of the wire by hand: open a socket to the listener,
+// Hello/Welcome, push a LogBatch, then query the hub's LogStore.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use aether_hub::{EngineRegistry, LogStore, PendingSpawns, SessionRegistry, run_engine_listener};
+use aether_hub_protocol::{
+    EngineId, EngineToHub, Hello, HubToEngine, LogEntry, LogLevel, encode_frame,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+async fn spawn_hub_with_logs() -> (SocketAddr, EngineRegistry, LogStore) {
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let registry = EngineRegistry::new();
+    let sessions = SessionRegistry::new();
+    let pending = PendingSpawns::new();
+    let logs = LogStore::new();
+    tokio::spawn(run_engine_listener(
+        addr,
+        registry.clone(),
+        sessions,
+        pending,
+        logs.clone(),
+    ));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, registry, logs)
+}
+
+async fn handshake(stream: &mut TcpStream) -> EngineId {
+    let hello = EngineToHub::Hello(Hello {
+        name: "log-test".into(),
+        pid: 1,
+        started_unix: 0,
+        version: "0".into(),
+        kinds: vec![],
+    });
+    stream.write_all(&encode_frame(&hello)).await.unwrap();
+
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await.unwrap();
+    let mut body = vec![0u8; u32::from_le_bytes(len) as usize];
+    stream.read_exact(&mut body).await.unwrap();
+    let welcome: HubToEngine = postcard::from_bytes(&body).unwrap();
+    match welcome {
+        HubToEngine::Welcome(w) => w.engine_id,
+        other => panic!("expected Welcome, got {other:?}"),
+    }
+}
+
+fn entry(seq: u64, level: LogLevel, target: &str, message: &str) -> LogEntry {
+    LogEntry {
+        timestamp_unix_ms: seq * 1000,
+        level,
+        target: target.into(),
+        message: message.into(),
+        sequence: seq,
+    }
+}
+
+#[tokio::test]
+async fn log_batch_arrives_and_is_queryable() {
+    let (addr, _registry, logs) = spawn_hub_with_logs().await;
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let engine_id = handshake(&mut stream).await;
+
+    let batch = EngineToHub::LogBatch(vec![
+        entry(0, LogLevel::Info, "aether_substrate::boot", "ready"),
+        entry(1, LogLevel::Error, "aether_substrate::component", "trap"),
+    ]);
+    stream.write_all(&encode_frame(&batch)).await.unwrap();
+
+    // The hub appends asynchronously on the read loop; poll briefly.
+    let mut got = Vec::new();
+    for _ in 0..50 {
+        let r = logs.read(engine_id, 100, LogLevel::Trace, 0);
+        if r.entries.len() == 1 {
+            got = r.entries;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    // since=0 is exclusive: only sequence 1 (the Error) should come back.
+    assert_eq!(got.len(), 1, "expected exactly one entry above seq 0");
+    assert_eq!(got[0].sequence, 1);
+    assert_eq!(got[0].level, LogLevel::Error);
+}
+
+#[tokio::test]
+async fn level_filter_drops_below_min() {
+    let (addr, _registry, logs) = spawn_hub_with_logs().await;
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let engine_id = handshake(&mut stream).await;
+
+    let batch = EngineToHub::LogBatch(vec![
+        entry(1, LogLevel::Debug, "t", "noise"),
+        entry(2, LogLevel::Warn, "t", "important"),
+        entry(3, LogLevel::Error, "t", "critical"),
+    ]);
+    stream.write_all(&encode_frame(&batch)).await.unwrap();
+
+    let mut filtered = Vec::new();
+    for _ in 0..50 {
+        let r = logs.read(engine_id, 100, LogLevel::Warn, 0);
+        if r.entries.len() == 2 {
+            filtered = r.entries;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(filtered.len(), 2);
+    assert!(filtered.iter().all(|e| e.level >= LogLevel::Warn));
+}
+
+#[tokio::test]
+async fn cursor_advances_with_next_since() {
+    let (addr, _registry, logs) = spawn_hub_with_logs().await;
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let engine_id = handshake(&mut stream).await;
+
+    let batch = EngineToHub::LogBatch(vec![
+        entry(1, LogLevel::Info, "t", "a"),
+        entry(2, LogLevel::Info, "t", "b"),
+        entry(3, LogLevel::Info, "t", "c"),
+    ]);
+    stream.write_all(&encode_frame(&batch)).await.unwrap();
+
+    // Wait for delivery.
+    for _ in 0..50 {
+        let r = logs.read(engine_id, 100, LogLevel::Trace, 0);
+        if r.entries.len() == 3 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let first = logs.read(engine_id, 2, LogLevel::Trace, 0);
+    assert_eq!(first.entries.len(), 2);
+    assert_eq!(first.next_since, 2);
+
+    let second = logs.read(engine_id, 100, LogLevel::Trace, first.next_since);
+    assert_eq!(second.entries.len(), 1);
+    assert_eq!(second.entries[0].sequence, 3);
+}
+
+#[tokio::test]
+async fn buffer_survives_engine_disconnect() {
+    let (addr, _registry, logs) = spawn_hub_with_logs().await;
+    let engine_id = {
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let id = handshake(&mut stream).await;
+        let batch = EngineToHub::LogBatch(vec![entry(1, LogLevel::Info, "t", "before-exit")]);
+        stream.write_all(&encode_frame(&batch)).await.unwrap();
+        // Wait for the hub to process the batch before dropping the socket.
+        for _ in 0..50 {
+            if !logs.read(id, 100, LogLevel::Trace, 0).entries.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        id
+    };
+    // Socket closed; engine record gone (the read loop hits EOF and
+    // `registry.remove` fires). Log store must still serve the entry.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let r = logs.read(engine_id, 100, LogLevel::Trace, 0);
+    assert_eq!(r.entries.len(), 1);
+    assert_eq!(r.entries[0].message, "before-exit");
+}

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -11,6 +11,8 @@ bytemuck = "1.19"
 pollster = "0.4.0"
 postcard = { version = "1.1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wasmtime = "30"
 wgpu = "29.0.1"
 winit = "0.30.13"

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -131,7 +131,7 @@ impl Component {
         if let Some(f) = self.on_replace.clone()
             && let Err(e) = f.call(&mut self.store, ())
         {
-            eprintln!("substrate: on_replace hook trapped: {e}");
+            tracing::error!(target: "aether_substrate::component", error = %e, "on_replace hook trapped");
         }
     }
 
@@ -141,7 +141,7 @@ impl Component {
         if let Some(f) = self.on_drop.clone()
             && let Err(e) = f.call(&mut self.store, ())
         {
-            eprintln!("substrate: on_drop hook trapped: {e}");
+            tracing::error!(target: "aether_substrate::component", error = %e, "on_drop hook trapped");
         }
     }
 

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -239,8 +239,10 @@ impl ControlPlane {
             let result = self.handle_unsubscribe(bytes);
             self.reply(sender, SubscribeInputResult::NAME, &result);
         } else {
-            eprintln!(
-                "aether-substrate: {AETHER_CONTROL} received unrecognised kind {kind_name:?} — dropping"
+            tracing::warn!(
+                target: "aether_substrate::control",
+                kind = %kind_name,
+                "{AETHER_CONTROL} received unrecognised kind — dropping",
             );
         }
     }
@@ -641,7 +643,7 @@ impl ControlPlane {
         let payload = match postcard::to_allocvec(result) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("aether-substrate: {kind_name} encode failed: {e}");
+                tracing::error!(target: "aether_substrate::control", kind = %kind_name, error = %e, "result encode failed");
                 return;
             }
         };

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -116,15 +116,19 @@ impl SubstrateCtx {
                     .push(Mail::new(recipient, kind, payload, count).with_origin(self.sender));
             }
             Some(MailboxEntry::Dropped) => {
-                eprintln!(
-                    "substrate: component {:?} sent mail to dropped mailbox {:?} — discarded",
-                    self.sender, recipient
+                tracing::warn!(
+                    target: "aether_substrate::ctx",
+                    sender = ?self.sender,
+                    mailbox = ?recipient,
+                    "component sent mail to dropped mailbox — discarded",
                 );
             }
             None => {
-                eprintln!(
-                    "substrate: dropped mail from {:?} to unknown mailbox {:?}",
-                    self.sender, recipient
+                tracing::warn!(
+                    target: "aether_substrate::ctx",
+                    sender = ?self.sender,
+                    mailbox = ?recipient,
+                    "component sent mail to unknown mailbox — dropped",
                 );
             }
         }

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -60,7 +60,7 @@ impl HubOutbound {
 
     fn attach(&self, tx: Sender<EngineToHub>) {
         if self.tx.set(tx).is_err() {
-            eprintln!("aether-substrate: HubOutbound attached twice — ignoring second attach");
+            tracing::warn!(target: "aether_substrate::hub_client", "HubOutbound attached twice — ignoring second attach");
         }
     }
 
@@ -141,7 +141,7 @@ impl HubClient {
                 ));
             }
         };
-        eprintln!("aether-substrate: hub registered as engine {}", engine_id.0);
+        tracing::info!(target: "aether_substrate::hub_client", engine_id = %engine_id.0, "hub registered engine");
 
         let (tx, rx) = mpsc::channel::<EngineToHub>();
         let reader_stream = stream.try_clone()?;
@@ -167,14 +167,14 @@ fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<MailQue
             Ok(HubToEngine::Mail(frame)) => dispatch_mail(frame, &registry, &queue),
             Ok(HubToEngine::Heartbeat) => {}
             Ok(HubToEngine::Welcome(_)) => {
-                eprintln!("aether-substrate: unexpected post-handshake Welcome, ignoring");
+                tracing::warn!(target: "aether_substrate::hub_client", "unexpected post-handshake Welcome, ignoring");
             }
             Ok(HubToEngine::Goodbye(g)) => {
-                eprintln!("aether-substrate: hub Goodbye: {}", g.reason);
+                tracing::info!(target: "aether_substrate::hub_client", reason = %g.reason, "hub Goodbye");
                 return;
             }
             Err(e) => {
-                eprintln!("aether-substrate: hub read error: {e}");
+                tracing::error!(target: "aether_substrate::hub_client", error = %e, "hub read error");
                 return;
             }
         }
@@ -184,7 +184,7 @@ fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<MailQue
 fn run_writer(mut stream: TcpStream, rx: mpsc::Receiver<EngineToHub>) {
     while let Ok(frame) = rx.recv() {
         if let Err(e) = write_frame(&mut stream, &frame) {
-            eprintln!("aether-substrate: hub write error: {e}");
+            tracing::error!(target: "aether_substrate::hub_client", error = %e, "hub write error");
             return;
         }
     }
@@ -201,16 +201,18 @@ fn run_heartbeat(tx: Sender<EngineToHub>) {
 
 fn dispatch_mail(frame: MailFrame, registry: &Registry, queue: &MailQueue) {
     let Some(recipient) = registry.lookup(&frame.recipient_name) else {
-        eprintln!(
-            "aether-substrate: dropping hub mail to unknown mailbox {:?}",
-            frame.recipient_name
+        tracing::warn!(
+            target: "aether_substrate::hub_client",
+            mailbox = %frame.recipient_name,
+            "dropping hub mail to unknown mailbox",
         );
         return;
     };
     let Some(kind) = registry.kind_id(&frame.kind_name) else {
-        eprintln!(
-            "aether-substrate: dropping hub mail of unknown kind {:?}",
-            frame.kind_name
+        tracing::warn!(
+            target: "aether_substrate::hub_client",
+            kind = %frame.kind_name,
+            "dropping hub mail of unknown kind",
         );
         return;
     };

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ctx;
 pub mod host_fns;
 pub mod hub_client;
 pub mod input;
+pub mod log_capture;
 pub mod mail;
 pub mod queue;
 pub mod registry;

--- a/crates/aether-substrate/src/log_capture.rs
+++ b/crates/aether-substrate/src/log_capture.rs
@@ -1,0 +1,357 @@
+// ADR-0023 substrate-side log capture. Installs a tracing-subscriber
+// `Layer` that captures formatted events into a bounded ring and a
+// background thread that drains the ring into `EngineToHub::LogBatch`
+// frames via the existing `HubOutbound`. Capture is additive — the
+// `init` function also installs a stderr `fmt` layer so the existing
+// console output behaviour (what `eprintln!` used to give) is
+// preserved for operators reading the substrate's terminal.
+//
+// Filter: `AETHER_LOG_FILTER` (standard `EnvFilter` syntax) overrides
+// the INFO+ default. Unset = INFO+.
+//
+// Bounds: per-line cap 16 KiB (truncated with `...[truncated]`),
+// ring cap 2_000 entries / 2 MiB total. Overflow drops oldest and
+// surfaces a synthetic `Warn` entry at the next flush so the loss is
+// observable.
+//
+// The flush task is a `std::thread` per the substrate's stay-sync
+// stance (see `hub_client.rs`). Wakeup is a `Condvar` poked when the
+// ring crosses the batch threshold; otherwise the timer fires every
+// 250 ms.
+
+use std::collections::VecDeque;
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use aether_hub_protocol::{EngineToHub, LogEntry, LogLevel};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::field::Visit;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{Layer, fmt as tsfmt};
+
+use crate::hub_client::HubOutbound;
+
+/// Per-event message cap before truncation.
+const MESSAGE_CAP: usize = 16 * 1024;
+const TRUNCATED_SUFFIX: &str = "...[truncated]";
+
+/// Default ring caps. Mirror the values quoted in ADR-0023.
+const DEFAULT_RING_ENTRIES: usize = 2_000;
+const DEFAULT_RING_BYTES: usize = 2 * 1024 * 1024;
+
+/// Flush triggers. Whichever fires first.
+const BATCH_TRIGGER_ENTRIES: usize = 100;
+const BATCH_TRIGGER_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Env var name for overriding the default filter.
+const FILTER_ENV: &str = "AETHER_LOG_FILTER";
+
+/// Install the global tracing subscriber and spawn the flush thread.
+///
+/// `outbound` is the same handle the hub client populates; this lets
+/// the capture layer drop its frames silently when no hub is attached
+/// rather than buffering forever. The flush thread keeps running for
+/// the process lifetime — there's no clean handoff because the global
+/// subscriber installation is also process-lifetime.
+///
+/// Returns silently on the second call (a global subscriber was
+/// already installed); intended to be called exactly once during
+/// substrate boot.
+pub fn init(outbound: Arc<HubOutbound>) {
+    let filter = EnvFilter::try_from_env(FILTER_ENV).unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let inner = Arc::new(Inner::new(outbound));
+    let capture = CaptureLayer {
+        inner: Arc::clone(&inner),
+    };
+    let stderr_fmt = tsfmt::layer().with_writer(std::io::stderr);
+
+    let registered = tracing_subscriber::registry()
+        .with(filter)
+        .with(stderr_fmt)
+        .with(capture)
+        .try_init()
+        .is_ok();
+
+    if registered {
+        let flusher = Arc::clone(&inner);
+        thread::Builder::new()
+            .name("aether-log-flush".into())
+            .spawn(move || flush_loop(flusher))
+            .expect("spawn flush thread");
+    }
+}
+
+struct Inner {
+    state: Mutex<RingState>,
+    cv: Condvar,
+    outbound: Arc<HubOutbound>,
+    shutdown: AtomicBool,
+}
+
+struct RingState {
+    entries: VecDeque<LogEntry>,
+    next_sequence: u64,
+    dropped_since_last_flush: u64,
+    current_bytes: usize,
+}
+
+impl Inner {
+    fn new(outbound: Arc<HubOutbound>) -> Self {
+        Self {
+            state: Mutex::new(RingState {
+                entries: VecDeque::new(),
+                // Sequences start at 1 so a `since=0` (the natural
+                // first-poll default at the MCP tool) returns the
+                // very first captured entry instead of missing it.
+                next_sequence: 1,
+                dropped_since_last_flush: 0,
+                current_bytes: 0,
+            }),
+            cv: Condvar::new(),
+            outbound,
+            shutdown: AtomicBool::new(false),
+        }
+    }
+
+    fn push(&self, level: LogLevel, target: String, message: String) {
+        let mut s = self.state.lock().unwrap();
+        let seq = s.next_sequence;
+        s.next_sequence = s.next_sequence.wrapping_add(1);
+        let entry = LogEntry {
+            timestamp_unix_ms: now_unix_ms(),
+            level,
+            target,
+            message,
+            sequence: seq,
+        };
+        let entry_bytes = entry_size(&entry);
+        s.current_bytes = s.current_bytes.saturating_add(entry_bytes);
+        s.entries.push_back(entry);
+        while s.entries.len() > DEFAULT_RING_ENTRIES || s.current_bytes > DEFAULT_RING_BYTES {
+            let Some(dropped) = s.entries.pop_front() else {
+                break;
+            };
+            s.current_bytes = s.current_bytes.saturating_sub(entry_size(&dropped));
+            s.dropped_since_last_flush = s.dropped_since_last_flush.saturating_add(1);
+        }
+        if s.entries.len() >= BATCH_TRIGGER_ENTRIES || s.dropped_since_last_flush > 0 {
+            self.cv.notify_one();
+        }
+    }
+}
+
+fn entry_size(entry: &LogEntry) -> usize {
+    // Approximate; tracks only the variable-length parts. Constant
+    // per-entry overhead (timestamps, level, sequence) is not counted
+    // since the ring cap is a guard against runaway message volume,
+    // not a precise wire-size accounting.
+    entry.target.len() + entry.message.len()
+}
+
+fn flush_loop(inner: Arc<Inner>) {
+    while !inner.shutdown.load(Ordering::Acquire) {
+        let batch = {
+            let mut s = inner.state.lock().unwrap();
+            while s.entries.is_empty() && s.dropped_since_last_flush == 0 {
+                let (next, timeout) = inner
+                    .cv
+                    .wait_timeout(s, BATCH_TRIGGER_INTERVAL)
+                    .expect("flush condvar poisoned");
+                s = next;
+                if timeout.timed_out() {
+                    break;
+                }
+                if inner.shutdown.load(Ordering::Acquire) {
+                    return;
+                }
+            }
+            take_batch(&mut s)
+        };
+        if !batch.is_empty() {
+            inner.outbound.send(EngineToHub::LogBatch(batch));
+        }
+    }
+}
+
+fn take_batch(s: &mut RingState) -> Vec<LogEntry> {
+    let mut out: Vec<LogEntry> = Vec::with_capacity(s.entries.len() + 1);
+    if s.dropped_since_last_flush > 0 {
+        let dropped = std::mem::take(&mut s.dropped_since_last_flush);
+        let seq = s.next_sequence;
+        s.next_sequence = s.next_sequence.wrapping_add(1);
+        out.push(LogEntry {
+            timestamp_unix_ms: now_unix_ms(),
+            level: LogLevel::Warn,
+            target: "aether_substrate::log_capture".into(),
+            message: format!("dropped {dropped} entries (capture ring full)"),
+            sequence: seq,
+        });
+    }
+    let drained: Vec<LogEntry> = s.entries.drain(..).collect();
+    s.current_bytes = 0;
+    out.extend(drained);
+    out
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+struct CaptureLayer {
+    inner: Arc<Inner>,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = match *metadata.level() {
+            tracing::Level::TRACE => LogLevel::Trace,
+            tracing::Level::DEBUG => LogLevel::Debug,
+            tracing::Level::INFO => LogLevel::Info,
+            tracing::Level::WARN => LogLevel::Warn,
+            tracing::Level::ERROR => LogLevel::Error,
+        };
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        let message = visitor.finish();
+        self.inner
+            .push(level, metadata.target().to_owned(), message);
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    /// Primary `message` field (tracing's implicit format-string slot).
+    message: String,
+    /// Other structured fields, flattened as `name=value` pairs.
+    rest: String,
+}
+
+impl MessageVisitor {
+    fn finish(self) -> String {
+        let mut out = self.message;
+        if !self.rest.is_empty() {
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(&self.rest);
+        }
+        truncate_in_place(out)
+    }
+}
+
+fn truncate_in_place(mut s: String) -> String {
+    if s.len() > MESSAGE_CAP {
+        let cut = MESSAGE_CAP.saturating_sub(TRUNCATED_SUFFIX.len());
+        // Step back to a char boundary so the resulting `String` stays
+        // valid UTF-8 even if the cap fell mid-codepoint.
+        let mut boundary = cut.min(s.len());
+        while boundary > 0 && !s.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        s.truncate(boundary);
+        s.push_str(TRUNCATED_SUFFIX);
+    }
+    s
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(&mut self.message, "{value:?}");
+        } else {
+            if !self.rest.is_empty() {
+                self.rest.push(' ');
+            }
+            let _ = write!(&mut self.rest, "{}={value:?}", field.name());
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            if !self.rest.is_empty() {
+                self.rest.push(' ');
+            }
+            let _ = write!(&mut self.rest, "{}={value:?}", field.name());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_inner() -> (Arc<Inner>, std::sync::mpsc::Receiver<EngineToHub>) {
+        let (outbound, rx) = HubOutbound::test_channel();
+        (Arc::new(Inner::new(outbound)), rx)
+    }
+
+    #[test]
+    fn push_assigns_monotonic_sequence() {
+        let (inner, _rx) = make_inner();
+        inner.push(LogLevel::Info, "t".into(), "first".into());
+        inner.push(LogLevel::Info, "t".into(), "second".into());
+        let s = inner.state.lock().unwrap();
+        assert_eq!(s.entries[0].sequence, 1);
+        assert_eq!(s.entries[1].sequence, 2);
+        assert_eq!(s.next_sequence, 3);
+    }
+
+    #[test]
+    fn ring_evicts_oldest_at_entry_cap() {
+        let (inner, _rx) = make_inner();
+        for i in 0..(DEFAULT_RING_ENTRIES + 5) {
+            inner.push(LogLevel::Info, "t".into(), format!("msg-{i}"));
+        }
+        let s = inner.state.lock().unwrap();
+        assert_eq!(s.entries.len(), DEFAULT_RING_ENTRIES);
+        assert_eq!(s.dropped_since_last_flush, 5);
+        // Sequences start at 1; first 5 (seq 1..=5) evicted, so the
+        // oldest surviving entry has sequence 6.
+        assert_eq!(s.entries.front().unwrap().sequence, 6);
+    }
+
+    #[test]
+    fn take_batch_prepends_drop_warning() {
+        let (inner, _rx) = make_inner();
+        // Force a drop without churning thousands of pushes.
+        {
+            let mut s = inner.state.lock().unwrap();
+            s.dropped_since_last_flush = 7;
+        }
+        inner.push(LogLevel::Info, "t".into(), "kept".into());
+        let mut s = inner.state.lock().unwrap();
+        let batch = take_batch(&mut s);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].level, LogLevel::Warn);
+        assert!(batch[0].message.contains("dropped 7 entries"));
+        assert_eq!(batch[1].message, "kept");
+        // Counter resets after flush.
+        assert_eq!(s.dropped_since_last_flush, 0);
+    }
+
+    #[test]
+    fn message_truncation_preserves_utf8_and_marker() {
+        let huge = "ä".repeat(MESSAGE_CAP);
+        let truncated = truncate_in_place(huge);
+        assert!(truncated.len() <= MESSAGE_CAP);
+        assert!(truncated.ends_with(TRUNCATED_SUFFIX));
+        // String is still valid UTF-8 (no multibyte char half-cut).
+        assert!(std::str::from_utf8(truncated.as_bytes()).is_ok());
+    }
+}

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -130,9 +130,11 @@ impl ApplicationHandler for App {
                 self.frame += 1;
                 if self.frame.is_multiple_of(LOG_EVERY_FRAMES) {
                     let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-                    eprintln!(
-                        "  frame {:>5}  triangles_rendered={}",
-                        self.frame, triangles,
+                    tracing::info!(
+                        target: "aether_substrate::frame_loop",
+                        frame = self.frame,
+                        triangles,
+                        "frame stats",
                     );
                     // Emit an observation to every attached Claude
                     // session. No-op when no hub is connected.
@@ -198,6 +200,17 @@ impl ApplicationHandler for App {
 }
 
 fn main() -> wasmtime::Result<()> {
+    // Reserved well-known sink: mail sent here is forwarded to every
+    // attached Claude session via the hub. The handle is created up
+    // front (before the hub is dialed) so the log capture layer can
+    // share it; the hub client populates it later if `AETHER_HUB_URL`
+    // is set, otherwise sends are silently dropped.
+    let outbound = HubOutbound::disconnected();
+
+    // ADR-0023: install the tracing subscriber + log capture early so
+    // bring-up errors (renderer init, hub handshake) are captured.
+    aether_substrate::log_capture::init(Arc::clone(&outbound));
+
     let engine = Arc::new(Engine::default());
 
     let registry = Arc::new(Registry::new());
@@ -243,8 +256,8 @@ fn main() -> wasmtime::Result<()> {
     // Reserved well-known sink: mail sent here is forwarded to every
     // attached Claude session via the hub. If no hub is connected, the
     // outbound handle is disconnected and the sink silently drops —
-    // the component doesn't have to care either way.
-    let outbound = HubOutbound::disconnected();
+    // the component doesn't have to care either way. (Handle created
+    // earlier so the log capture layer could share it.)
     let broadcast_mbox = {
         let outbound = Arc::clone(&outbound);
         registry.register_sink(
@@ -256,8 +269,9 @@ fn main() -> wasmtime::Result<()> {
                       bytes: &[u8],
                       _count: u32| {
                     if kind_name.is_empty() {
-                        eprintln!(
-                            "aether-substrate: {HUB_CLAUDE_BROADCAST} received mail with unregistered kind — dropping"
+                        tracing::warn!(
+                            target: "aether_substrate::broadcast",
+                            "{HUB_CLAUDE_BROADCAST} received mail with unregistered kind — dropping",
                         );
                         return;
                     }
@@ -330,16 +344,22 @@ fn main() -> wasmtime::Result<()> {
         ) {
             Ok(c) => Some(c),
             Err(e) => {
-                eprintln!("aether-substrate: hub connect to {url} failed: {e}");
+                tracing::error!(
+                    target: "aether_substrate::boot",
+                    url = %url,
+                    error = %e,
+                    "hub connect failed",
+                );
                 None
             }
         },
         Err(_) => None,
     };
 
-    eprintln!(
-        "aether-substrate: componentless boot — {WORKERS} workers, close window to exit. \
-         Load a component via `aether.control.load_component`."
+    tracing::info!(
+        target: "aether_substrate::boot",
+        workers = WORKERS,
+        "componentless boot — close window to exit; load a component via aether.control.load_component",
     );
 
     let event_loop = EventLoop::new()?;
@@ -368,12 +388,13 @@ fn main() -> wasmtime::Result<()> {
 
     let total = triangles_rendered.load(Ordering::Relaxed);
     let elapsed = app.started.map(|s| s.elapsed()).unwrap_or_default();
-    eprintln!(
-        "\nran {} frames in {:.2}ms ({:.1} fps) — triangles rendered = {}",
-        app.frame,
-        elapsed.as_secs_f64() * 1000.0,
-        app.frame as f64 / elapsed.as_secs_f64().max(0.001),
-        total,
+    tracing::info!(
+        target: "aether_substrate::shutdown",
+        frames = app.frame,
+        elapsed_ms = elapsed.as_secs_f64() * 1000.0,
+        fps = app.frame as f64 / elapsed.as_secs_f64().max(0.001),
+        triangles = total,
+        "frame loop exited",
     );
     Ok(())
 }

--- a/crates/aether-substrate/src/render.rs
+++ b/crates/aether-substrate/src/render.rs
@@ -172,16 +172,22 @@ impl Gpu {
                 return;
             }
             other => {
-                eprintln!("surface.get_current_texture: {other:?}");
+                tracing::warn!(
+                    target: "aether_substrate::render",
+                    status = ?other,
+                    "surface.get_current_texture returned unexpected status",
+                );
                 return;
             }
         };
 
         let vertex_bytes = vertices.len() as u64;
         if vertex_bytes > VERTEX_BUFFER_BYTES {
-            eprintln!(
-                "dropping frame: {} vertex bytes exceeds fixed buffer of {}",
-                vertex_bytes, VERTEX_BUFFER_BYTES
+            tracing::warn!(
+                target: "aether_substrate::render",
+                vertex_bytes,
+                cap = VERTEX_BUFFER_BYTES,
+                "dropping frame: vertex bytes exceed fixed buffer",
             );
             return;
         }

--- a/crates/aether-substrate/src/scheduler.rs
+++ b/crates/aether-substrate/src/scheduler.rs
@@ -224,24 +224,26 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
                         entry.pending.fetch_sub(1, Ordering::AcqRel);
                     }
                     None => {
-                        eprintln!(
-                            "substrate: mail to registered-component mailbox {:?} \
-                             but no component bound to it — dropped",
-                            recipient
+                        tracing::warn!(
+                            target: "aether_substrate::scheduler",
+                            mailbox = ?recipient,
+                            "mail to registered-component mailbox but no component bound — dropped",
                         );
                     }
                 }
             }
             Some(MailboxEntry::Dropped) => {
-                eprintln!(
-                    "substrate: mail to dropped mailbox {:?} — discarded",
-                    recipient
+                tracing::warn!(
+                    target: "aether_substrate::scheduler",
+                    mailbox = ?recipient,
+                    "mail to dropped mailbox — discarded",
                 );
             }
             None => {
-                eprintln!(
-                    "substrate: mail to unknown mailbox {:?} — dropped",
-                    recipient
+                tracing::warn!(
+                    target: "aether_substrate::scheduler",
+                    mailbox = ?recipient,
+                    "mail to unknown mailbox — dropped",
                 );
             }
         }

--- a/docs/adr/0023-engine-logs-mcp-tool.md
+++ b/docs/adr/0023-engine-logs-mcp-tool.md
@@ -1,7 +1,8 @@
 # ADR-0023: Substrate log capture and the `engine_logs` MCP tool
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-17
+- **Accepted:** 2026-04-18
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Substrate-side `tracing-subscriber` capture layer + flush thread that batches events into a new `EngineToHub::LogBatch` frame; bounded ring (2k entries / 2 MiB) with overflow surfaced as a synthetic warn entry.
- Hub-side per-engine `LogStore` (same caps) keyed by `EngineId`. Buffer outlives engine records so post-mortem `engine_logs` polls succeed after a substrate exit.
- New `mcp__aether-hub__engine_logs(engine_id, max?, level?, since?)` tool with cursor-based pagination, server-side level filter, `truncated_before` on eviction. `AETHER_LOG_FILTER` overrides the substrate-side `INFO+` default.
- Migrated every substrate `eprintln!`/`println!` callsite (ADR-0015 trap containment, scheduler/ctx no-component-bound logs, hub_client errors, frame_loop, render, boot/shutdown banners) to `tracing::*` so the headline trap-visibility motivation actually works.
- Sequences start at 1 so default `since=0` first poll catches the boot/handshake messages.

Implements ADR-0023 (flipped to Accepted in this PR).

## Test plan
- [x] `cargo test --workspace` — all green; 13 new tests across protocol roundtrip, substrate capture unit, hub LogStore unit, and 4-test end-to-end integration suite (`crates/aether-hub/tests/engine_logs.rs`) covering happy-path, level filter, cursor advance, post-mortem buffer survival.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Live-smoke against running hub: `spawn_substrate` → `engine_logs` returned the boot, hub-registration, and recurring frame_stats events (target/level/timestamp/sequence + structured fields flattened into message). Verified `since` cursor, `level=warn` filter (drops INFO), `max` clamp, and post-mortem read after `terminate_substrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)