### PR TITLE
refactor: rename Sender → ReplyTo to reflect reply-to semantics

### DIFF
--- a/crates/aether-component/examples/echoer.rs
+++ b/crates/aether-component/examples/echoer.rs
@@ -3,7 +3,7 @@
 //! `demo.response { seq }` to whatever component sent it.
 //!
 //! ADR-0033 phase 3: uses `#[handlers]` as the only receive path.
-//! The synthesized dispatcher reads `ctx.sender()` (threaded from the
+//! The synthesized dispatcher reads `ctx.reply_to()` (threaded from the
 //! inbound mail by `#[handlers]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
@@ -39,7 +39,7 @@ impl Component for Echoer {
 
     #[handler]
     fn on_request(&mut self, ctx: &mut Ctx<'_>, req: Request) {
-        if let Some(sender) = ctx.sender() {
+        if let Some(sender) = ctx.reply_to() {
             ctx.reply(sender, self.response, &Response { seq: req.seq });
         }
     }

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -22,7 +22,7 @@
 //!     substrate hands it to the new instance via `on_rehydrate` with
 //!     a populated `PriorState<'_>`. Opt-in — components that don't
 //!     override either hook migrate nothing.
-//!   - ADR-0013: Reply-to-sender. `Mail::sender()` returns `Some(Sender)`
+//!   - ADR-0013: Reply-to-sender. `Mail::sender()` returns `Some(ReplyTo)`
 //!     for mail that came from a Claude session; `Ctx::reply` takes a
 //!     `Sender` and a typed `KindId<K>` to answer the originating
 //!     session. The 4-param `receive(kind, ptr, count, sender)` ABI is
@@ -362,11 +362,11 @@ impl InitCtx<'_> {
 /// is not a supported shape.
 ///
 /// ADR-0033: typed handlers receive `K` by value, so they no longer
-/// hold a `Mail<'_>` to call `mail.sender()` on. The synthesized
+/// hold a `Mail<'_>` to call `mail.reply_to()` on. The synthesized
 /// dispatcher threads the inbound mail's sender onto `Ctx` via
-/// `__set_sender` before every handler call, and `Ctx::sender()`
+/// `__set_reply_to` before every handler call, and `Ctx::sender()`
 /// reads it back. `#[fallback]` methods still receive the raw
-/// `Mail<'_>` and can call `mail.sender()` directly.
+/// `Mail<'_>` and can call `mail.reply_to()` directly.
 pub struct Ctx<'a> {
     sender: Option<u32>,
     _borrow: PhantomData<&'a ()>,
@@ -383,21 +383,21 @@ impl Ctx<'_> {
     }
 
     /// Not part of the public API; called only by the `#[handlers]`
-    /// dispatcher. Accepts `None` or `Some(Sender)` — the dispatcher
-    /// passes `mail.sender()` verbatim so component-origin and
+    /// dispatcher. Accepts `None` or `Some(ReplyTo)` — the dispatcher
+    /// passes `mail.reply_to()` verbatim so component-origin and
     /// broadcast mail (which have no reply target) land as `None`.
     #[doc(hidden)]
-    pub fn __set_sender(&mut self, sender: Option<Sender>) {
+    pub fn __set_reply_to(&mut self, sender: Option<ReplyTo>) {
         self.sender = sender.map(|s| s.raw);
     }
 
     /// Reply handle for the mail currently being dispatched. `None`
-    /// for component-origin and broadcast-origin mail; `Some(Sender)`
+    /// for component-origin and broadcast-origin mail; `Some(ReplyTo)`
     /// when the inbound came from a Claude session. Pass the returned
     /// `Sender` back to `Ctx::reply` to answer the originating
     /// session (ADR-0013).
-    pub fn sender(&self) -> Option<Sender> {
-        self.sender.map(|raw| Sender { raw })
+    pub fn reply_to(&self) -> Option<ReplyTo> {
+        self.sender.map(|raw| ReplyTo { raw })
     }
 
     /// Send a single payload to `sink`. Typed wrapper around
@@ -414,7 +414,7 @@ impl Ctx<'_> {
     }
 
     /// Reply to the Claude session that originated the inbound mail
-    /// (ADR-0013). `sender` came from `mail.sender()` on the current
+    /// (ADR-0013). `sender` came from `mail.reply_to()` on the current
     /// receive — pass it back as the routing handle. The kind is
     /// supplied as a typed `KindId<K>` so the same compile-time
     /// matching the rest of the SDK uses applies here too.
@@ -424,7 +424,7 @@ impl Ctx<'_> {
     /// hub silently discards the frame.
     pub fn reply<K: Kind + bytemuck::NoUninit>(
         &self,
-        sender: Sender,
+        sender: ReplyTo,
         kind: KindId<K>,
         payload: &K,
     ) {
@@ -441,29 +441,31 @@ impl Ctx<'_> {
     }
 }
 
-/// Sentinel the substrate passes as the `sender` parameter on the
-/// `receive` shim when there is no meaningful reply target — for
+/// Sentinel the substrate passes as the reply-handle parameter on
+/// the `receive` shim when there is no reply target — for
 /// component-originated mail (no Claude session involved) and for
-/// broadcast-origin mail. `Mail::sender()` returns `None` in this
-/// case; `Sender` is only constructable via the `Mail` accessor.
-pub const SENDER_NONE: u32 = u32::MAX;
+/// broadcast-origin mail. `Mail::reply_to()` returns `None` in this
+/// case; `ReplyTo` is only constructable via the `Mail` accessor.
+pub const NO_REPLY_HANDLE: u32 = u32::MAX;
 
-/// Opaque per-instance handle identifying the originating Claude
-/// session of an inbound mail. Hand it back to `Ctx::reply` to send
-/// a session-targeted response.
+/// Opaque per-instance handle identifying the reply destination for
+/// an inbound mail. Pass it back to `Ctx::reply` to answer — the
+/// substrate routes it to the right target (a Claude MCP session,
+/// another local component, or a remote engine's mailbox) depending
+/// on where the inbound came from. Mail is pushed at a recipient
+/// and has no real "from" concept; this handle is purely a
+/// reply-to address.
 ///
 /// `Copy` because the handle is a `u32` underneath; cloning is free.
 /// Cloning is also fine for stashing across receives — the substrate
-/// guarantees the handle stays valid until the originating session
-/// disconnects (in which case the eventual reply silently drops on
-/// the hub side; ADR-0013 §1's session-gone status is not yet
-/// detected synchronously).
+/// guarantees the handle stays valid for the lifetime of the
+/// receiving component instance.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Sender {
+pub struct ReplyTo {
     raw: u32,
 }
 
-impl Sender {
+impl ReplyTo {
     /// Raw handle value. Exposed for components that need to call a
     /// host fn the SDK doesn't yet wrap.
     pub fn raw(self) -> u32 {
@@ -640,13 +642,13 @@ impl<'a> Mail<'a> {
 
     /// Reply handle for the session that originated this mail. `None`
     /// for component-to-component mail and broadcast-origin mail;
-    /// `Some(Sender)` when the inbound came from a Claude session and
+    /// `Some(ReplyTo)` when the inbound came from a Claude session and
     /// can be answered via `Ctx::reply`.
-    pub fn sender(&self) -> Option<Sender> {
-        if self.sender == SENDER_NONE {
+    pub fn reply_to(&self) -> Option<ReplyTo> {
+        if self.sender == NO_REPLY_HANDLE {
             None
         } else {
-            Some(Sender { raw: self.sender })
+            Some(ReplyTo { raw: self.sender })
         }
     }
 
@@ -813,7 +815,7 @@ macro_rules! export {
         /// Called by the substrate with `(kind, ptr, count, sender)`
         /// matching the FFI contract in
         /// `aether-substrate/src/host_fns.rs`. `sender` is the per-
-        /// instance reply-to handle (ADR-0013) or `SENDER_NONE` for
+        /// instance reply-to handle (ADR-0013) or `NO_REPLY_HANDLE` for
         /// mail with no meaningful reply target. Exported under the
         /// `_p32` suffix per ADR-0024 Phase 1. Returns the `u32` the
         /// `#[handlers]`-synthesized `__aether_dispatch` produces —
@@ -953,7 +955,7 @@ mod tests {
         // has to arrange for that address to point at valid bytes.
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -966,7 +968,7 @@ mod tests {
     fn mail_decode_wrong_kind_returns_none() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, NO_REPLY_HANDLE) };
         let wrong: KindId<FakePod> = KindId {
             raw: 8,
             _k: PhantomData,
@@ -978,7 +980,7 @@ mod tests {
     fn mail_decode_wrong_count_returns_none() {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -991,7 +993,7 @@ mod tests {
     fn mail_decode_slice_roundtrip() {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -1002,14 +1004,14 @@ mod tests {
 
     #[test]
     fn mail_sender_none_for_sentinel_handle() {
-        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, SENDER_NONE) };
-        assert!(mail.sender().is_none());
+        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, NO_REPLY_HANDLE) };
+        assert!(mail.reply_to().is_none());
     }
 
     #[test]
     fn mail_sender_some_for_real_handle() {
         let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, 42) };
-        let s = mail.sender().expect("non-sentinel handle yields Some");
+        let s = mail.reply_to().expect("non-sentinel handle yields Some");
         assert_eq!(s.raw(), 42);
     }
 
@@ -1059,7 +1061,7 @@ mod tests {
 
     #[test]
     fn mail_is_typed_matches_kind_id() {
-        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, 0, 0, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.is::<FakeKind>());
         assert!(!mail.is::<FakePod>());
     }
@@ -1068,7 +1070,7 @@ mod tests {
     fn mail_decode_typed_roundtrip() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 1, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 1, NO_REPLY_HANDLE) };
         let out = mail.decode_typed::<FakePod>().unwrap();
         assert_eq!(out, value);
     }
@@ -1078,7 +1080,7 @@ mod tests {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
         // Kind id deliberately mismatched (FakeKind instead of FakePod).
-        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, ptr_raw, 1, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, ptr_raw, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1086,7 +1088,7 @@ mod tests {
     fn mail_decode_typed_wrong_count_returns_none() {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1094,7 +1096,7 @@ mod tests {
     fn mail_decode_slice_typed_roundtrip() {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, SENDER_NONE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, NO_REPLY_HANDLE) };
         let out = mail.decode_slice_typed::<FakePod>().unwrap();
         assert_eq!(out, &values);
     }

--- a/crates/aether-hello-component/src/lib.rs
+++ b/crates/aether-hello-component/src/lib.rs
@@ -83,7 +83,7 @@ impl Component for Hello {
     /// are in flight.
     #[handler]
     fn on_ping(&mut self, ctx: &mut Ctx<'_>, ping: Ping) {
-        if let Some(sender) = ctx.sender() {
+        if let Some(sender) = ctx.reply_to() {
             ctx.reply(sender, self.pong, &Pong { seq: ping.seq });
         }
     }

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -832,7 +832,7 @@ pub enum LogLevel {
 /// wire — the hub knows which TCP connection the frame arrived on.
 /// `None` means "no reply target" (broadcast-origin, substrate-
 /// generated, no `from_component` attribution); the hub-side
-/// sender handle will be `SENDER_NONE` for the receiving
+/// sender handle will be `NO_REPLY_HANDLE` for the receiving
 /// component.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineMailToHubSubstrateFrame {
@@ -846,7 +846,7 @@ pub struct EngineMailToHubSubstrateFrame {
 /// Reply mail leaving the hub-substrate for a remote engine's
 /// mailbox (ADR-0037 Phase 2). The hub-chassis's reply peripheral
 /// emits this when a hub-resident component calls `ctx.reply` on
-/// a sender that resolves to `SenderEntry::RemoteEngineMailbox`.
+/// a sender that resolves to `ReplyEntry::RemoteEngineMailbox`.
 /// The hub then forwards to the target engine's connection as
 /// `HubToEngine::MailById`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -873,7 +873,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 
     quote! {
         let __aether_kind = __aether_mail.kind();
-        __aether_ctx.__set_sender(__aether_mail.sender());
+        __aether_ctx.__set_reply_to(__aether_mail.reply_to());
         #( #arms )*
         #tail
     }

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -6,8 +6,8 @@
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
-use crate::mail::{Mail, Sender};
-use crate::sender_table::{SENDER_NONE, SenderEntry};
+use crate::mail::{Mail, ReplyTo};
+use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -32,7 +32,7 @@ const STATE_OFFSET: u32 = 8192;
 /// `receive(kind, ptr, count, sender) -> u32` entrypoint and a `memory`
 /// named `memory`. ADR-0013 widened the receive ABI with a fourth
 /// `sender: u32` parameter — a per-instance handle the guest can pass
-/// back to `reply_mail`, or `SENDER_NONE` for component-originated
+/// back to `reply_mail`, or `NO_REPLY_HANDLE` for component-originated
 /// mail. ADR-0015 adds optional `on_replace`, `on_drop`, and
 /// `on_rehydrate` exports; the substrate calls them at the right
 /// lifecycle moments when present and silently skips when absent
@@ -113,27 +113,27 @@ impl Component {
     /// `wasmtime::Error`).
     ///
     /// ADR-0013 + ADR-0017: a fresh sender handle is allocated from
-    /// the per-instance `SenderTable` for every inbound that has a
+    /// the per-instance `ReplyTable` for every inbound that has a
     /// meaningful reply target — a Claude session (non-NIL
     /// `SessionToken`) or another component (`from_component`
     /// populated by `SubstrateCtx::send`). Broadcast-origin and
-    /// system-generated mail pass `SENDER_NONE` so the guest's
-    /// `mail.sender()` accessor returns `None`.
+    /// system-generated mail pass `NO_REPLY_HANDLE` so the guest's
+    /// `mail.reply_to()` accessor returns `None`.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
-        let entry = match &mail.sender {
-            Sender::Session(token) => Some(SenderEntry::Session(*token)),
-            Sender::EngineMailbox {
+        let entry = match &mail.reply_to {
+            ReplyTo::Session(token) => Some(ReplyEntry::Session(*token)),
+            ReplyTo::EngineMailbox {
                 engine_id,
                 mailbox_id,
-            } => Some(SenderEntry::RemoteEngineMailbox {
+            } => Some(ReplyEntry::RemoteEngineMailbox {
                 engine_id: *engine_id,
                 mailbox_id: *mailbox_id,
             }),
-            Sender::None => mail.from_component.map(SenderEntry::Component),
+            ReplyTo::None => mail.from_component.map(ReplyEntry::Component),
         };
         let handle = match entry {
-            Some(e) => self.store.data_mut().sender_table.allocate(e),
-            None => SENDER_NONE,
+            Some(e) => self.store.data_mut().reply_table.allocate(e),
+            None => NO_REPLY_HANDLE,
         };
         self.memory
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
@@ -486,38 +486,38 @@ mod tests {
     #[test]
     fn deliver_with_nil_sender_passes_sender_none() {
         use crate::mail::{Mail as SubstrateMail, MailboxId as M};
-        use crate::sender_table::SENDER_NONE;
+        use crate::reply_table::NO_REPLY_HANDLE;
 
         let mut component = instantiate(WAT_STORES_SENDER);
         // Mail::new defaults sender to SessionToken::NIL.
         let mail = SubstrateMail::new(M(0), 0, vec![], 1);
         component.deliver(&mail).expect("deliver");
-        assert_eq!(component.read_u32(500), SENDER_NONE);
+        assert_eq!(component.read_u32(500), NO_REPLY_HANDLE);
     }
 
     #[test]
     fn deliver_with_real_token_allocates_session_handle() {
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
-        use crate::sender_table::{SENDER_NONE, SenderEntry};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
+        use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xaaaa));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(Sender::Session(token));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_reply_to(ReplyTo::Session(token));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
-        assert_ne!(observed, SENDER_NONE);
+        assert_ne!(observed, NO_REPLY_HANDLE);
         assert_eq!(
-            component.store.data().sender_table.resolve(observed),
-            Some(SenderEntry::Session(token)),
+            component.store.data().reply_table.resolve(observed),
+            Some(ReplyEntry::Session(token)),
         );
     }
 
     #[test]
     fn deliver_with_from_component_allocates_component_handle() {
         use crate::mail::{Mail as SubstrateMail, MailboxId as M};
-        use crate::sender_table::{SENDER_NONE, SenderEntry};
+        use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         // ADR-0017: component-origin mail (no session token, but a
@@ -525,10 +525,10 @@ mod tests {
         let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_origin(M(7));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
-        assert_ne!(observed, SENDER_NONE);
+        assert_ne!(observed, NO_REPLY_HANDLE);
         assert_eq!(
-            component.store.data().sender_table.resolve(observed),
-            Some(SenderEntry::Component(M(7))),
+            component.store.data().reply_table.resolve(observed),
+            Some(ReplyEntry::Component(M(7))),
         );
     }
 
@@ -540,18 +540,18 @@ mod tests {
         // session is the more specific reply target.
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
-        use crate::sender_table::SenderEntry;
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
+        use crate::reply_table::ReplyEntry;
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xbbbb));
         let mail = SubstrateMail::new(M(0), 0, vec![], 1)
-            .with_sender(Sender::Session(token))
+            .with_reply_to(ReplyTo::Session(token))
             .with_origin(M(99));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
-        match component.store.data().sender_table.resolve(observed) {
-            Some(SenderEntry::Session(t)) => assert_eq!(t, token),
+        match component.store.data().reply_table.resolve(observed) {
+            Some(ReplyEntry::Session(t)) => assert_eq!(t, token),
             other => panic!("expected Session, got {other:?}"),
         }
     }
@@ -597,13 +597,13 @@ mod tests {
     fn reply_mail_emits_session_addressed_frame() {
         use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, Sender};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
 
         let (ctx, rx, pong_id) = plane_ctx_for_reply();
         let mut component = instantiate_with_ctx(&wat_replies(pong_id), ctx);
 
         let token = SessionToken(Uuid::from_u128(0xbeef));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_sender(Sender::Session(token));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_reply_to(ReplyTo::Session(token));
         component.deliver(&mail).expect("deliver");
 
         let frame = rx.try_recv().expect("outbound frame queued");
@@ -621,7 +621,7 @@ mod tests {
         let (ctx, rx, pong_id) = plane_ctx_for_reply();
         let mut component = instantiate_with_ctx(&wat_replies(pong_id), ctx);
 
-        // NIL sender → SENDER_NONE reaches the guest → reply_mail
+        // NIL sender → NO_REPLY_HANDLE reaches the guest → reply_mail
         // returns REPLY_UNKNOWN_HANDLE and outbound stays quiet.
         let mail = SubstrateMail::new(M(0), 0, vec![], 1);
         component.deliver(&mail).expect("deliver");

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -170,7 +170,7 @@ pub struct ControlPlane {
 /// at `aether.control` that core's ControlPlane doesn't recognise.
 /// The chassis is responsible for decoding, replying (via the
 /// outbound it constructed with), and any mail orchestration.
-pub type ChassisControlHandler = Arc<dyn Fn(u64, &str, crate::mail::Sender, &[u8]) + Send + Sync>;
+pub type ChassisControlHandler = Arc<dyn Fn(u64, &str, crate::mail::ReplyTo, &[u8]) + Send + Sync>;
 
 impl ControlPlane {
     /// Build the sink handler that should be registered against the
@@ -182,7 +182,7 @@ impl ControlPlane {
             move |kind_id: u64,
                   kind_name: &str,
                   _origin: Option<&str>,
-                  sender: crate::mail::Sender,
+                  sender: crate::mail::ReplyTo,
                   bytes: &[u8],
                   _count: u32| {
                 self.dispatch(kind_id, kind_name, sender, bytes);
@@ -190,7 +190,7 @@ impl ControlPlane {
         )
     }
 
-    fn dispatch(&self, kind_id: u64, kind_name: &str, sender: crate::mail::Sender, bytes: &[u8]) {
+    fn dispatch(&self, kind_id: u64, kind_name: &str, sender: crate::mail::ReplyTo, bytes: &[u8]) {
         if kind_id == LoadComponent::ID {
             let result = self.handle_load(bytes);
             self.outbound.send_reply(sender, &result);
@@ -1227,7 +1227,7 @@ mod tests {
         plane.dispatch(
             0xdead_beef_dead_beef,
             "aether.control.does_not_exist",
-            crate::mail::Sender::None,
+            crate::mail::ReplyTo::None,
             &[],
         );
     }
@@ -1668,7 +1668,7 @@ mod tests {
         plane.dispatch(
             SubscribeInput::ID,
             SubscribeInput::NAME,
-            crate::mail::Sender::None,
+            crate::mail::ReplyTo::None,
             &postcard::to_allocvec(&SubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1678,7 +1678,7 @@ mod tests {
         plane.dispatch(
             UnsubscribeInput::ID,
             UnsubscribeInput::NAME,
-            crate::mail::Sender::None,
+            crate::mail::ReplyTo::None,
             &postcard::to_allocvec(&UnsubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1816,7 +1816,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: crate::mail::Sender::None,
+                sender: crate::mail::ReplyTo::None,
                 from_component: None,
             });
         }
@@ -1889,7 +1889,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: crate::mail::Sender::None,
+                sender: crate::mail::ReplyTo::None,
                 from_component: None,
             });
         }

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 
 use crate::hub_client::HubOutbound;
 use crate::input::InputSubscribers;
-use crate::mail::{Mail, MailKind, MailboxId, Sender};
+use crate::mail::{Mail, MailKind, MailboxId, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::{MailboxEntry, Registry};
-use crate::sender_table::SenderTable;
+use crate::reply_table::ReplyTable;
 
 /// ADR-0016 §3: opt-in state migration payload. The substrate owns the
 /// buffer from the moment `save_state` is called on the old instance
@@ -49,13 +49,13 @@ pub struct SubstrateCtx {
     pub input_subscribers: InputSubscribers,
     /// ADR-0013 + ADR-0017: handle→entry map populated by
     /// `Component::deliver` whenever an inbound mail has a meaningful
-    /// reply target — a Claude session (`SenderEntry::Session`) or
-    /// another component (`SenderEntry::Component`). The guest
+    /// reply target — a Claude session (`ReplyEntry::Session`) or
+    /// another component (`ReplyEntry::Component`). The guest
     /// receives an opaque `u32` handle as the 4th param on its
     /// `receive` shim and passes it back to `reply_mail`; the
     /// substrate routes either over `HubOutbound` or back through
     /// `Mailer` based on the variant.
-    pub sender_table: SenderTable,
+    pub reply_table: ReplyTable,
     /// Set by the `save_state` host fn during `on_replace`. The
     /// substrate extracts it after hooks return via
     /// `Component::take_saved_state`. Never read by the guest —
@@ -72,7 +72,7 @@ pub struct SubstrateCtx {
 impl SubstrateCtx {
     /// Build a fresh ctx with empty state-migration slots and an
     /// empty sender table. Using this over the struct literal keeps
-    /// the private fields (sender_table, saved_state,
+    /// the private fields (reply_table, saved_state,
     /// save_state_error) internal to the wiring — callers should
     /// never set them directly.
     pub fn new(
@@ -88,7 +88,7 @@ impl SubstrateCtx {
             queue,
             outbound,
             input_subscribers,
-            sender_table: SenderTable::new(),
+            reply_table: ReplyTable::new(),
             saved_state: None,
             save_state_error: None,
         }
@@ -111,7 +111,7 @@ impl SubstrateCtx {
                     kind,
                     &kind_name,
                     origin.as_deref(),
-                    Sender::None,
+                    ReplyTo::None,
                     &payload,
                     count,
                 );
@@ -119,7 +119,7 @@ impl SubstrateCtx {
             Some(MailboxEntry::Component) => {
                 // ADR-0017: component-to-component mail carries the
                 // sender's mailbox id so `Component::deliver` can
-                // allocate a Component-variant `SenderEntry`. The
+                // allocate a Component-variant `ReplyEntry`. The
                 // receiving guest gets a reply-capable handle that
                 // routes back through the local queue.
                 self.queue

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -9,7 +9,7 @@ use wasmtime::{Caller, Linker};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::MailboxId;
-use crate::sender_table::SenderEntry;
+use crate::reply_table::ReplyEntry;
 
 /// Status codes returned by the `reply_mail` host fn (ADR-0013 §3).
 /// `0` is success; non-zero values distinguish call-site errors
@@ -125,7 +125,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
 
     // ADR-0013 + ADR-0017: `reply_mail` addresses the originator of
     // the inbound mail whose sender handle the guest received.
-    // Branches on the `SenderEntry` variant:
+    // Branches on the `ReplyEntry` variant:
     //   - Session: ship as a `ClaudeAddress::Session` frame through
     //     `HubOutbound` (same route as ADR-0013's original design).
     //   - Component: enqueue on the local `Mailer` via
@@ -156,11 +156,11 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
             let payload = data[start..end].to_vec();
 
             let ctx = caller.data();
-            let Some(entry) = ctx.sender_table.resolve(sender) else {
+            let Some(entry) = ctx.reply_table.resolve(sender) else {
                 return REPLY_UNKNOWN_HANDLE;
             };
             match entry {
-                SenderEntry::Session(token) => {
+                ReplyEntry::Session(token) => {
                     let Some(kind_name) = ctx.registry.kind_name(kind) else {
                         return REPLY_KIND_NOT_FOUND;
                     };
@@ -172,7 +172,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                         origin,
                     }));
                 }
-                SenderEntry::Component(mbox) => {
+                ReplyEntry::Component(mbox) => {
                     // Validate the kind id cheaply — the guest might
                     // have passed a bogus one and we'd rather return
                     // a meaningful status than silently enqueue mail
@@ -182,7 +182,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                     }
                     ctx.send(mbox, kind, payload, count);
                 }
-                SenderEntry::RemoteEngineMailbox {
+                ReplyEntry::RemoteEngineMailbox {
                     engine_id,
                     mailbox_id,
                 } => {

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -31,7 +31,7 @@ use aether_hub_protocol::{
     MailByIdFrame, MailFrame, MailToEngineMailboxFrame, read_frame, write_frame,
 };
 
-use crate::mail::{Mail, Sender};
+use crate::mail::{Mail, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::Registry;
 
@@ -92,7 +92,7 @@ impl HubOutbound {
     /// Silent on disconnected outbound and on encode failure.
     /// Returns `true` when the frame was enqueued on the writer
     /// channel.
-    pub fn send_reply<K>(&self, sender: Sender, result: &K) -> bool
+    pub fn send_reply<K>(&self, sender: ReplyTo, result: &K) -> bool
     where
         K: aether_mail::Kind + serde::Serialize,
     {
@@ -109,13 +109,13 @@ impl HubOutbound {
             }
         };
         match sender {
-            Sender::Session(token) => self.send(EngineToHub::Mail(EngineMailFrame {
+            ReplyTo::Session(token) => self.send(EngineToHub::Mail(EngineMailFrame {
                 address: ClaudeAddress::Session(token),
                 kind_name: K::NAME.to_owned(),
                 payload,
                 origin: None,
             })),
-            Sender::EngineMailbox {
+            ReplyTo::EngineMailbox {
                 engine_id,
                 mailbox_id,
             } => self.send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
@@ -125,7 +125,7 @@ impl HubOutbound {
                 payload,
                 count: 1,
             })),
-            Sender::None => false,
+            ReplyTo::None => false,
         }
     }
 
@@ -279,7 +279,7 @@ pub fn dispatch_hub_to_engine_mail(frame: MailFrame, registry: &Registry, queue:
     };
     queue.push(
         Mail::new(recipient, kind, frame.payload, frame.count)
-            .with_sender(Sender::Session(frame.sender)),
+            .with_reply_to(ReplyTo::Session(frame.sender)),
     );
 }
 

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -1,8 +1,8 @@
 //! aether-substrate-core: runtime that every substrate chassis shares.
 //!
 //! Hosts the wasmtime engine, the mail scheduler, the per-mailbox
-//! component table, the kind manifest, the sender table, the control-
-//! plane dispatcher, and the hub-socket client. Chassis-specific
+//! component table, the kind manifest, the reply-handle table, the
+//! control-plane dispatcher, and the hub-socket client. Chassis-specific
 //! peripherals (window, GPU, TCP listener, event loop) live in the
 //! chassis crate that binds this as a dependency. See ADR-0035.
 //!
@@ -33,8 +33,8 @@ pub mod log_capture;
 pub mod mail;
 pub mod mailer;
 pub mod registry;
+pub mod reply_table;
 pub mod scheduler;
-pub mod sender_table;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use chassis::{Chassis, ChassisCapabilities};
@@ -45,7 +45,7 @@ pub use hub_client::{
     HubClient, HubOutbound, dispatch_hub_mail_by_id, dispatch_hub_to_engine_mail,
 };
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
-pub use mail::{Mail, MailKind, MailboxId, Sender};
+pub use mail::{Mail, MailKind, MailboxId, ReplyTo};
 pub use mailer::Mailer;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;

--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -13,10 +13,10 @@ use aether_mail::mailbox_id_from_name;
 pub struct MailboxId(pub u64);
 
 impl MailboxId {
-    /// Reserved sentinel for "no sender". ADR-0011 / ADR-0017 treat
-    /// `MailboxId(0)` as the unassigned origin; registration rejects
-    /// any name whose hash collides with 0 (practical probability
-    /// ~2⁻⁶⁴, but the guard is cheap).
+    /// Reserved sentinel for "no origin". Registration rejects any
+    /// name whose hash collides with 0 (practical probability
+    /// ~2⁻⁶⁴, but the guard is cheap) so this id never belongs to a
+    /// real mailbox.
     pub const NONE: MailboxId = MailboxId(0);
 
     /// Compute the deterministic id for a mailbox name. Same algorithm
@@ -34,25 +34,30 @@ impl MailboxId {
 /// preparation for hashed derivation (Phase 2).
 pub type MailKind = u64;
 
-/// Attribution of the remote-origin side of a `Mail` (ADR-0008,
-/// ADR-0037). `None` is the default — broadcast / substrate-generated
-/// mail with no meaningful reply-over-the-hub-wire target. `Session`
-/// tags mail that arrived from a Claude MCP session (ADR-0008).
-/// `EngineMailbox` tags mail bubbled up from a component on another
-/// engine (ADR-0037 Phase 2) — the hub-chassis fills this in on the
-/// receiving side of `EngineMailToHubSubstrate` frames so the
-/// `ctx.reply` round trip can route back to the originating engine.
+/// Reply destination for a `Mail` (ADR-0008, ADR-0037). Strictly a
+/// reply-to hint: mail is pushed at a recipient, not sent from a
+/// mailbox, so there is no actual "sender" concept in the system —
+/// this field records where an optional reply should be routed.
 ///
-/// Note: local component-to-component attribution lives in
-/// `Mail.from_component`, not here — it's pure substrate-local and
-/// needs no hub-wire story. The two fields are complementary, not
-/// redundant (broadcast mail from a local sink arrives with
-/// `sender = None` and `from_component = None`; a session mail with
-/// a typo-routed recipient arrives with `sender = Session(token)`
-/// and `from_component = None`; a replied bubble arrives with
-/// `sender = EngineMailbox {..}` and `from_component = None`).
+/// `None` is the default — broadcast / substrate-generated mail
+/// with no meaningful reply target. `Session` tags mail that
+/// arrived from a Claude MCP session, so replies route back to
+/// that session (ADR-0008). `EngineMailbox` tags mail bubbled up
+/// from a component on another engine, so replies route to the
+/// originating engine's mailbox (ADR-0037 Phase 2). The hub-
+/// chassis fills in the engine id on `EngineMailToHubSubstrate`
+/// reception from the TCP connection it arrived on.
+///
+/// Local component-to-component reply routing lives in
+/// `Mail.from_component`, not here — that path is pure substrate-
+/// local and needs no hub-wire story. The two fields are
+/// complementary: broadcast mail from a local sink arrives with
+/// `reply_to = None` and `from_component = None`; session mail
+/// arrives with `reply_to = Session(token)` and `from_component =
+/// None`; a bubbled mail with an attributed source arrives with
+/// `reply_to = EngineMailbox { .. }` and `from_component = None`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Sender {
+pub enum ReplyTo {
     None,
     Session(SessionToken),
     EngineMailbox {
@@ -61,13 +66,12 @@ pub enum Sender {
     },
 }
 
-impl Sender {
-    /// Back-compat helper: true when the variant carries no reply
-    /// target (replaces the old `sender == SessionToken::NIL`
-    /// check). Callers deciding whether to allocate a sender table
-    /// handle use this before pattern matching on the payload.
+impl ReplyTo {
+    /// Whether the variant carries no reply target. Callers deciding
+    /// whether to allocate a reply-handle table entry use this
+    /// before pattern matching on the payload.
     pub fn is_none(&self) -> bool {
-        matches!(self, Sender::None)
+        matches!(self, ReplyTo::None)
     }
 }
 
@@ -75,26 +79,27 @@ impl Sender {
 /// implies; `count` is the number of items the layout implies, where
 /// applicable.
 ///
-/// Origin attribution is carried in two complementary fields:
-/// - `sender` is the remote origin (ADR-0008 / ADR-0037). `Session`
-///   means the mail arrived from a Claude MCP session;
-///   `EngineMailbox` means it bubbled up from a component on another
+/// Reply routing is carried in two complementary fields. Neither
+/// describes where the mail came from; both describe where a reply
+/// would go if the receiver chooses to make one.
+/// - `reply_to` is the remote destination (ADR-0008 / ADR-0037).
+///   `Session` means reply routes back to a Claude MCP session;
+///   `EngineMailbox` means reply routes to a component on another
 ///   engine; `None` means no remote reply target.
 /// - `from_component` is the `MailboxId` of a local originating
 ///   component for mail enqueued by `SubstrateCtx::send` (ADR-0017).
-///   `Some` means "originated from another component on this
-///   substrate."
+///   `Some` means reply routes back to that local mailbox.
 ///
-/// Both-absent (`sender = None`, `from_component = None`) means
-/// broadcast-origin or substrate-generated mail with no meaningful
-/// reply target.
+/// Both-absent (`reply_to = None`, `from_component = None`) means
+/// broadcast-origin or substrate-generated mail with no reply
+/// target.
 #[derive(Debug)]
 pub struct Mail {
     pub recipient: MailboxId,
     pub kind: MailKind,
     pub payload: Vec<u8>,
     pub count: u32,
-    pub sender: Sender,
+    pub reply_to: ReplyTo,
     pub from_component: Option<MailboxId>,
 }
 
@@ -105,25 +110,25 @@ impl Mail {
             kind,
             payload,
             count,
-            sender: Sender::None,
+            reply_to: ReplyTo::None,
             from_component: None,
         }
     }
 
-    /// Attach a sender attribution (session or engine mailbox). Used
-    /// by the hub client when forwarding inbound frames (ADR-0008)
-    /// and by the hub-chassis loopback when delivering bubbled-up
-    /// mail (ADR-0037 Phase 2); other mail paths leave the default
-    /// `Sender::None`.
-    pub fn with_sender(mut self, sender: Sender) -> Self {
-        self.sender = sender;
+    /// Attach a reply-to destination (session or engine mailbox).
+    /// Used by the hub client when forwarding inbound frames
+    /// (ADR-0008) and by the hub-chassis loopback when delivering
+    /// bubbled-up mail (ADR-0037 Phase 2); other mail paths leave
+    /// the default `ReplyTo::None`.
+    pub fn with_reply_to(mut self, reply_to: ReplyTo) -> Self {
+        self.reply_to = reply_to;
         self
     }
 
     /// Attach the originating component's mailbox id. Set by
     /// `SubstrateCtx::send` when enqueueing component-to-component
     /// mail (ADR-0017) so `Component::deliver` can allocate a
-    /// `SenderEntry::Component` handle for the receiving guest.
+    /// Component-variant reply handle for the receiving guest.
     pub fn with_origin(mut self, origin: MailboxId) -> Self {
         self.from_component = Some(origin);
         self

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -130,7 +130,7 @@ fn route_mail(
                 mail.kind,
                 &kind_name,
                 None,
-                mail.sender,
+                mail.reply_to,
                 &mail.payload,
                 mail.count,
             );
@@ -176,7 +176,7 @@ fn route_mail(
             {
                 // ADR-0037 Phase 2: carry the local sending
                 // component's mailbox id so the hub can build a
-                // `Sender::EngineMailbox { engine_id, mailbox_id }`
+                // `ReplyTo::EngineMailbox { engine_id, mailbox_id }`
                 // for the receiving component. `None` for mail
                 // with no local component origin (broadcast-
                 // originated, substrate-generated).

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, RwLock};
 use aether_hub_protocol::canonical::kind_id_from_parts;
 use aether_hub_protocol::{KindDescriptor, SchemaType};
 
-use crate::mail::{MailboxId, Sender};
+use crate::mail::{MailboxId, ReplyTo};
 
 /// Handler invoked when mail is delivered to a substrate-owned sink.
 /// Called on a scheduler worker thread; must be `Send + Sync`.
@@ -27,11 +27,11 @@ use crate::mail::{MailboxId, Sender};
 /// mailbox's registered name if the mail came from a component
 /// (`None` for substrate-core pushes with no sending mailbox, per
 /// ADR-0011), the remote origin of the mail per ADR-0008 / ADR-0037
-/// (`Sender::Session` for hub-inbound, `Sender::EngineMailbox` for
-/// bubbled-up, `Sender::None` for substrate-local), payload bytes,
+/// (`Sender::Session` for hub-inbound, `ReplyTo::EngineMailbox` for
+/// bubbled-up, `ReplyTo::None` for substrate-local), payload bytes,
 /// and the kind-implied count.
 pub type SinkHandler =
-    Arc<dyn Fn(u64, &str, Option<&str>, Sender, &[u8], u32) + Send + Sync + 'static>;
+    Arc<dyn Fn(u64, &str, Option<&str>, ReplyTo, &[u8], u32) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -454,8 +454,8 @@ mod tests {
             panic!("expected sink")
         };
         // Test-side id is irrelevant — the handler ignores it.
-        h(0, "aether.tick", None, Sender::None, &[], 7);
-        h(0, "aether.tick", Some("physics"), Sender::None, &[], 3);
+        h(0, "aether.tick", None, ReplyTo::None, &[], 7);
+        h(0, "aether.tick", Some("physics"), ReplyTo::None, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 

--- a/crates/aether-substrate-core/src/reply_table.rs
+++ b/crates/aether-substrate-core/src/reply_table.rs
@@ -1,13 +1,13 @@
-// Per-component-instance mapping from guest-visible sender handles
-// (opaque `u32`) to the substrate-internal identity of whoever
-// originated an inbound mail. Handles are allocated when a component
-// receives non-broadcast mail and resolved when the guest calls
-// `reply_mail` to answer it.
+// Per-component-instance mapping from guest-visible reply handles
+// (opaque `u32`) to the substrate-internal reply destination. Handles
+// are allocated when a component receives mail that carries a reply
+// target and resolved when the guest calls `reply_mail` to answer.
 //
-// ADR-0013 covered session origins; ADR-0017 widened the table so
-// component-originated mail also produces a handle — a component can
-// now reply to a runtime-discovered peer without knowing its name at
-// init, using the same `ctx.reply` API regardless of who called.
+// ADR-0013 covered session-bound replies; ADR-0017 widened the table
+// so component-originated mail also produces a handle — a component
+// can now reply to a runtime-discovered peer without knowing its
+// name at init, using the same `ctx.reply` API regardless of who
+// called. ADR-0037 widened it again with a remote-engine variant.
 //
 // Handles are monotonically increasing per instance. Exhaustion at
 // 2³² dispatches is out of scope for V0; when it becomes real, the
@@ -25,16 +25,16 @@ use aether_hub_protocol::{EngineId, SessionToken};
 use crate::mail::MailboxId;
 
 /// Sentinel passed to the guest's `receive` shim when the inbound
-/// mail has no meaningful reply target (broadcast origin — ADR-0013
-/// §1). A `reply_mail` call with this handle fails with the "unknown
+/// mail has no reply target (broadcast origin — ADR-0013 §1). A
+/// `reply_mail` call with this handle fails with the "unknown
 /// handle" status.
-pub const SENDER_NONE: u32 = u32::MAX;
+pub const NO_REPLY_HANDLE: u32 = u32::MAX;
 
-/// What a sender handle resolves to on the substrate side. The guest
+/// What a reply handle resolves to on the substrate side. The guest
 /// sees only the opaque `u32` — the variant is purely host-side so
 /// `reply_mail` can pick the right outbound route.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SenderEntry {
+pub enum ReplyEntry {
     /// Reply routes over `HubOutbound` as a session-addressed frame.
     Session(SessionToken),
     /// Reply routes through the local `Mailer` as ordinary
@@ -53,22 +53,22 @@ pub enum SenderEntry {
 
 /// Maintains the handle→entry map for one component instance.
 #[derive(Debug, Default)]
-pub struct SenderTable {
-    entries: HashMap<u32, SenderEntry>,
+pub struct ReplyTable {
+    entries: HashMap<u32, ReplyEntry>,
     next: u32,
 }
 
-impl SenderTable {
+impl ReplyTable {
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Allocate a fresh handle bound to `entry`. The returned handle
-    /// is never `SENDER_NONE` — wraps past it silently.
-    pub fn allocate(&mut self, entry: SenderEntry) -> u32 {
+    /// is never `NO_REPLY_HANDLE` — wraps past it silently.
+    pub fn allocate(&mut self, entry: ReplyEntry) -> u32 {
         // Skip the sentinel. In practice `next` never hits `u32::MAX`
         // before the instance is replaced/dropped; this is hygiene.
-        if self.next == SENDER_NONE {
+        if self.next == NO_REPLY_HANDLE {
             self.next = 0;
         }
         let handle = self.next;
@@ -78,9 +78,10 @@ impl SenderTable {
     }
 
     /// Look up the entry for a guest-supplied handle. Returns `None`
-    /// for `SENDER_NONE` and for handles that were never allocated.
-    pub fn resolve(&self, handle: u32) -> Option<SenderEntry> {
-        if handle == SENDER_NONE {
+    /// for `NO_REPLY_HANDLE` and for handles that were never
+    /// allocated.
+    pub fn resolve(&self, handle: u32) -> Option<ReplyEntry> {
+        if handle == NO_REPLY_HANDLE {
             return None;
         }
         self.entries.get(&handle).copied()
@@ -99,38 +100,38 @@ mod tests {
 
     #[test]
     fn allocate_session_and_component_handles_roundtrip() {
-        let mut t = SenderTable::new();
-        let h_sess = t.allocate(SenderEntry::Session(token(1)));
-        let h_comp = t.allocate(SenderEntry::Component(MailboxId(42)));
+        let mut t = ReplyTable::new();
+        let h_sess = t.allocate(ReplyEntry::Session(token(1)));
+        let h_comp = t.allocate(ReplyEntry::Component(MailboxId(42)));
         assert_ne!(h_sess, h_comp);
-        assert_eq!(t.resolve(h_sess), Some(SenderEntry::Session(token(1))));
+        assert_eq!(t.resolve(h_sess), Some(ReplyEntry::Session(token(1))));
         assert_eq!(
             t.resolve(h_comp),
-            Some(SenderEntry::Component(MailboxId(42))),
+            Some(ReplyEntry::Component(MailboxId(42))),
         );
     }
 
     #[test]
     fn resolve_sentinel_is_none() {
-        let t = SenderTable::new();
-        assert!(t.resolve(SENDER_NONE).is_none());
+        let t = ReplyTable::new();
+        assert!(t.resolve(NO_REPLY_HANDLE).is_none());
     }
 
     #[test]
     fn resolve_unknown_handle_is_none() {
-        let mut t = SenderTable::new();
-        let _ = t.allocate(SenderEntry::Session(token(7)));
+        let mut t = ReplyTable::new();
+        let _ = t.allocate(ReplyEntry::Session(token(7)));
         assert!(t.resolve(9999).is_none());
     }
 
     #[test]
     fn allocate_skips_sentinel_on_wrap() {
-        let mut t = SenderTable::new();
-        t.next = SENDER_NONE;
-        let h = t.allocate(SenderEntry::Session(token(3)));
+        let mut t = ReplyTable::new();
+        t.next = NO_REPLY_HANDLE;
+        let h = t.allocate(ReplyEntry::Session(token(3)));
         // First handle after the wrap is 0 — the sentinel is never
         // handed out.
         assert_eq!(h, 0);
-        assert_ne!(h, SENDER_NONE);
+        assert_ne!(h, NO_REPLY_HANDLE);
     }
 }

--- a/crates/aether-substrate-desktop/src/capture.rs
+++ b/crates/aether-substrate-desktop/src/capture.rs
@@ -19,15 +19,15 @@
 
 use std::sync::{Arc, Mutex};
 
-use aether_substrate_core::{Mail, Sender};
+use aether_substrate_core::{Mail, ReplyTo};
 
-/// One pending capture request. Carries the originating sender so
-/// the render thread can reply-to-sender once it has bytes, plus a
-/// resolved list of `after_mails` the control plane already
-/// validated; the render thread pushes them onto the queue after
-/// readback, before replying.
+/// One pending capture request. Carries the reply handle so the
+/// render thread can reply once it has bytes, plus a resolved list
+/// of `after_mails` the control plane already validated; the
+/// render thread pushes them onto the queue after readback, before
+/// replying.
 pub struct PendingCapture {
-    pub sender: Sender,
+    pub reply_to: ReplyTo,
     pub after_mails: Vec<Mail>,
 }
 
@@ -69,13 +69,13 @@ mod tests {
     use super::*;
     use aether_hub_protocol::{SessionToken, Uuid};
 
-    fn sender(u: u128) -> Sender {
-        Sender::Session(SessionToken(Uuid::from_u128(u)))
+    fn reply_to(u: u128) -> ReplyTo {
+        ReplyTo::Session(SessionToken(Uuid::from_u128(u)))
     }
 
     fn pending(u: u128) -> PendingCapture {
         PendingCapture {
-            sender: sender(u),
+            reply_to: reply_to(u),
             after_mails: Vec::new(),
         }
     }
@@ -98,7 +98,7 @@ mod tests {
         let q = CaptureQueue::new();
         assert!(q.request(pending(1)));
         let got = q.take().expect("pending");
-        assert_eq!(got.sender, sender(1));
+        assert_eq!(got.reply_to, reply_to(1));
         // Slot is empty again.
         assert!(q.take().is_none());
         // Next request lands.

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -21,7 +21,7 @@ use aether_kinds::{
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
-    ChassisControlHandler, HubOutbound, Mailer, Registry, Sender,
+    ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo,
     control::{decode_payload, resolve_bundle},
 };
 use winit::event_loop::EventLoopProxy;
@@ -40,12 +40,12 @@ pub enum UserEvent {
     Capture,
     /// An MCP session asked for a `platform_info` snapshot. The
     /// event-loop thread snapshots + replies via outbound.
-    PlatformInfo { sender: Sender },
+    PlatformInfo { reply_to: ReplyTo },
     /// An MCP session asked to switch the window mode. The event
     /// loop resolves fullscreen modes against the current monitor,
     /// applies the change, and replies with the new state.
     SetWindowMode {
-        sender: Sender,
+        reply_to: ReplyTo,
         mode: WindowMode,
         width: Option<u32>,
         height: Option<u32>,
@@ -66,7 +66,7 @@ pub fn chassis_control_handler(
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
-        move |kind_id: u64, kind_name: &str, sender: Sender, bytes: &[u8]| {
+        move |kind_id: u64, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
                 handle_capture_frame(
                     &proxy,
@@ -81,7 +81,7 @@ pub fn chassis_control_handler(
                 // Empty payload; forward the sender straight to the
                 // event loop and let it snapshot + reply on its own
                 // thread (winit monitor / scale-factor APIs require it).
-                let _ = proxy.send_event(UserEvent::PlatformInfo { sender });
+                let _ = proxy.send_event(UserEvent::PlatformInfo { reply_to: sender });
             } else if kind_id == SetWindowMode::ID {
                 handle_set_window_mode(&proxy, &outbound, sender, bytes);
             } else {
@@ -107,7 +107,7 @@ fn handle_capture_frame(
     registry: &Registry,
     queue: &Mailer,
     outbound: &HubOutbound,
-    sender: Sender,
+    sender: ReplyTo,
     bytes: &[u8],
 ) {
     let payload: CaptureFrame = match decode_payload(bytes) {
@@ -145,7 +145,7 @@ fn handle_capture_frame(
     }
 
     let pending = PendingCapture {
-        sender,
+        reply_to: sender,
         after_mails: after,
     };
     if !capture_queue.request(pending) {
@@ -170,7 +170,7 @@ fn handle_capture_frame(
 fn handle_set_window_mode(
     proxy: &EventLoopProxy<UserEvent>,
     outbound: &HubOutbound,
-    sender: Sender,
+    sender: ReplyTo,
     bytes: &[u8],
 ) {
     let payload: SetWindowMode = match decode_payload(bytes) {
@@ -181,7 +181,7 @@ fn handle_set_window_mode(
         }
     };
     let _ = proxy.send_event(UserEvent::SetWindowMode {
-        sender,
+        reply_to: sender,
         mode: payload.mode,
         width: payload.width,
         height: payload.height,

--- a/crates/aether-substrate-desktop/src/lib.rs
+++ b/crates/aether-substrate-desktop/src/lib.rs
@@ -19,9 +19,9 @@ pub mod chassis;
 pub use aether_substrate_core::{
     AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,
     HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailboxEntry,
-    MailboxId, Mailer, Registry, Scheduler, Sender, SinkHandler, SubstrateBoot, SubstrateCtx,
+    MailboxId, Mailer, Registry, ReplyTo, Scheduler, SinkHandler, SubstrateBoot, SubstrateCtx,
     component, control, ctx, host_fns, hub_client, input, kind_manifest, log_capture, mail, mailer,
-    new_subscribers, registry, remove_from_all, scheduler, sender_table, subscribers_for,
+    new_subscribers, registry, remove_from_all, reply_table, scheduler, subscribers_for,
 };
 
 pub use capture::{CaptureQueue, PendingCapture};

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -461,18 +461,18 @@ impl ApplicationHandler<UserEvent> for App {
                     w.request_redraw();
                 }
             }
-            UserEvent::PlatformInfo { sender } => {
+            UserEvent::PlatformInfo { reply_to } => {
                 let result = self.snapshot_platform_info(event_loop);
-                self.outbound.send_reply(sender, &result);
+                self.outbound.send_reply(reply_to, &result);
             }
             UserEvent::SetWindowMode {
-                sender,
+                reply_to,
                 mode,
                 width,
                 height,
             } => {
                 let result = self.apply_window_mode(mode, width, height);
-                self.outbound.send_reply(sender, &result);
+                self.outbound.send_reply(reply_to, &result);
             }
         }
     }
@@ -578,7 +578,7 @@ impl ApplicationHandler<UserEvent> for App {
                             for mail in req.after_mails {
                                 self.queue.push(mail);
                             }
-                            self.outbound.send_reply(req.sender, &result);
+                            self.outbound.send_reply(req.reply_to, &result);
                         }
                         None => {
                             gpu.render(&verts);
@@ -591,7 +591,7 @@ impl ApplicationHandler<UserEvent> for App {
                     // is dropped — the pre-capture bundle wasn't processed
                     // either, so there's nothing to clean up.
                     self.outbound.send_reply(
-                        req.sender,
+                        req.reply_to,
                         &CaptureFrameResult::Err {
                             error: "capture requested before GPU initialized".to_owned(),
                         },

--- a/crates/aether-substrate-desktop/tests/hub_client.rs
+++ b/crates/aether-substrate-desktop/tests/hub_client.rs
@@ -14,7 +14,7 @@ use aether_hub_protocol::{
     SessionToken, Uuid, Welcome, read_frame, write_frame,
 };
 use aether_substrate_desktop::{
-    HubClient, HubOutbound, Mailer, Registry, Scheduler, Sender, mail::MailboxId,
+    HubClient, HubOutbound, Mailer, Registry, ReplyTo, Scheduler, mail::MailboxId,
 };
 
 /// Start a mock hub on a random port. Returns the bound address and a
@@ -92,7 +92,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     struct Seen {
         count_sum: u32,
         payload_lens: Vec<usize>,
-        senders: Vec<Sender>,
+        senders: Vec<ReplyTo>,
     }
     let seen = Arc::new((Mutex::new(Seen::default()), Condvar::new()));
     let seen_for_sink = Arc::clone(&seen);
@@ -104,7 +104,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             move |_kind_id: u64,
                   _kind: &str,
                   _origin: Option<&str>,
-                  sender: Sender,
+                  sender: ReplyTo,
                   bytes: &[u8],
                   count: u32| {
                 let (lock, cv) = &*seen_for_sink;
@@ -196,7 +196,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     assert_eq!(s.payload_lens, vec![3, 1]);
     assert_eq!(
         s.senders,
-        vec![Sender::Session(alice), Sender::Session(SessionToken::NIL)],
+        vec![ReplyTo::Session(alice), ReplyTo::Session(SessionToken::NIL)],
     );
     assert_eq!(recipient, MailboxId::from_name("hello"));
 

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -118,7 +118,7 @@ fn dispatch<K: aether_mail::Kind + serde::Serialize>(plane: &ControlPlane, paylo
         K::ID,
         K::NAME,
         None,
-        aether_substrate_desktop::Sender::None,
+        aether_substrate_desktop::ReplyTo::None,
         &bytes,
         0,
     );

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -16,13 +16,13 @@ use aether_kinds::{
     CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode, SetWindowModeResult,
 };
 use aether_mail::Kind;
-use aether_substrate_core::{ChassisControlHandler, HubOutbound, Sender};
+use aether_substrate_core::{ChassisControlHandler, HubOutbound, ReplyTo};
 
 const UNSUPPORTED: &str = "unsupported on headless chassis — no GPU or window peripherals";
 
 pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHandler {
     Arc::new(
-        move |kind_id: u64, kind_name: &str, sender: Sender, _bytes: &[u8]| {
+        move |kind_id: u64, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
                 outbound.send_reply(
                     sender,

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -41,7 +41,7 @@ use aether_hub_protocol::{
     EngineId, EngineMailToHubSubstrateFrame, EngineToHub, HubToEngine, MailByIdFrame, Uuid,
 };
 use aether_substrate_core::{
-    Mail, MailboxId, Mailer, Registry, Sender, SubstrateBoot, dispatch_hub_to_engine_mail,
+    Mail, MailboxId, Mailer, Registry, ReplyTo, SubstrateBoot, dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
 
@@ -106,7 +106,7 @@ impl LoopbackHandle {
     /// `source_engine_id` is the originating engine (known by the
     /// hub from the TCP connection, not on the wire). Combined with
     /// `frame.source_mailbox_id` it becomes
-    /// `Sender::EngineMailbox { engine_id, mailbox_id }` on the
+    /// `ReplyTo::EngineMailbox { engine_id, mailbox_id }` on the
     /// delivered `Mail` — the hub-resident component's
     /// `ctx.reply(sender)` then routes through
     /// `HubOutbound::send_reply` which forks on the enum variant
@@ -134,14 +134,15 @@ impl LoopbackHandle {
             return;
         }
         let sender = match source_mailbox_id {
-            Some(mailbox_id) => Sender::EngineMailbox {
+            Some(mailbox_id) => ReplyTo::EngineMailbox {
                 engine_id: source_engine_id,
                 mailbox_id,
             },
-            None => Sender::None,
+            None => ReplyTo::None,
         };
         self.queue.push(
-            Mail::new(MailboxId(recipient_mailbox_id), kind_id, payload, count).with_sender(sender),
+            Mail::new(MailboxId(recipient_mailbox_id), kind_id, payload, count)
+                .with_reply_to(sender),
         );
     }
 }

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -301,7 +301,7 @@ impl Sokoban {
     }
 
     fn reply_state(&self, ctx: &mut Ctx<'_>) {
-        let Some(sender) = ctx.sender() else {
+        let Some(sender) = ctx.reply_to() else {
             return;
         };
         ctx.reply(sender, self.state_kind, &self.state);

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -252,7 +252,7 @@ impl TicTacToe {
     }
 
     fn reply(&self, ctx: &mut Ctx<'_>, status: u8) {
-        let Some(sender) = ctx.sender() else {
+        let Some(sender) = ctx.reply_to() else {
             return;
         };
         let result = MoveResult {


### PR DESCRIPTION
## Summary

**Stacked on #179.** Pure rename PR — zero behaviour change.

`Mail.sender` isn't actually "who sent this" — mail is pushed at a recipient, there's no real sender semantic in the system. The field records where an optional reply should be routed. The old name was legacy of ADR-0013 when only Claude sessions produced reply handles; ADR-0017 added local components and ADR-0037 Phase 2 added remote engine mailboxes, further widening the "sender" into an arbitrary reply destination.

## Rename map

Substrate-core:
- `mail::Sender` enum → `mail::ReplyTo`
- `Mail.sender` field → `Mail.reply_to`
- `Mail::with_sender(...)` → `Mail::with_reply_to(...)`
- `sender_table` module → `reply_table` (via `git mv`; history preserved)
- `SenderEntry` → `ReplyEntry`
- `SenderTable` → `ReplyTable`
- `SENDER_NONE` const → `NO_REPLY_HANDLE`

Guest SDK (`aether-component`):
- `pub struct Sender { raw }` → `pub struct ReplyTo { raw }`
- `SENDER_NONE: u32` → `NO_REPLY_HANDLE: u32`
- `Ctx::sender()` / `Mail::sender()` → `Ctx::reply_to()` / `Mail::reply_to()`
- `Ctx::__set_sender` → `Ctx::__set_reply_to` (hidden, macro-emitted)

Wire protocol stays as-is. `MailFrame.sender: SessionToken` is Claude-session-specific at the hub boundary; the name matches the hub's perspective there.

Downstream fixups:
- Desktop `PendingCapture.sender` → `.reply_to`; `UserEvent::{PlatformInfo, SetWindowMode}.sender` → `.reply_to`.
- Demos (tic-tac-toe, sokoban, hello-component, echoer example) updated to `ctx.reply_to()`.

Doc comments across the renamed surface now call out the reply-to-address semantic explicitly — the distinction matters when reasoning about ADR-0037's attribution path (the hub synthesises a `ReplyTo::EngineMailbox` from the TCP connection + the source mailbox id on the frame).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green, no count regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Rebase on main once #179 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)