### PR TITLE
chore: gitignore .claude/ session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 # Spike crates under spikes/ are standalone Cargo workspaces with
 # their own target dirs (per ADR-0003 §Consequences).
 spikes/*/target/
+# Claude Code session-local state (scheduled tasks, etc.).
+.claude/


### PR DESCRIPTION
## Summary

`.claude/scheduled_tasks.lock` has been showing up as untracked across the last several PRs (the `gh pr create` "1 uncommitted change" warning each time). It's Claude Code's local session state — never intended for the repo.

Adds `.claude/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)