### PR TITLE
feat(substrate,hub): surface unresolved-mail diagnostics back to originating engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,8 @@ name = "aether-substrate-hub"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
+ "aether-kinds",
+ "aether-mail",
  "aether-substrate-core",
  "axum",
  "base64 0.22.1",

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -21,7 +21,7 @@ use crate::{
     CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats, Key,
     LoadComponent, LoadResult, MouseButton, MouseMove, Ping, PlatformInfo, PlatformInfoResult,
     Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult, SubscribeInput,
-    SubscribeInputResult, Tick, UnsubscribeInput, WindowSize,
+    SubscribeInputResult, Tick, UnresolvedMail, UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -38,6 +38,11 @@ pub fn all() -> Vec<KindDescriptor> {
         // nested `Struct { repr_c: true }` exactly like a flat Pod).
         schema::<DrawTriangle>(),
         schema::<FrameStats>(),
+        // Hub → originating-engine diagnostic when a bubbled-up mail
+        // doesn't resolve at the hub either (ADR-0037 follow-up,
+        // issue #185). Delivered to the engine's `aether.diagnostics`
+        // sink, which re-warns locally.
+        schema::<UnresolvedMail>(),
         // ADR-0013 smoke-test vocabulary.
         schema::<Ping>(),
         schema::<Pong>(),

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -221,6 +221,36 @@ pub struct FrameStats {
     pub triangles: u64,
 }
 
+/// Diagnostic the hub emits back to an originating engine when mail
+/// that engine bubbled up (ADR-0037) doesn't resolve at the hub
+/// either. Lands on the engine's `aether.diagnostics` sink, which
+/// re-warns locally so the unresolved address surfaces in that
+/// engine's `engine_logs` rather than only in the hub's. Closes the
+/// "typo diagnostics" follow-up from ADR-0037 (issue #185).
+///
+/// `recipient_mailbox_id` is the hashed mailbox id the originator
+/// sent to — the id space is cross-process-stable (ADR-0029 /
+/// ADR-0030 / issue #186) so agents can map it back to a name in
+/// tooling. `kind_id` is the kind the original mail carried.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.mail.unresolved")]
+pub struct UnresolvedMail {
+    pub recipient_mailbox_id: u64,
+    pub kind_id: u64,
+}
+
 // Reserved control-plane vocabulary (ADR-0010). The substrate handles
 // these kinds inline rather than dispatching to a component — the
 // namespace itself is the routing discriminator. ADR-0019 PR 5 turned

--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -24,8 +24,8 @@ use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub, KindDescr
 use wasmtime::{Engine, Linker};
 
 use crate::{
-    AETHER_CONTROL, ChassisControlHandler, ControlPlane, HUB_CLAUDE_BROADCAST, HubClient,
-    HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx, host_fns,
+    AETHER_CONTROL, AETHER_DIAGNOSTICS, ChassisControlHandler, ControlPlane, HUB_CLAUDE_BROADCAST,
+    HubClient, HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx, host_fns,
     input::new_subscribers, log_capture, mail::MailboxId,
 };
 
@@ -177,6 +177,45 @@ impl<'a> SubstrateBootBuilder<'a> {
                 ),
             )
         };
+
+        // Diagnostic sink for hub → originating-engine typo reports
+        // (ADR-0037 follow-up, issue #185). Re-emits the unresolved-
+        // mail record as a local `tracing::warn!` so the detail
+        // surfaces in this engine's own `engine_logs` rather than only
+        // in the hub's. Kind vocabulary is `aether.mail.unresolved`
+        // today; the sink is structured as a general diagnostic
+        // channel so future diagnostic kinds can land here without
+        // needing another sink.
+        registry.register_sink(
+            AETHER_DIAGNOSTICS,
+            Arc::new(
+                |_kind_id: u64,
+                 kind_name: &str,
+                 _origin: Option<&str>,
+                 _sender,
+                 bytes: &[u8],
+                 _count: u32| {
+                    if kind_name == <aether_kinds::UnresolvedMail as aether_mail::Kind>::NAME
+                        && let Ok(record) =
+                            bytemuck::try_from_bytes::<aether_kinds::UnresolvedMail>(bytes)
+                    {
+                        tracing::warn!(
+                            target: "aether_substrate::diagnostics",
+                            recipient_mailbox_id = format_args!("{:#x}", record.recipient_mailbox_id),
+                            kind_id = format_args!("{:#x}", record.kind_id),
+                            "hub could not resolve bubbled-up mail recipient (ADR-0037); \
+                             mail dropped. Likely a typoed mailbox name at the sender.",
+                        );
+                        return;
+                    }
+                    tracing::warn!(
+                        target: "aether_substrate::diagnostics",
+                        kind = %kind_name,
+                        "aether.diagnostics received an unexpected kind or malformed payload",
+                    );
+                },
+            ),
+        );
 
         let queue = Arc::new(Mailer::new());
         queue.wire_outbound(Arc::clone(&outbound));

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -55,3 +55,11 @@ pub use scheduler::Scheduler;
 /// this name the same way it sends to any local sink; the forwarder
 /// translates to `EngineToHub::Mail { address: Broadcast, ... }`.
 pub const HUB_CLAUDE_BROADCAST: &str = "hub.claude.broadcast";
+
+/// Well-known mailbox name for substrate-level diagnostic events
+/// delivered back to this engine. Today the only kind delivered here
+/// is `aether.mail.unresolved` (issue #185), pushed by the hub when
+/// an engine's bubbled-up mail (ADR-0037) can't be resolved at the
+/// hub either. The sink handler re-warns via `tracing::warn!` so the
+/// diagnostic surfaces in this engine's own `engine_logs`.
+pub const AETHER_DIAGNOSTICS: &str = "aether.diagnostics";

--- a/crates/aether-substrate-hub/Cargo.toml
+++ b/crates/aether-substrate-hub/Cargo.toml
@@ -5,9 +5,12 @@ edition.workspace = true
 
 [dependencies]
 aether-hub-protocol = { path = "../aether-hub-protocol" }
+aether-kinds = { path = "../aether-kinds" }
+aether-mail = { path = "../aether-mail" }
 aether-substrate-core = { path = "../aether-substrate-core" }
 axum = "0.8"
 base64 = "0.22"
+bytemuck = { version = "1.19", features = ["derive"] }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 rmcp = { version = "0.8", features = [
     "server",
@@ -26,5 +29,4 @@ wasmtime = "30"
 libc = "0.2"
 
 [dev-dependencies]
-bytemuck = { version = "1.19", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }

--- a/crates/aether-substrate-hub/src/engine.rs
+++ b/crates/aether-substrate-hub/src/engine.rs
@@ -171,8 +171,11 @@ async fn read_loop(
                 // ADR-0037 Phase 2: attribute the bubbled-up mail
                 // to the sending engine so the hub-resident
                 // component's reply-to-sender has an `engine_id`
-                // to route back to.
-                loopback.deliver_bubbled_mail(engine_id, frame)
+                // to route back to. The `registry` (engine
+                // registry) is handed through so the loopback can
+                // reach the originator if it needs to emit an
+                // `aether.mail.unresolved` diagnostic (issue #185).
+                loopback.deliver_bubbled_mail(engine_id, frame, registry)
             }
             EngineToHub::MailToEngineMailbox(frame) => {
                 // ADR-0037 Phase 2: a remote engine's component

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -40,8 +40,11 @@ use std::sync::Arc;
 use aether_hub_protocol::{
     EngineId, EngineMailToHubSubstrateFrame, EngineToHub, HubToEngine, MailByIdFrame, Uuid,
 };
+use aether_kinds::UnresolvedMail;
+use aether_mail::{Kind, mailbox_id_from_name};
 use aether_substrate_core::{
-    Mail, MailboxId, Mailer, Registry, ReplyTo, SubstrateBoot, dispatch_hub_to_engine_mail,
+    AETHER_DIAGNOSTICS, Mail, MailboxId, Mailer, Registry, ReplyTo, SubstrateBoot,
+    dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
 
@@ -99,9 +102,10 @@ impl LoopbackHandle {
     /// Phase 1 + Phase 2). The sender has already hashed the target
     /// mailbox's name into `recipient_mailbox_id`; we resolve it
     /// id-based against the loopback registry and push onto the
-    /// `Mailer`. Unknown ids warn-drop on the hub side (end of
-    /// line for Phase 1 — a future `mail.unresolved` observation
-    /// sends the warn back to the originating engine's logs).
+    /// `Mailer`. Unknown ids emit an `aether.mail.unresolved`
+    /// diagnostic back to the originating engine's
+    /// `aether.diagnostics` sink (issue #185) so the typo surfaces in
+    /// the sender's own `engine_logs`, not only the hub's.
     ///
     /// `source_engine_id` is the originating engine (known by the
     /// hub from the TCP connection, not on the wire). Combined with
@@ -111,10 +115,16 @@ impl LoopbackHandle {
     /// `ctx.reply(sender)` then routes through
     /// `HubOutbound::send_reply` which forks on the enum variant
     /// and emits `EngineToHub::MailToEngineMailbox` for this case.
+    ///
+    /// `engines` is the hub's engine registry; needed only on the
+    /// unresolved path to look up the originating engine's mail
+    /// channel for the diagnostic reach-back. Passed by the caller
+    /// (`engine::read_loop`) which already holds it.
     pub fn deliver_bubbled_mail(
         &self,
         source_engine_id: EngineId,
         frame: EngineMailToHubSubstrateFrame,
+        engines: &EngineRegistry,
     ) {
         let EngineMailToHubSubstrateFrame {
             recipient_mailbox_id,
@@ -133,6 +143,25 @@ impl LoopbackHandle {
             );
             return;
         }
+        // Recipient lookup: if the hub can't resolve the mailbox id,
+        // don't push onto the queue (where it'd warn-drop silently
+        // on the hub side). Instead, echo an
+        // `aether.mail.unresolved` observation back to the
+        // originating engine so the typo surfaces in that engine's
+        // own `engine_logs`. ADR-0037 follow-up / issue #185.
+        if self
+            .registry
+            .entry(MailboxId(recipient_mailbox_id))
+            .is_none()
+        {
+            eprintln!(
+                "aether-substrate-hub: bubbled-up mail from engine {source_engine_id:?} to \
+                 unknown mailbox_id={recipient_mailbox_id:#x} kind_id={kind_id:#x} — returning \
+                 `aether.mail.unresolved` diagnostic to originator"
+            );
+            send_unresolved_diagnostic(engines, source_engine_id, recipient_mailbox_id, kind_id);
+            return;
+        }
         let sender = match source_mailbox_id {
             Some(mailbox_id) => ReplyTo::EngineMailbox {
                 engine_id: source_engine_id,
@@ -143,6 +172,41 @@ impl LoopbackHandle {
         self.queue.push(
             Mail::new(MailboxId(recipient_mailbox_id), kind_id, payload, count)
                 .with_reply_to(sender),
+        );
+    }
+}
+
+/// Build an `aether.mail.unresolved` `HubToEngine::MailById` frame and
+/// push it onto the originating engine's `mail_tx`. Targets the
+/// engine's `aether.diagnostics` sink (pre-registered by
+/// `SubstrateBoot::build` so resolution is guaranteed on the receiver
+/// — no bubble-up loop). Silently drops if the originating engine is
+/// no longer connected or its channel is full; this is a best-effort
+/// diagnostic, not a guaranteed delivery.
+fn send_unresolved_diagnostic(
+    engines: &EngineRegistry,
+    source_engine_id: EngineId,
+    recipient_mailbox_id: u64,
+    kind_id: u64,
+) {
+    let Some(record) = engines.get(&source_engine_id) else {
+        return;
+    };
+    let payload = bytemuck::bytes_of(&UnresolvedMail {
+        recipient_mailbox_id,
+        kind_id,
+    })
+    .to_vec();
+    let frame = HubToEngine::MailById(MailByIdFrame {
+        recipient_mailbox_id: mailbox_id_from_name(AETHER_DIAGNOSTICS),
+        kind_id: UnresolvedMail::ID,
+        payload,
+        count: 1,
+    });
+    if let Err(e) = record.mail_tx.try_send(frame) {
+        eprintln!(
+            "aether-substrate-hub: unresolved-mail diagnostic to engine {source_engine_id:?} \
+             dropped: {e}"
         );
     }
 }
@@ -405,10 +469,74 @@ mod tests {
                 count: 1,
                 source_mailbox_id: None,
             },
+            &engines,
         );
         // No panic == pass. The production flow logs a warn and
         // returns; we can't assert on the warn without threading
         // a tracing subscriber, which is out of scope for the
         // Phase-1 smoke.
+    }
+
+    /// Issue #185: when the hub can't resolve a bubbled-up mail's
+    /// recipient mailbox id, it pushes an
+    /// `aether.mail.unresolved` `MailById` frame onto the
+    /// originating engine's `mail_tx`. Test by registering a fake
+    /// engine record in the registry, feeding a frame whose
+    /// recipient id has no hub-side mailbox, and asserting the
+    /// registered `mail_tx` receives exactly one `UnresolvedMail`
+    /// frame targeting the `aether.diagnostics` sink.
+    #[test]
+    fn deliver_bubbled_mail_unknown_recipient_emits_diagnostic_to_originator() {
+        let engines = EngineRegistry::new();
+        let loopback = LoopbackEngine::boot(&engines).expect("loopback boot");
+        let handle = LoopbackHandle::from_boot(&loopback.boot);
+
+        let originator_id = EngineId(Uuid::from_u128(0x4242));
+        let (mail_tx, mut mail_rx) = mpsc::channel::<HubToEngine>(8);
+        engines.insert(EngineRecord {
+            id: originator_id,
+            name: "test-originator".into(),
+            pid: 1,
+            version: "0".into(),
+            kinds: vec![],
+            components: HashMap::new(),
+            mail_tx,
+            spawned: false,
+        });
+
+        // Tick's id is registered; the recipient mailbox id is bogus
+        // (no hub-side component binds it, no sink uses it), so the
+        // unresolved path fires.
+        handle.deliver_bubbled_mail(
+            originator_id,
+            EngineMailToHubSubstrateFrame {
+                recipient_mailbox_id: 0xBAD_C0FFEE_u64,
+                kind_id: <aether_kinds::Tick as Kind>::ID,
+                payload: vec![],
+                count: 1,
+                source_mailbox_id: Some(0x5151),
+            },
+            &engines,
+        );
+
+        let got = mail_rx
+            .try_recv()
+            .expect("diagnostic frame pushed onto originator's mail_tx");
+        let HubToEngine::MailById(frame) = got else {
+            panic!("expected MailById, got {got:?}");
+        };
+        assert_eq!(frame.kind_id, UnresolvedMail::ID);
+        assert_eq!(
+            frame.recipient_mailbox_id,
+            mailbox_id_from_name(AETHER_DIAGNOSTICS),
+        );
+        let record: &UnresolvedMail = bytemuck::from_bytes(&frame.payload);
+        assert_eq!(record.recipient_mailbox_id, 0xBAD_C0FFEE_u64);
+        assert_eq!(record.kind_id, <aether_kinds::Tick as Kind>::ID);
+        assert_eq!(frame.count, 1);
+        assert!(
+            mail_rx.try_recv().is_err(),
+            "only one diagnostic frame per unresolved recipient",
+        );
     }
 }


### PR DESCRIPTION
## Summary

When an engine bubbles up mail (ADR-0037) whose recipient the hub can't resolve either, echo an `aether.mail.unresolved` diagnostic back to the originating engine so the typo surfaces in that engine's own `engine_logs` rather than only in the hub's.

Before: the hub warn-dropped silently. A component on engine A mailing a typoed mailbox name saw nothing in its own `engine_logs` — the signal landed on the hub's logs, which most callers don't check first.

After: the hub pushes an `aether.mail.unresolved` `MailById` frame onto engine A's mail channel. Engine A's pre-registered `aether.diagnostics` sink decodes the record and re-emits a `tracing::warn!` locally, which flows through ADR-0023's `log_capture` to engine A's own `engine_logs`.

## Shape

- **New kind** `aether.mail.unresolved` — `#[repr(C)]` Pod with `recipient_mailbox_id: u64` + `kind_id: u64`. Registered in `aether_kinds::descriptors::all()` so every engine's boot registry knows it.
- **New well-known sink** `aether.diagnostics` — pre-registered by `SubstrateBoot::build` on every chassis. Handler decodes `aether.mail.unresolved` payloads via `bytemuck::try_from_bytes` and emits a `tracing::warn!` with the recipient + kind ids. Future diagnostic kinds can land on the same sink.
- **Hub-side emission** — `LoopbackHandle::deliver_bubbled_mail` gains a mailbox-resolution check. On `None`, it calls `send_unresolved_diagnostic`, which looks up the originator's `EngineRecord.mail_tx` and pushes a `HubToEngine::MailById { recipient_mailbox_id: mailbox_id_from_name("aether.diagnostics"), kind_id: UnresolvedMail::ID, ... }` frame. Short-circuits before the queue push so the existing warn-drop path doesn't double-fire.
- **Loop prevention** — the diagnostic targets `aether.diagnostics`, which is pre-registered on every substrate. The receiver can always resolve it; it never bubbles up.
- **`deliver_bubbled_mail` signature** gains `&EngineRegistry` (the hub's engine registry) so the diagnostic path can reach the originator's mail channel. The caller in `engine::read_loop` already holds it.

## Non-goals

- Name-resolution of the unresolved mailbox id for the warn message. The diagnostic carries the raw 64-bit id; tooling can reverse-resolve against the sender's declared kinds if it cares.
- Diagnostic for hub-local unresolved sends (e.g. a bad name used from within the hub's own substrate). Out of scope for issue #185 — the motivating case is remote engines, and this change doesn't regress the hub-local path.
- Batching. One diagnostic per unresolved frame. Cheap enough at typo frequency; revisit if a bug storm changes the arithmetic.

## Tests

- `deliver_bubbled_mail_unknown_recipient_emits_diagnostic_to_originator` (new, in `loopback.rs`): registers a fake engine in the hub's `EngineRegistry` with a probe `mail_tx`, feeds a bubbled frame with a bogus recipient id, asserts the exact `HubToEngine::MailById` frame landing on that channel carries an `UnresolvedMail` payload matching the input ids and targets `aether.diagnostics`.
- `deliver_bubbled_mail_drops_unknown_kind` updated for the new signature — unknown kind still takes precedence over unknown recipient (no diagnostic when the kind itself is bogus).
- Full `cargo test` (all 400+) + `cargo clippy --all-targets -- -D warnings` + `cargo fmt -- --check` green.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test`

Closes #185
