### PR TITLE
feat(kinds): add substrate I/O vocabulary (ADR-0041 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "aether-hub-protocol",
  "aether-mail",
  "bytemuck",
+ "postcard",
  "serde",
 ]
 

--- a/crates/aether-kinds/Cargo.toml
+++ b/crates/aether-kinds/Cargo.toml
@@ -13,3 +13,8 @@ aether-mail = { path = "../aether-mail", features = ["derive"] }
 aether-hub-protocol = { path = "../aether-hub-protocol", default-features = false }
 bytemuck = { version = "1.19", features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+
+[dev-dependencies]
+# ADR-0041 I/O kind roundtrip tests exercise the postcard wire
+# directly (the mail-path `encode_struct` helper wraps this).
+postcard = { version = "1.1", default-features = false, features = ["alloc"] }

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -18,14 +18,15 @@ use aether_hub_protocol::KindDescriptor;
 use aether_mail::{Kind, Schema};
 
 use crate::{
-    Camera, CaptureFrame, CaptureFrameResult, DrawTriangle, DropComponent, DropResult, FrameStats,
-    Key, KeyRelease, LoadComponent, LoadResult, MouseButton, MouseMove, NoteOff, NoteOn,
-    OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping,
-    PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition,
-    PlayerSetVelocity, PlayerStepResult, Pong, ReplaceComponent, ReplaceResult, SetMasterGain,
-    SetMasterGainResult, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
-    SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
-    UnsubscribeInput, WindowSize,
+    Camera, CaptureFrame, CaptureFrameResult, Delete, DeleteResult, DrawTriangle, DropComponent,
+    DropResult, FrameStats, Key, KeyRelease, List, ListResult, LoadComponent, LoadResult,
+    MouseButton, MouseMove, NoteOff, NoteOn, OrbitSetDistance, OrbitSetFov, OrbitSetPitch,
+    OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo, PlatformInfoResult,
+    PlayerRequestStep, PlayerSetMode, PlayerSetPosition, PlayerSetVelocity, PlayerStepResult, Pong,
+    Read, ReadResult, ReplaceComponent, ReplaceResult, SetMasterGain, SetMasterGainResult,
+    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, SubscribeInput,
+    SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
+    UnsubscribeInput, WindowSize, Write, WriteResult,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -120,6 +121,19 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<NoteOff>(),
         schema::<SetMasterGain>(),
         schema::<SetMasterGainResult>(),
+        // Substrate file I/O (ADR-0041). Components mail Read / Write
+        // / Delete / List to the `io` sink with a namespace + path
+        // pair; the substrate resolves the namespace to an adapter
+        // (local file in v1) and replies with the paired `*Result`
+        // kind. Failure variants carry a structured `IoError`.
+        schema::<Read>(),
+        schema::<ReadResult>(),
+        schema::<Write>(),
+        schema::<WriteResult>(),
+        schema::<Delete>(),
+        schema::<DeleteResult>(),
+        schema::<List>(),
+        schema::<ListResult>(),
     ]
 }
 
@@ -158,6 +172,50 @@ mod tests {
         assert!(names.contains(&NoteOn::NAME));
         assert!(names.contains(&NoteOff::NAME));
         assert!(names.contains(&SetMasterGain::NAME));
+        assert!(names.contains(&Read::NAME));
+        assert!(names.contains(&ReadResult::NAME));
+        assert!(names.contains(&Write::NAME));
+        assert!(names.contains(&WriteResult::NAME));
+        assert!(names.contains(&Delete::NAME));
+        assert!(names.contains(&DeleteResult::NAME));
+        assert!(names.contains(&List::NAME));
+        assert!(names.contains(&ListResult::NAME));
+    }
+
+    #[test]
+    fn io_requests_are_postcard_schemas() {
+        // ADR-0041 §1: request kinds carry `String` namespace + path
+        // (and `Vec<u8>` bytes on `Write`), so they must serialize as
+        // non-cast structs. Catches an accidental `#[repr(C)]` +
+        // `Pod` derive that would silently flip the wire format.
+        let descs = all();
+        for name in [Read::NAME, Write::NAME, Delete::NAME, List::NAME] {
+            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let SchemaType::Struct { repr_c, .. } = &d.schema else {
+                panic!("{name} should be Struct, got {:?}", d.schema);
+            };
+            assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
+        }
+    }
+
+    #[test]
+    fn io_results_are_enum_schemas() {
+        // Each reply kind is an Ok/Err enum; `Err` wraps `IoError`,
+        // `Ok` shape varies per operation.
+        let descs = all();
+        for name in [
+            ReadResult::NAME,
+            WriteResult::NAME,
+            DeleteResult::NAME,
+            ListResult::NAME,
+        ] {
+            let d = descs.iter().find(|d| d.name == name).unwrap();
+            assert!(
+                matches!(d.schema, SchemaType::Enum { .. }),
+                "{name} should be Enum, got {:?}",
+                d.schema
+            );
+        }
     }
 
     #[test]

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1050,6 +1050,122 @@ mod control_plane {
         Ok { applied_gain: f32 },
         Err { error: String },
     }
+
+    // ADR-0041 substrate file I/O. Four request kinds on the `"io"`
+    // sink (read / write / delete / list), paired 1:1 with reply kinds
+    // that carry a structured `IoError` on failure. All postcard-
+    // shaped because every request carries String namespace/path
+    // fields and writes carry `Vec<u8>` bytes.
+    //
+    // `namespace` is the logical prefix without the `://`: mail
+    // carries `"save"`, not `"save://"`. Paths are relative to the
+    // namespace root; `..` and absolute prefixes are rejected at the
+    // adapter boundary as `IoError::Forbidden`.
+
+    /// Structured failure reason for an I/O request (ADR-0041 §1).
+    /// Components can pattern-match on the variant to decide whether
+    /// to retry (`AdapterError`), prompt the user (`NotFound`), or
+    /// surface a bug (`Forbidden` / `UnknownNamespace`). `AdapterError`
+    /// preserves backend-specific detail as free-form text — e.g.
+    /// permission-denied text from the OS, an HTTP status from a
+    /// future cloud adapter — without locking the enum shape to any
+    /// one backend.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub enum IoError {
+        NotFound,
+        Forbidden,
+        UnknownNamespace,
+        AdapterError(String),
+    }
+
+    /// `aether.io.read` — request the substrate read a file and reply
+    /// with its bytes. Mailed to the `"io"` sink; reply lands via
+    /// `reply_mail` as `ReadResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.read")]
+    pub struct Read {
+        pub namespace: String,
+        pub path: String,
+    }
+
+    /// Reply to `Read`. `Ok` carries the full file contents (the
+    /// adapter decides whether partial reads are permitted — v1's
+    /// local-file adapter is whole-file only). `Err` carries an
+    /// `IoError` variant.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.read_result")]
+    pub enum ReadResult {
+        Ok { bytes: Vec<u8> },
+        Err { error: IoError },
+    }
+
+    /// `aether.io.write` — request the substrate write `bytes` to
+    /// `namespace://path`. v1's local-file adapter stages to a
+    /// temporary sibling and `rename`s on success so a crash
+    /// mid-write leaves either the old contents or the new, never a
+    /// torn file. Reply: `WriteResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.write")]
+    pub struct Write {
+        pub namespace: String,
+        pub path: String,
+        pub bytes: Vec<u8>,
+    }
+
+    /// Reply to `Write`. `Ok` on success. `Err` carries an `IoError`
+    /// — `Forbidden` for read-only namespaces (e.g. `assets://`),
+    /// `AdapterError` for disk-full / permission / rename failures.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.write_result")]
+    pub enum WriteResult {
+        Ok,
+        Err { error: IoError },
+    }
+
+    /// `aether.io.delete` — request the substrate remove a file.
+    /// Missing files surface as `NotFound` (not silent success) so
+    /// callers that care about the distinction can tell; callers
+    /// that don't ignore it. Reply: `DeleteResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.delete")]
+    pub struct Delete {
+        pub namespace: String,
+        pub path: String,
+    }
+
+    /// Reply to `Delete`. `Ok` on successful removal. `Err` on any
+    /// adapter-reported failure, including `NotFound` for a file
+    /// that wasn't there to delete.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.delete_result")]
+    pub enum DeleteResult {
+        Ok,
+        Err { error: IoError },
+    }
+
+    /// `aether.io.list` — enumerate entries under `prefix` in
+    /// `namespace`. Shallow (no recursion) and prefix-filtered —
+    /// callers that want a tree walk paginate themselves. Empty
+    /// `prefix` lists the namespace root. Reply: `ListResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.list")]
+    pub struct List {
+        pub namespace: String,
+        pub prefix: String,
+    }
+
+    /// Reply to `List`. `Ok` carries the matching entry names —
+    /// bare file/dir names, not fully-qualified paths — so the caller
+    /// composes `{prefix}{entry}` when turning an entry back into a
+    /// read. Empty `Vec` means "namespace exists, nothing matched";
+    /// `Err { UnknownNamespace }` means the namespace itself wasn't
+    /// registered.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.io.list_result")]
+    pub enum ListResult {
+        Ok { entries: Vec<String> },
+        Err { error: IoError },
+    }
 }
 
 #[cfg(test)]
@@ -1159,6 +1275,14 @@ mod tests {
             SetMasterGainResult::NAME,
             "aether.audio.set_master_gain_result"
         );
+        assert_eq!(Read::NAME, "aether.io.read");
+        assert_eq!(ReadResult::NAME, "aether.io.read_result");
+        assert_eq!(Write::NAME, "aether.io.write");
+        assert_eq!(WriteResult::NAME, "aether.io.write_result");
+        assert_eq!(Delete::NAME, "aether.io.delete");
+        assert_eq!(DeleteResult::NAME, "aether.io.delete_result");
+        assert_eq!(List::NAME, "aether.io.list");
+        assert_eq!(ListResult::NAME, "aether.io.list_result");
     }
 
     #[test]
@@ -1248,6 +1372,92 @@ mod tests {
             assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U64));
             assert_eq!(fields[1].name, "triangles");
             assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U64));
+        }
+    }
+
+    // ADR-0041 I/O kind roundtrips. Request types carry String /
+    // Vec<u8>, reply types are Ok/Err enums with the error arm
+    // wrapping `IoError`. postcard roundtrip proves the derived
+    // Serialize/Deserialize agree on the wire for each shape.
+    mod io_roundtrips {
+        use super::*;
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        #[test]
+        fn read_request_roundtrip() {
+            let r = Read {
+                namespace: "save".to_string(),
+                path: "slot1.bin".to_string(),
+            };
+            let bytes = postcard::to_allocvec(&r).unwrap();
+            let back: Read = postcard::from_bytes(&bytes).unwrap();
+            assert_eq!(back.namespace, r.namespace);
+            assert_eq!(back.path, r.path);
+        }
+
+        #[test]
+        fn read_result_ok_roundtrip() {
+            let r = ReadResult::Ok {
+                bytes: vec![1, 2, 3, 4],
+            };
+            let bytes = postcard::to_allocvec(&r).unwrap();
+            let back: ReadResult = postcard::from_bytes(&bytes).unwrap();
+            match back {
+                ReadResult::Ok { bytes } => assert_eq!(bytes, vec![1, 2, 3, 4]),
+                ReadResult::Err { .. } => panic!("expected Ok"),
+            }
+        }
+
+        #[test]
+        fn read_result_err_roundtrip_preserves_io_error_variant() {
+            let r = ReadResult::Err {
+                error: IoError::NotFound,
+            };
+            let bytes = postcard::to_allocvec(&r).unwrap();
+            let back: ReadResult = postcard::from_bytes(&bytes).unwrap();
+            assert!(matches!(
+                back,
+                ReadResult::Err {
+                    error: IoError::NotFound
+                }
+            ));
+        }
+
+        #[test]
+        fn io_error_adapter_carries_payload() {
+            let e = IoError::AdapterError("disk full".to_string());
+            let bytes = postcard::to_allocvec(&e).unwrap();
+            let back: IoError = postcard::from_bytes(&bytes).unwrap();
+            match back {
+                IoError::AdapterError(msg) => assert_eq!(msg, "disk full"),
+                other => panic!("expected AdapterError, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn write_request_roundtrip() {
+            let w = Write {
+                namespace: "save".to_string(),
+                path: "state.bin".to_string(),
+                bytes: vec![0xde, 0xad, 0xbe, 0xef],
+            };
+            let bytes = postcard::to_allocvec(&w).unwrap();
+            let back: Write = postcard::from_bytes(&bytes).unwrap();
+            assert_eq!(back.bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+        }
+
+        #[test]
+        fn list_result_ok_roundtrip_preserves_entry_order() {
+            let r = ListResult::Ok {
+                entries: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            };
+            let bytes = postcard::to_allocvec(&r).unwrap();
+            let back: ListResult = postcard::from_bytes(&bytes).unwrap();
+            match back {
+                ListResult::Ok { entries } => assert_eq!(entries, vec!["a", "b", "c"]),
+                ListResult::Err { .. } => panic!("expected Ok"),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds the eight I/O kinds ADR-0041 commits to: `Read`/`Write`/`Delete`/`List` request kinds on `aether.io.*`, each paired 1:1 with an Ok/Err result kind.
- Introduces `IoError` as a structured failure enum (NotFound, Forbidden, UnknownNamespace, AdapterError(String)) so components pattern-match on reason instead of parsing free-form text.
- Registers every new kind in `descriptors::all()` and locks the shape with: `covers_every_substrate_kind` inclusion, `io_requests_are_postcard_schemas` / `io_results_are_enum_schemas` wire-shape checks, and roundtrip tests for Read/Write request + Read/List result + IoError::AdapterError payload.

## Test plan
- [x] `cargo test -p aether-kinds` (26 tests, 7 new roundtrips + 2 new schema-shape asserts)
- [x] `cargo test --workspace` green
- [x] `cargo clippy --all-targets -- -D warnings` green
- [x] `cargo fmt -- --check` clean

Follow-on phases (separate PRs): substrate-side `FileAdapter` trait + `LocalFileAdapter` + the `"io"` sink dispatcher + env-var config; then SDK ergonomics (`ctx.read()` / `ctx.write()` helpers).