### PR TITLE
refactor(hub): split mcp.rs into args/codecs/tools submodules

### DIFF
--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -1,79 +1,76 @@
-// Claude-facing MCP tool surface. ADR-0006 V0 + ADR-0007 +
-// ADR-0008 + ADR-0009: send_mail / list_engines / describe_kinds /
-// receive_mail / spawn_substrate.
-//
-// The rmcp `Service` factory is invoked per session, so `Hub` is cheap
-// to clone and shares a single `HubState` via `Arc`. Per-tool output is
-// returned as a JSON-encoded `String`; rmcp wraps it into a
-// `Content::text` automatically via `IntoContents`.
+//! Claude-facing MCP tool surface (ADR-0006 V0, ADR-0007, ADR-0008,
+//! ADR-0009). Exposes eight tools for sending and receiving mail,
+//! introspecting engine state, spawning and terminating substrates,
+//! draining logs, and capturing frames.
+//!
+//! The rmcp `Service` factory is invoked per session, so `Hub` is cheap
+//! to clone and shares a single `HubState` via `Arc`. Per-tool output
+//! is returned as a JSON-encoded `String`; rmcp wraps it into a
+//! `Content::text` automatically via `IntoContents`.
+//!
+//! Submodule split:
+//!   - `args`: request/response shapes (pure data).
+//!   - `codecs`: schema-driven encode/decode between tool JSON and
+//!     wire bytes.
+//!   - `tools`: the `#[tool_router] impl Hub` block and the
+//!     `ServerHandler` impl.
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
-use aether_hub_protocol::{
-    EngineId, HubToEngine, KindDescriptor, LogLevel, MailFrame, SchemaType, SessionToken, Uuid,
-};
-use base64::Engine as _;
 use rmcp::{
-    ErrorData as McpError, ServerHandler,
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo},
-    tool, tool_handler, tool_router,
+    handler::server::router::tool::ToolRouter,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
 };
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc};
-use tokio::time::timeout;
 
-use crate::decoder::decode_schema;
-use crate::encoder::encode_schema;
-use crate::log_store::{LogStore, TOOL_DEFAULT_ENTRIES, TOOL_MAX_ENTRIES};
-use crate::registry::{EngineRecord, EngineRegistry};
+use crate::log_store::LogStore;
+use crate::registry::EngineRegistry;
 use crate::session::{QueuedMail, SessionHandle, SessionRegistry};
-use crate::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnOpts};
+use crate::spawn::PendingSpawns;
+
+mod args;
+mod codecs;
+mod tools;
+
+// Bring args types and commonly-referenced protocol types into mcp's
+// namespace so the tests module below can reach them via `use
+// super::*;` without repeating imports for every case. Internal
+// helpers in `codecs` stay `pub(super)` and are reachable from
+// `tools` only.
+#[cfg(test)]
+use aether_hub_protocol::{HubToEngine, SessionToken, Uuid};
+#[cfg(test)]
+use args::{
+    CaptureFrameArgs, DescribeKindsArgs, EngineInfo, MailSpec, MailStatus, ReceiveMailArgs,
+    ReceivedMail, SendMailArgs, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
+};
+#[cfg(test)]
+use base64::Engine as _;
+#[cfg(test)]
+use rmcp::handler::server::wrapper::Parameters;
+#[cfg(test)]
+use std::collections::HashMap;
 
 /// Default port the hub binds for MCP clients. Overridable via
 /// `AETHER_MCP_PORT`.
 pub const DEFAULT_MCP_PORT: u16 = 8888;
 
-/// Substrate control-plane kind name for a capture request. String
-/// constants rather than an `aether-kinds` dependency to keep the hub
-/// agnostic of the substrate's typed kind vocabulary at crate level —
-/// the schema-driven descriptor path already provides wire-level
-/// compatibility.
-const KIND_CAPTURE_FRAME: &str = "aether.control.capture_frame";
-const KIND_CAPTURE_FRAME_RESULT: &str = "aether.control.capture_frame_result";
-
-/// Default cap on how long `capture_frame` waits for the substrate's
-/// reply before returning an error. Long enough to tolerate one
-/// stalled frame (monitor refresh + GPU readback + PNG encode); short
-/// enough that a stuck substrate doesn't hang the tool call.
-const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Hard ceiling on `timeout_ms`. A request that needs more than 30s
-/// is probably a bug on the substrate side; surfacing it as a bound
-/// rather than letting it hang preserves the harness's responsiveness.
-const MAX_CAPTURE_TIMEOUT: Duration = Duration::from_secs(30);
-
 /// Shared state across all rmcp sessions. Cheap to `Arc::clone` into
 /// each per-session `Hub` instance.
 pub struct HubState {
-    engines: EngineRegistry,
-    sessions: SessionRegistry,
-    pending_spawns: PendingSpawns,
+    pub(crate) engines: EngineRegistry,
+    pub(crate) sessions: SessionRegistry,
+    pub(crate) pending_spawns: PendingSpawns,
     /// ADR-0023 per-engine log buffers. Outlives engine records so
     /// post-mortem `engine_logs` polls succeed after a substrate exit.
-    logs: LogStore,
+    pub(crate) logs: LogStore,
     /// Address of the hub's engine TCP listener. Injected as
     /// `AETHER_HUB_URL` into spawned substrates so they dial back to
     /// this hub instance.
-    hub_engine_addr: SocketAddr,
+    pub(crate) hub_engine_addr: SocketAddr,
 }
 
 impl HubState {
@@ -100,753 +97,20 @@ impl HubState {
 /// goes away when the last clone drops.
 #[derive(Clone)]
 pub struct Hub {
-    state: Arc<HubState>,
-    tool_router: ToolRouter<Self>,
-    session: Arc<SessionHandle>,
-    /// Drain for this session's inbound observation mail. `receive_mail`
-    /// pulls from it non-blocking; wrapping in an `Arc<Mutex<_>>` lets
-    /// rmcp's per-tool-call clones share the same receiver.
-    inbound: Arc<Mutex<mpsc::Receiver<QueuedMail>>>,
+    pub(crate) state: Arc<HubState>,
+    pub(crate) tool_router: ToolRouter<Self>,
+    pub(crate) session: Arc<SessionHandle>,
+    /// Drain for this session's inbound observation mail.
+    /// `receive_mail` pulls from it non-blocking; wrapping in an
+    /// `Arc<Mutex<_>>` lets rmcp's per-tool-call clones share the same
+    /// receiver.
+    pub(crate) inbound: Arc<Mutex<mpsc::Receiver<QueuedMail>>>,
 }
 
-impl Hub {
-    pub fn new(state: Arc<HubState>) -> Self {
-        let (session, rx) = SessionHandle::mint(&state.sessions);
-        Self {
-            state,
-            tool_router: Self::tool_router(),
-            session: Arc::new(session),
-            inbound: Arc::new(Mutex::new(rx)),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DescribeKindsArgs {
-    /// Hub-assigned engine UUID as a string (from `list_engines`).
-    pub engine_id: String,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SendMailArgs {
-    /// One or more mail items to deliver. Each item is processed
-    /// independently — a single failure doesn't abort the batch. The
-    /// response carries a per-item status so the caller decides retry
-    /// vs abort policy.
-    pub mails: Vec<MailSpec>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct MailSpec {
-    /// Hub-assigned engine UUID as a string (from `list_engines`).
-    pub engine_id: String,
-    /// Mailbox name as registered by the engine.
-    pub recipient_name: String,
-    /// Kind name (e.g. `"aether.tick"`) the engine's registry knows.
-    pub kind_name: String,
-    /// Structured params for schema-driven encoding. The hub looks up
-    /// this kind's descriptor (from `describe_kinds`) and writes bytes
-    /// matching the kind's wire format — `#[repr(C)]` layout for
-    /// cast-shaped kinds, postcard for everything else.
-    ///
-    /// ADR-0019 PR 5 removed the `payload_bytes` escape hatch from
-    /// this surface. Every aether-shipped kind has a schema; if a
-    /// future kind doesn't, that's an engine bug to fix, not a
-    /// workaround to paper over.
-    #[serde(default)]
-    pub params: Option<serde_json::Value>,
-    /// Count carried on the mail frame. For single-struct payloads
-    /// this is 1 (the default); for cast-shaped slices it's the
-    /// number of elements the bytes represent.
-    #[serde(default = "one")]
-    pub count: u32,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct MailStatus {
-    /// Index into the `mails` array the caller supplied.
-    pub index: u32,
-    /// `"delivered"` on success, or `"error: <reason>"` on failure.
-    pub status: String,
-}
-
-fn one() -> u32 {
-    1
-}
-
-fn log_level_to_str(level: LogLevel) -> &'static str {
-    match level {
-        LogLevel::Trace => "trace",
-        LogLevel::Debug => "debug",
-        LogLevel::Info => "info",
-        LogLevel::Warn => "warn",
-        LogLevel::Error => "error",
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct EngineInfo {
-    pub engine_id: String,
-    pub name: String,
-    pub pid: u32,
-    pub version: String,
-    /// `true` if this engine was spawned by the hub (ADR-0009), `false`
-    /// if it connected externally.
-    pub spawned: bool,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SpawnSubstrateArgs {
-    /// Absolute path to the substrate binary the hub should launch.
-    /// The hub does not build, resolve, or locate binaries — the caller
-    /// passes a path that exists.
-    pub binary_path: String,
-    /// Additional command-line arguments to pass to the substrate.
-    #[serde(default)]
-    pub args: Vec<String>,
-    /// Extra environment variables for the child. `AETHER_HUB_URL` is
-    /// injected automatically to point at this hub; if the caller
-    /// includes it here, the caller's value wins.
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-    /// Handshake timeout in milliseconds. Defaults to 5 seconds if
-    /// omitted — override for slow CI machines or debug builds.
-    #[serde(default)]
-    pub timeout_ms: Option<u32>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct SpawnResult {
-    /// UUID assigned by the hub once the substrate completed its
-    /// `Hello` handshake.
-    pub engine_id: String,
-    /// Operating-system PID of the spawned substrate.
-    pub pid: u32,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct TerminateSubstrateArgs {
-    /// Hub-assigned engine UUID (from `list_engines`).
-    pub engine_id: String,
-    /// SIGTERM grace period in milliseconds. Defaults to 2 seconds —
-    /// long enough for a well-behaved substrate to drain, short enough
-    /// not to stall interactive agent flows.
-    #[serde(default)]
-    pub grace_ms: Option<u32>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct TerminateResult {
-    pub engine_id: String,
-    /// `true` if the child ignored SIGTERM and the hub escalated to
-    /// SIGKILL after the grace window. `false` for clean exits.
-    pub sigkilled: bool,
-    /// Exit code if the child exited normally; `null` if it was killed
-    /// by a signal (the common case when `sigkilled` is true).
-    pub exit_code: Option<i32>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct EngineLogsArgs {
-    /// Hub-assigned engine UUID as a string (from `list_engines`).
-    pub engine_id: String,
-    /// Maximum entries to return. Defaults to 100; clamped to 1000.
-    #[serde(default)]
-    pub max: Option<u32>,
-    /// Minimum log level (`"trace"|"debug"|"info"|"warn"|"error"`).
-    /// Defaults to `"trace"` (every captured entry).
-    #[serde(default)]
-    pub level: Option<String>,
-    /// Cursor: only entries with `sequence > since` are returned.
-    /// Pass back the previous response's `next_since` to poll
-    /// incrementally without re-receiving.
-    #[serde(default)]
-    pub since: Option<u64>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct EngineLogsResponse {
-    pub engine_id: String,
-    pub entries: Vec<EngineLogEntry>,
-    /// Highest `sequence` returned in `entries`, or the request's
-    /// `since` value if the response is empty. Use as the next
-    /// `since` for incremental polling.
-    pub next_since: u64,
-    /// Set when the hub-side ring evicted entries the caller hadn't
-    /// seen — `Some(seq)` means the gap above the request's `since`
-    /// extends up to (but not including) `seq`. Treat as a signal to
-    /// poll more often or accept the loss.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub truncated_before: Option<u64>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct EngineLogEntry {
-    pub timestamp_unix_ms: u64,
-    /// Lowercase level: `"trace"|"debug"|"info"|"warn"|"error"`.
-    pub level: String,
-    /// Module path the event was emitted from
-    /// (e.g. `"aether_substrate::scheduler"`).
-    pub target: String,
-    /// Already-formatted event text. Tracing's structured fields are
-    /// flattened into this string by the substrate's capture layer.
-    pub message: String,
-    pub sequence: u64,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CaptureFrameArgs {
-    /// Hub-assigned engine UUID as a string (from `list_engines`).
-    pub engine_id: String,
-    /// Optional bundle of mails to dispatch on the substrate *before*
-    /// the capture fires. Each item has the same shape as a
-    /// `send_mail` entry — `recipient_name`, `kind_name`, structured
-    /// `params` encoded via the kind's descriptor, `count`. The
-    /// substrate resolves every envelope atomically: if any fails
-    /// (unknown kind, unknown recipient), no mail is dispatched and
-    /// the reply is an `Err`. An empty bundle means "just capture the
-    /// current state."
-    #[serde(default)]
-    pub mails: Vec<MailSpec>,
-    /// Optional bundle of cleanup mails dispatched *after* the frame
-    /// is captured. Useful for "set a flag, capture, unset the flag"
-    /// patterns in one atomic tool call. Resolved against the same
-    /// abort-on-first-failure policy as `mails` — a bad envelope in
-    /// either bundle aborts the whole request before any mail moves.
-    #[serde(default)]
-    pub after_mails: Vec<MailSpec>,
-    /// Maximum time to wait for the substrate's reply, in
-    /// milliseconds. Defaults to 5000 (5 s). Clamped to 30000 (30 s).
-    #[serde(default)]
-    pub timeout_ms: Option<u32>,
-}
-
-/// Wire-format mirror of the substrate's `CaptureFrameResult` kind.
-/// Lives in the hub so we can postcard-decode the reply payload
-/// without pulling in the substrate's typed kind crate. Must stay in
-/// lockstep with `aether-kinds::CaptureFrameResult` — the comment on
-/// that type is the canonical spec.
-#[derive(Debug, Deserialize)]
-enum CaptureFrameResultWire {
-    Ok { png: Vec<u8> },
-    Err { error: String },
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ReceiveMailArgs {
-    /// Maximum number of items to return in this call. `None` drains
-    /// everything currently queued. Defaults to unlimited.
-    #[serde(default)]
-    pub max: Option<u32>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ReceivedMail {
-    /// Hub-assigned UUID of the engine that sent this mail.
-    pub engine_id: String,
-    /// Kind name the engine declared at handshake.
-    pub kind_name: String,
-    /// Structured value decoded against the engine's kind descriptor —
-    /// the symmetric counterpart to `send_mail`'s `params` field
-    /// (ADR-0020). `null` if the hub couldn't decode (no descriptor for
-    /// this kind, or decode failed), in which case `decode_error` is
-    /// populated and the agent falls back to `payload_bytes`.
-    pub params: Option<serde_json::Value>,
-    /// Decode failure reason. Populated only when `params` is `null`
-    /// because the hub's decoder rejected the payload (e.g. schema
-    /// drift, truncation, unknown kind). Always paired with intact
-    /// `payload_bytes` for an escape-hatch decode.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub decode_error: Option<String>,
-    /// Raw payload bytes. Always populated. Prefer `params`; reach for
-    /// `payload_bytes` only when `params` is `null` (decode failed) or
-    /// when the agent genuinely needs the wire bytes.
-    pub payload_bytes: Vec<u8>,
-    /// `true` if this mail was addressed to every attached session;
-    /// `false` if it was a reply targeted at this session specifically.
-    pub broadcast: bool,
-    /// Substrate-attested name of the emitting mailbox (ADR-0011).
-    /// Distinguishes components that share a kind. `None` for mail
-    /// pushed by substrate core (e.g. the frame loop's `FrameStats`),
-    /// which has no sending mailbox.
-    pub origin: Option<String>,
-}
-
-#[tool_router]
-impl Hub {
-    #[tool(
-        description = "Send one or more mail items. Each item takes `params` — structured JSON encoded via the engine's kind descriptor (cast-shaped or postcard, ADR-0019). The batch is best-effort: per-item status is returned and failures don't abort siblings. 'delivered' means the hub queued the frame to the engine's socket — not that the engine processed it."
-    )]
-    async fn send_mail(
-        &self,
-        Parameters(args): Parameters<SendMailArgs>,
-    ) -> Result<String, McpError> {
-        let mut statuses = Vec::with_capacity(args.mails.len());
-        for (i, spec) in args.mails.into_iter().enumerate() {
-            let result = deliver_one(spec, &self.state.engines, self.session.token).await;
-            let status = match result {
-                Ok(()) => "delivered".into(),
-                Err(e) => format!("error: {e}"),
-            };
-            statuses.push(MailStatus {
-                index: i as u32,
-                status,
-            });
-        }
-        serde_json::to_string(&statuses).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "List every kind the given engine declared at handshake, with enough structural detail for clients to build params for send_mail. ADR-0019 Schema kinds describe their full shape (scalars, strings, vecs, options, enums, nested structs); the cast-shaped subset (`Struct{repr_c:true}`) is wire-compatible with `#[repr(C)]` layout."
-    )]
-    async fn describe_kinds(
-        &self,
-        Parameters(args): Parameters<DescribeKindsArgs>,
-    ) -> Result<String, McpError> {
-        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
-            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
-        })?;
-        let id = EngineId(uuid);
-        let Some(record) = self.state.engines.get(&id) else {
-            return Err(McpError::invalid_params(
-                format!("unknown engine_id {}", args.engine_id),
-                None,
-            ));
-        };
-        serde_json::to_string(&record.kinds)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, structured `params` decoded against the engine's kind descriptor (ADR-0020 — symmetric to `send_mail`), the raw `payload_bytes` (always populated; primarily a fallback when `params` is null), an optional `decode_error` explaining why decode failed when `params` is null, a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false), and an optional `origin` — the substrate-local mailbox name of the emitting component (absent for substrate-core pushes with no sending mailbox). Non-blocking: returns an empty array if nothing is queued."
-    )]
-    async fn receive_mail(
-        &self,
-        Parameters(args): Parameters<ReceiveMailArgs>,
-    ) -> Result<String, McpError> {
-        let cap = args.max.map(|n| n as usize).unwrap_or(usize::MAX);
-        let mut rx = self.inbound.lock().await;
-        let mut out = Vec::new();
-        while out.len() < cap {
-            match rx.try_recv() {
-                Ok(m) => {
-                    let (params, decode_error) =
-                        decode_inbound(&m.engine_id, &m.kind_name, &m.payload, &self.state.engines);
-                    out.push(ReceivedMail {
-                        engine_id: m.engine_id.0.to_string(),
-                        kind_name: m.kind_name,
-                        params,
-                        decode_error,
-                        payload_bytes: m.payload,
-                        broadcast: m.broadcast,
-                        origin: m.origin,
-                    });
-                }
-                Err(_) => break,
-            }
-        }
-        serde_json::to_string(&out).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "Launch a substrate binary as a child process of the hub. The hub injects `AETHER_HUB_URL` so the child dials back to this hub instance. Blocks until the substrate completes its `Hello` handshake (or the handshake timeout fires — default 5 seconds, overridable via `timeout_ms`). Returns the assigned `engine_id` and the child `pid`. The hub owns the child for its lifetime; dropping the engine from the registry (socket disconnect or `terminate_substrate`) reaps the process."
-    )]
-    async fn spawn_substrate(
-        &self,
-        Parameters(args): Parameters<SpawnSubstrateArgs>,
-    ) -> Result<String, McpError> {
-        let handshake_timeout = args
-            .timeout_ms
-            .map(|ms| Duration::from_millis(ms as u64))
-            .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT);
-        let opts = SpawnOpts {
-            binary_path: PathBuf::from(args.binary_path),
-            args: args.args,
-            env: args.env,
-            handshake_timeout,
-        };
-        let engine_id = crate::spawn::spawn_substrate(
-            opts,
-            self.state.hub_engine_addr,
-            &self.state.pending_spawns,
-            &self.state.engines,
-        )
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn failed: {e}"), None))?;
-
-        let pid = self
-            .state
-            .engines
-            .get(&engine_id)
-            .map(|r| r.pid)
-            .unwrap_or(0);
-        let result = SpawnResult {
-            engine_id: engine_id.0.to_string(),
-            pid,
-        };
-        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "Terminate a substrate the hub previously spawned. Sends SIGTERM, waits up to `grace_ms` milliseconds (default 2000) for the child to exit, then escalates to SIGKILL if it's still running. Returns the exit code (if any) and a `sigkilled` flag indicating whether escalation was necessary. Errors if the engine id is unknown or refers to an externally connected substrate — the hub only terminates children it owns."
-    )]
-    async fn terminate_substrate(
-        &self,
-        Parameters(args): Parameters<TerminateSubstrateArgs>,
-    ) -> Result<String, McpError> {
-        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
-            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
-        })?;
-        let id = EngineId(uuid);
-
-        if self.state.engines.get(&id).is_none() {
-            return Err(McpError::invalid_params(
-                format!("unknown engine_id {}", args.engine_id),
-                None,
-            ));
-        }
-
-        let Some(child) = self.state.engines.take_child(&id) else {
-            return Err(McpError::invalid_params(
-                format!(
-                    "engine {} is not hub-spawned; terminate it externally",
-                    args.engine_id
-                ),
-                None,
-            ));
-        };
-
-        let grace = args
-            .grace_ms
-            .map(|ms| Duration::from_millis(ms as u64))
-            .unwrap_or(DEFAULT_TERMINATE_GRACE);
-
-        let outcome = crate::spawn::terminate_substrate(child, grace)
-            .await
-            .map_err(|e| McpError::internal_error(format!("terminate failed: {e}"), None))?;
-
-        let result = TerminateResult {
-            engine_id: args.engine_id,
-            sigkilled: outcome.sigkilled,
-            exit_code: outcome.exit_code,
-        };
-        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "Drain captured substrate log entries for an engine (ADR-0023). Cursor-based polling: pass back `next_since` from the previous response to receive only new entries. `level` (default `\"trace\"`) filters server-side. `max` defaults to 100, clamped to 1000. `truncated_before` is set when the hub-side ring evicted entries the caller hadn't seen — treat it as a signal to poll more often or accept the gap. Buffer survives engine exit until hub shutdown, so post-mortem polls work after the substrate has crashed."
-    )]
-    async fn engine_logs(
-        &self,
-        Parameters(args): Parameters<EngineLogsArgs>,
-    ) -> Result<String, McpError> {
-        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
-            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
-        })?;
-        let id = EngineId(uuid);
-        let min_level = match args.level.as_deref() {
-            None | Some("trace") => LogLevel::Trace,
-            Some("debug") => LogLevel::Debug,
-            Some("info") => LogLevel::Info,
-            Some("warn") => LogLevel::Warn,
-            Some("error") => LogLevel::Error,
-            Some(other) => {
-                return Err(McpError::invalid_params(
-                    format!("level {other:?} is not one of trace|debug|info|warn|error",),
-                    None,
-                ));
-            }
-        };
-        let max = args
-            .max
-            .map(|n| n as usize)
-            .unwrap_or(TOOL_DEFAULT_ENTRIES)
-            .min(TOOL_MAX_ENTRIES);
-        let since = args.since.unwrap_or(0);
-        let result = self.state.logs.read(id, max, min_level, since);
-        let response = EngineLogsResponse {
-            engine_id: args.engine_id,
-            entries: result
-                .entries
-                .into_iter()
-                .map(|e| EngineLogEntry {
-                    timestamp_unix_ms: e.timestamp_unix_ms,
-                    level: log_level_to_str(e.level).to_owned(),
-                    target: e.target,
-                    message: e.message,
-                    sequence: e.sequence,
-                })
-                .collect(),
-            next_since: result.next_since,
-            truncated_before: result.truncated_before,
-        };
-        serde_json::to_string(&response).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-
-    #[tool(
-        description = "Capture the current frame contents of the given engine as a PNG and return it inline as MCP image content. The substrate renders to an offscreen target so the capture works regardless of window visibility (important on macOS where occluded windows would otherwise block). Optionally carries two mail bundles dispatched atomically around the capture: `mails` fires *before* the frame is read back (state-changing mail whose effects should appear in the image), and `after_mails` fires *after* readback (cleanup such as restoring a flag the caller flipped for the capture). The substrate resolves every envelope in both bundles first (abort-on-first-failure); any failure means no mail moves. The render loop's `queue.wait_idle()` ensures the pre-capture bundle has been fully processed before the frame is read back. Empty bundles mean \"just capture\" / \"no cleanup\". Rejects if another capture is already in flight on this session, or if the wait exceeds `timeout_ms` (default 5000, clamped to 30000). Use this to verify substrate rendering end-to-end and to bundle \"set X, show me, restore X\" into one atomic tool call."
-    )]
-    async fn capture_frame(
-        &self,
-        Parameters(args): Parameters<CaptureFrameArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
-            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
-        })?;
-        let id = EngineId(uuid);
-        let record = self.state.engines.get(&id).ok_or_else(|| {
-            McpError::invalid_params(format!("unknown engine_id {}", args.engine_id), None)
-        })?;
-
-        // Encode each envelope in both bundles against its kind's
-        // descriptor. Done before we register the reply-waiter or
-        // send anything, so a bad bundle produces a clean invalid-
-        // params error and never touches the engine wire.
-        let envelopes = encode_capture_bundle(&args.mails, &record).map_err(|e| {
-            McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
-        })?;
-        let after_envelopes = encode_capture_bundle(&args.after_mails, &record).map_err(|e| {
-            McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
-        })?;
-        let bundle_params = serde_json::json!({
-            "mails": envelopes,
-            "after_mails": after_envelopes,
-        });
-
-        // Register the reply-waiter BEFORE sending the request, so the
-        // engine reader can divert the reply to our oneshot the moment
-        // it arrives. If another capture is already pending on this
-        // session, surface it as a clear error rather than silently
-        // waiting behind the first.
-        let (_guard, rx) = self
-            .session
-            .replies
-            .register(KIND_CAPTURE_FRAME_RESULT.to_owned())
-            .ok_or_else(|| {
-                McpError::invalid_params(
-                    "a capture is already in flight on this session; wait for it to complete"
-                        .to_owned(),
-                    None,
-                )
-            })?;
-
-        // Send the capture_frame request carrying the pre-encoded
-        // bundle. The substrate's schema decoder reconstructs each
-        // envelope's `payload: Vec<u8>` from the JSON byte array the
-        // hub encoder wrote — postcard-equivalent round-trip.
-        let spec = MailSpec {
-            engine_id: args.engine_id.clone(),
-            recipient_name: "aether.control".to_owned(),
-            kind_name: KIND_CAPTURE_FRAME.to_owned(),
-            params: Some(bundle_params),
-            count: 1,
-        };
-        deliver_one(spec, &self.state.engines, self.session.token)
-            .await
-            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
-
-        // Wait for the reply (or timeout). `_guard` drops when this
-        // future resolves — on any path — which removes the registry
-        // entry. The record lookup above already pinned `record` for
-        // the duration of the send; we don't need it past this point.
-        let _ = record;
-        let wait = args
-            .timeout_ms
-            .map(|ms| Duration::from_millis(ms as u64).min(MAX_CAPTURE_TIMEOUT))
-            .unwrap_or(DEFAULT_CAPTURE_TIMEOUT);
-        let queued = match timeout(wait, rx).await {
-            Ok(Ok(m)) => m,
-            Ok(Err(_)) => {
-                return Err(McpError::internal_error(
-                    "capture reply channel closed before reply arrived".to_owned(),
-                    None,
-                ));
-            }
-            Err(_) => {
-                return Err(McpError::internal_error(
-                    format!(
-                        "timed out after {}ms waiting for capture_frame_result",
-                        wait.as_millis()
-                    ),
-                    None,
-                ));
-            }
-        };
-
-        // Decode the reply. The payload is a postcard-encoded
-        // `CaptureFrameResult` — either `Ok { png }` or `Err { error }`.
-        let result: CaptureFrameResultWire = postcard::from_bytes(&queued.payload)
-            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?;
-        match result {
-            CaptureFrameResultWire::Err { error } => Err(McpError::internal_error(
-                format!("substrate capture failed: {error}"),
-                None,
-            )),
-            CaptureFrameResultWire::Ok { png } => {
-                let encoded = base64::engine::general_purpose::STANDARD.encode(&png);
-                Ok(CallToolResult::success(vec![Content::image(
-                    encoded,
-                    "image/png",
-                )]))
-            }
-        }
-    }
-
-    #[tool(
-        description = "List all engines currently connected to the hub. Each item reports the hub-assigned engine_id, the engine's self-declared name/pid/version, and a `spawned` flag: `true` if the hub launched this engine as a child process (ADR-0009), `false` if it connected externally."
-    )]
-    async fn list_engines(&self) -> Result<String, McpError> {
-        let engines: Vec<EngineInfo> = self
-            .state
-            .engines
-            .list()
-            .into_iter()
-            .map(|r| EngineInfo {
-                engine_id: r.id.0.to_string(),
-                name: r.name,
-                pid: r.pid,
-                version: r.version,
-                spawned: r.spawned,
-            })
-            .collect();
-        serde_json::to_string(&engines).map_err(|e| McpError::internal_error(e.to_string(), None))
-    }
-}
-
-#[tool_handler]
-impl ServerHandler for Hub {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "aether-hub".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-    }
-}
-
-/// Resolve one `MailSpec` against the registry, encode its payload,
-/// and push to the engine's mail channel. Returns a human-readable
-/// error string rather than `Err` so the batch driver can emit it as
-/// a per-mail status without losing sibling success.
-async fn deliver_one(
-    spec: MailSpec,
-    engines: &EngineRegistry,
-    sender: SessionToken,
-) -> Result<(), String> {
-    let uuid = Uuid::parse_str(&spec.engine_id)
-        .map_err(|e| format!("engine_id is not a valid UUID: {e}"))?;
-    let id = EngineId(uuid);
-    let record = engines
-        .get(&id)
-        .ok_or_else(|| format!("unknown engine_id {}", spec.engine_id))?;
-
-    let payload = resolve_payload(&spec, &record)?;
-
-    let frame = HubToEngine::Mail(MailFrame {
-        recipient_name: spec.recipient_name,
-        kind_name: spec.kind_name,
-        payload,
-        count: spec.count,
-        sender,
-    });
-    record
-        .mail_tx
-        .send(frame)
-        .await
-        .map_err(|_| "engine disconnected".to_owned())
-}
-
-/// Decide the wire bytes for a mail by looking up the kind's
-/// descriptor and feeding `params` through `encode_schema`. ADR-0019:
-/// every kind has a schema; absent params is only legal when the
-/// schema is `Unit`.
-fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, String> {
-    let desc = find_kind(record, &spec.kind_name)
-        .ok_or_else(|| format!("kind {:?} has no descriptor on this engine", spec.kind_name))?;
-    match (&spec.params, &desc.schema) {
-        (None, SchemaType::Unit) => Ok(Vec::new()),
-        (None, _) => Err(format!(
-            "kind {:?} requires `params` (only Unit kinds may omit them)",
-            spec.kind_name
-        )),
-        (Some(p), schema) => encode_schema(p, schema).map_err(|e| e.to_string()),
-    }
-}
-
-fn find_kind<'a>(record: &'a EngineRecord, name: &str) -> Option<&'a KindDescriptor> {
-    record.kinds.iter().find(|k| k.name == name)
-}
-
-/// Encode each `MailSpec` in a `capture_frame` bundle against the
-/// engine's descriptors, producing the JSON shape the `CaptureFrame`
-/// kind's schema expects (`{mails: [{recipient_name, kind_name,
-/// payload, count}]}`'s `mails` array — returned here as a JSON
-/// array ready to be slotted under the outer `mails` key).
-///
-/// Abort-on-first-failure: a single bad envelope aborts the whole
-/// bundle, matching the substrate's atomic-dispatch guarantee. This
-/// also short-circuits the tool before it touches the engine wire.
-fn encode_capture_bundle(
-    specs: &[MailSpec],
-    record: &EngineRecord,
-) -> Result<Vec<serde_json::Value>, String> {
-    let mut out = Vec::with_capacity(specs.len());
-    for (i, spec) in specs.iter().enumerate() {
-        let payload = resolve_payload(spec, record)
-            .map_err(|e| format!("envelope[{i}] ({}): {e}", spec.kind_name))?;
-        let payload_bytes: Vec<serde_json::Value> = payload
-            .into_iter()
-            .map(|b| serde_json::Value::Number(b.into()))
-            .collect();
-        out.push(serde_json::json!({
-            "recipient_name": spec.recipient_name,
-            "kind_name": spec.kind_name,
-            "payload": payload_bytes,
-            "count": spec.count,
-        }));
-    }
-    Ok(out)
-}
-
-/// Decode an inbound observation payload against the originating
-/// engine's kind descriptor (ADR-0020). Returns the structured `params`
-/// on success; on any failure (engine no longer in the registry, kind
-/// not declared, decode error) returns `(None, Some(reason))` so the
-/// agent sees both the bytes and a human-readable explanation. Lookup
-/// failures are treated as decode failures rather than tool errors —
-/// the rest of the batch should still drain.
-fn decode_inbound(
-    engine_id: &EngineId,
-    kind_name: &str,
-    payload: &[u8],
-    engines: &EngineRegistry,
-) -> (Option<serde_json::Value>, Option<String>) {
-    let Some(record) = engines.get(engine_id) else {
-        return (
-            None,
-            Some(format!(
-                "engine {} no longer connected; cannot resolve schema",
-                engine_id.0
-            )),
-        );
-    };
-    let Some(desc) = find_kind(&record, kind_name) else {
-        return (
-            None,
-            Some(format!(
-                "kind {kind_name:?} has no descriptor on this engine"
-            )),
-        );
-    };
-    match decode_schema(payload, &desc.schema) {
-        Ok(v) => (Some(v), None),
-        Err(e) => (None, Some(e.to_string())),
-    }
-}
+// `Hub::new` lives in `tools.rs` next to the `#[tool_router]` impl —
+// rmcp's macro emits a private `Self::tool_router()` that the
+// constructor calls, and a sibling impl block in the same module can
+// reach it without widening the macro-generated visibility.
 
 /// Bind an axum server on `addr` exposing the MCP tool surface at
 /// `/mcp`. Returns on axum error. The caller owns the cancellation.

--- a/crates/aether-hub/src/mcp/args.rs
+++ b/crates/aether-hub/src/mcp/args.rs
@@ -1,0 +1,263 @@
+//! Request / response shapes for the MCP tool surface. These types
+//! only carry data — no hub state, no business logic. Each request type
+//! is deserialized from the MCP tool call's `Parameters`, and each
+//! response type is serialized back out as JSON. `JsonSchema` is
+//! required on every type that appears in a tool signature so rmcp
+//! can publish the correct schema to the client.
+
+use std::collections::HashMap;
+
+use aether_hub_protocol::LogLevel;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeKindsArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SendMailArgs {
+    /// One or more mail items to deliver. Each item is processed
+    /// independently — a single failure doesn't abort the batch. The
+    /// response carries a per-item status so the caller decides retry
+    /// vs abort policy.
+    pub mails: Vec<MailSpec>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MailSpec {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Mailbox name as registered by the engine.
+    pub recipient_name: String,
+    /// Kind name (e.g. `"aether.tick"`) the engine's registry knows.
+    pub kind_name: String,
+    /// Structured params for schema-driven encoding. The hub looks up
+    /// this kind's descriptor (from `describe_kinds`) and writes bytes
+    /// matching the kind's wire format — `#[repr(C)]` layout for
+    /// cast-shaped kinds, postcard for everything else.
+    ///
+    /// ADR-0019 PR 5 removed the `payload_bytes` escape hatch from
+    /// this surface. Every aether-shipped kind has a schema; if a
+    /// future kind doesn't, that's an engine bug to fix, not a
+    /// workaround to paper over.
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+    /// Count carried on the mail frame. For single-struct payloads
+    /// this is 1 (the default); for cast-shaped slices it's the
+    /// number of elements the bytes represent.
+    #[serde(default = "one")]
+    pub count: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct MailStatus {
+    /// Index into the `mails` array the caller supplied.
+    pub index: u32,
+    /// `"delivered"` on success, or `"error: <reason>"` on failure.
+    pub status: String,
+}
+
+pub(super) fn one() -> u32 {
+    1
+}
+
+pub(super) fn log_level_to_str(level: LogLevel) -> &'static str {
+    match level {
+        LogLevel::Trace => "trace",
+        LogLevel::Debug => "debug",
+        LogLevel::Info => "info",
+        LogLevel::Warn => "warn",
+        LogLevel::Error => "error",
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct EngineInfo {
+    pub engine_id: String,
+    pub name: String,
+    pub pid: u32,
+    pub version: String,
+    /// `true` if this engine was spawned by the hub (ADR-0009), `false`
+    /// if it connected externally.
+    pub spawned: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SpawnSubstrateArgs {
+    /// Absolute path to the substrate binary the hub should launch.
+    /// The hub does not build, resolve, or locate binaries — the caller
+    /// passes a path that exists.
+    pub binary_path: String,
+    /// Additional command-line arguments to pass to the substrate.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Extra environment variables for the child. `AETHER_HUB_URL` is
+    /// injected automatically to point at this hub; if the caller
+    /// includes it here, the caller's value wins.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Handshake timeout in milliseconds. Defaults to 5 seconds if
+    /// omitted — override for slow CI machines or debug builds.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SpawnResult {
+    /// UUID assigned by the hub once the substrate completed its
+    /// `Hello` handshake.
+    pub engine_id: String,
+    /// Operating-system PID of the spawned substrate.
+    pub pid: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TerminateSubstrateArgs {
+    /// Hub-assigned engine UUID (from `list_engines`).
+    pub engine_id: String,
+    /// SIGTERM grace period in milliseconds. Defaults to 2 seconds —
+    /// long enough for a well-behaved substrate to drain, short enough
+    /// not to stall interactive agent flows.
+    #[serde(default)]
+    pub grace_ms: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct TerminateResult {
+    pub engine_id: String,
+    /// `true` if the child ignored SIGTERM and the hub escalated to
+    /// SIGKILL after the grace window. `false` for clean exits.
+    pub sigkilled: bool,
+    /// Exit code if the child exited normally; `null` if it was killed
+    /// by a signal (the common case when `sigkilled` is true).
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EngineLogsArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Maximum entries to return. Defaults to 100; clamped to 1000.
+    #[serde(default)]
+    pub max: Option<u32>,
+    /// Minimum log level (`"trace"|"debug"|"info"|"warn"|"error"`).
+    /// Defaults to `"trace"` (every captured entry).
+    #[serde(default)]
+    pub level: Option<String>,
+    /// Cursor: only entries with `sequence > since` are returned.
+    /// Pass back the previous response's `next_since` to poll
+    /// incrementally without re-receiving.
+    #[serde(default)]
+    pub since: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EngineLogsResponse {
+    pub engine_id: String,
+    pub entries: Vec<EngineLogEntry>,
+    /// Highest `sequence` returned in `entries`, or the request's
+    /// `since` value if the response is empty. Use as the next
+    /// `since` for incremental polling.
+    pub next_since: u64,
+    /// Set when the hub-side ring evicted entries the caller hadn't
+    /// seen — `Some(seq)` means the gap above the request's `since`
+    /// extends up to (but not including) `seq`. Treat as a signal to
+    /// poll more often or accept the loss.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated_before: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EngineLogEntry {
+    pub timestamp_unix_ms: u64,
+    /// Lowercase level: `"trace"|"debug"|"info"|"warn"|"error"`.
+    pub level: String,
+    /// Module path the event was emitted from
+    /// (e.g. `"aether_substrate::scheduler"`).
+    pub target: String,
+    /// Already-formatted event text. Tracing's structured fields are
+    /// flattened into this string by the substrate's capture layer.
+    pub message: String,
+    pub sequence: u64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureFrameArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Optional bundle of mails to dispatch on the substrate *before*
+    /// the capture fires. Each item has the same shape as a
+    /// `send_mail` entry — `recipient_name`, `kind_name`, structured
+    /// `params` encoded via the kind's descriptor, `count`. The
+    /// substrate resolves every envelope atomically: if any fails
+    /// (unknown kind, unknown recipient), no mail is dispatched and
+    /// the reply is an `Err`. An empty bundle means "just capture the
+    /// current state."
+    #[serde(default)]
+    pub mails: Vec<MailSpec>,
+    /// Optional bundle of cleanup mails dispatched *after* the frame
+    /// is captured. Useful for "set a flag, capture, unset the flag"
+    /// patterns in one atomic tool call. Resolved against the same
+    /// abort-on-first-failure policy as `mails` — a bad envelope in
+    /// either bundle aborts the whole request before any mail moves.
+    #[serde(default)]
+    pub after_mails: Vec<MailSpec>,
+    /// Maximum time to wait for the substrate's reply, in
+    /// milliseconds. Defaults to 5000 (5 s). Clamped to 30000 (30 s).
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+/// Wire-format mirror of the substrate's `CaptureFrameResult` kind.
+/// Lives in the hub so we can postcard-decode the reply payload
+/// without pulling in the substrate's typed kind crate. Must stay in
+/// lockstep with `aether-kinds::CaptureFrameResult` — the comment on
+/// that type is the canonical spec.
+#[derive(Debug, Deserialize)]
+pub(super) enum CaptureFrameResultWire {
+    Ok { png: Vec<u8> },
+    Err { error: String },
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReceiveMailArgs {
+    /// Maximum number of items to return in this call. `None` drains
+    /// everything currently queued. Defaults to unlimited.
+    #[serde(default)]
+    pub max: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ReceivedMail {
+    /// Hub-assigned UUID of the engine that sent this mail.
+    pub engine_id: String,
+    /// Kind name the engine declared at handshake.
+    pub kind_name: String,
+    /// Structured value decoded against the engine's kind descriptor —
+    /// the symmetric counterpart to `send_mail`'s `params` field
+    /// (ADR-0020). `null` if the hub couldn't decode (no descriptor for
+    /// this kind, or decode failed), in which case `decode_error` is
+    /// populated and the agent falls back to `payload_bytes`.
+    pub params: Option<serde_json::Value>,
+    /// Decode failure reason. Populated only when `params` is `null`
+    /// because the hub's decoder rejected the payload (e.g. schema
+    /// drift, truncation, unknown kind). Always paired with intact
+    /// `payload_bytes` for an escape-hatch decode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decode_error: Option<String>,
+    /// Raw payload bytes. Always populated. Prefer `params`; reach for
+    /// `payload_bytes` only when `params` is `null` (decode failed) or
+    /// when the agent genuinely needs the wire bytes.
+    pub payload_bytes: Vec<u8>,
+    /// `true` if this mail was addressed to every attached session;
+    /// `false` if it was a reply targeted at this session specifically.
+    pub broadcast: bool,
+    /// Substrate-attested name of the emitting mailbox (ADR-0011).
+    /// Distinguishes components that share a kind. `None` for mail
+    /// pushed by substrate core (e.g. the frame loop's `FrameStats`),
+    /// which has no sending mailbox.
+    pub origin: Option<String>,
+}

--- a/crates/aether-hub/src/mcp/codecs.rs
+++ b/crates/aether-hub/src/mcp/codecs.rs
@@ -1,0 +1,143 @@
+//! Schema-driven encoding and decoding for the MCP tool surface.
+//! Thin adapter layer between the tool-level JSON surface and the
+//! wire bytes the engine reads and writes:
+//!
+//! - `deliver_one` / `resolve_payload` / `encode_capture_bundle` go
+//!   outbound (tools → engine).
+//! - `decode_inbound` goes the other way for `receive_mail` (engine →
+//!   tools, ADR-0020).
+//!
+//! Every function here is pure data transformation against an
+//! `EngineRecord`'s declared kind descriptors — no `HubState`, no
+//! business logic, no concurrency primitives beyond the outbound
+//! `mail_tx`.
+
+use aether_hub_protocol::{
+    EngineId, HubToEngine, KindDescriptor, MailFrame, SchemaType, SessionToken, Uuid,
+};
+
+use crate::decoder::decode_schema;
+use crate::encoder::encode_schema;
+use crate::registry::{EngineRecord, EngineRegistry};
+
+use super::args::MailSpec;
+
+/// Resolve one `MailSpec` against the registry, encode its payload,
+/// and push to the engine's mail channel. Returns a human-readable
+/// error string rather than `Err` so the batch driver can emit it as
+/// a per-mail status without losing sibling success.
+pub(super) async fn deliver_one(
+    spec: MailSpec,
+    engines: &EngineRegistry,
+    sender: SessionToken,
+) -> Result<(), String> {
+    let uuid = Uuid::parse_str(&spec.engine_id)
+        .map_err(|e| format!("engine_id is not a valid UUID: {e}"))?;
+    let id = EngineId(uuid);
+    let record = engines
+        .get(&id)
+        .ok_or_else(|| format!("unknown engine_id {}", spec.engine_id))?;
+
+    let payload = resolve_payload(&spec, &record)?;
+
+    let frame = HubToEngine::Mail(MailFrame {
+        recipient_name: spec.recipient_name,
+        kind_name: spec.kind_name,
+        payload,
+        count: spec.count,
+        sender,
+    });
+    record
+        .mail_tx
+        .send(frame)
+        .await
+        .map_err(|_| "engine disconnected".to_owned())
+}
+
+/// Decide the wire bytes for a mail by looking up the kind's
+/// descriptor and feeding `params` through `encode_schema`. ADR-0019:
+/// every kind has a schema; absent params is only legal when the
+/// schema is `Unit`.
+pub(super) fn resolve_payload(spec: &MailSpec, record: &EngineRecord) -> Result<Vec<u8>, String> {
+    let desc = find_kind(record, &spec.kind_name)
+        .ok_or_else(|| format!("kind {:?} has no descriptor on this engine", spec.kind_name))?;
+    match (&spec.params, &desc.schema) {
+        (None, SchemaType::Unit) => Ok(Vec::new()),
+        (None, _) => Err(format!(
+            "kind {:?} requires `params` (only Unit kinds may omit them)",
+            spec.kind_name
+        )),
+        (Some(p), schema) => encode_schema(p, schema).map_err(|e| e.to_string()),
+    }
+}
+
+pub(super) fn find_kind<'a>(record: &'a EngineRecord, name: &str) -> Option<&'a KindDescriptor> {
+    record.kinds.iter().find(|k| k.name == name)
+}
+
+/// Encode each `MailSpec` in a `capture_frame` bundle against the
+/// engine's descriptors, producing the JSON shape the `CaptureFrame`
+/// kind's schema expects (`{mails: [{recipient_name, kind_name,
+/// payload, count}]}`'s `mails` array — returned here as a JSON
+/// array ready to be slotted under the outer `mails` key).
+///
+/// Abort-on-first-failure: a single bad envelope aborts the whole
+/// bundle, matching the substrate's atomic-dispatch guarantee. This
+/// also short-circuits the tool before it touches the engine wire.
+pub(super) fn encode_capture_bundle(
+    specs: &[MailSpec],
+    record: &EngineRecord,
+) -> Result<Vec<serde_json::Value>, String> {
+    let mut out = Vec::with_capacity(specs.len());
+    for (i, spec) in specs.iter().enumerate() {
+        let payload = resolve_payload(spec, record)
+            .map_err(|e| format!("envelope[{i}] ({}): {e}", spec.kind_name))?;
+        let payload_bytes: Vec<serde_json::Value> = payload
+            .into_iter()
+            .map(|b| serde_json::Value::Number(b.into()))
+            .collect();
+        out.push(serde_json::json!({
+            "recipient_name": spec.recipient_name,
+            "kind_name": spec.kind_name,
+            "payload": payload_bytes,
+            "count": spec.count,
+        }));
+    }
+    Ok(out)
+}
+
+/// Decode an inbound observation payload against the originating
+/// engine's kind descriptor (ADR-0020). Returns the structured `params`
+/// on success; on any failure (engine no longer in the registry, kind
+/// not declared, decode error) returns `(None, Some(reason))` so the
+/// agent sees both the bytes and a human-readable explanation. Lookup
+/// failures are treated as decode failures rather than tool errors —
+/// the rest of the batch should still drain.
+pub(super) fn decode_inbound(
+    engine_id: &EngineId,
+    kind_name: &str,
+    payload: &[u8],
+    engines: &EngineRegistry,
+) -> (Option<serde_json::Value>, Option<String>) {
+    let Some(record) = engines.get(engine_id) else {
+        return (
+            None,
+            Some(format!(
+                "engine {} no longer connected; cannot resolve schema",
+                engine_id.0
+            )),
+        );
+    };
+    let Some(desc) = find_kind(&record, kind_name) else {
+        return (
+            None,
+            Some(format!(
+                "kind {kind_name:?} has no descriptor on this engine"
+            )),
+        );
+    };
+    match decode_schema(payload, &desc.schema) {
+        Ok(v) => (Some(v), None),
+        Err(e) => (None, Some(e.to_string())),
+    }
+}

--- a/crates/aether-hub/src/mcp/tools.rs
+++ b/crates/aether-hub/src/mcp/tools.rs
@@ -1,0 +1,426 @@
+//! The `#[tool_router] impl Hub` block — every MCP tool the hub
+//! exposes lives here. Each method is a thin adapter that parses
+//! arguments, looks up registry state, delegates to the helpers in
+//! `codecs.rs` for encode/decode work, and serializes the response.
+//! Business logic that isn't request/response glue belongs in
+//! `crate::registry`, `crate::spawn`, `crate::session`, or the codec
+//! module — not here.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aether_hub_protocol::{EngineId, LogLevel, Uuid};
+use base64::Engine as _;
+use rmcp::{
+    ErrorData as McpError, ServerHandler,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+};
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+use crate::log_store::{TOOL_DEFAULT_ENTRIES, TOOL_MAX_ENTRIES};
+use crate::session::SessionHandle;
+use crate::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, SpawnOpts};
+
+use super::args::{
+    CaptureFrameArgs, CaptureFrameResultWire, DescribeKindsArgs, EngineInfo, EngineLogEntry,
+    EngineLogsArgs, EngineLogsResponse, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail,
+    SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
+    log_level_to_str,
+};
+use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
+use super::{Hub, HubState};
+
+/// Substrate control-plane kind name for a capture request. String
+/// constants rather than an `aether-kinds` dependency to keep the hub
+/// agnostic of the substrate's typed kind vocabulary at crate level —
+/// the schema-driven descriptor path already provides wire-level
+/// compatibility.
+const KIND_CAPTURE_FRAME: &str = "aether.control.capture_frame";
+const KIND_CAPTURE_FRAME_RESULT: &str = "aether.control.capture_frame_result";
+
+/// Default cap on how long `capture_frame` waits for the substrate's
+/// reply before returning an error. Long enough to tolerate one
+/// stalled frame (monitor refresh + GPU readback + PNG encode); short
+/// enough that a stuck substrate doesn't hang the tool call.
+const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Hard ceiling on `timeout_ms`. A request that needs more than 30s
+/// is probably a bug on the substrate side; surfacing it as a bound
+/// rather than letting it hang preserves the harness's responsiveness.
+const MAX_CAPTURE_TIMEOUT: Duration = Duration::from_secs(30);
+
+impl Hub {
+    /// Construct a per-session `Hub`. Lives in this module (rather
+    /// than `mcp.rs` with the struct) because `Self::tool_router()` is
+    /// generated private by rmcp's `#[tool_router]` macro below and
+    /// only siblings in the same module can call it.
+    pub fn new(state: Arc<HubState>) -> Self {
+        let (session, rx) = SessionHandle::mint(&state.sessions);
+        Self {
+            state,
+            tool_router: Self::tool_router(),
+            session: Arc::new(session),
+            inbound: Arc::new(Mutex::new(rx)),
+        }
+    }
+}
+
+#[tool_router]
+impl Hub {
+    #[tool(
+        description = "Send one or more mail items. Each item takes `params` — structured JSON encoded via the engine's kind descriptor (cast-shaped or postcard, ADR-0019). The batch is best-effort: per-item status is returned and failures don't abort siblings. 'delivered' means the hub queued the frame to the engine's socket — not that the engine processed it."
+    )]
+    pub(super) async fn send_mail(
+        &self,
+        Parameters(args): Parameters<SendMailArgs>,
+    ) -> Result<String, McpError> {
+        let mut statuses = Vec::with_capacity(args.mails.len());
+        for (i, spec) in args.mails.into_iter().enumerate() {
+            let result = deliver_one(spec, &self.state.engines, self.session.token).await;
+            let status = match result {
+                Ok(()) => "delivered".into(),
+                Err(e) => format!("error: {e}"),
+            };
+            statuses.push(MailStatus {
+                index: i as u32,
+                status,
+            });
+        }
+        serde_json::to_string(&statuses).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "List every kind the given engine declared at handshake, with enough structural detail for clients to build params for send_mail. ADR-0019 Schema kinds describe their full shape (scalars, strings, vecs, options, enums, nested structs); the cast-shaped subset (`Struct{repr_c:true}`) is wire-compatible with `#[repr(C)]` layout."
+    )]
+    pub(super) async fn describe_kinds(
+        &self,
+        Parameters(args): Parameters<DescribeKindsArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let Some(record) = self.state.engines.get(&id) else {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        };
+        serde_json::to_string(&record.kinds)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Drain observation mail addressed to this MCP session. Returns everything currently queued (up to `max`, if provided). Each item reports the originating engine_id, the kind name, structured `params` decoded against the engine's kind descriptor (ADR-0020 — symmetric to `send_mail`), the raw `payload_bytes` (always populated; primarily a fallback when `params` is null), an optional `decode_error` explaining why decode failed when `params` is null, a `broadcast` flag indicating whether this mail also went to every other attached session (true) or was targeted specifically at this one (false), and an optional `origin` — the substrate-local mailbox name of the emitting component (absent for substrate-core pushes with no sending mailbox). Non-blocking: returns an empty array if nothing is queued."
+    )]
+    pub(super) async fn receive_mail(
+        &self,
+        Parameters(args): Parameters<ReceiveMailArgs>,
+    ) -> Result<String, McpError> {
+        let cap = args.max.map(|n| n as usize).unwrap_or(usize::MAX);
+        let mut rx = self.inbound.lock().await;
+        let mut out = Vec::new();
+        while out.len() < cap {
+            match rx.try_recv() {
+                Ok(m) => {
+                    let (params, decode_error) =
+                        decode_inbound(&m.engine_id, &m.kind_name, &m.payload, &self.state.engines);
+                    out.push(ReceivedMail {
+                        engine_id: m.engine_id.0.to_string(),
+                        kind_name: m.kind_name,
+                        params,
+                        decode_error,
+                        payload_bytes: m.payload,
+                        broadcast: m.broadcast,
+                        origin: m.origin,
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+        serde_json::to_string(&out).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Launch a substrate binary as a child process of the hub. The hub injects `AETHER_HUB_URL` so the child dials back to this hub instance. Blocks until the substrate completes its `Hello` handshake (or the handshake timeout fires — default 5 seconds, overridable via `timeout_ms`). Returns the assigned `engine_id` and the child `pid`. The hub owns the child for its lifetime; dropping the engine from the registry (socket disconnect or `terminate_substrate`) reaps the process."
+    )]
+    pub(super) async fn spawn_substrate(
+        &self,
+        Parameters(args): Parameters<SpawnSubstrateArgs>,
+    ) -> Result<String, McpError> {
+        let handshake_timeout = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64))
+            .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT);
+        let opts = SpawnOpts {
+            binary_path: PathBuf::from(args.binary_path),
+            args: args.args,
+            env: args.env,
+            handshake_timeout,
+        };
+        let engine_id = crate::spawn::spawn_substrate(
+            opts,
+            self.state.hub_engine_addr,
+            &self.state.pending_spawns,
+            &self.state.engines,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("spawn failed: {e}"), None))?;
+
+        let pid = self
+            .state
+            .engines
+            .get(&engine_id)
+            .map(|r| r.pid)
+            .unwrap_or(0);
+        let result = SpawnResult {
+            engine_id: engine_id.0.to_string(),
+            pid,
+        };
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Terminate a substrate the hub previously spawned. Sends SIGTERM, waits up to `grace_ms` milliseconds (default 2000) for the child to exit, then escalates to SIGKILL if it's still running. Returns the exit code (if any) and a `sigkilled` flag indicating whether escalation was necessary. Errors if the engine id is unknown or refers to an externally connected substrate — the hub only terminates children it owns."
+    )]
+    pub(super) async fn terminate_substrate(
+        &self,
+        Parameters(args): Parameters<TerminateSubstrateArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+
+        if self.state.engines.get(&id).is_none() {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        }
+
+        let Some(child) = self.state.engines.take_child(&id) else {
+            return Err(McpError::invalid_params(
+                format!(
+                    "engine {} is not hub-spawned; terminate it externally",
+                    args.engine_id
+                ),
+                None,
+            ));
+        };
+
+        let grace = args
+            .grace_ms
+            .map(|ms| Duration::from_millis(ms as u64))
+            .unwrap_or(DEFAULT_TERMINATE_GRACE);
+
+        let outcome = crate::spawn::terminate_substrate(child, grace)
+            .await
+            .map_err(|e| McpError::internal_error(format!("terminate failed: {e}"), None))?;
+
+        let result = TerminateResult {
+            engine_id: args.engine_id,
+            sigkilled: outcome.sigkilled,
+            exit_code: outcome.exit_code,
+        };
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Drain captured substrate log entries for an engine (ADR-0023). Cursor-based polling: pass back `next_since` from the previous response to receive only new entries. `level` (default `\"trace\"`) filters server-side. `max` defaults to 100, clamped to 1000. `truncated_before` is set when the hub-side ring evicted entries the caller hadn't seen — treat it as a signal to poll more often or accept the gap. Buffer survives engine exit until hub shutdown, so post-mortem polls work after the substrate has crashed."
+    )]
+    pub(super) async fn engine_logs(
+        &self,
+        Parameters(args): Parameters<EngineLogsArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let min_level = match args.level.as_deref() {
+            None | Some("trace") => LogLevel::Trace,
+            Some("debug") => LogLevel::Debug,
+            Some("info") => LogLevel::Info,
+            Some("warn") => LogLevel::Warn,
+            Some("error") => LogLevel::Error,
+            Some(other) => {
+                return Err(McpError::invalid_params(
+                    format!("level {other:?} is not one of trace|debug|info|warn|error",),
+                    None,
+                ));
+            }
+        };
+        let max = args
+            .max
+            .map(|n| n as usize)
+            .unwrap_or(TOOL_DEFAULT_ENTRIES)
+            .min(TOOL_MAX_ENTRIES);
+        let since = args.since.unwrap_or(0);
+        let result = self.state.logs.read(id, max, min_level, since);
+        let response = EngineLogsResponse {
+            engine_id: args.engine_id,
+            entries: result
+                .entries
+                .into_iter()
+                .map(|e| EngineLogEntry {
+                    timestamp_unix_ms: e.timestamp_unix_ms,
+                    level: log_level_to_str(e.level).to_owned(),
+                    target: e.target,
+                    message: e.message,
+                    sequence: e.sequence,
+                })
+                .collect(),
+            next_since: result.next_since,
+            truncated_before: result.truncated_before,
+        };
+        serde_json::to_string(&response).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Capture the current frame contents of the given engine as a PNG and return it inline as MCP image content. The substrate renders to an offscreen target so the capture works regardless of window visibility (important on macOS where occluded windows would otherwise block). Optionally carries two mail bundles dispatched atomically around the capture: `mails` fires *before* the frame is read back (state-changing mail whose effects should appear in the image), and `after_mails` fires *after* readback (cleanup such as restoring a flag the caller flipped for the capture). The substrate resolves every envelope in both bundles first (abort-on-first-failure); any failure means no mail moves. The render loop's `queue.wait_idle()` ensures the pre-capture bundle has been fully processed before the frame is read back. Empty bundles mean \"just capture\" / \"no cleanup\". Rejects if another capture is already in flight on this session, or if the wait exceeds `timeout_ms` (default 5000, clamped to 30000). Use this to verify substrate rendering end-to-end and to bundle \"set X, show me, restore X\" into one atomic tool call."
+    )]
+    pub(super) async fn capture_frame(
+        &self,
+        Parameters(args): Parameters<CaptureFrameArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let record = self.state.engines.get(&id).ok_or_else(|| {
+            McpError::invalid_params(format!("unknown engine_id {}", args.engine_id), None)
+        })?;
+
+        // Encode each envelope in both bundles against its kind's
+        // descriptor. Done before we register the reply-waiter or
+        // send anything, so a bad bundle produces a clean invalid-
+        // params error and never touches the engine wire.
+        let envelopes = encode_capture_bundle(&args.mails, &record).map_err(|e| {
+            McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
+        })?;
+        let after_envelopes = encode_capture_bundle(&args.after_mails, &record).map_err(|e| {
+            McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
+        })?;
+        let bundle_params = serde_json::json!({
+            "mails": envelopes,
+            "after_mails": after_envelopes,
+        });
+
+        // Register the reply-waiter BEFORE sending the request, so the
+        // engine reader can divert the reply to our oneshot the moment
+        // it arrives. If another capture is already pending on this
+        // session, surface it as a clear error rather than silently
+        // waiting behind the first.
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(KIND_CAPTURE_FRAME_RESULT.to_owned())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a capture is already in flight on this session; wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        // Send the capture_frame request carrying the pre-encoded
+        // bundle. The substrate's schema decoder reconstructs each
+        // envelope's `payload: Vec<u8>` from the JSON byte array the
+        // hub encoder wrote — postcard-equivalent round-trip.
+        let spec = MailSpec {
+            engine_id: args.engine_id.clone(),
+            recipient_name: "aether.control".to_owned(),
+            kind_name: KIND_CAPTURE_FRAME.to_owned(),
+            params: Some(bundle_params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        // Wait for the reply (or timeout). `_guard` drops when this
+        // future resolves — on any path — which removes the registry
+        // entry. The record lookup above already pinned `record` for
+        // the duration of the send; we don't need it past this point.
+        let _ = record;
+        let wait = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_CAPTURE_TIMEOUT))
+            .unwrap_or(DEFAULT_CAPTURE_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "capture reply channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for capture_frame_result",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        // Decode the reply. The payload is a postcard-encoded
+        // `CaptureFrameResult` — either `Ok { png }` or `Err { error }`.
+        let result: CaptureFrameResultWire = postcard::from_bytes(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?;
+        match result {
+            CaptureFrameResultWire::Err { error } => Err(McpError::internal_error(
+                format!("substrate capture failed: {error}"),
+                None,
+            )),
+            CaptureFrameResultWire::Ok { png } => {
+                let encoded = base64::engine::general_purpose::STANDARD.encode(&png);
+                Ok(CallToolResult::success(vec![Content::image(
+                    encoded,
+                    "image/png",
+                )]))
+            }
+        }
+    }
+
+    #[tool(
+        description = "List all engines currently connected to the hub. Each item reports the hub-assigned engine_id, the engine's self-declared name/pid/version, and a `spawned` flag: `true` if the hub launched this engine as a child process (ADR-0009), `false` if it connected externally."
+    )]
+    pub(super) async fn list_engines(&self) -> Result<String, McpError> {
+        let engines: Vec<EngineInfo> = self
+            .state
+            .engines
+            .list()
+            .into_iter()
+            .map(|r| EngineInfo {
+                engine_id: r.id.0.to_string(),
+                name: r.name,
+                pid: r.pid,
+                version: r.version,
+                spawned: r.spawned,
+            })
+            .collect();
+        serde_json::to_string(&engines).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Hub {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: "aether-hub".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Splits the 2017-line `crates/aether-hub/src/mcp.rs` along the seams we agreed on:

- **`mcp/args.rs`** (263 lines) — every `*Args` request struct and every response type (`MailStatus`, `EngineInfo`, `SpawnResult`, etc.), plus the tiny `one()` / `log_level_to_str()` helpers and the `CaptureFrameResultWire` decode mirror. Pure data, no logic.
- **`mcp/codecs.rs`** (143 lines) — `deliver_one`, `resolve_payload`, `find_kind`, `encode_capture_bundle`, `decode_inbound`. Schema-driven encode/decode between tool JSON and wire bytes.
- **`mcp/tools.rs`** (426 lines) — the `#[tool_router] impl Hub` block with all eight tool methods, the `ServerHandler` impl, and `Hub::new` (moved here so it can call the macro-generated private `Self::tool_router()`). Capture-specific constants scoped here.
- **`mcp.rs`** (root, ~130 non-test lines) — `HubState`, `Hub` struct, `run_mcp_server`, and the untouched `#[cfg(test)] mod tests` block.

**Test module preserved verbatim.** Test-only imports from the protocol crate and args submodule are gated on `#[cfg(test)]` at the root so `use super::*;` in tests keeps working without touching individual test cases. Tool methods are `pub(super)` so the test module can still call them as methods on `Hub`.

**Public API unchanged.** `lib.rs` still re-exports `DEFAULT_MCP_PORT`, `HubState`, and `run_mcp_server` — the only items external consumers use today.

## Quirk worth calling out
`Hub::new` moved from `mcp.rs` to `mcp/tools.rs` because rmcp's `#[tool_router]` macro emits a *private* `fn tool_router()` associated function. The constructor needs to call it, and only impl blocks in the same module can reach that private fn. Moving `Hub::new` into `tools.rs` (while keeping the `struct Hub` in `mcp.rs`) is the minimal fix; a comment in both files points the reader at the other.

## Numbers
- `mcp.rs`: 2017 → 1281 (1150 of those are the unchanged test module; non-test drops from ~860 to ~130)
- Three new focused submodules, each under ~430 lines
- Net line count +96 (module headers + re-imports)

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all 111 hub unit tests pass unchanged; full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)