### PR TITLE
fix(hub-protocol,mail-derive): pair kind labels by id, not declaration order

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -84,7 +84,7 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 /// Not part of the public API; the macro is the only intended caller.
 #[doc(hidden)]
 pub mod __macro_internals {
-    pub use aether_mail::__derive_runtime::{SchemaType, canonical};
+    pub use aether_mail::__derive_runtime::{Cow, KindLabels, SchemaType, canonical};
     pub use aether_mail::{Kind, Schema};
 }
 

--- a/crates/aether-hub-protocol/src/canonical/labels.rs
+++ b/crates/aether-hub-protocol/src/canonical/labels.rs
@@ -7,7 +7,8 @@ use crate::types::{KindLabels, LabelCell, LabelNode, VariantLabel};
 
 use super::primitives::{
     cow_label_nodes, cow_str_as_str, cow_strs, cow_variant_labels, option_str_len, str_len,
-    varint_usize_len, write_option_str, write_str, write_varint_usize,
+    varint_u64_len, varint_usize_len, write_option_str, write_str, write_varint_u64,
+    write_varint_usize,
 };
 
 const LABEL_ANONYMOUS: u8 = 0;
@@ -23,7 +24,9 @@ const VARIANT_LABEL_STRUCT: u8 = 2;
 
 /// Byte length for `KindLabels` postcard encoding.
 pub const fn canonical_len_labels(labels: &KindLabels) -> usize {
-    str_len(cow_str_as_str(&labels.kind_label)) + label_node_len(&labels.root)
+    varint_u64_len(labels.kind_id)
+        + str_len(cow_str_as_str(&labels.kind_label))
+        + label_node_len(&labels.root)
 }
 
 const fn label_node_len(node: &LabelNode) -> usize {
@@ -121,7 +124,8 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
 /// Serialize `labels` into `N` bytes of canonical postcard form.
 pub const fn canonical_serialize_labels<const N: usize>(labels: &KindLabels) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = write_str(cow_str_as_str(&labels.kind_label), &mut out, 0);
+    let mut pos = write_varint_u64(labels.kind_id, &mut out, 0);
+    pos = write_str(cow_str_as_str(&labels.kind_label), &mut out, pos);
     pos = write_label_node(&labels.root, &mut out, pos);
     if pos != N {
         panic!("canonical_serialize_labels: size mismatch between len pass and serialize pass");

--- a/crates/aether-hub-protocol/src/canonical/mod.rs
+++ b/crates/aether-hub-protocol/src/canonical/mod.rs
@@ -49,7 +49,7 @@ pub use labels::{canonical_len_labels, canonical_serialize_labels};
 pub use primitives::{varint_u32_len, varint_u64_len, varint_usize_len};
 pub use schema::{
     canonical_kind_bytes, canonical_len_kind, canonical_len_schema, canonical_serialize_kind,
-    canonical_serialize_schema, kind_id_from_parts,
+    canonical_serialize_schema, kind_id_from_parts, kind_id_from_shape,
 };
 
 #[cfg(test)]
@@ -274,6 +274,7 @@ mod tests {
     };
 
     static TRIANGLE_LABELS: KindLabels = KindLabels {
+        kind_id: 0,
         kind_label: Cow::Borrowed("my_crate::Triangle"),
         root: LabelNode::Struct {
             type_label: Some(Cow::Borrowed("my_crate::Triangle")),
@@ -291,6 +292,7 @@ mod tests {
     }
 
     static RESULT_LABELS: KindLabels = KindLabels {
+        kind_id: 0,
         kind_label: Cow::Borrowed("my_crate::Result"),
         root: LabelNode::Enum {
             type_label: Some(Cow::Borrowed("my_crate::Result")),

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -240,6 +240,17 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
     fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema))
 }
 
+/// Derive a `Kind::ID` from a decoded `KindShape`. Same hash as
+/// `kind_id_from_parts` — the canonical bytes format is
+/// `postcard(KindShape)`, so we postcard the shape directly without a
+/// `SchemaShape → SchemaType` detour. Used by `kind_manifest` to key
+/// labels records by id after decoding both sections off the wasm.
+pub fn kind_id_from_shape(shape: &crate::types::KindShape) -> u64 {
+    let bytes =
+        postcard::to_allocvec(shape).expect("canonical KindShape serialization is infallible");
+    fnv1a_64_prefixed(KIND_DOMAIN, &bytes)
+}
+
 /// FNV-1a 64 over `prefix ++ payload`, mirrored from
 /// `aether_mail::fnv1a_64_prefixed`. Duplicated here because
 /// `aether-mail` depends on `aether-hub-protocol`, not the other way

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -693,11 +693,15 @@ impl<'de> Deserialize<'de> for VariantLabel {
 }
 
 /// One record in the `aether.kinds.labels` section: the kind's own
-/// Rust type label plus the parallel-shape `LabelNode` tree. Paired
-/// with the matching `SchemaShape` record from `aether.kinds` (same
-/// declaration order) to reconstruct a named `SchemaType`.
+/// `Kind::ID` (so the record is self-identifying), the Rust type
+/// label, and the parallel-shape `LabelNode` tree. Paired with the
+/// matching `SchemaShape` record from `aether.kinds` by id, not by
+/// declaration order — any emitter (the Kind derive, `#[handlers]`
+/// retention, a third-party shared-rlib wrapper) can write records
+/// in any order and the reader will rejoin them correctly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindLabels {
+    pub kind_id: u64,
     pub kind_label: Cow<'static, str>,
     pub root: LabelNode,
 }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -136,6 +136,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         // `&#labels_ident` see a stable `'static` reference.
         static #labels_ident: ::aether_mail::__derive_runtime::KindLabels =
             ::aether_mail::__derive_runtime::KindLabels {
+                kind_id: <#name as ::aether_mail::Kind>::ID,
                 kind_label: ::aether_mail::__derive_runtime::Cow::Borrowed(
                     ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#name)),
                 ),
@@ -167,7 +168,9 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #[unsafe(link_section = "aether.kinds.labels")]
         static #kind_labels_static_ident: [u8; #labels_len_ident + 1] = {
             let mut out = [0u8; #labels_len_ident + 1];
-            out[0] = 0x02;
+            // v0x03: `KindLabels` gained `kind_id`, making records
+            // self-identifying. Reader pairs by id, not index.
+            out[0] = 0x03;
             let mut i = 0;
             while i < #labels_len_ident {
                 out[i + 1] = #labels_bytes_ident[i];
@@ -1119,12 +1122,32 @@ fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn])
             self_ty_hint,
             idx
         );
+        let labels_static_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_LABELS_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let labels_len_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_LABELS_LEN_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let labels_bytes_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_LABELS_BYTES_{}_{}",
+            self_ty_hint,
+            idx
+        );
+        let labels_section_ident = quote::format_ident!(
+            "__AETHER_HANDLERS_KIND_LABELS_MANIFEST_{}_{}",
+            self_ty_hint,
+            idx
+        );
         quote! {
             // Mirrors the intermediate-static pattern in `expand_kind`
             // (mail-derive/src/lib.rs) so const-eval of the serializer
-            // sees a `&'static SchemaType` instead of materializing a
-            // temporary whose non-trivial Drop can't run at compile
-            // time.
+            // sees a `&'static SchemaType` / `&'static KindLabels`
+            // instead of materializing a temporary whose non-trivial
+            // Drop can't run at compile time.
             static #schema_ident: ::aether_component::__macro_internals::SchemaType =
                 <#k as ::aether_component::__macro_internals::Schema>::SCHEMA;
             const #len_ident: usize =
@@ -1146,6 +1169,49 @@ fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn])
                 let mut i = 0;
                 while i < #len_ident {
                     out[i + 1] = #bytes_ident[i];
+                    i += 1;
+                }
+                out
+            };
+
+            // Parallel labels retention. Without this, kinds defined
+            // in a dependency rlib (whose Kind-derive labels get
+            // stripped at rlib→cdylib) survive via `aether.kinds`
+            // retention but have no labels counterpart, and the
+            // reader can't reconstruct named fields — the symptom the
+            // by-id pairing replaced by-index pairing to avoid.
+            // `kind_label` falls back to the empty string for types
+            // without a `Schema::LABEL` (none today — every derived
+            // Kind sets one — but defensive against future hand-rolled
+            // Schema impls).
+            static #labels_static_ident: ::aether_component::__macro_internals::KindLabels =
+                ::aether_component::__macro_internals::KindLabels {
+                    kind_id: <#k as ::aether_component::__macro_internals::Kind>::ID,
+                    kind_label: ::aether_component::__macro_internals::Cow::Borrowed(
+                        match <#k as ::aether_component::__macro_internals::Schema>::LABEL {
+                            ::core::option::Option::Some(s) => s,
+                            ::core::option::Option::None => "",
+                        },
+                    ),
+                    root: <#k as ::aether_component::__macro_internals::Schema>::LABEL_NODE,
+                };
+            const #labels_len_ident: usize =
+                ::aether_component::__macro_internals::canonical::canonical_len_labels(
+                    &#labels_static_ident,
+                );
+            const #labels_bytes_ident: [u8; #labels_len_ident] =
+                ::aether_component::__macro_internals::canonical::canonical_serialize_labels::<#labels_len_ident>(
+                    &#labels_static_ident,
+                );
+            #[cfg(target_arch = "wasm32")]
+            #[used]
+            #[unsafe(link_section = "aether.kinds.labels")]
+            static #labels_section_ident: [u8; #labels_len_ident + 1] = {
+                let mut out = [0u8; #labels_len_ident + 1];
+                out[0] = 0x03;
+                let mut i = 0;
+                while i < #labels_len_ident {
+                    out[i + 1] = #labels_bytes_ident[i];
                     i += 1;
                 }
                 out

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -799,6 +799,7 @@ mod tests {
             },
         };
         let labels = aether_hub_protocol::KindLabels {
+            kind_id: aether_hub_protocol::canonical::kind_id_from_shape(&shape),
             kind_label: std::borrow::Cow::Borrowed("demo::EmbeddedKind"),
             root: aether_hub_protocol::LabelNode::Struct {
                 type_label: Some(std::borrow::Cow::Borrowed("demo::EmbeddedKind")),
@@ -808,7 +809,7 @@ mod tests {
         };
         let mut canonical = vec![0x02u8];
         canonical.extend(postcard::to_allocvec(&shape).unwrap());
-        let mut labels_bytes = vec![0x02u8];
+        let mut labels_bytes = vec![0x03u8];
         labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
         let esc = |bs: &[u8]| -> String { bs.iter().map(|b| format!("\\{b:02x}")).collect() };
         let wat = format!(
@@ -879,12 +880,13 @@ mod tests {
             schema: aether_hub_protocol::SchemaShape::Scalar(Primitive::U64),
         };
         let labels = aether_hub_protocol::KindLabels {
+            kind_id: aether_hub_protocol::canonical::kind_id_from_shape(&shape),
             kind_label: std::borrow::Cow::Borrowed("demo::Conflict"),
             root: aether_hub_protocol::LabelNode::Anonymous,
         };
         let mut canonical = vec![0x02u8];
         canonical.extend(postcard::to_allocvec(&shape).unwrap());
-        let mut labels_bytes = vec![0x02u8];
+        let mut labels_bytes = vec![0x03u8];
         labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
         let esc = |bs: &[u8]| -> String { bs.iter().map(|b| format!("\\{b:02x}")).collect() };
         let wat = format!(

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -1,19 +1,32 @@
 // ADR-0028 / ADR-0032: read a component's embedded kind manifest
-// from two wasm custom sections — `aether.kinds` (positional
-// canonical bytes, the `Kind::ID` hash input) and
-// `aether.kinds.labels` (Rust-nominal sidecar: type paths, field
-// names, variant names). Records in the two sections pair by
-// declaration order.
+// from two wasm custom sections — `aether.kinds` (canonical bytes,
+// the `Kind::ID` hash input) and `aether.kinds.labels` (Rust-nominal
+// sidecar: type paths, field names, variant names).
 //
-// Record format (v2):
-//   [0x02] [postcard(KindShape)] — in `aether.kinds`
-//   [0x02] [postcard(KindLabels)] — in `aether.kinds.labels`
+// Record formats:
+//   `aether.kinds`         — [0x02] [postcard(KindShape)]
+//   `aether.kinds.labels`  — [0x03] [postcard(KindLabels)]
+//
+// `aether.kinds` records are identified by computing
+// `kind_id_from_parts(&shape.name, &shape.schema)`. `aether.kinds.labels`
+// records carry their `kind_id` inline (v0x03 field), so the reader
+// indexes labels by id and looks up per shape. Pairing is robust
+// against emit order, duplicates, and mixed emitters (the Kind derive,
+// `#[handlers]` retention for kinds defined in rlib dependencies, and
+// future external sources of kind metadata).
+//
+// Pre-v0x03 labels lacked `kind_id` and were paired by declaration
+// order. That was fragile once any second emitter wrote to only one
+// of the two sections (issue tracked in the
+// "demo.sokoban.load_level.id" empty-field-name regression); v0x03
+// rejects old-format bytes loudly so a rebuild-required boundary is
+// explicit rather than "single-field cast kinds have empty fields
+// and encode-from-JSON silently fails."
 //
 // The parser walks each section sequentially; postcard stops decoding
 // exactly at the record's end, so the next byte is the next record's
 // version tag. Unknown version bytes abort the parse rather than
-// silently skip — a kind missing from the caller's build would
-// otherwise surface much later as an unrecognized-ID routing failure.
+// silently skip.
 //
 // Wasmtime 30 doesn't expose custom sections on `Module`, so we walk
 // the raw bytes via `wasmparser` before compilation. The section data
@@ -23,10 +36,12 @@
 // compile.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use aether_hub_protocol::{
     EnumVariant, INPUTS_SECTION, INPUTS_SECTION_VERSION, InputsRecord, KindDescriptor, KindLabels,
     KindShape, LabelNode, NamedField, SchemaCell, SchemaShape, SchemaType, VariantLabel,
+    canonical::kind_id_from_shape,
 };
 use aether_kinds::{ComponentCapabilities, FallbackCapability, HandlerCapability};
 use wasmparser::{Parser, Payload};
@@ -43,20 +58,31 @@ pub const MANIFEST_SECTION: &str = "aether.kinds";
 /// anonymous field names.
 pub const LABELS_SECTION: &str = "aether.kinds.labels";
 
-const SUPPORTED_VERSIONS: &[u8] = &[0x02];
+/// Wire versions accepted in `aether.kinds`. The shape record's bytes
+/// are `Kind::ID` hash input, so the format is pinned indefinitely at
+/// 0x02 — any change would shift every id.
+const KINDS_SUPPORTED_VERSIONS: &[u8] = &[0x02];
+
+/// Wire versions accepted in `aether.kinds.labels`. v0x03 added
+/// `kind_id` to `KindLabels`, making records self-identifying so the
+/// reader pairs by id rather than by declaration order. v0x02 is no
+/// longer accepted — a loud rebuild-required boundary.
+const LABELS_SUPPORTED_VERSIONS: &[u8] = &[0x03];
 
 /// Decode every kind record in the component's `aether.kinds` and
-/// (when present) `aether.kinds.labels` sections, merging each pair
-/// into a named `KindDescriptor`. Components without the canonical
-/// section return an empty vec — matches the behavior of a
-/// `LoadComponent` with empty `kinds` and lets WAT-only tests keep
-/// working. Components with canonical bytes but no labels produce
-/// anonymous descriptors (empty field names) — the load succeeds at
-/// the substrate but hub-side encode-from-JSON is expected to error
-/// on such kinds.
+/// (when present) `aether.kinds.labels` sections, merging labels into
+/// each shape by `Kind::ID`. Components without the canonical section
+/// return an empty vec — matches the behavior of a `LoadComponent`
+/// with empty `kinds` and lets WAT-only tests keep working. Shapes
+/// without a matching labels record produce anonymous descriptors
+/// (empty field names) — the load succeeds at the substrate but
+/// hub-side encode-from-JSON is expected to error on such kinds.
+/// Orphan labels (a labels record whose id has no shape) are
+/// silently ignored so third-party emitters can add labels for kinds
+/// not present in this particular binary without breaking loads.
 pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
     let mut shapes: Vec<KindShape> = Vec::new();
-    let mut labels: Vec<KindLabels> = Vec::new();
+    let mut labels_list: Vec<KindLabels> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm) {
         let payload = payload.map_err(|e| format!("wasmparser: {e}"))?;
@@ -64,15 +90,29 @@ pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
             continue;
         };
         match reader.name() {
-            MANIFEST_SECTION => decode_records(MANIFEST_SECTION, reader.data(), &mut shapes)?,
-            LABELS_SECTION => decode_records(LABELS_SECTION, reader.data(), &mut labels)?,
+            MANIFEST_SECTION => decode_records(
+                MANIFEST_SECTION,
+                KINDS_SUPPORTED_VERSIONS,
+                reader.data(),
+                &mut shapes,
+            )?,
+            LABELS_SECTION => decode_records(
+                LABELS_SECTION,
+                LABELS_SUPPORTED_VERSIONS,
+                reader.data(),
+                &mut labels_list,
+            )?,
             _ => continue,
         }
     }
 
+    let labels_by_id: HashMap<u64, KindLabels> =
+        labels_list.into_iter().map(|l| (l.kind_id, l)).collect();
+
     let mut descriptors = Vec::with_capacity(shapes.len());
-    for (idx, shape) in shapes.into_iter().enumerate() {
-        let label = labels.get(idx);
+    for shape in shapes {
+        let id = kind_id_from_shape(&shape);
+        let label = labels_by_id.get(&id);
         descriptors.push(merge(shape, label));
     }
     Ok(descriptors)
@@ -167,16 +207,18 @@ fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(),
 
 /// Walk one custom section: `[version][postcard(T)]` records until
 /// the section is exhausted. Abort on unknown version or postcard
-/// decode error.
+/// decode error. Per-section version allowlists are passed in so the
+/// shape and labels sections can evolve independently.
 fn decode_records<T: serde::de::DeserializeOwned>(
     section_name: &str,
+    supported_versions: &[u8],
     data: &[u8],
     out: &mut Vec<T>,
 ) -> Result<(), String> {
     let mut cursor = data;
     while !cursor.is_empty() {
         let version = cursor[0];
-        if !SUPPORTED_VERSIONS.contains(&version) {
+        if !supported_versions.contains(&version) {
             return Err(format!(
                 "{section_name}: record version {version:#x} not understood by this substrate build"
             ));
@@ -382,6 +424,23 @@ mod tests {
         wat::parse_str(wat).unwrap()
     }
 
+    /// Append `[0x02][postcard(shape)]` to `canonical`. Matches what
+    /// the Kind derive emits into the `aether.kinds` section.
+    fn push_shape(canonical: &mut Vec<u8>, shape: &KindShape) {
+        canonical.push(0x02);
+        canonical.extend(postcard::to_allocvec(shape).unwrap());
+    }
+
+    /// Append `[0x03][postcard(labels)]` to `labels_bytes`, and stamp
+    /// `labels.kind_id` from the paired shape so the reader's by-id
+    /// merge finds it. Matches what the Kind derive emits into
+    /// `aether.kinds.labels` (v0x03 adds `kind_id`).
+    fn push_labels(labels_bytes: &mut Vec<u8>, shape: &KindShape, labels: &mut KindLabels) {
+        labels.kind_id = kind_id_from_shape(shape);
+        labels_bytes.push(0x03);
+        labels_bytes.extend(postcard::to_allocvec(labels).unwrap());
+    }
+
     #[test]
     fn reads_single_record_with_labels() {
         let shape = KindShape {
@@ -391,7 +450,8 @@ mod tests {
                 repr_c: true,
             },
         };
-        let labels = KindLabels {
+        let mut labels = KindLabels {
+            kind_id: 0,
             kind_label: Cow::Borrowed("my_crate::TestKind"),
             root: LabelNode::Struct {
                 type_label: Some(Cow::Borrowed("my_crate::TestKind")),
@@ -399,10 +459,10 @@ mod tests {
                 fields: Cow::Owned(vec![LabelNode::Anonymous]),
             },
         };
-        let mut canonical = vec![0x02u8];
-        canonical.extend(postcard::to_allocvec(&shape).unwrap());
-        let mut labels_bytes = vec![0x02u8];
-        labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
+        let mut canonical = Vec::new();
+        push_shape(&mut canonical, &shape);
+        let mut labels_bytes = Vec::new();
+        push_labels(&mut labels_bytes, &shape, &mut labels);
 
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
@@ -419,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn reads_multiple_records_pair_by_index() {
+    fn reads_multiple_records_pair_by_id() {
         let shapes = [
             KindShape {
                 name: Cow::Borrowed("a"),
@@ -430,25 +490,26 @@ mod tests {
                 schema: SchemaShape::Scalar(Primitive::U8),
             },
         ];
-        let labels_a = KindLabels {
+        let mut labels_a = KindLabels {
+            kind_id: 0,
             kind_label: Cow::Borrowed("my::A"),
             root: LabelNode::Anonymous,
         };
-        let labels_b = KindLabels {
+        let mut labels_b = KindLabels {
+            kind_id: 0,
             kind_label: Cow::Borrowed("my::B"),
             root: LabelNode::Anonymous,
         };
 
         let mut canonical = Vec::new();
         for s in &shapes {
-            canonical.push(0x02);
-            canonical.extend(postcard::to_allocvec(s).unwrap());
+            push_shape(&mut canonical, s);
         }
+        // Emit labels in REVERSE order relative to shapes, to prove
+        // the reader's by-id pairing doesn't rely on declaration order.
         let mut labels_bytes = Vec::new();
-        for l in [&labels_a, &labels_b] {
-            labels_bytes.push(0x02);
-            labels_bytes.extend(postcard::to_allocvec(l).unwrap());
-        }
+        push_labels(&mut labels_bytes, &shapes[1], &mut labels_b);
+        push_labels(&mut labels_bytes, &shapes[0], &mut labels_a);
 
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
@@ -495,6 +556,125 @@ mod tests {
     }
 
     #[test]
+    fn labels_v0x02_rejected_loudly() {
+        // Pre-id-pairing labels records lacked `kind_id`; a substrate
+        // running this build against an old wasm build would silently
+        // fail-merge everything and surface empty field names only at
+        // hub encode time. Reject with a clear version-mismatch error
+        // instead.
+        let old_labels_payload = [0x02, 0x00];
+        let wasm = wasm_with_section(LABELS_SECTION, &old_labels_payload);
+        let err = read_from_bytes(&wasm).unwrap_err();
+        assert!(err.contains("0x2"), "err was: {err}");
+        assert!(err.contains(LABELS_SECTION), "err was: {err}");
+    }
+
+    #[test]
+    fn duplicate_kinds_records_tolerated_under_by_id_pairing() {
+        // `#[handlers]` retention emits both an `aether.kinds` and an
+        // `aether.kinds.labels` record per handler kind; when the
+        // defining crate also emits via `Kind` derive, a kind ends up
+        // with duplicate records in both sections. The by-id merge
+        // tolerates duplicates because records with the same id are
+        // byte-identical by construction (name + schema → canonical
+        // bytes → hash).
+        let shape = KindShape {
+            name: Cow::Borrowed("test.dup"),
+            schema: SchemaShape::Struct {
+                fields: vec![SchemaShape::Scalar(Primitive::U32)],
+                repr_c: true,
+            },
+        };
+        let mut labels = KindLabels {
+            kind_id: 0,
+            kind_label: Cow::Borrowed("my::Dup"),
+            root: LabelNode::Struct {
+                type_label: Some(Cow::Borrowed("my::Dup")),
+                field_names: Cow::Owned(vec![Cow::Borrowed("n")]),
+                fields: Cow::Owned(vec![LabelNode::Anonymous]),
+            },
+        };
+        let mut canonical = Vec::new();
+        push_shape(&mut canonical, &shape);
+        push_shape(&mut canonical, &shape);
+        let mut labels_bytes = Vec::new();
+        push_labels(&mut labels_bytes, &shape, &mut labels);
+        push_labels(&mut labels_bytes, &shape, &mut labels);
+        let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
+        let descs = read_from_bytes(&wasm).unwrap();
+        // Two shape records surface as two descriptors; merging each
+        // with the same labels record by id is the correct behavior
+        // (the substrate's `register_kind_with_descriptor` then
+        // dedupes by id on register).
+        assert_eq!(descs.len(), 2);
+        for desc in &descs {
+            let SchemaType::Struct { fields, .. } = &desc.schema else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields[0].name, "n");
+        }
+    }
+
+    #[test]
+    fn orphan_labels_record_ignored() {
+        // A labels record whose `kind_id` doesn't match any shape is
+        // harmlessly ignored. Future-proofs the reader against mixed
+        // manifests where a third-party emitter contributes labels
+        // for kinds not in this particular binary.
+        let shape = KindShape {
+            name: Cow::Borrowed("present"),
+            schema: SchemaShape::Unit,
+        };
+        let mut orphan = KindLabels {
+            // Deliberately a id that won't match `shape`.
+            kind_id: 0xDEADBEEF_DEADBEEF,
+            kind_label: Cow::Borrowed("my::Missing"),
+            root: LabelNode::Anonymous,
+        };
+        let mut canonical = Vec::new();
+        push_shape(&mut canonical, &shape);
+        let mut labels_bytes = Vec::new();
+        labels_bytes.push(0x03);
+        labels_bytes.extend(postcard::to_allocvec(&orphan).unwrap());
+        let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
+        let descs = read_from_bytes(&wasm).unwrap();
+        assert_eq!(descs.len(), 1);
+        assert_eq!(descs[0].name, "present");
+        let _ = &mut orphan;
+    }
+
+    #[test]
+    fn sokoban_load_level_single_field_has_name() {
+        // Regression: `#[handlers]` retention historically wrote kinds
+        // records into `aether.kinds` without parallel labels records
+        // into `aether.kinds.labels`, desyncing the old by-index
+        // pairing. `demo.sokoban.load_level`'s single `id` field came
+        // back with an empty name, blocking hub encode-from-params
+        // for that kind. With by-id pairing + parallel labels
+        // retention the field name survives all emitter
+        // configurations. Skipped when the wasm isn't built.
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../target/wasm32-unknown-unknown/release/aether_demo_sokoban.wasm"
+        );
+        let Ok(bytes) = std::fs::read(path) else {
+            eprintln!("skipping: sokoban wasm not built at {path}");
+            return;
+        };
+        let descs = read_from_bytes(&bytes).expect("decode");
+        let load_level = descs
+            .iter()
+            .find(|d| d.name == "demo.sokoban.load_level")
+            .expect("load_level descriptor present");
+        let SchemaType::Struct { fields, repr_c } = &load_level.schema else {
+            panic!("expected Struct, got {:?}", load_level.schema);
+        };
+        assert!(*repr_c);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "id");
+    }
+
+    #[test]
     fn enum_shape_merges_variants_and_field_names() {
         let shape = KindShape {
             name: Cow::Borrowed("test.result"),
@@ -512,7 +692,8 @@ mod tests {
                 ],
             },
         };
-        let labels = KindLabels {
+        let mut labels = KindLabels {
+            kind_id: 0,
             kind_label: Cow::Borrowed("my::Outcome"),
             root: LabelNode::Enum {
                 type_label: Some(Cow::Borrowed("my::Outcome")),
@@ -532,10 +713,10 @@ mod tests {
                 ]),
             },
         };
-        let mut canonical = vec![0x02u8];
-        canonical.extend(postcard::to_allocvec(&shape).unwrap());
-        let mut labels_bytes = vec![0x02u8];
-        labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
+        let mut canonical = Vec::new();
+        push_shape(&mut canonical, &shape);
+        let mut labels_bytes = Vec::new();
+        push_labels(&mut labels_bytes, &shape, &mut labels);
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
         let SchemaType::Enum { variants } = &descs[0].schema else {
@@ -587,7 +768,8 @@ mod tests {
         };
         // Array's child goes through a LabelCell::Owned because we
         // build it at runtime here. Derive-time would use Static.
-        let labels = KindLabels {
+        let mut labels = KindLabels {
+            kind_id: 0,
             kind_label: Cow::Borrowed("my::Triangle"),
             root: LabelNode::Struct {
                 type_label: Some(Cow::Borrowed("my::Triangle")),
@@ -595,10 +777,10 @@ mod tests {
                 fields: Cow::Owned(vec![LabelNode::Array(LabelCell::owned(vertex_labels))]),
             },
         };
-        let mut canonical = vec![0x02u8];
-        canonical.extend(postcard::to_allocvec(&shape).unwrap());
-        let mut labels_bytes = vec![0x02u8];
-        labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
+        let mut canonical = Vec::new();
+        push_shape(&mut canonical, &shape);
+        let mut labels_bytes = Vec::new();
+        push_labels(&mut labels_bytes, &shape, &mut labels);
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
         let SchemaType::Struct { fields, .. } = &descs[0].schema else {


### PR DESCRIPTION
## Summary

Fixes the single-field cast-kind descriptor bug flagged post-#202, where `demo.sokoban.load_level`'s `id: u32` field came back with an empty name in `describe_kinds` — blocking `send_mail` from encoding agent params for that kind.

## Root cause

`kind_manifest::read_from_bytes` pairs `aether.kinds` shape records with `aether.kinds.labels` records by array index. That worked under the original assumption that the `Kind` derive is the sole emitter per kind. `#[handlers]` later added retention emission (so kinds defined in rlib dependencies survive wasm-ld `--gc-sections`), but only to `aether.kinds`, without a parallel labels emission. Cardinalities desynced and the Kind-derive `load_level` labels record ended up paired with the wrong shape.

## Fix

- Add `kind_id: u64` to `KindLabels` so each labels record is self-identifying.
- `read_from_bytes` indexes labels by id (`HashMap<u64, KindLabels>`) and looks up per shape via `kind_id_from_shape(&shape)`. Ordering, duplicates, and mixed emitters all work.
- Restore `aether.kinds` retention in `#[handlers]` and add parallel `aether.kinds.labels` retention. With by-id pairing the retention can never misalign.
- New helper: `kind_id_from_shape(&KindShape) -> u64` in `aether_hub_protocol::canonical`, complement to `kind_id_from_parts` (which takes `SchemaType`).

## Wire change

- `aether.kinds.labels` version bumps 0x02 → 0x03. v0x02 is rejected loudly so a substrate running this build against an old wasm build surfaces a clear version-mismatch error rather than silently producing anonymous descriptors.
- `aether.kinds` stays at 0x02 — those bytes are `Kind::ID` hash input and can't move without shifting every id.

## Verification

Post-fix dump of `aether_demo_sokoban.wasm`:

```
== aether.kinds (193 bytes) ==
  [0] demo.sokoban.reset        (derive)
  [1] demo.sokoban.state        (derive)
  [2] aether.tick               (retention, from aether-kinds rlib)
  [3] aether.player.request_step(retention, from aether-kinds rlib)
  [4] demo.sokoban.reset        (retention, duplicate — same id → tolerated)
  [5] demo.sokoban.load_level   (retention)
  [6] demo.sokoban.load_level   (derive, duplicate — same id → tolerated)
== aether.kinds.labels (644 bytes) ==
  [0] aether_demo_sokoban::SokobanReset       (derive)
  [1] aether_demo_sokoban::SokobanState       (derive)
  [2] aether_kinds::Tick                      (retention — labels now emitted!)
  [3] aether_kinds::PlayerRequestStep         (retention)
  [4] aether_demo_sokoban::SokobanReset       (retention)
  [5] aether_demo_sokoban::SokobanLoadLevel   (retention)
  [6] aether_demo_sokoban::SokobanLoadLevel   (derive)
```

Seven records in each section; reader looks up by id, ordering is irrelevant.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] New regression + robustness tests in `kind_manifest::tests`:
  - `reads_multiple_records_pair_by_id` — emits labels in reverse of shape order, confirms by-id lookup.
  - `duplicate_kinds_records_tolerated_under_by_id_pairing` — pins that retention + derive writing the same kind twice is harmless.
  - `orphan_labels_record_ignored` — covers future mixed-emitter cases (labels for a kind not in this binary).
  - `labels_v0x02_rejected_loudly` — pins the version bump.
  - `sokoban_load_level_single_field_has_name` — reads the built sokoban wasm and asserts the original regression is gone.
- [x] MCP harness: `describe_kinds` on a sokoban-loaded substrate shows `demo.sokoban.load_level` with `fields: [{name: "id", ty: U32}]` and `send_mail` with `params: {id: 0}` delivers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)