### PR TITLE
docs: drop stale milestone/issue-#18 breadcrumbs

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -23,8 +23,8 @@ use bytemuck::{Pod, Zeroable};
 // `Schema` impls feed `descriptors.rs`, which `Hello`-ships the kind
 // vocabulary to the hub for agent-side encoding (ADR-0019).
 
-/// Per-frame signal from the substrate's frame loop. Empty payload for
-/// now; milestone 4 will add an elapsed-seconds field.
+/// Per-frame signal from the substrate's frame loop. Empty payload —
+/// elapsed-time is parked until a subscriber actually needs it.
 #[derive(aether_mail::Kind)]
 #[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
 #[kind(name = "aether.tick")]

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -1,7 +1,7 @@
 // A loaded WASM component: its wasmtime `Store<SubstrateCtx>`, instance,
-// and the cached handles needed to deliver mail. Milestone 1 uses a
-// static-offset convention (mail payload written at `MAIL_OFFSET`) to
-// match the spike; a guest-side allocator is future work per issue #18.
+// and the cached handles needed to deliver mail. Mail payloads are
+// written to the guest at a static `MAIL_OFFSET`; a guest-side
+// allocator is parked until an actual use case forces the question.
 
 use aether_hub_protocol::SessionToken;
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -1,11 +1,6 @@
 // aether-substrate: the thin native base layer that owns hardware and
 // hosts the WASM runtime. See ADR-0002 for the architecture and
 // ADR-0004 for the scheduler baseline this library embodies.
-//
-// Milestone 1 (issue #18) provides the library shape only: mail
-// envelope, mailbox registry, WASM component wrapper, worker-pool
-// scheduler, and the `send_mail` host function. Milestone 1 PR B
-// wires these into a real frame-loop binary with a first component.
 
 pub mod capture;
 pub mod component;

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -10,8 +10,9 @@ use aether_hub_protocol::SessionToken;
 pub struct MailboxId(pub u32);
 
 /// Host/guest contract tag for the payload layout. The substrate and the
-/// components that talk to it agree on a specific layout per kind. Typed
-/// facade over this is deferred to a later milestone per issue #18.
+/// components that talk to it agree on a specific layout per kind. The
+/// typed facade over this is ADR-0005 (mail typing system) and ADR-0019
+/// (schema-described kinds).
 pub type MailKind = u32;
 
 /// The transport envelope. `payload` is the exact byte layout the kind

--- a/crates/aether-substrate/src/render.rs
+++ b/crates/aether-substrate/src/render.rs
@@ -1,8 +1,8 @@
-// wgpu plumbing for milestone 3b: owns the device/queue/surface as in
-// 3a, plus a fixed vertex buffer, a shader module, and a render
-// pipeline matching the (pos vec2, color vec3) vertex layout. Each
-// frame the main thread hands in a byte blob drained from the render
-// sink; render() uploads it and issues one draw call.
+// wgpu plumbing: owns the device/queue/surface plus a fixed vertex
+// buffer, a shader module, and a render pipeline matching the
+// (pos vec2, color vec3) vertex layout. Each frame the main thread
+// hands in a byte blob drained from the render sink; render() uploads
+// it and issues one draw call.
 //
 // The surface holds a `'static` lifetime because it takes an owned
 // `Arc<Window>`; the App owns the same Arc, so the window outlives

--- a/crates/aether-substrate/src/shader.wgsl
+++ b/crates/aether-substrate/src/shader.wgsl
@@ -1,6 +1,6 @@
-// Milestone 3b: one vertex + fragment pair. Positions are already
-// clip-space (the component has no camera concept yet); colors pass
-// straight through to the fragment stage.
+// One vertex + fragment pair. Positions are already clip-space (the
+// component has no camera concept yet); colors pass straight through
+// to the fragment stage.
 
 struct VertexInput {
     @location(0) position: vec2<f32>,

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -1,6 +1,6 @@
-// End-to-end wiring test for milestone 1 PR A. Uses an inline WAT guest
-// to avoid pulling in a separate guest crate at this stage — PR B adds
-// the real `aether-hello-component` guest and the build.rs integration.
+// End-to-end wiring test. Uses an inline WAT guest so the test stays
+// self-contained; `tests/*` that need the real `aether-hello-component`
+// guest pull it in separately.
 //
 // The test is deliberately shaped like the real substrate flow:
 //   1. Registry populated with one component mailbox + one sink.


### PR DESCRIPTION
## Summary
Final sweep before 0.1.0-alpha. Drops early-development breadcrumbs from module-level doc comments:

- Removes the \"Milestone 1 (issue #18)\" paragraph from `aether-substrate/src/lib.rs` — the ADR references in the preceding sentence already carry the architectural context.
- Drops issue-#18 / \"milestone N\" references from `component.rs`, `mail.rs`, `render.rs`, `shader.wgsl`, `tests/end_to_end.rs`, and `aether-kinds/src/lib.rs`.
- Points `MailKind`'s doc at ADR-0005 / ADR-0019 rather than the orphaned issue.
- Updates the `Tick` doc to reflect current state (empty payload, parked) rather than \"milestone 4 will add\".

Doc-only. No code change. Everything still compiles and all tests pass.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)