### PR TITLE
feat(schema): const-constructible SchemaType via SchemaCell (ADR-0031)

### DIFF
--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -146,7 +146,8 @@ mod tests {
                         fields: vec![NamedField {
                             name: "code".into(),
                             ty: SchemaType::Scalar(Primitive::U32),
-                        }],
+                        }]
+                        .into(),
                     },
                 },
             ],
@@ -420,17 +421,19 @@ mod tests {
                     name: "y".into(),
                     ty: SchemaType::Scalar(Primitive::F32),
                 },
-            ],
+            ]
+            .into(),
         };
         let triangle = SchemaType::Struct {
             repr_c: true,
             fields: vec![NamedField {
                 name: "verts".into(),
                 ty: SchemaType::Array {
-                    element: Box::new(vertex),
+                    element: SchemaCell::owned(vertex),
                     len: 3,
                 },
-            }],
+            }]
+            .into(),
         };
         let desc = KindDescriptor {
             name: "demo.draw_triangle".into(),
@@ -456,13 +459,14 @@ mod tests {
                 },
                 NamedField {
                     name: "name".into(),
-                    ty: SchemaType::Option(Box::new(SchemaType::String)),
+                    ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
                 },
                 NamedField {
                     name: "tags".into(),
-                    ty: SchemaType::Vec(Box::new(SchemaType::String)),
+                    ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
                 },
-            ],
+            ]
+            .into(),
         };
         let desc = KindDescriptor {
             name: "demo.load_component".into(),
@@ -488,7 +492,7 @@ mod tests {
                 EnumVariant::Tuple {
                     name: "Ok".into(),
                     discriminant: 1,
-                    fields: vec![SchemaType::Scalar(Primitive::U64)],
+                    fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
                 },
                 EnumVariant::Struct {
                     name: "Err".into(),
@@ -496,9 +500,11 @@ mod tests {
                     fields: vec![NamedField {
                         name: "reason".into(),
                         ty: SchemaType::String,
-                    }],
+                    }]
+                    .into(),
                 },
-            ],
+            ]
+            .into(),
         };
         let desc = KindDescriptor {
             name: "demo.load_result".into(),
@@ -528,7 +534,8 @@ mod tests {
                     fields: vec![NamedField {
                         name: "body".into(),
                         ty: SchemaType::String,
-                    }],
+                    }]
+                    .into(),
                 },
             }],
         });

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -2,7 +2,9 @@
 // the top-level enums `EngineToHub` / `HubToEngine`; the bodies are
 // plain structs so they're ergonomic to construct and pattern-match.
 
-use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 /// Hub-assigned stable identity for an engine connection. Fresh per
@@ -62,6 +64,13 @@ pub struct KindDescriptor {
 /// cast-eligible — `Scalar`, `Array` of cast-eligible elements, or a
 /// nested `Struct { repr_c: true, .. }`. `String`, `Bytes`, `Vec`,
 /// `Option`, and `Enum` fields disqualify a struct from `repr_c`.
+///
+/// ADR-0031: every recursive field uses `SchemaCell` (static-or-owned)
+/// and every collection/string uses `Cow<'static, _>` so the whole type
+/// is const-constructible. Derive(Schema) emits a single
+/// `const SCHEMA: SchemaType = …` literal; the hub's deserializer
+/// produces the `Owned` / `Cow::Owned` variants. Walkers Deref through
+/// both without observing the difference.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SchemaType {
     Unit,
@@ -69,19 +78,90 @@ pub enum SchemaType {
     Scalar(Primitive),
     String,
     Bytes,
-    Option(Box<SchemaType>),
-    Vec(Box<SchemaType>),
+    Option(SchemaCell),
+    Vec(SchemaCell),
     Array {
-        element: Box<SchemaType>,
+        element: SchemaCell,
         len: u32,
     },
     Struct {
-        fields: Vec<NamedField>,
+        fields: Cow<'static, [NamedField]>,
         repr_c: bool,
     },
     Enum {
-        variants: Vec<EnumVariant>,
+        variants: Cow<'static, [EnumVariant]>,
     },
+}
+
+/// Recursion-breaking indirection for nested `SchemaType` fields
+/// (ADR-0031). `Static(&'static SchemaType)` is the const-literal arm —
+/// derives and hand-rolled impls reference the nested type's
+/// `<T as Schema>::SCHEMA` through this variant at compile time.
+/// `Owned(Box<SchemaType>)` is the wire arm — the hub's postcard
+/// decoder allocates one `Box` per recursive node. Both `Deref` to
+/// `&SchemaType`, so walkers don't observe which variant carries the
+/// value. `Cow<'static, SchemaType>` would infinite-size through its
+/// `Owned(T)` arm; `SchemaCell` breaks the cycle via `Box`.
+#[derive(Debug)]
+pub enum SchemaCell {
+    Static(&'static SchemaType),
+    Owned(Box<SchemaType>),
+}
+
+impl SchemaCell {
+    /// Construct an `Owned` cell from a schema value. Convenience for
+    /// code paths that build schemas at runtime (mostly tests and the
+    /// hub's decoder). Production const callers use `Static(&FOO)`.
+    pub fn owned(schema: SchemaType) -> Self {
+        SchemaCell::Owned(Box::new(schema))
+    }
+}
+
+impl core::ops::Deref for SchemaCell {
+    type Target = SchemaType;
+    fn deref(&self) -> &SchemaType {
+        match self {
+            SchemaCell::Static(r) => r,
+            SchemaCell::Owned(b) => b,
+        }
+    }
+}
+
+impl AsRef<SchemaType> for SchemaCell {
+    fn as_ref(&self) -> &SchemaType {
+        self
+    }
+}
+
+impl Clone for SchemaCell {
+    fn clone(&self) -> Self {
+        // Clone normalizes to Owned so the clone doesn't require the
+        // source to be 'static. A Static cell cloned from a const
+        // literal lands as Owned(Box::new(copy_of_value)); the value
+        // is identical, the variant chosen expresses "this clone has
+        // its own allocation."
+        SchemaCell::Owned(Box::new((**self).clone()))
+    }
+}
+
+impl PartialEq for SchemaCell {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl Eq for SchemaCell {}
+
+impl Serialize for SchemaCell {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        (**self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SchemaCell {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        SchemaType::deserialize(deserializer).map(SchemaCell::owned)
+    }
 }
 
 /// One field inside a `SchemaType::Struct` or struct-shaped enum
@@ -89,7 +169,7 @@ pub enum SchemaType {
 /// structs (`repr_c: true`) it also matches `#[repr(C)]` layout.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamedField {
-    pub name: String,
+    pub name: Cow<'static, str>,
     pub ty: SchemaType,
 }
 
@@ -100,18 +180,18 @@ pub struct NamedField {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EnumVariant {
     Unit {
-        name: String,
+        name: Cow<'static, str>,
         discriminant: u32,
     },
     Tuple {
-        name: String,
+        name: Cow<'static, str>,
         discriminant: u32,
-        fields: Vec<SchemaType>,
+        fields: Cow<'static, [SchemaType]>,
     },
     Struct {
-        name: String,
+        name: Cow<'static, str>,
         discriminant: u32,
-        fields: Vec<NamedField>,
+        fields: Cow<'static, [NamedField]>,
     },
 }
 
@@ -123,7 +203,7 @@ impl EnumVariant {
         match self {
             EnumVariant::Unit { name, .. }
             | EnumVariant::Tuple { name, .. }
-            | EnumVariant::Struct { name, .. } => name.as_str(),
+            | EnumVariant::Struct { name, .. } => name,
         }
     }
 

--- a/crates/aether-hub/src/decoder.rs
+++ b/crates/aether-hub/src/decoder.rs
@@ -737,19 +737,19 @@ mod tests {
         SchemaType::Enum {
             variants: vec![
                 EnumVariant::Unit {
-                    name: "Pending".to_string().into(),
+                    name: "Pending".into(),
                     discriminant: 0,
                 },
                 EnumVariant::Tuple {
-                    name: "Ok".to_string().into(),
+                    name: "Ok".into(),
                     discriminant: 1,
                     fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
                 },
                 EnumVariant::Struct {
-                    name: "Err".to_string().into(),
+                    name: "Err".into(),
                     discriminant: 2,
                     fields: vec![NamedField {
-                        name: "reason".to_string().into(),
+                        name: "reason".into(),
                         ty: SchemaType::String,
                     }]
                     .into(),

--- a/crates/aether-hub/src/decoder.rs
+++ b/crates/aether-hub/src/decoder.rs
@@ -137,7 +137,7 @@ fn decode_cast_struct(
     for field in fields {
         let field_path = format!("{path}.{}", field.name);
         let value = decode_cast_field(cur, &field.ty, &field_path)?;
-        out.insert(field.name.clone(), value);
+        out.insert(field.name.to_string(), value);
     }
     Ok(out)
 }
@@ -304,10 +304,10 @@ fn decode_postcard(
             // Postcard struct: concatenated field bytes in declaration
             // order.
             let mut obj = Map::with_capacity(fields.len());
-            for field in fields {
+            for field in fields.iter() {
                 let field_path = format!("{path}.{}", field.name);
                 let value = decode_postcard(cur, &field.ty, &field_path)?;
-                obj.insert(field.name.clone(), value);
+                obj.insert(field.name.to_string(), value);
             }
             Ok(Value::Object(obj))
         }
@@ -392,10 +392,10 @@ fn decode_enum_body(
         }
         EnumVariant::Struct { fields, .. } => {
             let mut body = Map::with_capacity(fields.len());
-            for field in fields {
+            for field in fields.iter() {
                 let nested = format!("{path}::{name}.{}", field.name);
                 let v = decode_postcard(cur, &field.ty, &nested)?;
-                body.insert(field.name.clone(), v);
+                body.insert(field.name.to_string(), v);
             }
             let mut obj = Map::with_capacity(1);
             obj.insert(name, Value::Object(body));
@@ -490,25 +490,26 @@ impl<'a> Cursor<'a> {
 mod tests {
     use super::*;
     use crate::encoder::encode_schema;
+    use aether_hub_protocol::SchemaCell;
     use serde_json::json;
 
     fn scalar(name: &str, ty: Primitive) -> NamedField {
         NamedField {
-            name: name.into(),
+            name: name.to_string().into(),
             ty: SchemaType::Scalar(ty),
         }
     }
 
     fn cast_struct(fields: Vec<NamedField>) -> SchemaType {
         SchemaType::Struct {
-            fields,
+            fields: fields.into(),
             repr_c: true,
         }
     }
 
     fn pc_struct(fields: Vec<NamedField>) -> SchemaType {
         SchemaType::Struct {
-            fields,
+            fields: fields.into(),
             repr_c: false,
         }
     }
@@ -588,7 +589,7 @@ mod tests {
             &cast_struct(vec![NamedField {
                 name: "xs".into(),
                 ty: SchemaType::Array {
-                    element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                    element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),
                     len: 4,
                 },
             }]),
@@ -615,12 +616,13 @@ mod tests {
                 scalar("r", Primitive::F32),
                 scalar("g", Primitive::F32),
                 scalar("b", Primitive::F32),
-            ],
+            ]
+            .into(),
         };
         let triangle = cast_struct(vec![NamedField {
             name: "verts".into(),
             ty: SchemaType::Array {
-                element: Box::new(vertex),
+                element: SchemaCell::owned(vertex),
                 len: 3,
             },
         }]);
@@ -703,7 +705,7 @@ mod tests {
     fn postcard_option_some_and_none() {
         let schema = pc_struct(vec![NamedField {
             name: "name".into(),
-            ty: SchemaType::Option(Box::new(SchemaType::String)),
+            ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
         }]);
         roundtrip(json!({"name": "Aether"}), &schema);
         roundtrip(json!({"name": null}), &schema);
@@ -713,7 +715,7 @@ mod tests {
     fn postcard_vec_of_strings() {
         let schema = pc_struct(vec![NamedField {
             name: "tags".into(),
-            ty: SchemaType::Vec(Box::new(SchemaType::String)),
+            ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
         }]);
         roundtrip(json!({"tags": ["alpha", "beta", "gamma"]}), &schema);
     }
@@ -723,7 +725,7 @@ mod tests {
         let inner = pc_struct(vec![scalar("seq", Primitive::U32)]);
         let schema = pc_struct(vec![NamedField {
             name: "items".into(),
-            ty: SchemaType::Vec(Box::new(inner)),
+            ty: SchemaType::Vec(SchemaCell::owned(inner)),
         }]);
         roundtrip(
             json!({"items": [{"seq": 1u32}, {"seq": 256u32}, {"seq": 0xDEADu32}]}),
@@ -735,23 +737,25 @@ mod tests {
         SchemaType::Enum {
             variants: vec![
                 EnumVariant::Unit {
-                    name: "Pending".into(),
+                    name: "Pending".to_string().into(),
                     discriminant: 0,
                 },
                 EnumVariant::Tuple {
-                    name: "Ok".into(),
+                    name: "Ok".to_string().into(),
                     discriminant: 1,
-                    fields: vec![SchemaType::Scalar(Primitive::U64)],
+                    fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
                 },
                 EnumVariant::Struct {
-                    name: "Err".into(),
+                    name: "Err".to_string().into(),
                     discriminant: 2,
                     fields: vec![NamedField {
-                        name: "reason".into(),
+                        name: "reason".to_string().into(),
                         ty: SchemaType::String,
-                    }],
+                    }]
+                    .into(),
                 },
-            ],
+            ]
+            .into(),
         }
     }
 

--- a/crates/aether-hub/src/encoder.rs
+++ b/crates/aether-hub/src/encoder.rs
@@ -119,7 +119,7 @@ pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, Enc
         } => {
             let obj = params.as_object().ok_or(EncodeError::NotAnObject)?;
             for key in obj.keys() {
-                if !fields.iter().any(|f| &f.name == key) {
+                if !fields.iter().any(|f| f.name == *key) {
                     return Err(EncodeError::UnexpectedField(key.clone()));
                 }
             }
@@ -231,13 +231,13 @@ fn encode_postcard(
                 expected: "object",
             })?;
             for key in obj.keys() {
-                if !fields.iter().any(|f| &f.name == key) {
+                if !fields.iter().any(|f| f.name == *key) {
                     return Err(EncodeError::UnexpectedField(format!("{path}.{key}")));
                 }
             }
-            for field in fields {
+            for field in fields.iter() {
                 let v = obj
-                    .get(&field.name)
+                    .get(&*field.name)
                     .ok_or_else(|| EncodeError::MissingField(format!("{path}.{}", field.name)))?;
                 let field_path = format!("{path}.{}", field.name);
                 encode_postcard(v, &field.ty, &field_path, out)?;
@@ -415,14 +415,14 @@ fn encode_enum_body(
                 expected: "struct variant body as object",
             })?;
             for key in obj.keys() {
-                if !fields.iter().any(|f| &f.name == key) {
+                if !fields.iter().any(|f| f.name == *key) {
                     return Err(EncodeError::UnexpectedField(format!(
                         "{path}::{name}.{key}"
                     )));
                 }
             }
-            for field in fields {
-                let v = obj.get(&field.name).ok_or_else(|| {
+            for field in fields.iter() {
+                let v = obj.get(&*field.name).ok_or_else(|| {
                     EncodeError::MissingField(format!("{path}::{name}.{}", field.name))
                 })?;
                 let nested = format!("{path}::{name}.{}", field.name);
@@ -442,10 +442,10 @@ fn encode_struct_fields(
     fields: &[NamedField],
 ) -> Result<usize, EncodeError> {
     let mut max_align = 1usize;
-    for field in fields {
+    for field in fields.iter() {
         let value = obj
-            .get(&field.name)
-            .ok_or_else(|| EncodeError::MissingField(field.name.clone()))?;
+            .get(&*field.name)
+            .ok_or_else(|| EncodeError::MissingField(field.name.to_string()))?;
         let a = encode_field_value(out, &field.name, &field.ty, value)?;
         max_align = max_align.max(a);
     }
@@ -507,7 +507,7 @@ fn encode_field_value(
                 expected: "object",
             })?;
             for key in obj.keys() {
-                if !fields.iter().any(|f| &f.name == key) {
+                if !fields.iter().any(|f| f.name == *key) {
                     return Err(EncodeError::UnexpectedField(format!("{name}.{key}")));
                 }
             }
@@ -541,7 +541,7 @@ fn alignment_of_schema(ty: &SchemaType) -> Result<usize, EncodeError> {
             repr_c: true,
         } => {
             let mut a = 1usize;
-            for f in fields {
+            for f in fields.iter() {
                 a = a.max(alignment_of_schema(&f.ty)?);
             }
             Ok(a)
@@ -656,19 +656,33 @@ fn oor(name: &str, ty: &str) -> EncodeError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_hub_protocol::SchemaCell;
     use serde_json::json;
 
     fn scalar(name: &str, ty: Primitive) -> NamedField {
         NamedField {
-            name: name.into(),
+            name: name.to_string().into(),
             ty: SchemaType::Scalar(ty),
         }
     }
 
     fn cast_struct(fields: Vec<NamedField>) -> SchemaType {
         SchemaType::Struct {
-            fields,
+            fields: fields.into(),
             repr_c: true,
+        }
+    }
+
+    fn postcard_struct(fields: Vec<NamedField>) -> SchemaType {
+        SchemaType::Struct {
+            fields: fields.into(),
+            repr_c: false,
+        }
+    }
+
+    fn enum_schema(variants: Vec<EnumVariant>) -> SchemaType {
+        SchemaType::Enum {
+            variants: variants.into(),
         }
     }
 
@@ -738,7 +752,7 @@ mod tests {
         let schema = cast_struct(vec![NamedField {
             name: "xs".into(),
             ty: SchemaType::Array {
-                element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),
                 len: 4,
             },
         }]);
@@ -802,7 +816,7 @@ mod tests {
         let schema = cast_struct(vec![NamedField {
             name: "xs".into(),
             ty: SchemaType::Array {
-                element: Box::new(SchemaType::Scalar(Primitive::U8)),
+                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),
                 len: 4,
             },
         }]);
@@ -836,12 +850,13 @@ mod tests {
                 scalar("r", Primitive::F32),
                 scalar("g", Primitive::F32),
                 scalar("b", Primitive::F32),
-            ],
+            ]
+            .into(),
         };
         let triangle = cast_struct(vec![NamedField {
             name: "verts".into(),
             ty: SchemaType::Array {
-                element: Box::new(vertex),
+                element: SchemaCell::owned(vertex),
                 len: 3,
             },
         }]);
@@ -925,13 +940,10 @@ mod tests {
     }
 
     fn pc_string_schema() -> SchemaType {
-        SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "body".into(),
-                ty: SchemaType::String,
-            }],
-        }
+        postcard_struct(vec![NamedField {
+            name: "body".to_string().into(),
+            ty: SchemaType::String,
+        }])
     }
 
     #[test]
@@ -957,26 +969,20 @@ mod tests {
             blob: vec![1, 2, 3, 4, 5],
         };
         let expected = postcard::to_allocvec(&value).unwrap();
-        let schema = SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "blob".into(),
-                ty: SchemaType::Bytes,
-            }],
-        };
+        let schema = postcard_struct(vec![NamedField {
+            name: "blob".to_string().into(),
+            ty: SchemaType::Bytes,
+        }]);
         let bytes = encode_schema(&json!({"blob": [1, 2, 3, 4, 5]}), &schema).unwrap();
         assert_eq!(bytes, expected);
     }
 
     #[test]
     fn postcard_option_some_and_none() {
-        let schema = SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "name".into(),
-                ty: SchemaType::Option(Box::new(SchemaType::String)),
-            }],
-        };
+        let schema = postcard_struct(vec![NamedField {
+            name: "name".to_string().into(),
+            ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
+        }]);
         let some = PostcardOption {
             name: Some("Aether".into()),
         };
@@ -994,13 +1000,10 @@ mod tests {
             tags: vec!["alpha".into(), "beta".into(), "gamma".into()],
         };
         let expected = postcard::to_allocvec(&value).unwrap();
-        let schema = SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "tags".into(),
-                ty: SchemaType::Vec(Box::new(SchemaType::String)),
-            }],
-        };
+        let schema = postcard_struct(vec![NamedField {
+            name: "tags".to_string().into(),
+            ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
+        }]);
         let bytes = encode_schema(&json!({"tags": ["alpha", "beta", "gamma"]}), &schema).unwrap();
         assert_eq!(bytes, expected);
     }
@@ -1011,20 +1014,14 @@ mod tests {
             items: vec![Inner { seq: 1 }, Inner { seq: 256 }, Inner { seq: 0xDEAD }],
         };
         let expected = postcard::to_allocvec(&value).unwrap();
-        let inner_schema = SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "seq".into(),
-                ty: SchemaType::Scalar(Primitive::U32),
-            }],
-        };
-        let schema = SchemaType::Struct {
-            repr_c: false,
-            fields: vec![NamedField {
-                name: "items".into(),
-                ty: SchemaType::Vec(Box::new(inner_schema)),
-            }],
-        };
+        let inner_schema = postcard_struct(vec![NamedField {
+            name: "seq".to_string().into(),
+            ty: SchemaType::Scalar(Primitive::U32),
+        }]);
+        let schema = postcard_struct(vec![NamedField {
+            name: "items".to_string().into(),
+            ty: SchemaType::Vec(SchemaCell::owned(inner_schema)),
+        }]);
         let bytes = encode_schema(
             &json!({"items": [{"seq": 1}, {"seq": 256}, {"seq": 0xDEAD}]}),
             &schema,
@@ -1034,27 +1031,26 @@ mod tests {
     }
 
     fn sum_schema() -> SchemaType {
-        SchemaType::Enum {
-            variants: vec![
-                EnumVariant::Unit {
-                    name: "Pending".into(),
-                    discriminant: 0,
-                },
-                EnumVariant::Tuple {
-                    name: "Ok".into(),
-                    discriminant: 1,
-                    fields: vec![SchemaType::Scalar(Primitive::U64)],
-                },
-                EnumVariant::Struct {
-                    name: "Err".into(),
-                    discriminant: 2,
-                    fields: vec![NamedField {
-                        name: "reason".into(),
-                        ty: SchemaType::String,
-                    }],
-                },
-            ],
-        }
+        enum_schema(vec![
+            EnumVariant::Unit {
+                name: "Pending".to_string().into(),
+                discriminant: 0,
+            },
+            EnumVariant::Tuple {
+                name: "Ok".to_string().into(),
+                discriminant: 1,
+                fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
+            },
+            EnumVariant::Struct {
+                name: "Err".to_string().into(),
+                discriminant: 2,
+                fields: vec![NamedField {
+                    name: "reason".to_string().into(),
+                    ty: SchemaType::String,
+                }]
+                .into(),
+            },
+        ])
     }
 
     #[test]

--- a/crates/aether-hub/src/encoder.rs
+++ b/crates/aether-hub/src/encoder.rs
@@ -941,7 +941,7 @@ mod tests {
 
     fn pc_string_schema() -> SchemaType {
         postcard_struct(vec![NamedField {
-            name: "body".to_string().into(),
+            name: "body".into(),
             ty: SchemaType::String,
         }])
     }
@@ -970,7 +970,7 @@ mod tests {
         };
         let expected = postcard::to_allocvec(&value).unwrap();
         let schema = postcard_struct(vec![NamedField {
-            name: "blob".to_string().into(),
+            name: "blob".into(),
             ty: SchemaType::Bytes,
         }]);
         let bytes = encode_schema(&json!({"blob": [1, 2, 3, 4, 5]}), &schema).unwrap();
@@ -980,7 +980,7 @@ mod tests {
     #[test]
     fn postcard_option_some_and_none() {
         let schema = postcard_struct(vec![NamedField {
-            name: "name".to_string().into(),
+            name: "name".into(),
             ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
         }]);
         let some = PostcardOption {
@@ -1001,7 +1001,7 @@ mod tests {
         };
         let expected = postcard::to_allocvec(&value).unwrap();
         let schema = postcard_struct(vec![NamedField {
-            name: "tags".to_string().into(),
+            name: "tags".into(),
             ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
         }]);
         let bytes = encode_schema(&json!({"tags": ["alpha", "beta", "gamma"]}), &schema).unwrap();
@@ -1015,11 +1015,11 @@ mod tests {
         };
         let expected = postcard::to_allocvec(&value).unwrap();
         let inner_schema = postcard_struct(vec![NamedField {
-            name: "seq".to_string().into(),
+            name: "seq".into(),
             ty: SchemaType::Scalar(Primitive::U32),
         }]);
         let schema = postcard_struct(vec![NamedField {
-            name: "items".to_string().into(),
+            name: "items".into(),
             ty: SchemaType::Vec(SchemaCell::owned(inner_schema)),
         }]);
         let bytes = encode_schema(
@@ -1033,19 +1033,19 @@ mod tests {
     fn sum_schema() -> SchemaType {
         enum_schema(vec![
             EnumVariant::Unit {
-                name: "Pending".to_string().into(),
+                name: "Pending".into(),
                 discriminant: 0,
             },
             EnumVariant::Tuple {
-                name: "Ok".to_string().into(),
+                name: "Ok".into(),
                 discriminant: 1,
                 fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
             },
             EnumVariant::Struct {
-                name: "Err".to_string().into(),
+                name: "Err".into(),
                 discriminant: 2,
                 fields: vec![NamedField {
-                    name: "reason".to_string().into(),
+                    name: "reason".into(),
                     ty: SchemaType::String,
                 }]
                 .into(),

--- a/crates/aether-hub/src/mcp.rs
+++ b/crates/aether-hub/src/mcp.rs
@@ -271,7 +271,8 @@ mod tests {
                         name: "y".into(),
                         ty: SchemaType::Scalar(Primitive::F32),
                     },
-                ],
+                ]
+                .into(),
             },
         }];
         let (rec, mut rx) = record_with_kinds(3, kinds);
@@ -388,7 +389,8 @@ mod tests {
                     fields: vec![NamedField {
                         name: "body".into(),
                         ty: SchemaType::String,
-                    }],
+                    }]
+                    .into(),
                 },
             },
             KindDescriptor {
@@ -398,7 +400,8 @@ mod tests {
                     fields: vec![NamedField {
                         name: "n".into(),
                         ty: SchemaType::Scalar(Primitive::U32),
-                    }],
+                    }]
+                    .into(),
                 },
             },
         ];
@@ -556,7 +559,8 @@ mod tests {
                         name: "triangles".into(),
                         ty: SchemaType::Scalar(Primitive::U64),
                     },
-                ],
+                ]
+                .into(),
             },
         }];
         let (rec, _rx) = record_with_kinds(33, kinds);
@@ -609,7 +613,8 @@ mod tests {
                 fields: vec![NamedField {
                     name: "n".into(),
                     ty: SchemaType::Scalar(Primitive::U64),
-                }],
+                }]
+                .into(),
             },
         }];
         let (rec, _rx) = record_with_kinds(34, kinds);
@@ -750,7 +755,7 @@ mod tests {
     /// across capture_frame tests so they all exercise the same
     /// wire shape.
     fn capture_frame_kind_descriptor() -> aether_hub_protocol::KindDescriptor {
-        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaType};
+        use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
         let envelope = SchemaType::Struct {
             repr_c: false,
             fields: vec![
@@ -770,7 +775,8 @@ mod tests {
                     name: "count".into(),
                     ty: SchemaType::Scalar(Primitive::U32),
                 },
-            ],
+            ]
+            .into(),
         };
         KindDescriptor {
             name: "aether.control.capture_frame".into(),
@@ -779,13 +785,14 @@ mod tests {
                 fields: vec![
                     NamedField {
                         name: "mails".into(),
-                        ty: SchemaType::Vec(Box::new(envelope.clone())),
+                        ty: SchemaType::Vec(SchemaCell::owned(envelope.clone())),
                     },
                     NamedField {
                         name: "after_mails".into(),
-                        ty: SchemaType::Vec(Box::new(envelope)),
+                        ty: SchemaType::Vec(SchemaCell::owned(envelope)),
                     },
-                ],
+                ]
+                .into(),
             },
         }
     }

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -74,7 +74,7 @@ pub fn all() -> Vec<KindDescriptor> {
 fn schema<K: Kind + Schema>() -> KindDescriptor {
     KindDescriptor {
         name: K::NAME.to_string(),
-        schema: K::schema(),
+        schema: K::SCHEMA.clone(),
     }
 }
 
@@ -204,7 +204,7 @@ mod tests {
         let SchemaType::Struct {
             repr_c: nested_repr,
             fields: nested_fields,
-        } = element.as_ref()
+        } = &**element
         else {
             panic!("expected nested Struct");
         };

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -640,11 +640,8 @@ mod tests {
 
         #[test]
         fn unit_kinds_emit_schema_unit() {
-            assert!(matches!(<Tick as Schema>::SCHEMA.clone(), SchemaType::Unit));
-            assert!(matches!(
-                <MouseButton as Schema>::SCHEMA.clone(),
-                SchemaType::Unit
-            ));
+            assert!(matches!(<Tick as Schema>::SCHEMA, SchemaType::Unit));
+            assert!(matches!(<MouseButton as Schema>::SCHEMA, SchemaType::Unit));
         }
 
         #[test]
@@ -660,10 +657,10 @@ mod tests {
 
         #[test]
         fn key_schema_is_one_u32_field() {
-            let SchemaType::Struct { repr_c, fields } = <Key as Schema>::SCHEMA.clone() else {
+            let SchemaType::Struct { repr_c, fields } = &<Key as Schema>::SCHEMA else {
                 panic!("expected Struct");
             };
-            assert!(repr_c);
+            assert!(*repr_c);
             assert_eq!(fields.len(), 1);
             assert_eq!(fields[0].name, "code");
             assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
@@ -671,11 +668,10 @@ mod tests {
 
         #[test]
         fn draw_triangle_schema_recurses_into_vertex() {
-            let SchemaType::Struct { repr_c, fields } = <DrawTriangle as Schema>::SCHEMA.clone()
-            else {
+            let SchemaType::Struct { repr_c, fields } = &<DrawTriangle as Schema>::SCHEMA else {
                 panic!("expected Struct");
             };
-            assert!(repr_c);
+            assert!(*repr_c);
             assert_eq!(fields.len(), 1);
             assert_eq!(fields[0].name, "verts");
             let SchemaType::Array { element, len } = &fields[0].ty else {
@@ -685,7 +681,7 @@ mod tests {
             let SchemaType::Struct {
                 repr_c: nested_repr,
                 fields: nested_fields,
-            } = element.as_ref()
+            } = &**element
             else {
                 panic!("expected nested Struct");
             };
@@ -697,11 +693,10 @@ mod tests {
 
         #[test]
         fn frame_stats_schema_is_two_u64_fields() {
-            let SchemaType::Struct { repr_c, fields } = <FrameStats as Schema>::SCHEMA.clone()
-            else {
+            let SchemaType::Struct { repr_c, fields } = &<FrameStats as Schema>::SCHEMA else {
                 panic!("expected Struct");
             };
-            assert!(repr_c);
+            assert!(*repr_c);
             assert_eq!(fields.len(), 2);
             assert_eq!(fields[0].name, "frame");
             assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U64));

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -640,9 +640,9 @@ mod tests {
 
         #[test]
         fn unit_kinds_emit_schema_unit() {
-            assert!(matches!(<Tick as Schema>::schema(), SchemaType::Unit));
+            assert!(matches!(<Tick as Schema>::SCHEMA.clone(), SchemaType::Unit));
             assert!(matches!(
-                <MouseButton as Schema>::schema(),
+                <MouseButton as Schema>::SCHEMA.clone(),
                 SchemaType::Unit
             ));
         }
@@ -660,7 +660,7 @@ mod tests {
 
         #[test]
         fn key_schema_is_one_u32_field() {
-            let SchemaType::Struct { repr_c, fields } = <Key as Schema>::schema() else {
+            let SchemaType::Struct { repr_c, fields } = <Key as Schema>::SCHEMA.clone() else {
                 panic!("expected Struct");
             };
             assert!(repr_c);
@@ -671,7 +671,8 @@ mod tests {
 
         #[test]
         fn draw_triangle_schema_recurses_into_vertex() {
-            let SchemaType::Struct { repr_c, fields } = <DrawTriangle as Schema>::schema() else {
+            let SchemaType::Struct { repr_c, fields } = <DrawTriangle as Schema>::SCHEMA.clone()
+            else {
                 panic!("expected Struct");
             };
             assert!(repr_c);
@@ -696,7 +697,8 @@ mod tests {
 
         #[test]
         fn frame_stats_schema_is_two_u64_fields() {
-            let SchemaType::Struct { repr_c, fields } = <FrameStats as Schema>::schema() else {
+            let SchemaType::Struct { repr_c, fields } = <FrameStats as Schema>::SCHEMA.clone()
+            else {
                 panic!("expected Struct");
             };
             assert!(repr_c);

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -190,9 +190,7 @@ fn expand_schema(input: &DeriveInput) -> syn::Result<TokenStream2> {
     };
     Ok(quote! {
         impl ::aether_mail::Schema for #name {
-            fn schema() -> ::aether_hub_protocol::SchemaType {
-                #body
-            }
+            const SCHEMA: ::aether_hub_protocol::SchemaType = #body;
         }
 
         impl ::aether_mail::CastEligible for #name {
@@ -217,7 +215,7 @@ fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
         let ty_expr = field_type_schema_expr(&f.ty);
         quote! {
             ::aether_hub_protocol::NamedField {
-                name: ::aether_mail::__derive_runtime::string_from(#name),
+                name: ::aether_mail::__derive_runtime::Cow::Borrowed(#name),
                 ty: #ty_expr,
             }
         }
@@ -225,7 +223,7 @@ fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
 
     Ok(quote! {
         ::aether_hub_protocol::SchemaType::Struct {
-            fields: ::aether_mail::__derive_runtime::vec_from([ #( #entries ),* ]),
+            fields: ::aether_mail::__derive_runtime::Cow::Borrowed(&[ #( #entries ),* ]),
             repr_c: <Self as ::aether_mail::CastEligible>::ELIGIBLE,
         }
     })
@@ -238,7 +236,7 @@ fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
         match &v.fields {
             Fields::Unit => quote! {
                 ::aether_hub_protocol::EnumVariant::Unit {
-                    name: ::aether_mail::__derive_runtime::string_from(#name),
+                    name: ::aether_mail::__derive_runtime::Cow::Borrowed(#name),
                     discriminant: #discriminant,
                 }
             },
@@ -249,9 +247,9 @@ fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
                     .map(|f| field_type_schema_expr(&f.ty));
                 quote! {
                     ::aether_hub_protocol::EnumVariant::Tuple {
-                        name: ::aether_mail::__derive_runtime::string_from(#name),
+                        name: ::aether_mail::__derive_runtime::Cow::Borrowed(#name),
                         discriminant: #discriminant,
-                        fields: ::aether_mail::__derive_runtime::vec_from([ #( #field_exprs ),* ]),
+                        fields: ::aether_mail::__derive_runtime::Cow::Borrowed(&[ #( #field_exprs ),* ]),
                     }
                 }
             }
@@ -261,16 +259,16 @@ fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
                     let ty_expr = field_type_schema_expr(&f.ty);
                     quote! {
                         ::aether_hub_protocol::NamedField {
-                            name: ::aether_mail::__derive_runtime::string_from(#fname),
+                            name: ::aether_mail::__derive_runtime::Cow::Borrowed(#fname),
                             ty: #ty_expr,
                         }
                     }
                 });
                 quote! {
                     ::aether_hub_protocol::EnumVariant::Struct {
-                        name: ::aether_mail::__derive_runtime::string_from(#name),
+                        name: ::aether_mail::__derive_runtime::Cow::Borrowed(#name),
                         discriminant: #discriminant,
-                        fields: ::aether_mail::__derive_runtime::vec_from([ #( #field_exprs ),* ]),
+                        fields: ::aether_mail::__derive_runtime::Cow::Borrowed(&[ #( #field_exprs ),* ]),
                     }
                 }
             }
@@ -279,19 +277,21 @@ fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
 
     Ok(quote! {
         ::aether_hub_protocol::SchemaType::Enum {
-            variants: ::aether_mail::__derive_runtime::vec_from([ #( #variant_entries ),* ]),
+            variants: ::aether_mail::__derive_runtime::Cow::Borrowed(&[ #( #variant_entries ),* ]),
         }
     })
 }
 
 // Pattern-match `Vec<u8>` at the field-type level so it lands as
 // `SchemaType::Bytes` rather than the generic `Vec(Scalar(U8))`. Every
-// other shape just delegates to the `Schema` trait.
+// other shape delegates to the `Schema` trait's const — wrapped in
+// `SchemaCell::Static` at recursive positions so the literal stays
+// const-constructible.
 fn field_type_schema_expr(ty: &Type) -> TokenStream2 {
     if is_vec_u8(ty) {
         quote! { ::aether_hub_protocol::SchemaType::Bytes }
     } else {
-        quote! { <#ty as ::aether_mail::Schema>::schema() }
+        quote! { <#ty as ::aether_mail::Schema>::SCHEMA }
     }
 }
 

--- a/crates/aether-mail-derive/src/manifest.rs
+++ b/crates/aether-mail-derive/src/manifest.rs
@@ -19,7 +19,11 @@
 //! per-record with a `0x01` version byte so the format can evolve
 //! (ADR-0028 §Versioning).
 
-use aether_hub_protocol::{EnumVariant, KindDescriptor, NamedField, Primitive, SchemaType};
+use std::borrow::Cow;
+
+use aether_hub_protocol::{
+    EnumVariant, KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType,
+};
 use syn::{DataEnum, Fields, GenericArgument, PathArguments, Type};
 
 use crate::FieldInfo;
@@ -46,12 +50,12 @@ pub fn struct_descriptor(
                 None => idx.to_string(),
             };
             named.push(NamedField {
-                name: fname,
+                name: Cow::Owned(fname),
                 ty: resolve(&f.ty)?,
             });
         }
         SchemaType::Struct {
-            fields: named,
+            fields: Cow::Owned(named),
             repr_c: has_repr_c,
         }
     };
@@ -70,7 +74,7 @@ pub fn enum_descriptor(name: &str, data: &DataEnum) -> Option<KindDescriptor> {
         let discriminant = idx as u32;
         let variant = match &v.fields {
             Fields::Unit => EnumVariant::Unit {
-                name: vname,
+                name: Cow::Owned(vname),
                 discriminant,
             },
             Fields::Unnamed(u) => {
@@ -79,9 +83,9 @@ pub fn enum_descriptor(name: &str, data: &DataEnum) -> Option<KindDescriptor> {
                     tys.push(resolve(&f.ty)?);
                 }
                 EnumVariant::Tuple {
-                    name: vname,
+                    name: Cow::Owned(vname),
                     discriminant,
-                    fields: tys,
+                    fields: Cow::Owned(tys),
                 }
             }
             Fields::Named(n) => {
@@ -89,14 +93,14 @@ pub fn enum_descriptor(name: &str, data: &DataEnum) -> Option<KindDescriptor> {
                 for f in &n.named {
                     let fname = f.ident.as_ref().map(|i| i.to_string()).unwrap_or_default();
                     fs.push(NamedField {
-                        name: fname,
+                        name: Cow::Owned(fname),
                         ty: resolve(&f.ty)?,
                     });
                 }
                 EnumVariant::Struct {
-                    name: vname,
+                    name: Cow::Owned(vname),
                     discriminant,
-                    fields: fs,
+                    fields: Cow::Owned(fs),
                 }
             }
         };
@@ -104,7 +108,9 @@ pub fn enum_descriptor(name: &str, data: &DataEnum) -> Option<KindDescriptor> {
     }
     Some(KindDescriptor {
         name: name.to_string(),
-        schema: SchemaType::Enum { variants },
+        schema: SchemaType::Enum {
+            variants: Cow::Owned(variants),
+        },
     })
 }
 
@@ -128,7 +134,7 @@ fn resolve(ty: &Type) -> Option<SchemaType> {
             let element = resolve(&arr.elem)?;
             let len = array_len(&arr.len)?;
             Some(SchemaType::Array {
-                element: Box::new(element),
+                element: SchemaCell::owned(element),
                 len,
             })
         }
@@ -162,12 +168,12 @@ fn resolve(ty: &Type) -> Option<SchemaType> {
                     if is_u8_ident(inner) {
                         Some(SchemaType::Bytes)
                     } else {
-                        Some(SchemaType::Vec(Box::new(resolve(inner)?)))
+                        Some(SchemaType::Vec(SchemaCell::owned(resolve(inner)?)))
                     }
                 }
                 "Option" => {
                     let inner = first_generic(seg)?;
-                    Some(SchemaType::Option(Box::new(resolve(inner)?)))
+                    Some(SchemaType::Option(SchemaCell::owned(resolve(inner)?)))
                 }
                 _ => None,
             }

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -69,17 +69,17 @@ enum Outcome {
 #[test]
 fn unit_struct_emits_name_and_unit_schema() {
     assert_eq!(<Tick as Kind>::NAME, "test.tick");
-    assert!(matches!(<Tick as Schema>::SCHEMA.clone(), SchemaType::Unit));
+    assert!(matches!(<Tick as Schema>::SCHEMA, SchemaType::Unit));
 }
 
 #[test]
 fn cast_eligible_struct_picks_repr_c_true() {
     assert_eq!(<Key as Kind>::NAME, "test.key");
     const { assert!(<Key as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Key as Schema>::SCHEMA.clone() else {
+    let SchemaType::Struct { repr_c, fields } = &<Key as Schema>::SCHEMA else {
         panic!("expected Struct schema");
     };
-    assert!(repr_c);
+    assert!(*repr_c);
     assert_eq!(fields.len(), 1);
     assert_eq!(fields[0].name, "code");
     assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
@@ -89,10 +89,10 @@ fn cast_eligible_struct_picks_repr_c_true() {
 fn cast_eligible_propagates_through_array_of_substruct() {
     const { assert!(<Vertex as CastEligible>::ELIGIBLE) };
     const { assert!(<Triangle as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Triangle as Schema>::SCHEMA.clone() else {
+    let SchemaType::Struct { repr_c, fields } = &<Triangle as Schema>::SCHEMA else {
         panic!("expected Struct schema");
     };
-    assert!(repr_c);
+    assert!(*repr_c);
     assert_eq!(fields.len(), 1);
     assert_eq!(fields[0].name, "verts");
     let SchemaType::Array { element, len } = &fields[0].ty else {
@@ -102,7 +102,7 @@ fn cast_eligible_propagates_through_array_of_substruct() {
     let SchemaType::Struct {
         repr_c: nested_repr,
         fields: nested_fields,
-    } = element.as_ref()
+    } = &**element
     else {
         panic!("expected nested Struct");
     };
@@ -113,10 +113,10 @@ fn cast_eligible_propagates_through_array_of_substruct() {
 #[test]
 fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
     const { assert!(!<Note as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Note as Schema>::SCHEMA.clone() else {
+    let SchemaType::Struct { repr_c, fields } = &<Note as Schema>::SCHEMA else {
         panic!("expected Struct schema");
     };
-    assert!(!repr_c);
+    assert!(!*repr_c);
     let by_name: std::collections::HashMap<&str, &SchemaType> =
         fields.iter().map(|f| (&*f.name, &f.ty)).collect();
     assert_eq!(by_name["body"], &SchemaType::String);
@@ -132,11 +132,11 @@ fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
 
 #[test]
 fn tuple_struct_names_fields_positionally() {
-    let SchemaType::Struct { fields, repr_c } = <TupleStruct as Schema>::SCHEMA.clone() else {
+    let SchemaType::Struct { fields, repr_c } = &<TupleStruct as Schema>::SCHEMA else {
         panic!("expected Struct schema");
     };
     // No `#[repr(C)]` on the tuple struct → not cast eligible.
-    assert!(!repr_c);
+    assert!(!*repr_c);
     assert_eq!(fields.len(), 2);
     assert_eq!(fields[0].name, "0");
     assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
@@ -148,7 +148,7 @@ fn tuple_struct_names_fields_positionally() {
 fn enum_emits_each_variant_shape_with_sequential_discriminants() {
     assert_eq!(<Outcome as Kind>::NAME, "test.result");
     const { assert!(!<Outcome as CastEligible>::ELIGIBLE) };
-    let SchemaType::Enum { variants } = <Outcome as Schema>::SCHEMA.clone() else {
+    let SchemaType::Enum { variants } = &<Outcome as Schema>::SCHEMA else {
         panic!("expected Enum schema");
     };
     assert_eq!(variants.len(), 3);
@@ -207,8 +207,8 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
         label: String,
     }
     const { assert!(!<ReprCButStrung as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, .. } = <ReprCButStrung as Schema>::SCHEMA.clone() else {
+    let SchemaType::Struct { repr_c, .. } = &<ReprCButStrung as Schema>::SCHEMA else {
         panic!("expected Struct");
     };
-    assert!(!repr_c);
+    assert!(!*repr_c);
 }

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -69,14 +69,14 @@ enum Outcome {
 #[test]
 fn unit_struct_emits_name_and_unit_schema() {
     assert_eq!(<Tick as Kind>::NAME, "test.tick");
-    assert!(matches!(<Tick as Schema>::schema(), SchemaType::Unit));
+    assert!(matches!(<Tick as Schema>::SCHEMA.clone(), SchemaType::Unit));
 }
 
 #[test]
 fn cast_eligible_struct_picks_repr_c_true() {
     assert_eq!(<Key as Kind>::NAME, "test.key");
     const { assert!(<Key as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Key as Schema>::schema() else {
+    let SchemaType::Struct { repr_c, fields } = <Key as Schema>::SCHEMA.clone() else {
         panic!("expected Struct schema");
     };
     assert!(repr_c);
@@ -89,7 +89,7 @@ fn cast_eligible_struct_picks_repr_c_true() {
 fn cast_eligible_propagates_through_array_of_substruct() {
     const { assert!(<Vertex as CastEligible>::ELIGIBLE) };
     const { assert!(<Triangle as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Triangle as Schema>::schema() else {
+    let SchemaType::Struct { repr_c, fields } = <Triangle as Schema>::SCHEMA.clone() else {
         panic!("expected Struct schema");
     };
     assert!(repr_c);
@@ -113,12 +113,12 @@ fn cast_eligible_propagates_through_array_of_substruct() {
 #[test]
 fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
     const { assert!(!<Note as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, fields } = <Note as Schema>::schema() else {
+    let SchemaType::Struct { repr_c, fields } = <Note as Schema>::SCHEMA.clone() else {
         panic!("expected Struct schema");
     };
     assert!(!repr_c);
     let by_name: std::collections::HashMap<&str, &SchemaType> =
-        fields.iter().map(|f| (f.name.as_str(), &f.ty)).collect();
+        fields.iter().map(|f| (&*f.name, &f.ty)).collect();
     assert_eq!(by_name["body"], &SchemaType::String);
     assert!(matches!(by_name["tags"], SchemaType::Vec(inner) if **inner == SchemaType::String));
     assert!(
@@ -132,7 +132,7 @@ fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
 
 #[test]
 fn tuple_struct_names_fields_positionally() {
-    let SchemaType::Struct { fields, repr_c } = <TupleStruct as Schema>::schema() else {
+    let SchemaType::Struct { fields, repr_c } = <TupleStruct as Schema>::SCHEMA.clone() else {
         panic!("expected Struct schema");
     };
     // No `#[repr(C)]` on the tuple struct → not cast eligible.
@@ -148,7 +148,7 @@ fn tuple_struct_names_fields_positionally() {
 fn enum_emits_each_variant_shape_with_sequential_discriminants() {
     assert_eq!(<Outcome as Kind>::NAME, "test.result");
     const { assert!(!<Outcome as CastEligible>::ELIGIBLE) };
-    let SchemaType::Enum { variants } = <Outcome as Schema>::schema() else {
+    let SchemaType::Enum { variants } = <Outcome as Schema>::SCHEMA.clone() else {
         panic!("expected Enum schema");
     };
     assert_eq!(variants.len(), 3);
@@ -207,7 +207,7 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
         label: String,
     }
     const { assert!(!<ReprCButStrung as CastEligible>::ELIGIBLE) };
-    let SchemaType::Struct { repr_c, .. } = <ReprCButStrung as Schema>::schema() else {
+    let SchemaType::Struct { repr_c, .. } = <ReprCButStrung as Schema>::SCHEMA.clone() else {
         panic!("expected Struct");
     };
     assert!(!repr_c);

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -119,9 +119,10 @@ pub const fn mailbox_id_from_name(name: &str) -> u64 {
 pub use aether_mail_derive::{Kind, Schema};
 
 /// ADR-0019 schema producer. The substrate (and tooling that builds
-/// hub descriptors) calls `T::schema()` to learn how a kind's payload
-/// is laid out. Wasm guests typically don't need this — they send and
-/// receive bytes — so the trait sits behind the `descriptors` feature.
+/// hub descriptors) reads `<T as Schema>::SCHEMA` — a compile-time
+/// const — to learn how a kind's payload is laid out. Wasm guests
+/// typically don't need this, so the trait sits behind the
+/// `descriptors` feature.
 ///
 /// Blanket impls cover the leaf types in the schema vocabulary
 /// (primitives, `String`, `[u8]`-shaped `Vec`s, fixed arrays,
@@ -130,46 +131,41 @@ pub use aether_mail_derive::{Kind, Schema};
 #[cfg(feature = "descriptors")]
 pub use schema::Schema;
 
-/// Internal helpers the `#[derive(Schema)]` macro uses to construct
-/// `String` and `Vec` values without forcing every consumer crate to
-/// `extern crate alloc;`. Not part of the public API; the macro is the
-/// only intended caller.
+/// Internal re-exports the `#[derive(Schema)]` macro points at so its
+/// output compiles in no_std + alloc consumer crates (notably
+/// aether-kinds) without the consumer needing `extern crate alloc;`
+/// at the site. Not part of the public API; the macro is the only
+/// intended caller.
 #[cfg(feature = "descriptors")]
 #[doc(hidden)]
 pub mod __derive_runtime {
-    use alloc::string::String;
-    use alloc::vec::Vec;
-
-    pub fn string_from(s: &str) -> String {
-        String::from(s)
-    }
-
-    pub fn vec_from<T, const N: usize>(arr: [T; N]) -> Vec<T> {
-        Vec::from(arr)
-    }
+    pub use alloc::borrow::Cow;
 }
 
 #[cfg(feature = "descriptors")]
 mod schema {
-    use alloc::boxed::Box;
     use alloc::string::String;
     use alloc::vec::Vec;
 
-    use aether_hub_protocol::{Primitive, SchemaType};
+    use aether_hub_protocol::{Primitive, SchemaCell, SchemaType};
 
     /// Produces the `SchemaType` describing how this type lays out as
     /// a mail payload. Implemented by `#[derive(Schema)]` on user
     /// structs, and by blanket impl on the schema-vocabulary leaves.
+    ///
+    /// ADR-0031: the schema is a compile-time `const` rather than a
+    /// runtime `fn`. Taking a reference produces a `&'static SchemaType`
+    /// which is what `SchemaCell::Static` holds, so nested types
+    /// (`Vec<T>`, `Option<T>`, `[T; N]`, user structs) resolve by
+    /// trait dispatch at compile time without a syntactic walker.
     pub trait Schema {
-        fn schema() -> SchemaType;
+        const SCHEMA: SchemaType;
     }
 
     macro_rules! scalar {
         ($t:ty, $p:ident) => {
             impl Schema for $t {
-                fn schema() -> SchemaType {
-                    SchemaType::Scalar(Primitive::$p)
-                }
+                const SCHEMA: SchemaType = SchemaType::Scalar(Primitive::$p);
             }
         };
     }
@@ -186,15 +182,11 @@ mod schema {
     scalar!(f64, F64);
 
     impl Schema for bool {
-        fn schema() -> SchemaType {
-            SchemaType::Bool
-        }
+        const SCHEMA: SchemaType = SchemaType::Bool;
     }
 
     impl Schema for String {
-        fn schema() -> SchemaType {
-            SchemaType::String
-        }
+        const SCHEMA: SchemaType = SchemaType::String;
     }
 
     // Generic `Vec<T>`. `Vec<u8>` is the canonical byte-buffer shape
@@ -206,25 +198,19 @@ mod schema {
     // `SchemaType::Bytes` directly, bypassing this blanket. Standalone
     // `Vec<u8>` outside a derived struct still routes through this
     // impl and lands as `Vec(Scalar(U8))`.
-    impl<T: Schema> Schema for Vec<T> {
-        fn schema() -> SchemaType {
-            SchemaType::Vec(Box::new(T::schema()))
-        }
+    impl<T: Schema + 'static> Schema for Vec<T> {
+        const SCHEMA: SchemaType = SchemaType::Vec(SchemaCell::Static(&T::SCHEMA));
     }
 
-    impl<T: Schema> Schema for Option<T> {
-        fn schema() -> SchemaType {
-            SchemaType::Option(Box::new(T::schema()))
-        }
+    impl<T: Schema + 'static> Schema for Option<T> {
+        const SCHEMA: SchemaType = SchemaType::Option(SchemaCell::Static(&T::SCHEMA));
     }
 
-    impl<T: Schema, const N: usize> Schema for [T; N] {
-        fn schema() -> SchemaType {
-            SchemaType::Array {
-                element: Box::new(T::schema()),
-                len: N as u32,
-            }
-        }
+    impl<T: Schema + 'static, const N: usize> Schema for [T; N] {
+        const SCHEMA: SchemaType = SchemaType::Array {
+            element: SchemaCell::Static(&T::SCHEMA),
+            len: N as u32,
+        };
     }
 }
 

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -960,7 +960,7 @@ mod tests {
             name: "demo.embedded.kind".to_string(),
             schema: SchemaType::Struct {
                 fields: vec![NamedField {
-                    name: "code".to_string().into(),
+                    name: "code".into(),
                     ty: SchemaType::Scalar(Primitive::U32),
                 }]
                 .into(),

--- a/crates/aether-substrate/src/control.rs
+++ b/crates/aether-substrate/src/control.rs
@@ -960,9 +960,10 @@ mod tests {
             name: "demo.embedded.kind".to_string(),
             schema: SchemaType::Struct {
                 fields: vec![NamedField {
-                    name: "code".to_string(),
+                    name: "code".to_string().into(),
                     ty: SchemaType::Scalar(Primitive::U32),
-                }],
+                }]
+                .into(),
                 repr_c: true,
             },
         };

--- a/crates/aether-substrate/src/kind_manifest.rs
+++ b/crates/aether-substrate/src/kind_manifest.rs
@@ -105,7 +105,7 @@ mod tests {
             name: "test.kind".to_string(),
             schema: SchemaType::Struct {
                 fields: vec![NamedField {
-                    name: "x".to_string().into(),
+                    name: "x".into(),
                     ty: SchemaType::Scalar(Primitive::U32),
                 }]
                 .into(),

--- a/crates/aether-substrate/src/kind_manifest.rs
+++ b/crates/aether-substrate/src/kind_manifest.rs
@@ -105,9 +105,10 @@ mod tests {
             name: "test.kind".to_string(),
             schema: SchemaType::Struct {
                 fields: vec![NamedField {
-                    name: "x".to_string(),
+                    name: "x".to_string().into(),
                     ty: SchemaType::Scalar(Primitive::U32),
-                }],
+                }]
+                .into(),
                 repr_c: true,
             },
         };

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -516,7 +516,7 @@ mod tests {
             schema: SchemaType::Struct {
                 repr_c: true,
                 fields: vec![NamedField {
-                    name: "x".to_string().into(),
+                    name: "x".into(),
                     ty: SchemaType::Scalar(Primitive::U32),
                 }]
                 .into(),

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -516,9 +516,10 @@ mod tests {
             schema: SchemaType::Struct {
                 repr_c: true,
                 fields: vec![NamedField {
-                    name: "x".to_string(),
+                    name: "x".to_string().into(),
                     ty: SchemaType::Scalar(Primitive::U32),
-                }],
+                }]
+                .into(),
             },
         }
     }


### PR DESCRIPTION
## Summary

ADR-0031 implementation: `SchemaType` becomes const-constructible so future work can emit `const ID: u64` on `Kind` at compile time (the blocker for ADR-0030 Phase 2).

Core primitive is `SchemaCell` — a hand-rolled Cow-shaped sum that handles recursive-type size-breaking without needing heap at compile time:

- `SchemaCell::Static(&'static SchemaType)` — const-literal arm; derives and blanket impls use this.
- `SchemaCell::Owned(Box<SchemaType>)` — wire/runtime arm; hub's postcard decoder lands here.
- Both `Deref` to `&SchemaType`; walkers don't observe the variant. Custom serde delegates serialize through Deref, always produces `Owned` on deserialize.

For non-recursive fields we use `Cow<'static, [T]>` and `Cow<'static, str>` — serde handles them natively, so no custom impls needed there.

## What changed

- **aether-hub-protocol**: `SchemaType`, `NamedField`, `EnumVariant` rewritten with the new containers. `SchemaCell` gets custom Serialize/Deserialize + Deref/AsRef/Clone/PartialEq/Eq.
- **aether-mail**: `Schema` trait shift `fn schema() -> SchemaType` → `const SCHEMA: SchemaType`. Blanket impls for primitives, bool, String, Vec<T>, Option<T>, [T; N] all become const. `__derive_runtime` now just re-exports `Cow` for the derive.
- **aether-mail-derive**: `Schema` derive emits a const literal tree instead of an `fn` body. Nested types resolve via trait dispatch at compile time (`<FieldT as Schema>::SCHEMA`). Type aliases work for free as a side benefit.
- **Hub encoder/decoder/mcp**: access pattern shifts (`.iter()` on Cow-backed slices, `.to_string()` to produce `String` from `Cow<str>`, `SchemaCell::owned(…)` for recursive constructors). Deref bridges the walker bodies unchanged.
- **Substrate registry, kind_manifest, control plane**: fixture updates for new constructors.
- **`manifest.rs` syntactic walker stays**: retiring it is deferred to a follow-up — the wasm custom section format is tied to it, and the simpler path to Phase 2 is to build const-ID support first.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 500+ tests green
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`

## Follow-ups

- Retire the `manifest.rs` syntactic walker in favor of a const-fn postcard serializer or build-script path (separate PR).
- ADR-0030 Phase 2: emit `const ID: u64 = fnv1a_schema_hash(NAME, &SCHEMA)` on Kind, retire `resolve_kind_p32`, and register kinds by hashed id on the substrate side.