### PR TITLE
feat(mail,kinds,hub,component,substrate): widen MailboxId u32 to u64 (adr-0029 phase 1)

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -56,7 +56,7 @@ pub const KIND_NOT_FOUND: u32 = u32::MAX;
 
 /// Sentinel returned by `raw::resolve_mailbox` when the substrate has
 /// not registered the requested mailbox name. Mirrors the host constant.
-pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
+pub const MAILBOX_NOT_FOUND: u64 = u64::MAX;
 
 /// Phantom-typed wrapper around a resolved kind id. A `KindId<Tick>`
 /// cannot be passed where a `KindId<DrawTriangle>` is expected — the
@@ -105,7 +105,7 @@ impl<K: Kind> KindId<K> {
 ///
 /// Built via `resolve_sink::<K>(name)` during init.
 pub struct Sink<K: Kind> {
-    mailbox: u32,
+    mailbox: u64,
     kind: u32,
     _k: PhantomData<fn() -> K>,
 }
@@ -120,7 +120,7 @@ impl<K: Kind> Clone for Sink<K> {
 impl<K: Kind> Sink<K> {
     /// Raw mailbox id. Exposed for components that need to pass the
     /// id to a host fn not yet wrapped by the SDK.
-    pub fn mailbox(self) -> u32 {
+    pub fn mailbox(self) -> u64 {
         self.mailbox
     }
 
@@ -876,11 +876,11 @@ mod tests {
     #[test]
     fn sink_accessors() {
         let s: Sink<FakeKind> = Sink {
-            mailbox: 3,
+            mailbox: 3u64,
             kind: 11,
             _k: PhantomData,
         };
-        assert_eq!(s.mailbox(), 3);
+        assert_eq!(s.mailbox(), 3u64);
         assert_eq!(s.kind(), 11);
     }
 

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -19,13 +19,13 @@
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
     #[link_name = "send_mail_p32"]
-    pub fn send_mail(recipient: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    pub fn send_mail(recipient: u64, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
     #[link_name = "reply_mail_p32"]
     pub fn reply_mail(sender: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
     #[link_name = "resolve_kind_p32"]
     pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
     #[link_name = "resolve_mailbox_p32"]
-    pub fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u32;
+    pub fn resolve_mailbox(name_ptr: u32, name_len: u32) -> u64;
     #[link_name = "save_state_p32"]
     pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
 }
@@ -34,7 +34,7 @@ unsafe extern "C" {
 /// Host-target stub for the wasm `aether::send_mail` import. Always
 /// panics — callers on non-wasm targets are misusing the SDK.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn send_mail(_recipient: u32, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
+pub unsafe fn send_mail(_recipient: u64, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-component: send_mail called on non-wasm target");
 }
 
@@ -58,7 +58,7 @@ pub unsafe fn resolve_kind(_name_ptr: u32, _name_len: u32) -> u32 {
 /// Host-target stub for the wasm `aether::resolve_mailbox` import.
 /// Always panics — callers on non-wasm targets are misusing the SDK.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn resolve_mailbox(_name_ptr: u32, _name_len: u32) -> u32 {
+pub unsafe fn resolve_mailbox(_name_ptr: u32, _name_len: u32) -> u64 {
     panic!("aether-component: resolve_mailbox called on non-wasm target");
 }
 

--- a/crates/aether-hub/src/mcp/args.rs
+++ b/crates/aether-hub/src/mcp/args.rs
@@ -252,7 +252,7 @@ pub struct LoadComponentArgs {
 /// with `aether-kinds::LoadResult` — that type is canonical.
 #[derive(Debug, Deserialize)]
 pub(super) enum LoadResultWire {
-    Ok { mailbox_id: u32, name: String },
+    Ok { mailbox_id: u64, name: String },
     Err { error: String },
 }
 
@@ -261,7 +261,7 @@ pub struct LoadComponentResponse {
     /// Substrate-assigned mailbox id for the loaded component. Hand
     /// this to `replace_component` or use as the `mailbox` in
     /// `subscribe_input`.
-    pub mailbox_id: u32,
+    pub mailbox_id: u64,
     /// Substrate-resolved name. Matches the `name` in the request if
     /// provided; otherwise the substrate-defaulted value.
     pub name: String,
@@ -273,7 +273,7 @@ pub struct ReplaceComponentArgs {
     pub engine_id: String,
     /// Mailbox id of the live component to replace (from a prior
     /// `load_component` or `list_engines`-derived lookup).
-    pub mailbox_id: u32,
+    pub mailbox_id: u64,
     /// Absolute path to the replacement WASM binary on the hub's
     /// filesystem. Same filesystem rule as `load_component`. Kind
     /// vocabulary is embedded in the wasm's `aether.kinds` custom

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -167,7 +167,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.load_result")]
     pub enum LoadResult {
-        Ok { mailbox_id: u32, name: String },
+        Ok { mailbox_id: u64, name: String },
         Err { error: String },
     }
 
@@ -176,7 +176,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.drop_component")]
     pub struct DropComponent {
-        pub mailbox_id: u32,
+        pub mailbox_id: u64,
     }
 
     /// Reply to `DropComponent`. `Ok` on success; `Err` if the
@@ -199,7 +199,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.replace_component")]
     pub struct ReplaceComponent {
-        pub mailbox_id: u32,
+        pub mailbox_id: u64,
         pub wasm: Vec<u8>,
         pub drain_timeout_ms: Option<u32>,
     }
@@ -252,7 +252,7 @@ mod control_plane {
     #[kind(name = "aether.control.subscribe_input")]
     pub struct SubscribeInput {
         pub stream: InputStream,
-        pub mailbox: u32,
+        pub mailbox: u64,
     }
 
     /// `aether.control.unsubscribe_input` — remove `mailbox` from the
@@ -263,7 +263,7 @@ mod control_plane {
     #[kind(name = "aether.control.unsubscribe_input")]
     pub struct UnsubscribeInput {
         pub stream: InputStream,
-        pub mailbox: u32,
+        pub mailbox: u64,
     }
 
     /// Reply to both subscribe and unsubscribe (ADR-0021 §2). Only

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -1451,7 +1451,7 @@ mod tests {
             .unwrap_or_default()
     }
 
-    fn load_blank(plane: &ControlPlane, name: &str) -> u32 {
+    fn load_blank(plane: &ControlPlane, name: &str) -> u64 {
         let wasm = wat::parse_str(WAT).unwrap();
         let result = plane.handle_load(
             &postcard::to_allocvec(&LoadComponent {
@@ -1468,7 +1468,7 @@ mod tests {
 
     fn do_subscribe(
         plane: &ControlPlane,
-        mailbox: u32,
+        mailbox: u64,
         stream: InputStream,
     ) -> SubscribeInputResult {
         plane.handle_subscribe(&postcard::to_allocvec(&SubscribeInput { stream, mailbox }).unwrap())
@@ -1476,7 +1476,7 @@ mod tests {
 
     fn do_unsubscribe(
         plane: &ControlPlane,
-        mailbox: u32,
+        mailbox: u64,
         stream: InputStream,
     ) -> SubscribeInputResult {
         plane.handle_unsubscribe(
@@ -1908,13 +1908,13 @@ mod tests {
     const WAT_FORWARDS_TO_SINK: &str = r#"
         (module
             (import "aether" "send_mail_p32"
-                (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+                (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (func (export "receive_p32")
                 (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
                 (result i32)
                 (drop (call $send_mail
-                    (i32.load8_u (local.get $ptr))
+                    (i64.load8_u (local.get $ptr))
                     (i32.const 0)
                     (i32.const 0)
                     (i32.const 0)

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -12,11 +12,12 @@ use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::MailboxId;
 use crate::sender_table::SenderEntry;
 
-/// Returned by `resolve_kind` / `resolve_mailbox` when the requested
-/// name has not been registered. Guests use this as a "lookup failed"
-/// sentinel.
+/// Returned by `resolve_kind` when the requested name has not been
+/// registered. Guests use this as a "lookup failed" sentinel.
 pub const KIND_NOT_FOUND: u32 = u32::MAX;
-pub const MAILBOX_NOT_FOUND: u32 = u32::MAX;
+/// Symmetric sentinel for `resolve_mailbox`. Widened to 64 bits in
+/// lockstep with `MailboxId` (ADR-0029 PR 1).
+pub const MAILBOX_NOT_FOUND: u64 = u64::MAX;
 
 /// Map a resolved kind name to the substrate input stream it belongs
 /// to. The four built-in input kinds (`aether.tick`, `aether.key`,
@@ -73,7 +74,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         "aether",
         "send_mail_p32",
         |mut caller: Caller<'_, SubstrateCtx>,
-         recipient: u32,
+         recipient: u64,
          kind: u32,
          ptr: u32,
          len: u32,
@@ -253,7 +254,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "resolve_mailbox_p32",
-        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
+        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u64 {
             let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
                 Some(m) => m,
                 None => return MAILBOX_NOT_FOUND,

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -4,10 +4,11 @@
 use aether_hub_protocol::SessionToken;
 
 /// Addressing token for any mailbox — component or substrate-owned sink.
-/// Opaque `u32` newtype so it can't be accidentally mixed with wasmtime
-/// indices or raw integers.
+/// Opaque `u64` newtype so it can't be accidentally mixed with wasmtime
+/// indices or raw integers. Width is sized for the ADR-0029 move to
+/// name-derived ids; today the registry still allocates sequentially.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct MailboxId(pub u32);
+pub struct MailboxId(pub u64);
 
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -149,7 +149,7 @@ impl Registry {
         if inner.by_name.contains_key(&name) {
             panic!("mailbox name already registered: {name}");
         }
-        let id = MailboxId(inner.entries.len() as u32);
+        let id = MailboxId(inner.entries.len() as u64);
         inner.entries.push(entry);
         inner.mailbox_names.push(name.clone());
         inner.by_name.insert(name, id);
@@ -178,7 +178,7 @@ impl Registry {
         if inner.by_name.contains_key(&name) {
             return Err(NameConflict { name });
         }
-        let id = MailboxId(inner.entries.len() as u32);
+        let id = MailboxId(inner.entries.len() as u64);
         inner.entries.push(MailboxEntry::Component);
         inner.mailbox_names.push(name.clone());
         inner.by_name.insert(name, id);

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -25,14 +25,14 @@ use wasmtime::{Engine, Linker, Module};
 const WAT: &str = r#"
 (module
   (import "aether" "send_mail_p32"
-    (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+    (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
     (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     ;; Forward a send_mail call to mailbox 1 (the sink in this test).
     ;; recipient=1, kind=99, ptr=0, len=0, count=<same as incoming count>.
-    i32.const 1
+    i64.const 1
     i32.const 99
     i32.const 0
     i32.const 0

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -32,13 +32,13 @@ use wasmtime::{Engine, Linker};
 const WAT: &str = r#"
 (module
   (import "aether" "send_mail_p32"
-    (func $send_mail (param i32 i32 i32 i32 i32) (result i32)))
+    (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
     (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     (drop (call $send_mail
-        (i32.const 1) (i32.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))
+        (i64.const 1) (i32.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))
     i32.const 0))
 "#;
 
@@ -130,8 +130,8 @@ fn dispatch<K: serde::Serialize>(plane: &ControlPlane, kind_name: &str, payload:
     handler(kind_name, None, SessionToken::NIL, &bytes, 0);
 }
 
-fn load_wat(plane: &ControlPlane, name: &str) -> u32 {
-    let before: std::collections::HashSet<u32> = plane
+fn load_wat(plane: &ControlPlane, name: &str) -> u64 {
+    let before: std::collections::HashSet<u64> = plane
         .components
         .read()
         .unwrap()
@@ -146,7 +146,7 @@ fn load_wat(plane: &ControlPlane, name: &str) -> u32 {
             name: Some(name.into()),
         },
     );
-    let after: std::collections::HashSet<u32> = plane
+    let after: std::collections::HashSet<u64> = plane
         .components
         .read()
         .unwrap()
@@ -159,7 +159,7 @@ fn load_wat(plane: &ControlPlane, name: &str) -> u32 {
         .expect("load inserted a new component")
 }
 
-fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
+fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
     dispatch(
         plane,
         SubscribeInput::NAME,
@@ -167,7 +167,7 @@ fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
     );
 }
 
-fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
+fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
     dispatch(
         plane,
         UnsubscribeInput::NAME,
@@ -175,7 +175,7 @@ fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u32) {
     );
 }
 
-fn drop_component(plane: &ControlPlane, mailbox_id: u32) {
+fn drop_component(plane: &ControlPlane, mailbox_id: u64) {
     dispatch(plane, DropComponent::NAME, &DropComponent { mailbox_id });
 }
 


### PR DESCRIPTION
## Summary
- Widens `MailboxId` and every wire/FFI field that carries one from `u32` to `u64`, ahead of the ADR-0029 switch to hashed ids.
- Pure plumbing change: registry still allocates sequential ids; no behavior change.
- `send_mail_p32`'s recipient param becomes `i64` at the wasm FFI (scalar, not pointer — the `_p32` suffix still applies only to pointer-typed imports per ADR-0024). `resolve_mailbox_p32` returns `i64`. `MAILBOX_NOT_FOUND` widens to `u64::MAX`.
- Wire kinds widened: `LoadResult.mailbox_id`, `DropComponent.mailbox_id`, `ReplaceComponent.mailbox_id`, `SubscribeInput.mailbox`, `UnsubscribeInput.mailbox`.
- WAT fixtures (`end_to_end.rs`, `input_subscriptions.rs`, `control.rs::WAT_FORWARDS_TO_SINK`) track the recipient-arg width bump with `i64.const` / `i64.load8_u`.

## Test plan
- [x] `cargo test --workspace` — 93 substrate unit tests + 6 main bin + 1 end_to_end + 6 hub_client + 5 input_subscriptions all pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo build -p aether-hello-component --target wasm32-unknown-unknown` builds clean
- [x] `cargo build -p aether-demo-sokoban --target wasm32-unknown-unknown` builds clean

Phase 2 (hash-based derivation, retire `resolve_mailbox_p32`, shrink registry) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)