### PR TITLE
fix(substrate): drop_component no longer requires unique Arc ownership

### DIFF
--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -368,21 +368,40 @@ impl ControlPlane {
         // ADR-0021 §4: clear this mailbox from every input subscriber
         // set. Done after the registry marks the mailbox `Dropped` so
         // the invariant "every subscriber id references a live mailbox"
-        // holds across the short window before `remove_component`
-        // finishes — any mail the platform thread publishes in that
-        // window is already discarded by the scheduler's `Dropped`
-        // arm, so fan-out to a soon-to-be-empty subscriber set is
-        // harmless.
+        // holds across the short window before the entry is removed
+        // from the scheduler table — any mail the platform thread
+        // publishes in that window is already discarded by the
+        // scheduler's `Dropped` arm, so fan-out to a soon-to-be-empty
+        // subscriber set is harmless.
         input::remove_from_all(&self.input_subscribers, id);
-        // Pull the Component out of the scheduler table, fire the
-        // ADR-0015 `on_drop` hook on it, then let it drop at end of
-        // scope so wasmtime reclaims linear memory. The mailbox was
-        // already marked `Dropped` above, so any mail racing in
-        // parallel will be discarded regardless of when the hook
-        // runs.
-        if let Some(mut component) = self.remove_component(id) {
-            component.on_drop();
+        let Some(entry) = self.components.write().unwrap().remove(&id) else {
+            return DropResult::Ok;
+        };
+        // Bound-wait for any in-flight `deliver` to return. The
+        // registry is already `Dropped`, so workers that had not yet
+        // claimed this mailbox will take the Dropped branch (discard)
+        // rather than entering the Component branch; drain_pending
+        // only has to wait for workers already past the frozen check.
+        // Without the bound, a stuck wasm deliver would hang the
+        // control-plane thread indefinitely.
+        let timeout = Duration::from_millis(DEFAULT_DRAIN_TIMEOUT_MS as u64);
+        if !drain_pending(&entry, timeout) {
+            return DropResult::Err {
+                error: format!(
+                    "drain timeout after {}ms; component may be stuck in deliver",
+                    timeout.as_millis()
+                ),
+            };
         }
+        // Fire `on_drop` under the Component mutex. The entry `Arc`
+        // may still be clone-held by a worker's post-dispatch tail —
+        // harmless because the worker never touches `component` after
+        // `dispatch_mail` returns (any subsequent mail takes the
+        // Dropped branch). `ComponentEntry` deallocates when the last
+        // Arc clone drops: ours at end of scope, the worker's when it
+        // finishes its drain loop. Avoids the `Arc::into_inner` trap
+        // where the prior code panicked on strand-tail ownership.
+        entry.component.lock().unwrap().on_drop();
         DropResult::Ok
     }
 
@@ -611,11 +630,6 @@ impl ControlPlane {
             id,
             Arc::new(crate::scheduler::ComponentEntry::new(component)),
         );
-    }
-
-    fn remove_component(&self, id: MailboxId) -> Option<Component> {
-        let entry = self.components.write().unwrap().remove(&id)?;
-        Some(crate::scheduler::extract_component(entry))
     }
 
     /// Ship the complete current kind vocabulary to the hub so its
@@ -1040,6 +1054,48 @@ mod tests {
                 .contains_key(&MailboxId(mailbox_id)),
             "component must be removed from scheduler table",
         );
+    }
+
+    #[test]
+    fn drop_component_succeeds_with_outstanding_entry_arc_clone() {
+        // Regression for the scheduler strand-tail race: a worker's
+        // post-dispatch tail can still hold a clone of the
+        // `Arc<ComponentEntry>` at the instant `handle_drop` runs,
+        // because the worker's `strand_scheduled.store(false)` + Arc
+        // drop happens after `mark_completed` already woke any
+        // `wait_idle` the drop caller was parked on. Before the fix
+        // `handle_drop` panicked in `extract_component`'s
+        // `Arc::into_inner` when `strong_count > 1`.
+        let plane = make_plane();
+        let wasm = wat::parse_str(WAT).unwrap();
+        let LoadResult::Ok { mailbox_id, .. } = plane.handle_load(
+            &postcard::to_allocvec(&LoadComponent {
+                wasm,
+                name: Some("pinned".into()),
+            })
+            .unwrap(),
+        ) else {
+            panic!("load should succeed");
+        };
+
+        // Pin an extra Arc clone — mimics the worker's strand tail.
+        let pinned = plane
+            .components
+            .read()
+            .unwrap()
+            .get(&MailboxId(mailbox_id))
+            .cloned()
+            .expect("entry must be bound after load");
+
+        let result =
+            plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id }).unwrap());
+        assert!(
+            matches!(result, DropResult::Ok),
+            "drop must succeed even with outstanding Arc clone",
+        );
+
+        // Cleanup: drop the extra ref so `ComponentEntry` deallocates.
+        drop(pinned);
     }
 
     #[test]

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -175,35 +175,6 @@ impl Scheduler {
             .unwrap()
             .insert(id, Arc::new(ComponentEntry::new(component)));
     }
-
-    /// Remove and return the component bound to `id`, if any. The
-    /// caller is responsible for ensuring no further mail is dispatched
-    /// to this mailbox; workers that look up `id` after removal log a
-    /// "no component bound" drop, consistent with the pre-ADR-0010
-    /// unknown-mailbox path.
-    pub fn remove_component(&self, id: MailboxId) -> Option<Component> {
-        self.ctx
-            .components
-            .write()
-            .unwrap()
-            .remove(&id)
-            .map(extract_component)
-    }
-}
-
-/// Pull the wasmtime instance out of a removed entry. Panics if any
-/// other `Arc` clone is still live (e.g. a worker holding a reference
-/// across a deliver that's about to return). The control plane only
-/// removes entries after either (a) `drop_component` marked the
-/// mailbox `Dropped` so workers refuse new dispatches, or (b) the
-/// freeze-drain path of `handle_replace` confirmed `pending == 0`,
-/// so no worker should be holding a clone in either case.
-pub(crate) fn extract_component(entry: Arc<ComponentEntry>) -> Component {
-    Arc::into_inner(entry)
-        .expect("component entry still referenced by a worker")
-        .component
-        .into_inner()
-        .expect("component mutex poisoned")
 }
 
 impl Drop for Scheduler {


### PR DESCRIPTION
## Summary
- `handle_drop` was extracting the `Component` via `Arc::into_inner(entry).expect("component entry still referenced by a worker")`, which panics if a worker's post-dispatch tail still holds a clone of the `ComponentEntry` Arc. That window is narrow but real: `mark_completed` wakes a parked `wait_idle` before the worker sets `strand_scheduled=false` and drops its Arc clone, so a test that `wait_idle`s then drops can observe `strong_count == 2`.
- Under mac CI runner jitter (and in the `drop_clears_subscriptions` failure surfaced on the hub-chassis branch), this fired and aborted the substrate.
- Drops `Arc::into_inner` entirely. After `drop_mailbox` marks the mailbox `Dropped`, workers take the Dropped branch in `dispatch_mail` and never touch the Component again — so locking `Mutex<Component>` is sufficient synchronization for `on_drop`. `ComponentEntry` deallocates when the last Arc clone drops naturally (handle_drop's at scope exit, the worker's when it finishes its drain loop).
- Bounded `drain_pending` keeps the control plane responsive if a wasm `deliver` hangs — matches the existing `handle_replace` timeout shape.
- Deletes the now-unused `Scheduler::remove_component` and `scheduler::extract_component` — they were the only path carrying the uniqueness assumption.

## Regression coverage
New `drop_component_succeeds_with_outstanding_entry_arc_clone` test pins an extra Arc clone before calling `handle_drop`; under the old code this panicked deterministically, now it passes.

`drop_clears_subscriptions` still passes (5/5 consecutive runs locally).

## Follow-up
Longer-term structural fix is an actor-per-component dispatch model (mpsc inbox + task handle) that makes `drop = close sender + await task exit` the structural shape and retires `ComponentEntry`'s three loose invariants (`pending`, `frozen`, `strand_scheduled`) into one primitive. Will open as an ADR after this lands.

## Test plan
- [ ] CI green on all platforms
- [x] Run `cargo test --workspace --all-targets` locally — done, all green
- [ ] `cargo clippy --all-targets -- -D warnings` — done, clean
- [x] `cargo fmt -- --check` — done, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)