### PR TITLE
feat(demos): tic-tac-toe desktop client component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-demo-tic-tac-toe-client"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-component",
+ "aether-demo-tic-tac-toe",
+ "aether-kinds",
+]
+
+[[package]]
 name = "aether-hello-component"
 version = "0.2.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/aether-mail-derive",
     "demos/sokoban",
     "demos/tic-tac-toe",
+    "demos/tic-tac-toe-client",
 ]
 # Reference artefacts under spikes/ are standalone Cargo workspaces
 # (see ADR-0003 §Consequences) and must be excluded so they aren't

--- a/demos/tic-tac-toe-client/Cargo.toml
+++ b/demos/tic-tac-toe-client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aether-demo-tic-tac-toe-client"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aether-component = { path = "../../crates/aether-component" }
+aether-demo-tic-tac-toe = { path = "../tic-tac-toe" }
+aether-kinds = { path = "../../crates/aether-kinds" }

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -225,4 +225,8 @@ fn push_quad(
     *n += 2;
 }
 
+// Gated on wasm32 for the same reason the server crate gates its
+// `export!` — host test builds link against the server rlib and
+// would hit duplicate `init` / `receive_p32` / ... symbols.
+#[cfg(target_arch = "wasm32")]
 aether_component::export!(TicTacToeClient);

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -1,0 +1,228 @@
+//! Tic-tac-toe client component: renders the board the
+//! `aether-demo-tic-tac-toe` server publishes. Registers itself under
+//! the well-known mailbox name the server fans state to
+//! (`tic_tac_toe.client`), stores every incoming `GameState`, and
+//! re-emits the board as colored quads to the `render` sink on each
+//! tick.
+//!
+//! No input handling yet — moves are driven by MCP `send_mail`
+//! (`tic_tac_toe.play_move`) against the server component on the
+//! same substrate. Mouse-click → row/col is the next step.
+//!
+//! Rendering:
+//! - 3×3 grid of cell quads, slightly inset inside the window.
+//! - Cell background: dark gray.
+//! - Occupied cells get a smaller inner mark quad — red for X,
+//!   blue for O.
+//! - Last-moved cell gets a slightly brighter background so it
+//!   stands out after a move.
+//!
+//! That's as shape-y as this first pass gets; proper X / O glyphs
+//! are a rendering-polish pass for later.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
+use aether_demo_tic_tac_toe::{CELL_EMPTY, GameState, LAST_MOVE_NONE, PLAYER_X};
+use aether_kinds::{DrawTriangle, Tick, Vertex};
+
+/// Clip-space half-extent the board uses. Board lives inside
+/// `[-BOARD_EXTENT, BOARD_EXTENT]²`; the rest of the viewport is the
+/// window's clear color.
+const BOARD_EXTENT: f32 = 0.9;
+/// Gap between cells (clip-space units). Shows as a thin unrendered
+/// strip between cells so the grid reads as a grid rather than one
+/// big rectangle.
+const CELL_GAP: f32 = 0.02;
+/// Inner-mark inset as a fraction of cell width. A value of `0.25`
+/// means the mark is 50% of cell edge length (25% margin on every
+/// side).
+const MARK_INSET: f32 = 0.25;
+
+const CELL_BG: (f32, f32, f32) = (0.15, 0.15, 0.18);
+/// Last-moved cell tint — same hue family as the base cell, a
+/// notch brighter. Subtle on purpose; the primary mark-vs-empty
+/// signal is the inner quad.
+const CELL_BG_RECENT: (f32, f32, f32) = (0.25, 0.25, 0.30);
+/// Brighter border tint used once the game has ended — makes the
+/// win/draw state visually obvious without a separate status glyph.
+const CELL_BG_GAMEOVER: (f32, f32, f32) = (0.10, 0.22, 0.10);
+
+const MARK_X: (f32, f32, f32) = (0.90, 0.25, 0.25);
+const MARK_O: (f32, f32, f32) = (0.25, 0.45, 0.95);
+
+/// Per-component state. Starts with an empty default `GameState` so
+/// the first tick can render before the server has sent anything —
+/// produces a dark empty grid until the first move lands.
+pub struct TicTacToeClient {
+    state: GameState,
+    render: Sink<DrawTriangle>,
+}
+
+impl Default for TicTacToeClient {
+    fn default() -> Self {
+        Self {
+            // `GameState::new_game()` (not `::default()`) — default is
+            // zero-init which leaves `last_move_row`/`last_move_col`
+            // at 0, and the renderer's "recent move" check would
+            // highlight cell (0,0) on an untouched board. `new_game`
+            // sets the LAST_MOVE_NONE sentinel (255) the server also
+            // uses.
+            state: GameState::new_game(),
+            render: aether_component::resolve_sink::<DrawTriangle>("render"),
+        }
+    }
+}
+
+/// Tic-tac-toe board renderer. Listens for `tic_tac_toe.game_state`
+/// mail addressed to its well-known mailbox (`tic_tac_toe.client`)
+/// and reflects whatever state it last received on every render
+/// tick.
+///
+/// # Agent
+/// Load this component under the mailbox name `tic_tac_toe.client`
+/// so the server's local-observer fan-out lands here. Drive moves
+/// against the `tic_tac_toe` server component with
+/// `tic_tac_toe.play_move`; the board should update on the next
+/// frame. Use `capture_frame` to verify rendering — the 3×3 grid
+/// should be visible, occupied cells carry a colored inner square
+/// (red X, blue O), and a game-over state tints every cell green.
+#[handlers]
+impl Component for TicTacToeClient {
+    fn init(_ctx: &mut InitCtx<'_>) -> Self {
+        TicTacToeClient::default()
+    }
+
+    /// Cached copy of the latest authoritative state. Overwrites
+    /// unconditionally — the server is the source of truth and we
+    /// don't try to merge or validate.
+    ///
+    /// # Agent
+    /// You shouldn't send this mail directly. It arrives from the
+    /// `tic_tac_toe` server's `client_observer` fan-out whenever a
+    /// move or reset applies.
+    #[handler]
+    fn on_game_state(&mut self, _ctx: &mut Ctx<'_>, state: GameState) {
+        self.state = state;
+    }
+
+    /// Per-tick render: draw nine cell quads plus up to nine
+    /// inner-mark quads depending on occupancy. Sends one batch of
+    /// up to eighteen `DrawTriangle`s to the `render` sink.
+    ///
+    /// # Agent
+    /// Not useful to mail directly — the substrate drives ticks.
+    /// Use `capture_frame` to observe the output.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        self.render(ctx);
+    }
+}
+
+impl TicTacToeClient {
+    fn render(&self, ctx: &mut Ctx<'_>) {
+        // 9 cell quads + up to 9 mark quads; each quad is 2
+        // triangles. Budget 36 slots.
+        let mut tris: [DrawTriangle; 36] = [DrawTriangle::default(); 36];
+        let mut n = 0;
+
+        // Per-cell edge length. Subtract gaps so there's negative
+        // space between cells.
+        let span = 2.0 * BOARD_EXTENT;
+        let cell_edge = (span - 2.0 * CELL_GAP) / 3.0;
+
+        let game_over = self.state.status != 0;
+
+        for row in 0..3u8 {
+            for col in 0..3u8 {
+                // Clip-space box for this cell. Row 0 is the top
+                // row — y decreases as row increases.
+                let x0 = -BOARD_EXTENT + col as f32 * (cell_edge + CELL_GAP);
+                let x1 = x0 + cell_edge;
+                let y1 = BOARD_EXTENT - row as f32 * (cell_edge + CELL_GAP);
+                let y0 = y1 - cell_edge;
+
+                let is_recent = !game_over
+                    && row == self.state.last_move_row
+                    && col == self.state.last_move_col
+                    && self.state.last_move_row != LAST_MOVE_NONE;
+                let bg = if game_over {
+                    CELL_BG_GAMEOVER
+                } else if is_recent {
+                    CELL_BG_RECENT
+                } else {
+                    CELL_BG
+                };
+                push_quad(&mut tris, &mut n, x0, y0, x1, y1, bg);
+
+                let occupant = self.state.board[row as usize][col as usize];
+                if occupant != CELL_EMPTY {
+                    let color = if occupant == PLAYER_X { MARK_X } else { MARK_O };
+                    let inset = cell_edge * MARK_INSET;
+                    push_quad(
+                        &mut tris,
+                        &mut n,
+                        x0 + inset,
+                        y0 + inset,
+                        x1 - inset,
+                        y1 - inset,
+                        color,
+                    );
+                }
+            }
+        }
+
+        ctx.send_many(&self.render, &tris[..n]);
+    }
+}
+
+/// Push two triangles covering the axis-aligned rectangle
+/// `[x0, x1] × [y0, y1]` with solid color `(r, g, b)` into `tris`.
+/// Vertex winding is `(tl, tr, br)` then `(tl, br, bl)` so the
+/// front face matches the substrate's existing render setup.
+fn push_quad(
+    tris: &mut [DrawTriangle],
+    n: &mut usize,
+    x0: f32,
+    y0: f32,
+    x1: f32,
+    y1: f32,
+    color: (f32, f32, f32),
+) {
+    let (r, g, b) = color;
+    let tl = Vertex {
+        x: x0,
+        y: y1,
+        r,
+        g,
+        b,
+    };
+    let tr = Vertex {
+        x: x1,
+        y: y1,
+        r,
+        g,
+        b,
+    };
+    let br = Vertex {
+        x: x1,
+        y: y0,
+        r,
+        g,
+        b,
+    };
+    let bl = Vertex {
+        x: x0,
+        y: y0,
+        r,
+        g,
+        b,
+    };
+    tris[*n] = DrawTriangle {
+        verts: [tl, tr, br],
+    };
+    tris[*n + 1] = DrawTriangle {
+        verts: [tl, br, bl],
+    };
+    *n += 2;
+}
+
+aether_component::export!(TicTacToeClient);

--- a/demos/tic-tac-toe/Cargo.toml
+++ b/demos/tic-tac-toe/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+# cdylib for wasm loading (the primary product); rlib so the client
+# demo can `use` shared kinds + constants without duplicating them.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-component = { path = "../../crates/aether-component" }

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -284,6 +284,14 @@ fn is_board_full(board: &[[u8; 3]; 3]) -> bool {
     true
 }
 
+// Gated on wasm32: the `export!` macro emits `#[no_mangle]`
+// `init` / `receive_p32` / `on_drop` / `on_replace` /
+// `on_rehydrate_p32` shims the substrate calls over FFI. Those
+// symbols only mean something in a wasm guest — emitting them in
+// host builds causes duplicate-symbol link errors when a sibling
+// rlib (e.g. the tic-tac-toe-client demo) depends on this crate
+// and also has its own `export!`. Host unit tests don't need them.
+#[cfg(target_arch = "wasm32")]
 aether_component::export!(TicTacToe);
 
 #[cfg(test)]

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -129,7 +129,17 @@ pub struct TicTacToe {
     state: GameState,
     move_result_kind: KindId<MoveResult>,
     broadcast: Sink<GameState>,
+    client_observer: Sink<GameState>,
 }
+
+/// Well-known local mailbox name the server fans `GameState` to in
+/// addition to `hub.claude.broadcast`. Any component loaded under
+/// this name on the same substrate as the server will receive every
+/// state update — the intended consumer is the `aether-demo-tic-tac-
+/// toe-client` renderer, but any observer-style component works.
+/// If no component is registered under this name the send is a
+/// harmless "mailbox unknown" warn-drop.
+pub const CLIENT_OBSERVER: &str = "tic_tac_toe.client";
 
 /// Authoritative tic-tac-toe server. Accepts `PlayMove` and `Reset`
 /// from any attached Claude session, replies to the sender with the
@@ -154,6 +164,7 @@ impl Component for TicTacToe {
             state: GameState::new_game(),
             move_result_kind: ctx.resolve::<MoveResult>(),
             broadcast: ctx.resolve_sink::<GameState>("hub.claude.broadcast"),
+            client_observer: ctx.resolve_sink::<GameState>(CLIENT_OBSERVER),
         }
     }
 
@@ -174,6 +185,7 @@ impl Component for TicTacToe {
         self.reply(ctx, status);
         if status == MOVE_OK {
             ctx.send(&self.broadcast, &self.state);
+            ctx.send(&self.client_observer, &self.state);
         }
     }
 
@@ -189,6 +201,7 @@ impl Component for TicTacToe {
         self.state = GameState::new_game();
         self.reply(ctx, MOVE_OK);
         ctx.send(&self.broadcast, &self.state);
+        ctx.send(&self.client_observer, &self.state);
     }
 }
 
@@ -299,6 +312,7 @@ mod tests {
             state: GameState::new_game(),
             move_result_kind: aether_component::resolve::<MoveResult>(),
             broadcast: aether_component::resolve_sink::<GameState>("hub.claude.broadcast"),
+            client_observer: aether_component::resolve_sink::<GameState>(CLIENT_OBSERVER),
         }
     }
 


### PR DESCRIPTION
## Summary

- New `demos/tic-tac-toe-client` WASM component that renders the tic-tac-toe server's `GameState` on the desktop chassis.
- Board renders as a 3×3 grid of cell quads with inner-mark quads for occupied cells (red X, blue O). Last-moved cell is tinted; entire board tints green once the game ends.
- Server change: fan each state update to a second, locally-addressable sink (`tic_tac_toe.client`) in addition to `hub.claude.broadcast`. Client registers under that well-known name.
- No input handling, no hub-chassis, no cross-substrate routing — single-process demo on a desktop substrate. Step 1 of the critical path toward the client↔server-over-hub version.

## Why

First use case that exercises more than one component on the same substrate, and the first rendering output beyond a static triangle. Validates the rendering approach (cell grid + inner-mark quads) and the "local observer" pattern that step 5 will eventually replace with mail-bubbles-up over the hub-chassis.

## Test plan

- [x] Existing server unit tests (8) still pass after the `client_observer` field addition.
- [x] `cargo clippy --all-targets` clean across the workspace.
- [x] Full workspace `cargo test`: 116 hub + 18 end-to-end + 5 input-subscription + 4 hub_client + 8 server tests all green.
- [x] MCP smoke via `capture_frame` on the desktop chassis. Sequence + observations:
  - Empty board: uniform dark grid.
  - X at (0,0): red inner quad, cell tinted as last-move.
  - O at (1,1): blue inner quad in center, last-move tint moved to center.
  - X at (0,1), O at (2,0), X at (0,2): top-row win. Every cell tints green. Three red X marks across the top, two blue O marks at (1,1) and (2,0).
  - `tic_tac_toe.reset`: board returns to the uniform empty state.

## Out of scope

- Mouse-click input. Next step.
- Proper X/O glyph shapes. Solid inner squares are legible enough for the smoke; polish can follow.
- Cross-substrate client↔server. Requires the hub-chassis (ADR-0034 Phase 1) and mail-bubbles-up (ADR-0037); both are upcoming.