### PR TITLE
chore(substrate): unify reply helpers and normalize error messages

### DIFF
--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -28,9 +28,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use aether_hub_protocol::{
-    ClaudeAddress, EngineMailFrame, EngineToHub, KindDescriptor, NamedField, Primitive, SchemaType,
-};
+use aether_hub_protocol::{EngineToHub, KindDescriptor, NamedField, Primitive, SchemaType};
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, DropComponent, DropResult, LoadComponent, LoadKind,
     LoadKindEncoding, LoadKindPrimitive, LoadResult, MailEnvelope, PlatformInfo, ReplaceComponent,
@@ -38,7 +36,6 @@ use aether_kinds::{
     UnsubscribeInput,
 };
 use aether_mail::Kind;
-use serde::Serialize;
 use wasmtime::{Engine, Linker, Module};
 
 use crate::capture::{CaptureQueue, PendingCapture};
@@ -266,19 +263,19 @@ impl ControlPlane {
     fn dispatch(&self, kind_name: &str, sender: aether_hub_protocol::SessionToken, bytes: &[u8]) {
         if kind_name == LoadComponent::NAME {
             let result = self.handle_load(bytes);
-            self.reply(sender, LoadResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         } else if kind_name == DropComponent::NAME {
             let result = self.handle_drop(bytes);
-            self.reply(sender, DropResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         } else if kind_name == ReplaceComponent::NAME {
             let result = self.handle_replace(bytes);
-            self.reply(sender, ReplaceResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         } else if kind_name == SubscribeInput::NAME {
             let result = self.handle_subscribe(bytes);
-            self.reply(sender, SubscribeInputResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         } else if kind_name == UnsubscribeInput::NAME {
             let result = self.handle_unsubscribe(bytes);
-            self.reply(sender, SubscribeInputResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         } else if kind_name == CaptureFrame::NAME {
             self.handle_capture_frame(sender, bytes);
         } else if kind_name == PlatformInfo::NAME {
@@ -319,7 +316,7 @@ impl ControlPlane {
             {
                 return LoadResult::Err {
                     error: format!(
-                        "kind {:?} already registered with a different encoding",
+                        "kind `{}` already registered with a different encoding",
                         kind.name
                     ),
                 };
@@ -504,7 +501,7 @@ impl ControlPlane {
                 let result = CaptureFrameResult::Err {
                     error: format!("postcard decode failed: {e}"),
                 };
-                self.reply(sender, CaptureFrameResult::NAME, &result);
+                self.outbound.send_reply(sender, &result);
                 return;
             }
         };
@@ -518,11 +515,8 @@ impl ControlPlane {
         let pre = match resolve_bundle(&self.registry, &payload.mails, "capture bundle") {
             Ok(v) => v,
             Err(e) => {
-                self.reply(
-                    sender,
-                    CaptureFrameResult::NAME,
-                    &CaptureFrameResult::Err { error: e },
-                );
+                self.outbound
+                    .send_reply(sender, &CaptureFrameResult::Err { error: e });
                 return;
             }
         };
@@ -530,11 +524,8 @@ impl ControlPlane {
             match resolve_bundle(&self.registry, &payload.after_mails, "capture after bundle") {
                 Ok(v) => v,
                 Err(e) => {
-                    self.reply(
-                        sender,
-                        CaptureFrameResult::NAME,
-                        &CaptureFrameResult::Err { error: e },
-                    );
+                    self.outbound
+                        .send_reply(sender, &CaptureFrameResult::Err { error: e });
                     return;
                 }
             };
@@ -557,7 +548,7 @@ impl ControlPlane {
                     request completes"
                     .to_owned(),
             };
-            self.reply(sender, CaptureFrameResult::NAME, &result);
+            self.outbound.send_reply(sender, &result);
         }
         // Else: render thread will reply on its next redraw.
     }
@@ -574,7 +565,7 @@ impl ControlPlane {
                 let result = SetWindowModeResult::Err {
                     error: format!("postcard decode failed: {e}"),
                 };
-                self.reply(sender, SetWindowModeResult::NAME, &result);
+                self.outbound.send_reply(sender, &result);
                 return;
             }
         };
@@ -602,17 +593,17 @@ impl ControlPlane {
             Some(crate::registry::MailboxEntry::Component) => {}
             Some(crate::registry::MailboxEntry::Sink(_)) => {
                 return ReplaceResult::Err {
-                    error: format!("mailbox {:?} is a sink, not a component", id),
+                    error: format!("mailbox {} is a sink, not a component", id.0),
                 };
             }
             Some(crate::registry::MailboxEntry::Dropped) => {
                 return ReplaceResult::Err {
-                    error: format!("mailbox {:?} already dropped", id),
+                    error: format!("mailbox {} already dropped", id.0),
                 };
             }
             None => {
                 return ReplaceResult::Err {
-                    error: format!("unknown mailbox id {:?}", id),
+                    error: format!("unknown mailbox id {}", id.0),
                 };
             }
         }
@@ -626,7 +617,7 @@ impl ControlPlane {
             {
                 return ReplaceResult::Err {
                     error: format!(
-                        "kind {:?} already registered with a different encoding",
+                        "kind `{}` already registered with a different encoding",
                         kind.name
                     ),
                 };
@@ -660,7 +651,7 @@ impl ControlPlane {
                 // — happens if instantiation lost the race with a
                 // concurrent drop. Treat as a stale id.
                 return ReplaceResult::Err {
-                    error: format!("mailbox {:?} has no bound component", id),
+                    error: format!("mailbox {} has no bound component", id.0),
                 };
             }
         };
@@ -787,27 +778,6 @@ impl ControlPlane {
     fn announce_kinds(&self) {
         let kinds = self.registry.list_kind_descriptors();
         self.outbound.send(EngineToHub::KindsChanged(kinds));
-    }
-
-    fn reply<T: Serialize>(
-        &self,
-        sender: aether_hub_protocol::SessionToken,
-        kind_name: &str,
-        result: &T,
-    ) {
-        let payload = match postcard::to_allocvec(result) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!(target: "aether_substrate::control", kind = %kind_name, error = %e, "result encode failed");
-                return;
-            }
-        };
-        self.outbound.send(EngineToHub::Mail(EngineMailFrame {
-            address: ClaudeAddress::Session(sender),
-            kind_name: kind_name.to_owned(),
-            payload,
-            origin: None,
-        }));
     }
 }
 

--- a/crates/aether-substrate/src/hub_client.rs
+++ b/crates/aether-substrate/src/hub_client.rs
@@ -27,7 +27,8 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aether_hub_protocol::{
-    EngineId, EngineToHub, Hello, HubToEngine, KindDescriptor, MailFrame, read_frame, write_frame,
+    ClaudeAddress, EngineId, EngineMailFrame, EngineToHub, Hello, HubToEngine, KindDescriptor,
+    MailFrame, SessionToken, read_frame, write_frame,
 };
 
 use crate::mail::Mail;
@@ -72,6 +73,36 @@ impl HubOutbound {
             Some(tx) => tx.send(frame).is_ok(),
             None => false,
         }
+    }
+
+    /// Encode `result` with postcard and send it as a reply addressed
+    /// at `sender`. Uses the kind's own `NAME` so call sites don't
+    /// repeat it. Silent on disconnected outbound (no hub attached)
+    /// and on encode failure (logged at error — a corrupt reply can't
+    /// be delivered meaningfully). Returns `true` when the frame was
+    /// enqueued on the writer channel.
+    pub fn send_reply<K>(&self, sender: SessionToken, result: &K) -> bool
+    where
+        K: aether_mail::Kind + serde::Serialize,
+    {
+        let payload = match postcard::to_allocvec(result) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(
+                    target: "aether_substrate::hub_client",
+                    kind = K::NAME,
+                    error = %e,
+                    "reply encode failed",
+                );
+                return false;
+            }
+        };
+        self.send(EngineToHub::Mail(EngineMailFrame {
+            address: ClaudeAddress::Session(sender),
+            kind_name: K::NAME.to_owned(),
+            payload,
+            origin: None,
+        }))
     }
 
     /// Whether this handle has a live outbound channel.

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -179,62 +179,6 @@ struct App {
     _scheduler: Scheduler,
 }
 
-/// Encode + send a `CaptureFrameResult` reply addressed to the
-/// originating session. Silent if the outbound is disconnected (no
-/// hub attached) — the result goes nowhere, which matches the
-/// broadcast sink's behavior for observations.
-fn send_capture_reply(
-    outbound: &HubOutbound,
-    sender: aether_hub_protocol::SessionToken,
-    result: CaptureFrameResult,
-) {
-    let payload = match postcard::to_allocvec(&result) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::capture",
-                error = %e,
-                "capture result encode failed",
-            );
-            return;
-        }
-    };
-    outbound.send(EngineToHub::Mail(EngineMailFrame {
-        address: ClaudeAddress::Session(sender),
-        kind_name: CaptureFrameResult::NAME.to_owned(),
-        payload,
-        origin: None,
-    }));
-}
-
-/// Encode + send a `PlatformInfoResult` reply addressed at the
-/// originating session. Mirrors `send_capture_reply` in shape — silent
-/// on disconnected outbound since `PlatformInfoNotifier` fired without
-/// awaiting an ack anyway.
-fn send_platform_info_reply(
-    outbound: &HubOutbound,
-    sender: aether_hub_protocol::SessionToken,
-    result: PlatformInfoResult,
-) {
-    let payload = match postcard::to_allocvec(&result) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::platform_info",
-                error = %e,
-                "platform_info result encode failed",
-            );
-            return;
-        }
-    };
-    outbound.send(EngineToHub::Mail(EngineMailFrame {
-        address: ClaudeAddress::Session(sender),
-        kind_name: PlatformInfoResult::NAME.to_owned(),
-        payload,
-        origin: None,
-    }));
-}
-
 /// Copy winit's `VideoModeHandle` fields into the wire-stable mirror
 /// in `aether-kinds`. Separate type so the kind's schema doesn't ride
 /// winit's layout.
@@ -272,32 +216,6 @@ fn map_backend(b: wgpu::Backend) -> GpuBackend {
         wgpu::Backend::Gl => GpuBackend::Gl,
         wgpu::Backend::BrowserWebGpu => GpuBackend::BrowserWebGpu,
     }
-}
-
-/// Encode + send a `SetWindowModeResult` reply to the originating
-/// session. Mirrors the other `send_*_reply` helpers.
-fn send_set_window_mode_reply(
-    outbound: &HubOutbound,
-    sender: aether_hub_protocol::SessionToken,
-    result: SetWindowModeResult,
-) {
-    let payload = match postcard::to_allocvec(&result) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::window_mode",
-                error = %e,
-                "set_window_mode result encode failed",
-            );
-            return;
-        }
-    };
-    outbound.send(EngineToHub::Mail(EngineMailFrame {
-        address: ClaudeAddress::Session(sender),
-        kind_name: SetWindowModeResult::NAME.to_owned(),
-        payload,
-        origin: None,
-    }));
 }
 
 /// Parse `AETHER_WINDOW_MODE`. Grammar:
@@ -422,7 +340,7 @@ impl App {
         // returning a half-populated snapshot.
         let Some(gpu) = self.gpu.as_ref() else {
             return PlatformInfoResult::Err {
-                error: "platform info requested before GPU / window came up".to_owned(),
+                error: "platform_info requested before GPU and window initialized".to_owned(),
             };
         };
 
@@ -513,7 +431,7 @@ impl App {
     ) -> SetWindowModeResult {
         let Some(window) = self.window.as_ref().cloned() else {
             return SetWindowModeResult::Err {
-                error: "window not ready; set_window_mode arrived before resumed".to_owned(),
+                error: "set_window_mode requested before window initialized".to_owned(),
             };
         };
         let monitor = window.current_monitor();
@@ -570,7 +488,7 @@ impl ApplicationHandler<UserEvent> for App {
             }
             UserEvent::PlatformInfo { sender } => {
                 let result = self.snapshot_platform_info(event_loop);
-                send_platform_info_reply(&self.outbound, sender, result);
+                self.outbound.send_reply(sender, &result);
             }
             UserEvent::SetWindowMode {
                 sender,
@@ -579,7 +497,7 @@ impl ApplicationHandler<UserEvent> for App {
                 height,
             } => {
                 let result = self.apply_window_mode(mode, width, height);
-                send_set_window_mode_reply(&self.outbound, sender, result);
+                self.outbound.send_reply(sender, &result);
             }
         }
     }
@@ -659,7 +577,7 @@ impl ApplicationHandler<UserEvent> for App {
                             for mail in req.after_mails {
                                 self.queue.push(mail);
                             }
-                            send_capture_reply(&self.outbound, req.sender, result);
+                            self.outbound.send_reply(req.sender, &result);
                         }
                         None => {
                             gpu.render(&verts);
@@ -671,10 +589,9 @@ impl ApplicationHandler<UserEvent> for App {
                     // caller hanging on an await-reply slot. `after_mails`
                     // is dropped — the pre-capture bundle wasn't processed
                     // either, so there's nothing to clean up.
-                    send_capture_reply(
-                        &self.outbound,
+                    self.outbound.send_reply(
                         req.sender,
-                        CaptureFrameResult::Err {
+                        &CaptureFrameResult::Err {
                             error: "capture requested before GPU initialized".to_owned(),
                         },
                     );


### PR DESCRIPTION
## Summary
- Collapse four near-duplicate reply-send helpers into one `HubOutbound::send_reply<K: Kind + Serialize>`. `K::NAME` drives the wire `kind_name`, so call sites no longer pass it explicitly alongside the typed payload. Removed: three free fns in `main.rs` (`send_capture_reply`, `send_platform_info_reply`, `send_set_window_mode_reply`) and the `ControlPlane::reply` method.
- Normalize error-message formatting: `MailboxId` prints as its inner `u32` (e.g. `mailbox 7 is a sink, not a component`) instead of `MailboxId(7)` via `Debug`; kind names get backticks instead of `Debug`-quotes; the three "operation requested before GPU/window initialized" replies follow a uniform shape.

No behavior change — this is a drop-in refactor. Net **−82 lines**.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite passes, including the input_subscriptions integration test that constructs `ControlPlane` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)