### PR TITLE
feat(camera,kinds): orbit camera gains runtime control surface

### DIFF
--- a/crates/aether-camera-component/src/lib.rs
+++ b/crates/aether-camera-component/src/lib.rs
@@ -1,34 +1,40 @@
 //! Orbit camera that drives the substrate's `aether.camera` sink.
 //!
-//! Auto-orbits around the world origin on a yaw-only circle at a
-//! fixed distance, updating each tick. Aspect ratio tracks the live
-//! window size via `WindowSize`, so the projection stays square
-//! regardless of window shape. First real second drawing-adjacent
-//! component (after `aether-hello-component`) and the forcing
-//! function for the `aether-math` + GPU-uniform plumbing.
+//! Yaws around a configurable world-space target at a configurable
+//! distance, updating each tick. Aspect ratio tracks the live window
+//! size via `WindowSize`, so the projection stays square regardless
+//! of window shape.
 //!
-//! WASD / arrow-key input is deliberately deferred to a follow-up —
-//! winit's `KeyCode as u32` discriminants aren't a stable named
-//! contract through `aether-kinds`, so hardcoding raw numbers here
-//! would be fragile. Auto-orbit gets the pipeline end-to-end
-//! working; key-driven control lands once we have either a named
-//! keycode export or a smoke-tested lookup.
+//! Runtime-controllable via `aether.camera.orbit.set_*` mail kinds:
+//! distance, pitch, yaw, speed (auto-rotation rate), FoV, and the
+//! world-space target point. Sending `OrbitSetSpeed { rad_per_tick:
+//! 0.0 }` freezes the camera at its current yaw so an absolute
+//! `OrbitSetYaw` holds; any non-zero speed resumes auto-rotation
+//! from whatever the current yaw is.
+//!
+//! WASD / arrow-key input is deliberately deferred — winit's
+//! `KeyCode as u32` discriminants aren't a stable named contract
+//! through `aether-kinds`, so hardcoding raw numbers here would be
+//! fragile. Control mail is the current driver surface.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
-use aether_kinds::{Camera, Tick, WindowSize};
+use aether_kinds::{
+    Camera, OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget,
+    OrbitSetYaw, Tick, WindowSize,
+};
 use aether_math::{Mat4, PI, Quat, Vec3};
 
-/// Orbit radius — how far the eye sits from the world origin.
-const DISTANCE: f32 = 3.0;
-/// Yaw delta per tick. At 60 fps this is a full revolution every
-/// ~12 seconds — slow enough to watch, fast enough to obviously be
-/// moving.
-const YAW_PER_TICK: f32 = PI / 360.0;
-/// Fixed downward pitch so the camera looks slightly down at the
-/// origin, giving a sense of depth. Positive pitch = tilt toward +Y.
-const PITCH: f32 = 0.3;
-/// Vertical field of view, 60°.
-const FOV_Y: f32 = PI / 3.0;
+/// Default orbit radius — how far the eye sits from the target.
+const DEFAULT_DISTANCE: f32 = 3.0;
+/// Default yaw delta per tick. At 60 fps this is a full revolution
+/// every ~12 seconds — slow enough to watch, fast enough to obviously
+/// be moving.
+const DEFAULT_SPEED: f32 = PI / 360.0;
+/// Default downward pitch so the camera looks slightly down at the
+/// target, giving a sense of depth. Positive pitch = tilt toward +Y.
+const DEFAULT_PITCH: f32 = 0.3;
+/// Default vertical field of view, 60°.
+const DEFAULT_FOV: f32 = PI / 3.0;
 const Z_NEAR: f32 = 0.1;
 const Z_FAR: f32 = 100.0;
 /// Fallback aspect ratio used before the first `WindowSize` arrives.
@@ -39,24 +45,44 @@ const DEFAULT_ASPECT: f32 = 16.0 / 9.0;
 pub struct Orbit {
     camera: Sink<Camera>,
     yaw: f32,
+    pitch: f32,
+    distance: f32,
+    speed: f32,
+    fov: f32,
+    target: Vec3,
     aspect: f32,
 }
 
 /// Orbit camera that publishes a view*projection matrix to the
-/// substrate every tick.
+/// substrate every tick. Configurable at runtime via the
+/// `aether.camera.orbit.set_*` mail family.
 ///
 /// # Agent
 /// Load this alongside a drawing component (e.g. `aether-hello-component`)
-/// to see the triangle viewed through a moving 3D camera. Use
-/// `capture_frame` frame-to-frame — the triangle should drift across
-/// the view horizontally as the camera yaws around origin. No mail
-/// endpoints to poke; it runs itself off the tick stream.
+/// to see its geometry viewed through a moving 3D camera. To poke the
+/// camera, send control mail to this component's mailbox:
+///
+/// - `OrbitSetDistance { distance }` — zoom (default 3.0)
+/// - `OrbitSetPitch { pitch }` — vertical tilt radians (default 0.3)
+/// - `OrbitSetYaw { yaw }` — absolute yaw radians; pair with
+///   `OrbitSetSpeed { 0.0 }` to pin
+/// - `OrbitSetSpeed { rad_per_tick }` — auto-rotation rate;
+///   `0.0` freezes
+/// - `OrbitSetFov { fov_y_rad }` — vertical field of view
+/// - `OrbitSetTarget { x, y, z }` — world-space pivot
+///
+/// Use `capture_frame` between sends to verify each change.
 #[handlers]
 impl Component for Orbit {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Orbit {
             camera: ctx.resolve_sink::<Camera>("camera"),
             yaw: 0.0,
+            pitch: DEFAULT_PITCH,
+            distance: DEFAULT_DISTANCE,
+            speed: DEFAULT_SPEED,
+            fov: DEFAULT_FOV,
+            target: Vec3::ZERO,
             aspect: DEFAULT_ASPECT,
         }
     }
@@ -67,20 +93,22 @@ impl Component for Orbit {
     /// Tick-driven; not useful to send manually.
     #[handler]
     fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
-        self.yaw += YAW_PER_TICK;
+        self.yaw += self.speed;
         if self.yaw > PI * 2.0 {
             self.yaw -= PI * 2.0;
+        } else if self.yaw < 0.0 {
+            self.yaw += PI * 2.0;
         }
 
-        // Orbit Vec3::new(0, 0, DISTANCE) by yaw around Y and pitch
-        // around local X. YXZ order: yaw applied first, then pitch
-        // in the yaw-rotated frame — identical to a first-person
-        // camera's look direction math.
-        let orientation = Quat::from_euler_yxz(self.yaw, PITCH, 0.0);
-        let eye = orientation * Vec3::new(0.0, 0.0, DISTANCE);
+        // Orbit `(0, 0, distance)` by yaw around Y and pitch around
+        // local X, then translate to the target. YXZ order: yaw first,
+        // then pitch in the yaw-rotated frame — identical to a
+        // first-person camera's look direction math.
+        let orientation = Quat::from_euler_yxz(self.yaw, self.pitch, 0.0);
+        let eye = self.target + orientation * Vec3::new(0.0, 0.0, self.distance);
 
-        let view = Mat4::look_at_rh(eye, Vec3::ZERO, Vec3::Y);
-        let proj = Mat4::perspective_rh(FOV_Y, self.aspect, Z_NEAR, Z_FAR);
+        let view = Mat4::look_at_rh(eye, self.target, Vec3::Y);
+        let proj = Mat4::perspective_rh(self.fov, self.aspect, Z_NEAR, Z_FAR);
         let view_proj = proj * view;
 
         ctx.send(
@@ -102,6 +130,66 @@ impl Component for Orbit {
         if size.width > 0 && size.height > 0 {
             self.aspect = size.width as f32 / size.height as f32;
         }
+    }
+
+    /// Set orbit distance from target.
+    ///
+    /// # Agent
+    /// Sending larger values zooms out; smaller zooms in. Visible
+    /// next frame.
+    #[handler]
+    fn on_set_distance(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetDistance) {
+        self.distance = msg.distance;
+    }
+
+    /// Set vertical tilt (radians).
+    ///
+    /// # Agent
+    /// Positive tilts the eye up (camera looks down); negative tilts
+    /// the eye down (camera looks up). `±π/2` are degenerate.
+    #[handler]
+    fn on_set_pitch(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetPitch) {
+        self.pitch = msg.pitch;
+    }
+
+    /// Set absolute yaw (radians). Auto-advance keeps ticking from
+    /// the new value on subsequent frames.
+    ///
+    /// # Agent
+    /// Combine with `OrbitSetSpeed { 0.0 }` to pin the camera to a
+    /// specific yaw — otherwise the next tick advances it.
+    #[handler]
+    fn on_set_yaw(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetYaw) {
+        self.yaw = msg.yaw;
+    }
+
+    /// Set auto-rotation rate (radians per tick). `0.0` freezes.
+    ///
+    /// # Agent
+    /// Negative reverses direction. Combined with `OrbitSetYaw`,
+    /// pins the camera at a chosen angle.
+    #[handler]
+    fn on_set_speed(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetSpeed) {
+        self.speed = msg.rad_per_tick;
+    }
+
+    /// Set vertical field of view (radians).
+    ///
+    /// # Agent
+    /// Typical values `π/4` (45°, tight) to `π/2` (90°, wide).
+    /// Above `π` the view inverts; below `0` is degenerate.
+    #[handler]
+    fn on_set_fov(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetFov) {
+        self.fov = msg.fov_y_rad;
+    }
+
+    /// Set the world-space point the camera orbits around.
+    ///
+    /// # Agent
+    /// Re-target per tick to follow a moving object.
+    #[handler]
+    fn on_set_target(&mut self, _ctx: &mut Ctx<'_>, msg: OrbitSetTarget) {
+        self.target = Vec3::new(msg.x, msg.y, msg.z);
     }
 }
 

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -19,10 +19,11 @@ use aether_mail::{Kind, Schema};
 
 use crate::{
     Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
-    Key, LoadComponent, LoadResult, MouseButton, MouseMove, Ping, PlatformInfo, PlatformInfoResult,
-    Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult, SetWindowTitle,
-    SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick, UnresolvedMail,
-    UnsubscribeInput, WindowSize,
+    Key, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance, OrbitSetFov,
+    OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
+    PlatformInfoResult, Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult,
+    SetWindowTitle, SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick,
+    UnresolvedMail, UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -83,6 +84,15 @@ pub fn all() -> Vec<KindDescriptor> {
         // `camera` sink — latest value wins, uploaded to the GPU
         // uniform before each draw. Fire-and-forget; no reply.
         schema::<Camera>(),
+        // Orbit camera control surface. Each kind pokes one field of
+        // the camera component's state; no reply kinds — state
+        // changes become visible in the next frame's `Camera` mail.
+        schema::<OrbitSetDistance>(),
+        schema::<OrbitSetPitch>(),
+        schema::<OrbitSetYaw>(),
+        schema::<OrbitSetSpeed>(),
+        schema::<OrbitSetFov>(),
+        schema::<OrbitSetTarget>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -172,6 +172,79 @@ pub struct Camera {
     pub view_proj: [f32; 16],
 }
 
+/// Set the orbit camera's distance from its target (eye radius).
+/// Typical values 1.0–100.0; 0.0 collapses to the target point and
+/// produces a degenerate view. Applied on the next tick.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_distance")]
+pub struct OrbitSetDistance {
+    pub distance: f32,
+}
+
+/// Set the orbit camera's pitch (radians). Positive tilts the eye
+/// upward so the camera looks down; negative tilts down so it looks
+/// up. Not clamped — `±π/2` are degenerate.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_pitch")]
+pub struct OrbitSetPitch {
+    pub pitch: f32,
+}
+
+/// Set the orbit camera's absolute yaw (radians). Auto-advance still
+/// ticks from this value on the next frame; pair with
+/// `OrbitSetSpeed { rad_per_tick: 0.0 }` to pin a specific yaw.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_yaw")]
+pub struct OrbitSetYaw {
+    pub yaw: f32,
+}
+
+/// Set the orbit camera's auto-rotation rate (radians per tick).
+/// `0.0` freezes the camera at its current yaw. Negative reverses
+/// direction.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_speed")]
+pub struct OrbitSetSpeed {
+    pub rad_per_tick: f32,
+}
+
+/// Set the orbit camera's vertical field of view (radians). Typical
+/// values `π/4` (45°) to `π/2` (90°).
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_fov")]
+pub struct OrbitSetFov {
+    pub fov_y_rad: f32,
+}
+
+/// Set the world-space point the orbit camera orbits around (default
+/// `(0, 0, 0)`). Useful for following an object by re-targeting the
+/// camera each frame.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.orbit.set_target")]
+pub struct OrbitSetTarget {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
 /// Request addressed to a component that supports the ADR-0013
 /// reply-to-sender smoke path. The component answers with `Pong`
 /// carrying the same `seq`; the round trip proves that a Claude
@@ -836,6 +909,12 @@ mod tests {
             "aether.control.set_window_title_result"
         );
         assert_eq!(Camera::NAME, "aether.camera");
+        assert_eq!(OrbitSetDistance::NAME, "aether.camera.orbit.set_distance");
+        assert_eq!(OrbitSetPitch::NAME, "aether.camera.orbit.set_pitch");
+        assert_eq!(OrbitSetYaw::NAME, "aether.camera.orbit.set_yaw");
+        assert_eq!(OrbitSetSpeed::NAME, "aether.camera.orbit.set_speed");
+        assert_eq!(OrbitSetFov::NAME, "aether.camera.orbit.set_fov");
+        assert_eq!(OrbitSetTarget::NAME, "aether.camera.orbit.set_target");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Six cast-tier control kinds on `aether.camera.orbit.set_*` — distance, pitch, yaw, speed, fov, target — make the orbit camera configurable at runtime from any component (or MCP session) via mail. The component stores them on mutable fields and applies them on the next tick.

## Kinds

All in `aether-kinds`, all `#[repr(C)]` + `Pod` + cast-tier:

- `OrbitSetDistance { distance: f32 }`
- `OrbitSetPitch { pitch: f32 }`
- `OrbitSetYaw { yaw: f32 }` — absolute
- `OrbitSetSpeed { rad_per_tick: f32 }` — `0.0` freezes, negative reverses
- `OrbitSetFov { fov_y_rad: f32 }`
- `OrbitSetTarget { x, y, z }` — world-space pivot

Kinds live in `aether-kinds` (not inline in the camera crate) because game components and the camera component both need to reference them from Rust. cdylib crates aren't importable as deps.

## Component

`Orbit` gains mutable fields: `pitch`, `distance`, `speed`, `fov`, `target`. Six new `#[handler]` methods, one per kind. Auto-advance uses `self.speed` instead of a const, and now handles negative speeds (wraps yaw in both directions).

Behaviour notes in the kind + handler docs:

- Auto-advance keeps ticking after `OrbitSetYaw` — pair with `OrbitSetSpeed { 0.0 }` to pin.
- Default speed is `π/360` rad/tick (full revolution every ~12s at 60 fps).
- `OrbitSetTarget` is useful for re-targeting per tick to follow a moving object.

## Why this shape (control kinds in aether-kinds + per-camera-type vocabulary)

Per the design thread: cameras are autonomous publishers of `aether.camera` state. Control comes in via mail sent to the camera component's mailbox. Per-camera-type vocabulary (not abstract intents) because:

- No second camera yet to pressure-test a shared intent abstraction.
- Strongly typed per kind; each camera gets exactly the controls that make sense for it.
- Factor into shared kinds (`CameraLookAt` etc.) later if/when a second camera wants the same intent.

## Test plan

- [x] `cargo test --workspace` — all green, `kind_names_are_stable` extended with six new entries.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p aether-camera-component --target wasm32-unknown-unknown --release`
- [x] **MCP round-trip**: spawned substrate with hello + orbit loaded; froze camera with `set_speed 0 / set_yaw 0 / set_pitch 0 / set_distance 3` for deterministic baseline; verified:
  - `OrbitSetDistance { 10 }` → triangle visibly shrinks by ~3.3×
  - `OrbitSetFov { 1.2 }` (up from `π/3 ≈ 1.047`) at distance 3 → slight size decrease, consistent with wider FoV
  - `OrbitSetTarget { x: 1 }` → triangle shifts left in view (camera looking at `(1, 0, 0)`; origin is now left-of-center)
- [x] `describe_component` on the orbit mailbox lists all eight handlers (the two existing inputs + six new control kinds) with per-handler docs.

## What's next

Follow-up PRs (deferred, each its own concept):

- Sokoban rework to world-space + ortho top-down camera mode (the forcing function for a second camera variant).
- Mode switching in the camera component (once a second camera exists). Parked until pressure — the control-kind shape here works fine as precedent.
