### PR TITLE
docs(adr): flip 0028, 0029, 0031, 0032 to accepted

### DIFF
--- a/docs/adr/0028-component-embedded-kind-manifest.md
+++ b/docs/adr/0028-component-embedded-kind-manifest.md
@@ -1,7 +1,8 @@
 # ADR-0028: Component-embedded kind manifest
 
-- **Status:** Proposed
+- **Status:** Accepted (phases 1–2 shipped)
 - **Date:** 2026-04-19
+- **Accepted:** 2026-04-19
 
 ## Context
 

--- a/docs/adr/0029-name-derived-mailbox-ids.md
+++ b/docs/adr/0029-name-derived-mailbox-ids.md
@@ -1,7 +1,8 @@
 # ADR-0029: Name-derived MailboxIds
 
-- **Status:** Proposed
+- **Status:** Accepted (phases 1–2 shipped)
 - **Date:** 2026-04-19
+- **Accepted:** 2026-04-20
 
 ## Context
 

--- a/docs/adr/0031-const-constructible-schema-representation.md
+++ b/docs/adr/0031-const-constructible-schema-representation.md
@@ -1,7 +1,8 @@
 # ADR-0031: Const-constructible schema representation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-20
+- **Accepted:** 2026-04-20
 
 ## Context
 

--- a/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md
+++ b/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md
@@ -1,7 +1,8 @@
 # ADR-0032: Canonical schema bytes and labels sidecar
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-20
+- **Accepted:** 2026-04-20
 
 ## Context
 


### PR DESCRIPTION
## Summary

Doc-drift sweep. Four ADRs shipped already but their status headers never got updated from Proposed. Accepted dates taken from each ADR's final shipping commit.

- ADR-0028 Component-embedded kind manifest — Accepted (phases 1–2 shipped), 2026-04-19 (PR #127).
- ADR-0029 Name-derived MailboxIds — Accepted (phases 1–2 shipped), 2026-04-20 (PR #130).
- ADR-0031 Const-constructible schema representation — Accepted, 2026-04-20 (PR #134).
- ADR-0032 Canonical schema bytes + labels sidecar — Accepted, 2026-04-20 (PR #135).

ADR-0025 (art direction) and ADR-0026 (primitive-composition DSL) stay Proposed — those are genuinely parked render architecture awaiting a second drawing component to force the question.

## Test plan

- [x] Header-only change, no code impact.