### PR TITLE
feat(kinds,substrate): audio kinds and sink stubs (ADR-0039 phase 1)

### DIFF
--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -19,12 +19,13 @@ use aether_mail::{Kind, Schema};
 
 use crate::{
     Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
-    Key, KeyRelease, LoadComponent, LoadResult, MouseButton, MouseMove, OrbitSetDistance,
-    OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo,
-    PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition, PlayerSetVelocity,
-    PlayerStepResult, Pong, ReplaceComponent, ReplaceResult, SetWindowMode, SetWindowModeResult,
-    SetWindowTitle, SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick,
-    TopdownSetCenter, TopdownSetExtent, UnresolvedMail, UnsubscribeInput, WindowSize,
+    Key, KeyRelease, LoadComponent, LoadResult, MouseButton, MouseMove, NoteOff, NoteOn,
+    OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping,
+    PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition,
+    PlayerSetVelocity, PlayerStepResult, Pong, ReplaceComponent, ReplaceResult, SetMasterGain,
+    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, SubscribeInput,
+    SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
+    UnsubscribeInput, WindowSize,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -111,6 +112,13 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<PlayerSetMode>(),
         schema::<PlayerRequestStep>(),
         schema::<PlayerStepResult>(),
+        // Desktop MIDI synth (ADR-0039). Components emit `NoteOn` /
+        // `NoteOff` to the `audio` sink on desktop; `SetMasterGain`
+        // controls the substrate-level output scalar. Headless / hub
+        // nop the hot-path kinds and reject `SetMasterGain` loudly.
+        schema::<NoteOn>(),
+        schema::<NoteOff>(),
+        schema::<SetMasterGain>(),
     ]
 }
 
@@ -146,6 +154,9 @@ mod tests {
         assert!(names.contains(&SubscribeInput::NAME));
         assert!(names.contains(&UnsubscribeInput::NAME));
         assert!(names.contains(&SubscribeInputResult::NAME));
+        assert!(names.contains(&NoteOn::NAME));
+        assert!(names.contains(&NoteOff::NAME));
+        assert!(names.contains(&SetMasterGain::NAME));
     }
 
     #[test]
@@ -186,6 +197,9 @@ mod tests {
             FrameStats::NAME,
             Ping::NAME,
             Pong::NAME,
+            NoteOn::NAME,
+            NoteOff::NAME,
+            SetMasterGain::NAME,
         ] {
             let d = descs.iter().find(|d| d.name == name).unwrap();
             let SchemaType::Struct { repr_c, .. } = &d.schema else {

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -390,6 +390,77 @@ pub struct PlayerStepResult {
     pub new_y: f32,
 }
 
+/// Start a note playing on the desktop chassis's MIDI synth (ADR-0039).
+/// `pitch` is a standard MIDI note number (0–127, middle C = 60).
+/// `velocity` is 0–127 (MIDI convention; 0 has the same effect as a
+/// `NoteOff`, but agents should prefer `NoteOff` for clarity).
+/// `instrument_id` indexes the substrate-resident instrument registry
+/// — v1 ships a fixed set; future patch-based instruments (Phase 2
+/// follow-up) will extend the id space without a wire change. The
+/// substrate keys the allocated voice by `(sender_mailbox, instrument_id,
+/// pitch)` so same-pitch notes from different senders or different
+/// instruments don't stomp each other. Fire-and-forget; no reply.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.audio.note_on")]
+pub struct NoteOn {
+    pub pitch: u8,
+    pub velocity: u8,
+    pub instrument_id: u8,
+}
+
+/// Release a note previously started with `NoteOn`. The substrate
+/// matches on `(sender_mailbox, instrument_id, pitch)` — the sender
+/// is taken from the mail envelope, not carried in the payload. A
+/// `NoteOff` that doesn't match any live voice is silently ignored
+/// (normal during race windows between envelope release and late
+/// note-offs). Fire-and-forget; no reply.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_mail::Kind,
+    aether_mail::Schema,
+)]
+#[kind(name = "aether.audio.note_off")]
+pub struct NoteOff {
+    pub pitch: u8,
+    pub instrument_id: u8,
+}
+
+/// Set the substrate's master audio gain. `gain` is a linear scalar
+/// applied to the summed voice output before the cpal device buffer;
+/// `1.0` is unity, `0.0` mutes, values above `1.0` are clamped to
+/// avoid clipping. This is the only substrate-level gain control —
+/// per-source and bus-level attenuation are user-space concerns (ADR-0039).
+/// Desktop-only: headless and hub chassis reply with an
+/// `unsupported on <chassis>` error. Fire-and-forget in the happy path.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
+)]
+#[kind(name = "aether.audio.set_master_gain")]
+pub struct SetMasterGain {
+    pub gain: f32,
+}
+
 /// Request addressed to a component that supports the ADR-0013
 /// reply-to-sender smoke path. The component answers with `Pong`
 /// carrying the same `seq`; the round trip proves that a Claude
@@ -1069,6 +1140,9 @@ mod tests {
         assert_eq!(PlayerSetMode::NAME, "aether.player.set_mode");
         assert_eq!(PlayerRequestStep::NAME, "aether.player.request_step");
         assert_eq!(PlayerStepResult::NAME, "aether.player.step_result");
+        assert_eq!(NoteOn::NAME, "aether.audio.note_on");
+        assert_eq!(NoteOff::NAME, "aether.audio.note_off");
+        assert_eq!(SetMasterGain::NAME, "aether.audio.set_master_gain");
     }
 
     #[test]

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -874,6 +874,23 @@ fn main() -> wasmtime::Result<()> {
         );
     }
 
+    // `aether.audio.*`: Phase 1 stub per ADR-0039. The sink exists so
+    // components emitting NoteOn / NoteOff / SetMasterGain don't
+    // warn-drop, and so the mailbox name resolves on desktop chassis.
+    // Phase 2 wires a cpal stream + synth behind it via an SPSC queue;
+    // for now the handler discards every byte it receives.
+    boot.registry.register_sink(
+        "audio",
+        Arc::new(
+            |_kind_id: u64,
+             _kind_name: &str,
+             _origin: Option<&str>,
+             _sender,
+             _bytes: &[u8],
+             _count: u32| {},
+        ),
+    );
+
     // `aether.camera`: latest-value-wins sink. One payload is 64
     // bytes (4x4 f32 column-major view_proj). The render loop reads
     // the stored value each frame and uploads to the GPU uniform.

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -158,6 +158,22 @@ fn main() -> wasmtime::Result<()> {
              _count: u32| {},
         ),
     );
+    // `aether.audio.*` per ADR-0039: headless has no audio device, so
+    // NoteOn / NoteOff / SetMasterGain are discarded. The sink keeps
+    // the mailbox resolvable so desktop-designed music components
+    // loaded on headless don't warn-storm. Phase 2 adds a loud reject
+    // path specifically for SetMasterGain on this chassis.
+    boot.registry.register_sink(
+        "audio",
+        Arc::new(
+            |_kind_id: u64,
+             _kind_name: &str,
+             _origin: Option<&str>,
+             _sender,
+             _bytes: &[u8],
+             _count: u32| {},
+        ),
+    );
 
     let tick_hz = parse_tick_hz_env();
     let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));

--- a/docs/adr/0039-desktop-midi-synth-and-audio-sink.md
+++ b/docs/adr/0039-desktop-midi-synth-and-audio-sink.md
@@ -1,6 +1,6 @@
 # ADR-0039: Desktop MIDI synthesis and audio sink
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-23
 
 ## Context


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0039 — wire the audio sink into the chassis plumbing without any audio output yet. The next PR (phase 2) adds cpal + a real synth behind this stub.

- Three cast-shaped kinds in aether-kinds: NoteOn, NoteOff, SetMasterGain (all aether.audio.* prefixed; per-field rustdoc covers the sender-keyed voice semantics planned for Phase 2).
- Registered in descriptors::all() with matching coverage tests (covers_every_substrate_kind, cast_kinds_emit_struct_with_repr_c).
- Desktop chassis registers an audio sink that accepts all three kinds and drops the payload.
- Headless chassis registers a nop audio sink so desktop-designed music components don't warn-storm engine_logs when loaded there.
- Hub chassis is untouched (no chassis-specific sinks there).
- ADR-0039 bumped Proposed → Accepted.

Deferred to phase 2:
- cpal stream + Instrument trait + 4–5 built-in instruments.
- Voice table keyed by (sender_mailbox, instrument_id, pitch).
- SPSC from sink to the audio callback thread.
- SetMasterGain control-plane reply path (loud Err on headless/hub; apply on desktop).
- resolve_instrument lookup pair.

## Test plan

- [x] cargo check --workspace
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --workspace
- [x] cargo fmt -- --check

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>