### PR TITLE
fix(substrate-core): per-mailbox strand preserves FIFO under worker contention

### DIFF
--- a/crates/aether-substrate-core/src/queue.rs
+++ b/crates/aether-substrate-core/src/queue.rs
@@ -69,6 +69,10 @@ impl MailQueue {
         self.pending.lock().unwrap().pop_front()
     }
 
+    /// Test helper — unconditional FIFO pop. Production workers use
+    /// `pop_blocking_if` so the per-mailbox strand claim can veto a
+    /// pop; tests that don't exercise strands keep the simple path.
+    #[cfg(test)]
     pub(crate) fn pop_blocking(&self) -> Option<Mail> {
         let mut q = self.pending.lock().unwrap();
         loop {
@@ -80,6 +84,55 @@ impl MailQueue {
             }
             q = self.pending_cv.wait(q).unwrap();
         }
+    }
+
+    /// Block until a mail for which `pred` returns `true` exists at
+    /// some position in the queue, then pop it. The scheduler's
+    /// per-mailbox strand uses this: `pred` atomically tries to claim
+    /// the strand for the mail's recipient, returning `true` (pop me)
+    /// iff it succeeded and `false` (skip me, try later mails)
+    /// otherwise. `pred` is called left-to-right across the queue each
+    /// scan and may short-circuit as soon as one mail returns `true`.
+    ///
+    /// `pred` is permitted to have atomic side effects (it must, to
+    /// reserve the strand). The contract: if `pred` returns `true`,
+    /// the caller guarantees to dispatch that mail; no "uncommit" path
+    /// is provided, so `pred` must not reserve on anything other than
+    /// the mail it's about to green-light.
+    pub(crate) fn pop_blocking_if<F>(&self, mut pred: F) -> Option<Mail>
+    where
+        F: FnMut(&Mail) -> bool,
+    {
+        let mut q = self.pending.lock().unwrap();
+        loop {
+            if let Some(idx) = q.iter().position(&mut pred) {
+                return q.remove(idx);
+            }
+            if self.shutdown.load(Ordering::SeqCst) {
+                return None;
+            }
+            q = self.pending_cv.wait(q).unwrap();
+        }
+    }
+
+    /// Non-blocking: pop the first mail whose recipient matches.
+    /// Returns `None` immediately if no matching mail is queued. Used
+    /// by the strand owner to drain every remaining mail for its
+    /// recipient before releasing the strand.
+    pub(crate) fn try_pop_for_recipient(&self, recipient: crate::mail::MailboxId) -> Option<Mail> {
+        let mut q = self.pending.lock().unwrap();
+        let idx = q.iter().position(|m| m.recipient == recipient)?;
+        q.remove(idx)
+    }
+
+    /// Wake every worker parked on `pending_cv`. Called when a strand
+    /// releases so workers that previously skipped mail for that
+    /// recipient can re-scan. `notify_one` on push is not enough on
+    /// its own: a release can happen without a push (the strand owner
+    /// drains the last pending mail for its recipient and finds the
+    /// queue contains only skipped mails that are now unblocked).
+    pub(crate) fn notify_waiters(&self) {
+        self.pending_cv.notify_all();
     }
 
     pub(crate) fn mark_completed(&self) {

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -27,6 +27,20 @@
 // zero before swapping. The swap step (and the parked-mail flush) is
 // driven by `ControlPlane::handle_replace`; this module just owns
 // the per-entry state and the worker dispatch path that respects it.
+//
+// Issue 157 (2026-04-20): the original worker loop popped mail in
+// FIFO order from the main queue and serialised delivery through
+// `Mutex<Component>`. That preserved "one deliver at a time per
+// component" but NOT "deliver in pop order": mutex acquisition is
+// non-FIFO under contention, so two workers each popping sequential
+// mails for the same mailbox could invert the deliver order (the
+// `_row_/_col_` scramble the tic-tac-toe batch smoke caught). The fix
+// is the per-mailbox strand: `ComponentEntry.strand_scheduled` is a
+// claim flag the worker sets under the queue lock during the pop
+// scan, and the strand owner drains every same-recipient mail still
+// in the queue before releasing. Different mailboxes still dispatch
+// in parallel; only same-mailbox mail serialises, and now it
+// serialises in pop (== push) order.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -49,6 +63,22 @@ pub struct ComponentEntry {
     pub pending: AtomicU32,
     pub frozen: AtomicBool,
     pub parked: Mutex<VecDeque<Mail>>,
+    /// Per-mailbox strand lock. A worker that pops mail for this
+    /// component flips this to `true` before leaving the queue's scan
+    /// path; other workers whose scan lands on mail for the same
+    /// recipient treat the strand as unavailable and keep scanning.
+    /// The strand owner drains every same-recipient mail in the queue
+    /// before flipping this back to `false`. Net effect: FIFO per
+    /// mailbox even across multiple workers, without serialising the
+    /// whole scheduler.
+    ///
+    /// Preserves the invariant the old `Mutex<Component>`-only design
+    /// tried to rely on: that `pop_blocking` FIFO order equals deliver
+    /// order for a given mailbox. The `Mutex<Component>` alone did not
+    /// preserve it — mutex acquisition is not FIFO under contention, so
+    /// two workers popping mail for the same mailbox could invert the
+    /// deliver order. See issue 157.
+    pub strand_scheduled: AtomicBool,
 }
 
 impl ComponentEntry {
@@ -58,6 +88,7 @@ impl ComponentEntry {
             pending: AtomicU32::new(0),
             frozen: AtomicBool::new(false),
             parked: Mutex::new(VecDeque::new()),
+            strand_scheduled: AtomicBool::new(false),
         }
     }
 }
@@ -185,87 +216,166 @@ impl Drop for Scheduler {
 }
 
 fn worker_loop(ctx: Arc<WorkerContext>) {
-    while let Some(mail) = ctx.queue.pop_blocking() {
-        let recipient = mail.recipient;
-        match ctx.registry.entry(recipient) {
-            Some(MailboxEntry::Sink(handler)) => {
-                let kind_name = ctx.registry.kind_name(mail.kind).unwrap_or_default();
-                // Mail reaching a sink through the scheduler queue
-                // came from substrate core (e.g. the frame loop's
-                // FrameStats push) and has no sending mailbox; per
-                // ADR-0011 origin is `None`. Components reach sinks
-                // inline via `SubstrateCtx::send`, not this path.
-                handler(
-                    mail.kind,
-                    &kind_name,
-                    None,
-                    mail.sender,
-                    &mail.payload,
-                    mail.count,
-                );
+    loop {
+        // Pick the next runnable mail. For Component recipients,
+        // `pop_blocking_if`'s predicate tries to claim the per-mailbox
+        // strand atomically; the pop only commits if the claim
+        // succeeds. Sinks, dropped/unknown recipients, and dangling
+        // component ids (registered but no `ComponentEntry`) pop
+        // unconditionally.
+        let claimed_entry = std::sync::Mutex::new(None::<Arc<ComponentEntry>>);
+        let Some(mail) = ctx.queue.pop_blocking_if(|m| {
+            match ctx.registry.entry(m.recipient) {
+                Some(MailboxEntry::Component) => {
+                    let entry = ctx
+                        .components
+                        .read()
+                        .unwrap()
+                        .get(&m.recipient)
+                        .map(Arc::clone);
+                    match entry {
+                        Some(e) => {
+                            // `swap(true)` returns the previous value.
+                            // If it was `false` we just claimed the
+                            // strand; otherwise another worker owns it
+                            // and we keep scanning.
+                            if !e.strand_scheduled.swap(true, Ordering::AcqRel) {
+                                *claimed_entry.lock().unwrap() = Some(e);
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        // Dangling id: warn-drop path below handles it;
+                        // nothing to serialise on.
+                        None => true,
+                    }
+                }
+                // Sinks are stateless and safe under concurrent calls;
+                // dropped/unknown mail just warn-drops.
+                _ => true,
             }
-            Some(MailboxEntry::Component) => {
-                let entry = ctx
+        }) else {
+            return;
+        };
+
+        // Capture the recipient before `mail` is consumed — we need
+        // it to drain same-recipient follow-ups below.
+        let recipient = mail.recipient;
+        let strand = claimed_entry.lock().unwrap().take();
+        dispatch_mail(&ctx, mail, strand.as_ref());
+
+        // If we owned a strand, drain any further mail for the same
+        // recipient before releasing it. This is what preserves FIFO
+        // per-mailbox: same-recipient mail that arrived between the
+        // first pop and this drain goes through us, not through a
+        // racing worker.
+        if let Some(entry) = strand {
+            while let Some(next) = ctx.queue.try_pop_for_recipient(recipient) {
+                dispatch_mail(&ctx, next, Some(&entry));
+            }
+            entry.strand_scheduled.store(false, Ordering::Release);
+            // Wake any worker that skipped this recipient during the
+            // drain so it can re-scan the queue.
+            ctx.queue.notify_waiters();
+        }
+    }
+}
+
+/// Deliver one mail to its recipient. Strand claim (if any) is the
+/// caller's job — this function only dispatches. `strand` carries the
+/// already-claimed `ComponentEntry` for Component recipients so we
+/// don't hit the components table lookup twice.
+fn dispatch_mail(ctx: &Arc<WorkerContext>, mail: Mail, strand: Option<&Arc<ComponentEntry>>) {
+    let recipient = mail.recipient;
+    match ctx.registry.entry(recipient) {
+        Some(MailboxEntry::Sink(handler)) => {
+            let kind_name = ctx.registry.kind_name(mail.kind).unwrap_or_default();
+            // Mail reaching a sink through the scheduler queue came
+            // from substrate core (e.g. the frame loop's FrameStats
+            // push) and has no sending mailbox; per ADR-0011 origin is
+            // `None`. Components reach sinks inline via
+            // `SubstrateCtx::send`, not this path.
+            handler(
+                mail.kind,
+                &kind_name,
+                None,
+                mail.sender,
+                &mail.payload,
+                mail.count,
+            );
+            ctx.queue.mark_completed();
+        }
+        Some(MailboxEntry::Component) => {
+            let entry = match strand {
+                Some(e) => Some(Arc::clone(e)),
+                None => ctx
                     .components
                     .read()
                     .unwrap()
                     .get(&recipient)
-                    .map(Arc::clone);
-                match entry {
-                    Some(entry) => {
-                        // ADR-0022 freeze-drain: while frozen, mail is
-                        // parked on the entry without entering the
-                        // pending count. handle_replace flushes the
-                        // parked queue under the write lock once the
-                        // swap (or timeout) resolves.
-                        if entry.frozen.load(Ordering::Acquire) {
-                            entry.parked.lock().unwrap().push_back(mail);
-                            ctx.queue.mark_completed();
-                            continue;
-                        }
-                        entry.pending.fetch_add(1, Ordering::AcqRel);
-                        let rc = {
-                            let mut c = entry.component.lock().unwrap();
-                            c.deliver(&mail).expect("component.deliver failed")
-                        };
-                        entry.pending.fetch_sub(1, Ordering::AcqRel);
-                        if rc == crate::component::DISPATCH_UNKNOWN_KIND {
-                            let kind_name = ctx
-                                .registry
-                                .kind_name(mail.kind)
-                                .unwrap_or_else(|| format!("kind#{:#x}", mail.kind));
-                            tracing::warn!(
-                                target: "aether_substrate::scheduler",
-                                mailbox = ?recipient,
-                                kind = %kind_name,
-                                "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
-                            );
-                        }
+                    .map(Arc::clone),
+            };
+            match entry {
+                Some(entry) => {
+                    // ADR-0022 freeze-drain: while frozen, mail is
+                    // parked on the entry without entering the pending
+                    // count. handle_replace flushes the parked queue
+                    // under the write lock once the swap (or timeout)
+                    // resolves. The strand claim we made above stays
+                    // live — the freeze path coordinates with us via
+                    // `pending` (which we never incremented for parked
+                    // mail), not via `strand_scheduled`.
+                    if entry.frozen.load(Ordering::Acquire) {
+                        entry.parked.lock().unwrap().push_back(mail);
+                        ctx.queue.mark_completed();
+                        return;
                     }
-                    None => {
+                    entry.pending.fetch_add(1, Ordering::AcqRel);
+                    let rc = {
+                        let mut c = entry.component.lock().unwrap();
+                        c.deliver(&mail).expect("component.deliver failed")
+                    };
+                    entry.pending.fetch_sub(1, Ordering::AcqRel);
+                    if rc == crate::component::DISPATCH_UNKNOWN_KIND {
+                        let kind_name = ctx
+                            .registry
+                            .kind_name(mail.kind)
+                            .unwrap_or_else(|| format!("kind#{:#x}", mail.kind));
                         tracing::warn!(
                             target: "aether_substrate::scheduler",
                             mailbox = ?recipient,
-                            "mail to registered-component mailbox but no component bound — dropped",
+                            kind = %kind_name,
+                            "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
                         );
                     }
+                    ctx.queue.mark_completed();
+                }
+                None => {
+                    tracing::warn!(
+                        target: "aether_substrate::scheduler",
+                        mailbox = ?recipient,
+                        "mail to registered-component mailbox but no component bound — dropped",
+                    );
+                    ctx.queue.mark_completed();
                 }
             }
-            Some(MailboxEntry::Dropped) => {
-                tracing::warn!(
-                    target: "aether_substrate::scheduler",
-                    mailbox = ?recipient,
-                    "mail to dropped mailbox — discarded",
-                );
-            }
-            None => {
-                tracing::warn!(
-                    target: "aether_substrate::scheduler",
-                    mailbox = ?recipient,
-                    "mail to unknown mailbox — dropped",
-                );
-            }
         }
-        ctx.queue.mark_completed();
+        Some(MailboxEntry::Dropped) => {
+            tracing::warn!(
+                target: "aether_substrate::scheduler",
+                mailbox = ?recipient,
+                "mail to dropped mailbox — discarded",
+            );
+            ctx.queue.mark_completed();
+        }
+        None => {
+            tracing::warn!(
+                target: "aether_substrate::scheduler",
+                mailbox = ?recipient,
+                "mail to unknown mailbox — dropped",
+            );
+            ctx.queue.mark_completed();
+        }
     }
 }

--- a/crates/aether-substrate-desktop/tests/end_to_end.rs
+++ b/crates/aether-substrate-desktop/tests/end_to_end.rs
@@ -14,6 +14,7 @@
 // barrier's push/decrement/wait cycle.
 
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use aether_substrate_desktop::{
@@ -90,4 +91,70 @@ fn tick_roundtrip_component_to_sink() {
 
     // Sink saw count=1 + count=2 + count=3 = 6.
     assert_eq!(counter.load(Ordering::SeqCst), 1 + 2 + 3);
+}
+
+/// Regression for issue 157: batched mail to a single recipient must
+/// be delivered in push order even with multiple workers contending
+/// the component's mutex. Before the per-mailbox strand fix, two
+/// workers popping sequential mails from the FIFO queue could invert
+/// deliver order because `Mutex::lock()` is not FIFO under contention;
+/// the race showed up as `PlayMove { row, col }` values landing in
+/// the wrong cells during the tic-tac-toe batch smoke.
+///
+/// The test pushes N mails carrying `count = 1..=N` and lets the
+/// guest forward each one to a sink that appends the received `count`
+/// to a `Vec`. With the fix the vector ends up `[1, 2, ..., N]`; with
+/// the pre-fix scheduler it scrambled on most runs with workers=2 and
+/// N large enough to keep both workers busy.
+#[test]
+fn batched_mail_preserves_fifo_per_mailbox() {
+    const N: u32 = 200;
+
+    let engine = Engine::default();
+    let registry = Arc::new(Registry::new());
+    let component_mbox = registry.register_component("fifo");
+
+    let recorded: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::with_capacity(N as usize)));
+    let recorded_clone = Arc::clone(&recorded);
+    let sink_mbox = registry.register_sink(
+        "observer",
+        Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
+            recorded_clone.lock().unwrap().push(count);
+        }),
+    );
+
+    let module = Module::new(&engine, forwards_to_sink_wat(sink_mbox)).expect("compile wat");
+
+    let queue = Arc::new(MailQueue::new());
+    let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+    host_fns::register(&mut linker).expect("register host fns");
+
+    let ctx = SubstrateCtx::new(
+        component_mbox,
+        Arc::clone(&registry),
+        Arc::clone(&queue),
+        HubOutbound::disconnected(),
+        aether_substrate_desktop::new_subscribers(),
+    );
+    let component = Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
+
+    let mut components = std::collections::HashMap::new();
+    components.insert(component_mbox, component);
+    // Two workers — the race the strand fix closes only manifests
+    // with workers > 1 and the guest's deliver fast enough that
+    // both threads contend on the component mutex.
+    let _scheduler = Scheduler::new(registry, Arc::clone(&queue), components, 2);
+
+    for i in 1..=N {
+        queue.push(Mail::new(component_mbox, 1, vec![], i));
+    }
+    queue.wait_idle();
+
+    let got = recorded.lock().unwrap().clone();
+    assert_eq!(got.len(), N as usize, "sink saw the wrong number of mails");
+    let expected: Vec<u32> = (1..=N).collect();
+    assert_eq!(
+        got, expected,
+        "sink recorded out-of-order mail: per-mailbox FIFO broken"
+    );
 }


### PR DESCRIPTION
## Summary

- Two workers popping sequential mails from the shared FIFO queue for the same component could invert deliver order. `Mutex<Component>` serialised delivery but its acquisition is not FIFO under contention, so the lock race determined order.
- Fix: claim the recipient's strand under the queue lock during the pop scan (`pop_blocking_if`). A worker that successfully claims the strand drains every same-recipient mail remaining in the queue before releasing, so all deliveries to one mailbox serialise in pop order. Different mailboxes still dispatch in parallel — only same-mailbox mail serialises.
- Regression test pushes 200 mails to one component under 2 workers and asserts the recorded delivery order matches push order.

## Why

Issue 157: batched `send_mail` of five `PlayMove` mails during the tic-tac-toe smoke scrambled `row`/`col` values into the wrong cells. Turn alternation (X,O,X,O,X) stayed correct because the mutex serialised delivery; only the payloads carried by each lock-winning worker got out of order. Rules out encoder bugs; points squarely at the scheduler.

The scheduler comment already noted the aspiration "FIFO per mailbox via `Mutex<Component>`" — this PR closes the gap the aspiration was relying on but didn't actually enforce.

## Test plan

- [x] New unit regression `batched_mail_preserves_fifo_per_mailbox` — 200 mails to one component, 2 workers, assert recorded order == push order.
- [x] Full workspace `cargo test`: 18 tests in substrate-core integration, 2 end-to-end, 5 input-subscription, 6 hub-client, 114 hub, all green.
- [x] `cargo clippy --all-targets` clean across the workspace.
- [x] MCP smoke: the original issue 157 reproducer (batched five-move send to tic-tac-toe server) now lands X wins row 0 correctly, with every move landing in the intended cell.

## Out of scope

During the smoke I hit a separate issue where the MCP session receive-path went stale (replies dropped on the floor even though the engine was healthy and ticking). A `/mcp` reconnect cleared it. That's orthogonal to this fix — filing it as its own issue.