### PR TITLE
feat(substrate,component): widen kind id u32 → u64 (ADR-0030 Phase 1)

### DIFF
--- a/crates/aether-component/src/kinds.rs
+++ b/crates/aether-component/src/kinds.rs
@@ -195,7 +195,7 @@ struct KindTableInner {
 #[derive(Copy, Clone)]
 struct Entry {
     type_id: Option<TypeId>,
-    raw: u32,
+    raw: u64,
 }
 
 impl KindTable {
@@ -220,7 +220,7 @@ impl KindTable {
     /// Caller must guarantee no concurrent access. Intended to be
     /// called only from `KindList::resolve_all`, which the `export!`
     /// macro's init shim invokes before any reads.
-    pub unsafe fn insert(&self, type_id: TypeId, raw: u32) {
+    pub unsafe fn insert(&self, type_id: TypeId, raw: u64) {
         let inner = unsafe { &mut *self.inner.get() };
         if inner.len >= MAX_KINDS {
             panic!("aether-component: KindTable overflow (>{MAX_KINDS} kinds)");
@@ -234,7 +234,7 @@ impl KindTable {
 
     /// Linear-scan lookup. Returns `Some(raw)` if `type_id` was
     /// inserted, `None` otherwise.
-    pub fn lookup(&self, type_id: TypeId) -> Option<u32> {
+    pub fn lookup(&self, type_id: TypeId) -> Option<u64> {
         let inner = unsafe { &*self.inner.get() };
         for i in 0..inner.len {
             let entry = inner.entries[i];

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -52,7 +52,8 @@ pub use kinds::{Cons, KindList, KindTable, Nil};
 
 /// Sentinel returned by `raw::resolve_kind` when the substrate has not
 /// registered the requested kind name. Mirrors the host constant.
-pub const KIND_NOT_FOUND: u32 = u32::MAX;
+/// Widened to `u64` in ADR-0030 Phase 1.
+pub const KIND_NOT_FOUND: u64 = u64::MAX;
 
 /// Phantom-typed wrapper around a resolved kind id. A `KindId<Tick>`
 /// cannot be passed where a `KindId<DrawTriangle>` is expected — the
@@ -63,7 +64,7 @@ pub const KIND_NOT_FOUND: u32 = u32::MAX;
 /// `kind` parameters in a hand-rolled `receive` shim (ADR-0014's
 /// `Mail::decode` will make the raw-int compare go away).
 pub struct KindId<K: Kind> {
-    raw: u32,
+    raw: u64,
     _k: PhantomData<fn() -> K>,
 }
 
@@ -82,14 +83,14 @@ impl<K: Kind> Eq for KindId<K> {}
 
 impl<K: Kind> KindId<K> {
     /// The raw kind id the substrate assigned. Exposed for hand-rolled
-    /// receive shims that `match` on the inbound `kind: u32` parameter.
-    pub fn raw(self) -> u32 {
+    /// receive shims that `match` on the inbound `kind: u64` parameter.
+    pub fn raw(self) -> u64 {
         self.raw
     }
 
     /// Returns `true` if `raw` is the id the substrate assigned to `K`.
     /// Convenience over `kind_id.raw() == raw`.
-    pub fn matches(self, raw: u32) -> bool {
+    pub fn matches(self, raw: u64) -> bool {
         self.raw == raw
     }
 }
@@ -102,7 +103,7 @@ impl<K: Kind> KindId<K> {
 /// Built via `resolve_sink::<K>(name)` during init.
 pub struct Sink<K: Kind> {
     mailbox: u64,
-    kind: u32,
+    kind: u64,
     _k: PhantomData<fn() -> K>,
 }
 
@@ -121,7 +122,7 @@ impl<K: Kind> Sink<K> {
     }
 
     /// Raw kind id. Exposed for the same reason as `mailbox`.
-    pub fn kind(self) -> u32 {
+    pub fn kind(self) -> u64 {
         self.kind
     }
 }
@@ -490,7 +491,7 @@ impl<'a> PriorState<'a> {
 /// linear memory (the substrate placed them there before the FFI
 /// call), so zero-copy is possible when alignment permits.
 pub struct Mail<'a> {
-    kind: u32,
+    kind: u64,
     // Stored as `usize` so `Mail::decode` can reconstruct a full host
     // pointer for tests, while the FFI path (`__from_raw`) widens the
     // incoming `u32` address. On wasm32 `usize == u32` so this is a
@@ -511,7 +512,7 @@ impl<'a> Mail<'a> {
     /// delivers `ptr` as a wasm32 offset (`u32`); this widens it.
     #[doc(hidden)]
     pub unsafe fn __from_raw(
-        kind: u32,
+        kind: u64,
         ptr: u32,
         count: u32,
         sender: u32,
@@ -531,7 +532,7 @@ impl<'a> Mail<'a> {
     /// from a host pointer go through here so 64-bit addresses survive.
     #[doc(hidden)]
     #[cfg(test)]
-    unsafe fn __from_ptr_test(kind: u32, ptr: usize, count: u32, sender: u32) -> Self {
+    unsafe fn __from_ptr_test(kind: u64, ptr: usize, count: u32, sender: u32) -> Self {
         Mail {
             kind,
             ptr,
@@ -547,7 +548,7 @@ impl<'a> Mail<'a> {
     #[doc(hidden)]
     #[cfg(test)]
     unsafe fn __from_ptr_test_with_table(
-        kind: u32,
+        kind: u64,
         ptr: usize,
         count: u32,
         sender: u32,
@@ -566,7 +567,7 @@ impl<'a> Mail<'a> {
     /// Raw kind id the substrate routed this mail under. Match against
     /// a cached `KindId<K>` via `kind_id.matches(mail.kind())`, or use
     /// `decode::<K>(kind_id)` and let it be the discriminator.
-    pub fn kind(&self) -> u32 {
+    pub fn kind(&self) -> u64 {
         self.kind
     }
 
@@ -779,7 +780,7 @@ macro_rules! export {
         /// mail with no meaningful reply target. Exported under the
         /// `_p32` suffix per ADR-0024 Phase 1.
         #[unsafe(export_name = "receive_p32")]
-        pub unsafe extern "C" fn receive(kind: u32, ptr: u32, count: u32, sender: u32) -> u32 {
+        pub unsafe extern "C" fn receive(kind: u64, ptr: u32, count: u32, sender: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -19,11 +19,11 @@
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
     #[link_name = "send_mail_p32"]
-    pub fn send_mail(recipient: u64, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    pub fn send_mail(recipient: u64, kind: u64, ptr: u32, len: u32, count: u32) -> u32;
     #[link_name = "reply_mail_p32"]
-    pub fn reply_mail(sender: u32, kind: u32, ptr: u32, len: u32, count: u32) -> u32;
+    pub fn reply_mail(sender: u32, kind: u64, ptr: u32, len: u32, count: u32) -> u32;
     #[link_name = "resolve_kind_p32"]
-    pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u32;
+    pub fn resolve_kind(name_ptr: u32, name_len: u32) -> u64;
     #[link_name = "save_state_p32"]
     pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
 }
@@ -32,7 +32,7 @@ unsafe extern "C" {
 /// Host-target stub for the wasm `aether::send_mail` import. Always
 /// panics — callers on non-wasm targets are misusing the SDK.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn send_mail(_recipient: u64, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
+pub unsafe fn send_mail(_recipient: u64, _kind: u64, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-component: send_mail called on non-wasm target");
 }
 
@@ -40,7 +40,7 @@ pub unsafe fn send_mail(_recipient: u64, _kind: u32, _ptr: u32, _len: u32, _coun
 /// Host-target stub for the wasm `aether::reply_mail` import. Always
 /// panics — callers on non-wasm targets are misusing the SDK.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn reply_mail(_sender: u32, _kind: u32, _ptr: u32, _len: u32, _count: u32) -> u32 {
+pub unsafe fn reply_mail(_sender: u32, _kind: u64, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-component: reply_mail called on non-wasm target");
 }
 
@@ -48,7 +48,7 @@ pub unsafe fn reply_mail(_sender: u32, _kind: u32, _ptr: u32, _len: u32, _count:
 /// Host-target stub for the wasm `aether::resolve_kind` import. Always
 /// panics — callers on non-wasm targets are misusing the SDK.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn resolve_kind(_name_ptr: u32, _name_len: u32) -> u32 {
+pub unsafe fn resolve_kind(_name_ptr: u32, _name_len: u32) -> u64 {
     panic!("aether-component: resolve_kind called on non-wasm target");
 }
 

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -23,8 +23,9 @@ use core::fmt;
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`). The name is resolved to a
-/// runtime `u32` id by the substrate's kind registry at init; see
-/// ADR-0005 for the resolution flow.
+/// runtime `u64` id by the substrate's kind registry at init; see
+/// ADR-0005 for the resolution flow. (Widened from `u32` in ADR-0030
+/// Phase 1.)
 ///
 /// `IS_INPUT` marks the kind as a substrate-published input stream
 /// (`Tick`, `Key`, `MouseMove`, `MouseButton` — ADR-0021). Defaults

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -33,7 +33,7 @@ const STATE_OFFSET: u32 = 8192;
 pub struct Component {
     store: Store<SubstrateCtx>,
     memory: Memory,
-    receive: TypedFunc<(u32, u32, u32, u32), u32>,
+    receive: TypedFunc<(u64, u32, u32, u32), u32>,
     on_replace: Option<TypedFunc<(), u32>>,
     on_drop: Option<TypedFunc<(), u32>>,
     on_rehydrate: Option<TypedFunc<(u32, u32, u32), u32>>,
@@ -55,7 +55,7 @@ impl Component {
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
         let receive =
-            instance.get_typed_func::<(u32, u32, u32, u32), u32>(&mut store, "receive_p32")?;
+            instance.get_typed_func::<(u64, u32, u32, u32), u32>(&mut store, "receive_p32")?;
 
         // Optional `init() -> u32` export: called once before the first
         // `receive`, used for one-shot bootstrap like resolving kind
@@ -249,7 +249,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -266,14 +266,14 @@ mod tests {
     const WAT_NO_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
     const WAT_TRAP_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -287,7 +287,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -305,7 +305,7 @@ mod tests {
             (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -322,7 +322,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 ;; *(u32*)396 = version
@@ -342,7 +342,7 @@ mod tests {
     const WAT_STORES_SENDER: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 500
                 local.get 3
                 i32.store
@@ -355,12 +355,12 @@ mod tests {
     const WAT_REPLIES: &str = r#"
         (module
             (import "aether" "reply_mail_p32"
-                (func $reply_mail (param i32 i32 i32 i32 i32) (result i32)))
+                (func $reply_mail (param i32 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 (drop (call $reply_mail
                     (local.get 3) ;; sender handle from receive param
-                    (i32.const 0) ;; kind id 0 — registered in the test
+                    (i64.const 0) ;; kind id 0 — registered in the test
                     (i32.const 0) ;; ptr
                     (i32.const 0) ;; len
                     (i32.const 1))) ;; count

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -767,7 +767,7 @@ mod tests {
     const WAT: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
@@ -778,7 +778,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -797,7 +797,7 @@ mod tests {
     const WAT_TRAPS_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -811,7 +811,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -829,7 +829,7 @@ mod tests {
             (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -845,7 +845,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 i32.const 396
@@ -973,7 +973,7 @@ mod tests {
             r#"(module
                 (@custom "aether.kinds" "{escaped}")
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                     i32.const 0))"#
         );
         let wasm = wat::parse_str(wat).unwrap();
@@ -1032,7 +1032,7 @@ mod tests {
             r#"(module
                 (@custom "aether.kinds" "{escaped}")
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i32 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                     i32.const 0))"#
         );
         let wasm = wat::parse_str(wat).unwrap();
@@ -1910,14 +1910,14 @@ mod tests {
     const WAT_FORWARDS_TO_SINK: &str = r#"
         (module
             (import "aether" "send_mail_p32"
-                (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
+                (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (func (export "receive_p32")
-                (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+                (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
                 (result i32)
                 (drop (call $send_mail
                     (i64.load (local.get $ptr))
-                    (i32.const 0)
+                    (i64.const 0)
                     (i32.const 0)
                     (i32.const 0)
                     (local.get $count)))

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -13,8 +13,9 @@ use crate::mail::MailboxId;
 use crate::sender_table::SenderEntry;
 
 /// Returned by `resolve_kind` when the requested name has not been
-/// registered. Guests use this as a "lookup failed" sentinel.
-pub const KIND_NOT_FOUND: u32 = u32::MAX;
+/// registered. Guests use this as a "lookup failed" sentinel. Widened
+/// to `u64` alongside `MailKind` in ADR-0030 Phase 1.
+pub const KIND_NOT_FOUND: u64 = u64::MAX;
 
 /// Map a resolved kind name to the substrate input stream it belongs
 /// to. The four built-in input kinds (`aether.tick`, `aether.key`,
@@ -72,7 +73,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         "send_mail_p32",
         |mut caller: Caller<'_, SubstrateCtx>,
          recipient: u64,
-         kind: u32,
+         kind: u64,
          ptr: u32,
          len: u32,
          count: u32|
@@ -101,7 +102,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "resolve_kind_p32",
-        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u32 {
+        |mut caller: Caller<'_, SubstrateCtx>, name_ptr: u32, name_len: u32| -> u64 {
             let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
                 Some(m) => m,
                 None => return KIND_NOT_FOUND,
@@ -193,7 +194,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         "reply_mail_p32",
         |mut caller: Caller<'_, SubstrateCtx>,
          sender: u32,
-         kind: u32,
+         kind: u64,
          ptr: u32,
          len: u32,
          count: u32|

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -30,8 +30,9 @@ impl MailboxId {
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The
 /// typed facade over this is ADR-0005 (mail typing system) and ADR-0019
-/// (schema-described kinds).
-pub type MailKind = u32;
+/// (schema-described kinds). Widened to `u64` in ADR-0030 Phase 1 in
+/// preparation for hashed derivation (Phase 2).
+pub type MailKind = u64;
 
 /// The transport envelope. `payload` is the exact byte layout the kind
 /// implies; `count` is the number of items the layout implies, where

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -138,11 +138,11 @@ struct App {
     /// boot state — mean the event is dropped at the source.
     input_subscribers: InputSubscribers,
     broadcast_mbox: MailboxId,
-    kind_tick: u32,
-    kind_key: u32,
-    kind_mouse_button: u32,
-    kind_mouse_move: u32,
-    kind_frame_stats: u32,
+    kind_tick: u64,
+    kind_key: u64,
+    kind_mouse_button: u64,
+    kind_mouse_move: u64,
+    kind_frame_stats: u64,
     frame_vertices: Arc<Mutex<Vec<u8>>>,
     triangles_rendered: Arc<AtomicU64>,
     /// Shared single-slot queue with the control plane. On each

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -1,6 +1,8 @@
 // Name registries. Two tables: mailboxes (MailboxId → name + entry,
 // ids derived from name via ADR-0029's stable hash) and kinds (name →
-// u32 kind id, per ADR-0005 — still sequentially assigned). The
+// u64 kind id, per ADR-0005 — still sequentially assigned; ADR-0030
+// Phase 1 widened the id type ahead of Phase 2's switch to hashed
+// derivation). The
 // registry uses interior mutability (`RwLock`) so mailboxes and kinds
 // can be added at runtime — ADR-0010's runtime component loading
 // mutates both tables after an `Arc<Registry>` has already been shared
@@ -62,7 +64,7 @@ struct Inner {
     /// Registration inserts; `drop_mailbox` transitions the entry to
     /// `Dropped` so the id stays addressable until re-registered.
     mailboxes: HashMap<MailboxId, Mailbox>,
-    kind_by_name: HashMap<String, u32>,
+    kind_by_name: HashMap<String, u64>,
     /// Parallel index: `kind_names[id]` is the canonical name the kind
     /// was first registered with. Kept in sync with `kind_by_name` so
     /// `kind_name(id)` is O(1); used by `SinkHandler` dispatch to hand
@@ -281,7 +283,7 @@ impl Registry {
     /// registrations that don't need the hub to encode params;
     /// production init should prefer `register_kind_with_descriptor`
     /// so the descriptor stored here matches the type definition.
-    pub fn register_kind(&self, name: impl Into<String>) -> u32 {
+    pub fn register_kind(&self, name: impl Into<String>) -> u64 {
         let name = name.into();
         let descriptor = KindDescriptor {
             name: name.clone(),
@@ -307,7 +309,7 @@ impl Registry {
     pub fn register_kind_with_descriptor(
         &self,
         descriptor: KindDescriptor,
-    ) -> Result<u32, KindConflict> {
+    ) -> Result<u64, KindConflict> {
         let name = descriptor.name.clone();
         self.register_kind_internal(name, descriptor, /*reject_conflict=*/ true)
     }
@@ -317,7 +319,7 @@ impl Registry {
         name: String,
         descriptor: KindDescriptor,
         reject_conflict: bool,
-    ) -> Result<u32, KindConflict> {
+    ) -> Result<u64, KindConflict> {
         let mut inner = self.inner.write().unwrap();
         if let Some(&id) = inner.kind_by_name.get(&name) {
             let existing = &inner.kind_descriptors[id as usize];
@@ -330,21 +332,21 @@ impl Registry {
             }
             return Ok(id);
         }
-        let id = inner.kind_names.len() as u32;
+        let id = inner.kind_names.len() as u64;
         inner.kind_names.push(name.clone());
         inner.kind_descriptors.push(descriptor);
         inner.kind_by_name.insert(name, id);
         Ok(id)
     }
 
-    pub fn kind_id(&self, name: &str) -> Option<u32> {
+    pub fn kind_id(&self, name: &str) -> Option<u64> {
         self.inner.read().unwrap().kind_by_name.get(name).copied()
     }
 
     /// Reverse of `kind_id`: name for a given id, or `None` if the id
     /// is out of range. Used by the scheduler to hand sink handlers a
     /// kind name without them keeping their own map.
-    pub fn kind_name(&self, id: u32) -> Option<String> {
+    pub fn kind_name(&self, id: u64) -> Option<String> {
         self.inner
             .read()
             .unwrap()
@@ -356,7 +358,7 @@ impl Registry {
     /// The descriptor stored for a given kind id, or `None` if the id
     /// is out of range. Returned as an owned clone so callers don't
     /// hold the read lock while inspecting the encoding.
-    pub fn kind_descriptor(&self, id: u32) -> Option<KindDescriptor> {
+    pub fn kind_descriptor(&self, id: u64) -> Option<KindDescriptor> {
         self.inner
             .read()
             .unwrap()

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -30,13 +30,13 @@ fn forwards_to_sink_wat(sink_id: MailboxId) -> String {
         r#"
 (module
   (import "aether" "send_mail_p32"
-    (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
+    (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
-    (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+    (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     i64.const {sink_id}
-    i32.const 99
+    i64.const 99
     i32.const 0
     i32.const 0
     local.get $count

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -35,13 +35,13 @@ fn tally_forwarding_wat(tally_id: u64) -> String {
         r#"
 (module
   (import "aether" "send_mail_p32"
-    (func $send_mail (param i64 i32 i32 i32 i32) (result i32)))
+    (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
-    (param $kind i32) (param $ptr i32) (param $count i32) (param $sender i32)
+    (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
     (result i32)
     (drop (call $send_mail
-        (i64.const {tally_id}) (i32.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))
+        (i64.const {tally_id}) (i64.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))
     i32.const 0))
 "#,
     )
@@ -52,7 +52,7 @@ struct Harness {
     queue: Arc<MailQueue>,
     input_subscribers: InputSubscribers,
     counter: Arc<AtomicU32>,
-    kind_tick: u32,
+    kind_tick: u64,
     wat: String,
     _scheduler: Scheduler,
 }


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0030: mechanical `u32 → u64` widen of every kind-id touchpoint. No behavior change — ids are still sequentially assigned by the registry. Phase 2 will swap the sequential assignment for `fnv1a(name ++ postcard(schema))` and retire `resolve_kind_p32`.

Mirrors the shape of ADR-0029's split (PR #129 widened mailbox ids before PR #130 switched to hashing).

**Touchpoints**

- `MailKind = u64`, `KIND_NOT_FOUND = u64::MAX`
- FFI: `send_mail_p32` / `reply_mail_p32` kind params widen to i64; `resolve_kind_p32` result widens to i64
- `Registry::{kind_id, kind_name, kind_descriptor, register_kind*}` return/accept u64
- Guest SDK: `KindId<K>.raw`, `Sink<K>.kind`, `Mail::kind`, `KindTable` entries → u64
- `Component::receive` typed func widens to `(u64, u32, u32, u32) -> u32`
- Every `receive_p32` WAT shim's first param widens `i32 → i64`; WAT `send_mail` / `reply_mail` call sites use `i64.const` for the kind arg
- `aether-substrate/main.rs`'s five cached input-kind ids widen to u64

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`