### PR TITLE
fix(hub): handle SIGTERM and drain spawned children on shutdown

### DIFF
--- a/crates/aether-substrate-hub/src/chassis.rs
+++ b/crates/aether-substrate-hub/src/chassis.rs
@@ -17,16 +17,26 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aether_substrate_core::{Chassis, ChassisCapabilities};
 
 use crate::loopback::{
     LoopbackEngine, LoopbackHandle, run_inbound_drainer, spawn_outbound_drainer,
 };
+use crate::spawn::terminate_substrate;
 use crate::{
     DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, LogStore, PendingSpawns,
     SessionRegistry, run_engine_listener, run_mcp_server,
 };
+
+/// Grace window per child when the hub shuts down. Shorter than
+/// `DEFAULT_TERMINATE_GRACE` (2s for individual MCP calls) because
+/// shutdown is latency-sensitive: a user hitting Ctrl-C or a system
+/// sending SIGTERM wants the hub gone promptly, and well-behaved
+/// substrates exit on SIGTERM near-instantly. A child that ignores
+/// SIGTERM gets SIGKILL'd after this window.
+const SHUTDOWN_CHILD_GRACE: Duration = Duration::from_millis(1500);
 
 /// Hub chassis handle. Holds the bound addresses + shared state
 /// handles and the in-process loopback engine (ADR-0034 Phase 2
@@ -128,6 +138,10 @@ impl HubChassis {
             logs.clone(),
         );
 
+        // Hold a separate clone for the shutdown handler — the
+        // `registry` binding is moved into `run_engine_listener`.
+        let registry_for_shutdown = registry.clone();
+
         let engine_task = tokio::spawn(run_engine_listener(
             engine_addr,
             registry,
@@ -142,10 +156,20 @@ impl HubChassis {
             r = engine_task => log_exit("engine listener", r),
             r = mcp_task => log_exit("mcp listener", r),
             r = loopback_inbound_task => log_exit("loopback inbound", r.map(Ok)),
-            _ = tokio::signal::ctrl_c() => {
-                eprintln!("aether-substrate-hub: shutting down");
+            sig = shutdown_signal() => {
+                eprintln!("aether-substrate-hub: {sig} received, shutting down");
             }
         }
+
+        // Drain spawned children explicitly before dropping `boot` and
+        // the tokio runtime. `kill_on_drop` would reap them on Arc
+        // drop, but the drop ordering across tasks holding registry
+        // clones isn't deterministic — an explicit pass guarantees
+        // every child gets SIGTERM + a grace window (+ SIGKILL
+        // escalation) regardless of which task drops its Arc last.
+        // Skipping this is what orphaned children into init on hub
+        // SIGTERM pre-fix.
+        terminate_all_children(&registry_for_shutdown).await;
 
         // `boot` drops here — scheduler workers join, HubOutbound's
         // Sender drops (closing the outbound channel), which lets
@@ -153,6 +177,78 @@ impl HubChassis {
         // explicitly join the thread: process shutdown handles any
         // still-draining frames.
         drop(boot);
+    }
+}
+
+/// Resolves when either SIGINT (Ctrl-C) or SIGTERM arrives on Unix;
+/// on non-Unix falls back to `ctrl_c()` since tokio doesn't expose
+/// named signals outside Unix. Returns a short label for the log line.
+///
+/// Why both signals: interactive shells deliver SIGINT, but process
+/// supervisors (systemd, supervisord), shell utilities (`pkill`,
+/// `kill` without `-9`), and CI cancellation all send SIGTERM.
+/// Ignoring SIGTERM means `pkill -f aether-substrate-hub` kills the
+/// hub without running drops, orphaning its spawned children.
+async fn shutdown_signal() -> &'static str {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("aether-substrate-hub: SIGTERM handler install failed: {e}");
+                // Fall through to ctrl_c-only — better than nothing.
+                let _ = tokio::signal::ctrl_c().await;
+                return "SIGINT";
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("aether-substrate-hub: SIGINT handler install failed: {e}");
+                // Wait on SIGTERM only; SIGINT default action still kills.
+                let _ = sigterm.recv().await;
+                return "SIGTERM";
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => "SIGTERM",
+            _ = sigint.recv() => "SIGINT",
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        "Ctrl-C"
+    }
+}
+
+/// Terminate every spawned substrate in parallel. Each call reuses
+/// the same SIGTERM → grace → SIGKILL machinery that the
+/// `terminate_substrate` MCP tool uses, so hub-shutdown cleanup and
+/// per-engine cleanup share a code path. Errors are logged per child
+/// but don't abort the loop — we want to reach every child.
+async fn terminate_all_children(registry: &EngineRegistry) {
+    let children = registry.drain_spawned_children();
+    if children.is_empty() {
+        return;
+    }
+    eprintln!(
+        "aether-substrate-hub: terminating {} spawned child(ren)",
+        children.len()
+    );
+    let handles: Vec<_> = children
+        .into_iter()
+        .map(|(id, child)| {
+            tokio::spawn(async move {
+                if let Err(e) = terminate_substrate(child, SHUTDOWN_CHILD_GRACE).await {
+                    eprintln!("aether-substrate-hub: shutdown terminate {id:?}: {e}");
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        let _ = h.await;
     }
 }
 
@@ -182,5 +278,68 @@ fn log_exit(label: &str, result: Result<std::io::Result<()>, tokio::task::JoinEr
         Ok(Ok(())) => eprintln!("aether-substrate-hub: {label} exited"),
         Ok(Err(e)) => eprintln!("aether-substrate-hub: {label} error: {e}"),
         Err(e) => eprintln!("aether-substrate-hub: {label} join error: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Stdio;
+
+    use aether_hub_protocol::{EngineId, Uuid};
+    use tokio::process::Command;
+
+    use super::*;
+
+    /// Spawn a `sleep 60` child so the terminate path has something
+    /// real to signal + reap. Mirrors the pattern the
+    /// `terminate_substrate` tests use in `spawn.rs`.
+    fn spawn_sleep() -> tokio::process::Child {
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg("sleep 60")
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn sh")
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn terminate_all_children_reaps_every_adopted_child() {
+        let registry = EngineRegistry::new();
+        let ids: Vec<EngineId> = (0..3)
+            .map(|i| EngineId(Uuid::from_u128(0xC0FFEE + i as u128)))
+            .collect();
+        let children: Vec<_> = (0..3).map(|_| spawn_sleep()).collect();
+        let pids: Vec<u32> = children
+            .iter()
+            .map(|c| c.id().expect("pid available"))
+            .collect();
+        for (id, child) in ids.iter().zip(children) {
+            registry.adopt_child(*id, child);
+        }
+
+        terminate_all_children(&registry).await;
+
+        // Registry is drained — `terminate_all_children` removed every
+        // entry via `drain_spawned_children`.
+        assert_eq!(
+            registry.drain_spawned_children().len(),
+            0,
+            "terminate_all_children consumed everything"
+        );
+        // `libc::kill(pid, 0)` probes liveness: returns 0 if the
+        // process exists and we can signal it, `-1` + `ESRCH` when
+        // the pid is gone (reaped or never existed). `sh -c sleep 60`
+        // handles SIGTERM immediately, so all three should be dead by
+        // the time `terminate_all_children` returns.
+        for pid in pids {
+            let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            assert!(
+                rc != 0 && errno == Some(libc::ESRCH),
+                "pid {pid} still signalable after shutdown (rc={rc}, errno={errno:?})"
+            );
+        }
     }
 }

--- a/crates/aether-substrate-hub/src/registry.rs
+++ b/crates/aether-substrate-hub/src/registry.rs
@@ -102,6 +102,21 @@ impl EngineRegistry {
         self.inner.lock().unwrap().spawned_children.remove(id)
     }
 
+    /// Drain every adopted child, returning them for orderly shutdown.
+    /// Used by the hub's signal handler to explicitly terminate every
+    /// spawned substrate before the process exits, so a SIGTERM on the
+    /// hub doesn't orphan children into init. `take_child`'s per-id
+    /// path covers normal `terminate_substrate` calls; this bulk
+    /// variant exists for shutdown only.
+    pub fn drain_spawned_children(&self) -> Vec<(EngineId, Child)> {
+        self.inner
+            .lock()
+            .unwrap()
+            .spawned_children
+            .drain()
+            .collect()
+    }
+
     pub fn remove(&self, id: &EngineId) {
         let mut inner = self.inner.lock().unwrap();
         inner.records.remove(id);


### PR DESCRIPTION
## Summary
Two related bugs behind the "orphaned window survives hub restart" observation from ADR-0037 Phase 3 verification.

### 1. Shutdown handler missed SIGTERM
`chassis.rs` only listened for `ctrl_c()` (SIGINT). `pkill`, `kill` (no -9), systemd `stop`, Docker container termination, and CI cancellation all send SIGTERM — none of those would fire the shutdown path, so the hub died without running any drops and the children orphaned into init.

**Fix**: `shutdown_signal()` on Unix listens for both `SignalKind::terminate()` and `SignalKind::interrupt()`; returns a short label the log line reports. Non-Unix still falls through to `tokio::signal::ctrl_c()`.

### 2. Child cleanup relied on implicit drop ordering
Even on clean Ctrl-C, cleanup was `drop(boot)` with nothing explicit for the `EngineRegistry.spawned_children` map. `kill_on_drop` would eventually fire when the last Arc dropped — but tokio tasks holding registry clones could race past the boot drop and keep children alive.

**Fix**: `terminate_all_children()` explicitly drains the registry's adopted `Child` map and runs each through the existing `terminate_substrate(child, grace)` helper in parallel. Same SIGTERM → grace → SIGKILL machinery that backs the per-engine MCP tool. Shorter grace (1.5s) than the MCP default (2s) because shutdown is latency-sensitive.

New `EngineRegistry::drain_spawned_children()` method exposes the bulk-take the shutdown handler needs without duplicating `take_child`'s per-id logic.

## Test plan
- [x] New `chassis::tests::terminate_all_children_reaps_every_adopted_child` — spawns three real `sleep 60` children, adopts them into the registry, calls `terminate_all_children`, asserts the registry is drained AND every pid is gone (via `libc::kill(pid, 0)` returning ESRCH). Covers both "drain consumes everything" and "terminate loop reaches every child".
- [x] `cargo test --workspace` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.