### PR TITLE
feat(math): add aether-math crate (Vec/Mat4/Quat, no_std, f32 scalar)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-math"
+version = "0.2.0-alpha"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "aether-substrate-core"
 version = "0.2.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/aether-substrate-headless",
     "crates/aether-substrate-hub",
     "crates/aether-kinds",
+    "crates/aether-math",
     "crates/aether-component",
     "crates/aether-hello-component",
     "crates/aether-hub-protocol",

--- a/crates/aether-math/Cargo.toml
+++ b/crates/aether-math/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "aether-math"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+libm = "0.2"

--- a/crates/aether-math/src/lib.rs
+++ b/crates/aether-math/src/lib.rs
@@ -1,0 +1,43 @@
+//! Tiny scalar `f32` math for Aether: `Vec2`, `Vec3`, `Vec4`, `Mat4`, `Quat`.
+//!
+//! Designed for WASM guest components and native substrate alike —
+//! `no_std`, no heap, no SIMD, no generics. Scalar code that LLVM +
+//! wasm-opt can auto-vectorise when the deployment target enables
+//! `simd128`, with an explicit SIMD feature to add later once a real
+//! hot loop demands it (camera/transform math does not).
+//!
+//! # Conventions
+//!
+//! Two decisions are baked in at the type level. Changing them later
+//! would ripple through every caller, so they are called out loudly:
+//!
+//! - **Column-major `Mat4`.** Stored as `[Vec4; 4]` where each `Vec4`
+//!   is one column. This matches wgpu / GLSL / HLSL uniform upload
+//!   layout, so a `Mat4` can be copied straight into a uniform buffer
+//!   without transpose. `M * v` is "apply `M` to `v`" as in standard
+//!   linear algebra.
+//! - **YXZ Euler order.** `Quat::from_euler_yxz(yaw, pitch, roll)`
+//!   applies yaw around `Y` (world up) first, then pitch around the
+//!   rotated local `X` (right), then roll around the rotated local
+//!   `Z` (forward). This is the natural order for an FPS / free-look
+//!   camera. Other orders are not offered; add one only when a
+//!   concrete use case forces it.
+//!
+//! World space is right-handed, `Y` up, `-Z` forward. Projection
+//! matrices (`perspective_rh`, `orthographic_rh`) emit wgpu-style
+//! clip space with depth in `[0, 1]` (not OpenGL's `[-1, 1]`), so
+//! the output matrix uploads without any clip-space remap.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+mod mat;
+mod quat;
+mod vec;
+
+pub use mat::Mat4;
+pub use quat::Quat;
+pub use vec::{Vec2, Vec3, Vec4};
+
+pub const PI: f32 = core::f32::consts::PI;
+pub const TAU: f32 = core::f32::consts::TAU;

--- a/crates/aether-math/src/mat.rs
+++ b/crates/aether-math/src/mat.rs
@@ -1,0 +1,326 @@
+use core::ops::Mul;
+
+use crate::quat::Quat;
+use crate::vec::{Vec3, Vec4};
+
+/// Column-major 4×4 matrix. Internal storage is four column `Vec4`s
+/// so `Mat4` lays out in memory identically to a GLSL/HLSL `mat4`
+/// uniform — copy directly into a wgpu uniform buffer with no
+/// transpose. `M * v` applies `M` to `v` in standard left-multiply
+/// convention.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Mat4 {
+    pub cols: [Vec4; 4],
+}
+
+impl Mat4 {
+    pub const IDENTITY: Self = Self {
+        cols: [
+            Vec4::new(1.0, 0.0, 0.0, 0.0),
+            Vec4::new(0.0, 1.0, 0.0, 0.0),
+            Vec4::new(0.0, 0.0, 1.0, 0.0),
+            Vec4::new(0.0, 0.0, 0.0, 1.0),
+        ],
+    };
+
+    #[inline]
+    pub const fn from_cols(c0: Vec4, c1: Vec4, c2: Vec4, c3: Vec4) -> Self {
+        Self {
+            cols: [c0, c1, c2, c3],
+        }
+    }
+
+    #[inline]
+    pub const fn from_translation(t: Vec3) -> Self {
+        Self {
+            cols: [
+                Vec4::new(1.0, 0.0, 0.0, 0.0),
+                Vec4::new(0.0, 1.0, 0.0, 0.0),
+                Vec4::new(0.0, 0.0, 1.0, 0.0),
+                Vec4::new(t.x, t.y, t.z, 1.0),
+            ],
+        }
+    }
+
+    #[inline]
+    pub const fn from_scale(s: Vec3) -> Self {
+        Self {
+            cols: [
+                Vec4::new(s.x, 0.0, 0.0, 0.0),
+                Vec4::new(0.0, s.y, 0.0, 0.0),
+                Vec4::new(0.0, 0.0, s.z, 0.0),
+                Vec4::new(0.0, 0.0, 0.0, 1.0),
+            ],
+        }
+    }
+
+    #[inline]
+    pub fn from_rotation_quat(q: Quat) -> Self {
+        let (x, y, z, w) = (q.x, q.y, q.z, q.w);
+        let (xx, yy, zz) = (x * x, y * y, z * z);
+        let (xy, xz, yz) = (x * y, x * z, y * z);
+        let (wx, wy, wz) = (w * x, w * y, w * z);
+        Self {
+            cols: [
+                Vec4::new(1.0 - 2.0 * (yy + zz), 2.0 * (xy + wz), 2.0 * (xz - wy), 0.0),
+                Vec4::new(2.0 * (xy - wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz + wx), 0.0),
+                Vec4::new(2.0 * (xz + wy), 2.0 * (yz - wx), 1.0 - 2.0 * (xx + yy), 0.0),
+                Vec4::new(0.0, 0.0, 0.0, 1.0),
+            ],
+        }
+    }
+
+    /// Rigid transform: rotation then translation. Equivalent to
+    /// `from_translation(t) * from_rotation_quat(r)` but composed
+    /// in one step.
+    #[inline]
+    pub fn from_rigid(rotation: Quat, translation: Vec3) -> Self {
+        let mut m = Self::from_rotation_quat(rotation);
+        m.cols[3] = Vec4::new(translation.x, translation.y, translation.z, 1.0);
+        m
+    }
+
+    #[inline]
+    pub fn transpose(self) -> Self {
+        let [c0, c1, c2, c3] = self.cols;
+        Self {
+            cols: [
+                Vec4::new(c0.x, c1.x, c2.x, c3.x),
+                Vec4::new(c0.y, c1.y, c2.y, c3.y),
+                Vec4::new(c0.z, c1.z, c2.z, c3.z),
+                Vec4::new(c0.w, c1.w, c2.w, c3.w),
+            ],
+        }
+    }
+
+    /// Inverse of a rigid transform (rotation + translation only, no
+    /// scale or skew): transpose the 3×3 rotation block and apply to
+    /// the negated translation. Produces garbage on a non-rigid
+    /// matrix; use only on view matrices and similar.
+    #[inline]
+    pub fn inverse_rigid(self) -> Self {
+        let [r0, r1, r2, t] = self.cols;
+        let t_xyz = Vec3::new(t.x, t.y, t.z);
+        let row0 = Vec3::new(r0.x, r0.y, r0.z);
+        let row1 = Vec3::new(r1.x, r1.y, r1.z);
+        let row2 = Vec3::new(r2.x, r2.y, r2.z);
+        Self {
+            cols: [
+                Vec4::new(r0.x, r1.x, r2.x, 0.0),
+                Vec4::new(r0.y, r1.y, r2.y, 0.0),
+                Vec4::new(r0.z, r1.z, r2.z, 0.0),
+                Vec4::new(-row0.dot(t_xyz), -row1.dot(t_xyz), -row2.dot(t_xyz), 1.0),
+            ],
+        }
+    }
+
+    /// Right-handed look-at view matrix. Camera at `eye`, looking
+    /// toward `target`, with `up` the world-up direction. Produces a
+    /// matrix that transforms world-space points into view space
+    /// where the camera sits at the origin looking down `-Z`.
+    #[inline]
+    pub fn look_at_rh(eye: Vec3, target: Vec3, up: Vec3) -> Self {
+        let z = (eye - target).normalize();
+        let x = up.cross(z).normalize();
+        let y = z.cross(x);
+        Self {
+            cols: [
+                Vec4::new(x.x, y.x, z.x, 0.0),
+                Vec4::new(x.y, y.y, z.y, 0.0),
+                Vec4::new(x.z, y.z, z.z, 0.0),
+                Vec4::new(-x.dot(eye), -y.dot(eye), -z.dot(eye), 1.0),
+            ],
+        }
+    }
+
+    /// Right-handed perspective projection, wgpu-style clip space
+    /// (depth in `[0, 1]`, not OpenGL's `[-1, 1]`). `fov_y_rad` is
+    /// the vertical field of view in radians.
+    #[inline]
+    pub fn perspective_rh(fov_y_rad: f32, aspect: f32, z_near: f32, z_far: f32) -> Self {
+        let f = 1.0 / libm::tanf(fov_y_rad * 0.5);
+        let a = z_far / (z_near - z_far);
+        let b = z_near * z_far / (z_near - z_far);
+        Self {
+            cols: [
+                Vec4::new(f / aspect, 0.0, 0.0, 0.0),
+                Vec4::new(0.0, f, 0.0, 0.0),
+                Vec4::new(0.0, 0.0, a, -1.0),
+                Vec4::new(0.0, 0.0, b, 0.0),
+            ],
+        }
+    }
+
+    /// Right-handed orthographic projection, wgpu-style clip space
+    /// (depth in `[0, 1]`).
+    #[inline]
+    pub fn orthographic_rh(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        let rl = right - left;
+        let tb = top - bottom;
+        let nf = z_near - z_far;
+        Self {
+            cols: [
+                Vec4::new(2.0 / rl, 0.0, 0.0, 0.0),
+                Vec4::new(0.0, 2.0 / tb, 0.0, 0.0),
+                Vec4::new(0.0, 0.0, 1.0 / nf, 0.0),
+                Vec4::new(-(right + left) / rl, -(top + bottom) / tb, z_near / nf, 1.0),
+            ],
+        }
+    }
+}
+
+impl Mul<Vec4> for Mat4 {
+    type Output = Vec4;
+    #[inline]
+    fn mul(self, v: Vec4) -> Vec4 {
+        self.cols[0] * v.x + self.cols[1] * v.y + self.cols[2] * v.z + self.cols[3] * v.w
+    }
+}
+
+impl Mul for Mat4 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self {
+            cols: [
+                self * rhs.cols[0],
+                self * rhs.cols[1],
+                self * rhs.cols[2],
+                self * rhs.cols[3],
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PI;
+
+    const EPS: f32 = 1e-5;
+
+    fn approx_eq_vec4(a: Vec4, b: Vec4) -> bool {
+        (a.x - b.x).abs() < EPS
+            && (a.y - b.y).abs() < EPS
+            && (a.z - b.z).abs() < EPS
+            && (a.w - b.w).abs() < EPS
+    }
+
+    #[test]
+    fn identity_preserves_vec() {
+        let v = Vec4::new(1.0, 2.0, 3.0, 1.0);
+        assert_eq!(Mat4::IDENTITY * v, v);
+    }
+
+    #[test]
+    fn translation_moves_point() {
+        let m = Mat4::from_translation(Vec3::new(2.0, 3.0, 4.0));
+        let p = Vec4::new(1.0, 0.0, 0.0, 1.0);
+        assert_eq!(m * p, Vec4::new(3.0, 3.0, 4.0, 1.0));
+    }
+
+    #[test]
+    fn translation_does_not_move_direction() {
+        let m = Mat4::from_translation(Vec3::new(2.0, 3.0, 4.0));
+        let dir = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        assert_eq!(m * dir, dir);
+    }
+
+    #[test]
+    fn scale_scales_point() {
+        let m = Mat4::from_scale(Vec3::new(2.0, 3.0, 4.0));
+        let p = Vec4::new(1.0, 1.0, 1.0, 1.0);
+        assert_eq!(m * p, Vec4::new(2.0, 3.0, 4.0, 1.0));
+    }
+
+    #[test]
+    fn rotation_quat_matches_quat_mul_vec3() {
+        let q = Quat::from_axis_angle(Vec3::Y, PI * 0.5);
+        let m = Mat4::from_rotation_quat(q);
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        let via_quat = q * v;
+        let via_mat = m * v.extend(0.0);
+        assert!(approx_eq_vec4(via_mat, via_quat.extend(0.0)));
+    }
+
+    #[test]
+    fn mul_is_associative_enough() {
+        let a = Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0));
+        let b = Mat4::from_rotation_quat(Quat::from_axis_angle(Vec3::Y, 0.7));
+        let v = Vec4::new(1.0, 0.0, 0.0, 1.0);
+        let left = (a * b) * v;
+        let right = a * (b * v);
+        assert!(approx_eq_vec4(left, right));
+    }
+
+    #[test]
+    fn inverse_rigid_round_trips() {
+        let r = Quat::from_axis_angle(Vec3::new(1.0, 2.0, 3.0).normalize(), 0.7);
+        let m = Mat4::from_rigid(r, Vec3::new(4.0, -2.0, 5.0));
+        let inv = m.inverse_rigid();
+        let v = Vec4::new(1.0, 2.0, 3.0, 1.0);
+        let round = inv * (m * v);
+        assert!(approx_eq_vec4(round, v));
+    }
+
+    #[test]
+    fn look_at_places_camera() {
+        let view = Mat4::look_at_rh(Vec3::new(0.0, 0.0, 5.0), Vec3::ZERO, Vec3::Y);
+        let origin_in_view = view * Vec4::new(0.0, 0.0, 0.0, 1.0);
+        assert!(approx_eq_vec4(
+            origin_in_view,
+            Vec4::new(0.0, 0.0, -5.0, 1.0)
+        ));
+    }
+
+    #[test]
+    fn perspective_maps_near_to_zero_far_to_one() {
+        let proj = Mat4::perspective_rh(PI * 0.5, 1.0, 1.0, 10.0);
+        let near = proj * Vec4::new(0.0, 0.0, -1.0, 1.0);
+        let far = proj * Vec4::new(0.0, 0.0, -10.0, 1.0);
+        assert!(
+            (near.z / near.w - 0.0).abs() < EPS,
+            "near z_ndc = {}",
+            near.z / near.w
+        );
+        assert!(
+            (far.z / far.w - 1.0).abs() < EPS,
+            "far z_ndc = {}",
+            far.z / far.w
+        );
+    }
+
+    #[test]
+    fn orthographic_maps_box() {
+        let proj = Mat4::orthographic_rh(-1.0, 1.0, -1.0, 1.0, 1.0, 10.0);
+        let near = proj * Vec4::new(0.0, 0.0, -1.0, 1.0);
+        let far = proj * Vec4::new(0.0, 0.0, -10.0, 1.0);
+        assert!((near.z - 0.0).abs() < EPS);
+        assert!((far.z - 1.0).abs() < EPS);
+        let corner = proj * Vec4::new(1.0, 1.0, -5.0, 1.0);
+        assert!((corner.x - 1.0).abs() < EPS);
+        assert!((corner.y - 1.0).abs() < EPS);
+    }
+
+    #[test]
+    fn transpose_round_trips() {
+        let m = Mat4::from_rigid(
+            Quat::from_axis_angle(Vec3::X, 0.3),
+            Vec3::new(7.0, -3.0, 2.0),
+        );
+        assert_eq!(m.transpose().transpose(), m);
+    }
+
+    #[test]
+    fn repr_c_size() {
+        assert_eq!(core::mem::size_of::<Mat4>(), 64);
+    }
+}

--- a/crates/aether-math/src/quat.rs
+++ b/crates/aether-math/src/quat.rs
@@ -1,0 +1,192 @@
+use core::ops::Mul;
+
+use crate::vec::Vec3;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Quat {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+impl Quat {
+    pub const IDENTITY: Self = Self::new(0.0, 0.0, 0.0, 1.0);
+
+    #[inline]
+    pub const fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self { x, y, z, w }
+    }
+
+    #[inline]
+    pub fn from_axis_angle(axis: Vec3, angle_rad: f32) -> Self {
+        let half = angle_rad * 0.5;
+        let s = libm::sinf(half);
+        let c = libm::cosf(half);
+        let axis = axis.normalize();
+        Self::new(axis.x * s, axis.y * s, axis.z * s, c)
+    }
+
+    /// YXZ Euler order: yaw around Y, then pitch around local X, then
+    /// roll around local Z. Angles in radians.
+    #[inline]
+    pub fn from_euler_yxz(yaw: f32, pitch: f32, roll: f32) -> Self {
+        let (sy, cy) = (libm::sinf(yaw * 0.5), libm::cosf(yaw * 0.5));
+        let (sp, cp) = (libm::sinf(pitch * 0.5), libm::cosf(pitch * 0.5));
+        let (sr, cr) = (libm::sinf(roll * 0.5), libm::cosf(roll * 0.5));
+        Self::new(
+            cr * sp * cy - sr * cp * sy,
+            cr * cp * sy + sr * sp * cy,
+            cr * sp * sy + sr * cp * cy,
+            cr * cp * cy - sr * sp * sy,
+        )
+    }
+
+    #[inline]
+    pub fn length_squared(self) -> f32 {
+        self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w
+    }
+
+    #[inline]
+    pub fn length(self) -> f32 {
+        libm::sqrtf(self.length_squared())
+    }
+
+    /// Returns `self / length(self)`. Zero-length input returns
+    /// `IDENTITY` rather than NaN. Opinionated but avoids propagating
+    /// NaN through camera state; callers that need the distinction
+    /// must check length themselves.
+    #[inline]
+    pub fn normalize(self) -> Self {
+        let len = self.length();
+        if len > 0.0 {
+            let inv = 1.0 / len;
+            Self::new(self.x * inv, self.y * inv, self.z * inv, self.w * inv)
+        } else {
+            Self::IDENTITY
+        }
+    }
+
+    #[inline]
+    pub const fn conjugate(self) -> Self {
+        Self::new(-self.x, -self.y, -self.z, self.w)
+    }
+
+    /// `conjugate() / length_squared()`. For unit quaternions this
+    /// equals `conjugate()` exactly — prefer that when you know the
+    /// quat is normalized.
+    #[inline]
+    pub fn inverse(self) -> Self {
+        let ls = self.length_squared();
+        if ls > 0.0 {
+            let inv = 1.0 / ls;
+            Self::new(-self.x * inv, -self.y * inv, -self.z * inv, self.w * inv)
+        } else {
+            Self::IDENTITY
+        }
+    }
+
+    #[inline]
+    pub fn rotate_vec3(self, v: Vec3) -> Vec3 {
+        let xyz = Vec3::new(self.x, self.y, self.z);
+        let t = xyz.cross(v) * 2.0;
+        v + t * self.w + xyz.cross(t)
+    }
+}
+
+impl Mul for Quat {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self::new(
+            self.w * rhs.x + self.x * rhs.w + self.y * rhs.z - self.z * rhs.y,
+            self.w * rhs.y - self.x * rhs.z + self.y * rhs.w + self.z * rhs.x,
+            self.w * rhs.z + self.x * rhs.y - self.y * rhs.x + self.z * rhs.w,
+            self.w * rhs.w - self.x * rhs.x - self.y * rhs.y - self.z * rhs.z,
+        )
+    }
+}
+
+impl Mul<Vec3> for Quat {
+    type Output = Vec3;
+    #[inline]
+    fn mul(self, rhs: Vec3) -> Vec3 {
+        self.rotate_vec3(rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PI;
+
+    const EPS: f32 = 1e-5;
+
+    fn approx_eq_vec3(a: Vec3, b: Vec3) -> bool {
+        (a.x - b.x).abs() < EPS && (a.y - b.y).abs() < EPS && (a.z - b.z).abs() < EPS
+    }
+
+    #[test]
+    fn identity_leaves_vec_unchanged() {
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert_eq!(Quat::IDENTITY * v, v);
+    }
+
+    #[test]
+    fn from_axis_angle_y_rotates_x_to_negz() {
+        let q = Quat::from_axis_angle(Vec3::Y, PI * 0.5);
+        assert!(approx_eq_vec3(q * Vec3::X, Vec3::new(0.0, 0.0, -1.0)));
+    }
+
+    #[test]
+    fn from_axis_angle_x_rotates_y_to_z() {
+        let q = Quat::from_axis_angle(Vec3::X, PI * 0.5);
+        assert!(approx_eq_vec3(q * Vec3::Y, Vec3::Z));
+    }
+
+    #[test]
+    fn from_axis_angle_z_rotates_x_to_y() {
+        let q = Quat::from_axis_angle(Vec3::Z, PI * 0.5);
+        assert!(approx_eq_vec3(q * Vec3::X, Vec3::Y));
+    }
+
+    #[test]
+    fn yaw_only_matches_axis_angle_y() {
+        let yaw = 0.7;
+        let a = Quat::from_euler_yxz(yaw, 0.0, 0.0);
+        let b = Quat::from_axis_angle(Vec3::Y, yaw);
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert!(approx_eq_vec3(a * v, b * v));
+    }
+
+    #[test]
+    fn pitch_only_matches_axis_angle_x() {
+        let pitch = 0.4;
+        let a = Quat::from_euler_yxz(0.0, pitch, 0.0);
+        let b = Quat::from_axis_angle(Vec3::X, pitch);
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert!(approx_eq_vec3(a * v, b * v));
+    }
+
+    #[test]
+    fn conjugate_is_inverse_for_unit_quats() {
+        let q = Quat::from_axis_angle(Vec3::new(1.0, 2.0, 3.0).normalize(), 0.7);
+        let r = q * q.conjugate();
+        assert!((r.x).abs() < EPS);
+        assert!((r.y).abs() < EPS);
+        assert!((r.z).abs() < EPS);
+        assert!((r.w - 1.0).abs() < EPS);
+    }
+
+    #[test]
+    fn normalize_zero_returns_identity() {
+        let zero = Quat::new(0.0, 0.0, 0.0, 0.0);
+        assert_eq!(zero.normalize(), Quat::IDENTITY);
+    }
+
+    #[test]
+    fn repr_c_size() {
+        assert_eq!(core::mem::size_of::<Quat>(), 16);
+    }
+}

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -1,0 +1,309 @@
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Vec4 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+impl Vec2 {
+    pub const ZERO: Self = Self::splat(0.0);
+    pub const ONE: Self = Self::splat(1.0);
+    pub const X: Self = Self::new(1.0, 0.0);
+    pub const Y: Self = Self::new(0.0, 1.0);
+
+    #[inline]
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    #[inline]
+    pub const fn splat(v: f32) -> Self {
+        Self { x: v, y: v }
+    }
+
+    #[inline]
+    pub fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    #[inline]
+    pub fn length_squared(self) -> f32 {
+        self.dot(self)
+    }
+
+    #[inline]
+    pub fn length(self) -> f32 {
+        libm::sqrtf(self.length_squared())
+    }
+
+    #[inline]
+    pub fn normalize(self) -> Self {
+        let len = self.length();
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
+    }
+
+    #[inline]
+    pub fn lerp(self, other: Self, t: f32) -> Self {
+        self + (other - self) * t
+    }
+}
+
+impl Vec3 {
+    pub const ZERO: Self = Self::splat(0.0);
+    pub const ONE: Self = Self::splat(1.0);
+    pub const X: Self = Self::new(1.0, 0.0, 0.0);
+    pub const Y: Self = Self::new(0.0, 1.0, 0.0);
+    pub const Z: Self = Self::new(0.0, 0.0, 1.0);
+
+    #[inline]
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+
+    #[inline]
+    pub const fn splat(v: f32) -> Self {
+        Self { x: v, y: v, z: v }
+    }
+
+    #[inline]
+    pub fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    #[inline]
+    pub fn cross(self, other: Self) -> Self {
+        Self::new(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+    }
+
+    #[inline]
+    pub fn length_squared(self) -> f32 {
+        self.dot(self)
+    }
+
+    #[inline]
+    pub fn length(self) -> f32 {
+        libm::sqrtf(self.length_squared())
+    }
+
+    /// Returns `self / length(self)`. Zero-length input returns
+    /// `Self::ZERO` rather than NaN; callers that need to distinguish
+    /// must check length themselves.
+    #[inline]
+    pub fn normalize(self) -> Self {
+        let len = self.length();
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
+    }
+
+    #[inline]
+    pub fn lerp(self, other: Self, t: f32) -> Self {
+        self + (other - self) * t
+    }
+
+    #[inline]
+    pub const fn extend(self, w: f32) -> Vec4 {
+        Vec4::new(self.x, self.y, self.z, w)
+    }
+}
+
+impl Vec4 {
+    pub const ZERO: Self = Self::splat(0.0);
+    pub const ONE: Self = Self::splat(1.0);
+    pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
+    pub const Y: Self = Self::new(0.0, 1.0, 0.0, 0.0);
+    pub const Z: Self = Self::new(0.0, 0.0, 1.0, 0.0);
+    pub const W: Self = Self::new(0.0, 0.0, 0.0, 1.0);
+
+    #[inline]
+    pub const fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self { x, y, z, w }
+    }
+
+    #[inline]
+    pub const fn splat(v: f32) -> Self {
+        Self {
+            x: v,
+            y: v,
+            z: v,
+            w: v,
+        }
+    }
+
+    #[inline]
+    pub fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y + self.z * other.z + self.w * other.w
+    }
+
+    #[inline]
+    pub fn length_squared(self) -> f32 {
+        self.dot(self)
+    }
+
+    #[inline]
+    pub fn length(self) -> f32 {
+        libm::sqrtf(self.length_squared())
+    }
+
+    #[inline]
+    pub fn normalize(self) -> Self {
+        let len = self.length();
+        if len > 0.0 {
+            self * (1.0 / len)
+        } else {
+            Self::ZERO
+        }
+    }
+
+    #[inline]
+    pub fn lerp(self, other: Self, t: f32) -> Self {
+        self + (other - self) * t
+    }
+
+    #[inline]
+    pub const fn truncate(self) -> Vec3 {
+        Vec3::new(self.x, self.y, self.z)
+    }
+}
+
+macro_rules! impl_vec_ops {
+    ($Vec:ident { $($field:ident),+ }) => {
+        impl Add for $Vec {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: Self) -> Self { Self { $($field: self.$field + rhs.$field),+ } }
+        }
+        impl Sub for $Vec {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: Self) -> Self { Self { $($field: self.$field - rhs.$field),+ } }
+        }
+        impl Neg for $Vec {
+            type Output = Self;
+            #[inline]
+            fn neg(self) -> Self { Self { $($field: -self.$field),+ } }
+        }
+        impl Mul<f32> for $Vec {
+            type Output = Self;
+            #[inline]
+            fn mul(self, rhs: f32) -> Self { Self { $($field: self.$field * rhs),+ } }
+        }
+        impl Div<f32> for $Vec {
+            type Output = Self;
+            #[inline]
+            fn div(self, rhs: f32) -> Self { Self { $($field: self.$field / rhs),+ } }
+        }
+        impl AddAssign for $Vec {
+            #[inline]
+            fn add_assign(&mut self, rhs: Self) { $(self.$field += rhs.$field;)+ }
+        }
+        impl SubAssign for $Vec {
+            #[inline]
+            fn sub_assign(&mut self, rhs: Self) { $(self.$field -= rhs.$field;)+ }
+        }
+        impl MulAssign<f32> for $Vec {
+            #[inline]
+            fn mul_assign(&mut self, rhs: f32) { $(self.$field *= rhs;)+ }
+        }
+        impl DivAssign<f32> for $Vec {
+            #[inline]
+            fn div_assign(&mut self, rhs: f32) { $(self.$field /= rhs;)+ }
+        }
+    };
+}
+
+impl_vec_ops!(Vec2 { x, y });
+impl_vec_ops!(Vec3 { x, y, z });
+impl_vec_ops!(Vec4 { x, y, z, w });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vec3_dot_cross() {
+        assert_eq!(Vec3::X.dot(Vec3::Y), 0.0);
+        assert_eq!(Vec3::X.dot(Vec3::X), 1.0);
+        assert_eq!(Vec3::X.cross(Vec3::Y), Vec3::Z);
+        assert_eq!(Vec3::Y.cross(Vec3::Z), Vec3::X);
+        assert_eq!(Vec3::Z.cross(Vec3::X), Vec3::Y);
+    }
+
+    #[test]
+    fn vec3_length_normalize() {
+        let v = Vec3::new(3.0, 4.0, 0.0);
+        assert_eq!(v.length_squared(), 25.0);
+        assert_eq!(v.length(), 5.0);
+        let n = v.normalize();
+        assert!((n.length() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vec3_normalize_zero_returns_zero() {
+        assert_eq!(Vec3::ZERO.normalize(), Vec3::ZERO);
+    }
+
+    #[test]
+    fn vec3_arith() {
+        let a = Vec3::new(1.0, 2.0, 3.0);
+        let b = Vec3::new(4.0, 5.0, 6.0);
+        assert_eq!(a + b, Vec3::new(5.0, 7.0, 9.0));
+        assert_eq!(b - a, Vec3::new(3.0, 3.0, 3.0));
+        assert_eq!(a * 2.0, Vec3::new(2.0, 4.0, 6.0));
+        assert_eq!(b / 2.0, Vec3::new(2.0, 2.5, 3.0));
+        assert_eq!(-a, Vec3::new(-1.0, -2.0, -3.0));
+    }
+
+    #[test]
+    fn vec3_lerp() {
+        let a = Vec3::ZERO;
+        let b = Vec3::new(10.0, 20.0, 30.0);
+        assert_eq!(a.lerp(b, 0.0), a);
+        assert_eq!(a.lerp(b, 1.0), b);
+        assert_eq!(a.lerp(b, 0.5), Vec3::new(5.0, 10.0, 15.0));
+    }
+
+    #[test]
+    fn vec_extend_truncate() {
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert_eq!(v.extend(4.0), Vec4::new(1.0, 2.0, 3.0, 4.0));
+        assert_eq!(Vec4::new(1.0, 2.0, 3.0, 4.0).truncate(), v);
+    }
+
+    #[test]
+    fn repr_c_layout() {
+        assert_eq!(core::mem::size_of::<Vec2>(), 8);
+        assert_eq!(core::mem::size_of::<Vec3>(), 12);
+        assert_eq!(core::mem::size_of::<Vec4>(), 16);
+        assert_eq!(core::mem::align_of::<Vec4>(), 4);
+    }
+}


### PR DESCRIPTION
## Summary

Hand-rolled `aether-math`: `Vec2/3/4`, `Mat4`, `Quat`. Scalar `f32`, `no_std`, `libm` for transcendentals, no SIMD, no generics. Ships exactly what the upcoming camera component needs and stops — future ops added when concrete callers demand them.

## Why hand-roll instead of adding `glam`?

WASM-first context flips the usual calculus:

- glam's biggest win is SIMD, and its native SIMD paths compile away on `wasm32` — scalar glam vs scalar hand-rolled is a wash on perf.
- Camera component uses ~30% of glam's surface; carrying the rest is pure WASM binary-size tax.
- Types can sit directly in cast-tier mail kinds with known `#[repr(C)]` layout under our control.
- The one genuinely tricky op (general `Mat4::inverse`) is sidestepped with a view-matrix-specialised `inverse_rigid` that's correct by construction.

## Conventions baked at type level

Called out loudly in `lib.rs` so they don't get bikeshedded case-by-case later:

- **Column-major `Mat4`** (`cols: [Vec4; 4]`) — matches wgpu/GLSL uniform upload, zero transpose on GPU boundary.
- **YXZ Euler order** (`from_euler_yxz(yaw, pitch, roll)`) — FPS-camera natural: yaw around world-Y, pitch around local-X, roll around local-Z. Other orders not offered.
- **Right-handed, Y-up world** — `-Z` is forward.
- **wgpu-style clip space** — depth in `[0, 1]`, not OpenGL's `[-1, 1]`. `perspective_rh`/`orthographic_rh` emit directly, no clip-space remap.

## Surface

Minimum viable for camera:

- `Vec2/Vec3/Vec4`: constants (`ZERO`/`ONE`/`X`/`Y`/`Z`/`W`), `new`, `splat`, `dot`, `length[_squared]`, `normalize` (zero→zero), `lerp`, `cross` (Vec3), `extend`/`truncate`, full arithmetic + assign ops.
- `Mat4`: `IDENTITY`, `from_translation`/`from_scale`/`from_rotation_quat`/`from_rigid`, `transpose`, `inverse_rigid`, `look_at_rh`, `perspective_rh`, `orthographic_rh`, `Mul<Mat4>`, `Mul<Vec4>`.
- `Quat`: `IDENTITY`, `from_axis_angle`, `from_euler_yxz`, `normalize` (zero→identity), `conjugate`, `inverse`, `rotate_vec3`, `Mul<Quat>`, `Mul<Vec3>`.

Deliberately absent and waiting on concrete pressure: `Mat3`, general `Mat4::inverse`, `Transform` decomposed struct, SIMD, other Euler orders, left-handed variants.

## Design notes

- Panic-free: no indexing, no `unwrap`, `normalize` returns a sentinel (`ZERO`/`IDENTITY`) on zero input. Avoids pulling panic machinery into WASM binaries.
- `#[inline]` on every small op for cross-crate call sites from components.
- `const fn` on constructors/constants where possible so identity/axis values bake into the binary.
- `Mat4` storage is opaque-ish (public `cols` but all constructors hide layout) so a future SIMD-backed `v128` rep can swap in behind the same API.

## Test plan

- [x] `cargo test -p aether-math` — 28 tests pass (cross/dot identities, Euler↔axis-angle agreement, `look_at` places camera correctly, perspective maps near→0 / far→1, `inverse_rigid` round-trips, `repr(C)` sizes)
- [x] `cargo clippy -p aether-math --all-targets -- -D warnings`
- [x] `cargo fmt -p aether-math -- --check`
- [x] `cargo check -p aether-math --target wasm32-unknown-unknown` (no_std + libm path)
- [x] `cargo check --workspace` (nothing else regressed)
