### PR TITLE
feat(hub): hub-chassis hosts its own substrate (ADR-0034 Phase 2 sub-phase A)

### DIFF
--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -73,6 +73,12 @@ pub struct SubstrateBootBuilder<'a> {
     version: &'a str,
     workers: usize,
     build_handler: ChassisHandlerFactory,
+    /// When `true`, `build()` skips the `AETHER_HUB_URL` env-var check
+    /// and leaves `boot.hub = None` unconditionally. Set by the hub
+    /// chassis (ADR-0034 Phase 2) since the hub is the hub — there is
+    /// no upstream parent to dial, and attaching to its own listener
+    /// would deadlock the tokio runtime at boot.
+    skip_upstream_hub: bool,
 }
 
 impl SubstrateBoot {
@@ -86,6 +92,7 @@ impl SubstrateBoot {
             version,
             workers: 2,
             build_handler: Box::new(|_| None),
+            skip_upstream_hub: false,
         }
     }
 }
@@ -94,6 +101,17 @@ impl<'a> SubstrateBootBuilder<'a> {
     /// Scheduler worker count. Default 2.
     pub fn workers(mut self, workers: usize) -> Self {
         self.workers = workers;
+        self
+    }
+
+    /// Skip the `AETHER_HUB_URL` env-var check during `build()`.
+    /// The hub chassis (ADR-0034 Phase 2) uses this because it *is*
+    /// the hub — no upstream to dial, and self-dialling before the
+    /// listener task is running would deadlock the tokio runtime.
+    /// The hub chassis wires an in-process loopback to
+    /// `boot.outbound` after `build()` returns.
+    pub fn skip_upstream_hub(mut self) -> Self {
+        self.skip_upstream_hub = true;
         self
     }
 
@@ -192,28 +210,32 @@ impl<'a> SubstrateBootBuilder<'a> {
         };
         registry.register_sink(AETHER_CONTROL, control_plane.into_sink_handler());
 
-        let hub = match std::env::var("AETHER_HUB_URL") {
-            Ok(url) => match HubClient::connect(
-                url.as_str(),
-                self.name,
-                self.version,
-                boot_descriptors.clone(),
-                Arc::clone(&registry),
-                Arc::clone(&queue),
-                Arc::clone(&outbound),
-            ) {
-                Ok(c) => Some(c),
-                Err(e) => {
-                    tracing::error!(
-                        target: "aether_substrate::boot",
-                        url = %url,
-                        error = %e,
-                        "hub connect failed",
-                    );
-                    None
-                }
-            },
-            Err(_) => None,
+        let hub = if self.skip_upstream_hub {
+            None
+        } else {
+            match std::env::var("AETHER_HUB_URL") {
+                Ok(url) => match HubClient::connect(
+                    url.as_str(),
+                    self.name,
+                    self.version,
+                    boot_descriptors.clone(),
+                    Arc::clone(&registry),
+                    Arc::clone(&queue),
+                    Arc::clone(&outbound),
+                ) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        tracing::error!(
+                            target: "aether_substrate::boot",
+                            url = %url,
+                            error = %e,
+                            "hub connect failed",
+                        );
+                        None
+                    }
+                },
+                Err(_) => None,
+            }
         };
 
         Ok(SubstrateBoot {

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -59,7 +59,15 @@ impl HubOutbound {
         })
     }
 
-    fn attach(&self, tx: Sender<EngineToHub>) {
+    /// Wire an outbound writer channel to this handle. Called once,
+    /// either by `HubClient::connect` after the TCP handshake
+    /// completes, or by a loopback chassis (ADR-0034 Phase 2) that
+    /// drains `EngineToHub` frames in-process rather than serialising
+    /// them over TCP. A second attach is ignored with a warning —
+    /// `HubOutbound` is single-writer by design so heartbeats and
+    /// outbound mail can't race on the socket (or the loopback
+    /// channel).
+    pub fn attach(&self, tx: Sender<EngineToHub>) {
         if self.tx.set(tx).is_err() {
             tracing::warn!(target: "aether_substrate::hub_client", "HubOutbound attached twice — ignoring second attach");
         }
@@ -195,7 +203,7 @@ impl HubClient {
 fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<Mailer>) {
     loop {
         match read_frame::<_, HubToEngine>(&mut stream) {
-            Ok(HubToEngine::Mail(frame)) => dispatch_mail(frame, &registry, &queue),
+            Ok(HubToEngine::Mail(frame)) => dispatch_hub_to_engine_mail(frame, &registry, &queue),
             Ok(HubToEngine::Heartbeat) => {}
             Ok(HubToEngine::Welcome(_)) => {
                 tracing::warn!(target: "aether_substrate::hub_client", "unexpected post-handshake Welcome, ignoring");
@@ -230,7 +238,12 @@ fn run_heartbeat(tx: Sender<EngineToHub>) {
     }
 }
 
-fn dispatch_mail(frame: MailFrame, registry: &Registry, queue: &Mailer) {
+/// Resolve a `HubToEngine::Mail` frame against the substrate's
+/// `Registry` and push the decoded `Mail` onto `queue`. Shared by the
+/// TCP `HubClient` reader (the canonical path) and the hub-chassis
+/// loopback drainer (ADR-0034 Phase 2), so both paths drop on unknown
+/// mailbox/kind with the same warning shape.
+pub fn dispatch_hub_to_engine_mail(frame: MailFrame, registry: &Registry, queue: &Mailer) {
     let Some(recipient) = registry.lookup(&frame.recipient_name) else {
         tracing::warn!(
             target: "aether_substrate::hub_client",

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -41,7 +41,7 @@ pub use chassis::{Chassis, ChassisCapabilities};
 pub use component::Component;
 pub use control::{AETHER_CONTROL, ChassisControlHandler, ControlPlane};
 pub use ctx::SubstrateCtx;
-pub use hub_client::{HubClient, HubOutbound};
+pub use hub_client::{HubClient, HubOutbound, dispatch_hub_to_engine_mail};
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{Mail, MailKind, MailboxId};
 pub use mailer::Mailer;

--- a/crates/aether-substrate-hub/src/chassis.rs
+++ b/crates/aether-substrate-hub/src/chassis.rs
@@ -20,14 +20,16 @@ use std::sync::Arc;
 
 use aether_substrate_core::{Chassis, ChassisCapabilities};
 
+use crate::loopback::{LoopbackEngine, run_inbound_drainer, spawn_outbound_drainer};
 use crate::{
     DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, LogStore, PendingSpawns,
     SessionRegistry, run_engine_listener, run_mcp_server,
 };
 
 /// Hub chassis handle. Holds the bound addresses + shared state
-/// handles; `run(self)` builds a tokio runtime and drives the
-/// listeners to termination.
+/// handles and the in-process loopback engine (ADR-0034 Phase 2
+/// sub-phase A); `run(self)` builds a tokio runtime and drives the
+/// listeners + the loopback drainers to termination.
 pub struct HubChassis {
     engine_addr: SocketAddr,
     mcp_addr: SocketAddr,
@@ -36,17 +38,22 @@ pub struct HubChassis {
     pending: PendingSpawns,
     logs: LogStore,
     state: Arc<HubState>,
+    loopback: LoopbackEngine,
 }
 
 impl HubChassis {
     /// Build a hub chassis with the given listener addresses. Fresh
     /// registry / session / spawn / log stores are created inline —
-    /// they never outlive the chassis.
-    pub fn new(engine_addr: SocketAddr, mcp_addr: SocketAddr) -> Self {
+    /// they never outlive the chassis. Boots the in-process
+    /// `SubstrateBoot` and registers it in the engine registry
+    /// under `HUB_SELF_ENGINE_ID` before returning, so MCP tools
+    /// see the hub-self engine from the moment `new()` completes.
+    pub fn new(engine_addr: SocketAddr, mcp_addr: SocketAddr) -> wasmtime::Result<Self> {
         let registry = EngineRegistry::new();
         let sessions = SessionRegistry::new();
         let pending = PendingSpawns::new();
         let logs = LogStore::new();
+        let loopback = LoopbackEngine::boot(&registry)?;
         let state = HubState::new(
             registry.clone(),
             sessions.clone(),
@@ -54,7 +61,7 @@ impl HubChassis {
             logs.clone(),
             engine_addr,
         );
-        Self {
+        Ok(Self {
             engine_addr,
             mcp_addr,
             registry,
@@ -62,7 +69,8 @@ impl HubChassis {
             pending,
             logs,
             state,
-        }
+            loopback,
+        })
     }
 
     /// Read `AETHER_ENGINE_PORT` / `AETHER_MCP_PORT` from the
@@ -70,7 +78,7 @@ impl HubChassis {
     /// `DEFAULT_MCP_PORT` when unset or unparseable. Binds both
     /// listeners on `127.0.0.1` — intentional for the current
     /// single-host development story.
-    pub fn from_env() -> Self {
+    pub fn from_env() -> wasmtime::Result<Self> {
         use std::net::{IpAddr, Ipv4Addr};
         let engine_port = env_port("AETHER_ENGINE_PORT").unwrap_or(DEFAULT_ENGINE_PORT);
         let mcp_port = env_port("AETHER_MCP_PORT").unwrap_or(DEFAULT_MCP_PORT);
@@ -90,7 +98,31 @@ impl HubChassis {
             pending,
             logs,
             state,
+            loopback,
         } = self;
+
+        let LoopbackEngine {
+            boot,
+            inbound_rx,
+            outbound_rx,
+        } = loopback;
+
+        // Loopback drainers. The inbound task runs alongside the
+        // TCP + MCP listeners; the outbound drainer runs on a
+        // dedicated std::thread because `std::sync::mpsc::Receiver`
+        // blocks synchronously. Both exit when their channel closes
+        // (at drop time on process shutdown).
+        let loopback_inbound_task = tokio::spawn(run_inbound_drainer(
+            inbound_rx,
+            Arc::clone(&boot.registry),
+            Arc::clone(&boot.queue),
+        ));
+        let _loopback_outbound_thread = spawn_outbound_drainer(
+            outbound_rx,
+            registry.clone(),
+            sessions.clone(),
+            logs.clone(),
+        );
 
         let engine_task = tokio::spawn(run_engine_listener(
             engine_addr,
@@ -104,10 +136,18 @@ impl HubChassis {
         tokio::select! {
             r = engine_task => log_exit("engine listener", r),
             r = mcp_task => log_exit("mcp listener", r),
+            r = loopback_inbound_task => log_exit("loopback inbound", r.map(Ok)),
             _ = tokio::signal::ctrl_c() => {
                 eprintln!("aether-substrate-hub: shutting down");
             }
         }
+
+        // `boot` drops here — scheduler workers join, HubOutbound's
+        // Sender drops (closing the outbound channel), which lets
+        // the outbound drainer thread exit naturally. We don't
+        // explicitly join the thread: process shutdown handles any
+        // still-draining frames.
+        drop(boot);
     }
 }
 

--- a/crates/aether-substrate-hub/src/engine.rs
+++ b/crates/aether-substrate-hub/src/engine.rs
@@ -153,7 +153,7 @@ async fn read_loop(
                 )));
             }
             EngineToHub::Heartbeat => {}
-            EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m).await,
+            EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m),
             EngineToHub::KindsChanged(kinds) => registry.update_kinds(&engine_id, kinds),
             EngineToHub::LogBatch(entries) => logs.append(engine_id, entries),
             EngineToHub::Goodbye(_) => return Ok(()),
@@ -183,7 +183,11 @@ async fn read_loop(
 /// Unknown / disconnected session tokens are logged and dropped; the
 /// engine wire has no reply, so there's nowhere to surface
 /// "sessionGone". `Broadcast` to an empty registry is a no-op.
-async fn route_engine_mail(sessions: &SessionRegistry, engine_id: EngineId, mail: EngineMailFrame) {
+pub(crate) fn route_engine_mail(
+    sessions: &SessionRegistry,
+    engine_id: EngineId,
+    mail: EngineMailFrame,
+) {
     let EngineMailFrame {
         address,
         kind_name,
@@ -331,8 +335,7 @@ mod tests {
             &sessions,
             engine_id(1),
             mail_with_origin(ClaudeAddress::Session(a.token), vec![1, 2, 3], "physics"),
-        )
-        .await;
+        );
 
         let got = rx_a.try_recv().expect("frame for a");
         assert_eq!(got.payload, vec![1, 2, 3]);
@@ -352,8 +355,7 @@ mod tests {
             &sessions,
             engine_id(1),
             mail(ClaudeAddress::Session(nobody), vec![]),
-        )
-        .await;
+        );
 
         assert!(rx_a.try_recv().is_err());
     }
@@ -369,8 +371,7 @@ mod tests {
             &sessions,
             engine_id(1),
             mail_with_origin(ClaudeAddress::Broadcast, vec![42], "render"),
-        )
-        .await;
+        );
 
         for (name, rx) in [("a", &mut rx_a), ("b", &mut rx_b), ("c", &mut rx_c)] {
             let got = rx.try_recv().unwrap_or_else(|_| panic!("{name} no frame"));
@@ -389,8 +390,7 @@ mod tests {
             &sessions,
             engine_id(1),
             mail(ClaudeAddress::Broadcast, vec![]),
-        )
-        .await;
+        );
     }
 
     /// Issue 159 regression. Fill a session's inbound mpsc to capacity,
@@ -409,22 +409,18 @@ mod tests {
                 &sessions,
                 engine_id(1),
                 mail(ClaudeAddress::Session(a.token), vec![0]),
-            )
-            .await;
+            );
         }
 
         // One more. Pre-fix: blocks forever. Post-fix: drops,
-        // returns promptly. The test's own timeout is the assertion.
-        tokio::time::timeout(
-            Duration::from_secs(2),
-            route_engine_mail(
-                &sessions,
-                engine_id(1),
-                mail(ClaudeAddress::Session(a.token), vec![99]),
-            ),
-        )
-        .await
-        .expect("route_engine_mail must not block when session queue is full");
+        // returns promptly. `route_engine_mail` is sync so a block
+        // would hang the test itself — the bare call *is* the
+        // assertion.
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Session(a.token), vec![99]),
+        );
 
         // Consumer drains capacity + the dropped one *must not* be in there
         // (last_tail is the final enqueued entry, which is the 256th, not 99).
@@ -451,25 +447,19 @@ mod tests {
                 &sessions,
                 engine_id(1),
                 mail(ClaudeAddress::Broadcast, vec![0]),
-            )
-            .await;
+            );
             // Drain B as we go so it stays empty; A fills up.
             while rx_b.try_recv().is_ok() {}
         }
 
-        // One more broadcast. A is full, must drop; B is empty, must
-        // receive. The fact that the call returns promptly is what the
-        // timeout wrapper verifies.
-        tokio::time::timeout(
-            Duration::from_secs(2),
-            route_engine_mail(
-                &sessions,
-                engine_id(1),
-                mail(ClaudeAddress::Broadcast, vec![77]),
-            ),
-        )
-        .await
-        .expect("broadcast must not block when one session is full");
+        // One more broadcast. A is full, must drop; B is empty,
+        // must receive. A block here would hang the test since the
+        // call is sync.
+        route_engine_mail(
+            &sessions,
+            engine_id(1),
+            mail(ClaudeAddress::Broadcast, vec![77]),
+        );
 
         let got_b = rx_b
             .try_recv()

--- a/crates/aether-substrate-hub/src/lib.rs
+++ b/crates/aether-substrate-hub/src/lib.rs
@@ -15,6 +15,7 @@ mod decoder;
 mod encoder;
 mod engine;
 mod log_store;
+mod loopback;
 mod mcp;
 mod registry;
 mod session;
@@ -23,6 +24,7 @@ mod spawn;
 pub use chassis::HubChassis;
 pub use decoder::{DecodeError, decode_schema};
 pub use encoder::{EncodeError, encode_schema};
+pub use loopback::HUB_SELF_ENGINE_ID;
 
 pub use engine::HEARTBEAT_INTERVAL;
 pub use engine::READ_TIMEOUT;

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -1,0 +1,202 @@
+//! Hub-chassis loopback: the hub as one of its own engines.
+//!
+//! ADR-0034 Phase 2 sub-phase A. The hub chassis boots its own
+//! `SubstrateBoot` (wasmtime + scheduler + mailer + registry +
+//! control plane) and registers itself in its own `EngineRegistry`
+//! under the reserved `HUB_SELF_ENGINE_ID`. After this, every
+//! existing MCP tool (`list_engines`, `describe_kinds`,
+//! `load_component`, `send_mail`, `engine_logs`,
+//! `describe_component`) works uniformly against the hub — no
+//! per-tool special-casing, no new protocol.
+//!
+//! Two channels bridge the in-process engine with the hub's routing
+//! layer:
+//!
+//!   - **Inbound** (`tokio::mpsc<HubToEngine>`): `mail_tx` goes into
+//!     the hub-self `EngineRecord`. MCP tools push frames at the
+//!     hub the same way they push at any other engine; the
+//!     inbound-drainer task resolves each `Mail` frame against the
+//!     substrate's `Registry` and pushes onto the substrate's
+//!     `Mailer` via `dispatch_hub_to_engine_mail` — the exact path a
+//!     remote engine's `HubClient` reader would take over TCP.
+//!
+//!   - **Outbound** (`std::sync::mpsc<EngineToHub>`): attached to
+//!     `SubstrateBoot.outbound` via `HubOutbound::attach`. Any frame
+//!     the substrate emits (component observation `Mail`, control
+//!     plane `KindsChanged`, captured `LogBatch`) drains through the
+//!     outbound-drainer thread and is dispatched into the hub's
+//!     `SessionRegistry` / `EngineRegistry` / `LogStore` the same
+//!     way `engine.rs::read_loop` handles frames arriving off a
+//!     remote engine's TCP socket.
+//!
+//! Self-dialling is explicitly avoided: the boot uses
+//! `SubstrateBootBuilder::skip_upstream_hub` so the substrate does
+//! not try to `HubClient::connect` to its own TCP listener (which
+//! wouldn't be bound yet at `new()` time anyway).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aether_hub_protocol::{EngineId, EngineToHub, HubToEngine, Uuid};
+use aether_substrate_core::{SubstrateBoot, dispatch_hub_to_engine_mail};
+use tokio::sync::mpsc;
+
+use crate::log_store::LogStore;
+use crate::registry::{EngineRecord, EngineRegistry};
+use crate::session::SessionRegistry;
+
+/// Reserved `EngineId` for the hub's own loopback engine. A nil UUID
+/// is externally unreachable (engines minted by the TCP handshake
+/// always get `Uuid::new_v4()`), and it surfaces uniquely in
+/// `list_engines` output so agents can pick it out without a runtime
+/// branch.
+pub const HUB_SELF_ENGINE_ID: EngineId = EngineId(Uuid::nil());
+
+/// Bound on the hub-self inbound mpsc. Matches the per-engine TCP
+/// writer capacity in `engine.rs` so MCP tools see the same
+/// back-pressure shape against the hub as against any remote engine.
+const INBOUND_CHANNEL_CAPACITY: usize = 256;
+
+/// Everything the hub-chassis needs to drive the in-process engine:
+/// the `SubstrateBoot` whose workers and runtime handles must
+/// outlive the chassis, plus the two receiver ends of the bridge
+/// channels. The chassis spawns two drainer tasks in its tokio
+/// runtime that pull from these receivers.
+pub struct LoopbackEngine {
+    pub boot: SubstrateBoot,
+    pub inbound_rx: mpsc::Receiver<HubToEngine>,
+    pub outbound_rx: std::sync::mpsc::Receiver<EngineToHub>,
+}
+
+impl LoopbackEngine {
+    /// Boot the in-process substrate, wire the two bridge channels,
+    /// and register the hub-self engine record. Must be called
+    /// before the hub's TCP + MCP listeners start so the registry
+    /// contains the hub-self entry by the time an MCP client
+    /// connects.
+    pub fn boot(engines: &EngineRegistry) -> wasmtime::Result<Self> {
+        let boot = SubstrateBoot::builder("aether-substrate-hub", env!("CARGO_PKG_VERSION"))
+            .skip_upstream_hub()
+            .build()?;
+
+        let (outbound_tx, outbound_rx) = std::sync::mpsc::channel::<EngineToHub>();
+        boot.outbound.attach(outbound_tx);
+
+        let (inbound_tx, inbound_rx) = mpsc::channel::<HubToEngine>(INBOUND_CHANNEL_CAPACITY);
+
+        engines.insert(EngineRecord {
+            id: HUB_SELF_ENGINE_ID,
+            name: "aether-substrate-hub".to_owned(),
+            pid: std::process::id(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            kinds: boot.boot_descriptors.clone(),
+            components: HashMap::new(),
+            mail_tx: inbound_tx,
+            spawned: false,
+        });
+
+        Ok(Self {
+            boot,
+            inbound_rx,
+            outbound_rx,
+        })
+    }
+}
+
+/// Drain `inbound_rx` and push each `Mail` frame onto the
+/// substrate's scheduler. Runs for the lifetime of the tokio
+/// runtime; exits when every `mail_tx` clone is dropped (which in
+/// practice means the hub is shutting down).
+///
+/// Non-`Mail` variants are frames the hub would normally send to a
+/// remote engine over TCP. They're harmless to ignore here: the hub
+/// will never send `Welcome` twice (we never minted it in the first
+/// place), heartbeats aren't meaningful to ourselves, and `Goodbye`
+/// is handled by runtime shutdown rather than a frame.
+pub async fn run_inbound_drainer(
+    mut inbound_rx: mpsc::Receiver<HubToEngine>,
+    registry: Arc<aether_substrate_core::Registry>,
+    queue: Arc<aether_substrate_core::Mailer>,
+) {
+    while let Some(frame) = inbound_rx.recv().await {
+        match frame {
+            HubToEngine::Mail(mail) => dispatch_hub_to_engine_mail(mail, &registry, &queue),
+            HubToEngine::Heartbeat | HubToEngine::Welcome(_) | HubToEngine::Goodbye(_) => {}
+        }
+    }
+}
+
+/// Drain `outbound_rx` and dispatch each frame into the hub's
+/// routing layer exactly as `engine.rs::read_loop` would for a
+/// remote engine. Runs on a dedicated std::thread because the
+/// `std::sync::mpsc::Receiver::recv` call blocks — a tokio task
+/// would stall a runtime worker for the thread's lifetime. Exits
+/// when the channel closes (every `Sender` clone held inside
+/// `HubOutbound` has dropped, which happens at process shutdown).
+///
+/// `Mail` frames are routed to Claude sessions via the same
+/// `crate::engine::route_engine_mail` path remote engines' mail
+/// takes (the function is sync — `tokio::sync::mpsc::Sender::try_send`
+/// is non-async — so no runtime handle is needed here);
+/// `KindsChanged` updates the hub's per-engine descriptor cache;
+/// `LogBatch` appends into the shared `LogStore`. `Hello` /
+/// `Heartbeat` / `Goodbye` are silently ignored — the loopback
+/// substrate never emits them (no handshake to initiate, heartbeat
+/// is meaningless against ourselves, shutdown happens via channel
+/// close rather than a frame).
+pub fn spawn_outbound_drainer(
+    outbound_rx: std::sync::mpsc::Receiver<EngineToHub>,
+    engines: EngineRegistry,
+    sessions: SessionRegistry,
+    logs: LogStore,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("hub-loopback-outbound".to_owned())
+        .spawn(move || {
+            while let Ok(frame) = outbound_rx.recv() {
+                match frame {
+                    EngineToHub::Mail(m) => {
+                        crate::engine::route_engine_mail(&sessions, HUB_SELF_ENGINE_ID, m);
+                    }
+                    EngineToHub::KindsChanged(kinds) => {
+                        engines.update_kinds(&HUB_SELF_ENGINE_ID, kinds);
+                    }
+                    EngineToHub::LogBatch(entries) => {
+                        logs.append(HUB_SELF_ENGINE_ID, entries);
+                    }
+                    EngineToHub::Hello(_) | EngineToHub::Heartbeat | EngineToHub::Goodbye(_) => {}
+                }
+            }
+        })
+        .expect("spawn hub-loopback-outbound thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `LoopbackEngine::boot` registers the hub in its own engine
+    /// registry under the reserved id, so subsequent MCP tool calls
+    /// (which look up engines through the same registry) can reach
+    /// the hub without any per-tool special-casing. Smoke-checks
+    /// the presence, name, and that declared kinds are non-empty
+    /// (the boot seeds `aether_kinds::descriptors::all()`).
+    #[test]
+    fn boot_registers_self_in_engine_registry() {
+        let engines = EngineRegistry::new();
+        assert!(engines.is_empty());
+
+        let _loopback = LoopbackEngine::boot(&engines).expect("loopback boot");
+
+        let record = engines
+            .get(&HUB_SELF_ENGINE_ID)
+            .expect("hub-self registered");
+        assert_eq!(record.name, "aether-substrate-hub");
+        assert_eq!(record.id, HUB_SELF_ENGINE_ID);
+        assert!(!record.spawned, "hub-self is not a spawned child");
+        assert!(
+            !record.kinds.is_empty(),
+            "boot descriptors should be non-empty",
+        );
+    }
+}

--- a/crates/aether-substrate-hub/src/main.rs
+++ b/crates/aether-substrate-hub/src/main.rs
@@ -7,5 +7,5 @@ use aether_substrate_core::Chassis;
 use aether_substrate_hub::HubChassis;
 
 fn main() -> wasmtime::Result<()> {
-    HubChassis::from_env().run()
+    HubChassis::from_env()?.run()
 }


### PR DESCRIPTION
## Summary

Sub-phase A of ADR-0034 Phase 2: hub-chassis gains the `SubstrateBoot` runtime (wasmtime + scheduler + mailer + registry + control plane) and registers itself in its own `EngineRegistry` under `HUB_SELF_ENGINE_ID` (`Uuid::nil()`). Existing MCP tools now reach the hub uniformly — no per-tool special-casing, no new protocol surface.

Two loopback channels bridge the in-process engine with the hub's routing layer:

- **Inbound** (`tokio::mpsc<HubToEngine>`): MCP tools push `HubToEngine::Mail` at the hub-self `EngineRecord.mail_tx` the same way they push at any remote engine. A drainer task resolves each frame against the substrate's `Registry` and pushes onto the `Mailer` via the newly-public `dispatch_hub_to_engine_mail`.
- **Outbound** (`std::mpsc<EngineToHub>`): attached to `SubstrateBoot.outbound`. Substrate-emitted frames (observation mail, `KindsChanged`, `LogBatch`) drain on a dedicated std::thread and fan into the hub's `SessionRegistry` / `EngineRegistry` / `LogStore` — same dispatch as `engine.rs::read_loop` for remote engines.

Self-dialling is avoided with the new `SubstrateBootBuilder::skip_upstream_hub()` — the hub is the hub; attaching to its own listener before tokio starts would deadlock.

`route_engine_mail` dropped `async` (its body never actually awaited — `tokio::sync::mpsc::Sender::try_send` is sync) so the outbound drainer can invoke it directly from a std::thread.

## Non-goals

- No routing extracted (sub-phase B).
- No cutover of native routing (sub-phase C).
- No ADR-0037 bubbles-up semantics.
- No new MCP tools.
- No change to the TCP engine handshake.

## What works post-PR

- Hub boots clean; both TCP + MCP listeners bind.
- Unit test: `loopback::tests::boot_registers_self_in_engine_registry` verifies the hub-self record is present after `LoopbackEngine::boot`.
- Logically: `list_engines` / `describe_kinds` / `load_component` / `send_mail` / `engine_logs` / `describe_component` reach hub-self by id the same way they reach any spawned substrate. Full harness verification lands with the sub-phase C cutover once the routing side is exercised end-to-end; for now the unit test plus a smoke-boot (`lsof` confirms both ports bound) covers the enabler.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green (117 hub tests incl. new `boot_registers_self_in_engine_registry`; full workspace unchanged in shape)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Smoke-boot: `AETHER_ENGINE_PORT=18889 AETHER_MCP_PORT=18888 cargo run -p aether-substrate-hub`; `lsof` confirms both ports `LISTEN`, no panic on loopback boot
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)