### PR TITLE
feat(substrate,hub): reply path for bubbled mail (ADR-0037 Phase 2)

### DIFF
--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -826,12 +826,47 @@ pub enum LogLevel {
 /// don't survive the hash; the hub-substrate looks up the
 /// component by id against its own registry.
 ///
-/// Phase 1 is fire-and-forget — no sender attribution, no reply
-/// path. Phase 2 (ADR-0037) widens this with source
-/// `(engine_id, mailbox_id)` so the hub-chassis's reply peripheral
-/// can route replies back to the originating engine's mailbox.
+/// `source_mailbox_id` (Phase 2) carries the sending component's
+/// local mailbox id so the hub-chassis's reply peripheral can
+/// route replies back to it. The source `engine_id` isn't on the
+/// wire — the hub knows which TCP connection the frame arrived on.
+/// `None` means "no reply target" (broadcast-origin, substrate-
+/// generated, no `from_component` attribution); the hub-side
+/// sender handle will be `SENDER_NONE` for the receiving
+/// component.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineMailToHubSubstrateFrame {
+    pub recipient_mailbox_id: u64,
+    pub kind_id: u64,
+    pub payload: Vec<u8>,
+    pub count: u32,
+    pub source_mailbox_id: Option<u64>,
+}
+
+/// Reply mail leaving the hub-substrate for a remote engine's
+/// mailbox (ADR-0037 Phase 2). The hub-chassis's reply peripheral
+/// emits this when a hub-resident component calls `ctx.reply` on
+/// a sender that resolves to `SenderEntry::RemoteEngineMailbox`.
+/// The hub then forwards to the target engine's connection as
+/// `HubToEngine::MailById`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailToEngineMailboxFrame {
+    pub target_engine_id: EngineId,
+    pub target_mailbox_id: u64,
+    pub kind_id: u64,
+    pub payload: Vec<u8>,
+    pub count: u32,
+}
+
+/// Mail delivered to a specific mailbox id on an engine (ADR-0037
+/// Phase 2 reply path). Unlike `MailFrame` which carries
+/// `recipient_name` (used by `HubToEngine::Mail`), this is strictly
+/// id-addressed — replies land without the sender having to know
+/// the mailbox's name. The receiver's `HubClient` reader resolves
+/// the id against the local `Registry` and pushes onto the
+/// `Mailer`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailByIdFrame {
     pub recipient_mailbox_id: u64,
     pub kind_id: u64,
     pub payload: Vec<u8>,
@@ -860,13 +895,21 @@ pub enum EngineToHub {
     LogBatch(Vec<LogEntry>),
     Goodbye(Goodbye),
     MailToHubSubstrate(EngineMailToHubSubstrateFrame),
+    /// Reply to a remote engine's mailbox (ADR-0037 Phase 2). The
+    /// hub looks up the target engine in its registry and forwards
+    /// via `HubToEngine::MailById`.
+    MailToEngineMailbox(MailToEngineMailboxFrame),
 }
 
-/// Frames the hub sends to an engine.
+/// Frames the hub sends to an engine. `MailById` (ADR-0037
+/// Phase 2) is the id-addressed delivery path used for replies
+/// routed back to an engine whose component originated a bubbled-
+/// up mail.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HubToEngine {
     Welcome(Welcome),
     Heartbeat,
     Mail(MailFrame),
     Goodbye(Goodbye),
+    MailById(MailByIdFrame),
 }

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -3,11 +3,10 @@
 // written to the guest at a static `MAIL_OFFSET`; a guest-side
 // allocator is parked until an actual use case forces the question.
 
-use aether_hub_protocol::SessionToken;
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
-use crate::mail::Mail;
+use crate::mail::{Mail, Sender};
 use crate::sender_table::{SENDER_NONE, SenderEntry};
 
 const MAIL_OFFSET: u32 = 1024;
@@ -121,10 +120,16 @@ impl Component {
     /// system-generated mail pass `SENDER_NONE` so the guest's
     /// `mail.sender()` accessor returns `None`.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
-        let entry = if mail.sender != SessionToken::NIL {
-            Some(SenderEntry::Session(mail.sender))
-        } else {
-            mail.from_component.map(SenderEntry::Component)
+        let entry = match &mail.sender {
+            Sender::Session(token) => Some(SenderEntry::Session(*token)),
+            Sender::EngineMailbox {
+                engine_id,
+                mailbox_id,
+            } => Some(SenderEntry::RemoteEngineMailbox {
+                engine_id: *engine_id,
+                mailbox_id: *mailbox_id,
+            }),
+            Sender::None => mail.from_component.map(SenderEntry::Component),
         };
         let handle = match entry {
             Some(e) => self.store.data_mut().sender_table.allocate(e),
@@ -494,12 +499,12 @@ mod tests {
     fn deliver_with_real_token_allocates_session_handle() {
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
         use crate::sender_table::{SENDER_NONE, SenderEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xaaaa));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(token);
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(Sender::Session(token));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
         assert_ne!(observed, SENDER_NONE);
@@ -535,13 +540,13 @@ mod tests {
         // session is the more specific reply target.
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
         use crate::sender_table::SenderEntry;
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xbbbb));
         let mail = SubstrateMail::new(M(0), 0, vec![], 1)
-            .with_sender(token)
+            .with_sender(Sender::Session(token))
             .with_origin(M(99));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
@@ -592,13 +597,13 @@ mod tests {
     fn reply_mail_emits_session_addressed_frame() {
         use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
 
         let (ctx, rx, pong_id) = plane_ctx_for_reply();
         let mut component = instantiate_with_ctx(&wat_replies(pong_id), ctx);
 
         let token = SessionToken(Uuid::from_u128(0xbeef));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(token);
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(Sender::Session(token));
         component.deliver(&mail).expect("deliver");
 
         let frame = rx.try_recv().expect("outbound frame queued");

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -170,8 +170,7 @@ pub struct ControlPlane {
 /// at `aether.control` that core's ControlPlane doesn't recognise.
 /// The chassis is responsible for decoding, replying (via the
 /// outbound it constructed with), and any mail orchestration.
-pub type ChassisControlHandler =
-    Arc<dyn Fn(u64, &str, aether_hub_protocol::SessionToken, &[u8]) + Send + Sync>;
+pub type ChassisControlHandler = Arc<dyn Fn(u64, &str, crate::mail::Sender, &[u8]) + Send + Sync>;
 
 impl ControlPlane {
     /// Build the sink handler that should be registered against the
@@ -183,7 +182,7 @@ impl ControlPlane {
             move |kind_id: u64,
                   kind_name: &str,
                   _origin: Option<&str>,
-                  sender: aether_hub_protocol::SessionToken,
+                  sender: crate::mail::Sender,
                   bytes: &[u8],
                   _count: u32| {
                 self.dispatch(kind_id, kind_name, sender, bytes);
@@ -191,13 +190,7 @@ impl ControlPlane {
         )
     }
 
-    fn dispatch(
-        &self,
-        kind_id: u64,
-        kind_name: &str,
-        sender: aether_hub_protocol::SessionToken,
-        bytes: &[u8],
-    ) {
+    fn dispatch(&self, kind_id: u64, kind_name: &str, sender: crate::mail::Sender, bytes: &[u8]) {
         if kind_id == LoadComponent::ID {
             let result = self.handle_load(bytes);
             self.outbound.send_reply(sender, &result);
@@ -570,7 +563,7 @@ impl ControlPlane {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_hub_protocol::{Primitive, SchemaType, SessionToken};
+    use aether_hub_protocol::{Primitive, SchemaType};
 
     #[test]
     fn load_payload_roundtrip() {
@@ -1234,7 +1227,7 @@ mod tests {
         plane.dispatch(
             0xdead_beef_dead_beef,
             "aether.control.does_not_exist",
-            SessionToken::NIL,
+            crate::mail::Sender::None,
             &[],
         );
     }
@@ -1675,7 +1668,7 @@ mod tests {
         plane.dispatch(
             SubscribeInput::ID,
             SubscribeInput::NAME,
-            SessionToken::NIL,
+            crate::mail::Sender::None,
             &postcard::to_allocvec(&SubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1685,7 +1678,7 @@ mod tests {
         plane.dispatch(
             UnsubscribeInput::ID,
             UnsubscribeInput::NAME,
-            SessionToken::NIL,
+            crate::mail::Sender::None,
             &postcard::to_allocvec(&UnsubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1823,7 +1816,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: SessionToken::NIL,
+                sender: crate::mail::Sender::None,
                 from_component: None,
             });
         }
@@ -1896,7 +1889,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: SessionToken::NIL,
+                sender: crate::mail::Sender::None,
                 from_component: None,
             });
         }

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -11,11 +11,9 @@
 
 use std::sync::Arc;
 
-use aether_hub_protocol::SessionToken;
-
 use crate::hub_client::HubOutbound;
 use crate::input::InputSubscribers;
-use crate::mail::{Mail, MailKind, MailboxId};
+use crate::mail::{Mail, MailKind, MailboxId, Sender};
 use crate::mailer::Mailer;
 use crate::registry::{MailboxEntry, Registry};
 use crate::sender_table::SenderTable;
@@ -105,14 +103,15 @@ impl SubstrateCtx {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 // Component-originated mail: the sender is this ctx's
                 // mailbox, so its registry name is the `origin` any
-                // sink cares about (ADR-0011). Claude-side session is
-                // `NIL` — component sends never have a reply-to target.
+                // sink cares about (ADR-0011). No remote sender —
+                // component-originated sends never have a
+                // reply-over-hub-wire target.
                 let origin = self.registry.mailbox_name(self.sender);
                 handler(
                     kind,
                     &kind_name,
                     origin.as_deref(),
-                    SessionToken::NIL,
+                    Sender::None,
                     &payload,
                     count,
                 );

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -182,6 +182,30 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                     }
                     ctx.send(mbox, kind, payload, count);
                 }
+                SenderEntry::RemoteEngineMailbox {
+                    engine_id,
+                    mailbox_id,
+                } => {
+                    // ADR-0037 Phase 2: reply to a component on
+                    // another engine. Validate the kind exists
+                    // locally so we surface a meaningful status
+                    // rather than shipping a frame the receiver
+                    // can't decode. The hub forwards the frame to
+                    // the target engine's connection as
+                    // `HubToEngine::MailById`.
+                    if ctx.registry.kind_name(kind).is_none() {
+                        return REPLY_KIND_NOT_FOUND;
+                    }
+                    ctx.outbound.send(EngineToHub::MailToEngineMailbox(
+                        aether_hub_protocol::MailToEngineMailboxFrame {
+                            target_engine_id: engine_id,
+                            target_mailbox_id: mailbox_id,
+                            kind_id: kind,
+                            payload,
+                            count,
+                        },
+                    ));
+                }
             }
             REPLY_OK
         },

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -21,17 +21,17 @@
 use std::io;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::process;
-use std::sync::mpsc::{self, Sender};
+use std::sync::mpsc;
 use std::sync::{Arc, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aether_hub_protocol::{
     ClaudeAddress, EngineId, EngineMailFrame, EngineToHub, Hello, HubToEngine, KindDescriptor,
-    MailFrame, SessionToken, read_frame, write_frame,
+    MailByIdFrame, MailFrame, MailToEngineMailboxFrame, read_frame, write_frame,
 };
 
-use crate::mail::Mail;
+use crate::mail::{Mail, Sender};
 use crate::mailer::Mailer;
 use crate::registry::Registry;
 
@@ -47,7 +47,7 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// isn't, the send silently drops. This lets the broadcast sink be
 /// registered unconditionally, before (or without) a hub connection.
 pub struct HubOutbound {
-    tx: OnceLock<Sender<EngineToHub>>,
+    tx: OnceLock<mpsc::Sender<EngineToHub>>,
 }
 
 impl HubOutbound {
@@ -67,7 +67,7 @@ impl HubOutbound {
     /// `HubOutbound` is single-writer by design so heartbeats and
     /// outbound mail can't race on the socket (or the loopback
     /// channel).
-    pub fn attach(&self, tx: Sender<EngineToHub>) {
+    pub fn attach(&self, tx: mpsc::Sender<EngineToHub>) {
         if self.tx.set(tx).is_err() {
             tracing::warn!(target: "aether_substrate::hub_client", "HubOutbound attached twice — ignoring second attach");
         }
@@ -84,12 +84,15 @@ impl HubOutbound {
     }
 
     /// Encode `result` with postcard and send it as a reply addressed
-    /// at `sender`. Uses the kind's own `NAME` so call sites don't
-    /// repeat it. Silent on disconnected outbound (no hub attached)
-    /// and on encode failure (logged at error — a corrupt reply can't
-    /// be delivered meaningfully). Returns `true` when the frame was
-    /// enqueued on the writer channel.
-    pub fn send_reply<K>(&self, sender: SessionToken, result: &K) -> bool
+    /// at `sender`. Forks on the sender variant: `Session` routes
+    /// back to the Claude MCP session (ADR-0008); `EngineMailbox`
+    /// routes via `EngineToHub::MailToEngineMailbox` to the hub,
+    /// which forwards to the target engine's mailbox (ADR-0037
+    /// Phase 2); `None` is a no-op (mail with no reply target).
+    /// Silent on disconnected outbound and on encode failure.
+    /// Returns `true` when the frame was enqueued on the writer
+    /// channel.
+    pub fn send_reply<K>(&self, sender: Sender, result: &K) -> bool
     where
         K: aether_mail::Kind + serde::Serialize,
     {
@@ -105,12 +108,25 @@ impl HubOutbound {
                 return false;
             }
         };
-        self.send(EngineToHub::Mail(EngineMailFrame {
-            address: ClaudeAddress::Session(sender),
-            kind_name: K::NAME.to_owned(),
-            payload,
-            origin: None,
-        }))
+        match sender {
+            Sender::Session(token) => self.send(EngineToHub::Mail(EngineMailFrame {
+                address: ClaudeAddress::Session(token),
+                kind_name: K::NAME.to_owned(),
+                payload,
+                origin: None,
+            })),
+            Sender::EngineMailbox {
+                engine_id,
+                mailbox_id,
+            } => self.send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
+                target_engine_id: engine_id,
+                target_mailbox_id: mailbox_id,
+                kind_id: K::ID,
+                payload,
+                count: 1,
+            })),
+            Sender::None => false,
+        }
     }
 
     /// Whether this handle has a live outbound channel.
@@ -204,6 +220,7 @@ fn run_reader(mut stream: TcpStream, registry: Arc<Registry>, queue: Arc<Mailer>
     loop {
         match read_frame::<_, HubToEngine>(&mut stream) {
             Ok(HubToEngine::Mail(frame)) => dispatch_hub_to_engine_mail(frame, &registry, &queue),
+            Ok(HubToEngine::MailById(frame)) => dispatch_hub_mail_by_id(frame, &registry, &queue),
             Ok(HubToEngine::Heartbeat) => {}
             Ok(HubToEngine::Welcome(_)) => {
                 tracing::warn!(target: "aether_substrate::hub_client", "unexpected post-handshake Welcome, ignoring");
@@ -229,7 +246,7 @@ fn run_writer(mut stream: TcpStream, rx: mpsc::Receiver<EngineToHub>) {
     }
 }
 
-fn run_heartbeat(tx: Sender<EngineToHub>) {
+fn run_heartbeat(tx: mpsc::Sender<EngineToHub>) {
     loop {
         thread::sleep(HEARTBEAT_INTERVAL);
         if tx.send(EngineToHub::Heartbeat).is_err() {
@@ -260,7 +277,35 @@ pub fn dispatch_hub_to_engine_mail(frame: MailFrame, registry: &Registry, queue:
         );
         return;
     };
-    queue.push(Mail::new(recipient, kind, frame.payload, frame.count).with_sender(frame.sender));
+    queue.push(
+        Mail::new(recipient, kind, frame.payload, frame.count)
+            .with_sender(Sender::Session(frame.sender)),
+    );
+}
+
+/// Resolve a `HubToEngine::MailById` frame against the substrate's
+/// `Registry` and push onto `queue`. Used by ADR-0037 Phase 2's
+/// reply path — the hub forwards engine-mailbox replies as
+/// id-addressed frames because the receiver's own mailbox name
+/// didn't make it across the hash boundary when the sender bubbled
+/// up. Public so the hub-chassis's engine read loop can call the
+/// same helper from its own side of the wire.
+pub fn dispatch_hub_mail_by_id(frame: MailByIdFrame, registry: &Registry, queue: &Mailer) {
+    if registry.kind_name(frame.kind_id).is_none() {
+        tracing::warn!(
+            target: "aether_substrate::hub_client",
+            kind_id = frame.kind_id,
+            mailbox_id = frame.recipient_mailbox_id,
+            "MailById with unknown kind — dropped",
+        );
+        return;
+    }
+    queue.push(Mail::new(
+        crate::mail::MailboxId(frame.recipient_mailbox_id),
+        frame.kind_id,
+        frame.payload,
+        frame.count,
+    ));
 }
 
 fn unix_now() -> u64 {

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -41,9 +41,11 @@ pub use chassis::{Chassis, ChassisCapabilities};
 pub use component::Component;
 pub use control::{AETHER_CONTROL, ChassisControlHandler, ControlPlane};
 pub use ctx::SubstrateCtx;
-pub use hub_client::{HubClient, HubOutbound, dispatch_hub_to_engine_mail};
+pub use hub_client::{
+    HubClient, HubOutbound, dispatch_hub_mail_by_id, dispatch_hub_to_engine_mail,
+};
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
-pub use mail::{Mail, MailKind, MailboxId};
+pub use mail::{Mail, MailKind, MailboxId, Sender};
 pub use mailer::Mailer;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;

--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -1,7 +1,7 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
-use aether_hub_protocol::SessionToken;
+use aether_hub_protocol::{EngineId, SessionToken};
 use aether_mail::mailbox_id_from_name;
 
 /// Addressing token for any mailbox — component or substrate-owned sink.
@@ -34,27 +34,67 @@ impl MailboxId {
 /// preparation for hashed derivation (Phase 2).
 pub type MailKind = u64;
 
+/// Attribution of the remote-origin side of a `Mail` (ADR-0008,
+/// ADR-0037). `None` is the default — broadcast / substrate-generated
+/// mail with no meaningful reply-over-the-hub-wire target. `Session`
+/// tags mail that arrived from a Claude MCP session (ADR-0008).
+/// `EngineMailbox` tags mail bubbled up from a component on another
+/// engine (ADR-0037 Phase 2) — the hub-chassis fills this in on the
+/// receiving side of `EngineMailToHubSubstrate` frames so the
+/// `ctx.reply` round trip can route back to the originating engine.
+///
+/// Note: local component-to-component attribution lives in
+/// `Mail.from_component`, not here — it's pure substrate-local and
+/// needs no hub-wire story. The two fields are complementary, not
+/// redundant (broadcast mail from a local sink arrives with
+/// `sender = None` and `from_component = None`; a session mail with
+/// a typo-routed recipient arrives with `sender = Session(token)`
+/// and `from_component = None`; a replied bubble arrives with
+/// `sender = EngineMailbox {..}` and `from_component = None`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Sender {
+    None,
+    Session(SessionToken),
+    EngineMailbox {
+        engine_id: EngineId,
+        mailbox_id: u64,
+    },
+}
+
+impl Sender {
+    /// Back-compat helper: true when the variant carries no reply
+    /// target (replaces the old `sender == SessionToken::NIL`
+    /// check). Callers deciding whether to allocate a sender table
+    /// handle use this before pattern matching on the payload.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Sender::None)
+    }
+}
+
 /// The transport envelope. `payload` is the exact byte layout the kind
 /// implies; `count` is the number of items the layout implies, where
 /// applicable.
 ///
-/// Origin attribution is carried in two mutually-exclusive fields:
-/// - `sender` is the hub-minted session token for mail that came in
-///   over the hub wire (ADR-0008). Non-NIL means "originated from a
-///   Claude session."
-/// - `from_component` is the `MailboxId` of the originating component
-///   for mail enqueued by `SubstrateCtx::send` (ADR-0017). `Some`
-///   means "originated from another component on this substrate."
+/// Origin attribution is carried in two complementary fields:
+/// - `sender` is the remote origin (ADR-0008 / ADR-0037). `Session`
+///   means the mail arrived from a Claude MCP session;
+///   `EngineMailbox` means it bubbled up from a component on another
+///   engine; `None` means no remote reply target.
+/// - `from_component` is the `MailboxId` of a local originating
+///   component for mail enqueued by `SubstrateCtx::send` (ADR-0017).
+///   `Some` means "originated from another component on this
+///   substrate."
 ///
-/// Both being absent (NIL + None) means broadcast-origin or
-/// system-generated mail with no meaningful reply target.
+/// Both-absent (`sender = None`, `from_component = None`) means
+/// broadcast-origin or substrate-generated mail with no meaningful
+/// reply target.
 #[derive(Debug)]
 pub struct Mail {
     pub recipient: MailboxId,
     pub kind: MailKind,
     pub payload: Vec<u8>,
     pub count: u32,
-    pub sender: SessionToken,
+    pub sender: Sender,
     pub from_component: Option<MailboxId>,
 }
 
@@ -65,15 +105,17 @@ impl Mail {
             kind,
             payload,
             count,
-            sender: SessionToken::NIL,
+            sender: Sender::None,
             from_component: None,
         }
     }
 
-    /// Attach a Claude session token as the sender. Used by the hub
-    /// client when forwarding `HubToEngine::Mail`; other mail paths
-    /// leave the default `NIL`.
-    pub fn with_sender(mut self, sender: SessionToken) -> Self {
+    /// Attach a sender attribution (session or engine mailbox). Used
+    /// by the hub client when forwarding inbound frames (ADR-0008)
+    /// and by the hub-chassis loopback when delivering bubbled-up
+    /// mail (ADR-0037 Phase 2); other mail paths leave the default
+    /// `Sender::None`.
+    pub fn with_sender(mut self, sender: Sender) -> Self {
         self.sender = sender;
         self
     }

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -174,12 +174,20 @@ fn route_mail(
             if let Some(outbound) = outbound
                 && outbound.is_connected()
             {
+                // ADR-0037 Phase 2: carry the local sending
+                // component's mailbox id so the hub can build a
+                // `Sender::EngineMailbox { engine_id, mailbox_id }`
+                // for the receiving component. `None` for mail
+                // with no local component origin (broadcast-
+                // originated, substrate-generated).
+                let source_mailbox_id = mail.from_component.map(|mbox| mbox.0);
                 let sent = outbound.send(EngineToHub::MailToHubSubstrate(
                     EngineMailToHubSubstrateFrame {
                         recipient_mailbox_id: recipient.0,
                         kind_id: mail.kind,
                         payload: mail.payload,
                         count: mail.count,
+                        source_mailbox_id,
                     },
                 ));
                 if !sent {

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -15,9 +15,9 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 use aether_hub_protocol::canonical::kind_id_from_parts;
-use aether_hub_protocol::{KindDescriptor, SchemaType, SessionToken};
+use aether_hub_protocol::{KindDescriptor, SchemaType};
 
-use crate::mail::MailboxId;
+use crate::mail::{MailboxId, Sender};
 
 /// Handler invoked when mail is delivered to a substrate-owned sink.
 /// Called on a scheduler worker thread; must be `Send + Sync`.
@@ -26,12 +26,12 @@ use crate::mail::MailboxId;
 /// logging — sinks that only match on id can ignore it), the sending
 /// mailbox's registered name if the mail came from a component
 /// (`None` for substrate-core pushes with no sending mailbox, per
-/// ADR-0011), the originating Claude session token for hub-inbound
-/// mail (or `SessionToken::NIL` for substrate-local mail) per
-/// ADR-0008's reply-to-sender primitive, payload bytes, and the
-/// kind-implied count.
+/// ADR-0011), the remote origin of the mail per ADR-0008 / ADR-0037
+/// (`Sender::Session` for hub-inbound, `Sender::EngineMailbox` for
+/// bubbled-up, `Sender::None` for substrate-local), payload bytes,
+/// and the kind-implied count.
 pub type SinkHandler =
-    Arc<dyn Fn(u64, &str, Option<&str>, SessionToken, &[u8], u32) + Send + Sync + 'static>;
+    Arc<dyn Fn(u64, &str, Option<&str>, Sender, &[u8], u32) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -454,8 +454,8 @@ mod tests {
             panic!("expected sink")
         };
         // Test-side id is irrelevant — the handler ignores it.
-        h(0, "aether.tick", None, SessionToken::NIL, &[], 7);
-        h(0, "aether.tick", Some("physics"), SessionToken::NIL, &[], 3);
+        h(0, "aether.tick", None, Sender::None, &[], 7);
+        h(0, "aether.tick", Some("physics"), Sender::None, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 

--- a/crates/aether-substrate-core/src/sender_table.rs
+++ b/crates/aether-substrate-core/src/sender_table.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 
-use aether_hub_protocol::SessionToken;
+use aether_hub_protocol::{EngineId, SessionToken};
 
 use crate::mail::MailboxId;
 
@@ -40,6 +40,15 @@ pub enum SenderEntry {
     /// Reply routes through the local `Mailer` as ordinary
     /// component-to-component mail.
     Component(MailboxId),
+    /// Reply routes over `HubOutbound` as
+    /// `EngineToHub::MailToEngineMailbox` (ADR-0037 Phase 2). The
+    /// hub forwards the frame to the target engine's connection as
+    /// `HubToEngine::MailById`; that engine's hub-client reader
+    /// resolves the mailbox id + kind locally and dispatches.
+    RemoteEngineMailbox {
+        engine_id: EngineId,
+        mailbox_id: u64,
+    },
 }
 
 /// Maintains the handle→entry map for one component instance.

--- a/crates/aether-substrate-desktop/src/capture.rs
+++ b/crates/aether-substrate-desktop/src/capture.rs
@@ -19,16 +19,15 @@
 
 use std::sync::{Arc, Mutex};
 
-use aether_hub_protocol::SessionToken;
-use aether_substrate_core::Mail;
+use aether_substrate_core::{Mail, Sender};
 
-/// One pending capture request. Carries the originating session's
-/// token so the render thread can reply-to-sender once it has bytes,
-/// plus a resolved list of `after_mails` the control plane already
+/// One pending capture request. Carries the originating sender so
+/// the render thread can reply-to-sender once it has bytes, plus a
+/// resolved list of `after_mails` the control plane already
 /// validated; the render thread pushes them onto the queue after
 /// readback, before replying.
 pub struct PendingCapture {
-    pub sender: SessionToken,
+    pub sender: Sender,
     pub after_mails: Vec<Mail>,
 }
 
@@ -68,15 +67,15 @@ impl CaptureQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_hub_protocol::Uuid;
+    use aether_hub_protocol::{SessionToken, Uuid};
 
-    fn token(u: u128) -> SessionToken {
-        SessionToken(Uuid::from_u128(u))
+    fn sender(u: u128) -> Sender {
+        Sender::Session(SessionToken(Uuid::from_u128(u)))
     }
 
     fn pending(u: u128) -> PendingCapture {
         PendingCapture {
-            sender: token(u),
+            sender: sender(u),
             after_mails: Vec::new(),
         }
     }
@@ -99,7 +98,7 @@ mod tests {
         let q = CaptureQueue::new();
         assert!(q.request(pending(1)));
         let got = q.take().expect("pending");
-        assert_eq!(got.sender, token(1));
+        assert_eq!(got.sender, sender(1));
         // Slot is empty again.
         assert!(q.take().is_none());
         // Next request lands.

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -16,13 +16,12 @@
 
 use std::sync::Arc;
 
-use aether_hub_protocol::SessionToken;
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode, SetWindowModeResult, WindowMode,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
-    ChassisControlHandler, HubOutbound, Mailer, Registry,
+    ChassisControlHandler, HubOutbound, Mailer, Registry, Sender,
     control::{decode_payload, resolve_bundle},
 };
 use winit::event_loop::EventLoopProxy;
@@ -41,12 +40,12 @@ pub enum UserEvent {
     Capture,
     /// An MCP session asked for a `platform_info` snapshot. The
     /// event-loop thread snapshots + replies via outbound.
-    PlatformInfo { sender: SessionToken },
+    PlatformInfo { sender: Sender },
     /// An MCP session asked to switch the window mode. The event
     /// loop resolves fullscreen modes against the current monitor,
     /// applies the change, and replies with the new state.
     SetWindowMode {
-        sender: SessionToken,
+        sender: Sender,
         mode: WindowMode,
         width: Option<u32>,
         height: Option<u32>,
@@ -67,7 +66,7 @@ pub fn chassis_control_handler(
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
-        move |kind_id: u64, kind_name: &str, sender: SessionToken, bytes: &[u8]| {
+        move |kind_id: u64, kind_name: &str, sender: Sender, bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
                 handle_capture_frame(
                     &proxy,
@@ -108,7 +107,7 @@ fn handle_capture_frame(
     registry: &Registry,
     queue: &Mailer,
     outbound: &HubOutbound,
-    sender: SessionToken,
+    sender: Sender,
     bytes: &[u8],
 ) {
     let payload: CaptureFrame = match decode_payload(bytes) {
@@ -171,7 +170,7 @@ fn handle_capture_frame(
 fn handle_set_window_mode(
     proxy: &EventLoopProxy<UserEvent>,
     outbound: &HubOutbound,
-    sender: SessionToken,
+    sender: Sender,
     bytes: &[u8],
 ) {
     let payload: SetWindowMode = match decode_payload(bytes) {

--- a/crates/aether-substrate-desktop/src/lib.rs
+++ b/crates/aether-substrate-desktop/src/lib.rs
@@ -19,8 +19,8 @@ pub mod chassis;
 pub use aether_substrate_core::{
     AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,
     HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailboxEntry,
-    MailboxId, Mailer, Registry, Scheduler, SinkHandler, SubstrateBoot, SubstrateCtx, component,
-    control, ctx, host_fns, hub_client, input, kind_manifest, log_capture, mail, mailer,
+    MailboxId, Mailer, Registry, Scheduler, Sender, SinkHandler, SubstrateBoot, SubstrateCtx,
+    component, control, ctx, host_fns, hub_client, input, kind_manifest, log_capture, mail, mailer,
     new_subscribers, registry, remove_from_all, scheduler, sender_table, subscribers_for,
 };
 

--- a/crates/aether-substrate-desktop/tests/hub_client.rs
+++ b/crates/aether-substrate-desktop/tests/hub_client.rs
@@ -14,7 +14,7 @@ use aether_hub_protocol::{
     SessionToken, Uuid, Welcome, read_frame, write_frame,
 };
 use aether_substrate_desktop::{
-    HubClient, HubOutbound, Mailer, Registry, Scheduler, mail::MailboxId,
+    HubClient, HubOutbound, Mailer, Registry, Scheduler, Sender, mail::MailboxId,
 };
 
 /// Start a mock hub on a random port. Returns the bound address and a
@@ -92,7 +92,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     struct Seen {
         count_sum: u32,
         payload_lens: Vec<usize>,
-        senders: Vec<SessionToken>,
+        senders: Vec<Sender>,
     }
     let seen = Arc::new((Mutex::new(Seen::default()), Condvar::new()));
     let seen_for_sink = Arc::clone(&seen);
@@ -104,7 +104,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             move |_kind_id: u64,
                   _kind: &str,
                   _origin: Option<&str>,
-                  sender: SessionToken,
+                  sender: Sender,
                   bytes: &[u8],
                   count: u32| {
                 let (lock, cv) = &*seen_for_sink;
@@ -194,7 +194,10 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     }
     assert_eq!(s.count_sum, 8);
     assert_eq!(s.payload_lens, vec![3, 1]);
-    assert_eq!(s.senders, vec![alice, SessionToken::NIL]);
+    assert_eq!(
+        s.senders,
+        vec![Sender::Session(alice), Sender::Session(SessionToken::NIL)],
+    );
     assert_eq!(recipient, MailboxId::from_name("hello"));
 
     drop(stream);

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -11,7 +11,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use aether_hub_protocol::SessionToken;
 use aether_kinds::{
     DropComponent, InputStream, LoadComponent, SubscribeInput, Tick, UnsubscribeInput,
 };
@@ -115,7 +114,14 @@ fn make_harness() -> Harness {
 fn dispatch<K: aether_mail::Kind + serde::Serialize>(plane: &ControlPlane, payload: &K) {
     let bytes = postcard::to_allocvec(payload).unwrap();
     let handler = plane.clone().into_sink_handler();
-    handler(K::ID, K::NAME, None, SessionToken::NIL, &bytes, 0);
+    handler(
+        K::ID,
+        K::NAME,
+        None,
+        aether_substrate_desktop::Sender::None,
+        &bytes,
+        0,
+    );
 }
 
 fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -12,18 +12,17 @@
 
 use std::sync::Arc;
 
-use aether_hub_protocol::SessionToken;
 use aether_kinds::{
     CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode, SetWindowModeResult,
 };
 use aether_mail::Kind;
-use aether_substrate_core::{ChassisControlHandler, HubOutbound};
+use aether_substrate_core::{ChassisControlHandler, HubOutbound, Sender};
 
 const UNSUPPORTED: &str = "unsupported on headless chassis — no GPU or window peripherals";
 
 pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHandler {
     Arc::new(
-        move |kind_id: u64, kind_name: &str, sender: SessionToken, _bytes: &[u8]| {
+        move |kind_id: u64, kind_name: &str, sender: Sender, _bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
                 outbound.send_reply(
                     sender,

--- a/crates/aether-substrate-hub/src/engine.rs
+++ b/crates/aether-substrate-hub/src/engine.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use aether_hub_protocol::{
     ClaudeAddress, EngineId, EngineMailFrame, EngineToHub, FrameError, HubToEngine, MAX_FRAME_SIZE,
-    Uuid, Welcome,
+    MailByIdFrame, Uuid, Welcome,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -167,7 +167,40 @@ async fn read_loop(
             EngineToHub::Mail(m) => route_engine_mail(sessions, engine_id, m),
             EngineToHub::KindsChanged(kinds) => registry.update_kinds(&engine_id, kinds),
             EngineToHub::LogBatch(entries) => logs.append(engine_id, entries),
-            EngineToHub::MailToHubSubstrate(frame) => loopback.deliver_bubbled_mail(frame),
+            EngineToHub::MailToHubSubstrate(frame) => {
+                // ADR-0037 Phase 2: attribute the bubbled-up mail
+                // to the sending engine so the hub-resident
+                // component's reply-to-sender has an `engine_id`
+                // to route back to.
+                loopback.deliver_bubbled_mail(engine_id, frame)
+            }
+            EngineToHub::MailToEngineMailbox(frame) => {
+                // ADR-0037 Phase 2: a remote engine's component
+                // replied to an engine-mailbox sender. Route the
+                // frame onward to the target engine's connection
+                // as `HubToEngine::MailById`. Drops silently if the
+                // target is unknown (could have disconnected
+                // mid-flight).
+                if let Some(record) = registry.get(&frame.target_engine_id) {
+                    let by_id = HubToEngine::MailById(MailByIdFrame {
+                        recipient_mailbox_id: frame.target_mailbox_id,
+                        kind_id: frame.kind_id,
+                        payload: frame.payload,
+                        count: frame.count,
+                    });
+                    if let Err(e) = record.mail_tx.try_send(by_id) {
+                        eprintln!(
+                            "aether-substrate-hub: reply to engine {:?} dropped: {e}",
+                            frame.target_engine_id,
+                        );
+                    }
+                } else {
+                    eprintln!(
+                        "aether-substrate-hub: reply to unknown engine {:?} dropped",
+                        frame.target_engine_id,
+                    );
+                }
+            }
             EngineToHub::Goodbye(_) => return Ok(()),
         }
     }

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -38,10 +38,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aether_hub_protocol::{
-    EngineId, EngineMailToHubSubstrateFrame, EngineToHub, HubToEngine, Uuid,
+    EngineId, EngineMailToHubSubstrateFrame, EngineToHub, HubToEngine, MailByIdFrame, Uuid,
 };
 use aether_substrate_core::{
-    Mail, MailboxId, Mailer, Registry, SubstrateBoot, dispatch_hub_to_engine_mail,
+    Mail, MailboxId, Mailer, Registry, Sender, SubstrateBoot, dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
 
@@ -96,18 +96,32 @@ impl LoopbackHandle {
     }
 
     /// Dispatch mail bubbled up from a remote engine (ADR-0037
-    /// Phase 1). The sender has already hashed the target
+    /// Phase 1 + Phase 2). The sender has already hashed the target
     /// mailbox's name into `recipient_mailbox_id`; we resolve it
     /// id-based against the loopback registry and push onto the
     /// `Mailer`. Unknown ids warn-drop on the hub side (end of
-    /// line for Phase 1 — Phase 2's reply path lets us route an
-    /// `mail.unresolved` observation back to the sender's logs).
-    pub fn deliver_bubbled_mail(&self, frame: EngineMailToHubSubstrateFrame) {
+    /// line for Phase 1 — a future `mail.unresolved` observation
+    /// sends the warn back to the originating engine's logs).
+    ///
+    /// `source_engine_id` is the originating engine (known by the
+    /// hub from the TCP connection, not on the wire). Combined with
+    /// `frame.source_mailbox_id` it becomes
+    /// `Sender::EngineMailbox { engine_id, mailbox_id }` on the
+    /// delivered `Mail` — the hub-resident component's
+    /// `ctx.reply(sender)` then routes through
+    /// `HubOutbound::send_reply` which forks on the enum variant
+    /// and emits `EngineToHub::MailToEngineMailbox` for this case.
+    pub fn deliver_bubbled_mail(
+        &self,
+        source_engine_id: EngineId,
+        frame: EngineMailToHubSubstrateFrame,
+    ) {
         let EngineMailToHubSubstrateFrame {
             recipient_mailbox_id,
             kind_id,
             payload,
             count,
+            source_mailbox_id,
         } = frame;
         // Kind lookup guards against an engine bubbling up a kind
         // the hub substrate doesn't know — without it the mail
@@ -119,12 +133,16 @@ impl LoopbackHandle {
             );
             return;
         }
-        self.queue.push(Mail::new(
-            MailboxId(recipient_mailbox_id),
-            kind_id,
-            payload,
-            count,
-        ));
+        let sender = match source_mailbox_id {
+            Some(mailbox_id) => Sender::EngineMailbox {
+                engine_id: source_engine_id,
+                mailbox_id,
+            },
+            None => Sender::None,
+        };
+        self.queue.push(
+            Mail::new(MailboxId(recipient_mailbox_id), kind_id, payload, count).with_sender(sender),
+        );
     }
 }
 
@@ -181,6 +199,9 @@ pub async fn run_inbound_drainer(
     while let Some(frame) = inbound_rx.recv().await {
         match frame {
             HubToEngine::Mail(mail) => dispatch_hub_to_engine_mail(mail, &registry, &queue),
+            HubToEngine::MailById(mail) => {
+                aether_substrate_core::dispatch_hub_mail_by_id(mail, &registry, &queue)
+            }
             HubToEngine::Heartbeat | HubToEngine::Welcome(_) | HubToEngine::Goodbye(_) => {}
         }
     }
@@ -234,6 +255,37 @@ pub fn spawn_outbound_drainer(
                         // future wiring change can't silently
                         // route hub-self bubbled mail to itself.
                     }
+                    EngineToHub::MailToEngineMailbox(frame) => {
+                        // ADR-0037 Phase 2: a hub-resident
+                        // component replied to a bubbled-up sender.
+                        // Look up the target engine's mail_tx in
+                        // our registry and forward as `MailById` so
+                        // the target engine's hub-client reader
+                        // resolves the mailbox id + kind locally
+                        // and dispatches. Drops silently if the
+                        // originating engine has since disconnected
+                        // — the mail was a reply to an engine that
+                        // no longer exists.
+                        if let Some(record) = engines.get(&frame.target_engine_id) {
+                            let by_id = HubToEngine::MailById(MailByIdFrame {
+                                recipient_mailbox_id: frame.target_mailbox_id,
+                                kind_id: frame.kind_id,
+                                payload: frame.payload,
+                                count: frame.count,
+                            });
+                            if let Err(e) = record.mail_tx.try_send(by_id) {
+                                eprintln!(
+                                    "aether-substrate-hub: reply to engine {:?} dropped: {e}",
+                                    frame.target_engine_id,
+                                );
+                            }
+                        } else {
+                            eprintln!(
+                                "aether-substrate-hub: reply to unknown engine {:?} dropped",
+                                frame.target_engine_id,
+                            );
+                        }
+                    }
                 }
             }
         })
@@ -269,6 +321,64 @@ mod tests {
         );
     }
 
+    /// ADR-0037 Phase 2: the outbound drainer forwards
+    /// `EngineToHub::MailToEngineMailbox` to the target engine's
+    /// `mail_tx` as `HubToEngine::MailById`. Proves the reply-path
+    /// routing hop without needing a full component stand-up.
+    #[tokio::test]
+    async fn outbound_drainer_routes_engine_mailbox_reply() {
+        use aether_hub_protocol::MailToEngineMailboxFrame;
+
+        use crate::registry::EngineRecord;
+
+        let engines = EngineRegistry::new();
+        let sessions = SessionRegistry::new();
+        let logs = LogStore::new();
+
+        // Synthesize a target engine with a mail_tx we control.
+        let (mail_tx, mut mail_rx) = mpsc::channel::<HubToEngine>(16);
+        let target_engine_id = EngineId(Uuid::new_v4());
+        engines.insert(EngineRecord {
+            id: target_engine_id,
+            name: "target".to_owned(),
+            pid: 1,
+            version: "0".to_owned(),
+            kinds: vec![],
+            components: HashMap::new(),
+            mail_tx,
+            spawned: false,
+        });
+
+        let (outbound_tx, outbound_rx) = std::sync::mpsc::channel::<EngineToHub>();
+        let _thread = spawn_outbound_drainer(outbound_rx, engines, sessions, logs);
+
+        // Simulate a hub-resident component's reply-to-engine-
+        // mailbox emission.
+        outbound_tx
+            .send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
+                target_engine_id,
+                target_mailbox_id: 99,
+                kind_id: 42,
+                payload: vec![1, 2, 3],
+                count: 1,
+            }))
+            .expect("outbound send");
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(2), mail_rx.recv())
+            .await
+            .expect("drainer forward timeout")
+            .expect("mail_rx closed");
+        match got {
+            HubToEngine::MailById(frame) => {
+                assert_eq!(frame.recipient_mailbox_id, 99);
+                assert_eq!(frame.kind_id, 42);
+                assert_eq!(frame.payload, vec![1, 2, 3]);
+                assert_eq!(frame.count, 1);
+            }
+            other => panic!("expected MailById, got {other:?}"),
+        }
+    }
+
     /// ADR-0037 Phase 1: `deliver_bubbled_mail` on an unknown kind
     /// id must drop silently (no panic, no queue push) — otherwise
     /// a component would receive mail of a layout it doesn't know.
@@ -285,12 +395,16 @@ mod tests {
         // registry has no entry for it, so the kind lookup inside
         // deliver_bubbled_mail returns None and the frame is
         // dropped.
-        handle.deliver_bubbled_mail(EngineMailToHubSubstrateFrame {
-            recipient_mailbox_id: 42,
-            kind_id: 0xDEAD_BEEF_DEAD_BEEF,
-            payload: vec![1, 2, 3],
-            count: 1,
-        });
+        handle.deliver_bubbled_mail(
+            EngineId(Uuid::from_u128(0x1234)),
+            EngineMailToHubSubstrateFrame {
+                recipient_mailbox_id: 42,
+                kind_id: 0xDEAD_BEEF_DEAD_BEEF,
+                payload: vec![1, 2, 3],
+                count: 1,
+                source_mailbox_id: None,
+            },
+        );
         // No panic == pass. The production flow logs a warn and
         // returns; we can't assert on the warn without threading
         // a tracing subscriber, which is out of scope for the


### PR DESCRIPTION
## Summary

Phase 2 of ADR-0037: bubbled mail now carries sender attribution round-trip. A hub-resident component calls `ctx.reply(sender)` uniformly for Claude-session and engine-mailbox senders; the hub transparently routes replies back to the originating engine's mailbox.

## Sender refactor

- New `Sender` enum in `aether-substrate-core::mail`: `None | Session(SessionToken) | EngineMailbox { engine_id, mailbox_id }`. Replaces `Mail.sender: SessionToken` (which had used `SessionToken::NIL` as a no-origin sentinel). `Mail.from_component` stays — complementary local-origin attribution, not redundant.
- `SinkHandler`'s sender argument widens to `Sender`. Broadcast sink ignores it (as before); control plane passes it through.
- `SenderEntry::RemoteEngineMailbox { engine_id, mailbox_id }` added. `Component::deliver` picks the SenderEntry variant at deliver time. Guest-side `u32` handle shape unchanged.
- `HubOutbound::send_reply` takes `Sender` and forks: `Session` → existing path; `EngineMailbox` → `EngineToHub::MailToEngineMailbox`; `None` → no-op.
- `reply_mail_p32` host fn gains the `RemoteEngineMailbox` arm.

## Protocol additions

- `EngineMailToHubSubstrateFrame.source_mailbox_id: Option<u64>` — populated from `mail.from_component` when bubbling up.
- `EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame)` — emitted by component replies to engine-mailbox senders.
- `HubToEngine::MailById(MailByIdFrame)` — id-addressed inbound delivery (reply counterpart; names don't survive the hash).

## Hub routing

- `engine.rs::read_loop` handles `MailToEngineMailbox` by looking up the target engine in the registry and rewriting the frame as `HubToEngine::MailById` on that engine's `mail_tx`. Symmetric handling in the loopback outbound drainer for hub-resident components.
- `LoopbackHandle::deliver_bubbled_mail(engine_id, frame)` now synthesises `Sender::EngineMailbox` on the delivered `Mail` when the frame carries a `source_mailbox_id`.
- Substrate-side `HubClient::run_reader` handles `MailById` via a public `dispatch_hub_mail_by_id` helper (companion to Phase 1's `dispatch_hub_to_engine_mail`).

## Tests

- `loopback::tests::outbound_drainer_routes_engine_mailbox_reply` — verifies the hub-side routing hop (`MailToEngineMailbox` → target engine's `mail_tx` as `MailById`).
- Existing Phase 1 tests (bubble-up emission + unknown-kind drop) continue to pass.

## Plumbing carried in this PR

- Desktop `PendingCapture.sender` + handler closures on desktop/headless chassis widen `SessionToken` → `Sender`.
- Existing test helpers that used `SessionToken::NIL` now use `Sender::None`; session senders use `Sender::Session(token)`.

## What's next (Phase 3)

- Tic-tac-toe client component on desktop loading a server component on the hub-self substrate, exercising the full round-trip (send move → hub dispatches → server validates → reply lands on client).
- `mail.unresolved` observation back to the originating engine for typo diagnostics.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green (hub: 119, core: 91, rest unchanged in shape)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI green
- [ ] End-to-end exercise in Phase 3 demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)