### PR TITLE
feat(player,kinds): player component with camera-follow via TopdownSetCenter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-player-component"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-component",
+ "aether-kinds",
+]
+
+[[package]]
 name = "aether-substrate-core"
 version = "0.2.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/aether-component",
     "crates/aether-camera-component",
     "crates/aether-hello-component",
+    "crates/aether-player-component",
     "crates/aether-hub-protocol",
     "crates/aether-mail",
     "crates/aether-mail-derive",

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -21,9 +21,10 @@ use crate::{
     Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
     Key, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance, OrbitSetFov,
     OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
-    PlatformInfoResult, Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult,
-    SetWindowTitle, SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick,
-    TopdownSetCenter, TopdownSetExtent, UnresolvedMail, UnsubscribeInput, WindowSize,
+    PlatformInfoResult, PlayerSetPosition, PlayerSetVelocity, Pong, ReplaceComponent,
+    ReplaceResult, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
+    SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
+    UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -97,6 +98,11 @@ pub fn all() -> Vec<KindDescriptor> {
         // fire-and-forget shape as the orbit controls.
         schema::<TopdownSetCenter>(),
         schema::<TopdownSetExtent>(),
+        // Player component control surface. Fire-and-forget cast
+        // kinds; state changes become visible via the player's next
+        // tick (new `TopdownSetCenter` + `DrawTriangle` emissions).
+        schema::<PlayerSetPosition>(),
+        schema::<PlayerSetVelocity>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -270,6 +270,32 @@ pub struct TopdownSetExtent {
     pub extent: f32,
 }
 
+/// Teleport the player to a world-space position. Also zeroes velocity
+/// isn't implied — send `PlayerSetVelocity { 0, 0 }` explicitly if you
+/// want to stop motion at the new point.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.player.set_position")]
+pub struct PlayerSetPosition {
+    pub x: f32,
+    pub y: f32,
+}
+
+/// Set the player's per-tick velocity in world units. `(0, 0)` stops
+/// motion; values compose per-axis so `(1, 0)` drifts +x, `(0, -1)`
+/// drifts -y.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.player.set_velocity")]
+pub struct PlayerSetVelocity {
+    pub vx: f32,
+    pub vy: f32,
+}
+
 /// Request addressed to a component that supports the ADR-0013
 /// reply-to-sender smoke path. The component answers with `Pong`
 /// carrying the same `seq`; the round trip proves that a Claude
@@ -942,6 +968,8 @@ mod tests {
         assert_eq!(OrbitSetTarget::NAME, "aether.camera.orbit.set_target");
         assert_eq!(TopdownSetCenter::NAME, "aether.camera.topdown.set_center");
         assert_eq!(TopdownSetExtent::NAME, "aether.camera.topdown.set_extent");
+        assert_eq!(PlayerSetPosition::NAME, "aether.player.set_position");
+        assert_eq!(PlayerSetVelocity::NAME, "aether.player.set_velocity");
     }
 
     #[test]

--- a/crates/aether-player-component/Cargo.toml
+++ b/crates/aether-player-component/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aether-player-component"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aether-component = { path = "../aether-component" }
+aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-player-component/src/lib.rs
+++ b/crates/aether-player-component/src/lib.rs
@@ -1,0 +1,132 @@
+//! Minimal player component: a world-space position that advances by a
+//! per-tick velocity, emits a small triangle at its location to the
+//! substrate's `render` sink, and pushes `TopdownSetCenter` to the
+//! top-down camera each tick so the camera follows.
+//!
+//! Controllable via `aether.player.set_*` mail:
+//!
+//! - `PlayerSetPosition { x, y }` — teleport.
+//! - `PlayerSetVelocity { vx, vy }` — per-tick drift in world units.
+//!
+//! The camera sink is hardcoded to the mailbox name `"topdown"` — load
+//! the top-down camera example under that name for follow to work. A
+//! different name (or no camera loaded) makes the `TopdownSetCenter`
+//! mail unresolved, which surfaces as an `UnresolvedMail` diagnostic
+//! but is otherwise inert.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
+use aether_kinds::{
+    DrawTriangle, PlayerSetPosition, PlayerSetVelocity, Tick, TopdownSetCenter, Vertex,
+};
+
+/// Half-extent of the player's triangular body in world units. The
+/// triangle is an isoceles apex-up around the player position.
+const PLAYER_HALF: f32 = 0.25;
+/// RGB color of the triangle body. Bright magenta — reads distinctly
+/// against the sokoban grid and any hello-component triangle.
+const PLAYER_R: f32 = 1.0;
+const PLAYER_G: f32 = 0.3;
+const PLAYER_B: f32 = 0.9;
+
+pub struct Player {
+    render: Sink<DrawTriangle>,
+    camera_follow: Sink<TopdownSetCenter>,
+    pos_x: f32,
+    pos_y: f32,
+    vel_x: f32,
+    vel_y: f32,
+}
+
+/// A player body with world-space position and per-tick velocity.
+/// Draws a small apex-up triangle at its position every tick and
+/// publishes `TopdownSetCenter` to a mailbox named `"topdown"` so an
+/// attached top-down camera follows.
+///
+/// # Agent
+/// Load alongside `aether-camera-component`'s `topdown` example (under
+/// the name `"topdown"`) and optionally `aether-demo-sokoban` for a
+/// backdrop. Controls:
+///
+/// - `PlayerSetPosition { x, y }` — teleport. Velocity is untouched;
+///   send `PlayerSetVelocity { 0, 0 }` separately to stop.
+/// - `PlayerSetVelocity { vx, vy }` — per-tick drift in world units.
+///   `(0, 0)` stops motion.
+///
+/// Use `capture_frame` between sends to verify each change.
+#[handlers]
+impl Component for Player {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        Player {
+            render: ctx.resolve_sink::<DrawTriangle>("render"),
+            camera_follow: ctx.resolve_sink::<TopdownSetCenter>("topdown"),
+            pos_x: 0.0,
+            pos_y: 0.0,
+            vel_x: 0.0,
+            vel_y: 0.0,
+        }
+    }
+
+    /// Advance position, draw body, and push a camera follow target.
+    ///
+    /// # Agent
+    /// Tick-driven; not useful to send manually.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        self.pos_x += self.vel_x;
+        self.pos_y += self.vel_y;
+
+        let body = DrawTriangle {
+            verts: [
+                Vertex {
+                    x: self.pos_x,
+                    y: self.pos_y + PLAYER_HALF,
+                    z: 0.0,
+                    r: PLAYER_R,
+                    g: PLAYER_G,
+                    b: PLAYER_B,
+                },
+                Vertex {
+                    x: self.pos_x - PLAYER_HALF,
+                    y: self.pos_y - PLAYER_HALF,
+                    z: 0.0,
+                    r: PLAYER_R,
+                    g: PLAYER_G,
+                    b: PLAYER_B,
+                },
+                Vertex {
+                    x: self.pos_x + PLAYER_HALF,
+                    y: self.pos_y - PLAYER_HALF,
+                    z: 0.0,
+                    r: PLAYER_R,
+                    g: PLAYER_G,
+                    b: PLAYER_B,
+                },
+            ],
+        };
+        ctx.send(&self.render, &body);
+
+        ctx.send(
+            &self.camera_follow,
+            &TopdownSetCenter {
+                x: self.pos_x,
+                y: self.pos_y,
+            },
+        );
+    }
+
+    /// Teleport to a new world-space position.
+    #[handler]
+    fn on_set_position(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetPosition) {
+        self.pos_x = msg.x;
+        self.pos_y = msg.y;
+    }
+
+    /// Replace per-tick velocity. `(0, 0)` stops.
+    #[handler]
+    fn on_set_velocity(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetVelocity) {
+        self.vel_x = msg.vx;
+        self.vel_y = msg.vy;
+    }
+}
+
+aether_component::export!(Player);


### PR DESCRIPTION
## Summary

New `aether-player-component` cdylib — a minimal driver for the control-mail pattern. Holds a world-space position + per-tick velocity, draws a small magenta triangle at its location, and publishes `TopdownSetCenter` every tick so a top-down camera loaded as `"topdown"` follows.

Gives the camera subsystem a real consumer: the orbit and topdown cameras shipped as standalone pipes with only external MCP-driven `*SetTarget` / `*SetCenter` pokes. This is the first component that drives them programmatically.

## Kinds

Two cast-tier kinds added to `aether-kinds`, same per-driver vocabulary pattern the camera controls established:

- `aether.player.set_position { x, y }` — teleport. Doesn't touch velocity; send a separate `PlayerSetVelocity { 0, 0 }` to stop.
- `aether.player.set_velocity { vx, vy }` — per-tick drift in world units. `(0, 0)` stops motion.

## Player

`aether-player-component/src/lib.rs` — new cdylib.

- State: `pos_x/y`, `vel_x/y`, cached `Sink<DrawTriangle>` to `"render"`, cached `Sink<TopdownSetCenter>` to `"topdown"`.
- `on_tick`: integrate (`pos += vel`), emit a magenta apex-up triangle centered at `pos` to the render sink, emit `TopdownSetCenter { pos.x, pos.y }` for camera follow.
- `on_set_position` / `on_set_velocity`: replace the respective state.

Follow target name is hardcoded to `"topdown"`. Loading the topdown camera under a different name leaves the follow mail unresolved — loud via `UnresolvedMail`, inert otherwise. Orbit-follow is deferred; there is no concrete scene pressuring the abstraction yet.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p aether-player-component --target wasm32-unknown-unknown --release`
- [x] **MCP round-trip**: spawned desktop substrate, loaded `topdown` camera + `player` + `hello` (as a world-origin reference triangle):
  - baseline: player + hello both at origin, camera at origin, triangles overlap at center
  - `PlayerSetPosition { x: 1.5, y: 0 }` → player centered, hello shifted left (camera followed +x)
  - `PlayerSetPosition { 0, 0 } + PlayerSetVelocity { 0.02, 0 }` then 2s drift → player centered, hello off-screen left (camera kept following during drift)
  - `PlayerSetPosition { 0, -2 }` → player centered, hello shifted up 2 units (camera followed -y)

## What's next

- Orbit-follow if/when a 3D scene wants it. No pressure today.
- Keycode-driven WASD remains parked — same winit discriminant stability issue as the orbit camera.