### PR TITLE
chore: lift EnumVariant helpers + extract decode_payload

### DIFF
--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -115,6 +115,30 @@ pub enum EnumVariant {
     },
 }
 
+impl EnumVariant {
+    /// Variant's wire name — matches the `#[postcard(...)]` rename (if
+    /// any) or the bare Rust variant identifier. Used on both the
+    /// encode and decode sides for lookup and error reporting.
+    pub fn name(&self) -> &str {
+        match self {
+            EnumVariant::Unit { name, .. }
+            | EnumVariant::Tuple { name, .. }
+            | EnumVariant::Struct { name, .. } => name.as_str(),
+        }
+    }
+
+    /// Postcard discriminant — the varint written on the wire before
+    /// the variant body. Assigned by the derive at schema-build time
+    /// and stable for the life of the kind vocabulary.
+    pub fn discriminant(&self) -> u32 {
+        match self {
+            EnumVariant::Unit { discriminant, .. }
+            | EnumVariant::Tuple { discriminant, .. }
+            | EnumVariant::Struct { discriminant, .. } => *discriminant,
+        }
+    }
+}
+
 /// Scalar primitives addressable by `SchemaType::Scalar`. Matches the
 /// Rust primitive set that's trivially `bytemuck::Pod` so cast-shaped
 /// structs can express their leaf types; `bool` is `SchemaType::Bool`,

--- a/crates/aether-hub/src/decoder.rs
+++ b/crates/aether-hub/src/decoder.rs
@@ -315,7 +315,7 @@ fn decode_postcard(
             let disc = read_varint_u64(cur, path)? as u32;
             let variant = variants
                 .iter()
-                .find(|v| variant_discriminant(v) == disc)
+                .find(|v| v.discriminant() == disc)
                 .ok_or_else(|| DecodeError::UnknownEnumDiscriminant {
                     path: path.into(),
                     discriminant: disc,
@@ -362,28 +362,12 @@ fn read_primitive_postcard(
     }
 }
 
-fn variant_discriminant(v: &EnumVariant) -> u32 {
-    match v {
-        EnumVariant::Unit { discriminant, .. }
-        | EnumVariant::Tuple { discriminant, .. }
-        | EnumVariant::Struct { discriminant, .. } => *discriminant,
-    }
-}
-
-fn variant_name(v: &EnumVariant) -> &str {
-    match v {
-        EnumVariant::Unit { name, .. }
-        | EnumVariant::Tuple { name, .. }
-        | EnumVariant::Struct { name, .. } => name.as_str(),
-    }
-}
-
 fn decode_enum_body(
     cur: &mut Cursor<'_>,
     variant: &EnumVariant,
     path: &str,
 ) -> Result<Value, DecodeError> {
-    let name = variant_name(variant).to_owned();
+    let name = variant.name().to_owned();
     match variant {
         EnumVariant::Unit { .. } => {
             // Unit variant: bare-string tag, no body. Symmetric to the

--- a/crates/aether-hub/src/encoder.rs
+++ b/crates/aether-hub/src/encoder.rs
@@ -249,13 +249,15 @@ fn encode_postcard(
             // tuple/struct variants, `"VariantName"` (string) for unit
             // variants. Same shape serde emits by default.
             let (tag, body) = decode_enum_tag(value, path)?;
-            let variant = variants.iter().find(|v| variant_name(v) == tag).ok_or(
-                EncodeError::TypeMismatch {
-                    field: path.to_owned(),
-                    expected: "enum variant matching schema",
-                },
-            )?;
-            write_varint_u64(out, variant_discriminant(variant) as u64);
+            let variant =
+                variants
+                    .iter()
+                    .find(|v| v.name() == tag)
+                    .ok_or(EncodeError::TypeMismatch {
+                        field: path.to_owned(),
+                        expected: "enum variant matching schema",
+                    })?;
+            write_varint_u64(out, variant.discriminant() as u64);
             encode_enum_body(body, variant, path, out)?;
             Ok(())
         }
@@ -359,22 +361,6 @@ fn decode_enum_tag<'a>(value: &'a Value, path: &str) -> Result<(&'a str, &'a Val
     }
     let (tag, body) = obj.iter().next().expect("len == 1");
     Ok((tag.as_str(), body))
-}
-
-fn variant_name(v: &EnumVariant) -> &str {
-    match v {
-        EnumVariant::Unit { name, .. }
-        | EnumVariant::Tuple { name, .. }
-        | EnumVariant::Struct { name, .. } => name.as_str(),
-    }
-}
-
-fn variant_discriminant(v: &EnumVariant) -> u32 {
-    match v {
-        EnumVariant::Unit { discriminant, .. }
-        | EnumVariant::Tuple { discriminant, .. }
-        | EnumVariant::Struct { discriminant, .. } => *discriminant,
-    }
 }
 
 fn encode_enum_body(

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -66,6 +66,13 @@ pub const DEFAULT_DRAIN_TIMEOUT_MS: u32 = 5_000;
 /// component has a slow `deliver`.
 const DRAIN_POLL_INTERVAL: Duration = Duration::from_micros(200);
 
+/// Postcard-decode a control-plane payload with the one error-message
+/// shape every handler uses. Handlers wrap the `String` in their own
+/// `*Result::Err` variant — the shape is uniform, the enum differs.
+fn decode_payload<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, String> {
+    postcard::from_bytes(bytes).map_err(|e| format!("postcard decode failed: {e}"))
+}
+
 /// Block until the entry's `pending` count reaches zero or `timeout`
 /// elapses. Returns `true` if the drain completed, `false` on
 /// timeout. Polled rather than condvar-driven to keep
@@ -295,13 +302,9 @@ impl ControlPlane {
     }
 
     fn handle_load(&self, bytes: &[u8]) -> LoadResult {
-        let payload: LoadComponent = match postcard::from_bytes(bytes) {
+        let payload: LoadComponent = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                return LoadResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-            }
+            Err(error) => return LoadResult::Err { error },
         };
 
         // Kind descriptors first: convert the agent's flat `LoadKind`
@@ -386,13 +389,9 @@ impl ControlPlane {
     }
 
     fn handle_drop(&self, bytes: &[u8]) -> DropResult {
-        let payload: DropComponent = match postcard::from_bytes(bytes) {
+        let payload: DropComponent = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                return DropResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-            }
+            Err(error) => return DropResult::Err { error },
         };
         let id = MailboxId(payload.mailbox_id);
         if let Err(e) = self.registry.drop_mailbox(id) {
@@ -422,13 +421,9 @@ impl ControlPlane {
     }
 
     fn handle_subscribe(&self, bytes: &[u8]) -> SubscribeInputResult {
-        let payload: SubscribeInput = match postcard::from_bytes(bytes) {
+        let payload: SubscribeInput = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                return SubscribeInputResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-            }
+            Err(error) => return SubscribeInputResult::Err { error },
         };
         let id = MailboxId(payload.mailbox);
         if let Err(e) = validate_subscriber_mailbox(&self.registry, id) {
@@ -444,13 +439,9 @@ impl ControlPlane {
     }
 
     fn handle_unsubscribe(&self, bytes: &[u8]) -> SubscribeInputResult {
-        let payload: UnsubscribeInput = match postcard::from_bytes(bytes) {
+        let payload: UnsubscribeInput = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                return SubscribeInputResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-            }
+            Err(error) => return SubscribeInputResult::Err { error },
         };
         let id = MailboxId(payload.mailbox);
         // Unsubscribe is idempotent on "not currently subscribed" but
@@ -495,13 +486,11 @@ impl ControlPlane {
     /// `Err` replies (decode failure, envelope-resolve failure,
     /// capture-already-pending) are sent inline.
     fn handle_capture_frame(&self, sender: aether_hub_protocol::SessionToken, bytes: &[u8]) {
-        let payload: CaptureFrame = match postcard::from_bytes(bytes) {
+        let payload: CaptureFrame = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                let result = CaptureFrameResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-                self.outbound.send_reply(sender, &result);
+            Err(error) => {
+                self.outbound
+                    .send_reply(sender, &CaptureFrameResult::Err { error });
                 return;
             }
         };
@@ -559,13 +548,11 @@ impl ControlPlane {
     /// applies the change, and replies on its own. Decode failures
     /// reply inline so the caller doesn't hang on a malformed body.
     fn handle_set_window_mode(&self, sender: aether_hub_protocol::SessionToken, bytes: &[u8]) {
-        let payload: SetWindowMode = match postcard::from_bytes(bytes) {
+        let payload: SetWindowMode = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                let result = SetWindowModeResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-                self.outbound.send_reply(sender, &result);
+            Err(error) => {
+                self.outbound
+                    .send_reply(sender, &SetWindowModeResult::Err { error });
                 return;
             }
         };
@@ -574,13 +561,9 @@ impl ControlPlane {
     }
 
     fn handle_replace(&self, bytes: &[u8]) -> ReplaceResult {
-        let payload: ReplaceComponent = match postcard::from_bytes(bytes) {
+        let payload: ReplaceComponent = match decode_payload(bytes) {
             Ok(p) => p,
-            Err(e) => {
-                return ReplaceResult::Err {
-                    error: format!("postcard decode failed: {e}"),
-                };
-            }
+            Err(error) => return ReplaceResult::Err { error },
         };
         let id = MailboxId(payload.mailbox_id);
         let drain_timeout = Duration::from_millis(


### PR DESCRIPTION
## Summary
Two small abstraction wins surfaced during the 0.1.0-alpha stabilization sweep. Net **−23 lines**, no behavior change.

**1. `EnumVariant` helpers → protocol crate.** `variant_name()` and `variant_discriminant()` were defined identically in `aether-hub/src/encoder.rs` and `aether-hub/src/decoder.rs`. Both callers already depend on `aether-hub-protocol`, so they're lifted to `impl EnumVariant` as `fn name(&self) -> &str` and `fn discriminant(&self) -> u32`. Call sites become `v.name()` / `v.discriminant()`.

**2. `decode_payload` helper in control.rs.** Seven control-plane handlers each repeated `match postcard::from_bytes(bytes) { Err(e) => reply Err(\"postcard decode failed: {e}\") }`. Extracts a private `fn decode_payload<T: DeserializeOwned>(bytes) -> Result<T, String>` so the error message lives in one place and each handler drops the boilerplate.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite passes, including encoder/decoder roundtrip tests that exercise every `EnumVariant` arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)