### PR TITLE
feat(sdk): auto-subscribe components to declared input kinds

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -27,7 +27,7 @@ use bytemuck::{Pod, Zeroable};
 /// elapsed-time is parked until a subscriber actually needs it.
 #[derive(aether_mail::Kind)]
 #[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
-#[kind(name = "aether.tick")]
+#[kind(name = "aether.tick", input)]
 pub struct Tick;
 
 /// A single keyboard keypress, identified by `winit::keyboard::KeyCode
@@ -35,7 +35,7 @@ pub struct Tick;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, aether_mail::Kind)]
 #[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
-#[kind(name = "aether.key")]
+#[kind(name = "aether.key", input)]
 pub struct Key {
     pub code: u32,
 }
@@ -43,14 +43,14 @@ pub struct Key {
 /// A mouse-button press. No payload today — which button isn't tracked.
 #[derive(aether_mail::Kind)]
 #[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
-#[kind(name = "aether.mouse_button")]
+#[kind(name = "aether.mouse_button", input)]
 pub struct MouseButton;
 
 /// Cursor position in window coordinates, as logical pixels cast to f32.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind)]
 #[cfg_attr(feature = "descriptors", derive(aether_mail::Schema))]
-#[kind(name = "aether.mouse_move")]
+#[kind(name = "aether.mouse_move", input)]
 pub struct MouseMove {
     pub x: f32,
     pub y: f32,

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -55,16 +55,28 @@ pub fn derive_schema(input: TokenStream) -> TokenStream {
 
 fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
-    let kind_name = parse_kind_name(&input.attrs)?;
+    let KindAttr {
+        name: kind_name,
+        is_input,
+    } = parse_kind_attr(&input.attrs)?;
     if let Data::Union(u) = &input.data {
         return Err(syn::Error::new_spanned(
             u.union_token,
             "Kind derive does not support unions",
         ));
     }
+    // Only emit `IS_INPUT` when true — relying on the trait default
+    // for non-input kinds keeps the generated code minimal and makes
+    // grep-for-IS_INPUT-true a reliable audit of the input set.
+    let is_input_item = if is_input {
+        quote! { const IS_INPUT: bool = true; }
+    } else {
+        quote! {}
+    };
     Ok(quote! {
         impl ::aether_mail::Kind for #name {
             const NAME: &'static str = #kind_name;
+            #is_input_item
         }
     })
 }
@@ -228,28 +240,41 @@ fn is_vec_u8(ty: &Type) -> bool {
 
 // ----- attribute and shape helpers --------------------------------------
 
-fn parse_kind_name(attrs: &[Attribute]) -> syn::Result<String> {
+struct KindAttr {
+    name: String,
+    is_input: bool,
+}
+
+fn parse_kind_attr(attrs: &[Attribute]) -> syn::Result<KindAttr> {
     for attr in attrs {
         if !attr.path().is_ident("kind") {
             continue;
         }
-        let mut found: Option<String> = None;
+        let mut name: Option<String> = None;
+        let mut is_input = false;
         attr.parse_nested_meta(|meta| {
-            if !meta.path.is_ident("name") {
-                return Err(meta.error("expected `name = \"...\"`"));
+            if meta.path.is_ident("name") {
+                let value = meta.value()?;
+                let expr: Expr = value.parse()?;
+                if let Expr::Lit(lit) = &expr
+                    && let Lit::Str(s) = &lit.lit
+                {
+                    name = Some(s.value());
+                    return Ok(());
+                }
+                return Err(meta.error("`name` must be a string literal"));
             }
-            let value = meta.value()?;
-            let expr: Expr = value.parse()?;
-            if let Expr::Lit(lit) = &expr
-                && let Lit::Str(s) = &lit.lit
-            {
-                found = Some(s.value());
+            if meta.path.is_ident("input") {
+                // Flag-shaped — no `= value`. ADR-0021: marks this
+                // kind as a substrate-published input stream so the
+                // SDK's auto-subscribe walk catches it at init.
+                is_input = true;
                 return Ok(());
             }
-            Err(meta.error("`name` must be a string literal"))
+            Err(meta.error("expected `name = \"...\"` or `input`"))
         })?;
-        if let Some(name) = found {
-            return Ok(name);
+        if let Some(name) = name {
+            return Ok(KindAttr { name, is_input });
         }
     }
     Err(syn::Error::new(

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -25,8 +25,17 @@ use core::fmt;
 /// `"aether.tick"`, `"hello.npc_health"`). The name is resolved to a
 /// runtime `u32` id by the substrate's kind registry at init; see
 /// ADR-0005 for the resolution flow.
+///
+/// `IS_INPUT` marks the kind as a substrate-published input stream
+/// (`Tick`, `Key`, `MouseMove`, `MouseButton` — ADR-0021). Defaults
+/// to `false`; the guest SDK auto-subscribes a component's mailbox
+/// to every input kind in its typelist before the first `receive`
+/// fires, so components declaring `type Kinds = (Tick, ...)` don't
+/// need to send `subscribe_input` themselves. Non-input kinds never
+/// touch this — leave the default alone.
 pub trait Kind {
     const NAME: &'static str;
+    const IS_INPUT: bool = false;
 }
 
 /// Compile-time predicate: can this type's payload travel across the

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -230,6 +230,7 @@ mod tests {
             Arc::new(Registry::new()),
             Arc::new(MailQueue::new()),
             HubOutbound::disconnected(),
+            crate::input::new_subscribers(),
         )
     }
 
@@ -547,7 +548,13 @@ mod tests {
                 schema: SchemaType::Unit,
             })
             .expect("register kind");
-        let ctx = SubstrateCtx::new(M(0), registry, Arc::new(MailQueue::new()), outbound);
+        let ctx = SubstrateCtx::new(
+            M(0),
+            registry,
+            Arc::new(MailQueue::new()),
+            outbound,
+            crate::input::new_subscribers(),
+        );
         (ctx, rx)
     }
 
@@ -622,7 +629,13 @@ mod tests {
             })
             .expect("register kind");
         let queue = Arc::new(MailQueue::new());
-        let ctx = SubstrateCtx::new(M(0), registry, Arc::clone(&queue), outbound);
+        let ctx = SubstrateCtx::new(
+            M(0),
+            registry,
+            Arc::clone(&queue),
+            outbound,
+            crate::input::new_subscribers(),
+        );
         (ctx, rx, queue, caller)
     }
 

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -364,6 +364,7 @@ impl ControlPlane {
             Arc::clone(&self.registry),
             Arc::clone(&self.queue),
             Arc::clone(&self.outbound),
+            Arc::clone(&self.input_subscribers),
         );
         let component = match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
             Ok(c) => c,
@@ -685,6 +686,7 @@ impl ControlPlane {
             Arc::clone(&self.registry),
             Arc::clone(&self.queue),
             Arc::clone(&self.outbound),
+            Arc::clone(&self.input_subscribers),
         );
         let mut new_component =
             match Component::instantiate(&self.engine, &self.linker, &module, ctx) {

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use aether_hub_protocol::SessionToken;
 
 use crate::hub_client::HubOutbound;
+use crate::input::InputSubscribers;
 use crate::mail::{Mail, MailKind, MailboxId};
 use crate::queue::MailQueue;
 use crate::registry::{MailboxEntry, Registry};
@@ -41,6 +42,12 @@ pub struct SubstrateCtx {
     /// `HubOutbound::disconnected` when no hub is attached — sends
     /// silently drop, matching the broadcast semantics.
     pub outbound: Arc<HubOutbound>,
+    /// ADR-0021 subscriber sets, shared with the platform-event
+    /// publisher in `main.rs`. `resolve_kind_p32` consults this when
+    /// the resolved kind is flagged `IS_INPUT`, auto-subscribing the
+    /// calling mailbox so components declaring `type Kinds = (Tick, ...)`
+    /// don't have to send `subscribe_input` themselves.
+    pub input_subscribers: InputSubscribers,
     /// ADR-0013 + ADR-0017: handle→entry map populated by
     /// `Component::deliver` whenever an inbound mail has a meaningful
     /// reply target — a Claude session (`SenderEntry::Session`) or
@@ -74,12 +81,14 @@ impl SubstrateCtx {
         registry: Arc<Registry>,
         queue: Arc<MailQueue>,
         outbound: Arc<HubOutbound>,
+        input_subscribers: InputSubscribers,
     ) -> Self {
         SubstrateCtx {
             sender,
             registry,
             queue,
             outbound,
+            input_subscribers,
             sender_table: SenderTable::new(),
             saved_state: None,
             save_state_error: None,

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -5,6 +5,7 @@
 // as any other architectural change.
 
 use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
+use aether_kinds::InputStream;
 use wasmtime::{Caller, Linker};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
@@ -16,6 +17,25 @@ use crate::sender_table::SenderEntry;
 /// sentinel.
 pub const KIND_NOT_FOUND: u32 = u32::MAX;
 pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
+
+/// Map a resolved kind name to the substrate input stream it belongs
+/// to. The four built-in input kinds (`aether.tick`, `aether.key`,
+/// `aether.mouse_button`, `aether.mouse_move`) are the only inputs
+/// today; a new input kind here would also need a publisher change
+/// in `main.rs`. Keeping the mapping in a small match — rather than a
+/// boot-time map on `Registry` — lets the guest's `resolve_kind`
+/// auto-subscribe without any new shared state: the Kind trait's
+/// `IS_INPUT` const on the kind definition is what the derive flags,
+/// and this mapping is the substrate-side counterpart.
+fn input_stream_for_name(name: &str) -> Option<InputStream> {
+    match name {
+        "aether.tick" => Some(InputStream::Tick),
+        "aether.key" => Some(InputStream::Key),
+        "aether.mouse_move" => Some(InputStream::MouseMove),
+        "aether.mouse_button" => Some(InputStream::MouseButton),
+        _ => None,
+    }
+}
 
 /// Status codes returned by the `reply_mail` host fn (ADR-0013 §3).
 /// `0` is success; non-zero values distinguish call-site errors
@@ -98,11 +118,25 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                 Ok(s) => s,
                 Err(_) => return KIND_NOT_FOUND,
             };
-            caller
-                .data()
-                .registry
-                .kind_id(name)
-                .unwrap_or(KIND_NOT_FOUND)
+            let ctx = caller.data();
+            let id = ctx.registry.kind_id(name).unwrap_or(KIND_NOT_FOUND);
+            // ADR-0021 auto-subscribe: if the resolved kind is one of
+            // the substrate's input streams, fold the caller's mailbox
+            // into the subscriber set. A component declaring
+            // `type Kinds = (Tick, ...)` gets Tick delivery without
+            // ever sending `aether.control.subscribe_input`. Idempotent:
+            // repeated resolves (e.g. replace_component) stay correct.
+            if id != KIND_NOT_FOUND
+                && let Some(stream) = input_stream_for_name(name)
+            {
+                ctx.input_subscribers
+                    .write()
+                    .unwrap()
+                    .entry(stream)
+                    .or_default()
+                    .insert(ctx.sender);
+            }
+            id
         },
     )?;
 

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -68,6 +68,7 @@ fn tick_roundtrip_component_to_sink() {
         Arc::clone(&registry),
         Arc::clone(&queue),
         HubOutbound::disconnected(),
+        aether_substrate::new_subscribers(),
     );
     let component = Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
 


### PR DESCRIPTION
## Summary
Components declaring Tick/Key/MouseMove/MouseButton in their `type Kinds` typelist now get auto-subscribed to the corresponding substrate input stream at init. No `aether.control.subscribe_input` call needed. Addresses finding (1) from the sokoban PR.

## Why
The sokoban demo hit this hard: zero triangles rendered after load, no warning, no signal that anything was wrong — until I remembered ADR-0021 requires an explicit `subscribe_input` mail. Every future component would hit the same footgun. The information ("this component wants Tick") is already in the typelist; we just weren't using it.

## Shape
- `Kind` trait grows `const IS_INPUT: bool = false`. Default stays false so non-input kinds specify nothing — zero boilerplate on the common case.
- `#[kind(...)]` derive accepts an `input` flag. Tick/Key/MouseMove/MouseButton each get `, input` in their attribute — one word each, at the declaration site where the information belongs.
- Substrate's `resolve_kind_p32` host fn consults a name-based match and folds the calling mailbox into the subscriber set when the resolved kind is an input stream. ADR-0027's typelist walker already calls `resolve_kind` for every `type Kinds` entry, so the SDK needed zero changes — the auto-subscribe rides the existing resolution path.
- `SubstrateCtx` gains a shared `InputSubscribers` handle so the host fn can mutate the subscriber set. Threaded through control.rs load/replace paths and the unit-test ctx constructors.

## Design notes
- **Why resolve_kind, not a new host fn**: a component resolving `Tick` is unambiguously expressing "I want Tick events." The auto-subscribe matches user intent with no ambiguity, so there's no reason to split resolution from subscription into two host calls.
- **Why name-match, not a substrate-side IS_INPUT registry**: the four built-in input kinds are a closed set — adding a fifth requires a publisher change in `main.rs` anyway. A small local match in `host_fns.rs` is the simplest thing that works; a boot-time registry would be infrastructure for flexibility we don't need.
- **Idempotent by construction**: subscribe set is a `BTreeSet`; repeated resolves are no-ops. `replace_component` already preserves subscriptions across swap (per ADR-0021 §3), so re-subscribing from the new instance's init is fine.
- **Loaders can still subscribe explicitly**: external callers wanting to subscribe a mailbox they didn't load still use `aether.control.subscribe_input` as before. That path is unchanged.

## Verified live
- Spawned substrate, loaded sokoban via the new `load_component` tool, sent **no** `subscribe_input` call.
- Triangle count jumped from 0 to 2040 at the frame sokoban loaded. Capture showed the board.
- Loop is now: load component → render. That's it.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` passes (all suites green)
- [x] End-to-end: load sokoban, observe auto-subscribe, capture frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
