### PR TITLE
feat(component): #[handlers] attribute macro + inputs manifest (ADR-0033 Phase 1)

### DIFF
--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -4,7 +4,12 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-aether-mail = { path = "../aether-mail" }
+# ADR-0033 attribute macros (`#[handlers]` / `#[handler]` / `#[fallback]`)
+# live in `aether-mail-derive` and are re-exported through `aether-mail`'s
+# `derive` feature. The SDK forwards them to consumers so they can
+# `use aether_component::{handlers, handler, fallback};` alongside the
+# rest of the component vocabulary.
+aether-mail = { path = "../aether-mail", features = ["derive"] }
 # ADR-0030 Phase 2: the init walker auto-subscribes each `K::IS_INPUT`
 # kind by mailing `aether.control.subscribe_input` — the SDK needs the
 # concrete `InputStream` + `SubscribeInput` types from the substrate's

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -52,6 +52,27 @@ pub mod raw;
 
 pub use kinds::{Cons, KindList, KindTable, Nil};
 
+/// ADR-0033 attribute macros. Applied to `impl Component for C`
+/// blocks: `#[handlers]` at the impl level; `#[handler]` on each
+/// typed handler method; `#[fallback]` on an optional catchall.
+/// Forwarded from `aether-mail-derive` so the full component
+/// vocabulary sits behind one `use aether_component::*` line.
+pub use aether_mail::{fallback, handler, handlers};
+
+/// Re-exports the `#[handlers]` macro relies on at expansion sites
+/// that don't depend on `aether-mail` directly (e.g., component
+/// crates that only pull in `aether-component`). Keeping the macro's
+/// emitted paths rooted at `::aether_component::__macro_internals`
+/// removes the "add aether-mail to your Cargo.toml" boilerplate that
+/// `::aether_mail::...` paths would otherwise force on every consumer.
+///
+/// Not part of the public API; the macro is the only intended caller.
+#[doc(hidden)]
+pub mod __macro_internals {
+    pub use aether_mail::__derive_runtime::canonical;
+    pub use aether_mail::Kind;
+}
+
 /// Phantom-typed wrapper around a resolved kind id. A `KindId<Tick>`
 /// cannot be passed where a `KindId<DrawTriangle>` is expected — the
 /// mismatch is a compile error rather than a runtime bad-dispatch.
@@ -338,7 +359,16 @@ impl InitCtx<'_> {
 /// Per-receive capability handle. Exposes send primitives only.
 /// Resolution is intentionally absent — runtime resolution after init
 /// is not a supported shape.
+///
+/// ADR-0033: typed handlers receive `K` by value, so they no longer
+/// hold a `Mail<'_>` to call `mail.sender()` on. The synthesized
+/// dispatcher threads the inbound mail's sender onto `Ctx` via
+/// `__set_sender` before every handler call, and `Ctx::sender()`
+/// reads it back. Components using the ADR-0027 `fn receive(&mut
+/// self, ctx, mail)` shape keep calling `mail.sender()` directly —
+/// the `Ctx` field stays `None` for them.
 pub struct Ctx<'a> {
+    sender: Option<u32>,
     _borrow: PhantomData<&'a ()>,
 }
 
@@ -347,8 +377,27 @@ impl Ctx<'_> {
     #[doc(hidden)]
     pub fn __new() -> Self {
         Ctx {
+            sender: None,
             _borrow: PhantomData,
         }
+    }
+
+    /// Not part of the public API; called only by the `#[handlers]`
+    /// dispatcher. Accepts `None` or `Some(Sender)` — the dispatcher
+    /// passes `mail.sender()` verbatim so component-origin and
+    /// broadcast mail (which have no reply target) land as `None`.
+    #[doc(hidden)]
+    pub fn __set_sender(&mut self, sender: Option<Sender>) {
+        self.sender = sender.map(|s| s.raw);
+    }
+
+    /// Reply handle for the mail currently being dispatched. `None`
+    /// for component-origin and broadcast-origin mail; `Some(Sender)`
+    /// when the inbound came from a Claude session. Pass the returned
+    /// `Sender` back to `Ctx::reply` to answer the originating
+    /// session (ADR-0013).
+    pub fn sender(&self) -> Option<Sender> {
+        self.sender.map(|raw| Sender { raw })
     }
 
     /// Send a single payload to `sink`. Typed wrapper around

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -4,13 +4,13 @@
 //! back to the originating Claude session — a minimal round-trip
 //! smoke test proving reply-to-sender works end-to-end over the hub.
 //!
-//! ADR-0027 shape: receive-side kinds (`Tick`, `Ping`) live in
-//! `type Kinds`; dispatch reads the per-component `KindTable` via
-//! `mail.is::<Tick>()` and `mail.decode_typed::<Ping>()`. Reply kind
-//! `Pong` keeps an explicit `KindId<Pong>` because `Ctx::reply` takes
-//! one (sender-side, type-driven reply is a follow-up).
+//! ADR-0033 shape: `#[handlers]` on the `impl Component` block emits
+//! both the dispatcher and the `aether.kinds.inputs` section entries.
+//! Per-handler rustdoc (with an optional `# Agent` section) feeds
+//! MCP via the same section so the harness sees typed capabilities
+//! plus author-written intent for each inbox.
 
-use aether_component::{Component, Ctx, InitCtx, KindId, Mail, Sink};
+use aether_component::{Component, Ctx, InitCtx, KindId, Sink, handlers};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
@@ -39,14 +39,21 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
     ],
 };
 
+/// Minimal end-to-end smoke component: draws a static triangle every
+/// tick and echoes pings back to the sender.
+///
+/// # Agent
+/// Watch the render output (via `capture_frame`) to see the triangle —
+/// if the frame goes solid color the tick path stalled. Send
+/// `aether.ping` with an incrementing `seq` to exercise reply-to-
+/// sender; the matching `aether.pong` lands back at your session.
 pub struct Hello {
     pong: KindId<Pong>,
     render: Sink<DrawTriangle>,
 }
 
+#[handlers]
 impl Component for Hello {
-    type Kinds = (Tick, Ping);
-
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Hello {
             pong: ctx.resolve::<Pong>(),
@@ -54,16 +61,28 @@ impl Component for Hello {
         }
     }
 
-    fn receive(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>) {
-        if mail.is::<Tick>() {
-            ctx.send(&self.render, &TRIANGLE);
-        } else if let Some(ping) = mail.decode_typed::<Ping>()
-            && let Some(sender) = mail.sender()
-        {
-            // Echo the sequence number so the caller can pair request
-            // and reply when multiple pings are in flight. No sender
-            // (component-origin or broadcast) silently drops the ping
-            // — there's nothing to reply to.
+    /// Emits the configured triangle to the render sink every tick.
+    ///
+    /// # Agent
+    /// Not useful to send manually — the substrate drives this from
+    /// its own tick loop. The effect is visible in `capture_frame`
+    /// output.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        ctx.send(&self.render, &TRIANGLE);
+    }
+
+    /// Replies to a ping with a pong carrying the same sequence
+    /// number. Silently drops pings that have no sender (component-
+    /// origin or broadcast) since there's nothing to reply to.
+    ///
+    /// # Agent
+    /// Send `{ seq: N }` and expect a matching pong at your session.
+    /// The seq echo lets you pair requests and replies when multiple
+    /// are in flight.
+    #[handler]
+    fn on_ping(&mut self, ctx: &mut Ctx<'_>, ping: Ping) {
+        if let Some(sender) = ctx.sender() {
             ctx.reply(sender, self.pong, &Pong { seq: ping.seq });
         }
     }

--- a/crates/aether-hub-protocol/src/canonical.rs
+++ b/crates/aether-hub-protocol/src/canonical.rs
@@ -783,6 +783,118 @@ const fn write_option_str(s: &Option<Cow<'static, str>>, out: &mut [u8], cursor:
     pos
 }
 
+// --- ADR-0033: const-fn encoders for `InputsRecord` ---
+//
+// The `#[handlers]` macro emits one postcard-compatible byte array per
+// handler/fallback/component-doc record, length-prefixed with the
+// section version tag and placed in the `aether.kinds.inputs` custom
+// section. Writing those bytes at const-eval time keeps everything in
+// `#[link_section]` statics without a runtime serializer on the guest.
+// The wire shape matches `postcard(InputsRecord)` byte-for-byte so the
+// substrate/hub reader can decode via `postcard::take_from_bytes`.
+
+/// Byte count of `val` in postcard's unsigned-varint encoding for u64.
+/// Extends `varint_u32_len` to the full u64 range needed by `Kind::ID`.
+pub const fn varint_u64_len(val: u64) -> usize {
+    let mut bytes = 1usize;
+    let mut v = val >> 7;
+    while v != 0 {
+        bytes += 1;
+        v >>= 7;
+    }
+    bytes
+}
+
+const fn write_varint_u64(mut val: u64, out: &mut [u8], cursor: usize) -> usize {
+    let mut pos = cursor;
+    while val >= 0x80 {
+        out[pos] = ((val & 0x7F) as u8) | 0x80;
+        val >>= 7;
+        pos += 1;
+    }
+    out[pos] = val as u8;
+    pos + 1
+}
+
+const fn option_borrowed_str_len(doc: Option<&str>) -> usize {
+    match doc {
+        None => 1, // discriminant byte only
+        Some(s) => 1 + str_len(s),
+    }
+}
+
+const fn write_option_borrowed_str(doc: Option<&str>, out: &mut [u8], cursor: usize) -> usize {
+    match doc {
+        None => {
+            out[cursor] = 0;
+            cursor + 1
+        }
+        Some(s) => {
+            out[cursor] = 1;
+            write_str(s, out, cursor + 1)
+        }
+    }
+}
+
+/// Byte length of a `Handler` record's postcard encoding. One-byte
+/// enum-variant tag (`0x00`) + `varint(id)` + `postcard(name)` +
+/// `option_str(doc)`.
+pub const fn inputs_handler_len(id: u64, name: &str, doc: Option<&str>) -> usize {
+    1 + varint_u64_len(id) + str_len(name) + option_borrowed_str_len(doc)
+}
+
+/// Serialize an `InputsRecord::Handler` into a fixed-size array sized
+/// by `inputs_handler_len`. Exact postcard wire shape for
+/// `InputsRecord::Handler { id, name, doc }`.
+pub const fn write_inputs_handler<const N: usize>(
+    id: u64,
+    name: &str,
+    doc: Option<&str>,
+) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut pos = 0usize;
+    out[pos] = 0; // variant tag: Handler
+    pos += 1;
+    pos = write_varint_u64(id, &mut out, pos);
+    pos = write_str(name, &mut out, pos);
+    pos = write_option_borrowed_str(doc, &mut out, pos);
+    // Silence "assigned but never read" warning on the final write.
+    let _ = pos;
+    out
+}
+
+/// Byte length of a `Fallback` record's postcard encoding.
+pub const fn inputs_fallback_len(doc: Option<&str>) -> usize {
+    1 + option_borrowed_str_len(doc)
+}
+
+/// Serialize an `InputsRecord::Fallback` into a fixed-size array.
+pub const fn write_inputs_fallback<const N: usize>(doc: Option<&str>) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut pos = 0usize;
+    out[pos] = 1; // variant tag: Fallback
+    pos += 1;
+    pos = write_option_borrowed_str(doc, &mut out, pos);
+    let _ = pos;
+    out
+}
+
+/// Byte length of a `Component` record's postcard encoding.
+pub const fn inputs_component_len(doc: &str) -> usize {
+    1 + str_len(doc)
+}
+
+/// Serialize an `InputsRecord::Component` into a fixed-size array.
+pub const fn write_inputs_component<const N: usize>(doc: &str) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut pos = 0usize;
+    out[pos] = 2; // variant tag: Component
+    pos += 1;
+    pos = write_str(doc, &mut out, pos);
+    let _ = pos;
+    out
+}
+
 #[cfg(test)]
 mod tests {
     //! The contract these tests pin: canonical bytes round-trip through
@@ -1040,5 +1152,84 @@ mod tests {
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&RESULT_LABELS);
         let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, RESULT_LABELS);
+    }
+
+    // ADR-0033: handler/fallback/component record encoders. Round-trip
+    // through `postcard::from_bytes::<InputsRecord>` so the substrate
+    // reader sees exactly the enum shapes the macro emits.
+    use crate::types::InputsRecord;
+
+    #[test]
+    fn inputs_handler_const_round_trips() {
+        const ID: u64 = 0xdead_beef_cafe_f00d;
+        const NAME: &str = "aether.tick";
+        const DOC: Option<&str> = Some("Not useful to send manually.");
+        const N: usize = inputs_handler_len(ID, NAME, DOC);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        match decoded {
+            InputsRecord::Handler { id, name, doc } => {
+                assert_eq!(id, ID);
+                assert_eq!(name, NAME);
+                assert_eq!(doc.as_deref(), DOC);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inputs_handler_without_doc_const_round_trips() {
+        const ID: u64 = 1;
+        const NAME: &str = "test.ping";
+        const DOC: Option<&str> = None;
+        const N: usize = inputs_handler_len(ID, NAME, DOC);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(
+            decoded,
+            InputsRecord::Handler {
+                id: ID,
+                name: NAME.into(),
+                doc: None,
+            }
+        );
+    }
+
+    #[test]
+    fn inputs_fallback_const_round_trips() {
+        const DOC: Option<&str> = Some("Forwards anything unrecognized.");
+        const N: usize = inputs_fallback_len(DOC);
+        const BYTES: [u8; N] = write_inputs_fallback::<N>(DOC);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(
+            decoded,
+            InputsRecord::Fallback {
+                doc: Some(DOC.unwrap().into()),
+            }
+        );
+    }
+
+    #[test]
+    fn inputs_component_const_round_trips() {
+        const DOC: &str = "Logs every input event to the broadcast sink.";
+        const N: usize = inputs_component_len(DOC);
+        const BYTES: [u8; N] = write_inputs_component::<N>(DOC);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(decoded, InputsRecord::Component { doc: DOC.into() });
+    }
+
+    #[test]
+    fn varint_u64_matches_postcard_encoding() {
+        // Spot-check the new u64 varint against postcard's own encoder.
+        // `varint_u64_len` / `write_varint_u64` must agree on every
+        // boundary — the macro relies on it for handler ids that are
+        // full 64-bit FNV hashes.
+        for &v in &[0u64, 1, 0x7f, 0x80, 0xff, 0xffff_ffff, u64::MAX] {
+            let mut out = [0u8; 10];
+            let used = write_varint_u64(v, &mut out, 0);
+            let postcard_bytes = postcard::to_allocvec(&v).unwrap();
+            assert_eq!(&out[..used], &postcard_bytes[..], "mismatch for {v:#x}");
+            assert_eq!(used, varint_u64_len(v), "len mismatch for {v:#x}");
+        }
     }
 }

--- a/crates/aether-hub-protocol/src/canonical.rs
+++ b/crates/aether-hub-protocol/src/canonical.rs
@@ -783,15 +783,14 @@ const fn write_option_str(s: &Option<Cow<'static, str>>, out: &mut [u8], cursor:
     pos
 }
 
-// --- ADR-0033: const-fn encoders for `InputsRecord` ---
-//
-// The `#[handlers]` macro emits one postcard-compatible byte array per
-// handler/fallback/component-doc record, length-prefixed with the
-// section version tag and placed in the `aether.kinds.inputs` custom
-// section. Writing those bytes at const-eval time keeps everything in
-// `#[link_section]` statics without a runtime serializer on the guest.
-// The wire shape matches `postcard(InputsRecord)` byte-for-byte so the
-// substrate/hub reader can decode via `postcard::take_from_bytes`.
+// ADR-0033: the `#[handlers]` macro emits one postcard-compatible
+// byte array per handler / fallback / component-doc record,
+// length-prefixed with the section version tag and placed in the
+// `aether.kinds.inputs` custom section. Writing those bytes at
+// const-eval time keeps everything in `#[link_section]` statics
+// without a runtime serializer on the guest. The wire shape matches
+// `postcard(InputsRecord)` byte-for-byte so the substrate/hub reader
+// can decode via `postcard::take_from_bytes`.
 
 /// Byte count of `val` in postcard's unsigned-varint encoding for u64.
 /// Extends `varint_u32_len` to the full u64 range needed by `Kind::ID`.

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -569,4 +569,96 @@ mod tests {
         assert_eq!(fields[0].name, "body");
         assert_eq!(fields[0].ty, SchemaType::String);
     }
+
+    // ADR-0033 — `InputsRecord` wire-format tests. The `#[handlers]`
+    // macro emits one `[INPUTS_SECTION_VERSION][postcard(InputsRecord)]`
+    // record per handler/fallback/component-doc, concatenated by the
+    // linker into the `aether.kinds.inputs` custom section. These tests
+    // pin the record shape both for the macro and for any downstream
+    // consumer that decodes the section.
+
+    #[test]
+    fn inputs_record_handler_roundtrip() {
+        let rec = InputsRecord::Handler {
+            id: 0xdead_beef_cafe_f00d,
+            name: "aether.tick".into(),
+            doc: Some("Not useful to send manually — the substrate drives this.".into()),
+        };
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), rec);
+    }
+
+    #[test]
+    fn inputs_record_handler_without_doc_roundtrip() {
+        let rec = InputsRecord::Handler {
+            id: 1,
+            name: "aether.key".into(),
+            doc: None,
+        };
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), rec);
+    }
+
+    #[test]
+    fn inputs_record_fallback_roundtrip() {
+        let rec = InputsRecord::Fallback {
+            doc: Some("Forwards anything unrecognized.".into()),
+        };
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), rec);
+
+        let bare = InputsRecord::Fallback { doc: None };
+        let bytes = postcard::to_allocvec(&bare).unwrap();
+        assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), bare);
+    }
+
+    #[test]
+    fn inputs_record_component_roundtrip() {
+        let rec = InputsRecord::Component {
+            doc: "Logs every input event to the broadcast sink.".into(),
+        };
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), rec);
+    }
+
+    #[test]
+    fn inputs_section_concatenated_records_streaming_decode() {
+        // Walk-the-section pattern the substrate reader will use:
+        // `[version][postcard(InputsRecord)]` back-to-back, consumed
+        // with `postcard::take_from_bytes` until the cursor empties.
+        let records = vec![
+            InputsRecord::Component {
+                doc: "A canary component.".into(),
+            },
+            InputsRecord::Handler {
+                id: 42,
+                name: "aether.tick".into(),
+                doc: Some("heartbeat".into()),
+            },
+            InputsRecord::Handler {
+                id: 0xff,
+                name: "test.ping".into(),
+                doc: None,
+            },
+            InputsRecord::Fallback {
+                doc: Some("catchall".into()),
+            },
+        ];
+
+        let mut section = Vec::new();
+        for rec in &records {
+            section.push(INPUTS_SECTION_VERSION);
+            section.extend(postcard::to_allocvec(rec).unwrap());
+        }
+
+        let mut cursor = &section[..];
+        let mut decoded = Vec::new();
+        while !cursor.is_empty() {
+            assert_eq!(cursor[0], INPUTS_SECTION_VERSION);
+            let (rec, rest) = postcard::take_from_bytes::<InputsRecord>(&cursor[1..]).unwrap();
+            decoded.push(rec);
+            cursor = rest;
+        }
+        assert_eq!(decoded, records);
+    }
 }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -701,6 +701,39 @@ pub struct KindLabels {
     pub root: LabelNode,
 }
 
+/// One record in the `aether.kinds.inputs` section (ADR-0033). The
+/// enum tag discriminates handler vs fallback vs component-level doc
+/// so the reader can classify before decoding further. `id` on a
+/// `Handler` is the compile-time `K::ID` (ADR-0030); the hub reuses
+/// it rather than re-deriving from the name. `doc` values come from
+/// rustdoc `///` comments filtered through an optional `# Agent`
+/// section — `None` when the source had no comment at all, `Some` of
+/// the filtered body otherwise.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InputsRecord {
+    /// A `#[handler]` method's advertised capability.
+    Handler {
+        id: u64,
+        name: Cow<'static, str>,
+        doc: Option<Cow<'static, str>>,
+    },
+    /// A `#[fallback]` method's presence and optional description.
+    Fallback { doc: Option<Cow<'static, str>> },
+    /// Component-wide rustdoc lifted from the `#[handlers]` impl block.
+    Component { doc: Cow<'static, str> },
+}
+
+/// Custom-section name for the inputs manifest (ADR-0033). Paired
+/// with `aether.kinds` and `aether.kinds.labels`; together they form
+/// the component's full declared surface — kinds introduced + kinds
+/// handled.
+pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
+
+/// Version byte prefixing every record in the `aether.kinds.inputs`
+/// section. Follows ADR-0028's per-record versioning convention —
+/// unknown versions abort the read rather than silently skip.
+pub const INPUTS_SECTION_VERSION: u8 = 0x01;
+
 /// Hub's reply to `Hello`. Carries the `EngineId` the engine should
 /// treat as its identity for the rest of this connection.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -26,7 +26,27 @@ use bytemuck::{Pod, Zeroable};
 
 /// Per-frame signal from the substrate's frame loop. Empty payload —
 /// elapsed-time is parked until a subscriber actually needs it.
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+///
+/// ADR-0033 handler dispatch (`#[handlers]` synthesized `fn receive`)
+/// decodes every typed handler via `Mail::decode_typed::<K>()`, which
+/// requires `K: AnyBitPattern`. Zero-sized unit kinds like `Tick`
+/// trivially satisfy that through `Pod` + `Zeroable` — no padding,
+/// no uninitialized bits. Adding the derives preserves backward
+/// compatibility with the ADR-0027 `mail.is::<Tick>()` path (which
+/// only needed `Kind + 'static`) while unlocking typed dispatch.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
 #[kind(name = "aether.tick", input)]
 pub struct Tick;
 
@@ -51,7 +71,21 @@ pub struct Key {
 }
 
 /// A mouse-button press. No payload today — which button isn't tracked.
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+/// Zero-sized but derives `Pod` / `Zeroable` for the same reason as
+/// `Tick` — see the note on that type.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
 #[kind(name = "aether.mouse_button", input)]
 pub struct MouseButton;
 

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -37,8 +37,9 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-    Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, GenericArgument, Lit, Meta,
-    PathArguments, Type, parse_macro_input, spanned::Spanned,
+    Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
+    GenericArgument, ImplItem, ItemImpl, Lit, Meta, PathArguments, Signature, Type,
+    parse_macro_input, spanned::Spanned,
 };
 
 #[proc_macro_derive(Kind, attributes(kind))]
@@ -546,4 +547,556 @@ fn to_screaming_snake_case(s: &str) -> String {
         out.push(ch.to_ascii_uppercase());
     }
     out
+}
+
+// ====================================================================
+// ADR-0033: `#[handlers]` attribute macro
+// ====================================================================
+//
+// Applied to `impl Component for C` blocks. Reshapes the impl so that
+// `#[handler] fn on_X(&mut self, &mut Ctx, K)` methods + an optional
+// `#[fallback]` method become both (a) dispatcher arms on a synthesized
+// `Component::receive` and (b) per-record statics in the
+// `aether.kinds.inputs` custom section (hub-facing capability
+// advertisement, ADR-0033). Non-trait helper methods migrate to a
+// sibling inherent impl since `impl Trait for Type` can't host them.
+//
+// The `type Kinds = (K1, K2, ...)` associated type is synthesized from
+// the handler set so the existing ADR-0027 / ADR-0030 init walker
+// (`KindList::resolve_all`) populates the per-component `KindTable` and
+// auto-subscribes every `K::IS_INPUT` kind unchanged.
+//
+// Rustdoc capture: `///` comments on the impl block (component-level),
+// each `#[handler]`, and each `#[fallback]` become MCP-facing prose. If
+// a `# Agent` section is present, only that section's body is sent;
+// otherwise the full doc is sent. `cargo doc` still renders the whole
+// comment — the `# Agent` heading sits alongside `# Safety`/`# Examples`
+// as a conventional reader-specific section.
+
+#[proc_macro_attribute]
+pub fn handlers(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[handlers] takes no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let item = parse_macro_input!(item as ItemImpl);
+    match expand_handlers(item) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn handler(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    // Real logic runs inside `#[handlers]` (the enclosing impl-block
+    // attribute scans for #[handler] markers). This standalone shim
+    // only exists so rustc accepts `#[handler]` syntactically outside
+    // macro expansion and so rust-analyzer doesn't redline it.
+    syn::Error::new(
+        proc_macro2::Span::call_site(),
+        "#[handler] may only appear inside a `#[handlers] impl Component for T` block",
+    )
+    .to_compile_error()
+    .into()
+}
+
+#[proc_macro_attribute]
+pub fn fallback(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    // Same story as `#[handler]` — marker attribute consumed by the
+    // enclosing `#[handlers]` scan. Standalone invocation is a
+    // compile-time error.
+    syn::Error::new(
+        proc_macro2::Span::call_site(),
+        "#[fallback] may only appear inside a `#[handlers] impl Component for T` block",
+    )
+    .to_compile_error()
+    .into()
+}
+
+struct HandlerFn {
+    method: syn::ImplItemFn,
+    kind_ty: Type,
+    agent_doc: Option<String>,
+}
+
+struct FallbackFn {
+    method: syn::ImplItemFn,
+    agent_doc: Option<String>,
+}
+
+fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
+    if item.trait_.is_none() {
+        return Err(syn::Error::new_spanned(
+            &item,
+            "#[handlers] must wrap `impl Component for T` — not an inherent impl",
+        ));
+    }
+    let self_ty = &item.self_ty;
+    let generics = &item.generics;
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let trait_path = item
+        .trait_
+        .as_ref()
+        .map(|(_, p, _)| p)
+        .expect("trait_ checked above");
+
+    let component_doc = extract_agent_doc(&item.attrs);
+
+    let mut init_method: Option<syn::ImplItemFn> = None;
+    let mut lifecycle_methods: Vec<syn::ImplItemFn> = Vec::new();
+    let mut handlers: Vec<HandlerFn> = Vec::new();
+    let mut fallback: Option<FallbackFn> = None;
+    let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
+
+    for impl_item in item.items {
+        match impl_item {
+            ImplItem::Type(it) if it.ident == "Kinds" => {
+                return Err(syn::Error::new_spanned(
+                    it,
+                    "#[handlers] synthesizes `type Kinds` from the #[handler] methods; remove this declaration",
+                ));
+            }
+            ImplItem::Fn(mut f) => {
+                let name = f.sig.ident.to_string();
+                let handler_attr_idx = f.attrs.iter().position(|a| a.path().is_ident("handler"));
+                let fallback_attr_idx = f.attrs.iter().position(|a| a.path().is_ident("fallback"));
+
+                if handler_attr_idx.is_some() && fallback_attr_idx.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &f,
+                        "method cannot be both #[handler] and #[fallback]",
+                    ));
+                }
+
+                if let Some(idx) = handler_attr_idx {
+                    let kind_ty = extract_handler_kind_type(&f.sig)?;
+                    let agent_doc = extract_agent_doc(&f.attrs);
+                    f.attrs.remove(idx);
+                    handlers.push(HandlerFn {
+                        method: f,
+                        kind_ty,
+                        agent_doc,
+                    });
+                } else if let Some(idx) = fallback_attr_idx {
+                    if fallback.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            &f,
+                            "at most one #[fallback] method per component",
+                        ));
+                    }
+                    validate_fallback_sig(&f.sig)?;
+                    let agent_doc = extract_agent_doc(&f.attrs);
+                    f.attrs.remove(idx);
+                    fallback = Some(FallbackFn {
+                        method: f,
+                        agent_doc,
+                    });
+                } else if name == "init" {
+                    init_method = Some(f);
+                } else if matches!(name.as_str(), "on_replace" | "on_drop" | "on_rehydrate") {
+                    lifecycle_methods.push(f);
+                } else if name == "receive" {
+                    return Err(syn::Error::new_spanned(
+                        &f,
+                        "#[handlers] synthesizes `fn receive`; remove this definition",
+                    ));
+                } else {
+                    helpers.push(f);
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unexpected item in #[handlers] impl (only fns and the synthesized `type Kinds` are allowed)",
+                ));
+            }
+        }
+    }
+
+    let init_method = init_method.ok_or_else(|| {
+        syn::Error::new_spanned(
+            self_ty,
+            "#[handlers] requires `fn init(ctx: &mut InitCtx<'_>) -> Self`",
+        )
+    })?;
+
+    if handlers.is_empty() && fallback.is_none() {
+        return Err(syn::Error::new_spanned(
+            self_ty,
+            "#[handlers] requires at least one #[handler] method or a #[fallback] method",
+        ));
+    }
+
+    let kinds_typelist = build_kinds_typelist(&handlers);
+    let receive_body = build_receive_body(&handlers, fallback.as_ref());
+
+    let handler_methods_tokens = handlers.iter().map(|h| &h.method);
+    let fallback_method_tokens = fallback.as_ref().map(|f| &f.method);
+    let helper_methods_tokens = helpers.iter();
+
+    let statics =
+        build_inputs_section_statics(self_ty, &handlers, fallback.as_ref(), &component_doc);
+
+    Ok(quote! {
+        impl #impl_generics #trait_path for #self_ty #where_clause {
+            type Kinds = #kinds_typelist;
+
+            #init_method
+
+            fn receive(
+                &mut self,
+                __aether_ctx: &mut ::aether_component::Ctx<'_>,
+                __aether_mail: ::aether_component::Mail<'_>,
+            ) {
+                #receive_body
+            }
+
+            #(#lifecycle_methods)*
+        }
+
+        impl #impl_generics #self_ty #where_clause {
+            #(#handler_methods_tokens)*
+            #fallback_method_tokens
+            #(#helper_methods_tokens)*
+        }
+
+        #statics
+    })
+}
+
+/// Extract `K` from a handler method's third parameter (`arg: K`).
+/// Accepts any type path — trait-bound validation lives in the
+/// generated call site: the `mail.decode_typed::<K>()` in the
+/// synthesized dispatcher requires `K: Kind + AnyBitPattern + 'static`,
+/// so unsupported types surface as a trait-bound error pointing at
+/// the user's signature.
+fn extract_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
+    if sig.inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "#[handler] method must have signature `(&mut self, ctx: &mut Ctx<'_>, arg: K)`",
+        ));
+    }
+    let first = &sig.inputs[0];
+    if !matches!(first, FnArg::Receiver(_)) {
+        return Err(syn::Error::new_spanned(
+            first,
+            "#[handler] first parameter must be `&mut self`",
+        ));
+    }
+    let third = &sig.inputs[2];
+    let FnArg::Typed(pt) = third else {
+        return Err(syn::Error::new_spanned(
+            third,
+            "#[handler] third parameter must be a typed `arg: K`",
+        ));
+    };
+    Ok((*pt.ty).clone())
+}
+
+/// Soft validation that a `#[fallback]` method's signature is shaped
+/// for `Mail<'_>`. We don't do deep type equality against
+/// `::aether_component::Mail<'_>` — the synthesized dispatcher's call
+/// to `self.<fallback>(ctx, mail)` will type-check at the call site
+/// and produce a clear error if the user wrote the wrong arg type.
+fn validate_fallback_sig(sig: &Signature) -> syn::Result<()> {
+    if sig.inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "#[fallback] method must have signature `(&mut self, ctx: &mut Ctx<'_>, mail: Mail<'_>)`",
+        ));
+    }
+    let first = &sig.inputs[0];
+    if !matches!(first, FnArg::Receiver(_)) {
+        return Err(syn::Error::new_spanned(
+            first,
+            "#[fallback] first parameter must be `&mut self`",
+        ));
+    }
+    let third = &sig.inputs[2];
+    if !matches!(third, FnArg::Typed(_)) {
+        return Err(syn::Error::new_spanned(
+            third,
+            "#[fallback] third parameter must be `mail: Mail<'_>`",
+        ));
+    }
+    Ok(())
+}
+
+/// Build the `type Kinds = (K1, K2, ...)` right-hand side. Matches
+/// ADR-0027's typelist so `KindList::resolve_all` populates the
+/// per-component `KindTable` and auto-subscribes input kinds without
+/// any macro-side duplication of that walker.
+fn build_kinds_typelist(handlers: &[HandlerFn]) -> TokenStream2 {
+    if handlers.is_empty() {
+        return quote! { () };
+    }
+    let tys = handlers.iter().map(|h| &h.kind_ty);
+    quote! { ( #( #tys, )* ) }
+}
+
+/// Synthesized body of `fn receive`. Compares `mail.kind()` against
+/// each `<K as Kind>::ID` const; on match, decodes the kind via
+/// `decode_typed::<K>()` (same runtime path the ADR-0027 helpers use)
+/// and calls the inherent-impl method the `#[handler]` annotation
+/// produced. When a `#[fallback]` exists, unhandled kinds land there;
+/// otherwise unhandled kinds silently drop (strict receiver).
+fn build_receive_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) -> TokenStream2 {
+    let arms = handlers.iter().map(|h| {
+        let k = &h.kind_ty;
+        let method = &h.method.sig.ident;
+        quote! {
+            if __aether_kind == <#k as ::aether_component::__macro_internals::Kind>::ID {
+                if let ::core::option::Option::Some(__aether_decoded) =
+                    __aether_mail.decode_typed::<#k>()
+                {
+                    self.#method(__aether_ctx, __aether_decoded);
+                }
+                return;
+            }
+        }
+    });
+
+    let fallback_call = match fallback {
+        Some(f) => {
+            let method = &f.method.sig.ident;
+            quote! { self.#method(__aether_ctx, __aether_mail); }
+        }
+        None => quote! { /* strict receiver: unhandled kinds drop */ },
+    };
+
+    quote! {
+        let __aether_kind = __aether_mail.kind();
+        __aether_ctx.__set_sender(__aether_mail.sender());
+        #( #arms )*
+        #fallback_call
+    }
+}
+
+/// Emit the `#[link_section = "aether.kinds.inputs"]` statics — one
+/// per `#[handler]`, one for `#[fallback]` (when present), and one
+/// for the component-level doc (when present). Each static's bytes
+/// are `[INPUTS_SECTION_VERSION, ..postcard(InputsRecord)..]`
+/// assembled at const-eval via the hub-protocol const-fn encoders.
+/// Statics are gated to `target_arch = "wasm32"` to keep the bytes
+/// out of native test executables (same pattern as the existing
+/// `aether.kinds` emission in the `Kind` derive).
+fn build_inputs_section_statics(
+    self_ty: &Type,
+    handlers: &[HandlerFn],
+    fallback: Option<&FallbackFn>,
+    component_doc: &Option<String>,
+) -> TokenStream2 {
+    let self_ty_hint = type_hint(self_ty);
+
+    let handler_statics = handlers.iter().enumerate().map(|(idx, h)| {
+        let len_ident = quote::format_ident!(
+            "__AETHER_INPUT_HANDLER_{}_{}_LEN",
+            self_ty_hint,
+            idx
+        );
+        let bytes_ident = quote::format_ident!(
+            "__AETHER_INPUT_HANDLER_{}_{}_BYTES",
+            self_ty_hint,
+            idx
+        );
+        let section_ident = quote::format_ident!(
+            "__AETHER_INPUT_HANDLER_{}_{}_SECTION",
+            self_ty_hint,
+            idx
+        );
+        let k = &h.kind_ty;
+        let doc_expr = option_str_token(&h.agent_doc);
+        quote! {
+            const #len_ident: usize =
+                ::aether_component::__macro_internals::canonical::inputs_handler_len(
+                    <#k as ::aether_component::__macro_internals::Kind>::ID,
+                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                    #doc_expr,
+                );
+            const #bytes_ident: [u8; #len_ident] =
+                ::aether_component::__macro_internals::canonical::write_inputs_handler::<#len_ident>(
+                    <#k as ::aether_component::__macro_internals::Kind>::ID,
+                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                    #doc_expr,
+                );
+            #[cfg(target_arch = "wasm32")]
+            #[used]
+            #[unsafe(link_section = "aether.kinds.inputs")]
+            static #section_ident: [u8; #len_ident + 1] = {
+                let mut out = [0u8; #len_ident + 1];
+                out[0] = 0x01;
+                let mut i = 0;
+                while i < #len_ident {
+                    out[i + 1] = #bytes_ident[i];
+                    i += 1;
+                }
+                out
+            };
+        }
+    });
+
+    let fallback_static = fallback.map(|f| {
+        let len_ident = quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_LEN", self_ty_hint);
+        let bytes_ident = quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_BYTES", self_ty_hint);
+        let section_ident =
+            quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_SECTION", self_ty_hint);
+        let doc_expr = option_str_token(&f.agent_doc);
+        quote! {
+            const #len_ident: usize =
+                ::aether_component::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
+            const #bytes_ident: [u8; #len_ident] =
+                ::aether_component::__macro_internals::canonical::write_inputs_fallback::<#len_ident>(#doc_expr);
+            #[cfg(target_arch = "wasm32")]
+            #[used]
+            #[unsafe(link_section = "aether.kinds.inputs")]
+            static #section_ident: [u8; #len_ident + 1] = {
+                let mut out = [0u8; #len_ident + 1];
+                out[0] = 0x01;
+                let mut i = 0;
+                while i < #len_ident {
+                    out[i + 1] = #bytes_ident[i];
+                    i += 1;
+                }
+                out
+            };
+        }
+    });
+
+    let component_static = component_doc.as_ref().map(|doc| {
+        let len_ident = quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_LEN", self_ty_hint);
+        let bytes_ident = quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_BYTES", self_ty_hint);
+        let section_ident =
+            quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_SECTION", self_ty_hint);
+        let doc_lit = doc.as_str();
+        quote! {
+            const #len_ident: usize =
+                ::aether_component::__macro_internals::canonical::inputs_component_len(#doc_lit);
+            const #bytes_ident: [u8; #len_ident] =
+                ::aether_component::__macro_internals::canonical::write_inputs_component::<#len_ident>(#doc_lit);
+            #[cfg(target_arch = "wasm32")]
+            #[used]
+            #[unsafe(link_section = "aether.kinds.inputs")]
+            static #section_ident: [u8; #len_ident + 1] = {
+                let mut out = [0u8; #len_ident + 1];
+                out[0] = 0x01;
+                let mut i = 0;
+                while i < #len_ident {
+                    out[i + 1] = #bytes_ident[i];
+                    i += 1;
+                }
+                out
+            };
+        }
+    });
+
+    quote! {
+        #(#handler_statics)*
+        #fallback_static
+        #component_static
+    }
+}
+
+/// Produce an identifier-safe hint from the Self type. For a plain
+/// type path (`InputLogger`, `my_crate::Hello`), use the last segment;
+/// otherwise fall back to "COMPONENT" so the statics still compile.
+fn type_hint(ty: &Type) -> syn::Ident {
+    if let Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+    {
+        return syn::Ident::new(
+            &to_screaming_snake_case(&seg.ident.to_string()),
+            seg.ident.span(),
+        );
+    }
+    syn::Ident::new("COMPONENT", proc_macro2::Span::call_site())
+}
+
+/// Produce the token stream for `Option<&'static str>` from an
+/// `Option<String>` captured at macro expansion. Used for every
+/// rustdoc-sourced doc field.
+fn option_str_token(doc: &Option<String>) -> TokenStream2 {
+    match doc {
+        Some(s) => {
+            let lit = s.as_str();
+            quote! { ::core::option::Option::Some(#lit) }
+        }
+        None => quote! { ::core::option::Option::None },
+    }
+}
+
+/// Extract rustdoc from a set of attributes and filter through the
+/// `# Agent` section convention. Returns `None` when there's no
+/// rustdoc at all; `Some(body)` otherwise — `body` is the `# Agent`
+/// section's content if one is present, or the full (trimmed) doc
+/// text if not.
+///
+/// Rustdoc `///` comments lower to `#[doc = "text"]` attributes with
+/// one attribute per source line. The text retains its leading space
+/// (`/// foo` → `" foo"`), which we preserve verbatim for the joined
+/// output — stripping it would alter the agent's view of formatted
+/// doc blocks and obscure intentional indentation.
+fn extract_agent_doc(attrs: &[Attribute]) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        let Meta::NameValue(nv) = &attr.meta else {
+            continue;
+        };
+        let Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) = &nv.value
+        else {
+            continue;
+        };
+        lines.push(s.value());
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    let full = lines.join("\n");
+    let full_trimmed = full.trim();
+    if full_trimmed.is_empty() {
+        return None;
+    }
+
+    // Scan for a `# Agent` heading (conventional rustdoc section
+    // heading, top-level `#` followed by space). Capture everything
+    // until the next top-level heading or end-of-doc.
+    let mut in_agent = false;
+    let mut found_agent = false;
+    let mut agent_lines: Vec<&str> = Vec::new();
+    for line in full.lines() {
+        let trimmed = line.trim_start();
+        let starts_h1 = trimmed.starts_with("# ") && !trimmed.starts_with("## ");
+        if starts_h1 {
+            if in_agent {
+                // A new top-level heading ends the Agent section.
+                break;
+            }
+            let heading = trimmed.trim_start_matches('#').trim();
+            if heading.eq_ignore_ascii_case("Agent") {
+                in_agent = true;
+                found_agent = true;
+                continue;
+            }
+            continue;
+        }
+        if in_agent {
+            agent_lines.push(line);
+        }
+    }
+
+    if found_agent {
+        let s = agent_lines.join("\n").trim().to_string();
+        if s.is_empty() { None } else { Some(s) }
+    } else {
+        Some(full_trimmed.to_string())
+    }
 }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -549,17 +549,14 @@ fn to_screaming_snake_case(s: &str) -> String {
     out
 }
 
-// ====================================================================
-// ADR-0033: `#[handlers]` attribute macro
-// ====================================================================
-//
-// Applied to `impl Component for C` blocks. Reshapes the impl so that
-// `#[handler] fn on_X(&mut self, &mut Ctx, K)` methods + an optional
-// `#[fallback]` method become both (a) dispatcher arms on a synthesized
-// `Component::receive` and (b) per-record statics in the
-// `aether.kinds.inputs` custom section (hub-facing capability
-// advertisement, ADR-0033). Non-trait helper methods migrate to a
-// sibling inherent impl since `impl Trait for Type` can't host them.
+// ADR-0033: `#[handlers]` applied to `impl Component for C` blocks.
+// Reshapes the impl so `#[handler] fn on_X(&mut self, &mut Ctx, K)`
+// methods plus an optional `#[fallback]` method become both (a)
+// dispatcher arms on a synthesized `Component::receive` and (b) per-
+// record statics in the `aether.kinds.inputs` custom section (hub-
+// facing capability advertisement). Non-trait helper methods migrate
+// to a sibling inherent impl since `impl Trait for Type` can't host
+// them.
 //
 // The `type Kinds = (K1, K2, ...)` associated type is synthesized from
 // the handler set so the existing ADR-0027 / ADR-0030 init walker

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -124,9 +124,14 @@ pub const fn fnv1a_64_bytes(bytes: &[u8]) -> u64 {
 
 /// Re-exported derive macros from `aether-mail-derive`. Behind the
 /// `derive` feature so `cargo build` on a guest that hand-writes
-/// `impl Kind` doesn't pay the proc-macro compile cost.
+/// `impl Kind` doesn't pay the proc-macro compile cost. The
+/// `#[handlers]` / `#[handler]` / `#[fallback]` attribute macros
+/// (ADR-0033) ride in the same crate because adding a second proc-
+/// macro crate would double consumer compile cost for no separation
+/// gain — both derives and attributes expand into the same runtime
+/// surface.
 #[cfg(feature = "derive")]
-pub use aether_mail_derive::{Kind, Schema};
+pub use aether_mail_derive::{Kind, Schema, fallback, handler, handlers};
 
 /// ADR-0019 schema producer. The substrate (and tooling that builds
 /// hub descriptors) reads `<T as Schema>::SCHEMA` — a compile-time


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0033. Ships the `#[handlers]` attribute macro end-to-end: `impl Component` blocks declare typed handlers with `#[handler]` / `#[fallback]`, and the macro synthesizes the dispatcher plus an `aether.kinds.inputs` custom section that advertises each handler's id, name, and rustdoc to the hub (Phase 2 will add the MCP surface that reads it).

- c1 `feat(hub-protocol):` types + const-fn encoders for the new section. `InputsRecord` enum (Handler / Fallback / Component), plus varint-u64 and postcard-compatible writers that compile to fixed byte arrays at const-eval. Round-trip tests against `postcard::from_bytes::<InputsRecord>`.
- c2 `feat(component):` the `#[handlers]` macro itself — scans the impl block, extracts K from each handler's third parameter, parses rustdoc with a conventional `# Agent` section filter, synthesizes `type Kinds = (...)` + `fn receive` dispatcher, moves non-trait methods to a sibling inherent impl, emits `#[link_section]` statics. Adds `Ctx::sender()` so typed handlers can still `ctx.reply(...)` after losing direct `Mail<'_>` access.
- c3 `feat(hello,kinds):` hello-component migrated to the new shape. `Tick` / `MouseButton` grow Pod + Zeroable derives (ZSTs trivially qualify) so the decode path works for unit kinds too.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build -p aether-hello-component --target wasm32-unknown-unknown --release` produces a wasm with a 325-byte `aether.kinds.inputs` section.
- [x] MCP smoke: `spawn_substrate` → `load_component` → `receive_mail` shows triangles climbing 0 → 89 → 209 → 329 (tick dispatch works); `send_mail aether.ping{seq:42}` → `receive_mail` returns `aether.pong{seq:42} broadcast:false origin:"hello"` (reply-to-sender works); `capture_frame` shows the rendered triangle.
- [ ] Follow-up (Phase 2): hub reads `aether.kinds.inputs` and exposes it via a new `describe_component` MCP tool.
- [ ] Follow-up (Phase 3): migrate remaining components (echoer, caller, input_logger) and retire `type Kinds` / `Component::receive` / `KindList` / `KindTable`.