### PR TITLE
chore(substrate): rename MailQueue → Mailer

### DIFF
--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -3,7 +3,7 @@
 //! ADR-0035 split peripheral code out of the runtime, but left every
 //! chassis's `main()` copying ~80 lines of identical initialisation:
 //! `HubOutbound` + `log_capture::init` + `Engine` + `Registry` + kind
-//! descriptor loop + broadcast sink + `MailQueue` + `Linker` +
+//! descriptor loop + broadcast sink + `Mailer` + `Linker` +
 //! `host_fns::register` + `Scheduler` + input subscribers +
 //! `ControlPlane` + optional `AETHER_HUB_URL` connect. `SubstrateBoot`
 //! folds that path into a single builder so adding a new chassis
@@ -25,7 +25,7 @@ use wasmtime::{Engine, Linker};
 
 use crate::{
     AETHER_CONTROL, ChassisControlHandler, ControlPlane, HUB_CLAUDE_BROADCAST, HubClient,
-    HubOutbound, InputSubscribers, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx, host_fns,
     input::new_subscribers, log_capture, mail::MailboxId,
 };
 
@@ -39,7 +39,7 @@ pub struct SubstrateBoot {
     pub engine: Arc<Engine>,
     pub registry: Arc<Registry>,
     pub linker: Arc<Linker<SubstrateCtx>>,
-    pub queue: Arc<MailQueue>,
+    pub queue: Arc<Mailer>,
     pub outbound: Arc<HubOutbound>,
     pub input_subscribers: InputSubscribers,
     pub broadcast_mbox: MailboxId,
@@ -61,7 +61,7 @@ pub struct SubstrateBoot {
 /// ownership away from the boot itself.
 pub struct ChassisHandlerContext<'a> {
     pub registry: &'a Arc<Registry>,
-    pub queue: &'a Arc<MailQueue>,
+    pub queue: &'a Arc<Mailer>,
     pub outbound: &'a Arc<HubOutbound>,
 }
 
@@ -160,7 +160,7 @@ impl<'a> SubstrateBootBuilder<'a> {
             )
         };
 
-        let queue = Arc::new(MailQueue::new());
+        let queue = Arc::new(Mailer::new());
 
         let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
         host_fns::register(&mut linker)?;

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -236,14 +236,14 @@ mod tests {
     use super::*;
     use crate::hub_client::HubOutbound;
     use crate::mail::MailboxId;
-    use crate::queue::MailQueue;
+    use crate::mailer::Mailer;
     use crate::registry::Registry;
 
     fn ctx() -> SubstrateCtx {
         SubstrateCtx::new(
             MailboxId(0),
             Arc::new(Registry::new()),
-            Arc::new(MailQueue::new()),
+            Arc::new(Mailer::new()),
             HubOutbound::disconnected(),
             crate::input::new_subscribers(),
         )
@@ -572,7 +572,7 @@ mod tests {
         let ctx = SubstrateCtx::new(
             M(0),
             registry,
-            Arc::new(MailQueue::new()),
+            Arc::new(Mailer::new()),
             outbound,
             crate::input::new_subscribers(),
         );
@@ -627,13 +627,13 @@ mod tests {
     /// has both a fake originating-component mailbox (id 1, name
     /// "caller") and a "test.pong" kind. When `WAT_REPLIES` calls
     /// `reply_mail` with the Component-variant handle the substrate
-    /// allocated, the reply lands on the local `MailQueue` —
+    /// allocated, the reply lands on the local `Mailer` —
     /// outbound stays empty.
     #[allow(dead_code)]
     fn plane_ctx_with_caller_mailbox() -> (
         SubstrateCtx,
         std::sync::mpsc::Receiver<aether_hub_protocol::EngineToHub>,
-        Arc<MailQueue>,
+        Arc<Mailer>,
         crate::mail::MailboxId,
         u64,
     ) {
@@ -651,7 +651,7 @@ mod tests {
                 schema: SchemaType::Unit,
             })
             .expect("register kind");
-        let queue = Arc::new(MailQueue::new());
+        let queue = Arc::new(Mailer::new());
         let ctx = SubstrateCtx::new(
             M(0),
             registry,
@@ -663,7 +663,7 @@ mod tests {
     }
 
     // Retired under ADR-0038 Phase 2: these two tests peeked at
-    // `MailQueue::try_pop` to observe reply-mail routing, but Phase 2
+    // `Mailer::try_pop` to observe reply-mail routing, but Phase 2
     // retired the queue's inspectable deque in favour of inline
     // routing directly into per-component inboxes. The component-
     // reply path (ADR-0017) is still covered end-to-end by the MCP

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -40,7 +40,7 @@ use crate::hub_client::HubOutbound;
 use crate::input::{self, InputSubscribers};
 use crate::kind_manifest;
 use crate::mail::{Mail, MailboxId};
-use crate::queue::MailQueue;
+use crate::mailer::Mailer;
 use crate::registry::{Registry, SinkHandler};
 use crate::scheduler::{ComponentEntry, ComponentTable, close_and_join};
 
@@ -143,7 +143,7 @@ pub struct ControlPlane {
     pub engine: Arc<Engine>,
     pub linker: Arc<Linker<SubstrateCtx>>,
     pub registry: Arc<Registry>,
-    pub queue: Arc<MailQueue>,
+    pub queue: Arc<Mailer>,
     pub outbound: Arc<HubOutbound>,
     pub components: ComponentTable,
     /// ADR-0021 per-stream subscriber sets, shared with the platform
@@ -705,7 +705,7 @@ mod tests {
         let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
         crate::host_fns::register(&mut linker).expect("register host fns");
         let registry = Arc::new(Registry::new());
-        let queue = Arc::new(MailQueue::new());
+        let queue = Arc::new(Mailer::new());
         let outbound = HubOutbound::disconnected();
         let components: ComponentTable = Arc::default();
 

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -6,7 +6,7 @@
 // Deliberately does NOT hold the scheduler's full shared state — doing
 // so would create an Arc cycle through `Scheduler owns Actor, Actor
 // owns Store<SubstrateCtx>, SubstrateCtx back to Scheduler`. By holding
-// only `Arc<Registry>` and `Arc<MailQueue>` the cycle is broken: neither
+// only `Arc<Registry>` and `Arc<Mailer>` the cycle is broken: neither
 // of those owns any actor.
 
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use aether_hub_protocol::SessionToken;
 use crate::hub_client::HubOutbound;
 use crate::input::InputSubscribers;
 use crate::mail::{Mail, MailKind, MailboxId};
-use crate::queue::MailQueue;
+use crate::mailer::Mailer;
 use crate::registry::{MailboxEntry, Registry};
 use crate::sender_table::SenderTable;
 
@@ -34,7 +34,7 @@ pub struct StateBundle {
 pub struct SubstrateCtx {
     pub sender: MailboxId,
     pub registry: Arc<Registry>,
-    pub queue: Arc<MailQueue>,
+    pub queue: Arc<Mailer>,
     /// ADR-0013: direct outbound handle so the `reply_mail` host fn
     /// can address a specific Claude session without routing through
     /// a well-known sink. Broadcast still goes through
@@ -56,7 +56,7 @@ pub struct SubstrateCtx {
     /// receives an opaque `u32` handle as the 4th param on its
     /// `receive` shim and passes it back to `reply_mail`; the
     /// substrate routes either over `HubOutbound` or back through
-    /// `MailQueue` based on the variant.
+    /// `Mailer` based on the variant.
     pub sender_table: SenderTable,
     /// Set by the `save_state` host fn during `on_replace`. The
     /// substrate extracts it after hooks return via
@@ -80,7 +80,7 @@ impl SubstrateCtx {
     pub fn new(
         sender: MailboxId,
         registry: Arc<Registry>,
-        queue: Arc<MailQueue>,
+        queue: Arc<Mailer>,
         outbound: Arc<HubOutbound>,
         input_subscribers: InputSubscribers,
     ) -> Self {

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -128,7 +128,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // Branches on the `SenderEntry` variant:
     //   - Session: ship as a `ClaudeAddress::Session` frame through
     //     `HubOutbound` (same route as ADR-0013's original design).
-    //   - Component: enqueue on the local `MailQueue` via
+    //   - Component: enqueue on the local `Mailer` via
     //     `SubstrateCtx::send`. Dropped-mailbox discard is handled
     //     there already, so a component that vanished between the
     //     request and the reply silently drops — the same contract

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -2,7 +2,7 @@
 // Hello/Welcome handshake, then runs three background threads:
 //
 //   - a reader that blocks on `HubToEngine` frames and funnels inbound
-//     `Mail` into the scheduler's `MailQueue` after resolving the
+//     `Mail` into the scheduler's `Mailer` after resolving the
 //     recipient and kind against the local `Registry`,
 //   - a writer that drains a `std::sync::mpsc::Receiver<EngineToHub>`
 //     and serialises its frames onto the TCP stream,
@@ -32,7 +32,7 @@ use aether_hub_protocol::{
 };
 
 use crate::mail::Mail;
-use crate::queue::MailQueue;
+use crate::mailer::Mailer;
 use crate::registry::Registry;
 
 /// Cadence at which this client emits `Heartbeat` to the hub. Must be
@@ -149,7 +149,7 @@ impl HubClient {
         version: impl Into<String>,
         kinds: Vec<KindDescriptor>,
         registry: Arc<Registry>,
-        queue: Arc<MailQueue>,
+        queue: Arc<Mailer>,
         outbound: Arc<HubOutbound>,
     ) -> io::Result<Self> {
         let mut stream = TcpStream::connect(addr)?;
@@ -192,7 +192,7 @@ impl HubClient {
     }
 }
 
-fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<MailQueue>) {
+fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<Mailer>) {
     loop {
         match read_frame::<_, HubToEngine>(&mut stream) {
             Ok(HubToEngine::Mail(frame)) => dispatch_mail(frame, &registry, &queue),
@@ -230,7 +230,7 @@ fn run_heartbeat(tx: Sender<EngineToHub>) {
     }
 }
 
-fn dispatch_mail(frame: MailFrame, registry: &Registry, queue: &MailQueue) {
+fn dispatch_mail(frame: MailFrame, registry: &Registry, queue: &Mailer) {
     let Some(recipient) = registry.lookup(&frame.recipient_name) else {
         tracing::warn!(
             target: "aether_substrate::hub_client",

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod input;
 pub mod kind_manifest;
 pub mod log_capture;
 pub mod mail;
-pub mod queue;
+pub mod mailer;
 pub mod registry;
 pub mod scheduler;
 pub mod sender_table;
@@ -44,7 +44,7 @@ pub use ctx::SubstrateCtx;
 pub use hub_client::{HubClient, HubOutbound};
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{Mail, MailKind, MailboxId};
-pub use queue::MailQueue;
+pub use mailer::Mailer;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;
 

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -19,7 +19,7 @@ use crate::mail::Mail;
 use crate::registry::{MailboxEntry, Registry};
 use crate::scheduler::ComponentTable;
 
-pub struct MailQueue {
+pub struct Mailer {
     /// Registry handle for resolving recipients on `push`. Wired once
     /// by `Scheduler::new`; expected to be set by the time any mail
     /// can land.
@@ -29,7 +29,7 @@ pub struct MailQueue {
     components: OnceLock<ComponentTable>,
 }
 
-impl MailQueue {
+impl Mailer {
     pub fn new() -> Self {
         Self {
             registry: OnceLock::new(),
@@ -43,10 +43,10 @@ impl MailQueue {
     pub fn wire(&self, registry: Arc<Registry>, components: ComponentTable) {
         self.registry
             .set(registry)
-            .unwrap_or_else(|_| panic!("MailQueue::wire called twice"));
+            .unwrap_or_else(|_| panic!("Mailer::wire called twice"));
         self.components
             .set(components)
-            .unwrap_or_else(|_| panic!("MailQueue::wire called twice"));
+            .unwrap_or_else(|_| panic!("Mailer::wire called twice"));
     }
 
     /// Hand `mail` to the substrate for dispatch. Sinks run on the
@@ -56,8 +56,8 @@ impl MailQueue {
     pub fn push(&self, mail: Mail) {
         route_mail(
             mail,
-            self.registry.get().expect("MailQueue not wired"),
-            self.components.get().expect("MailQueue not wired"),
+            self.registry.get().expect("Mailer not wired"),
+            self.components.get().expect("Mailer not wired"),
         );
     }
 
@@ -68,12 +68,12 @@ impl MailQueue {
     /// per-mailbox drain counter, re-checking in case one entry's
     /// delivery pushed fresh mail to another).
     pub fn drain_all(&self) {
-        let components = self.components.get().expect("MailQueue not wired");
+        let components = self.components.get().expect("Mailer not wired");
         crate::scheduler::drain_all(components);
     }
 }
 
-impl Default for MailQueue {
+impl Default for Mailer {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -2,12 +2,12 @@
 //
 // Phase 1 gave each component a dedicated dispatcher thread that
 // loops on an mpsc inbox. Phase 2 retires the router thread that
-// Phase 1 left in place: `MailQueue::push` now resolves the
+// Phase 1 left in place: `Mailer::push` now resolves the
 // recipient inline on the caller's thread and forwards directly into
 // the per-component inbox (see `queue.rs`). The per-mailbox dispatcher
 // is unchanged.
 //
-// `wait_idle` semantics are preserved: `MailQueue`'s `outstanding`
+// `wait_idle` semantics are preserved: `Mailer`'s `outstanding`
 // counter increments on `push` (before routing) and decrements inside
 // the dispatcher thread after `deliver` returns, or inline for sinks /
 // warn-drops. A `wait_idle` that returns still means every pushed
@@ -31,7 +31,7 @@ use std::thread::{self, JoinHandle};
 
 use crate::component::{Component, DISPATCH_UNKNOWN_KIND};
 use crate::mail::{Mail, MailboxId};
-use crate::queue::MailQueue;
+use crate::mailer::Mailer;
 use crate::registry::Registry;
 
 /// Per-entry quiescence counter + condvar, shared with the dispatcher
@@ -39,7 +39,7 @@ use crate::registry::Registry;
 /// the dispatcher decrements after each `deliver` and signals when the
 /// counter reaches zero. `drain` waits on the condvar for that signal,
 /// giving callers a per-mailbox barrier equivalent to the Phase-2
-/// global `MailQueue::wait_idle`.
+/// global `Mailer::wait_idle`.
 #[derive(Default)]
 struct PendingGate {
     pending: AtomicU32,
@@ -233,7 +233,7 @@ fn dispatcher_loop(
 }
 
 /// Shared, runtime-mutable table of bound components. Cloned into the
-/// `MailQueue` (for inline routing on push) and into the ADR-0010
+/// `Mailer` (for inline routing on push) and into the ADR-0010
 /// load handler so both read and write through the same `RwLock`.
 /// Values are `Arc`-shared so short-lived clones (e.g. the router's
 /// forward path) can outlive a concurrent `remove` without racing on
@@ -241,7 +241,7 @@ fn dispatcher_loop(
 pub type ComponentTable = Arc<RwLock<HashMap<MailboxId, Arc<ComponentEntry>>>>;
 
 pub struct Scheduler {
-    queue: Arc<MailQueue>,
+    queue: Arc<Mailer>,
     registry: Arc<Registry>,
     components: ComponentTable,
 }
@@ -253,7 +253,7 @@ impl Scheduler {
     /// compatibility (ADR-0004 sized the worker pool) but is ignored
     /// under ADR-0038: dispatch parallelism is one thread per
     /// component, and Phase 2 retired the shared router thread.
-    pub fn new(registry: Arc<Registry>, queue: Arc<MailQueue>, _k_workers: usize) -> Self {
+    pub fn new(registry: Arc<Registry>, queue: Arc<Mailer>, _k_workers: usize) -> Self {
         let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
         queue.wire(Arc::clone(&registry), Arc::clone(&components));
         Self {
@@ -263,7 +263,7 @@ impl Scheduler {
         }
     }
 
-    pub fn queue(&self) -> &Arc<MailQueue> {
+    pub fn queue(&self) -> &Arc<Mailer> {
         &self.queue
     }
 
@@ -289,7 +289,7 @@ impl Scheduler {
     }
 }
 
-/// Barrier equivalent to the Phase-2 `MailQueue::wait_idle`: block
+/// Barrier equivalent to the Phase-2 `Mailer::wait_idle`: block
 /// until every component in `components` has an empty inbox and no
 /// in-flight `deliver`. Iterates + re-checks in case a component's
 /// delivery pushes fresh mail to one we already drained (e.g. a

--- a/crates/aether-substrate-core/src/sender_table.rs
+++ b/crates/aether-substrate-core/src/sender_table.rs
@@ -37,7 +37,7 @@ pub const SENDER_NONE: u32 = u32::MAX;
 pub enum SenderEntry {
     /// Reply routes over `HubOutbound` as a session-addressed frame.
     Session(SessionToken),
-    /// Reply routes through the local `MailQueue` as ordinary
+    /// Reply routes through the local `Mailer` as ordinary
     /// component-to-component mail.
     Component(MailboxId),
 }

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -22,7 +22,7 @@ use aether_kinds::{
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
-    ChassisControlHandler, HubOutbound, MailQueue, Registry,
+    ChassisControlHandler, HubOutbound, Mailer, Registry,
     control::{decode_payload, resolve_bundle},
 };
 use winit::event_loop::EventLoopProxy;
@@ -63,7 +63,7 @@ pub fn chassis_control_handler(
     proxy: EventLoopProxy<UserEvent>,
     capture_queue: CaptureQueue,
     registry: Arc<Registry>,
-    queue: Arc<MailQueue>,
+    queue: Arc<Mailer>,
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
@@ -106,7 +106,7 @@ fn handle_capture_frame(
     proxy: &EventLoopProxy<UserEvent>,
     capture_queue: &CaptureQueue,
     registry: &Registry,
-    queue: &MailQueue,
+    queue: &Mailer,
     outbound: &HubOutbound,
     sender: SessionToken,
     bytes: &[u8],

--- a/crates/aether-substrate-desktop/src/lib.rs
+++ b/crates/aether-substrate-desktop/src/lib.rs
@@ -18,10 +18,10 @@ pub mod chassis;
 
 pub use aether_substrate_core::{
     AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,
-    HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailQueue,
-    MailboxEntry, MailboxId, Registry, Scheduler, SinkHandler, SubstrateBoot, SubstrateCtx,
-    component, control, ctx, host_fns, hub_client, input, kind_manifest, log_capture, mail,
-    new_subscribers, queue, registry, remove_from_all, scheduler, sender_table, subscribers_for,
+    HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailboxEntry,
+    MailboxId, Mailer, Registry, Scheduler, SinkHandler, SubstrateBoot, SubstrateCtx, component,
+    control, ctx, host_fns, hub_client, input, kind_manifest, log_capture, mail, mailer,
+    new_subscribers, registry, remove_from_all, scheduler, sender_table, subscribers_for,
 };
 
 pub use capture::{CaptureQueue, PendingCapture};

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -27,8 +27,8 @@ use aether_kinds::{
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
 use aether_substrate_desktop::{
-    CaptureQueue, Chassis, ChassisCapabilities, HubClient, HubOutbound, InputSubscribers,
-    MailQueue, Scheduler, SubstrateBoot, UserEvent, chassis_control_handler,
+    CaptureQueue, Chassis, ChassisCapabilities, HubClient, HubOutbound, InputSubscribers, Mailer,
+    Scheduler, SubstrateBoot, UserEvent, chassis_control_handler,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
@@ -93,7 +93,7 @@ impl Chassis for DesktopChassis {
 }
 
 struct App {
-    queue: Arc<MailQueue>,
+    queue: Arc<Mailer>,
     /// ADR-0021 per-stream subscribers. Shared with the control plane
     /// so subscribe / unsubscribe / drop write through the same table
     /// the platform thread reads on each event. Empty sets — the

--- a/crates/aether-substrate-desktop/tests/end_to_end.rs
+++ b/crates/aether-substrate-desktop/tests/end_to_end.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use aether_substrate_desktop::{
-    Component, HubOutbound, MailQueue, Registry, Scheduler, SubstrateCtx, host_fns,
+    Component, HubOutbound, Mailer, Registry, Scheduler, SubstrateCtx, host_fns,
     mail::{Mail, MailboxId},
 };
 use wasmtime::{Engine, Linker, Module};
@@ -65,7 +65,7 @@ fn tick_roundtrip_component_to_sink() {
     let module = Module::new(&engine, forwards_to_sink_wat(sink_mbox)).expect("compile wat");
     assert_eq!(component_mbox, MailboxId::from_name("hello"));
     assert_eq!(sink_mbox, MailboxId::from_name("heartbeat"));
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
 
     let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
     host_fns::register(&mut linker).expect("register host fns");
@@ -124,7 +124,7 @@ fn batched_mail_preserves_fifo_per_mailbox() {
 
     let module = Module::new(&engine, forwards_to_sink_wat(sink_mbox)).expect("compile wat");
 
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
     let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
     host_fns::register(&mut linker).expect("register host fns");
 

--- a/crates/aether-substrate-desktop/tests/hub_client.rs
+++ b/crates/aether-substrate-desktop/tests/hub_client.rs
@@ -14,7 +14,7 @@ use aether_hub_protocol::{
     SessionToken, Uuid, Welcome, read_frame, write_frame,
 };
 use aether_substrate_desktop::{
-    HubClient, HubOutbound, MailQueue, Registry, Scheduler, mail::MailboxId,
+    HubClient, HubOutbound, Mailer, Registry, Scheduler, mail::MailboxId,
 };
 
 /// Start a mock hub on a random port. Returns the bound address and a
@@ -39,7 +39,7 @@ fn handshake_exchanges_hello_and_welcome() {
     let (addr, conn_rx) = accept_one();
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -117,7 +117,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
         ),
     );
     registry.register_kind("aether.tick");
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
 
     let _sched = Scheduler::new(Arc::clone(&registry), Arc::clone(&queue), 1);
 
@@ -205,7 +205,7 @@ fn client_sends_periodic_heartbeats() {
     let (addr, conn_rx) = accept_one();
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -255,7 +255,7 @@ fn goodbye_stops_reader_thread() {
     // long as nothing hangs past the deadline.
     let (addr, conn_rx) = accept_one();
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -306,7 +306,7 @@ fn outbound_sends_reach_the_hub_wire() {
     assert!(!outbound.is_connected());
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
 
     let connect_outbound = Arc::clone(&outbound);
     let client_handle = thread::spawn({

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -17,7 +17,7 @@ use aether_kinds::{
 };
 use aether_mail::Kind;
 use aether_substrate_desktop::{
-    ControlPlane, HubOutbound, InputSubscribers, MailQueue, Registry, Scheduler, SubstrateCtx,
+    ControlPlane, HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx,
     host_fns,
     mail::{Mail, MailboxId},
     new_subscribers, subscribers_for,
@@ -49,7 +49,7 @@ fn tally_forwarding_wat(tally_id: u64) -> String {
 
 struct Harness {
     plane: ControlPlane,
-    queue: Arc<MailQueue>,
+    queue: Arc<Mailer>,
     input_subscribers: InputSubscribers,
     counter: Arc<AtomicU32>,
     kind_tick: u64,
@@ -81,7 +81,7 @@ fn make_harness() -> Harness {
     );
     let wat = tally_forwarding_wat(sink_mbox.0);
 
-    let queue = Arc::new(MailQueue::new());
+    let queue = Arc::new(Mailer::new());
     let scheduler = Scheduler::new(Arc::clone(&registry), Arc::clone(&queue), 2);
 
     let input_subscribers = new_subscribers();

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use aether_kinds::{FrameStats, InputStream, Tick};
 use aether_mail::{Kind, encode, encode_empty};
 use aether_substrate_core::{
-    Chassis, ChassisCapabilities, InputSubscribers, MailQueue, Scheduler, SubstrateBoot,
+    Chassis, ChassisCapabilities, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
@@ -31,7 +31,7 @@ const LOG_EVERY_FRAMES: u64 = 120;
 /// substrates) or SIGINT (manual `cargo run`); there's no clean
 /// return path because there's no event source that can close.
 struct HeadlessChassis {
-    queue: Arc<MailQueue>,
+    queue: Arc<Mailer>,
     input_subscribers: InputSubscribers,
     broadcast_mbox: MailboxId,
     kind_tick: u64,


### PR DESCRIPTION
## Summary
- The Phase 3 `MailQueue` carried no queue — just registry + components wiring plus inline routing on `push`. The name dated back to Phase 0 when it owned the shared VecDeque that the router popped from.
- Rename the struct, module, and file to `Mailer` / `mailer` so the name describes what the type actually is: the entry point for handing mail off to the substrate for dispatch.

## Scope
Pure rename, no behaviour change. Touches 17 files:
- Struct `MailQueue` → `Mailer`, module `queue` → `mailer`, file moved via `git mv` (92% similarity — blame follows through).
- `crate::queue::` → `crate::mailer::` imports.
- Doc comments that named the type updated.

Not renamed:
- Local variable / struct field names like `queue: Arc<Mailer>`. They still read fine as "the mail-handoff handle" and renaming across 15+ call sites is churn without clarity win.
- Historical ADR references (`ADR-0017`, `ADR-0038`) that describe design-at-the-time.

## Test plan
- [ ] CI green on all platforms
- [ ] `cargo test --workspace --all-targets` — done locally, all green
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — done, clean
- [ ] `cargo fmt -- --check` — done, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)