### PR TITLE
chore: bump workspace version to 0.2.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aether-component"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-kinds",
  "aether-mail",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "aether-hello-component"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-component",
  "aether-kinds",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "aether-hub"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "axum",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "aether-hub-protocol"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "postcard",
  "serde",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aether-kinds"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "aether-mail",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "aether-mail"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "aether-mail-derive",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aether-mail-derive"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "aether-mail",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "aether-substrate"
-version = "0.1.0"
+version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "aether-kinds",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ members = [
 exclude = ["spikes/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0-alpha"
 edition = "2024"


### PR DESCRIPTION
## Summary
Follows the `0.1.0-alpha` tag at bfc5130. Every in-tree commit from here forward is building toward `0.2.0` — the workspace version string in `cargo` output now reflects that rather than reading `0.1.0` (the tagged past).

No code change.

## Test plan
- [x] `cargo build` (all 8 crates now report `v0.2.0-alpha`)