### PR TITLE
chore(docs,hub): stale ADR crate paths + map_or cleanup

### DIFF
--- a/crates/aether-substrate-hub/src/log_store.rs
+++ b/crates/aether-substrate-hub/src/log_store.rs
@@ -121,7 +121,7 @@ impl LogStore {
             // gap the caller is missing starts above `since` and
             // ends just below this. Empty buffer post-eviction
             // shouldn't happen in practice but is handled safely.
-            buf.entries.front().map(|e| e.sequence).unwrap_or(0)
+            buf.entries.front().map_or(0, |e| e.sequence)
         });
         let max = max.min(TOOL_MAX_ENTRIES);
         let mut out: Vec<LogEntry> = Vec::with_capacity(max.min(buf.entries.len()));
@@ -137,7 +137,7 @@ impl LogStore {
                 break;
             }
         }
-        let next_since = out.last().map(|e| e.sequence).unwrap_or(since);
+        let next_since = out.last().map_or(since, |e| e.sequence);
         ReadResult {
             entries: out,
             next_since,

--- a/crates/aether-substrate-hub/src/mcp/tools.rs
+++ b/crates/aether-substrate-hub/src/mcp/tools.rs
@@ -135,7 +135,7 @@ impl Hub {
         &self,
         Parameters(args): Parameters<ReceiveMailArgs>,
     ) -> Result<String, McpError> {
-        let cap = args.max.map(|n| n as usize).unwrap_or(usize::MAX);
+        let cap = args.max.map_or(usize::MAX, |n| n as usize);
         let mut rx = self.inbound.lock().await;
         let mut out = Vec::new();
         while out.len() < cap {

--- a/docs/adr/0013-reply-to-sender-host-fn.md
+++ b/docs/adr/0013-reply-to-sender-host-fn.md
@@ -108,7 +108,7 @@ A component that wants to remember a sender across receives can `sender.clone()`
 
 - Substrate: per-instance `SenderTable`, allocation on inbound dispatch, expiry hooks on replace/drop/session-gone.
 - Wire-through on the receive shim ABI: fourth param `sender: u32`, `SENDER_NONE` sentinel for broadcast-origin.
-- New `reply_mail` host fn in `aether-substrate/src/host_fns.rs` with full status codes.
+- New `reply_mail` host fn in `aether-substrate-core/src/host_fns.rs` with full status codes.
 - `Sender` type and `ctx.reply` in `aether-component` (blocked on ADR-0012 landing).
 - Port the receive-side of `aether-hello-component` to read sender for a trivial round-trip smoke test (Claude sends `aether.ping`, component replies with `aether.pong`).
 - **Parked, not committed:** generational sender handles, multi-reply semantics (one sender, N replies over time — already works; naming it if constraints emerge), cross-instance sender migration on replace (tied to ADR-0016).

--- a/docs/adr/0024-dual-target-host-fn-ffi.md
+++ b/docs/adr/0024-dual-target-host-fn-ffi.md
@@ -38,7 +38,7 @@ Two phases, with a hard split.
 
 Rename every pointer-typed FFI symbol to a `_p32` suffix. This is the entire scope of Phase 1; nothing else in the substrate or SDK changes.
 
-**Imports renamed (substrate side, in `aether-substrate/src/host_fns.rs`):**
+**Imports renamed (substrate side, in `aether-substrate-core/src/host_fns.rs`):**
 
 | Before                       | After                              |
 | ---------------------------- | ---------------------------------- |


### PR DESCRIPTION
## Summary

Small audit-pass sweep, no behaviour change.

**Doc drift (2 ADRs):** ADR-0013 and ADR-0024 referenced the pre-split path `aether-substrate/src/host_fns.rs`. After the ADR-0035 chassis split, host fns live in `aether-substrate-core/src/host_fns.rs`. A future reader grepping either ADR for the path would currently hit a dead reference.

**Clippy style (3 sites):** Three `.map(|x| ...).unwrap_or(default)` sites in `aether-substrate-hub` flatten to `.map_or(default, |x| ...)`. Same closure, fewer allocations in the `Option::None` path, reads identically. Flagged by `cargo clippy -- -W clippy::pedantic`.

A broader audit (Rust best practices + doc drift) found no correctness issues — baseline clippy is clean, Arc/Mutex usage is sound, no across-await lock holds, no real dead code. These five edits are the only items worth shipping.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p aether-substrate-hub` (4 log-store tests still pass; these are the direct callers of the two changed sites)