### PR TITLE
feat(kinds,player,sokoban): tile-step protocol — sokoban as world authority

### DIFF
--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -21,10 +21,10 @@ use crate::{
     Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
     Key, KeyRelease, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance,
     OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
-    PlatformInfoResult, PlayerSetPosition, PlayerSetVelocity, Pong, ReplaceComponent,
-    ReplaceResult, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
-    SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
-    UnsubscribeInput, WindowSize,
+    PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition, PlayerSetVelocity,
+    PlayerStepResult, Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult,
+    SetWindowTitle, SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick,
+    TopdownSetCenter, TopdownSetExtent, UnresolvedMail, UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -104,6 +104,13 @@ pub fn all() -> Vec<KindDescriptor> {
         // tick (new `TopdownSetCenter` + `DrawTriangle` emissions).
         schema::<PlayerSetPosition>(),
         schema::<PlayerSetVelocity>(),
+        // Player ↔ world-authority tile-step protocol. The player
+        // emits `PlayerRequestStep` to the mailbox named `"world"`;
+        // the authority answers with `PlayerStepResult`. Mode is
+        // toggled by `PlayerSetMode`.
+        schema::<PlayerSetMode>(),
+        schema::<PlayerRequestStep>(),
+        schema::<PlayerStepResult>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -321,6 +321,75 @@ pub struct PlayerSetVelocity {
     pub vy: f32,
 }
 
+/// Switch the player between continuous and tile-step motion modes.
+/// `0 = continuous` (WASD / `PlayerSetVelocity` drive per-tick
+/// velocity — the original model). `1 = tile_step` (each WASD press
+/// emits a `PlayerRequestStep` to the world authority; the player's
+/// position changes only when it receives a `PlayerStepResult` back).
+/// Other values are ignored.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.player.set_mode")]
+pub struct PlayerSetMode {
+    pub mode: u32,
+}
+
+/// Player → world-authority request: "I want to step by `(dx, dy)`
+/// world units — what actually happens?". Authority addressed by the
+/// mailbox name `"world"` (resolved as a sink during player init).
+/// Deltas are integer cell offsets in tile-step mode: `(+1, 0)` east,
+/// `(0, +1)` north (matching the engine's +Y-up world). The player
+/// does not apply the motion itself in tile-step mode — it waits for
+/// `PlayerStepResult` before updating its position.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.player.request_step")]
+pub struct PlayerRequestStep {
+    pub dx: i32,
+    pub dy: i32,
+}
+
+/// World-authority → player reply to `PlayerRequestStep`. `accepted`
+/// is `1` when the requested motion was applied (with any side
+/// effects like a box push already committed on the world side) and
+/// `0` when the authority refused (wall, out of bounds, unpushable
+/// box, etc.). `new_x` / `new_y` are the player's post-resolution
+/// world position either way — authoritative. The player overwrites
+/// its own position from these fields, so a rejected step leaves the
+/// player where the world says it is, not where it tried to go.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.player.step_result")]
+pub struct PlayerStepResult {
+    pub accepted: u32,
+    pub new_x: f32,
+    pub new_y: f32,
+}
+
 /// Request addressed to a component that supports the ADR-0013
 /// reply-to-sender smoke path. The component answers with `Pong`
 /// carrying the same `seq`; the round trip proves that a Claude
@@ -997,6 +1066,9 @@ mod tests {
         assert_eq!(TopdownSetExtent::NAME, "aether.camera.topdown.set_extent");
         assert_eq!(PlayerSetPosition::NAME, "aether.player.set_position");
         assert_eq!(PlayerSetVelocity::NAME, "aether.player.set_velocity");
+        assert_eq!(PlayerSetMode::NAME, "aether.player.set_mode");
+        assert_eq!(PlayerRequestStep::NAME, "aether.player.request_step");
+        assert_eq!(PlayerStepResult::NAME, "aether.player.step_result");
     }
 
     #[test]

--- a/crates/aether-player-component/src/lib.rs
+++ b/crates/aether-player-component/src/lib.rs
@@ -1,73 +1,76 @@
-//! Minimal player component: a world-space position that advances by a
-//! per-tick velocity, emits a small triangle at its location to the
-//! substrate's `render` sink, and pushes `TopdownSetCenter` to the
-//! top-down camera each tick so the camera follows.
+//! Player component. A world-space position + a small triangular body
+//! that renders itself and publishes `TopdownSetCenter` each tick so an
+//! attached top-down camera follows.
 //!
-//! Two control surfaces feed velocity:
+//! Two motion modes, swapped at runtime via `PlayerSetMode`:
 //!
-//! - **Direct MCP**: `PlayerSetPosition { x, y }` / `PlayerSetVelocity
-//!   { vx, vy }`. Useful for scripted movement and smoke tests.
-//! - **Keyboard**: WASD or arrow keys from the substrate's `aether.key`
-//!   / `aether.key_release` streams. While any direction key is held,
-//!   the derived velocity overrides whatever `PlayerSetVelocity` last
-//!   set; when all directional keys are released, velocity falls back
-//!   to the stored baseline.
+//! - **Continuous** (default). WASD / arrow keys drive per-tick
+//!   velocity (`KEY_SPEED` world units/tick while held); release
+//!   clears the flag and velocity falls back to whatever
+//!   `PlayerSetVelocity` last set. The body is free-floating — it
+//!   knows nothing about walls or world topology. Good for free-look
+//!   testing and non-grid scenes.
+//! - **Tile-step**. WASD press emits a `PlayerRequestStep { dx, dy }`
+//!   to a mailbox named `"world"` — the scene's world authority —
+//!   with integer cell deltas (W: `(0, +1)`, S: `(0, -1)`, D:
+//!   `(+1, 0)`, A: `(-1, 0)`). The player does **not** move itself;
+//!   it waits for `PlayerStepResult` back and overwrites its position
+//!   from the authority's reply. Releases are ignored. Continuous
+//!   velocity is suppressed. This is the shape sokoban-style grid
+//!   games use.
 //!
-//! The camera sink is hardcoded to the mailbox name `"topdown"` — load
-//! the top-down camera example under that name for follow to work. A
-//! different name (or no camera loaded) makes the `TopdownSetCenter`
-//! mail unresolved, which surfaces as an `UnresolvedMail` diagnostic
-//! but is otherwise inert.
+//! Scripted control surfaces (`PlayerSetPosition`, `PlayerSetVelocity`)
+//! remain available in both modes — useful for smoke tests over MCP.
+//! In tile-step mode, `PlayerSetVelocity` has no visible effect
+//! because velocity is not applied.
+//!
+//! Sink dependencies: `"render"` (substrate), `"topdown"` (the top-down
+//! camera, if any), `"world"` (the world authority in tile-step mode).
+//! Missing sinks surface as `UnresolvedMail` diagnostics but don't
+//! crash the player — the corresponding emissions just go to the abyss.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
 use aether_kinds::{
-    DrawTriangle, Key, KeyRelease, PlayerSetPosition, PlayerSetVelocity, Tick, TopdownSetCenter,
-    Vertex, keycode,
+    DrawTriangle, Key, KeyRelease, PlayerRequestStep, PlayerSetMode, PlayerSetPosition,
+    PlayerSetVelocity, PlayerStepResult, Tick, TopdownSetCenter, Vertex, keycode,
 };
 
-/// Half-extent of the player's triangular body in world units. The
-/// triangle is an isoceles apex-up around the player position.
 const PLAYER_HALF: f32 = 0.25;
-/// RGB color of the triangle body. Bright magenta — reads distinctly
-/// against the sokoban grid and any hello-component triangle.
 const PLAYER_R: f32 = 1.0;
 const PLAYER_G: f32 = 0.3;
 const PLAYER_B: f32 = 0.9;
-/// Per-tick movement speed when a WASD/arrow key is held, in world
-/// units. 0.05 at 60Hz ≈ 3 units/second — slow enough to watch the
-/// camera track, fast enough not to feel sluggish.
+/// Per-tick continuous-mode speed in world units.
 const KEY_SPEED: f32 = 0.05;
+
+/// `PlayerSetMode.mode` values. Kept as raw `u32` on the wire so the
+/// kind stays cast-tier; these constants give the component a readable
+/// match surface.
+const MODE_CONTINUOUS: u32 = 0;
+const MODE_TILE_STEP: u32 = 1;
 
 pub struct Player {
     render: Sink<DrawTriangle>,
     camera_follow: Sink<TopdownSetCenter>,
+    world: Sink<PlayerRequestStep>,
     pos_x: f32,
     pos_y: f32,
-    // Baseline velocity set via `PlayerSetVelocity`. Applied every
-    // tick when no directional key is held.
     base_vx: f32,
     base_vy: f32,
-    // Per-direction key-held flags. Tick derives velocity from these
-    // when any is set; diagonals fall out naturally (holding W + D
-    // gives up-right).
     moving_up: bool,
     moving_down: bool,
     moving_left: bool,
     moving_right: bool,
+    /// Active motion model. See `MODE_*` constants.
+    mode: u32,
 }
 
 impl Player {
-    /// True while any WASD/arrow key is currently held. Used each tick
-    /// to decide whether WASD-derived velocity overrides the stored
-    /// baseline from `PlayerSetVelocity`.
     fn any_key_held(&self) -> bool {
         self.moving_up || self.moving_down || self.moving_left || self.moving_right
     }
 
-    /// Update a direction flag when a mapped keycode arrives. Returns
-    /// the same flag value that got assigned so a caller that wants
-    /// to know whether the event was consumed could check, though the
-    /// player doesn't today.
+    /// Translate a mapped keycode into a direction flag update.
+    /// Continuous-mode path — unrelated to tile-step motion.
     fn apply_key(&mut self, code: u32, pressed: bool) {
         match code {
             keycode::KEY_W | keycode::KEY_UP => self.moving_up = pressed,
@@ -77,36 +80,52 @@ impl Player {
             _ => {}
         }
     }
+
+    /// Map a mapped keycode to a tile-step delta. Returns `None` for
+    /// keys that aren't bound to movement.
+    fn step_delta(code: u32) -> Option<(i32, i32)> {
+        match code {
+            keycode::KEY_W | keycode::KEY_UP => Some((0, 1)),
+            keycode::KEY_S | keycode::KEY_DOWN => Some((0, -1)),
+            keycode::KEY_D | keycode::KEY_RIGHT => Some((1, 0)),
+            keycode::KEY_A | keycode::KEY_LEFT => Some((-1, 0)),
+            _ => None,
+        }
+    }
 }
 
-/// A player body with world-space position and per-tick velocity.
-/// Draws a small apex-up triangle at its position every tick and
-/// publishes `TopdownSetCenter` to a mailbox named `"topdown"` so an
-/// attached top-down camera follows. Keyboard-controllable via WASD
-/// or arrow keys (hold-to-move), or scripted via `PlayerSetPosition` /
-/// `PlayerSetVelocity`.
+/// Player body with runtime-switchable motion model.
 ///
 /// # Agent
-/// Load alongside `aether-camera-component`'s `topdown` example (under
-/// the name `"topdown"`) and optionally `aether-demo-sokoban` for a
-/// backdrop. Scripted controls:
+/// Load alongside the top-down camera (`aether-camera-component`'s
+/// `topdown` example, named `"topdown"`). For grid-game shapes, also
+/// load a world authority (e.g. `aether-demo-sokoban`, named
+/// `"world"`) and send `PlayerSetMode { mode: 1 }` to switch to
+/// tile-step motion.
 ///
-/// - `PlayerSetPosition { x, y }` — teleport. Velocity is untouched;
-///   send `PlayerSetVelocity { 0, 0 }` separately to stop.
-/// - `PlayerSetVelocity { vx, vy }` — per-tick drift in world units.
-///   `(0, 0)` stops motion. Overridden while any WASD/arrow key is
-///   held; restored when all are released.
+/// **Control surface**
 ///
-/// Keyboard controls require the substrate window to have focus —
-/// `capture_frame` alone won't deliver keys. For MCP-only smoke tests,
-/// send `Key { code: KEY_W }` / `KeyRelease { code: KEY_W }` directly
-/// to the player mailbox; the flag update path is the same.
+/// - `PlayerSetMode { mode }` — `0` continuous, `1` tile-step.
+/// - `PlayerSetPosition { x, y }` — teleport (both modes).
+/// - `PlayerSetVelocity { vx, vy }` — baseline velocity, applied each
+///   tick in continuous mode when no key is held. No-op visually in
+///   tile-step mode.
+///
+/// **Keyboard** (requires window focus for live keys; for MCP smoke
+/// tests send `Key` / `KeyRelease` directly to the player):
+///
+/// - Continuous mode: hold to move, release to stop.
+/// - Tile-step mode: press to request one cell step via the world
+///   authority; release does nothing. The world's reply updates the
+///   player's position, so a blocked step leaves the player where it
+///   was.
 #[handlers]
 impl Component for Player {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Player {
             render: ctx.resolve_sink::<DrawTriangle>("render"),
             camera_follow: ctx.resolve_sink::<TopdownSetCenter>("topdown"),
+            world: ctx.resolve_sink::<PlayerRequestStep>("world"),
             pos_x: 0.0,
             pos_y: 0.0,
             base_vx: 0.0,
@@ -115,24 +134,28 @@ impl Component for Player {
             moving_down: false,
             moving_left: false,
             moving_right: false,
+            mode: MODE_CONTINUOUS,
         }
     }
 
-    /// Advance position, draw body, and push a camera follow target.
+    /// Advance position (continuous mode only), draw the body, push a
+    /// camera follow target.
     ///
     /// # Agent
     /// Tick-driven; not useful to send manually.
     #[handler]
     fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
-        let (vx, vy) = if self.any_key_held() {
-            let dx = (self.moving_right as i32 - self.moving_left as i32) as f32;
-            let dy = (self.moving_up as i32 - self.moving_down as i32) as f32;
-            (dx * KEY_SPEED, dy * KEY_SPEED)
-        } else {
-            (self.base_vx, self.base_vy)
-        };
-        self.pos_x += vx;
-        self.pos_y += vy;
+        if self.mode == MODE_CONTINUOUS {
+            let (vx, vy) = if self.any_key_held() {
+                let dx = (self.moving_right as i32 - self.moving_left as i32) as f32;
+                let dy = (self.moving_up as i32 - self.moving_down as i32) as f32;
+                (dx * KEY_SPEED, dy * KEY_SPEED)
+            } else {
+                (self.base_vx, self.base_vy)
+            };
+            self.pos_x += vx;
+            self.pos_y += vy;
+        }
 
         let body = DrawTriangle {
             verts: [
@@ -173,41 +196,80 @@ impl Component for Player {
         );
     }
 
-    /// Teleport to a new world-space position.
+    /// Teleport. Honors both modes — in tile-step mode this is the
+    /// "force position" override (normally the world authority is the
+    /// only one driving position changes).
     #[handler]
     fn on_set_position(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetPosition) {
         self.pos_x = msg.x;
         self.pos_y = msg.y;
     }
 
-    /// Replace the baseline per-tick velocity. `(0, 0)` stops.
-    /// Overridden while any WASD/arrow key is held; restored when all
-    /// are released.
+    /// Set continuous-mode baseline velocity. No-op visually in
+    /// tile-step mode (velocity isn't applied to position there).
     #[handler]
     fn on_set_velocity(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetVelocity) {
         self.base_vx = msg.vx;
         self.base_vy = msg.vy;
     }
 
-    /// Record a key-down for WASD/arrow keys (other keys ignored).
+    /// Switch motion mode. Clears direction flags on transition to
+    /// avoid stale "still held" state leaking across modes.
     ///
     /// # Agent
-    /// Publish-subscribe; the substrate delivers this for every mapped
-    /// press. Holding a key produces one `Key` on the initial press
-    /// (winit suppresses auto-repeat) and one `KeyRelease` when
-    /// released — the component tracks hold state via that pair.
+    /// `0` = continuous (default, free-float), `1` = tile-step (grid
+    /// games with a `"world"` authority). Other values are ignored.
     #[handler]
-    fn on_key(&mut self, _ctx: &mut Ctx<'_>, key: Key) {
-        self.apply_key(key.code, true);
+    fn on_set_mode(&mut self, _ctx: &mut Ctx<'_>, msg: PlayerSetMode) {
+        if msg.mode == MODE_CONTINUOUS || msg.mode == MODE_TILE_STEP {
+            self.mode = msg.mode;
+            self.moving_up = false;
+            self.moving_down = false;
+            self.moving_left = false;
+            self.moving_right = false;
+        }
     }
 
-    /// Record a key-up for WASD/arrow keys (other keys ignored).
+    /// Handle a key-press mapped to movement. Dispatches by mode:
+    /// continuous sets a direction flag, tile-step fires off one
+    /// `PlayerRequestStep` to the world authority.
     ///
     /// # Agent
-    /// Publish-subscribe; the substrate delivers this on release.
+    /// Publish-subscribe; the substrate delivers this on every mapped
+    /// press. In tile-step mode, hold doesn't auto-repeat — one press
+    /// = one step request. Send a fresh `Key` for each step.
+    #[handler]
+    fn on_key(&mut self, ctx: &mut Ctx<'_>, key: Key) {
+        if self.mode == MODE_TILE_STEP {
+            if let Some((dx, dy)) = Self::step_delta(key.code) {
+                ctx.send(&self.world, &PlayerRequestStep { dx, dy });
+            }
+        } else {
+            self.apply_key(key.code, true);
+        }
+    }
+
+    /// Key-release. Continuous mode clears the direction flag;
+    /// tile-step mode ignores the event (each step is a fresh press).
     #[handler]
     fn on_key_release(&mut self, _ctx: &mut Ctx<'_>, key: KeyRelease) {
-        self.apply_key(key.code, false);
+        if self.mode == MODE_CONTINUOUS {
+            self.apply_key(key.code, false);
+        }
+    }
+
+    /// World-authority reply to a `PlayerRequestStep`. The authority
+    /// is the source of truth on where the player ended up — rejected
+    /// steps still carry a position (the unchanged original), so the
+    /// player overwrites its position unconditionally.
+    ///
+    /// # Agent
+    /// Replied by whichever component is loaded as `"world"`. No need
+    /// to send this manually unless simulating a world.
+    #[handler]
+    fn on_step_result(&mut self, _ctx: &mut Ctx<'_>, result: PlayerStepResult) {
+        self.pos_x = result.new_x;
+        self.pos_y = result.new_y;
     }
 }
 

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -1,26 +1,31 @@
-//! Sokoban demo: a turn-based puzzle component that exists to stress
-//! the Claude-in-harness loop. A Claude session drives gameplay via
-//! mail — `SokobanMove`, `SokobanReset`, `SokobanLoadLevel` — and the
-//! component replies with a `SokobanState` snapshot after every
-//! action. The grid is also rendered each tick as `DrawTriangle`s so
-//! `capture_frame` shows a human-readable board.
+//! Sokoban demo: a grid-based puzzle world. The world owns walls,
+//! boxes, targets, and the player's grid position; an external player
+//! component (`aether-player-component` in tile-step mode, loaded as
+//! `"player"`) renders itself and drives motion.
 //!
-//! Scope: this is a harness exercise, not a game. No undo, no replay,
-//! no move history — just enough state to play a level, observe, and
-//! reset. Soft-lock detection is deliberately absent; seeing Claude
-//! recognise and recover from unwinnable states is part of the point.
+//! Protocol:
 //!
-//! Grid is capped at 16×16 as a carryover from the pre-ADR-0028
-//! `LoadKind` wire shape, which only supported fixed-size scalar
-//! and array fields. Now that the kind vocabulary rides in the
-//! wasm's `aether.kinds` custom section (ADR-0028), the full
-//! `SchemaType` vocabulary is available — including `Vec<u8>` —
-//! and this cap can be lifted whenever we want to extend the
-//! demo. Left as-is for now so this PR stays focused on the wire
-//! removal.
+//! 1. On `SokobanLoadLevel` / `SokobanReset`, sokoban parses the level,
+//!    initializes the grid, stores the player's starting cell, and
+//!    emits `PlayerSetPosition` to the `"player"` mailbox to place the
+//!    external body at the starting world coordinate.
+//! 2. The player (in tile-step mode) emits
+//!    `PlayerRequestStep { dx, dy }` on each movement keypress,
+//!    addressed to the mailbox named `"world"` — i.e. this component.
+//! 3. Sokoban resolves the outcome (wall block, floor pass, box
+//!    push-or-block) and replies with `PlayerStepResult`, carrying the
+//!    authoritative world-space position. The player applies it.
+//!
+//! The world is rendered each tick (floor, walls, boxes, targets).
+//! The external player renders itself — the grid no longer tracks
+//! `CELL_PLAYER` state.
+//!
+//! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
 use aether_component::{Component, Ctx, InitCtx, KindId, Sink, handlers};
-use aether_kinds::{DrawTriangle, Tick, Vertex};
+use aether_kinds::{
+    DrawTriangle, PlayerRequestStep, PlayerSetPosition, PlayerStepResult, Tick, Vertex,
+};
 use aether_mail::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -32,25 +37,6 @@ pub const CELL_WALL: u8 = 1;
 pub const CELL_BOX: u8 = 2;
 pub const CELL_TARGET: u8 = 3;
 pub const CELL_BOX_ON_TARGET: u8 = 4;
-pub const CELL_PLAYER: u8 = 5;
-pub const CELL_PLAYER_ON_TARGET: u8 = 6;
-
-pub const DIR_NORTH: u8 = 0;
-pub const DIR_SOUTH: u8 = 1;
-pub const DIR_EAST: u8 = 2;
-pub const DIR_WEST: u8 = 3;
-
-/// Claude → component: move the player one cell in the given direction.
-/// `direction`: 0 = north, 1 = south, 2 = east, 3 = west. Illegal
-/// directions or blocked moves are no-ops — the component still
-/// replies with a fresh state so the caller always sees ground truth.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Pod, Zeroable, Kind, Schema)]
-#[kind(name = "demo.sokoban.move")]
-pub struct SokobanMove {
-    pub direction: u8,
-    pub _pad: [u8; 3],
-}
 
 /// Claude → component: reload the currently-active level. No payload.
 #[repr(C)]
@@ -70,7 +56,8 @@ pub struct SokobanLoadLevel {
 /// Component → Claude (reply-to-sender): full board snapshot. Always
 /// the same wire size regardless of the live grid dimensions — unused
 /// cells in `cells` are `CELL_FLOOR` (0). Consumers read `width` and
-/// `height` before indexing.
+/// `height` before indexing. `player_x` / `player_y` are grid cell
+/// coordinates (not world).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable, Kind, Schema)]
 #[kind(name = "demo.sokoban.state")]
@@ -103,10 +90,9 @@ impl Default for SokobanState {
 }
 
 /// Hand-authored starter levels. ASCII: `#` wall, `.` floor,
-/// `@` player, `$` box, `.` target-less floor, `T` target,
-/// `*` box on target, `+` player on target. Lines must be rectangular
-/// (shorter lines are padded with floor). The levels are deliberately
-/// small — they exist to be played by Claude, not to be fun.
+/// `@` player start, `$` box, `T` target, `*` box on target,
+/// `+` player start on target. The levels are deliberately small —
+/// they exist to be played, not to be fun.
 const LEVELS: &[&[&str]] = &[
     // 0: trivial — one box, one target, one push.
     &[
@@ -135,16 +121,38 @@ const LEVELS: &[&[&str]] = &[
 pub struct Sokoban {
     state: SokobanState,
     state_kind: KindId<SokobanState>,
+    step_result_kind: KindId<PlayerStepResult>,
     render: Sink<DrawTriangle>,
+    player: Sink<PlayerSetPosition>,
 }
 
+/// Sokoban world. Owns the grid and the player's grid cell; the
+/// external `aether-player-component` (loaded as `"player"`, mode set
+/// to tile-step) drives motion via `PlayerRequestStep`.
+///
+/// # Agent
+/// Load as `"world"` alongside the external player (`"player"`) and
+/// the top-down camera (`"topdown"`). On load, sokoban emits
+/// `PlayerSetPosition` to the external player so it arrives at the
+/// level's starting cell.
+///
+/// - `SokobanLoadLevel { id }` — switch levels. Out-of-range is a
+///   no-op.
+/// - `SokobanReset` — reload the active level.
+/// - `PlayerRequestStep { dx, dy }` — typically sent by the player on
+///   each WASD press; you can also send it directly for scripted
+///   moves. `dx`/`dy` are integer cell deltas (+1 east, +1 north in
+///   the engine's +Y-up world). Reply is `PlayerStepResult` with the
+///   authoritative post-move world coordinate.
 #[handlers]
 impl Component for Sokoban {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         let mut me = Sokoban {
             state: SokobanState::default(),
             state_kind: ctx.resolve::<SokobanState>(),
+            step_result_kind: ctx.resolve::<PlayerStepResult>(),
             render: ctx.resolve_sink::<DrawTriangle>("render"),
+            player: ctx.resolve_sink::<PlayerSetPosition>("player"),
         };
         me.load_level(0);
         me
@@ -155,21 +163,37 @@ impl Component for Sokoban {
         self.render_grid(ctx);
     }
 
+    /// Apply a player step request. Resolves wall/floor/box outcomes
+    /// against the current grid, updates state, and replies to the
+    /// sender with the authoritative new world position.
     #[handler]
-    fn on_move(&mut self, ctx: &mut Ctx<'_>, mv: SokobanMove) {
-        self.apply_move(mv.direction);
-        self.reply_state(ctx);
+    fn on_request_step(&mut self, ctx: &mut Ctx<'_>, req: PlayerRequestStep) {
+        let accepted = self.apply_step(req.dx, req.dy);
+        let (world_x, world_y) = self.player_world_pos();
+        if let Some(sender) = ctx.reply_to() {
+            ctx.reply(
+                sender,
+                self.step_result_kind,
+                &PlayerStepResult {
+                    accepted: u32::from(accepted),
+                    new_x: world_x,
+                    new_y: world_y,
+                },
+            );
+        }
     }
 
     #[handler]
     fn on_reset(&mut self, ctx: &mut Ctx<'_>, _rst: SokobanReset) {
         self.load_level(self.state.level_id);
+        self.sync_player(ctx);
         self.reply_state(ctx);
     }
 
     #[handler]
     fn on_load_level(&mut self, ctx: &mut Ctx<'_>, load: SokobanLoadLevel) {
         self.load_level(load.id);
+        self.sync_player(ctx);
         self.reply_state(ctx);
     }
 }
@@ -198,11 +222,11 @@ impl Sokoban {
                     '*' => CELL_BOX_ON_TARGET,
                     '@' => {
                         player = (x as u32, y as u32);
-                        CELL_PLAYER
+                        CELL_FLOOR
                     }
                     '+' => {
                         player = (x as u32, y as u32);
-                        CELL_PLAYER_ON_TARGET
+                        CELL_TARGET
                     }
                     _ => CELL_FLOOR,
                 };
@@ -223,81 +247,84 @@ impl Sokoban {
         self.state.solved = u32::from(is_solved(&self.state));
     }
 
-    fn apply_move(&mut self, direction: u8) {
+    /// Resolve a step request against the grid. `(dx, dy)` follows the
+    /// engine's world convention: +X east, +Y north. Sokoban's grid
+    /// stores rows top-down (gy=0 is top), so +Y north means gy - 1.
+    /// Returns `true` when the player moved; `false` when the step
+    /// was rejected (wall, out of bounds, unpushable box, post-solve,
+    /// diagonal or invalid delta).
+    fn apply_step(&mut self, dx: i32, dy: i32) -> bool {
         if self.state.solved == 1 {
-            return;
+            return false;
         }
-        let (dx, dy): (i32, i32) = match direction {
-            DIR_NORTH => (0, -1),
-            DIR_SOUTH => (0, 1),
-            DIR_EAST => (1, 0),
-            DIR_WEST => (-1, 0),
-            _ => return,
+        let (delta_gx, delta_gy) = match (dx.signum(), dy.signum()) {
+            (1, 0) => (1i32, 0i32),
+            (-1, 0) => (-1, 0),
+            (0, 1) => (0, -1), // world +Y → grid -gy
+            (0, -1) => (0, 1),
+            _ => return false,
         };
         let px = self.state.player_x as i32;
         let py = self.state.player_y as i32;
-        let tx = px + dx;
-        let ty = py + dy;
+        let tx = px + delta_gx;
+        let ty = py + delta_gy;
         if !in_bounds(&self.state, tx, ty) {
-            return;
+            return false;
         }
 
         let target = cell_at(&self.state, tx as u32, ty as u32);
         match target {
-            CELL_WALL => return,
-            CELL_FLOOR | CELL_TARGET => {
-                self.step_player(px as u32, py as u32, tx as u32, ty as u32);
-            }
+            CELL_WALL => return false,
+            CELL_FLOOR | CELL_TARGET => {}
             CELL_BOX | CELL_BOX_ON_TARGET => {
-                let bx = tx + dx;
-                let by = ty + dy;
+                let bx = tx + delta_gx;
+                let by = ty + delta_gy;
                 if !in_bounds(&self.state, bx, by) {
-                    return;
+                    return false;
                 }
                 let beyond = cell_at(&self.state, bx as u32, by as u32);
-                let (box_after, player_into) = match beyond {
-                    CELL_FLOOR => (CELL_BOX, (target == CELL_BOX_ON_TARGET)),
-                    CELL_TARGET => (CELL_BOX_ON_TARGET, (target == CELL_BOX_ON_TARGET)),
-                    _ => return,
+                let box_after = match beyond {
+                    CELL_FLOOR => CELL_BOX,
+                    CELL_TARGET => CELL_BOX_ON_TARGET,
+                    _ => return false,
                 };
                 set_cell(&mut self.state, bx as u32, by as u32, box_after);
-                // Player's new cell: was a box; if box had been on a
-                // target, the underlying target remains → player-on-target.
-                let new_player_cell = if player_into {
-                    CELL_PLAYER_ON_TARGET
+                // Vacate the box's old cell: if it was a box-on-target,
+                // the underlying target is re-exposed as CELL_TARGET.
+                let vacated = if target == CELL_BOX_ON_TARGET {
+                    CELL_TARGET
                 } else {
-                    CELL_PLAYER
+                    CELL_FLOOR
                 };
-                self.move_player_raw(px as u32, py as u32, tx as u32, ty as u32, new_player_cell);
+                set_cell(&mut self.state, tx as u32, ty as u32, vacated);
             }
-            _ => return,
+            _ => return false,
         }
 
+        self.state.player_x = tx as u32;
+        self.state.player_y = ty as u32;
         self.state.moves += 1;
         self.state.solved = u32::from(is_solved(&self.state));
+        true
     }
 
-    fn step_player(&mut self, px: u32, py: u32, tx: u32, ty: u32) {
-        let target = cell_at(&self.state, tx, ty);
-        let new_player_cell = if target == CELL_TARGET {
-            CELL_PLAYER_ON_TARGET
-        } else {
-            CELL_PLAYER
-        };
-        self.move_player_raw(px, py, tx, ty, new_player_cell);
+    /// Grid-space player cell → world-space coordinate. The rendering
+    /// mapping: one world unit per cell, centered on origin, +Y up.
+    /// Tile `(gx, gy)` has center at `(gx - w/2 + 0.5, h/2 - gy - 0.5)`.
+    fn player_world_pos(&self) -> (f32, f32) {
+        let w = self.state.width as f32;
+        let h = self.state.height as f32;
+        let gx = self.state.player_x as f32;
+        let gy = self.state.player_y as f32;
+        (gx - w * 0.5 + 0.5, h * 0.5 - gy - 0.5)
     }
 
-    fn move_player_raw(&mut self, px: u32, py: u32, tx: u32, ty: u32, new_cell: u8) {
-        let prev = cell_at(&self.state, px, py);
-        let vacated = if prev == CELL_PLAYER_ON_TARGET {
-            CELL_TARGET
-        } else {
-            CELL_FLOOR
-        };
-        set_cell(&mut self.state, px, py, vacated);
-        set_cell(&mut self.state, tx, ty, new_cell);
-        self.state.player_x = tx;
-        self.state.player_y = ty;
+    /// Emit a `PlayerSetPosition` to the external player with the
+    /// current player cell's world coordinate. Called after load /
+    /// reset so the rendered body snaps to the level's starting cell.
+    fn sync_player(&self, ctx: &mut Ctx<'_>) {
+        let (x, y) = self.player_world_pos();
+        ctx.send(&self.player, &PlayerSetPosition { x, y });
     }
 
     fn reply_state(&self, ctx: &mut Ctx<'_>) {
@@ -313,17 +340,6 @@ impl Sokoban {
         if w == 0 || h == 0 {
             return;
         }
-        // World-space grid: one world unit per cell, centered on the
-        // origin with +Y up. Tile `(gx, gy)` (row-major, gy=0 is the
-        // top row) covers world rect
-        //   x ∈ [gx - w/2, gx - w/2 + 1]
-        //   y ∈ [h/2 - gy - 1, h/2 - gy]
-        // and sits at z=0. A top-down ortho camera with extent ≥
-        // max(w, h)/2 frames the whole grid; the substrate's default
-        // identity camera preserves world coords as clip-space, which
-        // means pre-camera rendering shrinks from full-window to a
-        // unit-sized box on screen — loading the topdown camera is
-        // the expected workflow.
         let cell = 1.0_f32;
         let origin_x = -(w as f32) * 0.5;
         let origin_y = (h as f32) * 0.5;
@@ -415,12 +431,11 @@ fn set_cell(state: &mut SokobanState, x: u32, y: u32, value: u8) {
 }
 
 fn is_solved(state: &SokobanState) -> bool {
-    // Solved ⇔ no uncovered target cells. Player-on-target counts as
-    // uncovered (the player doesn't complete a goal; a box does).
+    // Solved ⇔ no uncovered target cells.
     for y in 0..state.height as usize {
         for x in 0..state.width as usize {
             let c = state.cells[y * GRID_MAX + x];
-            if c == CELL_TARGET || c == CELL_PLAYER_ON_TARGET {
+            if c == CELL_TARGET {
                 return false;
             }
         }
@@ -435,8 +450,6 @@ fn cell_color(cell: u8) -> (f32, f32, f32) {
         CELL_TARGET => (0.35, 0.22, 0.10),
         CELL_BOX => (0.65, 0.50, 0.28),
         CELL_BOX_ON_TARGET => (0.30, 0.70, 0.35),
-        CELL_PLAYER => (0.30, 0.55, 0.90),
-        CELL_PLAYER_ON_TARGET => (0.70, 0.45, 0.85),
         _ => (0.0, 0.0, 0.0),
     }
 }


### PR DESCRIPTION
## Summary

Refactors sokoban from a self-contained "grid + scripted player" into a world authority, with the external `aether-player-component` as the player body. This is the A2 path from design — proper decoupling rather than wiring WASD into the pre-existing `SokobanMove`.

Shipped together with #200 (atomic multi-component spawn), the canonical demo setup is now a single tool call: `spawn_substrate(..., components: [topdown, player, world])`.

## Protocol (new kinds in `aether-kinds`)

- `aether.player.set_mode { mode: u32 }` — toggle between `0 = continuous` (unchanged free-float + WASD + `PlayerSetVelocity`) and `1 = tile_step` (grid-aware).
- `aether.player.request_step { dx: i32, dy: i32 }` — in tile-step mode, each WASD press emits one to the mailbox named `"world"`. Deltas are integer cell offsets in engine coords (+X east, +Y north).
- `aether.player.step_result { accepted: u32, new_x: f32, new_y: f32 }` — authoritative reply. Player snaps to `new_x/new_y` regardless of `accepted` (a blocked step leaves the player where the world says it is, typically unchanged).

## Player

New `mode` state + `world: Sink<PlayerRequestStep>` at init.

- **Continuous mode** (default): existing behavior unchanged — flags, per-tick velocity, `PlayerSetVelocity` baseline.
- **Tile-step mode**: `on_key` routes to emit `PlayerRequestStep` (one press, one request). Key releases are ignored (each step is a fresh press). Velocity is suppressed. `on_step_result` snaps the player's position to the authority's reply.

Scripted controls (`PlayerSetPosition` / `PlayerSetVelocity`) remain usable in both modes; in tile-step mode, velocity has no visible effect.

## Sokoban

Stops tracking the player as a grid cell — no more `CELL_PLAYER` / `CELL_PLAYER_ON_TARGET` in the rendered state.

- `@` / `+` in levels still mark the starting square but parse to plain `CELL_FLOOR` / `CELL_TARGET`; the start coord is remembered for sync.
- On `LoadLevel` / `Reset`, sokoban emits `PlayerSetPosition` to the mailbox named `"player"` so the external body snaps to the starting cell.
- New `on_request_step` handler: resolves the move (wall block, floor pass, box push-or-block) and replies with `PlayerStepResult`. Returns `accepted` reflecting actual outcome.

The old `SokobanMove` kind is retired — the new protocol covers both scripted (direct `PlayerRequestStep` from MCP) and keyboard (via the player component) paths.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] **MCP protocol verification** (reply-to-sender via `receive_mail`, not dependent on rendering — see known issue below):
  - Compound spawn `[topdown, player, world]` with the new `spawn_substrate` components list.
  - `PlayerSetMode { mode: 1 }` switches the player to tile-step.
  - `PlayerRequestStep { dx: 1, dy: 0 }` east from starting cell → `PlayerStepResult { accepted: 1, new_x: 0.0, new_y: 0.0 }` (box at (2,1) pushed east onto target at (3,1), player advanced to box's old cell at grid (2,1) = world (0,0)).
  - Second east → `PlayerStepResult { accepted: 1, new_x: 0.0, new_y: 0.0 }` — player held; box would have pushed into wall. (Note: this exposes a correctness tweak — should be `accepted: 0` — already fixed in the committed version, verified in a second test pass.)

## Known issue (filed as #201, not blocking this PR)

The desktop render pipeline has `depth_stencil: None` and the frame vertex buffer appends in submission order. Where the sokoban floor quad and the player triangle overlap at the same z, whichever component ticks last wins. The player *is* rendering (visible in `frame_stats.triangles`) but can be visually occluded by a grid cell at the same world coord. Pre-existing — only surfaces now that two components draw overlapping geometry. Fix options in #201; leaning on enabling depth testing in the pipeline.

## What's next

- Resolve #201 so the visual demo matches the protocol's correctness.
- Deeper sokoban scenarios: level-switching (blocked on the pre-existing single-field-cast-kind descriptor bug where the `id` field shows as empty string in `demo.sokoban.load_level`'s descriptor — separate issue to file).