### PR TITLE
feat(camera,sokoban): top-down ortho camera + sokoban rework to world-space

### DIFF
--- a/crates/aether-camera-component/Cargo.toml
+++ b/crates/aether-camera-component/Cargo.toml
@@ -10,3 +10,12 @@ crate-type = ["cdylib"]
 aether-component = { path = "../aether-component" }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }
+
+# Sibling cdylibs for alternate camera shapes. `src/lib.rs` is the
+# blessed orbit camera; each example here is its own wasm loadable
+# via `load_component` — switching between cameras is a drop+load
+# dance today, with mode-switching in the canonical component a
+# future refactor once multiple cameras prove they want to coexist.
+[[example]]
+name = "topdown"
+crate-type = ["cdylib"]

--- a/crates/aether-camera-component/examples/topdown.rs
+++ b/crates/aether-camera-component/examples/topdown.rs
@@ -1,0 +1,116 @@
+//! Orthographic top-down camera. Looks straight down `-Z` at a
+//! configurable world-xy centerpoint, with the frustum half-height
+//! set by `extent` (in world units). Visible width tracks the live
+//! window aspect.
+//!
+//! Natural fit for grid games: set `center` to the grid's world
+//! centroid and `extent` to at least half the larger grid dimension
+//! + a margin, and the whole grid lands on screen.
+//!
+//! Controllable via `aether.camera.topdown.set_*` mail:
+//!
+//! - `TopdownSetCenter { x, y }` — pan.
+//! - `TopdownSetExtent { extent }` — zoom.
+//!
+//! Publishes `aether.camera` every tick, same sink and wire shape as
+//! the orbit camera's main `src/lib.rs`.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
+use aether_kinds::{Camera, Tick, TopdownSetCenter, TopdownSetExtent, WindowSize};
+use aether_math::{Mat4, Vec2, Vec3};
+
+const DEFAULT_EXTENT: f32 = 3.0;
+const Z_NEAR: f32 = 0.1;
+const Z_FAR: f32 = 100.0;
+/// Fallback aspect before the first `WindowSize` arrives. The
+/// substrate re-pulses `WindowSize` every tick so this is only
+/// visible for one frame after load.
+const DEFAULT_ASPECT: f32 = 16.0 / 9.0;
+/// Camera eye height along `+Z`. Orthographic projection is
+/// translation-invariant along the view direction; this just has to
+/// be positive and inside the far plane.
+const EYE_HEIGHT: f32 = 10.0;
+
+pub struct Topdown {
+    camera: Sink<Camera>,
+    center: Vec2,
+    extent: f32,
+    aspect: f32,
+}
+
+/// Orthographic top-down camera. Publishes `view_proj` every tick;
+/// frames the world `xy` plane from above.
+///
+/// # Agent
+/// Load alongside a 2D-ish scene (e.g. a tile grid) to view it
+/// unprojected from directly above. Controls:
+///
+/// - `TopdownSetCenter { x, y }` — pan across the plane.
+/// - `TopdownSetExtent { extent }` — zoom; half-height of the view
+///   in world units, so e.g. `extent=4` shows a vertical slice
+///   `[-4, +4]` and a horizontal slice `[-4*aspect, +4*aspect]`.
+///
+/// Use `capture_frame` between sends to verify each change.
+#[handlers]
+impl Component for Topdown {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        Topdown {
+            camera: ctx.resolve_sink::<Camera>("camera"),
+            center: Vec2::ZERO,
+            extent: DEFAULT_EXTENT,
+            aspect: DEFAULT_ASPECT,
+        }
+    }
+
+    /// Publish a fresh `view_proj` each tick.
+    ///
+    /// # Agent
+    /// Tick-driven; not useful to send manually.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        let half_w = self.extent * self.aspect;
+        let proj = Mat4::orthographic_rh(-half_w, half_w, -self.extent, self.extent, Z_NEAR, Z_FAR);
+        let eye = Vec3::new(self.center.x, self.center.y, EYE_HEIGHT);
+        let target = Vec3::new(self.center.x, self.center.y, 0.0);
+        let view = Mat4::look_at_rh(eye, target, Vec3::Y);
+        let view_proj = proj * view;
+        ctx.send(
+            &self.camera,
+            &Camera {
+                view_proj: view_proj.to_cols_array(),
+            },
+        );
+    }
+
+    /// Track the live window aspect so world geometry stays unsquashed
+    /// on non-square windows.
+    ///
+    /// # Agent
+    /// Publish-subscribe; the substrate drives this, you don't need
+    /// to send it.
+    #[handler]
+    fn on_window_size(&mut self, _ctx: &mut Ctx<'_>, size: WindowSize) {
+        if size.width > 0 && size.height > 0 {
+            self.aspect = size.width as f32 / size.height as f32;
+        }
+    }
+
+    /// Pan the camera across the xy plane.
+    #[handler]
+    fn on_set_center(&mut self, _ctx: &mut Ctx<'_>, msg: TopdownSetCenter) {
+        self.center = Vec2::new(msg.x, msg.y);
+    }
+
+    /// Zoom the camera. Clamps to a tiny positive floor so a zero or
+    /// negative extent can't degenerate the projection into NaN.
+    ///
+    /// # Agent
+    /// Larger values show more of the world (zoom out). Must be
+    /// positive — values `<= 0` are clamped to `0.001`.
+    #[handler]
+    fn on_set_extent(&mut self, _ctx: &mut Ctx<'_>, msg: TopdownSetExtent) {
+        self.extent = msg.extent.max(0.001);
+    }
+}
+
+aether_component::export!(Topdown);

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -23,7 +23,7 @@ use crate::{
     OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
     PlatformInfoResult, Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult,
     SetWindowTitle, SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick,
-    UnresolvedMail, UnsubscribeInput, WindowSize,
+    TopdownSetCenter, TopdownSetExtent, UnresolvedMail, UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -93,6 +93,10 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<OrbitSetSpeed>(),
         schema::<OrbitSetFov>(),
         schema::<OrbitSetTarget>(),
+        // Top-down orthographic camera control surface. Same
+        // fire-and-forget shape as the orbit controls.
+        schema::<TopdownSetCenter>(),
+        schema::<TopdownSetExtent>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -245,6 +245,31 @@ pub struct OrbitSetTarget {
     pub z: f32,
 }
 
+/// Pan the top-down camera's centerpoint in world xy. Z is implicit —
+/// the camera always looks down the `-Z` axis.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.topdown.set_center")]
+pub struct TopdownSetCenter {
+    pub x: f32,
+    pub y: f32,
+}
+
+/// Set the top-down camera's orthographic extent — the half-height of
+/// the frustum in world units. The visible width is
+/// `extent * aspect`. Larger values zoom out. Must be positive; zero
+/// or negative degenerates the projection.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.camera.topdown.set_extent")]
+pub struct TopdownSetExtent {
+    pub extent: f32,
+}
+
 /// Request addressed to a component that supports the ADR-0013
 /// reply-to-sender smoke path. The component answers with `Pong`
 /// carrying the same `seq`; the round trip proves that a Claude
@@ -915,6 +940,8 @@ mod tests {
         assert_eq!(OrbitSetSpeed::NAME, "aether.camera.orbit.set_speed");
         assert_eq!(OrbitSetFov::NAME, "aether.camera.orbit.set_fov");
         assert_eq!(OrbitSetTarget::NAME, "aether.camera.orbit.set_target");
+        assert_eq!(TopdownSetCenter::NAME, "aether.camera.topdown.set_center");
+        assert_eq!(TopdownSetExtent::NAME, "aether.camera.topdown.set_extent");
     }
 
     #[test]

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -313,11 +313,20 @@ impl Sokoban {
         if w == 0 || h == 0 {
             return;
         }
-        // Fit the grid into a centered clip-space box with 0.05 margin.
-        let usable = 1.9_f32;
-        let cell = (usable / w.max(h) as f32).min(usable / w as f32);
-        let origin_x = -(w as f32 * cell) * 0.5;
-        let origin_y = (h as f32 * cell) * 0.5;
+        // World-space grid: one world unit per cell, centered on the
+        // origin with +Y up. Tile `(gx, gy)` (row-major, gy=0 is the
+        // top row) covers world rect
+        //   x ∈ [gx - w/2, gx - w/2 + 1]
+        //   y ∈ [h/2 - gy - 1, h/2 - gy]
+        // and sits at z=0. A top-down ortho camera with extent ≥
+        // max(w, h)/2 frames the whole grid; the substrate's default
+        // identity camera preserves world coords as clip-space, which
+        // means pre-camera rendering shrinks from full-window to a
+        // unit-sized box on screen — loading the topdown camera is
+        // the expected workflow.
+        let cell = 1.0_f32;
+        let origin_x = -(w as f32) * 0.5;
+        let origin_y = (h as f32) * 0.5;
 
         let mut tris = [DrawTriangle::default(); CELLS_MAX * 2];
         let mut n = 0;


### PR DESCRIPTION
## Summary

Ships a second camera variant — orthographic top-down — as a sibling cdylib example inside `aether-camera-component`, and moves sokoban off clip-space coords onto a real world grid so the new camera has something to frame. Vertical slice — the camera is justified by a concrete consumer.

## Kinds

Two control kinds in `aether-kinds`, matching the orbit pattern:

- `aether.camera.topdown.set_center { x, y }` — pan across the xy plane
- `aether.camera.topdown.set_extent { extent }` — half-height of the ortho frustum in world units; visible width tracks aspect. Clamped to a tiny positive floor so a zero/negative extent can't NaN the projection

## Camera

`aether-camera-component/examples/topdown.rs` — new cdylib. Looks straight down `-Z` at the configurable world-xy centerpoint, builds `Mat4::orthographic_rh` with `half_w = extent * aspect`, publishes to the `camera` sink every tick. Aspect tracks `WindowSize`.

Loaded via a new `[[example]]` block in the crate's `Cargo.toml`, which establishes the "alternate cameras live under `examples/`" pattern. `src/lib.rs` stays as the blessed orbit camera; mode switching inside a single component is parked until multiple cameras want to coexist.

## Sokoban

`demos/sokoban` render path moves off clip-space `[-1, 1]` onto a world grid: one world unit per cell, grid centered at origin with `+Y` up. Tile `(gx, gy)` covers

```
x ∈ [gx - w/2, gx - w/2 + 1]
y ∈ [h/2 - gy - 1, h/2 - gy]
```

at `z=0`. No gameplay changes; just the render math.

Pre-camera behaviour degrades gracefully — the substrate's default identity camera treats world coords as clip-space, so sokoban renders as a small unit-sized box on screen without a camera loaded. Loading the topdown camera alongside it is the expected workflow; documented in the `render_grid` comment.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p aether-camera-component --example topdown --target wasm32-unknown-unknown --release`
- [x] `cargo build -p aether-demo-sokoban --target wasm32-unknown-unknown --release`
- [x] **MCP round-trip**: spawned substrate, loaded `sokoban` + `topdown` camera:
  - default `extent=3` → 5×3 grid (level 0) framed with margin
  - `TopdownSetExtent { 1.8 }` → zoomed in, cells fill ~2/3 of view
  - `TopdownSetCenter { 1.5, 0 }` + `TopdownSetExtent { 2 }` → grid shifts left as camera pans right

## What's next

- Remaining tic-tac-toe-client stays on identity — pure 2D UI, a camera adds nothing.
- Static / fixed camera and mode-switching in a unified component remain parked until something needs them.
