### PR TITLE
feat(kinds,substrate,player): named keycodes + KeyRelease + WASD player control

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -323,13 +323,15 @@ impl InitCtx<'_> {
     /// type error instead of silently skipping the subscribe.
     pub fn subscribe_input<K: Kind + 'static>(&self) {
         use aether_kinds::{
-            InputStream, Key, MouseButton, MouseMove, SubscribeInput, Tick, WindowSize,
+            InputStream, Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, Tick, WindowSize,
         };
         let tid = TypeId::of::<K>();
         let stream = if tid == TypeId::of::<Tick>() {
             InputStream::Tick
         } else if tid == TypeId::of::<Key>() {
             InputStream::Key
+        } else if tid == TypeId::of::<KeyRelease>() {
+            InputStream::KeyRelease
         } else if tid == TypeId::of::<MouseMove>() {
             InputStream::MouseMove
         } else if tid == TypeId::of::<MouseButton>() {

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -19,8 +19,8 @@ use aether_mail::{Kind, Schema};
 
 use crate::{
     Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
-    Key, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance, OrbitSetFov,
-    OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
+    Key, KeyRelease, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance,
+    OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
     PlatformInfoResult, PlayerSetPosition, PlayerSetVelocity, Pong, ReplaceComponent,
     ReplaceResult, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
     SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
@@ -33,6 +33,7 @@ pub fn all() -> Vec<KindDescriptor> {
     vec![
         schema::<Tick>(),
         schema::<Key>(),
+        schema::<KeyRelease>(),
         schema::<MouseButton>(),
         schema::<MouseMove>(),
         schema::<WindowSize>(),

--- a/crates/aether-kinds/src/keycode.rs
+++ b/crates/aether-kinds/src/keycode.rs
@@ -1,0 +1,81 @@
+//! Stable identifiers for keyboard keys, carried in `Key.code` and
+//! `KeyRelease.code`. These are the engine's own named u32 space —
+//! decoupled from winit's `KeyCode` discriminants, which have no
+//! stability guarantee across winit versions (the enum's repr is
+//! `#[repr(u32)]` but variant ordering is not a public contract).
+//!
+//! The substrate maps `winit::keyboard::KeyCode → u32` via the
+//! per-variant constants below; components match on these constants.
+//! Unmapped keys (any winit variant not listed here) produce no mail.
+//!
+//! Value convention:
+//!
+//! - Printable ASCII letters use their uppercase ASCII codepoint
+//!   (`KEY_A = 0x41`, `KEY_W = 0x57`, …). This keeps ASCII-range
+//!   values self-documenting in logs and tool output.
+//! - Digits use their ASCII codepoint (`KEY_0 = 0x30`, …).
+//! - Control keys (arrows, space, escape, modifiers) use values above
+//!   `0xFF` so ASCII values stay free for future printable keys.
+
+/// Letters — uppercase ASCII.
+pub const KEY_A: u32 = b'A' as u32;
+pub const KEY_B: u32 = b'B' as u32;
+pub const KEY_C: u32 = b'C' as u32;
+pub const KEY_D: u32 = b'D' as u32;
+pub const KEY_E: u32 = b'E' as u32;
+pub const KEY_F: u32 = b'F' as u32;
+pub const KEY_G: u32 = b'G' as u32;
+pub const KEY_H: u32 = b'H' as u32;
+pub const KEY_I: u32 = b'I' as u32;
+pub const KEY_J: u32 = b'J' as u32;
+pub const KEY_K: u32 = b'K' as u32;
+pub const KEY_L: u32 = b'L' as u32;
+pub const KEY_M: u32 = b'M' as u32;
+pub const KEY_N: u32 = b'N' as u32;
+pub const KEY_O: u32 = b'O' as u32;
+pub const KEY_P: u32 = b'P' as u32;
+pub const KEY_Q: u32 = b'Q' as u32;
+pub const KEY_R: u32 = b'R' as u32;
+pub const KEY_S: u32 = b'S' as u32;
+pub const KEY_T: u32 = b'T' as u32;
+pub const KEY_U: u32 = b'U' as u32;
+pub const KEY_V: u32 = b'V' as u32;
+pub const KEY_W: u32 = b'W' as u32;
+pub const KEY_X: u32 = b'X' as u32;
+pub const KEY_Y: u32 = b'Y' as u32;
+pub const KEY_Z: u32 = b'Z' as u32;
+
+/// Digits — ASCII codepoint.
+pub const KEY_0: u32 = b'0' as u32;
+pub const KEY_1: u32 = b'1' as u32;
+pub const KEY_2: u32 = b'2' as u32;
+pub const KEY_3: u32 = b'3' as u32;
+pub const KEY_4: u32 = b'4' as u32;
+pub const KEY_5: u32 = b'5' as u32;
+pub const KEY_6: u32 = b'6' as u32;
+pub const KEY_7: u32 = b'7' as u32;
+pub const KEY_8: u32 = b'8' as u32;
+pub const KEY_9: u32 = b'9' as u32;
+
+/// Control keys — above the ASCII range so printable codepoints stay
+/// free. Values are arbitrary-but-stable; additions go at the end.
+pub const KEY_SPACE: u32 = 0x0100;
+pub const KEY_ESCAPE: u32 = 0x0101;
+pub const KEY_ENTER: u32 = 0x0102;
+pub const KEY_TAB: u32 = 0x0103;
+pub const KEY_BACKSPACE: u32 = 0x0104;
+
+/// Arrow keys.
+pub const KEY_LEFT: u32 = 0x0110;
+pub const KEY_RIGHT: u32 = 0x0111;
+pub const KEY_UP: u32 = 0x0112;
+pub const KEY_DOWN: u32 = 0x0113;
+
+/// Modifiers. One code per physical key (left and right shift are
+/// distinct) — callers that don't care which side can match on both.
+pub const KEY_SHIFT_LEFT: u32 = 0x0120;
+pub const KEY_SHIFT_RIGHT: u32 = 0x0121;
+pub const KEY_CTRL_LEFT: u32 = 0x0122;
+pub const KEY_CTRL_RIGHT: u32 = 0x0123;
+pub const KEY_ALT_LEFT: u32 = 0x0124;
+pub const KEY_ALT_RIGHT: u32 = 0x0125;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -14,6 +14,7 @@
 extern crate alloc;
 
 pub mod descriptors;
+pub mod keycode;
 
 use bytemuck::{Pod, Zeroable};
 
@@ -48,8 +49,10 @@ use bytemuck::{Pod, Zeroable};
 #[kind(name = "aether.tick", input)]
 pub struct Tick;
 
-/// A single keyboard keypress, identified by `winit::keyboard::KeyCode
-/// as u32`. Dispatched on press only (not release, not repeat).
+/// A single keyboard keypress, identified by the stable codes in
+/// `keycode`. Dispatched on press only (no repeat). Released keys
+/// arrive as `KeyRelease`. Unmapped winit keys (any `KeyCode` variant
+/// the substrate doesn't translate) produce no mail.
 #[repr(C)]
 #[derive(
     Copy,
@@ -65,6 +68,28 @@ pub struct Tick;
 )]
 #[kind(name = "aether.key", input)]
 pub struct Key {
+    pub code: u32,
+}
+
+/// Release counterpart of `Key`. Dispatched once per key release, with
+/// the same `code` value the press carried. Components tracking
+/// hold-to-act semantics (e.g. WASD movement) pair subscription to
+/// both kinds so they can clear state on release.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.key_release", input)]
+pub struct KeyRelease {
     pub code: u32,
 }
 
@@ -557,6 +582,7 @@ mod control_plane {
         MouseMove,
         MouseButton,
         WindowSize,
+        KeyRelease,
     }
 
     /// `aether.control.subscribe_input` — add `mailbox` to the
@@ -921,6 +947,7 @@ mod tests {
     fn kind_names_are_stable() {
         assert_eq!(Tick::NAME, "aether.tick");
         assert_eq!(Key::NAME, "aether.key");
+        assert_eq!(KeyRelease::NAME, "aether.key_release");
         assert_eq!(MouseButton::NAME, "aether.mouse_button");
         assert_eq!(MouseMove::NAME, "aether.mouse_move");
         assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");

--- a/crates/aether-player-component/src/lib.rs
+++ b/crates/aether-player-component/src/lib.rs
@@ -3,10 +3,15 @@
 //! substrate's `render` sink, and pushes `TopdownSetCenter` to the
 //! top-down camera each tick so the camera follows.
 //!
-//! Controllable via `aether.player.set_*` mail:
+//! Two control surfaces feed velocity:
 //!
-//! - `PlayerSetPosition { x, y }` — teleport.
-//! - `PlayerSetVelocity { vx, vy }` — per-tick drift in world units.
+//! - **Direct MCP**: `PlayerSetPosition { x, y }` / `PlayerSetVelocity
+//!   { vx, vy }`. Useful for scripted movement and smoke tests.
+//! - **Keyboard**: WASD or arrow keys from the substrate's `aether.key`
+//!   / `aether.key_release` streams. While any direction key is held,
+//!   the derived velocity overrides whatever `PlayerSetVelocity` last
+//!   set; when all directional keys are released, velocity falls back
+//!   to the stored baseline.
 //!
 //! The camera sink is hardcoded to the mailbox name `"topdown"` — load
 //! the top-down camera example under that name for follow to work. A
@@ -16,7 +21,8 @@
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
 use aether_kinds::{
-    DrawTriangle, PlayerSetPosition, PlayerSetVelocity, Tick, TopdownSetCenter, Vertex,
+    DrawTriangle, Key, KeyRelease, PlayerSetPosition, PlayerSetVelocity, Tick, TopdownSetCenter,
+    Vertex, keycode,
 };
 
 /// Half-extent of the player's triangular body in world units. The
@@ -27,32 +33,74 @@ const PLAYER_HALF: f32 = 0.25;
 const PLAYER_R: f32 = 1.0;
 const PLAYER_G: f32 = 0.3;
 const PLAYER_B: f32 = 0.9;
+/// Per-tick movement speed when a WASD/arrow key is held, in world
+/// units. 0.05 at 60Hz ≈ 3 units/second — slow enough to watch the
+/// camera track, fast enough not to feel sluggish.
+const KEY_SPEED: f32 = 0.05;
 
 pub struct Player {
     render: Sink<DrawTriangle>,
     camera_follow: Sink<TopdownSetCenter>,
     pos_x: f32,
     pos_y: f32,
-    vel_x: f32,
-    vel_y: f32,
+    // Baseline velocity set via `PlayerSetVelocity`. Applied every
+    // tick when no directional key is held.
+    base_vx: f32,
+    base_vy: f32,
+    // Per-direction key-held flags. Tick derives velocity from these
+    // when any is set; diagonals fall out naturally (holding W + D
+    // gives up-right).
+    moving_up: bool,
+    moving_down: bool,
+    moving_left: bool,
+    moving_right: bool,
+}
+
+impl Player {
+    /// True while any WASD/arrow key is currently held. Used each tick
+    /// to decide whether WASD-derived velocity overrides the stored
+    /// baseline from `PlayerSetVelocity`.
+    fn any_key_held(&self) -> bool {
+        self.moving_up || self.moving_down || self.moving_left || self.moving_right
+    }
+
+    /// Update a direction flag when a mapped keycode arrives. Returns
+    /// the same flag value that got assigned so a caller that wants
+    /// to know whether the event was consumed could check, though the
+    /// player doesn't today.
+    fn apply_key(&mut self, code: u32, pressed: bool) {
+        match code {
+            keycode::KEY_W | keycode::KEY_UP => self.moving_up = pressed,
+            keycode::KEY_S | keycode::KEY_DOWN => self.moving_down = pressed,
+            keycode::KEY_A | keycode::KEY_LEFT => self.moving_left = pressed,
+            keycode::KEY_D | keycode::KEY_RIGHT => self.moving_right = pressed,
+            _ => {}
+        }
+    }
 }
 
 /// A player body with world-space position and per-tick velocity.
 /// Draws a small apex-up triangle at its position every tick and
 /// publishes `TopdownSetCenter` to a mailbox named `"topdown"` so an
-/// attached top-down camera follows.
+/// attached top-down camera follows. Keyboard-controllable via WASD
+/// or arrow keys (hold-to-move), or scripted via `PlayerSetPosition` /
+/// `PlayerSetVelocity`.
 ///
 /// # Agent
 /// Load alongside `aether-camera-component`'s `topdown` example (under
 /// the name `"topdown"`) and optionally `aether-demo-sokoban` for a
-/// backdrop. Controls:
+/// backdrop. Scripted controls:
 ///
 /// - `PlayerSetPosition { x, y }` — teleport. Velocity is untouched;
 ///   send `PlayerSetVelocity { 0, 0 }` separately to stop.
 /// - `PlayerSetVelocity { vx, vy }` — per-tick drift in world units.
-///   `(0, 0)` stops motion.
+///   `(0, 0)` stops motion. Overridden while any WASD/arrow key is
+///   held; restored when all are released.
 ///
-/// Use `capture_frame` between sends to verify each change.
+/// Keyboard controls require the substrate window to have focus —
+/// `capture_frame` alone won't deliver keys. For MCP-only smoke tests,
+/// send `Key { code: KEY_W }` / `KeyRelease { code: KEY_W }` directly
+/// to the player mailbox; the flag update path is the same.
 #[handlers]
 impl Component for Player {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
@@ -61,8 +109,12 @@ impl Component for Player {
             camera_follow: ctx.resolve_sink::<TopdownSetCenter>("topdown"),
             pos_x: 0.0,
             pos_y: 0.0,
-            vel_x: 0.0,
-            vel_y: 0.0,
+            base_vx: 0.0,
+            base_vy: 0.0,
+            moving_up: false,
+            moving_down: false,
+            moving_left: false,
+            moving_right: false,
         }
     }
 
@@ -72,8 +124,15 @@ impl Component for Player {
     /// Tick-driven; not useful to send manually.
     #[handler]
     fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
-        self.pos_x += self.vel_x;
-        self.pos_y += self.vel_y;
+        let (vx, vy) = if self.any_key_held() {
+            let dx = (self.moving_right as i32 - self.moving_left as i32) as f32;
+            let dy = (self.moving_up as i32 - self.moving_down as i32) as f32;
+            (dx * KEY_SPEED, dy * KEY_SPEED)
+        } else {
+            (self.base_vx, self.base_vy)
+        };
+        self.pos_x += vx;
+        self.pos_y += vy;
 
         let body = DrawTriangle {
             verts: [
@@ -121,11 +180,34 @@ impl Component for Player {
         self.pos_y = msg.y;
     }
 
-    /// Replace per-tick velocity. `(0, 0)` stops.
+    /// Replace the baseline per-tick velocity. `(0, 0)` stops.
+    /// Overridden while any WASD/arrow key is held; restored when all
+    /// are released.
     #[handler]
     fn on_set_velocity(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetVelocity) {
-        self.vel_x = msg.vx;
-        self.vel_y = msg.vy;
+        self.base_vx = msg.vx;
+        self.base_vy = msg.vy;
+    }
+
+    /// Record a key-down for WASD/arrow keys (other keys ignored).
+    ///
+    /// # Agent
+    /// Publish-subscribe; the substrate delivers this for every mapped
+    /// press. Holding a key produces one `Key` on the initial press
+    /// (winit suppresses auto-repeat) and one `KeyRelease` when
+    /// released — the component tracks hold state via that pair.
+    #[handler]
+    fn on_key(&mut self, _ctx: &mut Ctx<'_>, key: Key) {
+        self.apply_key(key.code, true);
+    }
+
+    /// Record a key-up for WASD/arrow keys (other keys ignored).
+    ///
+    /// # Agent
+    /// Publish-subscribe; the substrate delivers this on release.
+    #[handler]
+    fn on_key_release(&mut self, _ctx: &mut Ctx<'_>, key: KeyRelease) {
+        self.apply_key(key.code, false);
     }
 }
 

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -21,8 +21,9 @@ use std::time::Instant;
 
 use aether_kinds::{
     CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, InputStream,
-    Key, MonitorInfo, MouseButton, MouseMove, OsInfo, PlatformInfoResult, SetWindowModeResult,
-    SetWindowTitleResult, Tick, VideoMode, WindowInfo, WindowMode, WindowSize,
+    Key, KeyRelease, MonitorInfo, MouseButton, MouseMove, OsInfo, PlatformInfoResult,
+    SetWindowModeResult, SetWindowTitleResult, Tick, VideoMode, WindowInfo, WindowMode, WindowSize,
+    keycode,
 };
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
@@ -36,7 +37,7 @@ use render::{Gpu, IDENTITY_VIEW_PROJ};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::keyboard::PhysicalKey;
+use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::monitor::{MonitorHandle, VideoModeHandle};
 use winit::window::{Fullscreen, Window, WindowId};
 
@@ -102,6 +103,7 @@ struct App {
     broadcast_mbox: MailboxId,
     kind_tick: u64,
     kind_key: u64,
+    kind_key_release: u64,
     kind_mouse_button: u64,
     kind_mouse_move: u64,
     kind_window_size: u64,
@@ -156,6 +158,69 @@ struct App {
 /// Copy winit's `VideoModeHandle` fields into the wire-stable mirror
 /// in `aether-kinds`. Separate type so the kind's schema doesn't ride
 /// winit's layout.
+/// Translate a winit `KeyCode` into the engine's stable named-key u32
+/// space (`aether_kinds::keycode`). Returns `None` for any key the
+/// engine doesn't name yet — the event then drops at the source rather
+/// than leaking winit's unstable discriminants onto the wire. Adding
+/// a new key is a paired change: a constant in `aether-kinds::keycode`
+/// plus an arm here.
+fn map_winit_keycode(k: KeyCode) -> Option<u32> {
+    Some(match k {
+        KeyCode::KeyA => keycode::KEY_A,
+        KeyCode::KeyB => keycode::KEY_B,
+        KeyCode::KeyC => keycode::KEY_C,
+        KeyCode::KeyD => keycode::KEY_D,
+        KeyCode::KeyE => keycode::KEY_E,
+        KeyCode::KeyF => keycode::KEY_F,
+        KeyCode::KeyG => keycode::KEY_G,
+        KeyCode::KeyH => keycode::KEY_H,
+        KeyCode::KeyI => keycode::KEY_I,
+        KeyCode::KeyJ => keycode::KEY_J,
+        KeyCode::KeyK => keycode::KEY_K,
+        KeyCode::KeyL => keycode::KEY_L,
+        KeyCode::KeyM => keycode::KEY_M,
+        KeyCode::KeyN => keycode::KEY_N,
+        KeyCode::KeyO => keycode::KEY_O,
+        KeyCode::KeyP => keycode::KEY_P,
+        KeyCode::KeyQ => keycode::KEY_Q,
+        KeyCode::KeyR => keycode::KEY_R,
+        KeyCode::KeyS => keycode::KEY_S,
+        KeyCode::KeyT => keycode::KEY_T,
+        KeyCode::KeyU => keycode::KEY_U,
+        KeyCode::KeyV => keycode::KEY_V,
+        KeyCode::KeyW => keycode::KEY_W,
+        KeyCode::KeyX => keycode::KEY_X,
+        KeyCode::KeyY => keycode::KEY_Y,
+        KeyCode::KeyZ => keycode::KEY_Z,
+        KeyCode::Digit0 => keycode::KEY_0,
+        KeyCode::Digit1 => keycode::KEY_1,
+        KeyCode::Digit2 => keycode::KEY_2,
+        KeyCode::Digit3 => keycode::KEY_3,
+        KeyCode::Digit4 => keycode::KEY_4,
+        KeyCode::Digit5 => keycode::KEY_5,
+        KeyCode::Digit6 => keycode::KEY_6,
+        KeyCode::Digit7 => keycode::KEY_7,
+        KeyCode::Digit8 => keycode::KEY_8,
+        KeyCode::Digit9 => keycode::KEY_9,
+        KeyCode::Space => keycode::KEY_SPACE,
+        KeyCode::Escape => keycode::KEY_ESCAPE,
+        KeyCode::Enter => keycode::KEY_ENTER,
+        KeyCode::Tab => keycode::KEY_TAB,
+        KeyCode::Backspace => keycode::KEY_BACKSPACE,
+        KeyCode::ArrowLeft => keycode::KEY_LEFT,
+        KeyCode::ArrowRight => keycode::KEY_RIGHT,
+        KeyCode::ArrowUp => keycode::KEY_UP,
+        KeyCode::ArrowDown => keycode::KEY_DOWN,
+        KeyCode::ShiftLeft => keycode::KEY_SHIFT_LEFT,
+        KeyCode::ShiftRight => keycode::KEY_SHIFT_RIGHT,
+        KeyCode::ControlLeft => keycode::KEY_CTRL_LEFT,
+        KeyCode::ControlRight => keycode::KEY_CTRL_RIGHT,
+        KeyCode::AltLeft => keycode::KEY_ALT_LEFT,
+        KeyCode::AltRight => keycode::KEY_ALT_RIGHT,
+        _ => return None,
+    })
+}
+
 fn mirror_video_mode(m: winit::monitor::VideoModeHandle) -> VideoMode {
     VideoMode {
         width: m.size().width,
@@ -659,16 +724,41 @@ impl ApplicationHandler<UserEvent> for App {
             }
             WindowEvent::KeyboardInput {
                 event: key_event, ..
-            } if key_event.state == ElementState::Pressed && !key_event.repeat => {
-                let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
-                if !subs.is_empty() {
-                    let code: u32 = match key_event.physical_key {
-                        PhysicalKey::Code(k) => k as u32,
-                        PhysicalKey::Unidentified(_) => 0,
-                    };
-                    for mbox in subs {
-                        self.queue
-                            .push(Mail::new(mbox, self.kind_key, encode(&Key { code }), 1));
+            } if !key_event.repeat => {
+                // Unmapped keys drop at the source — `map_winit_keycode`
+                // returns None for anything the engine's stable code
+                // space doesn't name yet. Adding a new key is an
+                // additive constant in `aether-kinds::keycode` plus an
+                // arm here.
+                let Some(code) = (match key_event.physical_key {
+                    PhysicalKey::Code(k) => map_winit_keycode(k),
+                    PhysicalKey::Unidentified(_) => None,
+                }) else {
+                    return;
+                };
+                match key_event.state {
+                    ElementState::Pressed => {
+                        let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
+                        for mbox in subs {
+                            self.queue.push(Mail::new(
+                                mbox,
+                                self.kind_key,
+                                encode(&Key { code }),
+                                1,
+                            ));
+                        }
+                    }
+                    ElementState::Released => {
+                        let subs =
+                            subscribers_for(&self.input_subscribers, InputStream::KeyRelease);
+                        for mbox in subs {
+                            self.queue.push(Mail::new(
+                                mbox,
+                                self.kind_key_release,
+                                encode(&KeyRelease { code }),
+                                1,
+                            ));
+                        }
                     }
                 }
             }
@@ -739,6 +829,10 @@ fn main() -> wasmtime::Result<()> {
 
     let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
     let kind_key = boot.registry.kind_id(Key::NAME).expect("Key registered");
+    let kind_key_release = boot
+        .registry
+        .kind_id(KeyRelease::NAME)
+        .expect("KeyRelease registered");
     let kind_mouse_button = boot
         .registry
         .kind_id(MouseButton::NAME)
@@ -855,6 +949,7 @@ fn main() -> wasmtime::Result<()> {
         broadcast_mbox: boot.broadcast_mbox,
         kind_tick,
         kind_key,
+        kind_key_release,
         kind_mouse_button,
         kind_mouse_move,
         kind_window_size,


### PR DESCRIPTION
## Summary

Unblocks keyboard-driven components by retiring the unstable `winit::KeyCode as u32` cast, adding a symmetric `aether.key_release` kind for hold-to-move semantics, and wiring the player component to WASD / arrow keys. The three threads ship together because each only makes sense with the others — named codes without release is useless for movement, release without named codes puts wire stability back on winit's internals.

## Named keycodes

New `aether-kinds::keycode` module with stable `u32` constants:

- Letters / digits use uppercase ASCII codepoints (`KEY_A = 0x41`, `KEY_W = 0x57`, `KEY_0 = 0x30`, …) — readable in logs and tool output.
- Control keys, arrows, and modifiers use values above `0xFF` so ASCII stays free.

`aether.key.code` is unchanged on the wire (still a `u32`); the meaning of that `u32` becomes the engine's own space. The desktop substrate's new `map_winit_keycode` fn translates `winit::KeyCode → u32` at event time; anything it doesn't name yet drops at the source rather than leaking a raw discriminant downstream. Adding a key is a paired change: const + match arm.

## `aether.key_release`

Sibling kind carrying the same `{ code: u32 }`. Dispatched when `ElementState::Released`; press-only `aether.key` keeps its existing contract. New `InputStream::KeyRelease` variant routes subscriptions; guest SDK's `subscribe_input` adds the mapping so `#[handler] fn on_key_release(...)` auto-subscribes.

Orthogonal kinds (press vs release) over a single kind with a `state` field — keeps the press schema wire-stable and lets components that only care about press (hello-component's ping shape) stay press-only without decoding a `state` they don't want.

## Player WASD binding

Player now subscribes to `Key` + `KeyRelease` and tracks four direction flags (`moving_{up,down,left,right}`) mapped from W/A/S/D and arrow keys. Each tick:

- **Any flag held** → velocity derives from the flag set scaled by `KEY_SPEED = 0.05` world units/tick. Diagonals fall out naturally (W+D gives up-right).
- **No flag held** → velocity falls back to whatever `PlayerSetVelocity` last set.

MCP-scripted and keyboard control coexist: tests that drive the player via `PlayerSetVelocity` still work, and keyboard override is transient for the duration of the hold.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p aether-player-component --target wasm32-unknown-unknown --release`
- [x] **MCP synthetic-key smoke test**: `send_mail` pushes `Key { code: 68 }` (KEY_D) then after ~60 ticks pushes `KeyRelease { code: 68 }`. Captured frames show the player triangle drifted right and the camera followed (hello-component at origin off-screen left); post-release frames show no further drift. Synthetic mail bypasses winit's focus requirement so this works headlessly through the harness.

## What's next

Manual focus-the-window WASD test hasn't been run from this session — the harness covers the mail dispatch side but a sanity pass on the winit-handler side is worth doing locally. Beyond that, the obvious follow-on is binding space / other keys to actions (jumping, interact) once the game layer has something to trigger.