### PR TITLE
docs(adr): mark ADR-0038 accepted, ADR-0022 superseded

### DIFF
--- a/docs/adr/0022-drain-on-swap.md
+++ b/docs/adr/0022-drain-on-swap.md
@@ -1,6 +1,6 @@
 # ADR-0022: Drain in-flight mail before component swap
 
-- **Status:** Accepted
+- **Status:** Superseded by ADR-0038
 - **Date:** 2026-04-17
 
 ## Context

--- a/docs/adr/0038-actor-per-component-dispatch.md
+++ b/docs/adr/0038-actor-per-component-dispatch.md
@@ -1,6 +1,6 @@
 # ADR-0038: Actor-per-component dispatch
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context


### PR DESCRIPTION
## Summary
- ADR-0038 status: Proposed → Accepted. Phases 1–3 shipped across PRs #168 / #169 / #170.
- ADR-0022 status: Accepted → Superseded by ADR-0038. The drain-on-swap invariant survives structurally (channel splice preserves it) but the `pending` / `frozen` / `parked` machinery retired, so 0022 is no longer canonical.

Two-line diff; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)