### PR TITLE
fix(mail-derive,substrate): retain aether.kinds across rlib boundary

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -84,8 +84,8 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 /// Not part of the public API; the macro is the only intended caller.
 #[doc(hidden)]
 pub mod __macro_internals {
-    pub use aether_mail::__derive_runtime::canonical;
-    pub use aether_mail::Kind;
+    pub use aether_mail::__derive_runtime::{SchemaType, canonical};
+    pub use aether_mail::{Kind, Schema};
 }
 
 /// Phantom-typed wrapper around a resolved kind id. A `KindId<Tick>`

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -750,6 +750,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
 
     let statics =
         build_inputs_section_statics(self_ty, &handlers, fallback.as_ref(), &component_doc);
+    let kind_retention_statics = build_kinds_section_retention_statics(self_ty, &handlers);
 
     Ok(quote! {
         impl #impl_generics #trait_path for #self_ty #where_clause {
@@ -774,6 +775,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
         }
 
         #statics
+        #kind_retention_statics
     })
 }
 
@@ -1057,6 +1059,97 @@ fn build_inputs_section_statics(
         #fallback_static
         #component_static
     }
+}
+
+/// Emit `#[link_section = "aether.kinds"]` statics in the consumer
+/// crate — one per `#[handler]`-handled kind — so every kind the
+/// component listens for survives wasm-ld dead-section stripping.
+///
+/// Why this exists: the `Kind` derive emits `aether.kinds` and
+/// `aether.kinds.labels` statics in the *defining* crate. When the
+/// kind lives in a dependency rlib (e.g. `aether-kinds` or a shared
+/// demo crate), the linker strips those statics from the final cdylib
+/// because no Rust code in the consumer references the symbol by
+/// name. `#[used]` keeps the symbol in the rlib's object file but
+/// doesn't cross the rlib→cdylib boundary under `--gc-sections`. The
+/// `aether.kinds.inputs` section survives only because
+/// `#[handlers]` emits it here, in the consumer's own compilation
+/// unit. We apply the same trick to `aether.kinds`.
+///
+/// The bytes are computed via trait dispatch on `<K as Kind>::NAME`
+/// and `<K as Schema>::SCHEMA` so this doesn't require the kind's
+/// derive to expose its private canonical-bytes statics. Duplicate
+/// records (one from the defining crate when it also builds as a
+/// cdylib, one here in the consumer) are harmless: the substrate's
+/// `register_kind_with_descriptor` is idempotent on `(name, schema)`
+/// match (ADR-0030 Phase 2).
+///
+/// Scope is limited to handler-side kinds — kinds the component only
+/// *sends* don't need local retention because the receiving substrate
+/// is responsible for having them registered (it either hosts a
+/// component that declares them, or is the hub with its own server
+/// component). If that assumption ever breaks, extend this emitter to
+/// walk `Sink<K>` resolutions too.
+fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn]) -> TokenStream2 {
+    let self_ty_hint = type_hint(self_ty);
+
+    let statics = handlers.iter().enumerate().map(|(idx, h)| {
+        let k = &h.kind_ty;
+        let schema_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_SCHEMA_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let len_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_CANONICAL_LEN_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let bytes_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_CANONICAL_BYTES_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let section_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_MANIFEST_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        quote! {
+            // Mirrors the intermediate-static pattern in `expand_kind`
+            // (mail-derive/src/lib.rs) so const-eval of the serializer
+            // sees a `&'static SchemaType` instead of materializing a
+            // temporary whose non-trivial Drop can't run at compile
+            // time.
+            static #schema_ident: ::aether_component::__macro_internals::SchemaType =
+                <#k as ::aether_component::__macro_internals::Schema>::SCHEMA;
+            const #len_ident: usize =
+                ::aether_component::__macro_internals::canonical::canonical_len_kind(
+                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                    &#schema_ident,
+                );
+            const #bytes_ident: [u8; #len_ident] =
+                ::aether_component::__macro_internals::canonical::canonical_serialize_kind::<#len_ident>(
+                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                    &#schema_ident,
+                );
+            #[cfg(target_arch = "wasm32")]
+            #[used]
+            #[unsafe(link_section = "aether.kinds")]
+            static #section_ident: [u8; #len_ident + 1] = {
+                let mut out = [0u8; #len_ident + 1];
+                out[0] = 0x02;
+                let mut i = 0;
+                while i < #len_ident {
+                    out[i + 1] = #bytes_ident[i];
+                    i += 1;
+                }
+                out
+            };
+        }
+    });
+
+    quote! { #(#statics)* }
 }
 
 /// Produce an identifier-safe hint from the Self type. For a plain

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
-use aether_hub_protocol::canonical::kind_id_from_parts;
+use aether_hub_protocol::canonical::{canonical_kind_bytes, kind_id_from_parts};
 use aether_hub_protocol::{KindDescriptor, SchemaType};
 
 use crate::mail::{MailboxId, ReplyTo};
@@ -336,7 +336,17 @@ impl Registry {
         let id = kind_id_from_parts(&descriptor.name, &descriptor.schema);
         let mut inner = self.inner.write().unwrap();
         if let Some(slot) = inner.kinds.get(&id) {
-            if reject_conflict && slot.descriptor.schema != descriptor.schema {
+            if reject_conflict
+                && canonical_kind_bytes(&slot.descriptor.name, &slot.descriptor.schema)
+                    != canonical_kind_bytes(&descriptor.name, &descriptor.schema)
+            {
+                // Same 64-bit id but distinct canonical bytes — a real
+                // hash collision, keep the loud failure. Comparing
+                // canonical bytes (not `SchemaType` PartialEq) means
+                // nominal-only differences — named fields vs stripped
+                // names from a manifest round-trip — are treated as
+                // identical, since the canonical form is exactly the
+                // structure the id hashes over.
                 return Err(KindConflict {
                     name: descriptor.name,
                     existing: slot.descriptor.schema.clone(),
@@ -587,6 +597,48 @@ mod tests {
             .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
             .expect("same schema should succeed");
         assert_eq!(first, second);
+    }
+
+    /// The first registration stores the schema with named fields
+    /// (e.g. substrate boot via `aether_kinds::descriptors::all()`); a
+    /// second registration of the same structural kind with stripped
+    /// names (e.g. reconstructed from a component's `aether.kinds`
+    /// canonical bytes) must be accepted as idempotent because both
+    /// produce the same kind id. This is the path `#[handlers]`
+    /// consumer-crate retention relies on for cross-crate kinds that
+    /// duplicate boot-registered ones.
+    #[test]
+    fn register_kind_with_descriptor_accepts_nominal_only_differences() {
+        use aether_hub_protocol::{NamedField, Primitive};
+
+        let r = Registry::new();
+        let named_id = r
+            .register_kind_with_descriptor(cast_struct_desc("aether.foo"))
+            .expect("first");
+
+        let unnamed = KindDescriptor {
+            name: "aether.foo".into(),
+            schema: SchemaType::Struct {
+                repr_c: true,
+                fields: vec![NamedField {
+                    name: "".into(),
+                    ty: SchemaType::Scalar(Primitive::U32),
+                }]
+                .into(),
+            },
+        };
+        let unnamed_id = r
+            .register_kind_with_descriptor(unnamed)
+            .expect("same canonical bytes = same id = idempotent");
+        assert_eq!(named_id, unnamed_id);
+
+        // Named version stays in the stored slot — first writer wins.
+        let stored = r.kind_descriptor(named_id).expect("still there");
+        if let SchemaType::Struct { fields, .. } = &stored.schema {
+            assert_eq!(fields[0].name, "x");
+        } else {
+            panic!("expected struct schema");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two related bugs that only surface when a component's handled kinds live in dependency rlibs — first deployment to hit this is Phase 3 tic-tac-toe-client running cross-substrate.

### 1. Linker strips `aether.kinds` across rlib → cdylib
- `Kind` derive emits `#[used] #[link_section = \"aether.kinds\"]` statics in the crate that *defines* each kind. `#[used]` keeps the symbol in the rlib's object file but doesn't cross the rlib → cdylib boundary under wasm-ld's default `--gc-sections`.
- Components whose kinds all live in deps (tic-tac-toe-client reuses kinds from `aether-kinds` and `aether-demo-tic-tac-toe`) ship with an empty schema manifest. The substrate loads the component, reads no kinds, can't dispatch `MailById` replies whose kind id isn't locally known.
- **Fix**: `#[handlers]` now re-emits `#[link_section = \"aether.kinds\"]` per handled kind in the consumer crate's own compilation unit — same trick `aether.kinds.inputs` already uses. Bytes come from trait dispatch on `<K as Kind>::NAME` / `<K as Schema>::SCHEMA`, so the private derive statics don't need to be reachable.

### 2. Registry conflict check too strict for nominal-only differences
- After fix 1, the client's manifest redeclares kinds like `aether.mouse_move` that the substrate already registered at boot via `aether_kinds::descriptors::all()`. Canonical bytes strip nominal field info, so the manifest round-trip has empty field names while the bootstrap version has named ones. Same id, textually different `SchemaType` → `register_kind_with_descriptor` returned `KindConflict`.
- **Fix**: compare canonical bytes (what `kind_id_from_parts` actually hashes over) instead of `SchemaType` PartialEq. Equal canonical bytes = same kind identity; loud failure on genuine hash collisions is preserved. First writer wins for the stored descriptor, so hub MCP tooling keeps named fields when boot registers the richer descriptor first.

## Test plan
- [x] New `registry::tests::register_kind_with_descriptor_accepts_nominal_only_differences` — boot-vs-manifest round-trip.
- [x] `cargo test --workspace` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] End-to-end via MCP: rebuilt tic-tac-toe-client wasm now has `aether.kinds` section (was missing before); `describe_kinds` on a desktop substrate with the client loaded shows `tic_tac_toe.game_state` alongside boot-registered `aether.*` kinds with no conflict on load.

## Why this is a blocker for Phase 3
The tic-tac-toe-client's `on_move_result` handler (coming in the Phase 3 PR) needs `MoveResult`'s schema in the desktop substrate's registry so the hub's reply routes cleanly via `dispatch_hub_mail_by_id`. Without this fix, `MoveResult` was silently stripped from the wasm and the reply landed on the floor.