### PR TITLE
feat(substrate,component): suffix host fn FFI with _p32 (ADR-0024 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ Input streams (tick, key, mouse_move, mouse_button) are publish/subscribe (ADR-0
 
 `aether.control.replace_component` is freeze-drain-swap (ADR-0022): the substrate freezes the target mailbox, waits for in-flight `deliver` calls on the old instance to complete, then swaps. If the drain exceeds `drain_timeout_ms` (default 5000, per-replace overridable) the reply is `Err { error: "drain timeout ..." }` and the old instance stays bound — a loud failure rather than silent dropped mail. Mail that arrives during the freeze is parked and flushed through whichever instance ends up bound (new on success, old on timeout).
 
-Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), ADR-0021 (input stream subscriptions), ADR-0022 (drain-on-swap for replace_component), and ADR-0023 (substrate log capture + engine_logs).
+Design detail lives in ADR-0006 (wire + topology), ADR-0007 (schema-driven encoding), ADR-0008 (observation path), ADR-0009 (hub-supervised substrate spawn), ADR-0020 (symmetric receive_mail decode), ADR-0021 (input stream subscriptions), ADR-0022 (drain-on-swap for replace_component), ADR-0023 (substrate log capture + engine_logs), and ADR-0024 (`_p32`-suffixed FFI in anticipation of wasm64).
+
+The component FFI surface uses a `_p32` suffix on every pointer-typed import (`aether::send_mail_p32`, `reply_mail_p32`, `resolve_kind_p32`, `resolve_mailbox_p32`, `save_state_p32`) and on the `receive_p32` / `on_rehydrate_p32` exports. Non-pointer exports (`init`, `on_replace`, `on_drop`) are unsuffixed. The suffix locks the wasm32/wasm64 naming convention without committing to dual registration today — see ADR-0024 for the deferred Phase 2.
 
 ## Commands
 

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -659,8 +659,9 @@ macro_rules! export {
         /// matching the FFI contract in
         /// `aether-substrate/src/host_fns.rs`. `sender` is the per-
         /// instance reply-to handle (ADR-0013) or `SENDER_NONE` for
-        /// mail with no meaningful reply target.
-        #[unsafe(no_mangle)]
+        /// mail with no meaningful reply target. Exported under the
+        /// `_p32` suffix per ADR-0024 Phase 1.
+        #[unsafe(export_name = "receive_p32")]
         pub unsafe extern "C" fn receive(kind: u32, ptr: u32, count: u32, sender: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
@@ -701,8 +702,9 @@ macro_rules! export {
         /// Called by the substrate after `init` on a freshly
         /// instantiated replacement, with `(version, ptr, len)`
         /// describing the prior-state bundle the old instance
-        /// produced via `DropCtx::save_state`.
-        #[unsafe(no_mangle)]
+        /// produced via `DropCtx::save_state`. Exported under the
+        /// `_p32` suffix per ADR-0024 Phase 1.
+        #[unsafe(export_name = "on_rehydrate_p32")]
         pub unsafe extern "C" fn on_rehydrate(version: u32, ptr: u32, len: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -2,20 +2,31 @@
 // guest component tree that should write `extern "C"` decls or host-stub
 // panics; everything else goes through the typed wrappers in `lib.rs`.
 //
-// On wasm32 the three fns are imports from the `aether` module the
-// substrate exposes (see `aether-substrate/src/host_fns.rs`). On any
-// other target they're stubs that panic if called, which keeps the
-// crate (and every component that depends on it) compilable for
-// `cargo test --workspace` on the host — components can still be
-// unit-tested for pure logic there, they just can't cross the FFI.
+// On wasm32 the fns are imports from the `aether` module the substrate
+// exposes (see `aether-substrate/src/host_fns.rs`). On any other target
+// they're stubs that panic if called, which keeps the crate (and every
+// component that depends on it) compilable for `cargo test --workspace`
+// on the host — components can still be unit-tested for pure logic
+// there, they just can't cross the FFI.
+//
+// ADR-0024 Phase 1: the wasm-visible import names carry a `_p32`
+// suffix in anticipation of a future `_p64` sibling for wasm64
+// components. The Rust-side identifiers stay un-suffixed (`send_mail`,
+// not `send_mail_p32`) so callers in `lib.rs` don't have to thread the
+// suffix through every callsite — `#[link_name]` does the remap.
 
 #[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
+    #[link_name = "send_mail_p32"]
     pub fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    #[link_name = "reply_mail_p32"]
     pub fn reply_mail(sender: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    #[link_name = "resolve_kind_p32"]
     pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
+    #[link_name = "resolve_mailbox_p32"]
     pub fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u32;
+    #[link_name = "save_state_p32"]
     pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
 }
 

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -55,7 +55,7 @@ impl Component {
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
         let receive =
-            instance.get_typed_func::<(u32, u32, u32, u32), u32>(&mut store, "receive")?;
+            instance.get_typed_func::<(u32, u32, u32, u32), u32>(&mut store, "receive_p32")?;
 
         // Optional `init() -> u32` export: called once before the first
         // `receive`, used for one-shot bootstrap like resolving kind
@@ -80,7 +80,7 @@ impl Component {
         // `STATE_OFFSET`, then calls the shim with `(version,
         // STATE_OFFSET, len)`.
         let on_rehydrate = instance
-            .get_typed_func::<(u32, u32, u32), u32>(&mut store, "on_rehydrate")
+            .get_typed_func::<(u32, u32, u32), u32>(&mut store, "on_rehydrate_p32")
             .ok();
 
         Ok(Self {
@@ -248,7 +248,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -265,14 +265,14 @@ mod tests {
     const WAT_NO_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
     const WAT_TRAP_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -282,11 +282,11 @@ mod tests {
     /// version and 4 bytes at offset 300 (`0xDE 0xAD 0xBE 0xEF`).
     const WAT_SAVES_STATE: &str = r#"
         (module
-            (import "aether" "save_state"
+            (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -301,10 +301,10 @@ mod tests {
     /// returns status 3 (too-large). The guest drops the return.
     const WAT_SAVES_TOO_LARGE: &str = r#"
         (module
-            (import "aether" "save_state"
+            (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -321,9 +321,9 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
-            (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
+            (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 ;; *(u32*)396 = version
                 i32.const 396
                 local.get 0
@@ -341,7 +341,7 @@ mod tests {
     const WAT_STORES_SENDER: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 500
                 local.get 3
                 i32.store
@@ -353,10 +353,10 @@ mod tests {
     /// the round-trip is the observable behavior.
     const WAT_REPLIES: &str = r#"
         (module
-            (import "aether" "reply_mail"
+            (import "aether" "reply_mail_p32"
                 (func $reply_mail (param i32 i32 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 (drop (call $reply_mail
                     (local.get 3) ;; sender handle from receive param
                     (i32.const 0) ;; kind id 0 — registered in the test

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -702,7 +702,7 @@ mod tests {
     const WAT: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
@@ -713,7 +713,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -732,7 +732,7 @@ mod tests {
     const WAT_TRAPS_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -742,11 +742,11 @@ mod tests {
     /// with schema version 7.
     const WAT_SAVES_STATE: &str = r#"
         (module
-            (import "aether" "save_state"
+            (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -761,10 +761,10 @@ mod tests {
     /// the ctx error slot is populated.
     const WAT_SAVES_TOO_LARGE: &str = r#"
         (module
-            (import "aether" "save_state"
+            (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -780,9 +780,9 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
                 i32.const 0)
-            (func (export "on_rehydrate") (param i32 i32 i32) (result i32)
+            (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 i32.const 396
                 local.get 0
                 i32.store
@@ -1812,10 +1812,10 @@ mod tests {
     /// old) instance handled each parked mail.
     const WAT_FORWARDS_TO_SINK: &str = r#"
         (module
-            (import "aether" "send_mail"
+            (import "aether" "send_mail_p32"
                 (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive")
+            (func (export "receive_p32")
                 (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
                 (result i32)
                 (drop (call $send_mail

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -51,7 +51,7 @@ pub const SAVE_STATE_TOO_LARGE: u32 = 3;
 pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
-        "send_mail",
+        "send_mail_p32",
         |mut caller: Caller<'_, SubstrateCtx>,
          recipient: u32,
          kind: u32,
@@ -82,7 +82,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
 
     linker.func_wrap(
         "aether",
-        "resolve_kind",
+        "resolve_kind_p32",
         |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
             let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
                 Some(m) => m,
@@ -126,7 +126,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // for the success path and doesn't change behavior on error.
     linker.func_wrap(
         "aether",
-        "save_state",
+        "save_state_p32",
         |mut caller: Caller<'_, SubstrateCtx>, version: u32, ptr: u32, len: u32| -> u32 {
             if len as usize > MAX_STATE_BUNDLE_BYTES {
                 caller.data_mut().save_state_error = Some(format!(
@@ -164,7 +164,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     //     as any other send to a dropped mailbox.
     linker.func_wrap(
         "aether",
-        "reply_mail",
+        "reply_mail_p32",
         |mut caller: Caller<'_, SubstrateCtx>,
          sender: u32,
          kind: u32,
@@ -218,7 +218,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
 
     linker.func_wrap(
         "aether",
-        "resolve_mailbox",
+        "resolve_mailbox_p32",
         |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
             let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
                 Some(m) => m,

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -24,10 +24,10 @@ use wasmtime::{Engine, Linker, Module};
 
 const WAT: &str = r#"
 (module
-  (import "aether" "send_mail"
+  (import "aether" "send_mail_p32"
     (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
-  (func (export "receive")
+  (func (export "receive_p32")
     (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     ;; Forward a send_mail call to mailbox 1 (the sink in this test).

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -31,10 +31,10 @@ use wasmtime::{Engine, Linker};
 /// dispatch arrived.
 const WAT: &str = r#"
 (module
-  (import "aether" "send_mail"
+  (import "aether" "send_mail_p32"
     (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
-  (func (export "receive")
+  (func (export "receive_p32")
     (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     (drop (call $send_mail

--- a/docs/adr/0024-dual-target-host-fn-ffi.md
+++ b/docs/adr/0024-dual-target-host-fn-ffi.md
@@ -1,161 +1,135 @@
 # ADR-0024: Dual-target wasm32/wasm64 host fn FFI
 
-- **Status:** Proposed
+- **Status:** Accepted (Phase 1 only; Phase 2 deferred)
 - **Date:** 2026-04-17
+- **Accepted:** 2026-04-19
 
 ## Context
 
-The aether-component FFI is wasm32-pointer-shaped end to end. Every host fn the substrate registers — `aether::send_mail`, `aether::resolve_mailbox`, `aether::reply_mail` (ADR-0013), `aether::save_state` (ADR-0016), and the per-component receive shim (ADR-0014) — takes pointer-typed arguments as `u32`. The guest SDK reflects the same: `bytes.as_ptr().addr() as u32` is the documented pattern that survives `cargo check` for both wasm32 and host targets, and `Mail::__from_raw(u32)` is the FFI entry point. This is fine for `wasm32-unknown-unknown` and exactly what wasmtime expects for wasm32 modules.
+The aether-component FFI is wasm32-pointer-shaped end to end. Every host fn the substrate registers — `aether::send_mail`, `aether::resolve_mailbox`, `aether::resolve_kind`, `aether::reply_mail` (ADR-0013), `aether::save_state` (ADR-0016) — takes pointer-typed arguments as `u32`. The guest exports the substrate looks up at instantiation (`receive`, `on_rehydrate`) match the same shape. The guest SDK reflects all of it: `bytes.as_ptr().addr() as u32` is the documented pattern that survives `cargo check` for both wasm32 and host targets, and `Mail::__from_raw(u32)` is the FFI entry point. This is fine for `wasm32-unknown-unknown` and exactly what wasmtime expects for wasm32 modules.
 
 It is also the single thing standing between the project and ever loading a wasm64 component.
 
 Wasm32's hard linear-memory ceiling is 4 GiB — the address space, not anything aether sets. For current components that's not load-bearing: the hello-component is ~17 KiB compiled, runtime allocation is small, and the architecture pushes asset memory (textures, vertex buffers, audio) onto the substrate side via host fns rather than into the guest's linear memory. So far so good.
 
-The 4 GiB ceiling becomes load-bearing in two cases worth taking seriously now:
+The 4 GiB ceiling becomes load-bearing in two cases worth taking seriously:
 
-- **Debug builds.** Unoptimized wasm carries debug info inline, doesn't dead-code-eliminate, doesn't merge allocations, and runs without LTO. A component that's 100 MiB resident in release can be several times that in debug. Not 4 GiB today, but the gap closes faster than it opens as the engine grows. "We hit the ceiling first in debug" is an annoying failure mode — it punishes the iteration loop, not production.
+- **Debug builds.** Unoptimized wasm carries debug info inline, doesn't dead-code-eliminate, doesn't merge allocations, and runs without LTO. A component that's 100 MiB resident in release can be several times that in debug. Not 4 GiB today, but the gap closes faster than it opens as the engine grows.
 - **In-process simulation state.** Voxel grids, large entity systems, in-component physics state, ML inference weights — these don't always fit the substrate-side resource pattern. When they don't, they live in the guest's linear memory, and 4 GiB is a real ceiling rather than a theoretical one.
 
-The cost of dual-targeting *now* is bounded — five host fns on the substrate side, the SDK's `raw` module on the guest side, the `export!` macro's receive shim. The cost of dual-targeting *later* is the same five host fns plus every new host fn added between now and then, plus every guest crate that picked up the wasm32-only assumption, plus every test that hardcoded the pointer width. That's the wrong direction for a cost curve.
+wasmtime supports the memory64 proposal natively. The blocker is not the runtime; it's the import / export names the substrate publishes and the SDK declares.
 
-wasmtime supports the memory64 proposal natively. The blocker is not the runtime; it's the import signatures the substrate publishes.
+### Why two phases
+
+The full design (Phase 2, below) registers every host fn at *both* a `u32`- and `u64`-pointer signature, distinguished by name suffix. Implementing that today buys forward-compat that the project genuinely wants, but it pulls in costs that aren't paid back yet:
+
+- A `register_dual` helper and per-host-fn double maintenance every time a host fn is added.
+- A `target` field on `LoadComponent`, changing wire surface that has to be versioned.
+- Validating wasm64 in CI requires a nightly toolchain plus `-Z build-std=std,panic_abort` plus the `rust-src` component (a 2026-04 toolchain probe confirmed: stable can't add the target, nightly has no prebuilt artifacts, and `build-std` is the only path). Either the workspace pins to nightly (punishes the stable build for one example) or the wasm64 smoke gets carved out of CI (smoke without CI guards isn't worth much).
+- wasm64's Tier 3 status in Rust shows no concrete promotion timeline — multi-year horizon is the realistic forecast.
+
+Meanwhile, the *thing* that locks in forward-compat — the import / export naming convention — is small, mechanical, and one-time. Renaming the existing FFI surface to a `_p32` suffix now (while the audience is N=0 external component authors) means future wasm64 support is purely additive: drop in `_p64` siblings, no further breaking change. Shipping that piece on its own captures the strategic win without taking on the carry cost.
 
 ## Decision
 
-Every host fn is registered at *both* a `u32`-pointer and a `u64`-pointer signature, distinguished by name suffix. Guests declare one or the other based on their compile-time `target_pointer_width`. `LoadComponent` carries the target so the substrate enables the right wasmtime config and rejects modules whose declared imports don't match.
+Two phases, with a hard split.
 
-### 1. Naming convention
+### Phase 1 — naming convention only (this ADR)
 
-Each host fn ships under two names in the same `aether` module, suffixed by pointer width:
+Rename every pointer-typed FFI symbol to a `_p32` suffix. This is the entire scope of Phase 1; nothing else in the substrate or SDK changes.
 
-```
-aether::send_mail_p32   (ptr: u32, len: u32, ...)
-aether::send_mail_p64   (ptr: u64, len: u64, ...)
+**Imports renamed (substrate side, in `aether-substrate/src/host_fns.rs`):**
 
-aether::resolve_mailbox_p32 / _p64
-aether::reply_mail_p32      / _p64
-aether::save_state_p32      / _p64
-```
+| Before                       | After                              |
+| ---------------------------- | ---------------------------------- |
+| `aether::send_mail`          | `aether::send_mail_p32`            |
+| `aether::reply_mail`         | `aether::reply_mail_p32`           |
+| `aether::resolve_kind`       | `aether::resolve_kind_p32`         |
+| `aether::resolve_mailbox`    | `aether::resolve_mailbox_p32`      |
+| `aether::save_state`         | `aether::save_state_p32`           |
 
-Wasmtime resolves imports by `(module, name)` and validates signatures at instantiation. Pairing names rather than pairing modules (`aether32::send_mail` vs `aether64::send_mail`) keeps the import surface a single conceptual namespace and means a guest accidentally importing the wrong width fails with a clear "function not found" error rather than a silent module swap.
+**Exports renamed (guest side, emitted by the `export!` macro):**
 
-The receive shim that the guest *exports* follows the same pattern: `__aether_receive_p32` and `__aether_receive_p64`. The substrate, on instantiation, looks up whichever export matches the component's declared target.
+| Before          | After                |
+| --------------- | -------------------- |
+| `receive`       | `receive_p32`        |
+| `on_rehydrate`  | `on_rehydrate_p32`   |
 
-Length / count arguments stay `u32` regardless of target. The pointer-width parameter is exactly that — only pointers widen. Frame sizes are still capped at 1 MiB per ADR-0006; nothing about that changes for wasm64 guests.
+**Exports unchanged** because they take no pointer arguments: `init`, `on_replace`, `on_drop`. No width concern, no rename benefit, no churn.
 
-### 2. Substrate-side registration
+The substrate's `get_typed_func` lookups for `receive` / `on_rehydrate` are updated to the new names. The SDK's `raw` module keeps its Rust-side identifiers (`raw::send_mail`, etc.) and uses `#[link_name = "..._p32"]` attributes to remap the wasm-visible name — this minimises the diff in `aether-component/src/lib.rs`, which calls `raw::send_mail` and friends from many sites.
 
-A small helper in the substrate's host-fn module registers both variants of each host fn from one source:
+Length / count arguments stay `u32` regardless of target. Pointer-width is exactly what the suffix gates; only pointers will widen in Phase 2.
 
-```rust
-fn register_dual<F32, F64>(
-    linker: &mut Linker<SubstrateCtx>,
-    name: &str,
-    f32_impl: F32,
-    f64_impl: F64,
-) -> wasmtime::Result<()> { ... }
-```
+**Forward-compat property.** After Phase 1 ships, adding wasm64 in Phase 2 is purely additive: register `aether::send_mail_p64` next to `aether::send_mail_p32`, emit `receive_p64` next to `receive_p32`, no rename, no break. Existing components built against `_p32` keep loading exactly as they do today.
 
-The two implementations differ only in pointer width — both cast their pointer args to `usize` and call into a shared inner function. There is no per-target logic above the FFI boundary; the substrate's mail dispatch, state save, and reply paths are pointer-width-agnostic.
+### Phase 2 — dual registration, deferred
 
-The substrate's `Config` enables `wasm_memory64(true)` unconditionally (wasmtime supports both targets in a memory64-enabled engine — wasm32 modules just don't use the wider addressing). Per-engine config; not per-component.
+Phase 2 is the originally-proposed design. It is bookmarked here, not implemented now. Trigger to revisit: wasm64 is promoted to Tier 2 (a Rust toolchain shift), or a real component approaches the 4 GiB ceiling, whichever comes first.
 
-### 3. `LoadComponent` declares the target
+The design that will ship when Phase 2 is unblocked:
 
-```rust
-pub enum PointerTarget {
-    Wasm32,
-    Wasm64,
-}
+- A `register_dual<F32, F64>` helper in the substrate's host-fn module, registering both pointer-width variants of each host fn from one source. Implementations differ only in the `as usize` cast above the FFI boundary; the dispatch / state save / reply paths are pointer-width-agnostic.
+- `Config::wasm_memory64(true)` enabled unconditionally on the substrate engine (wasmtime supports both targets in a memory64-enabled engine; wasm32 modules just don't use the wider addressing).
+- A `PointerTarget` enum and `target: Option<PointerTarget>` field on `LoadComponent`, defaulting to `Wasm32`. The substrate uses the declared target to pick the receive-shim export name (`_p32` vs `_p64`), validate memory limits against the target's ceiling, and surface a clear `LoadResult::Err` when declared imports don't match the declared target.
+- The SDK's `raw` module gates the `extern "C"` block on `target_pointer_width`; the `export!` macro emits the correctly-named/typed receive shim per target. Mail/Sink/Ctx surface stays unchanged — already `usize`-based per ADR-0014.
+- A wasm64 smoke component (likely a wasm64 build of hello-component) demonstrating the dual-target path end-to-end: load, deliver, reply, save_state. CI carve-out for the nightly + `build-std` requirement, or run as a manually-invoked script outside CI; resolve at the time.
 
-pub struct LoadComponent {
-    // ... existing fields ...
-    pub target: Option<PointerTarget>,   // None defaults to Wasm32
-}
-```
-
-Defaulting to `Wasm32` matches the current toolchain reality — `wasm32-unknown-unknown` is Tier 1 in Rust; `wasm64-unknown-unknown` is Tier 3 (works for basic crates, no automated Rust CI coverage, some dependencies may not compile). Components opt into wasm64 explicitly.
-
-The substrate uses the declared target to:
-
-1. Pick the receive-shim export name to look up after instantiation (`_p32` vs `_p64`).
-2. Validate the loaded module's memory limits respect the target's ceiling — a wasm32 module declaring `memory.grow` past 4 GiB is rejected before instantiation; a wasm64 module declaring memory beyond `ComponentBudget.max_memory_bytes` is rejected the same way.
-3. Surface a clear `LoadResult::Err { reason: "module imports aether::send_mail_p64 but target is Wasm32" }` if the declared target doesn't match the imports the module actually pulls in.
-
-### 4. Guest SDK selects at compile time
-
-`aether-component`'s `raw` module emits the right `extern "C"` block per target:
-
-```rust
-#[cfg(target_pointer_width = "32")]
-extern "C" {
-    #[link_name = "send_mail_p32"]
-    fn send_mail(ptr: u32, len: u32, ...) -> u32;
-    // ...
-}
-
-#[cfg(target_pointer_width = "64")]
-extern "C" {
-    #[link_name = "send_mail_p64"]
-    fn send_mail(ptr: u64, len: u64, ...) -> u32;
-    // ...
-}
-```
-
-`Mail`, `Sink<K>`, `Ctx`, `InitCtx`, `Component`, `KindId<K>` and the rest of the user-facing surface stay unchanged — they already use `usize` internally per ADR-0014. The pointer-width difference is invisible above the `raw` module.
-
-The `export!` macro emits a single receive shim function with the correct name and signature for the target — `__aether_receive_p32` on wasm32, `__aether_receive_p64` on wasm64. Components don't pick; the macro picks.
-
-### 5. What this ADR does *not* do
-
-- **No mid-life retargeting.** A component is wasm32 or wasm64 for its lifetime. Replace can swap to a different target (rebuild + reload), but a single instance can't switch.
-- **No fat binaries.** Each compiled `.wasm` is one target. The agent picks which to load; the substrate doesn't transcode.
-- **No component-model adoption.** The component model has its own pointer-polymorphism story via canonical ABIs, but the aether-component SDK uses raw wasm imports. Migrating to the component model is a separate, much larger ADR.
-- **No automatic toolchain bootstrapping.** `rustup target add wasm64-unknown-unknown` is the developer's responsibility; the substrate just refuses to load a module whose imports it can't satisfy.
+Phase 2 is a meaningful chunk of work, but Phase 1 makes it strictly additive — no FFI break for any component that loaded successfully against the Phase 1 surface.
 
 ## Consequences
 
 ### Positive
 
-- **The 4 GiB ceiling stops being a strategic risk.** Components that need more declare wasm64 at load and get the room without any substrate-side change after this ADR ships.
-- **No retooling debt accumulates.** Every host fn added from this point forward is dual-registered automatically (the helper enforces it). The "migration to wasm64" never has to happen as a discrete event.
-- **Debug-build headroom is fixed.** A component that hits 4 GiB only in debug can flip to wasm64 for the dev cycle and back to wasm32 for release without changing engine code.
-- **Clean failure modes.** Mismatched targets fail at load (clear error message in `LoadResult::Err`), not at runtime. Imports resolve or they don't; wasmtime's signature checker does the work.
-- **Wasm32 stays the default.** Toolchain-mature path stays the easy path. wasm64 is opt-in for the cases that need it.
+- **Forward-compat is locked in cheaply.** ~30 lines of mechanical rename across substrate + SDK + test fixtures. Future wasm64 add becomes additive — no breaking FFI rename when the trigger fires.
+- **Carry cost is zero.** No `register_dual` helper, no per-host-fn double maintenance, no `target` field on `LoadComponent`. Adding a new host fn in Phase 1's world looks identical to today — just register one `*_p32`-suffixed name.
+- **Toolchain debt is zero.** Phase 1 doesn't touch the wasm64 toolchain. Workspace stays on stable; CI doesn't grow a nightly carve-out.
+- **Wasm32 stays the only deployed target.** Toolchain-mature path stays the easy path. wasm64 remains opt-in, unimplemented until needed.
+- **The breaking change happens once, while the audience is N=0.** All in-repo example components rebuild as part of this PR; no external consumers exist to migrate.
 
 ### Negative
 
-- **Every host fn is now two entries.** The `register_dual` helper keeps it mechanical, but a developer adding a host fn has to remember to write both impls. Mitigated by code review and by the helper signature requiring both. Still a sharp edge.
-- **Wasm64 toolchain is Tier 3.** A component author who flips to wasm64 may find a transitive dependency that doesn't compile. Mitigated by defaulting to wasm32 — only components that need wasm64 pay the toolchain tax.
-- **wasm64 has measurable bounds-check overhead.** wasmtime can't use the same signal-handler / guard-page tricks for 64-bit linear memories that it uses for 32-bit. Benchmarks suggest 10–20% throughput on memory-heavy hot loops. Acceptable for components that need the address space; an active reason not to default to wasm64.
-- **Receive shim export name lookup adds one branch at instantiation.** The substrate picks `_p32` or `_p64` based on the declared target. Negligible cost; one boolean.
-- **Error surface widens slightly.** "Wrong target" joins the existing list of `LoadResult::Err` reasons. Worth it for the explicit failure mode.
+- **The `_p32` suffix is aspirational.** Until Phase 2 ships, every host fn name carries a suffix that points at a target distinction the substrate doesn't yet implement. A newcomer will reasonably ask "why the suffix?" The answer is "future wasm64." The alternative — leaving names un-suffixed and renaming when wasm64 lands — is uglier (breaks every component that exists at that point).
+- **The `_p32` rename is itself a breaking FFI change.** Mitigated by the breakage being fully internal: hello-component, echoer, caller, input_logger all rebuild from this PR. No external authors to coordinate.
+- **Phase 2 is genuinely deferred, not "soon."** wasm64 might be years away. If a project pressure forces it sooner, Phase 2 still has to be implemented at that point — Phase 1 doesn't shortcut Phase 2's work, only its breakage cost.
 
 ### Neutral
 
-- **Engine ↔ hub wire format is untouched.** Pointer width is a substrate-internal concern; mail bytes don't carry it.
-- **No host-side change after this ADR ships.** Every future host fn just calls `register_dual`; the substrate runtime doesn't grow new code paths.
-- **Existing components don't migrate.** Hello-component stays wasm32, declared-by-default. No migration; no rebuild required.
+- **Engine ↔ hub wire format is untouched.** Pointer width is a substrate-internal concern; mail bytes don't carry it. This stays true through Phase 2.
+- **No host-side runtime change.** The substrate's mail dispatch, state save, and reply paths don't grow new code paths in Phase 1. Phase 2 adds dual registration but the inner logic remains pointer-width-agnostic.
+- **No component-model adoption.** The component model has its own pointer-polymorphism story via canonical ABIs; Phase 1 does not preempt or preclude eventually moving to it.
 
 ## Alternatives considered
 
-- **Wasm32-only forever, plan to migrate later.** Rejected: the cost of migrating later is the cost of doing it now plus the cost of every host fn added in between, and the strategic concern (debug-build ceilings, in-process simulation state) is real enough that "deal with it later" is a deferral, not a decision.
-- **Wasm64-only.** Pick one target, the bigger one. Rejected: wasm64 toolchain maturity is genuinely behind wasm32, and the bounds-check perf overhead is a real cost for components that don't need the address space. Forcing every component onto wasm64 is paying for a cost without getting the benefit.
+- **Wasm32-only forever.** Rejected: the strategic concern (debug-build ceilings, in-process simulation state) is real enough that "deal with it later" is a deferral rather than a decision. Phase 1 captures the cheap forward-compat win without committing to Phase 2's full implementation.
+- **Wasm64-only.** Rejected: wasm64 toolchain maturity is genuinely behind wasm32 (probe-confirmed: stable can't build the target; nightly + `build-std` is the only path), and the bounds-check perf overhead is a real cost for components that don't need the address space.
 - **Always-u64 host fn signatures with wasm32 guests zero-extending.** wasmtime resolves imports by exact signature match; a wasm32 guest declaring an import as `(u64) -> u32` and the host registering `(u64) -> u32` doesn't help, because the guest's pointer values are 32-bit and the wasm import declaration would need to be `(u32) -> u32` to compile against `wasm32-unknown-unknown`. Rejected as not actually possible without a wasmtime-side adapter.
-- **Two import modules (`aether32`, `aether64`) instead of suffixed names.** Same effect; cosmetic difference. Rejected because pairing names within one module is closer to the existing surface and keeps `aether::*` as the single conceptual namespace agents and component authors think about.
-- **Migrate to the wasmtime component model.** Component model has canonical ABI for pointer polymorphism and would handle this more elegantly. Rejected as out of scope for this ADR — it's a much larger surface change with its own design questions (typed interfaces, world definitions, host adapter generation). The dual-registration approach is a tactical fix that doesn't preclude eventually moving to the component model.
-- **Defer until a component actually hits 4 GiB.** Same shape as "wasm32-only forever." Rejected for the same reason: by the time the trigger fires, the migration is more expensive than the design.
+- **Two import modules (`aether32`, `aether64`) instead of suffixed names.** Same effect; cosmetic difference. Rejected because pairing names within one module is closer to the existing surface and keeps `aether::*` as the single conceptual namespace.
+- **Migrate to the wasmtime component model.** Component model has canonical ABI for pointer polymorphism and would handle this more elegantly. Rejected as out of scope for this ADR — much larger surface change with its own design questions. The dual-registration approach is a tactical fix that doesn't preclude eventually moving to the component model.
+- **Defer the whole ADR (no rename now).** Rejected after deliberation: the cost of the rename is fixed and small (audience is N=0); the cost of breaking the FFI later when external component authors exist is variable and grows with project adoption. Locking the convention while the cost is bounded is the higher-leverage move.
+- **Skip the `_p32` suffix; only suffix Phase 2's wasm64 additions.** Rejected: it leaves wasm32 imports asymmetrically un-suffixed forever, which is the cosmetic-debt outcome the explicit naming convention is trying to avoid.
 
 ## Follow-up work
 
-- **`aether-substrate`**: implement `register_dual` helper; convert every existing host fn (`send_mail`, `resolve_mailbox`, `reply_mail`, `save_state`) to dual-registration. Enable `Config::wasm_memory64(true)` unconditionally.
+### Phase 1 (this PR)
+
+- **`aether-substrate`**: rename the five `linker.func_wrap("aether", "<name>", ...)` entries in `host_fns.rs` to `<name>_p32`; update `get_typed_func` lookups for `receive` and `on_rehydrate` in `component.rs` to `_p32` siblings; update inline WAT test fixtures across `component.rs` and `control.rs` to match.
+- **`aether-component`**: add `#[link_name = "..._p32"]` attributes to each `extern "C"` import in `raw.rs`; update the `export!` macro in `lib.rs` to emit `receive_p32` and `on_rehydrate_p32` (other exports unchanged).
+- **Example components**: rebuild hello-component + echoer + caller + input_logger — no source change, just cargo build.
+- **CLAUDE.md**: brief note that the FFI surface is `_p32`-suffixed in anticipation of wasm64.
+
+### Phase 2 (deferred — not committed by this PR)
+
+- **`aether-substrate`**: implement `register_dual` helper; add `_p64` siblings for every existing host fn. Enable `Config::wasm_memory64(true)` unconditionally.
 - **`aether-substrate`**: thread `target` from `LoadComponent` through instantiation; pick the receive-shim export name based on it; validate import-target match and emit `LoadResult::Err` with a clear reason on mismatch.
 - **`aether-substrate-mail`**: add `PointerTarget` enum + `target: Option<PointerTarget>` field on `LoadComponent` (additive, defaults to `Wasm32`).
-- **`aether-component`**: gate the `raw` module's `extern "C"` blocks on `target_pointer_width`; update `export!` macro to emit the correctly-named/typed receive shim per target. Mail/Sink/Ctx surface unchanged.
-- **Tests**: build a minimal wasm64 smoke component (or repurpose hello-component) and verify the dual-target path end-to-end — load, deliver, reply, save_state. Confirm wasm32 hello-component still loads unchanged.
-- **CLAUDE.md**: brief note in the MCP harness section about `target` defaulting to wasm32 and the `rustup target add wasm64-unknown-unknown` step for components that opt in.
-- **Parked, not committed:**
-  - Substrate-level transcoding between targets (compile a wasm32 module to wasm64 on load) — out of scope and unmotivated.
-  - Per-component custom address-space ceilings beyond the 64 GiB substrate-level wasm64 sanity cap.
-  - Component-model migration (separate larger ADR if/when adopted).
-  - Wider integer parameters (e.g. count args going to u64) — kept as u32 here; revisit if ADR-0006's 1 MiB frame cap is ever lifted.
+- **`aether-component`**: gate the `raw` module's `extern "C"` blocks on `target_pointer_width`; update `export!` macro to emit the correctly-named/typed receive shim per target.
+- **Tests**: build a minimal wasm64 smoke component (or repurpose hello-component) and verify the dual-target path end-to-end. Resolve the nightly + `build-std` toolchain question (in-CI carve-out vs out-of-CI script) at the time.
+- **CLAUDE.md**: document `target` field default and the `rustup component add rust-src --toolchain nightly` step for components that opt in.
+
+### Parked, not committed
+
+- Substrate-level transcoding between targets (compile a wasm32 module to wasm64 on load) — out of scope and unmotivated.
+- Per-component custom address-space ceilings beyond the 64 GiB substrate-level wasm64 sanity cap.
+- Component-model migration (separate larger ADR if/when adopted).
+- Wider integer parameters (e.g. count args going to u64) — kept as u32 here; revisit if ADR-0006's 1 MiB frame cap is ever lifted.


### PR DESCRIPTION
## Summary

ADR-0024 Phase 1 — locks the wasm32/wasm64 naming convention now while the audience is N=0 external component authors. Phase 2 (full dual-registration, `_p64` siblings, wasm64 smoke) is deferred.

- Renames the 5 pointer-typed host fn imports to `_p32` suffix: `aether::send_mail_p32`, `reply_mail_p32`, `resolve_kind_p32`, `resolve_mailbox_p32`, `save_state_p32`.
- Renames the 2 pointer-typed guest exports: `receive_p32`, `on_rehydrate_p32`. Non-pointer exports (`init`, `on_replace`, `on_drop`) untouched.
- SDK's `raw` module keeps Rust-side identifiers (`raw::send_mail` etc.); `#[link_name]` remaps the wasm-visible name so callers in `lib.rs` don't churn.
- WAT test fixtures across `component.rs`, `control.rs`, `end_to_end.rs`, `input_subscriptions.rs` updated to match.

After this lands, adding wasm64 in Phase 2 is purely additive — drop in `_p64` siblings, no FFI break for any component built against the Phase 1 surface.

## Why now

Toolchain probe (2026-04) confirmed wasm64 currently requires nightly + `-Z build-std=std,panic_abort` + `rust-src` — Tier 3 with no committed promotion timeline. So Phase 2's full implementation isn't worth the carry cost yet (`register_dual` scaffolding, `target` field on `LoadComponent`, in-CI wasm64 toolchain). But the *naming convention* is small, mechanical, and one-time — locking it now is much cheaper than renaming the FFI later when external component authors exist. ADR-0024 has the full reasoning and the deferred Phase 2 design intact.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --workspace` — 188+ tests pass, including `end_to_end.rs` and `input_subscriptions.rs` which compile WAT against renamed `_p32` imports and instantiate via the substrate's renamed linker
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All 4 wasm32 example components rebuild against renamed SDK (hello, echoer, caller, input_logger)
- [x] Live substrate boots, registers host fns under new names without error, frame loop runs steady

🤖 Generated with [Claude Code](https://claude.com/claude-code)