### PR TITLE
feat(substrate): per-component sync-wait filter slot (ADR-0042)

### DIFF
--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -3,11 +3,14 @@
 // written to the guest at a static `MAIL_OFFSET`; a guest-side
 // allocator is parked until an actual use case forces the question.
 
+use std::sync::Arc;
+
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
 use crate::mail::{Mail, ReplyTo};
 use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
+use crate::wait::FilterSlot;
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -204,6 +207,16 @@ impl Component {
             (bundle.version, STATE_OFFSET, bundle.bytes.len() as u32),
         )?;
         Ok(())
+    }
+
+    /// Share the ADR-0042 sync-wait filter slot with the per-mailbox
+    /// scheduler entry. The slot is created by `SubstrateCtx::new`;
+    /// this method hands out a cloned `Arc` so the mailer's send path
+    /// (running on the pushing thread) and the host fn populating
+    /// the slot (running on the component's dispatcher thread) route
+    /// through the same instance.
+    pub fn filter_slot(&self) -> Arc<FilterSlot> {
+        Arc::clone(&self.store.data().filter_slot)
     }
 
     /// Read a `u32` from guest linear memory at `offset`. Test-only

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -479,13 +479,22 @@ impl ControlPlane {
         let saved = old_component.take_saved_state();
         old_component.on_drop();
 
+        // ADR-0042: the ADR-0022 invariant that a replaced mailbox is
+        // continuous — same `MailboxId`, preserved subscriptions,
+        // buffered mail drains through the new instance — extends to
+        // the sync-wait filter slot. The `ComponentEntry` consults a
+        // specific `Arc<FilterSlot>` on `send`; the incoming
+        // `SubstrateCtx` has to point at that same `Arc` so the new
+        // instance's `wait_reply_p32` host fn installs filters where
+        // `send` actually looks for them.
         let ctx = SubstrateCtx::new(
             id,
             Arc::clone(&self.registry),
             Arc::clone(&self.queue),
             Arc::clone(&self.outbound),
             Arc::clone(&self.input_subscribers),
-        );
+        )
+        .with_filter_slot(entry.filter_slot());
         let mut new_component =
             match Component::instantiate(&self.engine, &self.linker, &module, ctx) {
                 Ok(c) => c,

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -17,6 +17,7 @@ use crate::mail::{Mail, MailKind, MailboxId, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::{MailboxEntry, Registry};
 use crate::reply_table::ReplyTable;
+use crate::wait::FilterSlot;
 
 /// ADR-0016 §3: opt-in state migration payload. The substrate owns the
 /// buffer from the moment `save_state` is called on the old instance
@@ -67,6 +68,13 @@ pub struct SubstrateCtx {
     /// the replace; the substrate checks this after `on_replace` and
     /// surfaces the message back up the control plane.
     pub save_state_error: Option<String>,
+    /// ADR-0042 per-component sync-wait filter slot, shared by-Arc
+    /// with `ComponentEntry` so the mailer's send path can divert
+    /// matching mail to a parked waiter's oneshot before touching the
+    /// mpsc inbox. PR-1 only installs the plumbing; the
+    /// `wait_reply_p32` host fn that populates the slot lands in a
+    /// follow-up PR.
+    pub filter_slot: Arc<FilterSlot>,
 }
 
 impl SubstrateCtx {
@@ -91,7 +99,19 @@ impl SubstrateCtx {
             reply_table: ReplyTable::new(),
             saved_state: None,
             save_state_error: None,
+            filter_slot: Arc::new(FilterSlot::new()),
         }
+    }
+
+    /// Replace the ADR-0042 filter slot with one inherited from an
+    /// existing `ComponentEntry`. `handle_replace` calls this so the
+    /// incoming instance shares the mailbox's slot — the same `Arc`
+    /// that `ComponentEntry::send` consults — rather than booting with
+    /// a fresh one the entry would never see. Fresh loads leave the
+    /// default slot created by `new`.
+    pub fn with_filter_slot(mut self, slot: Arc<FilterSlot>) -> Self {
+        self.filter_slot = slot;
+        self
     }
 
     /// Dispatch mail. If the recipient is a sink, the handler runs inline

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mailer;
 pub mod registry;
 pub mod reply_table;
 pub mod scheduler;
+pub mod wait;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use chassis::{Chassis, ChassisCapabilities};

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -33,6 +33,7 @@ use crate::component::{Component, DISPATCH_UNKNOWN_KIND};
 use crate::mail::{Mail, MailboxId};
 use crate::mailer::Mailer;
 use crate::registry::Registry;
+use crate::wait::FilterSlot;
 
 /// Per-entry quiescence counter + condvar, shared with the dispatcher
 /// thread. `send` increments `pending` before forwarding to the inbox;
@@ -66,6 +67,14 @@ pub struct ComponentEntry {
     /// to the whole entry (which would create a cycle through the
     /// `JoinHandle`).
     gate: Arc<PendingGate>,
+    /// ADR-0042 sync-wait filter slot, shared by-Arc with the
+    /// component's `SubstrateCtx`. `send` consults it on the
+    /// pushing thread so matching mail lands directly on the
+    /// waiter's oneshot instead of the mpsc — the dispatcher
+    /// thread is already parked inside `deliver` while a wait is
+    /// in flight, so a check at the dispatcher's `rx.recv()` could
+    /// never run.
+    filter_slot: Arc<FilterSlot>,
 }
 
 impl ComponentEntry {
@@ -76,6 +85,7 @@ impl ComponentEntry {
         let (tx, rx) = mpsc::channel();
         let gate: Arc<PendingGate> = Arc::new(PendingGate::default());
         let gate_for_thread = Arc::clone(&gate);
+        let filter_slot = component.filter_slot();
         let handle = thread::Builder::new()
             .name("aether-component-dispatch".into())
             .spawn(move || dispatcher_loop(component, rx, registry, gate_for_thread))
@@ -84,6 +94,7 @@ impl ComponentEntry {
             sender: Mutex::new(Some(tx)),
             handle: Mutex::new(Some(handle)),
             gate,
+            filter_slot,
         }
     }
 
@@ -94,6 +105,15 @@ impl ComponentEntry {
     /// the counter is left untouched (nothing to deliver, nothing to
     /// drain).
     pub fn send(&self, mail: Mail) -> bool {
+        // ADR-0042: if a `wait_reply_p32` host fn is parked on the
+        // dispatcher thread and has registered a matching kind, hand
+        // the mail straight to its oneshot and skip the inbox. No
+        // `deliver` call is owed, so the pending counter stays
+        // untouched on this branch.
+        let mail = match self.filter_slot.try_match(mail) {
+            Ok(()) => return true,
+            Err(mail) => mail,
+        };
         let guard = self.sender.lock().unwrap();
         let Some(tx) = guard.as_ref() else {
             return false;
@@ -107,6 +127,14 @@ impl ComponentEntry {
             decrement_and_notify(&self.gate);
             false
         }
+    }
+
+    /// Expose the filter slot so the `wait_reply_p32` host fn (landing
+    /// in a follow-up PR) can install filters without reaching back
+    /// through the scheduler. Cheap `Arc::clone` — callers keep the
+    /// handle for the duration of a single wait.
+    pub fn filter_slot(&self) -> Arc<FilterSlot> {
+        Arc::clone(&self.filter_slot)
     }
 
     /// Block until every mail ever sent to this entry has been
@@ -140,6 +168,12 @@ fn decrement_and_notify(gate: &PendingGate) {
 /// Panics if the handle / sender have already been taken (a prior
 /// `close_and_join` or `splice_inbox` consumed them).
 pub fn close_and_join(entry: Arc<ComponentEntry>) -> Component {
+    // ADR-0042 §5: any in-flight sync wait must unpark before we try
+    // to join. Clearing the filter drops the oneshot sender; the
+    // dispatcher's parked `recv_timeout` wakes with `Disconnected` and
+    // the host fn returns the cancellation code, letting `deliver`
+    // return so the dispatcher can observe the closed inbox.
+    entry.filter_slot.clear();
     // Drop the Sender so the dispatcher sees recv() == None after it
     // drains any queued mail.
     let _ = entry
@@ -169,6 +203,12 @@ pub fn close_and_join(entry: Arc<ComponentEntry>) -> Component {
 /// between the `splice_inbox` return and the new dispatcher's spawn
 /// buffers in the new `Receiver`, preserving FIFO across the swap.
 pub fn splice_inbox(entry: &Arc<ComponentEntry>) -> (Component, Receiver<Mail>) {
+    // ADR-0042 §5: cancel any in-flight wait on the outgoing
+    // instance. Same invariant as `close_and_join`: the old
+    // dispatcher can't hit its closed-inbox exit condition while
+    // parked inside `wait_reply_p32`, so the oneshot must disconnect
+    // first. The successor instance starts with an empty slot.
+    entry.filter_slot.clear();
     let (new_tx, new_rx) = mpsc::channel();
     let old_tx = entry
         .sender
@@ -326,3 +366,125 @@ pub fn drain_all(components: &ComponentTable) {
 // returns `None`). The scheduler no longer owns a router thread, so
 // its `Drop` impl is redundant — the owning layer (chassis / test)
 // disposes of the `ComponentTable` when it wants dispatchers to exit.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::RecvTimeoutError;
+    use std::time::Duration;
+
+    use wasmtime::{Engine, Linker, Module};
+
+    use super::*;
+    use crate::ctx::SubstrateCtx;
+    use crate::hub_client::HubOutbound;
+    use crate::input;
+
+    /// Minimal guest: just exports `memory` and a no-op `receive_p32`.
+    /// Enough to satisfy `Component::instantiate`; these tests only
+    /// exercise the `ComponentEntry` send path, never `deliver`.
+    const WAT_NOOP: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                i32.const 0))
+    "#;
+
+    fn minimal_component() -> Component {
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        crate::host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT_NOOP).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        let ctx = SubstrateCtx::new(
+            MailboxId(0),
+            Arc::new(Registry::new()),
+            Arc::new(Mailer::new()),
+            HubOutbound::disconnected(),
+            input::new_subscribers(),
+        );
+        Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate")
+    }
+
+    fn spawn_entry() -> Arc<ComponentEntry> {
+        Arc::new(ComponentEntry::spawn(
+            minimal_component(),
+            Arc::new(Registry::new()),
+        ))
+    }
+
+    /// ADR-0042: matching mail on an installed filter bypasses the
+    /// mpsc and lands directly on the waiter's oneshot. The pending
+    /// counter is untouched — there's no `deliver` call owed.
+    #[test]
+    fn send_matching_mail_hands_off_to_filter_and_skips_pending() {
+        let entry = spawn_entry();
+        let slot = entry.filter_slot();
+        let rx = slot.install(0xAA);
+
+        assert!(entry.send(Mail::new(MailboxId(0), 0xAA, vec![7, 8, 9], 1)));
+
+        let delivered = rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("matched mail delivered on oneshot");
+        assert_eq!(delivered.kind, 0xAA);
+        assert_eq!(delivered.payload, vec![7, 8, 9]);
+        assert_eq!(
+            entry.gate.pending.load(Ordering::Acquire),
+            0,
+            "filter-match path must not touch pending",
+        );
+        // drain returns immediately because pending is zero.
+        entry.drain();
+    }
+
+    /// Non-matching mail falls through to the inbox even when a
+    /// filter is installed. The pending counter ticks up the normal
+    /// amount; the no-op dispatcher will drain it.
+    #[test]
+    fn send_non_matching_mail_falls_through_to_inbox() {
+        let entry = spawn_entry();
+        let slot = entry.filter_slot();
+        let _rx = slot.install(0xAA);
+
+        assert!(entry.send(Mail::new(MailboxId(0), 0xBB, vec![1], 1)));
+
+        // Wait for the no-op dispatcher to consume the mail. drain
+        // blocks on the condvar until pending hits zero.
+        entry.drain();
+        assert_eq!(entry.gate.pending.load(Ordering::Acquire), 0);
+    }
+
+    /// ADR-0042 §5: `close_and_join` must cancel any in-flight sync
+    /// wait before joining. The parked waiter's `recv_timeout` wakes
+    /// with `Disconnected`, which the host fn will surface to the
+    /// guest as the `-3` cancellation code.
+    #[test]
+    fn close_and_join_cancels_in_flight_wait() {
+        let entry = spawn_entry();
+        let rx = entry.filter_slot().install(0xAA);
+
+        let _component = close_and_join(entry);
+
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Err(RecvTimeoutError::Disconnected) => {}
+            other => panic!("expected Disconnected after close_and_join, got {other:?}"),
+        }
+    }
+
+    /// ADR-0042 §5 applied to replace: `splice_inbox` clears the
+    /// filter before joining the old dispatcher. The successor
+    /// instance starts with an empty slot.
+    #[test]
+    fn splice_inbox_cancels_in_flight_wait() {
+        let entry = spawn_entry();
+        let slot = entry.filter_slot();
+        let rx = slot.install(0xAA);
+
+        let (_old_component, _new_rx) = splice_inbox(&entry);
+
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Err(RecvTimeoutError::Disconnected) => {}
+            other => panic!("expected Disconnected after splice_inbox, got {other:?}"),
+        }
+    }
+}

--- a/crates/aether-substrate-core/src/wait.rs
+++ b/crates/aether-substrate-core/src/wait.rs
@@ -1,0 +1,185 @@
+// ADR-0042 per-component sync-wait filter slot.
+//
+// A component parked inside the `wait_reply_p32` host fn registers an
+// `expected_kind` with its entry's `FilterSlot` and parks its OS
+// thread on the returned `Receiver`. The mailer's send path consults
+// the slot before pushing into the component's mpsc: matching mail is
+// handed directly to the oneshot and bypasses the inbox entirely;
+// non-matching mail falls through and queues normally, draining
+// through `deliver` once the parked host fn returns.
+//
+// The slot is single-valued: only one wait in flight per component.
+// Installing a second filter while one is outstanding drops the old
+// sender, which wakes the prior waiter with `Disconnected` — the host
+// fn observes that as the cancellation code the ADR specifies.
+// ADR-0042 §5: replace/drop clear the slot through the same path so
+// an in-flight wait never outlives its component.
+
+use std::sync::Mutex;
+use std::sync::mpsc::{self, Receiver, SendError, Sender};
+
+use crate::mail::Mail;
+
+struct Filter {
+    expected_kind: u64,
+    tx: Sender<Mail>,
+}
+
+#[derive(Default)]
+pub struct FilterSlot {
+    inner: Mutex<Option<Filter>>,
+}
+
+impl FilterSlot {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Install a filter for `expected_kind` and return the `Receiver`
+    /// the caller parks on. Any previously-installed filter is
+    /// dropped; its waiter observes `Disconnected` (ADR-0042's `-3`
+    /// cancellation code) — the single-slot invariant is enforced
+    /// here rather than relying on callers.
+    pub fn install(&self, expected_kind: u64) -> Receiver<Mail> {
+        let (tx, rx) = mpsc::channel();
+        *self.inner.lock().unwrap() = Some(Filter { expected_kind, tx });
+        rx
+    }
+
+    /// Clear any installed filter. The sender drops, so a parked
+    /// `recv_timeout` wakes with `Disconnected`. No-op if the slot is
+    /// empty. Called by `splice_inbox` / `close_and_join` on the
+    /// control-plane thread when tearing down the component.
+    pub fn clear(&self) {
+        self.inner.lock().unwrap().take();
+    }
+
+    /// Offer `mail` to the installed filter. Returns `Ok(())` if the
+    /// filter's `expected_kind` matches — the mail is handed to the
+    /// waiter's `Receiver` and the filter is consumed (single-shot).
+    /// Returns `Err(mail)` when no filter is installed, when the
+    /// kinds don't match, or when the waiter has already dropped the
+    /// receiver (timeout race). In every `Err` path the caller
+    /// recovers the unconsumed mail and falls through to normal
+    /// mpsc routing.
+    pub fn try_match(&self, mail: Mail) -> Result<(), Mail> {
+        let mut slot = self.inner.lock().unwrap();
+        let matches = matches!(slot.as_ref(), Some(f) if f.expected_kind == mail.kind);
+        if !matches {
+            return Err(mail);
+        }
+        let filter = slot.take().expect("match implies slot is Some");
+        drop(slot);
+        match filter.tx.send(mail) {
+            Ok(()) => Ok(()),
+            Err(SendError(mail)) => Err(mail),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::RecvTimeoutError;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::mail::{Mail, MailboxId};
+
+    fn mail_for(kind: u64, payload: Vec<u8>) -> Mail {
+        Mail::new(MailboxId(0), kind, payload, 1)
+    }
+
+    #[test]
+    fn install_and_match_hands_off_mail() {
+        let slot = FilterSlot::new();
+        let rx = slot.install(0xAA);
+
+        let result = slot.try_match(mail_for(0xAA, vec![1, 2, 3]));
+        assert!(result.is_ok());
+
+        let delivered = rx
+            .recv_timeout(Duration::from_millis(50))
+            .expect("matched mail delivered");
+        assert_eq!(delivered.kind, 0xAA);
+        assert_eq!(delivered.payload, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn mismatch_returns_mail_and_preserves_filter() {
+        let slot = FilterSlot::new();
+        let rx = slot.install(0xAA);
+
+        let miss = slot
+            .try_match(mail_for(0xBB, vec![9]))
+            .expect_err("kind mismatch returns mail");
+        assert_eq!(miss.kind, 0xBB);
+        assert_eq!(miss.payload, vec![9]);
+
+        // Filter is still installed — matching mail afterwards still
+        // wins.
+        slot.try_match(mail_for(0xAA, vec![]))
+            .expect("filter still active");
+        let delivered = rx
+            .recv_timeout(Duration::from_millis(50))
+            .expect("matched mail delivered after miss");
+        assert_eq!(delivered.kind, 0xAA);
+    }
+
+    #[test]
+    fn match_consumes_filter() {
+        let slot = FilterSlot::new();
+        let _rx = slot.install(0xAA);
+
+        slot.try_match(mail_for(0xAA, vec![]))
+            .expect("first match wins");
+        // Second matching mail falls through — filter is gone.
+        let miss = slot
+            .try_match(mail_for(0xAA, vec![]))
+            .expect_err("filter consumed on match");
+        assert_eq!(miss.kind, 0xAA);
+    }
+
+    #[test]
+    fn clear_wakes_waiter_with_disconnect() {
+        let slot = FilterSlot::new();
+        let rx = slot.install(0xAA);
+
+        slot.clear();
+        match rx.recv_timeout(Duration::from_millis(50)) {
+            Err(RecvTimeoutError::Disconnected) => {}
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn second_install_cancels_previous_waiter() {
+        let slot = FilterSlot::new();
+        let rx_first = slot.install(0xAA);
+        let _rx_second = slot.install(0xBB);
+
+        // The old sender dropped; the original waiter observes
+        // Disconnected and the host fn will return ADR-0042's `-3`.
+        match rx_first.recv_timeout(Duration::from_millis(50)) {
+            Err(RecvTimeoutError::Disconnected) => {}
+            other => panic!("expected Disconnected after reinstall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn match_after_receiver_dropped_returns_mail() {
+        let slot = FilterSlot::new();
+        {
+            let _rx = slot.install(0xAA);
+            // Receiver dropped at end of scope; filter still nominally
+            // installed on the slot but the channel is broken.
+        }
+
+        let miss = slot
+            .try_match(mail_for(0xAA, vec![1]))
+            .expect_err("dead receiver returns mail to caller");
+        assert_eq!(miss.kind, 0xAA);
+        assert_eq!(miss.payload, vec![1]);
+    }
+}


### PR DESCRIPTION
First of three follow-on PRs from ADR-0042 (synchronous mail wait primitive). Runtime plumbing only — no host fn or SDK surface.

## What

- New `wait.rs` module with `FilterSlot`: install → `Receiver<Mail>`; `try_match` hands off on kind-match and consumes the filter; `clear` drops the sender so a parked receiver wakes with `Disconnected`.
- `ComponentEntry` now holds the slot's Arc, shared with the component's `SubstrateCtx`. `send` consults the filter on the pushing thread; matches bypass the mpsc entirely and don't touch the pending counter.
- `SubstrateCtx::with_filter_slot` builder lets `handle_replace` inherit the outgoing mailbox's slot, so the ADR-0022 mailbox-continuity invariant extends to sync-wait state.
- `splice_inbox` and `close_and_join` clear the slot before joining the old dispatcher — a wait parked inside a host fn inside `deliver` would otherwise block teardown past its timeout.

## Why send-time, not dispatch-time

Under ADR-0038 (actor-per-component) the dispatcher thread IS the component thread. A wait parks the dispatcher inside `deliver`, so any filter check at `rx.recv()` could never run while a wait is in flight. Checking at `ComponentEntry::send` — which runs on the mailer's thread — puts the match on the only thread that can still observe incoming mail.

## What is NOT in this PR

- The `wait_reply_p32` host fn (follow-up PR 2).
- Guest SDK wrappers `io::read_sync` etc. (follow-up PR 3).

The slot has no populator yet; the dispatch plumbing is exercised directly by the scheduler tests (install filter → send matching → receive on oneshot; cancel on teardown).

## Tests

- `wait::tests::*` — 6 tests on `FilterSlot` directly (install/match/clear/double-install cancellation/dead-receiver recovery).
- `scheduler::tests::*` — 4 tests wiring a real `Component` through `ComponentEntry`: match bypasses pending, mismatch falls through, both teardown paths cancel.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`

Refs: ADR-0042 Follow-up Work item 1.