### PR TITLE
docs: replace README stub with stable orientation text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # aether
+
+A game engine being built collaboratively with Claude.
+
+The vision is a harness where Claude sits as assistant, engineer, and designer — driving a running engine, observing it, modifying it. The architecture is a thin native **substrate** that owns I/O, GPU, and audio and hosts a WebAssembly runtime; engine **components** run as WASM modules and communicate with the substrate and with each other through a **mail** system.
+
+## Reading the codebase
+
+- Architectural decisions are recorded as ADRs under `docs/adr/`. Read in order to follow the design as it evolved; the latest ADRs describe current commitments.
+- `CLAUDE.md` at the repo root is the working-directory guide for collaborating in this codebase.


### PR DESCRIPTION
## Summary

The README was a one-line stub (`# aether`). Replaces with content meant to stay durable across the project's evolution:

- One-line pitch
- The architectural thesis (substrate + WASM components + mail) — the load-bearing commitment
- Generic pointers to `docs/adr/` and `CLAUDE.md`

Deliberately avoids anything that would drift: no feature list, no specific ADR numbers, no crate names, no file paths, no quickstart commands, no current-status section. New stable sections can be appended later without rewrites — the constraint is "stable text only" so future Claude sessions won't be on the hook to keep transient claims fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)