### PR TITLE
test(hub): lock in PendingReplies register atomicity + reuse-after-drop

### DIFF
--- a/crates/aether-substrate-hub/src/session.rs
+++ b/crates/aether-substrate-hub/src/session.rs
@@ -247,4 +247,63 @@ mod tests {
         assert!(tokens.contains(&h1.token));
         assert!(tokens.contains(&h3.token));
     }
+
+    /// Pins the check-and-insert atomicity of `PendingReplies::register`:
+    /// `N` threads racing to register the same kind must produce
+    /// exactly one `Some` and `N-1` `None`. Regression guard against a
+    /// future refactor that splits the `contains_key` check from the
+    /// `insert` across separate lock acquisitions — which would allow
+    /// two callers to both observe "not in flight" and both insert,
+    /// silently dropping one caller's waiter.
+    #[test]
+    fn register_is_atomic_under_concurrent_same_kind_calls() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        const RACERS: usize = 16;
+        const KIND: &str = "aether.capture_frame_result";
+
+        let replies = PendingReplies::new();
+        let barrier = Arc::new(Barrier::new(RACERS));
+
+        let handles: Vec<_> = (0..RACERS)
+            .map(|_| {
+                let replies = Arc::clone(&replies);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    // Every racer hits the mutex at the same moment so
+                    // the contention window is maximally exercised.
+                    // The returned Option<(guard, rx)> must be held by
+                    // the caller for the duration of the test — the
+                    // `join`-into-Vec below keeps the winner's guard
+                    // alive, so its Drop doesn't fire early and let a
+                    // late racer win "after" the winner.
+                    barrier.wait();
+                    replies.register(KIND.to_string())
+                })
+            })
+            .collect();
+
+        let outcomes: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let winners = outcomes.iter().filter(|o| o.is_some()).count();
+        let losers = outcomes.iter().filter(|o| o.is_none()).count();
+        assert_eq!(winners, 1, "exactly one racer must register successfully");
+        assert_eq!(losers, RACERS - 1, "every other racer must see None");
+    }
+
+    /// Companion to `register_is_atomic_...`: after the single winner
+    /// drops its guard, the slot is released and a subsequent
+    /// registration for the same kind succeeds. Protects against a
+    /// refactor that forgot to clear the map entry on drop.
+    #[test]
+    fn register_slot_is_reusable_after_guard_drop() {
+        let replies = PendingReplies::new();
+        let kind = "aether.capture_frame_result".to_string();
+
+        let first = replies.register(kind.clone()).expect("first register wins");
+        assert!(replies.register(kind.clone()).is_none());
+        drop(first);
+        let second = replies.register(kind.clone()).expect("slot reusable");
+        drop(second);
+    }
 }


### PR DESCRIPTION
## Summary

Locks in `PendingReplies::register`'s check-and-insert atomicity — the property that makes `capture_frame` / `load_component` / `replace_component` safe under concurrent calls on the same session. Also pins the reuse-after-guard-drop invariant.

## Why

A concurrency audit of `aether-substrate-hub` flagged — incorrectly — that `register` might race its "already in flight" check against the actual insert, letting two concurrent callers both observe "no waiter" and both insert. On code read the mutex acquisition makes the check-and-insert atomic, so the audit was wrong.

But the fact that a careful auditor misread it is evidence the property deserves a regression guard. A future refactor that split the check from the insert across separate lock acquisitions would silently reintroduce the hazard the guard now prevents.

## Tests

- `register_is_atomic_under_concurrent_same_kind_calls` — 16 threads race through a `std::sync::Barrier` to `register` the same kind. Asserts exactly one `Some` and 15 `None`.
- `register_slot_is_reusable_after_guard_drop` — after the winning registration's guard drops, the next register succeeds. Protects against a refactor that forgets to clear the map entry on drop.

## Audit findings (no code change — documentation only)

The audit traced five cancellation / cleanup edges:

1. `capture_frame` client disconnect mid-wait
2. `load_component` with substrate crash mid-load
3. Hub SIGTERM while a `capture_frame` is pending
4. Session drop with pending waiters still registered
5. MCP tool task panic mid-operation

All closed cleanly via RAII (`PendingReplyGuard::drop` runs on unwind, `Arc` refcounting handles session teardown), `tokio::time::timeout` bounds on every wait, and tokio's task-level panic isolation. No real gaps found — the existing design correctly composes these primitives.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test -p aether-substrate-hub` (all 123 green; 2 new)
