### PR TITLE
feat(substrate): wait_reply_p32 host fn (ADR-0042)

### DIFF
--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -736,4 +736,183 @@ mod tests {
             "reply to dropped mailbox must not enqueue"
         );
     }
+
+    /// ADR-0042 `wait_reply_p32` host fn. The guest expects a reply
+    /// of kind `0xAAAA_AAAA_AAAA_AAAA`, writes a maximum of 64 bytes
+    /// starting at offset 600, and uses the mail's `count` field as
+    /// the `timeout_ms` argument so tests can vary it per invocation.
+    /// The host fn's return value (bytes written, or a negative
+    /// sentinel) lands at offset 700.
+    const WAT_SYNC_WAIT: &str = r#"
+        (module
+            (import "aether" "wait_reply_p32"
+                (func $wait (param i64 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                i32.const 700
+                (call $wait
+                    (i64.const -6148914691236517206) ;; 0xAAAA_AAAA_AAAA_AAAA reinterpreted as i64
+                    (i32.const 600)                  ;; out_ptr
+                    (i32.const 64)                   ;; out_cap
+                    (local.get 2))                   ;; timeout_ms = count
+                i32.store
+                i32.const 0))
+    "#;
+
+    const SYNC_WAIT_EXPECTED_KIND: u64 = 0xAAAA_AAAA_AAAA_AAAA;
+
+    /// Helper: build a trigger mail whose `count` field carries the
+    /// timeout_ms argument into the WAT. The `kind` is irrelevant —
+    /// the guest ignores it and passes a hardcoded `expected_kind` to
+    /// the host fn.
+    fn trigger_wait(timeout_ms: u32) -> Mail {
+        use crate::mail::MailboxId;
+        Mail::new(MailboxId(0), 0xBEEF, vec![], timeout_ms)
+    }
+
+    #[test]
+    fn wait_reply_returns_timeout_when_no_match_arrives() {
+        let mut component = instantiate(WAT_SYNC_WAIT);
+        component.deliver(&trigger_wait(10)).expect("deliver");
+
+        let result = component.read_u32(700) as i32;
+        assert_eq!(
+            result,
+            crate::host_fns::WAIT_TIMEOUT,
+            "no matching mail pushed — expected WAIT_TIMEOUT",
+        );
+    }
+
+    #[test]
+    fn wait_reply_poll_mode_returns_timeout_immediately() {
+        // timeout_ms = 0 → try_recv path; no pre-queued mail → -1.
+        let mut component = instantiate(WAT_SYNC_WAIT);
+        component.deliver(&trigger_wait(0)).expect("deliver");
+
+        let result = component.read_u32(700) as i32;
+        assert_eq!(result, crate::host_fns::WAIT_TIMEOUT);
+    }
+
+    #[test]
+    fn wait_reply_writes_payload_and_returns_byte_count_on_match() {
+        use std::thread;
+        use std::time::Duration;
+
+        use wasmtime::{Engine, Linker, Module};
+
+        use crate::host_fns;
+        use crate::mail::MailboxId as M;
+
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT_SYNC_WAIT).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        let ctx = ctx();
+        // Stash the filter slot before ctx moves into the component —
+        // the push thread matches against it directly.
+        let filter_slot = Arc::clone(&ctx.filter_slot);
+        let component =
+            Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
+
+        // Deliver on a worker so we can push the matching mail from
+        // this thread while the guest is parked in the host fn.
+        let handle = thread::spawn(move || {
+            let mut component = component;
+            component.deliver(&trigger_wait(1000)).expect("deliver");
+            component
+        });
+
+        // Nudge past the `install`+`recv_timeout` prelude. The filter
+        // has to be installed before `try_match` will route to it.
+        thread::sleep(Duration::from_millis(50));
+
+        let payload = vec![1, 2, 3, 4, 5];
+        filter_slot
+            .try_match(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload.clone(), 1))
+            .expect("match");
+
+        let mut component = handle.join().expect("worker panicked");
+        let result = component.read_u32(700) as i32;
+        assert_eq!(result, payload.len() as i32, "byte count returned");
+        assert_eq!(
+            component.read_bytes(600, payload.len()),
+            payload,
+            "payload copied into guest memory at out_ptr",
+        );
+    }
+
+    #[test]
+    fn wait_reply_returns_buffer_too_small_when_payload_exceeds_cap() {
+        use std::thread;
+        use std::time::Duration;
+
+        use wasmtime::{Engine, Linker, Module};
+
+        use crate::host_fns;
+        use crate::mail::MailboxId as M;
+
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT_SYNC_WAIT).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        let ctx = ctx();
+        let filter_slot = Arc::clone(&ctx.filter_slot);
+        let component =
+            Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
+
+        let handle = thread::spawn(move || {
+            let mut component = component;
+            component.deliver(&trigger_wait(1000)).expect("deliver");
+            component
+        });
+
+        thread::sleep(Duration::from_millis(50));
+
+        // WAT's out_cap is 64; push a 128-byte payload.
+        let payload = vec![0x7Fu8; 128];
+        filter_slot
+            .try_match(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload, 1))
+            .expect("match");
+
+        let mut component = handle.join().expect("worker panicked");
+        let result = component.read_u32(700) as i32;
+        assert_eq!(result, host_fns::WAIT_BUFFER_TOO_SMALL);
+    }
+
+    #[test]
+    fn wait_reply_returns_cancelled_when_slot_cleared() {
+        use std::thread;
+        use std::time::Duration;
+
+        use wasmtime::{Engine, Linker, Module};
+
+        use crate::host_fns;
+
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT_SYNC_WAIT).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        let ctx = ctx();
+        let filter_slot = Arc::clone(&ctx.filter_slot);
+        let component =
+            Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
+
+        let handle = thread::spawn(move || {
+            let mut component = component;
+            component.deliver(&trigger_wait(1000)).expect("deliver");
+            component
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        // Teardown-style cancellation: clear the slot so the waiter
+        // observes a `Disconnected` on its oneshot.
+        filter_slot.clear();
+
+        let mut component = handle.join().expect("worker panicked");
+        let result = component.read_u32(700) as i32;
+        assert_eq!(result, host_fns::WAIT_CANCELLED);
+    }
 }

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -4,6 +4,10 @@
 // surface. Growth of this surface should be reviewed as deliberately
 // as any other architectural change.
 
+use std::sync::Arc;
+use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
+use std::time::Duration;
+
 use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
 use wasmtime::{Caller, Linker};
 
@@ -38,6 +42,20 @@ pub const SAVE_STATE_OK: u32 = 0;
 pub const SAVE_STATE_NO_MEMORY: u32 = 1;
 pub const SAVE_STATE_OOB: u32 = 2;
 pub const SAVE_STATE_TOO_LARGE: u32 = 3;
+
+/// Sentinel return values for `wait_reply_p32` (ADR-0042 §1). A
+/// non-negative result is the number of payload bytes written to the
+/// guest's out buffer; negatives are disjoint error codes.
+pub const WAIT_TIMEOUT: i32 = -1;
+pub const WAIT_BUFFER_TOO_SMALL: i32 = -2;
+pub const WAIT_CANCELLED: i32 = -3;
+
+/// Upper bound on the `timeout_ms` arg to `wait_reply_p32` (ADR-0042
+/// §3). Matches `capture_frame`'s ceiling so any substrate-side bug
+/// can't park a component thread indefinitely. Guests that want a
+/// genuine "wait forever" pass this constant and accept the eventual
+/// `WAIT_TIMEOUT`.
+pub const MAX_WAIT_TIMEOUT_MS: u32 = 30_000;
 
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
@@ -215,6 +233,90 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // `resolve_mailbox_p32` was retired in ADR-0029: mailbox ids are
     // now a deterministic hash of the mailbox name, computed on the
     // guest side. The corresponding host fn is gone.
+
+    // ADR-0042: synchronous mail wait. The guest parks on a reply
+    // whose kind id matches `expected_kind`; the scheduler's send
+    // path diverts matching mail to the waiter's oneshot (PR 1). On
+    // match we copy the payload into the guest's `out` buffer and
+    // return the byte count; non-negative return means "success,
+    // this many bytes written." Negative codes (`-1`/`-2`/`-3`)
+    // are the failure modes the ADR enumerates.
+    //
+    // The host fn blocks the dispatcher thread for the duration of
+    // the wait — under ADR-0038's actor-per-component model the
+    // dispatcher IS the component thread, so parking it is the
+    // whole mechanism. Mail pushed to this component during the
+    // wait either matches (handed to the oneshot) or queues in the
+    // mpsc (drains through `deliver` after the wait returns).
+    linker.func_wrap(
+        "aether",
+        "wait_reply_p32",
+        |mut caller: Caller<'_, SubstrateCtx>,
+         expected_kind: u64,
+         out_ptr: u32,
+         out_cap: u32,
+         timeout_ms: u32|
+         -> i32 {
+            let filter_slot = Arc::clone(&caller.data().filter_slot);
+            let rx = filter_slot.install(expected_kind);
+
+            let clamped = timeout_ms.min(MAX_WAIT_TIMEOUT_MS);
+            let recv = if clamped == 0 {
+                // ADR-0042 §6: `timeout_ms == 0` polls the oneshot
+                // once without parking — useful for "check if a
+                // reply already landed" without paying a
+                // scheduler round trip.
+                match rx.try_recv() {
+                    Ok(m) => Ok(m),
+                    Err(TryRecvError::Empty) => Err(RecvTimeoutError::Timeout),
+                    Err(TryRecvError::Disconnected) => Err(RecvTimeoutError::Disconnected),
+                }
+            } else {
+                rx.recv_timeout(Duration::from_millis(clamped as u64))
+            };
+
+            let mail = match recv {
+                Ok(m) => m,
+                Err(RecvTimeoutError::Timeout) => {
+                    // Clear eagerly so a late-arriving matching mail
+                    // doesn't consume the now-dead filter — `try_match`
+                    // would already recover the mail on a dead sender,
+                    // but clearing avoids that extra round trip for
+                    // every subsequent send until the next install.
+                    filter_slot.clear();
+                    return WAIT_TIMEOUT;
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    // ADR-0042 §5: teardown cleared the slot before
+                    // dropping the sender. Nothing left to clean up.
+                    return WAIT_CANCELLED;
+                }
+            };
+
+            // Single-shot semantics: `try_match` took the filter out
+            // on the match that produced this mail. Nothing to clear.
+
+            if mail.payload.len() > out_cap as usize {
+                return WAIT_BUFFER_TOO_SMALL;
+            }
+
+            let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
+                // Guest exports no memory; treat as buffer-unusable.
+                return WAIT_BUFFER_TOO_SMALL;
+            };
+            let start = out_ptr as usize;
+            let Some(end) = start.checked_add(mail.payload.len()) else {
+                return WAIT_BUFFER_TOO_SMALL;
+            };
+            let data = memory.data_mut(&mut caller);
+            if end > data.len() {
+                return WAIT_BUFFER_TOO_SMALL;
+            }
+            data[start..end].copy_from_slice(&mail.payload);
+
+            mail.payload.len() as i32
+        },
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Second of three follow-on PRs from ADR-0042. Adds the guest-facing host fn; the PR 1 filter slot now has a caller.

## What

New import on the `aether` module:

```rust
wait_reply_p32(expected_kind: u64, out_ptr: u32, out_cap: u32, timeout_ms: u32) -> i32
```

Return encoding per ADR-0042 §1:

| Return | Meaning |
|---|---|
| `>= 0` | bytes written to `out_ptr` |
| `-1` (WAIT_TIMEOUT) | `timeout_ms` elapsed without a matching reply |
| `-2` (WAIT_BUFFER_TOO_SMALL) | reply payload exceeded `out_cap` or would write OOB |
| `-3` (WAIT_CANCELLED) | substrate tore the component down while parked |

Implementation:

1. Install a filter for `expected_kind` on the ctx's `FilterSlot`.
2. Park on the returned `Receiver` via `recv_timeout` (or `try_recv` when `timeout_ms == 0`).
3. On match, copy payload into guest memory at `out_ptr` and return byte count.

`timeout_ms` is clamped to `MAX_WAIT_TIMEOUT_MS` (30s, matching `capture_frame`) so a guest bug can't produce an immortal parked thread.

## What is NOT in this PR

- Guest SDK wrappers: `raw::wait_reply_p32`, `io::read_sync`, `audio::set_master_gain_sync` (follow-up PR 3).

## Tests

Five tests in `component::tests` built on a minimal WAT guest that calls `wait_reply_p32` and stores the return value at a known offset:

- `wait_reply_returns_timeout_when_no_match_arrives` — 10ms wait, no match, expects `-1`.
- `wait_reply_poll_mode_returns_timeout_immediately` — `timeout_ms=0` path with no pre-queued mail.
- `wait_reply_writes_payload_and_returns_byte_count_on_match` — worker thread parks in the host fn; main thread pushes via `filter_slot.try_match`; payload copied into guest memory at `out_ptr`.
- `wait_reply_returns_buffer_too_small_when_payload_exceeds_cap` — 128-byte payload against 64-byte buffer, expects `-2`.
- `wait_reply_returns_cancelled_when_slot_cleared` — clears the slot externally, expects `-3`.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`

Refs: ADR-0042 Follow-up Work item 2.