### PR TITLE
docs: convert file-level // comments to crate-level //! docs

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -1,42 +1,42 @@
-// aether-component: guest-side SDK for WASM components that run on the
-// substrate. See ADR-0012 for motivation — this crate wraps the raw
-// `extern "C"` + `static mut u32` + sentinel pattern every component
-// previously wrote by hand, and presents typed handles instead.
-//
-// Shipped surfaces:
-//   - ADR-0012: `Sink<K>`, `KindId<K>`, `resolve::<K>()`, `resolve_sink::<K>(name)`,
-//     and the `raw` FFI module with host-target panicking stubs.
-//   - ADR-0014: `Component` trait (`init` / `receive`), typed `InitCtx`
-//     and `Ctx` with init-vs-receive capability fencing, `Mail<'_>` for
-//     inbound with typed `decode` / `decode_slice`, and the `export!`
-//     macro that owns the `#[no_mangle]` init/receive shims.
-//   - ADR-0015: Additive lifecycle hooks on the `Component` trait
-//     (`on_replace`, `on_drop`, `on_rehydrate`, all defaulted), plus
-//     the narrowed `DropCtx<'_>` capability type. `export!` emits the
-//     matching `#[no_mangle]` shims and the substrate invokes them at
-//     `drop_component` and `replace_component` call sites. Components
-//     that don't override stay green; hook traps are contained so a
-//     panicking hook doesn't stall teardown.
-//   - ADR-0016: Persistent state across hot reload. `DropCtx::save_state`
-//     lets `on_replace` deposit a version-tagged byte bundle; the
-//     substrate hands it to the new instance via `on_rehydrate` with
-//     a populated `PriorState<'_>`. Opt-in — components that don't
-//     override either hook migrate nothing.
-//   - ADR-0013: Reply-to-sender. `Mail::sender()` returns `Some(Sender)`
-//     for mail that came from a Claude session; `Ctx::reply` takes a
-//     `Sender` and a typed `KindId<K>` to answer the originating
-//     session. The 4-param `receive(kind, ptr, count, sender)` ABI is
-//     absorbed by the `export!` macro so component authors don't see it.
-//   - ADR-0027: Component-declared kind dependencies via `type Kinds`
-//     associated typelist. The SDK walks the list at init, resolves
-//     each `K::NAME`, and stashes `(TypeId, raw_id)` in a per-component
-//     `KindTable`. Receive-time helpers `Mail::is::<K>()` and
-//     `Mail::decode_typed::<K>()` consult the table by `TypeId`, so
-//     the user never threads a `KindId<K>` field through `Self` for
-//     kinds they only need at the dispatch site. Tuple syntax up to
-//     `MAX_KINDS = 32`; `Cons<H, T>` / `Nil` is the unbounded escape
-//     hatch. Coexists with the ADR-0014 `KindId<K>` field pattern;
-//     `Sink<K>` is unchanged.
+//! aether-component: guest-side SDK for WASM components that run on the
+//! substrate. See ADR-0012 for motivation — this crate wraps the raw
+//! `extern "C"` + `static mut u32` + sentinel pattern every component
+//! previously wrote by hand, and presents typed handles instead.
+//!
+//! Shipped surfaces:
+//!   - ADR-0012: `Sink<K>`, `KindId<K>`, `resolve::<K>()`, `resolve_sink::<K>(name)`,
+//!     and the `raw` FFI module with host-target panicking stubs.
+//!   - ADR-0014: `Component` trait (`init` / `receive`), typed `InitCtx`
+//!     and `Ctx` with init-vs-receive capability fencing, `Mail<'_>` for
+//!     inbound with typed `decode` / `decode_slice`, and the `export!`
+//!     macro that owns the `#[no_mangle]` init/receive shims.
+//!   - ADR-0015: Additive lifecycle hooks on the `Component` trait
+//!     (`on_replace`, `on_drop`, `on_rehydrate`, all defaulted), plus
+//!     the narrowed `DropCtx<'_>` capability type. `export!` emits the
+//!     matching `#[no_mangle]` shims and the substrate invokes them at
+//!     `drop_component` and `replace_component` call sites. Components
+//!     that don't override stay green; hook traps are contained so a
+//!     panicking hook doesn't stall teardown.
+//!   - ADR-0016: Persistent state across hot reload. `DropCtx::save_state`
+//!     lets `on_replace` deposit a version-tagged byte bundle; the
+//!     substrate hands it to the new instance via `on_rehydrate` with
+//!     a populated `PriorState<'_>`. Opt-in — components that don't
+//!     override either hook migrate nothing.
+//!   - ADR-0013: Reply-to-sender. `Mail::sender()` returns `Some(Sender)`
+//!     for mail that came from a Claude session; `Ctx::reply` takes a
+//!     `Sender` and a typed `KindId<K>` to answer the originating
+//!     session. The 4-param `receive(kind, ptr, count, sender)` ABI is
+//!     absorbed by the `export!` macro so component authors don't see it.
+//!   - ADR-0027: Component-declared kind dependencies via `type Kinds`
+//!     associated typelist. The SDK walks the list at init, resolves
+//!     each `K::NAME`, and stashes `(TypeId, raw_id)` in a per-component
+//!     `KindTable`. Receive-time helpers `Mail::is::<K>()` and
+//!     `Mail::decode_typed::<K>()` consult the table by `TypeId`, so
+//!     the user never threads a `KindId<K>` field through `Self` for
+//!     kinds they only need at the dispatch site. Tuple syntax up to
+//!     `MAX_KINDS = 32`; `Cons<H, T>` / `Nil` is the unbounded escape
+//!     hatch. Coexists with the ADR-0014 `KindId<K>` field pattern;
+//!     `Sink<K>` is unchanged.
 
 #![no_std]
 

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -1,14 +1,14 @@
-// First real aether component. On each tick it emits a fixed
-// clip-space triangle to the substrate's render sink. It also
-// answers ADR-0013 `aether.ping` mail with a matching `aether.pong`
-// back to the originating Claude session — a minimal round-trip
-// smoke test proving reply-to-sender works end-to-end over the hub.
-
-// ADR-0027 shape: receive-side kinds (`Tick`, `Ping`) live in
-// `type Kinds`; dispatch reads the per-component `KindTable` via
-// `mail.is::<Tick>()` and `mail.decode_typed::<Ping>()`. Reply kind
-// `Pong` keeps an explicit `KindId<Pong>` because `Ctx::reply` takes
-// one (sender-side, type-driven reply is a follow-up).
+//! First real aether component. On each tick it emits a fixed
+//! clip-space triangle to the substrate's render sink. It also
+//! answers ADR-0013 `aether.ping` mail with a matching `aether.pong`
+//! back to the originating Claude session — a minimal round-trip
+//! smoke test proving reply-to-sender works end-to-end over the hub.
+//!
+//! ADR-0027 shape: receive-side kinds (`Tick`, `Ping`) live in
+//! `type Kinds`; dispatch reads the per-component `KindTable` via
+//! `mail.is::<Tick>()` and `mail.decode_typed::<Ping>()`. Reply kind
+//! `Pong` keeps an explicit `KindId<Pong>` because `Ctx::reply` takes
+//! one (sender-side, type-driven reply is a follow-up).
 
 use aether_component::{Component, Ctx, InitCtx, KindId, Mail, Sink};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -1,13 +1,14 @@
-// aether-hub-protocol: engine ↔ hub wire types and framing per ADR-0006.
-//
-// Uni-directional mail flow for V0: frames go Claude → hub → engine.
-// Engines send only lifecycle frames (Hello, Heartbeat, Goodbye) —
-// engine-originated mail and replies are parked.
-//
-// Framing: each frame on the TCP stream is a 4-byte little-endian
-// length prefix followed by the postcard-encoded message. Two enum
-// types (`EngineToHub`, `HubToEngine`) enforce direction at the type
-// level.
+//! aether-hub-protocol: engine ↔ hub wire types and framing per ADR-0006.
+//!
+//! Mail flows in both directions: Claude → hub → engine (dispatch) and
+//! engine → hub → Claude (observations and reply-to-sender, ADRs 0008
+//! and 0013). Engines also send lifecycle frames (Hello, Heartbeat,
+//! Goodbye) and `KindsChanged` notifications.
+//!
+//! Framing: each frame on the TCP stream is a 4-byte little-endian
+//! length prefix followed by the postcard-encoded message. Two enum
+//! types (`EngineToHub`, `HubToEngine`) enforce direction at the type
+//! level.
 
 use std::fmt;
 use std::io::{self, Read, Write};

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -1,7 +1,7 @@
-// aether-hub: central broker between Claude MCP clients and engine
-// processes. This crate owns the engine-facing TCP listener, handshake,
-// and heartbeat/reaping per ADR-0006. The Claude-facing rmcp transport
-// and MCP tool surface land in a follow-up PR.
+//! aether-hub: central broker between Claude MCP clients and engine
+//! processes. Owns the engine-facing TCP listener, handshake, and
+//! heartbeat/reaping per ADR-0006, plus the Claude-facing rmcp
+//! transport and the MCP tool surface.
 
 use std::net::SocketAddr;
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1,12 +1,12 @@
-// aether-kinds: the substrate's own mail vocabulary. Imported
-// by any actor that wants to send mail to the substrate, receive mail
-// the substrate dispatches (tick, input), or consume the substrate's
-// sink kinds (draw_triangle). See ADR-0005.
-//
-// Kind ids are assigned at substrate boot via `Registry::register_kind`
-// and resolved by name at component init via the `resolve_kind` host
-// function. Consumers never depend on the id's numeric value — only on
-// the `NAME` constants on the `Kind` impls below.
+//! aether-kinds: the substrate's own mail vocabulary. Imported by any
+//! actor that wants to send mail to the substrate, receive mail the
+//! substrate dispatches (tick, input), or consume the substrate's sink
+//! kinds (draw_triangle). See ADR-0005.
+//!
+//! Kind ids are assigned at substrate boot via `Registry::register_kind`
+//! and resolved by name at component init via the `resolve_kind` host
+//! function. Consumers never depend on the id's numeric value — only on
+//! the `NAME` constants on the `Kind` impls below.
 
 #![no_std]
 

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -1,31 +1,31 @@
-// Proc-macro home for `#[derive(Kind)]` and `#[derive(Schema)]` per
-// ADR-0019. Kept separate from `aether-mail` because Rust requires
-// proc-macro crates to opt into `proc-macro = true` and forbids them
-// from exporting non-macro items; pairing them in the same crate would
-// force every consumer through the proc-macro toolchain even when they
-// just want the runtime traits.
-//
-// `Kind` emits only the `aether_mail::Kind` impl — a `const NAME` and
-// nothing else. Wasm guests that just want to address a kind by name
-// derive only this and stay free of hub-protocol entirely.
-//
-// `Schema` is opt-in (typically gated on a `descriptors` feature so
-// it expands only in std consumers). It emits *both* the
-// `aether_mail::Schema` impl returning a `SchemaType` AND a
-// `CastEligible` impl whose `ELIGIBLE` const propagates each field's
-// eligibility against `#[repr(C)]` presence. Pairing them here means
-// types used as schema fields (helper structs like `Vertex`) get
-// `CastEligible` for free without needing a separate derive — the
-// Schema derive is the only place that needs eligibility, so it owns
-// the impl.
-//
-// Field-type handling is the trickiest part. For most field types we
-// delegate to `<FieldT as Schema>::schema()` and let the blanket impls
-// in `aether-mail` do the work. The one exception is `Vec<u8>` —
-// stable Rust forbids the specialization (`Vec<u8>` would overlap
-// `Vec<T>` because `u8: Schema`), so the derive pattern-matches the
-// field type's syntax and emits `SchemaType::Bytes` directly when it
-// sees `Vec<u8>`. Every other shape goes through the trait.
+//! Proc-macro home for `#[derive(Kind)]` and `#[derive(Schema)]` per
+//! ADR-0019. Kept separate from `aether-mail` because Rust requires
+//! proc-macro crates to opt into `proc-macro = true` and forbids them
+//! from exporting non-macro items; pairing them in the same crate would
+//! force every consumer through the proc-macro toolchain even when they
+//! just want the runtime traits.
+//!
+//! `Kind` emits only the `aether_mail::Kind` impl — a `const NAME` and
+//! nothing else. Wasm guests that just want to address a kind by name
+//! derive only this and stay free of hub-protocol entirely.
+//!
+//! `Schema` is opt-in (typically gated on a `descriptors` feature so
+//! it expands only in std consumers). It emits *both* the
+//! `aether_mail::Schema` impl returning a `SchemaType` AND a
+//! `CastEligible` impl whose `ELIGIBLE` const propagates each field's
+//! eligibility against `#[repr(C)]` presence. Pairing them here means
+//! types used as schema fields (helper structs like `Vertex`) get
+//! `CastEligible` for free without needing a separate derive — the
+//! Schema derive is the only place that needs eligibility, so it owns
+//! the impl.
+//!
+//! Field-type handling is the trickiest part. For most field types we
+//! delegate to `<FieldT as Schema>::schema()` and let the blanket impls
+//! in `aether-mail` do the work. The one exception is `Vec<u8>` —
+//! stable Rust forbids the specialization (`Vec<u8>` would overlap
+//! `Vec<T>` because `u8: Schema`), so the derive pattern-matches the
+//! field type's syntax and emits `SchemaType::Bytes` directly when it
+//! sees `Vec<u8>`. Every other shape goes through the trait.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -1,18 +1,18 @@
-// aether-mail: shared machinery for the mail typing system described in
-// ADR-0005. No concrete kinds live here — each actor owns its kinds in
-// its own crate (substrate in `aether-kinds`, components in
-// `{component}-mail` crates as they define their own).
-//
-// Two payload tiers:
-//   - POD: #[repr(C)] types implementing `bytemuck::NoUninit` /
-//     `AnyBitPattern`. Encoded as their native byte layout; decoded
-//     zero-copy to `&T` or `&[T]`. Used for vertex streams, fixed-layout
-//     structs, anything where throughput or zero-copy matters.
-//   - Structural: `serde::Serialize + DeserializeOwned` types. Encoded
-//     with postcard (Rust-native, varint-compact, no_std-friendly).
-//     Used for small control messages with Option/Vec/enum shape.
-//
-// A type picks one tier — not both — as part of its contract.
+//! aether-mail: shared machinery for the mail typing system described in
+//! ADR-0005. No concrete kinds live here — each actor owns its kinds in
+//! its own crate (substrate in `aether-kinds`, components in
+//! `{component}-mail` crates as they define their own).
+//!
+//! Two payload tiers:
+//!   - POD: `#[repr(C)]` types implementing `bytemuck::NoUninit` /
+//!     `AnyBitPattern`. Encoded as their native byte layout; decoded
+//!     zero-copy to `&T` or `&[T]`. Used for vertex streams, fixed-layout
+//!     structs, anything where throughput or zero-copy matters.
+//!   - Structural: `serde::Serialize + DeserializeOwned` types. Encoded
+//!     with postcard (Rust-native, varint-compact, no_std-friendly).
+//!     Used for small control messages with Option/Vec/enum shape.
+//!
+//! A type picks one tier — not both — as part of its contract.
 
 #![no_std]
 

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -1,6 +1,6 @@
-// aether-substrate: the thin native base layer that owns hardware and
-// hosts the WASM runtime. See ADR-0002 for the architecture and
-// ADR-0004 for the scheduler baseline this library embodies.
+//! aether-substrate: the thin native base layer that owns hardware and
+//! hosts the WASM runtime. See ADR-0002 for the architecture and
+//! ADR-0004 for the scheduler baseline this library embodies.
 
 pub mod capture;
 pub mod component;


### PR DESCRIPTION
Converts eight crates' lib.rs top-of-file `//` comments to `//!` so rustdoc picks them up as each crate's landing page. Also tightens two drifted paragraphs:
- `aether-hub`: the "follow-up PR" the old comment referenced is long past — the MCP surface shipped.
- `aether-hub-protocol`: the "uni-directional mail flow for V0" framing is stale; mail flows in both directions now (ADR-0008 observations, ADR-0013 reply-to-sender).

No code change, just doc syntax and two small wording updates.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo doc --no-deps --workspace` — each crate now has a populated landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)