### PR TITLE
refactor(substrate,core): dispatch sinks by kind id instead of kind name

### DIFF
--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -217,7 +217,7 @@ pub struct ControlPlane {
 /// The chassis is responsible for decoding, replying (via the
 /// outbound it constructed with), and any mail orchestration.
 pub type ChassisControlHandler =
-    Arc<dyn Fn(&str, aether_hub_protocol::SessionToken, &[u8]) + Send + Sync>;
+    Arc<dyn Fn(u64, &str, aether_hub_protocol::SessionToken, &[u8]) + Send + Sync>;
 
 impl ControlPlane {
     /// Build the sink handler that should be registered against the
@@ -226,34 +226,41 @@ impl ControlPlane {
     /// the caller can discard the `ControlPlane` after registration.
     pub fn into_sink_handler(self) -> SinkHandler {
         Arc::new(
-            move |kind_name: &str,
+            move |kind_id: u64,
+                  kind_name: &str,
                   _origin: Option<&str>,
                   sender: aether_hub_protocol::SessionToken,
                   bytes: &[u8],
                   _count: u32| {
-                self.dispatch(kind_name, sender, bytes);
+                self.dispatch(kind_id, kind_name, sender, bytes);
             },
         )
     }
 
-    fn dispatch(&self, kind_name: &str, sender: aether_hub_protocol::SessionToken, bytes: &[u8]) {
-        if kind_name == LoadComponent::NAME {
+    fn dispatch(
+        &self,
+        kind_id: u64,
+        kind_name: &str,
+        sender: aether_hub_protocol::SessionToken,
+        bytes: &[u8],
+    ) {
+        if kind_id == LoadComponent::ID {
             let result = self.handle_load(bytes);
             self.outbound.send_reply(sender, &result);
-        } else if kind_name == DropComponent::NAME {
+        } else if kind_id == DropComponent::ID {
             let result = self.handle_drop(bytes);
             self.outbound.send_reply(sender, &result);
-        } else if kind_name == ReplaceComponent::NAME {
+        } else if kind_id == ReplaceComponent::ID {
             let result = self.handle_replace(bytes);
             self.outbound.send_reply(sender, &result);
-        } else if kind_name == SubscribeInput::NAME {
+        } else if kind_id == SubscribeInput::ID {
             let result = self.handle_subscribe(bytes);
             self.outbound.send_reply(sender, &result);
-        } else if kind_name == UnsubscribeInput::NAME {
+        } else if kind_id == UnsubscribeInput::ID {
             let result = self.handle_unsubscribe(bytes);
             self.outbound.send_reply(sender, &result);
         } else if let Some(handler) = &self.chassis_handler {
-            handler(kind_name, sender, bytes);
+            handler(kind_id, kind_name, sender, bytes);
         } else {
             tracing::warn!(
                 target: "aether_substrate::control",
@@ -1248,7 +1255,12 @@ mod tests {
         let plane = make_plane();
         // No panic; no outbound reply. Unknown kind arriving at the
         // control mailbox just logs and moves on.
-        plane.dispatch("aether.control.does_not_exist", SessionToken::NIL, &[]);
+        plane.dispatch(
+            0xdead_beef_dead_beef,
+            "aether.control.does_not_exist",
+            SessionToken::NIL,
+            &[],
+        );
     }
 
     #[test]
@@ -1519,7 +1531,7 @@ mod tests {
         let plane = make_plane();
         let sink = plane
             .registry
-            .register_sink("some.sink", Arc::new(|_, _, _, _, _| {}));
+            .register_sink("some.sink", Arc::new(|_, _, _, _, _, _| {}));
         assert!(matches!(
             do_subscribe(&plane, sink.0, InputStream::Tick),
             SubscribeInputResult::Err { .. }
@@ -1599,6 +1611,7 @@ mod tests {
         let plane = make_plane();
         let id = load_blank(&plane, "listener");
         plane.dispatch(
+            SubscribeInput::ID,
             SubscribeInput::NAME,
             SessionToken::NIL,
             &postcard::to_allocvec(&SubscribeInput {
@@ -1608,6 +1621,7 @@ mod tests {
             .unwrap(),
         );
         plane.dispatch(
+            UnsubscribeInput::ID,
             UnsubscribeInput::NAME,
             SessionToken::NIL,
             &postcard::to_allocvec(&UnsubscribeInput {
@@ -1706,7 +1720,7 @@ mod tests {
         let counter_for_sink = Arc::clone(&counter);
         let sink_id = plane.registry.register_sink(
             "drain-flush-sink",
-            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+            Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
                 counter_for_sink.fetch_add(count, Ordering::SeqCst);
             }),
         );
@@ -1784,7 +1798,7 @@ mod tests {
         let counter_for_sink = Arc::clone(&counter);
         let sink_id = plane.registry.register_sink(
             "drain-timeout-sink",
-            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+            Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
                 counter_for_sink.fetch_add(count, Ordering::SeqCst);
             }),
         );

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -109,6 +109,7 @@ impl SubstrateCtx {
                 // `NIL` — component sends never have a reply-to target.
                 let origin = self.registry.mailbox_name(self.sender);
                 handler(
+                    kind,
                     &kind_name,
                     origin.as_deref(),
                     SessionToken::NIL,

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -21,15 +21,17 @@ use crate::mail::MailboxId;
 
 /// Handler invoked when mail is delivered to a substrate-owned sink.
 /// Called on a scheduler worker thread; must be `Send + Sync`.
-/// Arguments: kind name (resolved by the dispatcher so sinks don't
-/// need a reverse lookup), the sending mailbox's registered name if
-/// the mail came from a component (`None` for substrate-core pushes
-/// with no sending mailbox, per ADR-0011), the originating Claude
-/// session token for hub-inbound mail (or `SessionToken::NIL` for
-/// substrate-local mail) per ADR-0008's reply-to-sender primitive,
-/// payload bytes, and the kind-implied count.
+/// Arguments: the kind's id (`K::ID`, ADR-0030 schema hash), the
+/// kind's registered name (resolved by the dispatcher for diagnostic
+/// logging — sinks that only match on id can ignore it), the sending
+/// mailbox's registered name if the mail came from a component
+/// (`None` for substrate-core pushes with no sending mailbox, per
+/// ADR-0011), the originating Claude session token for hub-inbound
+/// mail (or `SessionToken::NIL` for substrate-local mail) per
+/// ADR-0008's reply-to-sender primitive, payload bytes, and the
+/// kind-implied count.
 pub type SinkHandler =
-    Arc<dyn Fn(&str, Option<&str>, SessionToken, &[u8], u32) + Send + Sync + 'static>;
+    Arc<dyn Fn(u64, &str, Option<&str>, SessionToken, &[u8], u32) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -444,15 +446,16 @@ mod tests {
         let c2 = Arc::clone(&counter);
         let id = r.register_sink(
             "heartbeat",
-            Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+            Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
                 c2.fetch_add(count, Ordering::SeqCst);
             }),
         );
         let Some(MailboxEntry::Sink(h)) = r.entry(id) else {
             panic!("expected sink")
         };
-        h("aether.tick", None, SessionToken::NIL, &[], 7);
-        h("aether.tick", Some("physics"), SessionToken::NIL, &[], 3);
+        // Test-side id is irrelevant — the handler ignores it.
+        h(0, "aether.tick", None, SessionToken::NIL, &[], 7);
+        h(0, "aether.tick", Some("physics"), SessionToken::NIL, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 
@@ -460,7 +463,7 @@ mod tests {
     fn mailbox_ids_are_name_derived() {
         let r = Registry::new();
         let a = r.register_component("a");
-        let b = r.register_sink("b", Arc::new(|_, _, _, _, _| {}));
+        let b = r.register_sink("b", Arc::new(|_, _, _, _, _, _| {}));
         let c = r.register_component("c");
         assert_eq!(a, MailboxId::from_name("a"));
         assert_eq!(b, MailboxId::from_name("b"));
@@ -491,7 +494,7 @@ mod tests {
     fn mailbox_name_reverse_lookup() {
         let r = Registry::new();
         let a = r.register_component("physics");
-        let b = r.register_sink("hub.claude.broadcast", Arc::new(|_, _, _, _, _| {}));
+        let b = r.register_sink("hub.claude.broadcast", Arc::new(|_, _, _, _, _, _| {}));
         assert_eq!(r.mailbox_name(a).as_deref(), Some("physics"));
         assert_eq!(r.mailbox_name(b).as_deref(), Some("hub.claude.broadcast"));
         assert!(r.mailbox_name(MailboxId(999)).is_none());
@@ -680,7 +683,7 @@ mod tests {
     #[test]
     fn drop_mailbox_rejects_sink_and_unknown_and_repeat() {
         let r = Registry::new();
-        let sink = r.register_sink("heartbeat", Arc::new(|_, _, _, _, _| {}));
+        let sink = r.register_sink("heartbeat", Arc::new(|_, _, _, _, _, _| {}));
         assert!(matches!(
             r.drop_mailbox(sink),
             Err(DropError::NotComponent { .. })

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -195,7 +195,14 @@ fn worker_loop(ctx: Arc<WorkerContext>) {
                 // FrameStats push) and has no sending mailbox; per
                 // ADR-0011 origin is `None`. Components reach sinks
                 // inline via `SubstrateCtx::send`, not this path.
-                handler(&kind_name, None, mail.sender, &mail.payload, mail.count);
+                handler(
+                    mail.kind,
+                    &kind_name,
+                    None,
+                    mail.sender,
+                    &mail.payload,
+                    mail.count,
+                );
             }
             Some(MailboxEntry::Component) => {
                 let entry = ctx

--- a/crates/aether-substrate/src/chassis.rs
+++ b/crates/aether-substrate/src/chassis.rs
@@ -66,32 +66,34 @@ pub fn chassis_control_handler(
     queue: Arc<MailQueue>,
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
-    Arc::new(move |kind_name: &str, sender: SessionToken, bytes: &[u8]| {
-        if kind_name == CaptureFrame::NAME {
-            handle_capture_frame(
-                &proxy,
-                &capture_queue,
-                &registry,
-                &queue,
-                &outbound,
-                sender,
-                bytes,
-            );
-        } else if kind_name == PlatformInfo::NAME {
-            // Empty payload; forward the sender straight to the event
-            // loop and let it snapshot + reply on its own thread
-            // (winit monitor / scale-factor APIs require it).
-            let _ = proxy.send_event(UserEvent::PlatformInfo { sender });
-        } else if kind_name == SetWindowMode::NAME {
-            handle_set_window_mode(&proxy, &outbound, sender, bytes);
-        } else {
-            tracing::warn!(
-                target: "aether_substrate::chassis",
-                kind = %kind_name,
-                "desktop chassis has no handler for control kind — dropping",
-            );
-        }
-    })
+    Arc::new(
+        move |kind_id: u64, kind_name: &str, sender: SessionToken, bytes: &[u8]| {
+            if kind_id == CaptureFrame::ID {
+                handle_capture_frame(
+                    &proxy,
+                    &capture_queue,
+                    &registry,
+                    &queue,
+                    &outbound,
+                    sender,
+                    bytes,
+                );
+            } else if kind_id == PlatformInfo::ID {
+                // Empty payload; forward the sender straight to the
+                // event loop and let it snapshot + reply on its own
+                // thread (winit monitor / scale-factor APIs require it).
+                let _ = proxy.send_event(UserEvent::PlatformInfo { sender });
+            } else if kind_id == SetWindowMode::ID {
+                handle_set_window_mode(&proxy, &outbound, sender, bytes);
+            } else {
+                tracing::warn!(
+                    target: "aether_substrate::chassis",
+                    kind = %kind_name,
+                    "desktop chassis has no handler for control kind — dropping",
+                );
+            }
+        },
+    )
 }
 
 /// Two-phase capture request (pre-capture mail push + render handoff).

--- a/crates/aether-substrate/src/main.rs
+++ b/crates/aether-substrate/src/main.rs
@@ -682,7 +682,12 @@ fn main() -> wasmtime::Result<()> {
     registry.register_sink(
         "render",
         Arc::new(
-            move |_kind: &str, _origin: Option<&str>, _sender, bytes: &[u8], count: u32| {
+            move |_kind_id: u64,
+                  _kind_name: &str,
+                  _origin: Option<&str>,
+                  _sender,
+                  bytes: &[u8],
+                  count: u32| {
                 verts_for_sink.lock().unwrap().extend_from_slice(bytes);
                 tris_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
             },
@@ -699,7 +704,8 @@ fn main() -> wasmtime::Result<()> {
         registry.register_sink(
             HUB_CLAUDE_BROADCAST,
             Arc::new(
-                move |kind_name: &str,
+                move |_kind_id: u64,
+                      kind_name: &str,
                       origin: Option<&str>,
                       _sender,
                       bytes: &[u8],

--- a/crates/aether-substrate/tests/end_to_end.rs
+++ b/crates/aether-substrate/tests/end_to_end.rs
@@ -57,7 +57,7 @@ fn tick_roundtrip_component_to_sink() {
     let c2 = Arc::clone(&counter);
     let sink_mbox = registry.register_sink(
         "heartbeat",
-        Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+        Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
             c2.fetch_add(count, Ordering::SeqCst);
         }),
     );

--- a/crates/aether-substrate/tests/hub_client.rs
+++ b/crates/aether-substrate/tests/hub_client.rs
@@ -100,7 +100,8 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let recipient = registry.register_sink(
         "hello",
         Arc::new(
-            move |_kind: &str,
+            move |_kind_id: u64,
+                  _kind: &str,
                   _origin: Option<&str>,
                   sender: SessionToken,
                   bytes: &[u8],

--- a/crates/aether-substrate/tests/input_subscriptions.rs
+++ b/crates/aether-substrate/tests/input_subscriptions.rs
@@ -75,7 +75,7 @@ fn make_harness() -> Harness {
     let c2 = Arc::clone(&counter);
     let sink_mbox = registry.register_sink(
         "tally",
-        Arc::new(move |_kind, _origin, _sender, _bytes, count| {
+        Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
             c2.fetch_add(count, Ordering::SeqCst);
         }),
     );
@@ -117,10 +117,10 @@ fn make_harness() -> Harness {
 /// sink-handler surface. `ControlPlane::into_sink_handler` consumes
 /// its receiver, so the harness clones the plane (`Arc`-cheap) for
 /// each call. Mirrors how main.rs wires the handler at boot.
-fn dispatch<K: serde::Serialize>(plane: &ControlPlane, kind_name: &str, payload: &K) {
+fn dispatch<K: aether_mail::Kind + serde::Serialize>(plane: &ControlPlane, payload: &K) {
     let bytes = postcard::to_allocvec(payload).unwrap();
     let handler = plane.clone().into_sink_handler();
-    handler(kind_name, None, SessionToken::NIL, &bytes, 0);
+    handler(K::ID, K::NAME, None, SessionToken::NIL, &bytes, 0);
 }
 
 fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {
@@ -133,7 +133,6 @@ fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {
         .collect();
     dispatch(
         plane,
-        LoadComponent::NAME,
         &LoadComponent {
             wasm: wat::parse_str(wat).expect("compile WAT"),
             name: Some(name.into()),
@@ -153,23 +152,15 @@ fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {
 }
 
 fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
-    dispatch(
-        plane,
-        SubscribeInput::NAME,
-        &SubscribeInput { stream, mailbox },
-    );
+    dispatch(plane, &SubscribeInput { stream, mailbox });
 }
 
 fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
-    dispatch(
-        plane,
-        UnsubscribeInput::NAME,
-        &UnsubscribeInput { stream, mailbox },
-    );
+    dispatch(plane, &UnsubscribeInput { stream, mailbox });
 }
 
 fn drop_component(plane: &ControlPlane, mailbox_id: u64) {
-    dispatch(plane, DropComponent::NAME, &DropComponent { mailbox_id });
+    dispatch(plane, &DropComponent { mailbox_id });
 }
 
 /// Publish one Tick exactly as `App::window_event` does: snapshot the


### PR DESCRIPTION
## Summary

Follow-up to ADR-0035 PR #149 review. Sinks now match on kind id (u64, ADR-0030 schema hash) instead of kind name (&str). Name stays on the SinkHandler signature for diagnostic logging; it just doesn't participate in dispatch matching anymore.

- SinkHandler gains a leading kind_id: u64 argument. Scheduler + SubstrateCtx pass mail.kind as the new first arg; the kind_name reverse lookup still happens solely for diagnostic strings.
- ControlPlane::dispatch: if/else if chain on kind_id == LoadComponent::ID etc.
- ChassisControlHandler: same pattern for CaptureFrame::ID / PlatformInfo::ID / SetWindowMode::ID.
- Three main.rs sink registrations (render, hub.claude.broadcast, control) plus every test closure updated to the new 6-arg shape.

No behavioural change — same handlers for the same kinds; u64 equality replaces string compare.

## Test plan

- [x] cargo build --workspace clean.
- [x] cargo test --workspace — all suites green (98 substrate-core + 114 hub + 39 hub-protocol + 18 mail-derive + the rest).
- [x] cargo clippy --all-targets -- -D warnings clean.
- [x] cargo fmt --all -- --check clean.
- [x] Full MCP end-to-end smoke on a fresh hub session:
  - spawn_substrate + load_component returned capabilities inline.
  - capture_frame returned the triangle PNG (tick + render sink dispatched through new id match).
  - aether.ping → aether.pong {seq: 150} via reply-to-sender.
  - aether.control.set_window_mode → Ok {width: 512, height: 384} (chassis handler).
  - aether.control.platform_info → full snapshot with window sized 512×384.
  - aether.key (unhandled kind) → strict-receiver warn on aether_substrate::scheduler naming mailbox + kind.
  - Broadcast frame_stats observations drained throughout.