### PR TITLE
feat(substrate,kinds): platform_info mail for OS/GPU/monitor snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "aether-kinds",
  "aether-mail",
  "bytemuck",
+ "os_info",
  "png",
  "pollster",
  "postcard",
@@ -1835,6 +1836,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,8 +1923,8 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -1925,8 +1938,19 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1953,6 +1977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1995,19 @@ dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1976,6 +2023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2042,28 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2011,6 +2090,19 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.4",
@@ -2098,16 +2190,37 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -2130,8 +2243,18 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2178,6 +2301,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4458,7 +4596,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -19,8 +19,9 @@ use aether_mail::{Kind, Schema};
 
 use crate::{
     CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats, Key,
-    LoadComponent, LoadResult, MouseButton, MouseMove, Ping, Pong, ReplaceComponent, ReplaceResult,
-    SubscribeInput, SubscribeInputResult, Tick, UnsubscribeInput,
+    LoadComponent, LoadResult, MouseButton, MouseMove, Ping, PlatformInfo, PlatformInfoResult,
+    Pong, ReplaceComponent, ReplaceResult, SubscribeInput, SubscribeInputResult, Tick,
+    UnsubscribeInput,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -58,6 +59,10 @@ pub fn all() -> Vec<KindDescriptor> {
         // see what the engine is rendering.
         schema::<CaptureFrame>(),
         schema::<CaptureFrameResult>(),
+        // Read-only snapshot of OS / engine / GPU / monitors / window.
+        // Empty request, fat reply — see `PlatformInfoResult`.
+        schema::<PlatformInfo>(),
+        schema::<PlatformInfoResult>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -379,6 +379,171 @@ mod control_plane {
         Ok { png: Vec<u8> },
         Err { error: String },
     }
+
+    /// `aether.control.platform_info` — request a one-shot snapshot of
+    /// the host environment the substrate is running on: OS + engine
+    /// build + GPU adapter + monitors with video modes + current
+    /// window state. Empty payload; reply is `PlatformInfoResult`.
+    ///
+    /// Fat-query design: static environment (OS / GPU) and live state
+    /// (window mode / size) ride together in one snapshot. Callers
+    /// that mutate state (`set_window_mode`) get the new state in the
+    /// mutation's reply, so polling `platform_info` after every
+    /// change isn't necessary.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.control.platform_info")]
+    pub struct PlatformInfo;
+
+    /// Reply to `PlatformInfo`. `Err` is reserved for snapshot
+    /// failures that the substrate can articulate (e.g. monitor
+    /// enumeration failed) — today the happy path is essentially
+    /// infallible, but keeping the variant leaves room to surface
+    /// platform-specific issues without widening the kind later.
+    ///
+    /// `Ok` holds far more data than `Err`; the clippy lint is
+    /// accurate but the value is constructed once per request,
+    /// serialized, and dropped, so the in-memory enum-tag cost is
+    /// not a concern.
+    #[allow(clippy::large_enum_variant)]
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.control.platform_info_result")]
+    pub enum PlatformInfoResult {
+        Ok {
+            os: OsInfo,
+            engine: EngineInfo,
+            gpu: GpuInfo,
+            monitors: Vec<MonitorInfo>,
+            /// `None` before winit's `resumed` callback fires — there's
+            /// no window yet. After first resume this is populated for
+            /// the life of the process.
+            window: Option<WindowInfo>,
+        },
+        Err {
+            error: String,
+        },
+    }
+
+    /// Host OS identification. `name` / `arch` come from
+    /// `std::env::consts` (lowercase short names — `"macos"`,
+    /// `"linux"`, `"windows"`; `"aarch64"` / `"x86_64"`); `version`
+    /// is sourced from the `os_info` crate and is platform-formatted
+    /// (e.g. `"14.5"`, `"22.04"`).
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct OsInfo {
+        pub name: String,
+        pub version: String,
+        pub arch: String,
+    }
+
+    /// Engine-side build identification. `version` is the substrate
+    /// crate's `CARGO_PKG_VERSION`; `workers` is the scheduler's
+    /// configured worker count; `kinds_count` is the number of kinds
+    /// registered at boot (ADR-0010 load-time additions aren't
+    /// included — this is a static boot-time fingerprint).
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct EngineInfo {
+        pub version: String,
+        pub workers: u32,
+        pub kinds_count: u32,
+    }
+
+    /// wgpu adapter identification plus the limits most agents reach
+    /// for when planning work. Values are the ones wgpu reports; ids
+    /// are the raw `AdapterInfo::vendor` / `device` integers (PCI
+    /// ids on desktop GPUs, zero on software adapters).
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct GpuInfo {
+        pub name: String,
+        pub vendor_id: u32,
+        pub device_id: u32,
+        pub device_type: GpuDeviceType,
+        pub backend: GpuBackend,
+        pub driver: String,
+        pub driver_info: String,
+        pub max_texture_dim_2d: u32,
+        pub max_buffer_size: u64,
+        pub max_bind_groups: u32,
+    }
+
+    /// Mirror of `wgpu::DeviceType`. Kept as its own enum so the
+    /// kind's schema doesn't depend on wgpu version churn and so
+    /// agents see the same variant names on every platform.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum GpuDeviceType {
+        Other,
+        IntegratedGpu,
+        DiscreteGpu,
+        VirtualGpu,
+        Cpu,
+    }
+
+    /// Mirror of `wgpu::Backend`. Like `GpuDeviceType`, independent
+    /// of wgpu's enum so the wire shape is stable.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum GpuBackend {
+        Noop,
+        Vulkan,
+        Metal,
+        Dx12,
+        Gl,
+        BrowserWebGpu,
+    }
+
+    /// One monitor attached to the host. `position_x` / `position_y`
+    /// are the monitor's top-left in desktop coordinates; `width` /
+    /// `height` are the monitor's current resolution in physical
+    /// pixels. `current_mode` is `None` if winit couldn't determine
+    /// the active mode. `modes` is the full list winit reported —
+    /// callers pick one for `FullscreenExclusive`.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct MonitorInfo {
+        pub name: Option<String>,
+        pub is_primary: bool,
+        pub position_x: i32,
+        pub position_y: i32,
+        pub width: u32,
+        pub height: u32,
+        pub scale_factor: f64,
+        pub current_mode: Option<VideoMode>,
+        pub modes: Vec<VideoMode>,
+    }
+
+    /// A single video mode a monitor supports. `refresh_mhz` is
+    /// winit's millihertz unit (exact rational — divide by 1000 for
+    /// Hz). `bit_depth` is the per-channel count winit reports.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct VideoMode {
+        pub width: u32,
+        pub height: u32,
+        pub refresh_mhz: u32,
+        pub bit_depth: u16,
+    }
+
+    /// Current window state. `monitor_index` points into the
+    /// `monitors` vec on the same reply; `None` if winit couldn't
+    /// resolve a current monitor (rare).
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct WindowInfo {
+        pub mode: WindowMode,
+        pub width: u32,
+        pub height: u32,
+        pub scale_factor: f64,
+        pub monitor_index: Option<u32>,
+    }
+
+    /// The three window presentation modes PR B will let agents
+    /// switch between. Included in the read-only snapshot now so the
+    /// shape is stable across both PRs.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub enum WindowMode {
+        Windowed,
+        FullscreenBorderless,
+        FullscreenExclusive {
+            width: u32,
+            height: u32,
+            refresh_mhz: u32,
+        },
+    }
 }
 
 #[cfg(test)]
@@ -449,6 +614,11 @@ mod tests {
         assert_eq!(
             CaptureFrameResult::NAME,
             "aether.control.capture_frame_result"
+        );
+        assert_eq!(PlatformInfo::NAME, "aether.control.platform_info");
+        assert_eq!(
+            PlatformInfoResult::NAME,
+            "aether.control.platform_info_result"
         );
     }
 

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -8,6 +8,7 @@ aether-hub-protocol = { path = "../aether-hub-protocol" }
 aether-mail = { path = "../aether-mail" }
 aether-kinds = { path = "../aether-kinds", features = ["descriptors"] }
 bytemuck = "1.19"
+os_info = { version = "3", default-features = false }
 png = "0.17"
 pollster = "0.4.0"
 postcard = { version = "1.1", features = ["alloc"] }

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -33,8 +33,8 @@ use aether_hub_protocol::{
 };
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, DropComponent, DropResult, LoadComponent, LoadKind,
-    LoadKindEncoding, LoadKindPrimitive, LoadResult, MailEnvelope, ReplaceComponent, ReplaceResult,
-    SubscribeInput, SubscribeInputResult, UnsubscribeInput,
+    LoadKindEncoding, LoadKindPrimitive, LoadResult, MailEnvelope, PlatformInfo, ReplaceComponent,
+    ReplaceResult, SubscribeInput, SubscribeInputResult, UnsubscribeInput,
 };
 use aether_mail::Kind;
 use serde::Serialize;
@@ -46,6 +46,7 @@ use crate::ctx::SubstrateCtx;
 use crate::hub_client::HubOutbound;
 use crate::input::{self, InputSubscribers};
 use crate::mail::{Mail, MailboxId};
+use crate::platform_info::PlatformInfoNotifier;
 use crate::queue::MailQueue;
 use crate::registry::{Registry, SinkHandler};
 use crate::scheduler::ComponentTable;
@@ -225,6 +226,10 @@ pub struct ControlPlane {
     /// pushes a pending request here; the render thread pulls it on
     /// the next frame and fulfils the reply.
     pub capture_queue: CaptureQueue,
+    /// Fire-and-forget notifier for `aether.control.platform_info`.
+    /// The handler just hands the sender over; the event-loop thread
+    /// snapshots + replies. Tests use `NoopPlatformInfoNotifier`.
+    pub platform_info_notifier: Arc<dyn PlatformInfoNotifier>,
     /// ADR-0021 per-stream subscriber sets, shared with the platform
     /// thread. The control plane mutates this table on subscribe /
     /// unsubscribe / drop; the platform thread reads it to fan out
@@ -270,6 +275,11 @@ impl ControlPlane {
             self.reply(sender, SubscribeInputResult::NAME, &result);
         } else if kind_name == CaptureFrame::NAME {
             self.handle_capture_frame(sender, bytes);
+        } else if kind_name == PlatformInfo::NAME {
+            // Empty payload; forward the sender straight to the event
+            // loop and let it snapshot + reply on its own thread
+            // (winit monitor / scale-factor APIs require it).
+            self.platform_info_notifier.notify(sender);
         } else {
             tracing::warn!(
                 target: "aether_substrate::control",
@@ -929,6 +939,7 @@ mod tests {
             input_subscribers: input::new_subscribers(),
             default_name_counter: Arc::new(AtomicU64::new(0)),
             capture_queue: CaptureQueue::new(),
+            platform_info_notifier: Arc::new(crate::platform_info::NoopPlatformInfoNotifier),
         }
     }
 

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -16,6 +16,7 @@ pub mod hub_client;
 pub mod input;
 pub mod log_capture;
 pub mod mail;
+pub mod platform_info;
 pub mod queue;
 pub mod registry;
 pub mod scheduler;
@@ -25,6 +26,7 @@ pub use capture::{CaptureQueue, PendingCapture};
 pub use component::Component;
 pub use control::{AETHER_CONTROL, ControlPlane};
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
+pub use platform_info::{NoopPlatformInfoNotifier, PlatformInfoNotifier};
 // ADR-0019 PR 5: control-plane payload types now live as schema kinds
 // in `aether-kinds` (LoadComponent, LoadResult, etc.).
 // Re-exports of the old `*Payload` structs are gone — consumers

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -20,9 +20,11 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
+use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub, SessionToken};
 use aether_kinds::{
-    CaptureFrameResult, FrameStats, InputStream, Key, MouseButton, MouseMove, Tick,
+    CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, InputStream,
+    Key, MonitorInfo, MouseButton, MouseMove, OsInfo, PlatformInfoResult, Tick, VideoMode,
+    WindowInfo, WindowMode,
 };
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
@@ -32,6 +34,7 @@ use aether_substrate::{
     capture::CaptureWaker,
     host_fns,
     mail::{Mail, MailboxId},
+    platform_info::PlatformInfoNotifier,
     subscribers_for,
 };
 use render::Gpu;
@@ -43,12 +46,21 @@ use winit::keyboard::PhysicalKey;
 use winit::window::{Window, WindowId};
 
 /// Events the event loop can receive from outside the winit thread.
-/// The one variant exists so `CaptureRequestWaker` can nudge the loop
-/// when a capture lands while the window is occluded — without it the
-/// loop would sleep in `ControlFlow::Wait` and the capture would hang.
+/// Each variant corresponds to a control-plane request that needs to
+/// run on the event-loop thread — either because winit APIs require
+/// it (monitor enumeration, window state) or because the work has to
+/// be ordered with frame rendering (captures).
 #[derive(Debug, Clone, Copy)]
 enum UserEvent {
+    /// A capture is pending on `CaptureQueue`; wake the loop so its
+    /// `RedrawRequested` handler pulls and fulfils it, even if the
+    /// window is occluded (and `ControlFlow::Wait` would otherwise
+    /// keep the loop asleep).
     CaptureRequested,
+    /// An MCP session asked for a `platform_info` snapshot. The
+    /// handler is fire-and-forget — the sender rides inline, the
+    /// event loop snapshots on receipt and replies via `outbound`.
+    PlatformInfoRequested { sender: SessionToken },
 }
 
 /// Adapter that bridges `CaptureQueue::request` to the winit event
@@ -64,6 +76,22 @@ impl CaptureWaker for CaptureRequestWaker {
         // `send_event` only fails if the event loop has shut down; in
         // that case nothing listens for captures anyway.
         let _ = self.proxy.send_event(UserEvent::CaptureRequested);
+    }
+}
+
+/// Adapter that bridges `ControlPlane`'s `platform_info_notifier` to
+/// the winit event loop — same idea as `CaptureRequestWaker` but the
+/// per-request payload (the originating session token) rides inline
+/// on the event itself, so no shared queue is needed.
+struct PlatformInfoProxy {
+    proxy: EventLoopProxy<UserEvent>,
+}
+
+impl PlatformInfoNotifier for PlatformInfoProxy {
+    fn notify(&self, sender: SessionToken) {
+        let _ = self
+            .proxy
+            .send_event(UserEvent::PlatformInfoRequested { sender });
     }
 }
 
@@ -92,6 +120,11 @@ struct App {
     /// Hub outbound — also shared with the log-capture layer and the
     /// broadcast sink. The capture-reply path is the third consumer.
     outbound: Arc<HubOutbound>,
+    /// How many kinds the substrate registered at boot. Captured once
+    /// and cached so `platform_info` can report it without having to
+    /// consult the live registry (which also contains runtime-loaded
+    /// kinds — those aren't part of the build fingerprint).
+    boot_kinds_count: u32,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
     started: Option<Instant>,
@@ -130,7 +163,177 @@ fn send_capture_reply(
     }));
 }
 
+/// Encode + send a `PlatformInfoResult` reply addressed at the
+/// originating session. Mirrors `send_capture_reply` in shape — silent
+/// on disconnected outbound since `PlatformInfoNotifier` fired without
+/// awaiting an ack anyway.
+fn send_platform_info_reply(
+    outbound: &HubOutbound,
+    sender: aether_hub_protocol::SessionToken,
+    result: PlatformInfoResult,
+) {
+    let payload = match postcard::to_allocvec(&result) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(
+                target: "aether_substrate::platform_info",
+                error = %e,
+                "platform_info result encode failed",
+            );
+            return;
+        }
+    };
+    outbound.send(EngineToHub::Mail(EngineMailFrame {
+        address: ClaudeAddress::Session(sender),
+        kind_name: PlatformInfoResult::NAME.to_owned(),
+        payload,
+        origin: None,
+    }));
+}
+
+/// Copy winit's `VideoModeHandle` fields into the wire-stable mirror
+/// in `aether-kinds`. Separate type so the kind's schema doesn't ride
+/// winit's layout.
+fn mirror_video_mode(m: winit::monitor::VideoModeHandle) -> VideoMode {
+    VideoMode {
+        width: m.size().width,
+        height: m.size().height,
+        refresh_mhz: m.refresh_rate_millihertz(),
+        bit_depth: m.bit_depth(),
+    }
+}
+
+/// Convert wgpu's `DeviceType` into the wire-stable mirror enum in
+/// `aether-kinds`. Separate enum so the schema doesn't drift with
+/// wgpu versions.
+fn map_device_type(t: wgpu::DeviceType) -> GpuDeviceType {
+    match t {
+        wgpu::DeviceType::Other => GpuDeviceType::Other,
+        wgpu::DeviceType::IntegratedGpu => GpuDeviceType::IntegratedGpu,
+        wgpu::DeviceType::DiscreteGpu => GpuDeviceType::DiscreteGpu,
+        wgpu::DeviceType::VirtualGpu => GpuDeviceType::VirtualGpu,
+        wgpu::DeviceType::Cpu => GpuDeviceType::Cpu,
+    }
+}
+
+/// Convert wgpu's `Backend` into the wire-stable mirror. `Empty` is
+/// coalesced into `Noop` — the substrate never uses the empty
+/// backend, but the match needs to be exhaustive.
+fn map_backend(b: wgpu::Backend) -> GpuBackend {
+    match b {
+        wgpu::Backend::Noop => GpuBackend::Noop,
+        wgpu::Backend::Vulkan => GpuBackend::Vulkan,
+        wgpu::Backend::Metal => GpuBackend::Metal,
+        wgpu::Backend::Dx12 => GpuBackend::Dx12,
+        wgpu::Backend::Gl => GpuBackend::Gl,
+        wgpu::Backend::BrowserWebGpu => GpuBackend::BrowserWebGpu,
+    }
+}
+
 impl App {
+    /// Build a `PlatformInfoResult::Ok` from whatever the event loop
+    /// knows right now: OS via `std::env::consts` + `os_info`, engine
+    /// via compile-time + boot-time facts, GPU via the cached
+    /// `AdapterInfo` on `Gpu`, monitors via winit. `window` is `None`
+    /// until `resumed` fires and `self.window` / `self.gpu` are set.
+    fn snapshot_platform_info(&self, event_loop: &ActiveEventLoop) -> PlatformInfoResult {
+        let os_info = os_info::get();
+        let os = OsInfo {
+            name: std::env::consts::OS.to_owned(),
+            version: os_info.version().to_string(),
+            arch: std::env::consts::ARCH.to_owned(),
+        };
+        let engine = EngineInfo {
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            workers: WORKERS as u32,
+            kinds_count: self.boot_kinds_count,
+        };
+
+        // `Gpu` is absent until `resumed`; without an adapter we
+        // can't describe the GPU or the window. Surface that
+        // cleanly as `Err` so the caller sees why, rather than
+        // returning a half-populated snapshot.
+        let Some(gpu) = self.gpu.as_ref() else {
+            return PlatformInfoResult::Err {
+                error: "platform info requested before GPU / window came up".to_owned(),
+            };
+        };
+
+        let gpu_info = GpuInfo {
+            name: gpu.adapter_info.name.clone(),
+            vendor_id: gpu.adapter_info.vendor,
+            device_id: gpu.adapter_info.device,
+            device_type: map_device_type(gpu.adapter_info.device_type),
+            backend: map_backend(gpu.adapter_info.backend),
+            driver: gpu.adapter_info.driver.clone(),
+            driver_info: gpu.adapter_info.driver_info.clone(),
+            max_texture_dim_2d: gpu.limits.max_texture_dimension_2d,
+            max_buffer_size: gpu.limits.max_buffer_size,
+            max_bind_groups: gpu.limits.max_bind_groups,
+        };
+
+        // Monitor list + primary comparison. winit's `MonitorHandle`
+        // doesn't expose `is_primary` directly — compare against
+        // `primary_monitor()` by value (the handle is `PartialEq`).
+        let primary = event_loop.primary_monitor();
+        let monitors: Vec<MonitorInfo> = event_loop
+            .available_monitors()
+            .map(|m| {
+                let pos = m.position();
+                let size = m.size();
+                let current_refresh = m.refresh_rate_millihertz();
+                let modes: Vec<VideoMode> = m.video_modes().map(mirror_video_mode).collect();
+                // winit 0.30 exposes the monitor's current size +
+                // refresh but not a `current_video_mode` handle — we
+                // synthesize it by matching the listed modes against
+                // the live size/refresh, and settle for `None` if
+                // no entry matches (unusual but possible on virtual
+                // displays).
+                let current_mode = current_refresh.and_then(|mhz| {
+                    modes.iter().copied().find(|v| {
+                        v.width == size.width && v.height == size.height && v.refresh_mhz == mhz
+                    })
+                });
+                MonitorInfo {
+                    name: m.name(),
+                    is_primary: primary.as_ref() == Some(&m),
+                    position_x: pos.x,
+                    position_y: pos.y,
+                    width: size.width,
+                    height: size.height,
+                    scale_factor: m.scale_factor(),
+                    current_mode,
+                    modes,
+                }
+            })
+            .collect();
+
+        let window = self.window.as_ref().map(|w| {
+            let size = w.inner_size();
+            let monitor_index = w
+                .current_monitor()
+                .and_then(|m| event_loop.available_monitors().position(|other| other == m))
+                .map(|idx| idx as u32);
+            WindowInfo {
+                // PR B will track the active mode as actual state;
+                // today the substrate only boots windowed.
+                mode: WindowMode::Windowed,
+                width: size.width,
+                height: size.height,
+                scale_factor: w.scale_factor(),
+                monitor_index,
+            }
+        });
+
+        PlatformInfoResult::Ok {
+            os,
+            engine,
+            gpu: gpu_info,
+            monitors,
+            window,
+        }
+    }
+
     fn set_occluded(&mut self, occluded: bool, event_loop: &ActiveEventLoop) {
         if self.occluded == occluded {
             return;
@@ -148,7 +351,7 @@ impl App {
 }
 
 impl ApplicationHandler<UserEvent> for App {
-    fn user_event(&mut self, _: &ActiveEventLoop, event: UserEvent) {
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
         match event {
             UserEvent::CaptureRequested => {
                 // When occluded, `ControlFlow::Wait` stops the normal
@@ -157,6 +360,10 @@ impl ApplicationHandler<UserEvent> for App {
                 if let Some(w) = &self.window {
                     w.request_redraw();
                 }
+            }
+            UserEvent::PlatformInfoRequested { sender } => {
+                let result = self.snapshot_platform_info(event_loop);
+                send_platform_info_reply(&self.outbound, sender, result);
             }
         }
     }
@@ -439,6 +646,12 @@ fn main() -> wasmtime::Result<()> {
         proxy: event_loop.create_proxy(),
     }));
 
+    // Fire-and-forget notifier for `platform_info`. Carries the
+    // sender inline on each user event — no shared queue required.
+    let platform_info_notifier = Arc::new(PlatformInfoProxy {
+        proxy: event_loop.create_proxy(),
+    });
+
     // Wire the ADR-0010 control plane. Registered after the scheduler
     // exists so the handler can capture the runtime component table
     // directly rather than an `Arc<Scheduler>` (which would cycle back
@@ -454,6 +667,7 @@ fn main() -> wasmtime::Result<()> {
             input_subscribers: Arc::clone(&input_subscribers),
             default_name_counter: Arc::new(AtomicU64::new(0)),
             capture_queue: capture_queue.clone(),
+            platform_info_notifier: platform_info_notifier.clone(),
         };
         registry.register_sink(
             aether_substrate::AETHER_CONTROL,
@@ -495,6 +709,7 @@ fn main() -> wasmtime::Result<()> {
         "componentless boot — close window to exit; load a component via aether.control.load_component",
     );
 
+    let boot_kinds_count = boot_descriptors.len() as u32;
     let mut app = App {
         queue,
         input_subscribers,
@@ -508,6 +723,7 @@ fn main() -> wasmtime::Result<()> {
         triangles_rendered: Arc::clone(&triangles_rendered),
         capture_queue,
         outbound: Arc::clone(&outbound),
+        boot_kinds_count,
         window: None,
         gpu: None,
         started: None,

--- a/crates/aether-substrate/src/platform_info.rs
+++ b/crates/aether-substrate/src/platform_info.rs
@@ -1,0 +1,24 @@
+// Control-plane → event-loop notifier for
+// `aether.control.platform_info`. Mirrors the capture path's waker
+// idea but carries the `sender` inline — the whole snapshot happens
+// on the event-loop thread inside `user_event`, so there's no
+// separate "pending request" queue to hold state across threads.
+
+use aether_hub_protocol::SessionToken;
+
+/// Notifies the event-loop thread that an MCP session has asked for a
+/// platform snapshot. The substrate's event loop impls this over an
+/// `EventLoopProxy<UserEvent>`; tests pass a no-op impl.
+pub trait PlatformInfoNotifier: Send + Sync {
+    fn notify(&self, sender: SessionToken);
+}
+
+/// No-op notifier for tests and headless contexts where there is no
+/// event loop to wake. The control-plane handler still runs and
+/// replies with an `Err` when the snapshot can't be produced — but
+/// that's the caller's concern, not this trait's.
+pub struct NoopPlatformInfoNotifier;
+
+impl PlatformInfoNotifier for NoopPlatformInfoNotifier {
+    fn notify(&self, _sender: SessionToken) {}
+}

--- a/crates/aether-substrate/src/render.rs
+++ b/crates/aether-substrate/src/render.rs
@@ -40,6 +40,13 @@ pub struct Gpu {
     pub device: wgpu::Device,
     pub queue: wgpu::Queue,
     pub config: wgpu::SurfaceConfiguration,
+    /// Snapshot of the adapter chosen at `new()` — `AdapterInfo` plus
+    /// the resolved `Limits`. Retained so `platform_info` can report
+    /// what the substrate is running on without a second adapter
+    /// request (which would be expensive and is a one-time fact
+    /// anyway).
+    pub adapter_info: wgpu::AdapterInfo,
+    pub limits: wgpu::Limits,
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     /// Intermediate render target. Everything draws here; the swapchain
@@ -78,10 +85,12 @@ impl Gpu {
             force_fallback_adapter: false,
         }))
         .expect("no compatible wgpu adapter");
+        let adapter_info = adapter.get_info();
+        let limits = wgpu::Limits::default();
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
             label: Some("aether-substrate device"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
+            required_limits: limits.clone(),
             experimental_features: wgpu::ExperimentalFeatures::default(),
             memory_hints: wgpu::MemoryHints::default(),
             trace: wgpu::Trace::default(),
@@ -188,6 +197,8 @@ impl Gpu {
             device,
             queue,
             config,
+            adapter_info,
+            limits,
             pipeline,
             vertex_buffer,
             offscreen,

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -106,6 +106,7 @@ fn make_harness() -> Harness {
         input_subscribers: Arc::clone(&input_subscribers),
         default_name_counter: Arc::new(AtomicU64::new(0)),
         capture_queue: aether_substrate::CaptureQueue::new(),
+        platform_info_notifier: Arc::new(aether_substrate::NoopPlatformInfoNotifier),
     };
 
     Harness {


### PR DESCRIPTION
## Summary
- Adds `aether.control.platform_info` — a one-shot query that replies to the sender with a fat snapshot: OS (name/version/arch), engine (version/workers/kinds), GPU adapter (name/backend/device type + a subset of limits), every monitor (position, size, scale factor, resolved current mode, full supported modes list), and current window state. Agents enumerate everything they need in one round trip.
- No bespoke MCP tool — agents send via `send_mail` and read back via `receive_mail`, consistent with the rest of the control-plane vocabulary. Capture kept its tool because it returns image content; structured data flows through the normal mail pipeline.
- Plumbing: new `PlatformInfoNotifier` trait on `ControlPlane`; main.rs implements it over `EventLoopProxy<UserEvent>`. The user event carries the session token inline — no shared queue needed since each snapshot happens fully on the event-loop thread inside `user_event`. `Gpu` caches `AdapterInfo` + `Limits` at boot so snapshot building doesn't re-hit wgpu.
- First of a two-PR arc (read then write). PR B will add `set_window_mode` + `AETHER_WINDOW_MODE` boot env var; the notifier plumbing here is the path it extends.

## Test plan
- [x] `cargo test --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] MCP end-to-end: spawn substrate, send `aether.control.platform_info` via `send_mail`, drain via `receive_mail` — reply carries an `Ok` variant with populated OS / engine / GPU / monitors (60 video modes) / window state; `broadcast: false` confirms reply-to-sender routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)