### PR TITLE
docs(adr): flip ADR-0034 status to Accepted (Phase 1 shipped)

### DIFF
--- a/docs/adr/0034-hub-as-substrate.md
+++ b/docs/adr/0034-hub-as-substrate.md
@@ -1,6 +1,6 @@
 # ADR-0034: Hub-as-substrate
 
-- **Status:** Proposed
+- **Status:** Accepted (Phase 1 shipped; Phase 2 in progress)
 - **Date:** 2026-04-20
 
 ## Context


### PR DESCRIPTION
## Summary

- Flips ADR-0034 (Hub-as-substrate) from `Proposed` to `Accepted (Phase 1 shipped; Phase 2 in progress)`.
- Phase 1 landed via PR #162 (hub-chassis wrapper) and PR #163 (absorbing `aether-hub` into `aether-substrate-hub`); the ADR status was never updated to match.
- Bookkeeping only — no code changes, no behaviour change.
- Unblocks opening sub-phase A of Phase 2 (routing component) against an Accepted ADR rather than a Proposed one.

## Test plan

- [x] `grep "Status:" docs/adr/0034-hub-as-substrate.md` reflects the new mark
- [ ] CI passes (title-case + conventional-commits checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)