### PR TITLE
chore(ci): cap test + desktop jobs at 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # Normal run is ≤ 2 min; cap at 15 so a hang doesn't eat the
+    # default 6h quota before anyone notices. If this tripping
+    # becomes routine, lower it — routine failure is a signal.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -78,6 +82,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    # Normal run is ≤ 2 min; cap at 15 so a runner stall (hub mac
+    # CI flaked on 2026-04-21 against PR #164's commit, then
+    # re-ran clean on the same SHA) doesn't eat the default 6h
+    # quota. Long-term we'd rather treat repeat flakes as a real
+    # scheduler/concurrency signal than keep growing this bound.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Adds `timeout-minutes: 15` to the `test` (workspace, linux) and `desktop` (macos + windows) CI jobs. Normal runs are ≤ 2 min; the cap just stops a future hang from burning through the default 6 h GHA quota before someone cancels it.

**Context:** PR #164's first mac CI run hung for 10m48s on `batched_mail_preserves_fifo_per_mailbox`, a 2-worker / 200-mail concurrency regression test added in PR #158. Re-run on the same commit was clean; local reruns pass 40/40. Diagnosis: shared macOS GHA runner schedule jitter, not a real bug. Tracked as a one-off in memory — a second occurrence on a different commit would warrant actual scheduler investigation (per-test thread-timeout wrapper + stack dump), not a bigger bound here.

## Test plan

- [x] `yamllint` syntax check by eye — adds two `timeout-minutes: 15` lines inside existing job definitions
- [x] Workflow runs clean on this PR's own CI (normal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)