### PR TITLE
feat(substrate): correlation ids on ReplyTo to fix stale-reply bug (ADR-0042)

### DIFF
--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -105,7 +105,7 @@ pub fn list(namespace: &str, prefix: &str) {
     });
 }
 
-fn send<K: Kind + Serialize>(value: &K) {
+fn send<K: Kind + Serialize>(value: &K) -> u64 {
     let bytes = encode_postcard(value);
     unsafe {
         raw::send_mail(
@@ -115,6 +115,11 @@ fn send<K: Kind + Serialize>(value: &K) {
             bytes.len() as u32,
             1,
         );
+        // ADR-0042: capture the correlation the substrate just
+        // minted so the sync wrappers can filter on it. For the
+        // async helpers (`read` / `write` / `delete` / `list`),
+        // this is harmless noise — they don't wait.
+        raw::prev_correlation()
     }
 }
 
@@ -162,15 +167,18 @@ const LIST_REPLY_CAP: usize = 256 * 1024;
 /// calling component; other components on the same substrate are
 /// unaffected.
 ///
-/// Use for multi-step I/O where the state-machine cost of the
-/// async [`read`] + `#[handler] fn on_read_result` shape outweighs
-/// the single-tracked-component cost of a sync wait. ADR-0042.
+/// Uses ADR-0042 correlation to filter out stale replies: the
+/// substrate mints a fresh id for each `send_mail`, auto-echoes it
+/// on the reply, and the wrapper waits for *its* correlation
+/// specifically — not the first `ReadResult` to arrive. This fixes
+/// a footgun where a sync call could consume a prior async
+/// `io::read` reply that happened to be queued.
 pub fn read_sync(namespace: &str, path: &str, timeout_ms: u32) -> Result<Vec<u8>, SyncIoError> {
-    send(&Read {
+    let correlation = send(&Read {
         namespace: namespace.to_string(),
         path: path.to_string(),
     });
-    let reply: ReadResult = wait::<ReadResult>(timeout_ms, READ_REPLY_CAP)?;
+    let reply: ReadResult = wait::<ReadResult>(timeout_ms, READ_REPLY_CAP, correlation)?;
     match reply {
         ReadResult::Ok { bytes, .. } => Ok(bytes),
         ReadResult::Err { error, .. } => Err(SyncIoError::Io(error)),
@@ -186,12 +194,12 @@ pub fn write_sync(
     bytes: &[u8],
     timeout_ms: u32,
 ) -> Result<(), SyncIoError> {
-    send(&Write {
+    let correlation = send(&Write {
         namespace: namespace.to_string(),
         path: path.to_string(),
         bytes: bytes.to_vec(),
     });
-    match wait::<WriteResult>(timeout_ms, SMALL_REPLY_CAP)? {
+    match wait::<WriteResult>(timeout_ms, SMALL_REPLY_CAP, correlation)? {
         WriteResult::Ok { .. } => Ok(()),
         WriteResult::Err { error, .. } => Err(SyncIoError::Io(error)),
     }
@@ -201,11 +209,11 @@ pub fn write_sync(
 /// `Err(SyncIoError::Io(IoError::NotFound))` — callers that don't
 /// care about the distinction can `.ok()` and discard.
 pub fn delete_sync(namespace: &str, path: &str, timeout_ms: u32) -> Result<(), SyncIoError> {
-    send(&Delete {
+    let correlation = send(&Delete {
         namespace: namespace.to_string(),
         path: path.to_string(),
     });
-    match wait::<DeleteResult>(timeout_ms, SMALL_REPLY_CAP)? {
+    match wait::<DeleteResult>(timeout_ms, SMALL_REPLY_CAP, correlation)? {
         DeleteResult::Ok { .. } => Ok(()),
         DeleteResult::Err { error, .. } => Err(SyncIoError::Io(error)),
     }
@@ -219,20 +227,21 @@ pub fn list_sync(
     prefix: &str,
     timeout_ms: u32,
 ) -> Result<Vec<String>, SyncIoError> {
-    send(&List {
+    let correlation = send(&List {
         namespace: namespace.to_string(),
         prefix: prefix.to_string(),
     });
-    match wait::<ListResult>(timeout_ms, LIST_REPLY_CAP)? {
+    match wait::<ListResult>(timeout_ms, LIST_REPLY_CAP, correlation)? {
         ListResult::Ok { entries, .. } => Ok(entries),
         ListResult::Err { error, .. } => Err(SyncIoError::Io(error)),
     }
 }
 
 /// Allocate a `capacity`-sized scratch buffer in guest memory, park
-/// on `raw::wait_reply` for a mail of kind `K`, and postcard-decode
-/// the written bytes. Shared by every `*_sync` wrapper.
-fn wait<K>(timeout_ms: u32, capacity: usize) -> Result<K, SyncIoError>
+/// on `raw::wait_reply` for a mail of kind `K` with the given
+/// `expected_correlation`, and postcard-decode the written bytes.
+/// Shared by every `*_sync` wrapper.
+fn wait<K>(timeout_ms: u32, capacity: usize, expected_correlation: u64) -> Result<K, SyncIoError>
 where
     K: Kind + serde::de::DeserializeOwned,
 {
@@ -243,6 +252,7 @@ where
             buf.as_mut_ptr().addr() as u32,
             buf.len() as u32,
             timeout_ms,
+            expected_correlation,
         )
     };
     match rc {

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -25,14 +25,28 @@ unsafe extern "C" {
     #[link_name = "save_state_p32"]
     pub fn save_state(version: u32, ptr: u32, len: u32) -> u32;
     /// ADR-0042: block the component thread until a mail whose kind
-    /// id matches `expected_kind` arrives in the inbox, then copy up
-    /// to `out_cap` bytes of its payload to `out_ptr`. Return codes:
-    /// `>= 0` = bytes written, `-1` = timeout, `-2` = payload larger
-    /// than `out_cap` (mail is re-parked on overflow for retry),
-    /// `-3` = substrate tore the component down mid-wait. `timeout_ms`
-    /// is clamped to 30s substrate-side.
+    /// id matches `expected_kind` (and, when `expected_correlation`
+    /// != 0, whose `ReplyTo.correlation_id` also matches) arrives,
+    /// then copy up to `out_cap` bytes of its payload to `out_ptr`.
+    /// Return codes: `>= 0` = bytes written, `-1` = timeout, `-2` =
+    /// payload larger than `out_cap` (mail re-parked for retry),
+    /// `-3` = substrate tore the component down mid-wait.
+    /// `timeout_ms` is clamped to 30s substrate-side.
     #[link_name = "wait_reply_p32"]
-    pub fn wait_reply(expected_kind: u64, out_ptr: u32, out_cap: u32, timeout_ms: u32) -> i32;
+    pub fn wait_reply(
+        expected_kind: u64,
+        out_ptr: u32,
+        out_cap: u32,
+        timeout_ms: u32,
+        expected_correlation: u64,
+    ) -> i32;
+    /// ADR-0042: return the correlation id the substrate minted for
+    /// this component's most recent `send_mail`. `0` before any
+    /// send. Paired with `wait_reply` so sync wrappers can filter on
+    /// "the reply I just sent a request for" rather than "any reply
+    /// of this kind."
+    #[link_name = "prev_correlation_p32"]
+    pub fn prev_correlation() -> u64;
 }
 
 /// # Safety
@@ -68,6 +82,15 @@ pub unsafe fn wait_reply(
     _out_ptr: u32,
     _out_cap: u32,
     _timeout_ms: u32,
+    _expected_correlation: u64,
 ) -> i32 {
     panic!("aether-component: wait_reply called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::prev_correlation` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn prev_correlation() -> u64 {
+    panic!("aether-component: prev_correlation called on non-wasm target");
 }

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -207,6 +207,7 @@ mod tests {
             payload: vec![],
             count: 1,
             sender,
+            correlation_id: 0,
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();
@@ -230,6 +231,7 @@ mod tests {
             kind_name: "aether.observation.ping".into(),
             payload: vec![1, 2, 3],
             origin: Some("physics".into()),
+            correlation_id: 0,
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();
@@ -252,6 +254,7 @@ mod tests {
             kind_name: "aether.observation.world".into(),
             payload: vec![],
             origin: None,
+            correlation_id: 0,
         });
         let mut buf = Vec::new();
         write_frame(&mut buf, &msg).unwrap();

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -759,6 +759,13 @@ pub struct MailFrame {
     pub payload: Vec<u8>,
     pub count: u32,
     pub sender: SessionToken,
+    /// ADR-0042: opaque correlation id the session-originating
+    /// caller attached. Echoed verbatim on any reply the engine
+    /// emits. `0` means "no correlation" — current MCP `send_mail`
+    /// doesn't populate this; tooling that wants end-to-end
+    /// correlation sets it explicitly.
+    #[serde(default)]
+    pub correlation_id: u64,
 }
 
 /// A piece of mail the engine is sending to one or more Claude
@@ -774,6 +781,13 @@ pub struct EngineMailFrame {
     pub kind_name: String,
     pub payload: Vec<u8>,
     pub origin: Option<String>,
+    /// ADR-0042 correlation echo. For session-addressed replies,
+    /// the engine copies the `correlation_id` off the inbound
+    /// `MailFrame` so the originating session can correlate its
+    /// request to the reply. `0` for broadcasts and substrate-
+    /// originated mail that didn't originate a correlation.
+    #[serde(default)]
+    pub correlation_id: u64,
 }
 
 /// How an engine-originated mail is addressed at the hub. `Session`
@@ -846,6 +860,13 @@ pub struct EngineMailToHubSubstrateFrame {
     pub payload: Vec<u8>,
     pub count: u32,
     pub source_mailbox_id: Option<u64>,
+    /// ADR-0042 correlation id the originating component's
+    /// `SubstrateCtx::send` minted. Carried across the hub so a
+    /// bubbled-up mail's reply (ADR-0037 Phase 2) can echo back
+    /// through `MailByIdFrame` and reach a parked `wait_reply_p32`
+    /// on the original sender.
+    #[serde(default)]
+    pub correlation_id: u64,
 }
 
 /// Reply mail leaving the hub-substrate for a remote engine's
@@ -861,6 +882,11 @@ pub struct MailToEngineMailboxFrame {
     pub kind_id: u64,
     pub payload: Vec<u8>,
     pub count: u32,
+    /// ADR-0042 correlation echo. Set by the reply-emitting engine
+    /// so the target engine can correlate the reply to its original
+    /// bubble-up request.
+    #[serde(default)]
+    pub correlation_id: u64,
 }
 
 /// Mail delivered to a specific mailbox id on an engine (ADR-0037
@@ -876,6 +902,12 @@ pub struct MailByIdFrame {
     pub kind_id: u64,
     pub payload: Vec<u8>,
     pub count: u32,
+    /// ADR-0042 correlation echo. Carries through from
+    /// `EngineMailToHubSubstrateFrame.correlation_id` when the hub
+    /// forwards a reply for a bubbled-up request back to the
+    /// originating engine.
+    #[serde(default)]
+    pub correlation_id: u64,
 }
 
 /// Frames an engine sends to the hub. `Mail` is the observation path

--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -157,7 +157,7 @@ impl<'a> SubstrateBootBuilder<'a> {
                     move |_kind_id: u64,
                           kind_name: &str,
                           origin: Option<&str>,
-                          _sender,
+                          sender: crate::mail::ReplyTo,
                           bytes: &[u8],
                           _count: u32| {
                         if kind_name.is_empty() {
@@ -167,11 +167,18 @@ impl<'a> SubstrateBootBuilder<'a> {
                             );
                             return;
                         }
+                        // ADR-0042: preserve the auto-minted
+                        // correlation end-to-end so MCP-side tooling
+                        // can correlate broadcasts with their
+                        // originating sends if it wants to. Most
+                        // broadcast uses are fire-and-forget and
+                        // ignore it.
                         outbound.send(EngineToHub::Mail(EngineMailFrame {
                             address: ClaudeAddress::Broadcast,
                             kind_name: kind_name.to_owned(),
                             payload: bytes.to_vec(),
                             origin: origin.map(str::to_owned),
+                            correlation_id: sender.correlation_id,
                         }));
                     },
                 ),

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::Receiver;
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
-use crate::mail::{Mail, ReplyTo};
+use crate::mail::{Mail, ReplyTarget};
 use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
 const MAIL_OFFSET: u32 = 1024;
@@ -122,22 +122,34 @@ impl Component {
     /// system-generated mail pass `NO_REPLY_HANDLE` so the guest's
     /// `mail.reply_to()` accessor returns `None`.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
-        let entry = match &mail.reply_to {
-            ReplyTo::Session(token) => Some(ReplyEntry::Session(*token)),
-            ReplyTo::EngineMailbox {
+        // ADR-0042: carry the incoming correlation through to the
+        // ReplyEntry so a subsequent `reply_mail` echoes it on the
+        // outgoing reply. Session / engine mail that didn't originate
+        // a correlation carries 0 — fine, echo of 0 is a no-op.
+        let correlation = mail.reply_to.correlation_id;
+        let entry = match &mail.reply_to.target {
+            ReplyTarget::Session(token) => {
+                Some(ReplyEntry::new(ReplyTarget::Session(*token), correlation))
+            }
+            ReplyTarget::EngineMailbox {
                 engine_id,
                 mailbox_id,
-            } => Some(ReplyEntry::RemoteEngineMailbox {
-                engine_id: *engine_id,
-                mailbox_id: *mailbox_id,
-            }),
+            } => Some(ReplyEntry::new(
+                ReplyTarget::EngineMailbox {
+                    engine_id: *engine_id,
+                    mailbox_id: *mailbox_id,
+                },
+                correlation,
+            )),
             // Component-variant reply_to reaches a real component's
             // `deliver` only via the mailer-routed reply path (the
             // sink replied to a local component): the reply itself
             // has no one to reply back to, so the guest sees no
             // `reply_to`. Falls through to the `from_component`
             // check, matching the None path.
-            ReplyTo::None | ReplyTo::Component(_) => mail.from_component.map(ReplyEntry::Component),
+            ReplyTarget::None | ReplyTarget::Component(_) => mail
+                .from_component
+                .map(|m| ReplyEntry::new(ReplyTarget::Component(m), correlation)),
         };
         let handle = match entry {
             Some(e) => self.store.data_mut().reply_table.allocate(e),
@@ -539,18 +551,19 @@ mod tests {
     fn deliver_with_real_token_allocates_session_handle() {
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xaaaa));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_reply_to(ReplyTo::Session(token));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1)
+            .with_reply_to(ReplyTo::to(ReplyTarget::Session(token)));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
         assert_ne!(observed, NO_REPLY_HANDLE);
         assert_eq!(
             component.store.data().reply_table.resolve(observed),
-            Some(ReplyEntry::Session(token)),
+            Some(ReplyEntry::session(token)),
         );
     }
 
@@ -568,7 +581,7 @@ mod tests {
         assert_ne!(observed, NO_REPLY_HANDLE);
         assert_eq!(
             component.store.data().reply_table.resolve(observed),
-            Some(ReplyEntry::Component(M(7))),
+            Some(ReplyEntry::component(M(7))),
         );
     }
 
@@ -580,18 +593,21 @@ mod tests {
         // session is the more specific reply target.
         use aether_hub_protocol::{SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::reply_table::ReplyEntry;
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xbbbb));
         let mail = SubstrateMail::new(M(0), 0, vec![], 1)
-            .with_reply_to(ReplyTo::Session(token))
+            .with_reply_to(ReplyTo::to(ReplyTarget::Session(token)))
             .with_origin(M(99));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
         match component.store.data().reply_table.resolve(observed) {
-            Some(ReplyEntry::Session(t)) => assert_eq!(t, token),
+            Some(ReplyEntry {
+                target: ReplyTarget::Session(t),
+                ..
+            }) => assert_eq!(t, token),
             other => panic!("expected Session, got {other:?}"),
         }
     }
@@ -637,13 +653,14 @@ mod tests {
     fn reply_mail_emits_session_addressed_frame() {
         use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTo};
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
 
         let (ctx, rx, pong_id) = plane_ctx_for_reply();
         let mut component = instantiate_with_ctx(&wat_replies(pong_id), ctx);
 
         let token = SessionToken(Uuid::from_u128(0xbeef));
-        let mail = SubstrateMail::new(M(0), 0, vec![], 1).with_reply_to(ReplyTo::Session(token));
+        let mail = SubstrateMail::new(M(0), 0, vec![], 1)
+            .with_reply_to(ReplyTo::to(ReplyTarget::Session(token)));
         component.deliver(&mail).expect("deliver");
 
         let frame = rx.try_recv().expect("outbound frame queued");
@@ -773,7 +790,7 @@ mod tests {
     const WAT_SYNC_WAIT: &str = r#"
         (module
             (import "aether" "wait_reply_p32"
-                (func $wait (param i64 i32 i32 i32) (result i32)))
+                (func $wait (param i64 i32 i32 i32 i64) (result i32)))
             (memory (export "memory") 1)
             (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
                 i32.const 700
@@ -781,7 +798,8 @@ mod tests {
                     (i64.const -6148914691236517206) ;; 0xAAAA_AAAA_AAAA_AAAA reinterpreted as i64
                     (i32.const 600)                  ;; out_ptr
                     (i32.const 64)                   ;; out_cap
-                    (local.get 2))                   ;; timeout_ms = count
+                    (local.get 2)                    ;; timeout_ms = count
+                    (i64.const 0))                   ;; expected_correlation = 0 (kind-only filter)
                 i32.store
                 i32.const 0))
     "#;
@@ -937,6 +955,88 @@ mod tests {
         let mut component = handle.join().expect("worker panicked");
         let result = component.read_u32(700) as i32;
         assert_eq!(result, host_fns::WAIT_BUFFER_TOO_SMALL);
+    }
+
+    /// ADR-0042 correlation: a sync wait filters on
+    /// `expected_correlation` so it picks *its own* reply out of
+    /// the inbox rather than the first `ReadResult`-kind mail that
+    /// happens to be queued. Regression guard — without the
+    /// correlation filter, a stale prior reply of the same kind
+    /// would be consumed as if it were the one we're waiting on.
+    #[test]
+    fn wait_reply_filters_by_correlation_not_just_kind() {
+        use std::sync::mpsc;
+
+        use wasmtime::{Engine, Linker, Module};
+
+        use crate::mail::{MailboxId as M, ReplyTarget, ReplyTo};
+
+        // WAT that waits on kind `SYNC_WAIT_EXPECTED_KIND` with
+        // expected_correlation = 42, timeout = 1s. Stores payload
+        // byte count at offset 700.
+        const WAT: &str = r#"
+            (module
+                (import "aether" "wait_reply_p32"
+                    (func $wait (param i64 i32 i32 i32 i64) (result i32)))
+                (memory (export "memory") 1)
+                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                    i32.const 700
+                    (call $wait
+                        (i64.const -6148914691236517206) ;; expected_kind = 0xAAAA...
+                        (i32.const 600)                  ;; out_ptr
+                        (i32.const 64)                   ;; out_cap
+                        (i32.const 1000)                 ;; timeout_ms
+                        (i64.const 42))                  ;; expected_correlation
+                    i32.store
+                    i32.const 0))
+        "#;
+
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        crate::host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT).expect("compile WAT");
+        let module = Module::new(&engine, &wasm).expect("compile module");
+        let mut component =
+            Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate");
+        let (tx, rx) = mpsc::channel::<Mail>();
+        component.install_inbox_rx(rx);
+
+        // Pre-queue a decoy reply: same kind, different correlation.
+        // Without the correlation filter the sync wait would consume
+        // THIS one (first-in) as if it were the one we're waiting on.
+        let decoy_payload = vec![0xDE, 0xAD];
+        tx.send(
+            Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, decoy_payload, 1)
+                .with_reply_to(ReplyTo::with_correlation(ReplyTarget::None, 10)),
+        )
+        .expect("send decoy");
+
+        // Now the reply we're actually waiting on: correlation = 42.
+        let real_payload = vec![1, 2, 3, 4, 5];
+        tx.send(
+            Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, real_payload.clone(), 1)
+                .with_reply_to(ReplyTo::with_correlation(ReplyTarget::None, 42)),
+        )
+        .expect("send real reply");
+
+        component.deliver(&trigger_wait(0)).expect("deliver");
+
+        let result = component.read_u32(700) as i32;
+        assert_eq!(
+            result,
+            real_payload.len() as i32,
+            "expected byte count for the correlation-42 reply"
+        );
+        assert_eq!(
+            component.read_bytes(600, real_payload.len()),
+            real_payload,
+            "host fn copied the wrong payload — decoy reply consumed instead of real one",
+        );
+        // Decoy should still be sitting in overflow — the dispatcher
+        // would deliver it on its next pass after the wait returned.
+        let overflow = component.store.data().inbox_overflow.lock().unwrap();
+        assert_eq!(overflow.len(), 1, "decoy mail should be in overflow");
+        assert_eq!(overflow[0].reply_to.correlation_id, 10);
     }
 
     #[test]

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -1234,7 +1234,7 @@ mod tests {
         plane.dispatch(
             0xdead_beef_dead_beef,
             "aether.control.does_not_exist",
-            crate::mail::ReplyTo::None,
+            crate::mail::ReplyTo::NONE,
             &[],
         );
     }
@@ -1675,7 +1675,7 @@ mod tests {
         plane.dispatch(
             SubscribeInput::ID,
             SubscribeInput::NAME,
-            crate::mail::ReplyTo::None,
+            crate::mail::ReplyTo::NONE,
             &postcard::to_allocvec(&SubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1685,7 +1685,7 @@ mod tests {
         plane.dispatch(
             UnsubscribeInput::ID,
             UnsubscribeInput::NAME,
-            crate::mail::ReplyTo::None,
+            crate::mail::ReplyTo::NONE,
             &postcard::to_allocvec(&UnsubscribeInput {
                 stream: InputStream::Tick,
                 mailbox: id,
@@ -1823,7 +1823,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: crate::mail::ReplyTo::None,
+                sender: crate::mail::ReplyTo::NONE,
                 from_component: None,
             });
         }
@@ -1896,7 +1896,7 @@ mod tests {
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
-                sender: crate::mail::ReplyTo::None,
+                sender: crate::mail::ReplyTo::NONE,
                 from_component: None,
             });
         }

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -9,13 +9,14 @@
 // only `Arc<Registry>` and `Arc<Mailer>` the cycle is broken: neither
 // of those owns any actor.
 
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 
 use crate::hub_client::HubOutbound;
 use crate::input::InputSubscribers;
-use crate::mail::{Mail, MailKind, MailboxId, ReplyTo};
+use crate::mail::{Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::{MailboxEntry, Registry};
 use crate::reply_table::ReplyTable;
@@ -79,6 +80,17 @@ pub struct SubstrateCtx {
     /// `Mutex`es empty / default because it has no scheduler.
     pub inbox_rx: Mutex<Option<Receiver<Mail>>>,
     pub inbox_overflow: Mutex<VecDeque<Mail>>,
+    /// ADR-0042 correlation counter. Per-component (one
+    /// `SubstrateCtx` per component instance). Holds the *next* id
+    /// to mint; `prev_correlation()` reads `counter - 1` to return
+    /// the last one minted. Starts at `1` so that `0` always means
+    /// "no correlation" (backward-compat sentinel for waits that
+    /// don't filter, and for `prev_correlation` before any send).
+    ///
+    /// `Cell` instead of `AtomicU64`: the component is single-
+    /// threaded (ADR-0038 actor-per-component), so the counter is
+    /// never touched from multiple threads.
+    correlation_counter: Cell<u64>,
 }
 
 impl SubstrateCtx {
@@ -105,7 +117,29 @@ impl SubstrateCtx {
             save_state_error: None,
             inbox_rx: Mutex::new(None),
             inbox_overflow: Mutex::new(VecDeque::new()),
+            correlation_counter: Cell::new(1),
         }
+    }
+
+    /// Mint the next correlation id and bump the counter. Private —
+    /// callers that want a correlation use `SubstrateCtx::send`,
+    /// which mints internally and tags the outgoing mail.
+    fn mint_correlation(&self) -> u64 {
+        let id = self.correlation_counter.get();
+        self.correlation_counter.set(id + 1);
+        id
+    }
+
+    /// Return the correlation id used by the most recent
+    /// `SubstrateCtx::send` call. The `prev_correlation_p32` host fn
+    /// surfaces this to the guest so sync wrappers know what to
+    /// filter on in `wait_reply_p32`. Returns `0` (the "no
+    /// correlation" sentinel) before any send has been made.
+    pub fn prev_correlation(&self) -> u64 {
+        // counter holds the *next* id to mint; subtract to get the
+        // last one. `.saturating_sub(1)` covers the pre-send case
+        // where counter is still `1` (initial) → returns `0`.
+        self.correlation_counter.get().saturating_sub(1)
     }
 
     /// Install the mpsc `Receiver` the dispatcher will read from.
@@ -136,21 +170,30 @@ impl SubstrateCtx {
     /// mailboxes, or bubbles unknown ids up to the hub-substrate when
     /// a `HubOutbound` is wired (ADR-0037).
     pub fn send(&self, recipient: MailboxId, kind: MailKind, payload: Vec<u8>, count: u32) {
+        // ADR-0042: mint a fresh correlation_id for this send and
+        // stash it on `last_correlation` so `prev_correlation_p32`
+        // can return it to the guest. The minted id rides on the
+        // outgoing `ReplyTo.correlation_id`; the reply's echo
+        // (auto-routed by `Mailer::send_reply`) carries it back, and
+        // `wait_reply_p32` filters on it.
+        let correlation = self.mint_correlation();
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Component(self.sender), correlation);
+
         if let Some(MailboxEntry::Sink(handler)) = self.registry.entry(recipient) {
             let kind_name = self.registry.kind_name(kind).unwrap_or_default();
             // Component-originated mail: the sender is this ctx's
             // mailbox, so its registry name is the `origin` any
             // sink cares about (ADR-0011), and the same mailbox id
-            // rides on `ReplyTo::Component` so sink handlers that
-            // want to reply (ADR-0041's io sink is the motivating
-            // case) can route `*Result` back to this component via
+            // rides on `reply_to.target` so sink handlers that want
+            // to reply (ADR-0041's io sink is the motivating case)
+            // can route `*Result` back to this component via
             // `Mailer::send_reply`.
             let origin = self.registry.mailbox_name(self.sender);
             handler(
                 kind,
                 &kind_name,
                 origin.as_deref(),
-                ReplyTo::Component(self.sender),
+                reply_to,
                 &payload,
                 count,
             );
@@ -165,8 +208,11 @@ impl SubstrateCtx {
         // - Unknown (ADR-0037): bubbles up to the hub-substrate via
         //   `MailToHubSubstrate` with `source_mailbox_id = self.sender`
         //   when a `HubOutbound` is connected; warn-drops otherwise.
-        self.queue
-            .push(Mail::new(recipient, kind, payload, count).with_origin(self.sender));
+        self.queue.push(
+            Mail::new(recipient, kind, payload, count)
+                .with_reply_to(reply_to)
+                .with_origin(self.sender),
+        );
     }
 }
 

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -11,8 +11,7 @@ use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
 use wasmtime::{Caller, Linker};
 
 use crate::ctx::{StateBundle, SubstrateCtx};
-use crate::mail::MailboxId;
-use crate::reply_table::ReplyEntry;
+use crate::mail::{MailboxId, ReplyTarget};
 
 /// Status codes returned by the `reply_mail` host fn (ADR-0013 §3).
 /// `0` is success; non-zero values distinguish call-site errors
@@ -177,8 +176,12 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
             let Some(entry) = ctx.reply_table.resolve(sender) else {
                 return REPLY_UNKNOWN_HANDLE;
             };
-            match entry {
-                ReplyEntry::Session(token) => {
+            // ADR-0042: echo the inbound correlation on every reply
+            // path so a parked `wait_reply_p32` on the originator
+            // can filter its own reply out of a busy inbox.
+            let correlation = entry.correlation_id;
+            match entry.target {
+                ReplyTarget::Session(token) => {
                     let Some(kind_name) = ctx.registry.kind_name(kind) else {
                         return REPLY_KIND_NOT_FOUND;
                     };
@@ -188,9 +191,10 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                         kind_name,
                         payload,
                         origin,
+                        correlation_id: correlation,
                     }));
                 }
-                ReplyEntry::Component(mbox) => {
+                ReplyTarget::Component(mbox) => {
                     // Validate the kind id cheaply — the guest might
                     // have passed a bogus one and we'd rather return
                     // a meaningful status than silently enqueue mail
@@ -200,7 +204,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                     }
                     ctx.send(mbox, kind, payload, count);
                 }
-                ReplyEntry::RemoteEngineMailbox {
+                ReplyTarget::EngineMailbox {
                     engine_id,
                     mailbox_id,
                 } => {
@@ -221,8 +225,15 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                             kind_id: kind,
                             payload,
                             count,
+                            correlation_id: correlation,
                         },
                     ));
+                }
+                ReplyTarget::None => {
+                    // Shouldn't happen — `ReplyEntry`s only get
+                    // allocated for mail with a real reply target.
+                    // Treat as unknown-handle to avoid silent drops.
+                    return REPLY_UNKNOWN_HANDLE;
                 }
             }
             REPLY_OK
@@ -254,7 +265,8 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
          expected_kind: u64,
          out_ptr: u32,
          out_cap: u32,
-         timeout_ms: u32|
+         timeout_ms: u32,
+         expected_correlation: u64|
          -> i32 {
             let clamped = timeout_ms.min(MAX_WAIT_TIMEOUT_MS);
             let deadline = Instant::now() + Duration::from_millis(clamped as u64);
@@ -293,9 +305,18 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                         }
                     };
                     match recv {
-                        Ok(m) if m.kind == expected_kind => break m,
+                        Ok(m)
+                            if m.kind == expected_kind
+                                && (expected_correlation == 0
+                                    || m.reply_to.correlation_id == expected_correlation) =>
+                        {
+                            break m;
+                        }
                         Ok(m) => {
-                            // Non-match: to overflow, keep draining.
+                            // Non-match (wrong kind, or right kind but
+                            // not our correlation): park on overflow
+                            // so the dispatcher picks it up after we
+                            // unwind. ADR-0042 correlation filter.
                             ctx.inbox_overflow.lock().unwrap().push_back(m);
                         }
                         Err(RecvTimeoutError::Timeout) => return WAIT_TIMEOUT,
@@ -353,6 +374,20 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
 
             mail.payload.len() as i32
         },
+    )?;
+
+    // ADR-0042: read back the correlation id the substrate minted
+    // for this component's most recent `send_mail`. Sync SDK
+    // wrappers call this right after a send to capture the id,
+    // then pass it to `wait_reply_p32` so the drain loop picks out
+    // the matching reply among any prior async-request replies
+    // that share the same kind. Returns `0` (the
+    // `NO_CORRELATION` sentinel) before any send has been made;
+    // matches the "kind-only" fallback in `wait_reply_p32`.
+    linker.func_wrap(
+        "aether",
+        "prev_correlation_p32",
+        |caller: Caller<'_, SubstrateCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
     Ok(())

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -31,7 +31,7 @@ use aether_hub_protocol::{
     MailByIdFrame, MailFrame, MailToEngineMailboxFrame, read_frame, write_frame,
 };
 
-use crate::mail::{Mail, ReplyTo};
+use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::Registry;
 
@@ -108,14 +108,15 @@ impl HubOutbound {
                 return false;
             }
         };
-        match sender {
-            ReplyTo::Session(token) => self.send(EngineToHub::Mail(EngineMailFrame {
+        match sender.target {
+            ReplyTarget::Session(token) => self.send(EngineToHub::Mail(EngineMailFrame {
                 address: ClaudeAddress::Session(token),
                 kind_name: K::NAME.to_owned(),
                 payload,
                 origin: None,
+                correlation_id: sender.correlation_id,
             })),
-            ReplyTo::EngineMailbox {
+            ReplyTarget::EngineMailbox {
                 engine_id,
                 mailbox_id,
             } => self.send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
@@ -124,12 +125,13 @@ impl HubOutbound {
                 kind_id: K::ID,
                 payload,
                 count: 1,
+                correlation_id: sender.correlation_id,
             })),
             // `Component` replies route through `Mailer::send_reply`,
             // not the hub — silently drop if a caller misroutes one
             // here rather than introduce a second truth for where
             // local replies go.
-            ReplyTo::None | ReplyTo::Component(_) => false,
+            ReplyTarget::None | ReplyTarget::Component(_) => false,
         }
     }
 
@@ -283,7 +285,7 @@ pub fn dispatch_hub_to_engine_mail(frame: MailFrame, registry: &Registry, queue:
     };
     queue.push(
         Mail::new(recipient, kind, frame.payload, frame.count)
-            .with_reply_to(ReplyTo::Session(frame.sender)),
+            .with_reply_to(ReplyTo::to(ReplyTarget::Session(frame.sender))),
     );
 }
 

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -750,7 +750,7 @@ mod tests {
     }
 
     fn session_sender() -> ReplyTo {
-        ReplyTo::Session(SessionToken(Uuid::nil()))
+        ReplyTo::to(crate::mail::ReplyTarget::Session(SessionToken(Uuid::nil())))
     }
 
     /// Build a fully-wired `Mailer` connected to a fresh test
@@ -1125,7 +1125,7 @@ mod tests {
             <Read as Kind>::ID,
             Read::NAME,
             Some("test_caller"),
-            ReplyTo::Component(caller_mailbox),
+            ReplyTo::to(crate::mail::ReplyTarget::Component(caller_mailbox)),
             &req,
             1,
         );

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use hub_client::{
     HubClient, HubOutbound, dispatch_hub_mail_by_id, dispatch_hub_to_engine_mail,
 };
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
-pub use mail::{Mail, MailKind, MailboxId, ReplyTo};
+pub use mail::{Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;

--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -34,33 +34,22 @@ impl MailboxId {
 /// preparation for hashed derivation (Phase 2).
 pub type MailKind = u64;
 
-/// Reply destination for a `Mail` (ADR-0008, ADR-0037). Strictly a
-/// reply-to hint: mail is pushed at a recipient, not sent from a
-/// mailbox, so there is no actual "sender" concept in the system —
-/// this field records where an optional reply should be routed.
+/// Where a reply-bearing mail should route when the recipient
+/// answers. Strictly a routing hint: mail is pushed at a recipient,
+/// not sent from a mailbox.
 ///
 /// `None` is the default — broadcast / substrate-generated mail
 /// with no meaningful reply target. `Session` tags mail that
 /// arrived from a Claude MCP session, so replies route back to
 /// that session (ADR-0008). `EngineMailbox` tags mail bubbled up
 /// from a component on another engine, so replies route to the
-/// originating engine's mailbox (ADR-0037 Phase 2). The hub-
-/// chassis fills in the engine id on `EngineMailToHubSubstrate`
-/// reception from the TCP connection it arrived on.
-/// `Component` tags sink-bound mail that a local component
-/// pushed through `SubstrateCtx::send`, carrying the sender's
-/// own mailbox so sink reply paths (ADR-0041's io sink is the
-/// motivating case) can route the `*Result` back to the component
-/// via the mailer rather than the hub.
-///
-/// `Mail.from_component` carries the same information for mail
-/// the mailer routed into a recipient's inbox (so
-/// `Component::deliver` can allocate a Component-variant reply
-/// handle), but sink dispatch skips the `Mail` struct entirely —
-/// the handler is called inline. For that path the reply target
-/// rides on this enum.
+/// originating engine's mailbox (ADR-0037 Phase 2). `Component`
+/// tags sink-bound mail that a local component pushed through
+/// `SubstrateCtx::send`, so sink reply paths (ADR-0041's io sink is
+/// the motivating case) can route the `*Result` back to the
+/// component via the mailer rather than the hub.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ReplyTo {
+pub enum ReplyTarget {
     None,
     Session(SessionToken),
     EngineMailbox {
@@ -70,12 +59,58 @@ pub enum ReplyTo {
     Component(MailboxId),
 }
 
+/// Reply-routing info for a `Mail` (ADR-0008, ADR-0037, ADR-0042).
+/// The `target` describes where a reply goes; `correlation_id` is an
+/// opaque u64 the original sender attached so it can identify its
+/// specific request among replies of the same kind. The mailer
+/// auto-echoes `correlation_id` when constructing a reply via
+/// `send_reply`, so reply-bearing sinks (the io sink today) don't
+/// need per-sink echo code. `0` means "no correlation"; waits with
+/// `expected_correlation == 0` match any correlation (backward-compat
+/// and for non-correlating callers like broadcasts and input mail).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ReplyTo {
+    pub target: ReplyTarget,
+    pub correlation_id: u64,
+}
+
 impl ReplyTo {
-    /// Whether the variant carries no reply target. Callers deciding
-    /// whether to allocate a reply-handle table entry use this
-    /// before pattern matching on the payload.
+    /// Sentinel for no correlation. Using the explicit constant makes
+    /// call sites self-documenting; a plain `0` in code comments as
+    /// "why zero?" whereas `NO_CORRELATION` makes the intent obvious.
+    pub const NO_CORRELATION: u64 = 0;
+
+    /// `ReplyTo` with no target and no correlation.
+    pub const NONE: ReplyTo = ReplyTo {
+        target: ReplyTarget::None,
+        correlation_id: Self::NO_CORRELATION,
+    };
+
+    /// Reply target alone, no correlation. Short form for mail paths
+    /// that want to address a reply but don't participate in the
+    /// ADR-0042 correlation scheme (the hub's inbound session mail
+    /// today — a future change could have sessions carry correlation
+    /// when the MCP send_mail tool grows to expose it).
+    pub fn to(target: ReplyTarget) -> Self {
+        Self {
+            target,
+            correlation_id: Self::NO_CORRELATION,
+        }
+    }
+
+    /// Target + correlation. The common sync-wrapper shape.
+    pub fn with_correlation(target: ReplyTarget, correlation_id: u64) -> Self {
+        Self {
+            target,
+            correlation_id,
+        }
+    }
+
+    /// Whether the reply target is `None`. Existing callers that
+    /// were pattern-matching on the pre-refactor `ReplyTo::None`
+    /// variant use this instead.
     pub fn is_none(&self) -> bool {
-        matches!(self, ReplyTo::None)
+        matches!(self.target, ReplyTarget::None)
     }
 }
 
@@ -114,7 +149,7 @@ impl Mail {
             kind,
             payload,
             count,
-            reply_to: ReplyTo::None,
+            reply_to: ReplyTo::NONE,
             from_component: None,
         }
     }

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, OnceLock};
 use aether_hub_protocol::{EngineMailToHubSubstrateFrame, EngineToHub};
 
 use crate::hub_client::HubOutbound;
-use crate::mail::{Mail, ReplyTo};
+use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use crate::registry::{MailboxEntry, Registry};
 use crate::scheduler::ComponentTable;
 
@@ -103,13 +103,15 @@ impl Mailer {
     where
         K: aether_mail::Kind + serde::Serialize,
     {
-        match sender {
-            ReplyTo::None => false,
-            ReplyTo::Session(_) | ReplyTo::EngineMailbox { .. } => match self.outbound.get() {
-                Some(outbound) => outbound.send_reply(sender, result),
-                None => false,
-            },
-            ReplyTo::Component(mailbox) => {
+        match sender.target {
+            ReplyTarget::None => false,
+            ReplyTarget::Session(_) | ReplyTarget::EngineMailbox { .. } => {
+                match self.outbound.get() {
+                    Some(outbound) => outbound.send_reply(sender, result),
+                    None => false,
+                }
+            }
+            ReplyTarget::Component(mailbox) => {
                 let payload = match postcard::to_allocvec(result) {
                     Ok(p) => p,
                     Err(e) => {
@@ -122,7 +124,12 @@ impl Mailer {
                         return false;
                     }
                 };
-                self.push(Mail::new(mailbox, K::ID, payload, 1));
+                // ADR-0042: echo the caller's correlation_id onto the
+                // reply envelope so a `wait_reply_p32` parked on this
+                // correlation picks the right reply out of the mpsc.
+                // Reply target is None — nobody replies to a reply.
+                let reply_to = ReplyTo::with_correlation(ReplyTarget::None, sender.correlation_id);
+                self.push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
                 true
             }
         }
@@ -221,6 +228,10 @@ fn route_mail(
                 // with no local component origin (broadcast-
                 // originated, substrate-generated).
                 let source_mailbox_id = mail.from_component.map(|mbox| mbox.0);
+                // ADR-0042: carry the correlation through the bubble-
+                // up frame so a reply coming back via Phase-2 reply
+                // routing lands at the originator's `wait_reply_p32`.
+                let correlation_id = mail.reply_to.correlation_id;
                 let sent = outbound.send(EngineToHub::MailToHubSubstrate(
                     EngineMailToHubSubstrateFrame {
                         recipient_mailbox_id: recipient.0,
@@ -228,6 +239,7 @@ fn route_mail(
                         payload: mail.payload,
                         count: mail.count,
                         source_mailbox_id,
+                        correlation_id,
                     },
                 ));
                 if !sent {

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -28,7 +28,7 @@ use crate::mail::{MailboxId, ReplyTo};
 /// (`None` for substrate-core pushes with no sending mailbox, per
 /// ADR-0011), the remote origin of the mail per ADR-0008 / ADR-0037
 /// (`Sender::Session` for hub-inbound, `ReplyTo::EngineMailbox` for
-/// bubbled-up, `ReplyTo::None` for substrate-local), payload bytes,
+/// bubbled-up, `ReplyTo::NONE` for substrate-local), payload bytes,
 /// and the kind-implied count.
 pub type SinkHandler =
     Arc<dyn Fn(u64, &str, Option<&str>, ReplyTo, &[u8], u32) + Send + Sync + 'static>;
@@ -464,8 +464,8 @@ mod tests {
             panic!("expected sink")
         };
         // Test-side id is irrelevant — the handler ignores it.
-        h(0, "aether.tick", None, ReplyTo::None, &[], 7);
-        h(0, "aether.tick", Some("physics"), ReplyTo::None, &[], 3);
+        h(0, "aether.tick", None, ReplyTo::NONE, &[], 7);
+        h(0, "aether.tick", Some("physics"), ReplyTo::NONE, &[], 3);
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 

--- a/crates/aether-substrate-core/src/reply_table.rs
+++ b/crates/aether-substrate-core/src/reply_table.rs
@@ -20,9 +20,9 @@
 
 use std::collections::HashMap;
 
-use aether_hub_protocol::{EngineId, SessionToken};
+use aether_hub_protocol::SessionToken;
 
-use crate::mail::MailboxId;
+use crate::mail::{MailboxId, ReplyTarget};
 
 /// Sentinel passed to the guest's `receive` shim when the inbound
 /// mail has no reply target (broadcast origin — ADR-0013 §1). A
@@ -31,24 +31,42 @@ use crate::mail::MailboxId;
 pub const NO_REPLY_HANDLE: u32 = u32::MAX;
 
 /// What a reply handle resolves to on the substrate side. The guest
-/// sees only the opaque `u32` — the variant is purely host-side so
-/// `reply_mail` can pick the right outbound route.
+/// sees only the opaque `u32` — the `target` variant lets `reply_mail`
+/// pick the right outbound route, and `correlation_id` carries the
+/// ADR-0042 correlation from the inbound mail so the reply's echo
+/// happens automatically when `reply_mail` constructs the outbound
+/// `ReplyTo`.
+///
+/// Invariant: `target` is never `ReplyTarget::None` — the table only
+/// allocates entries for mail that had a meaningful reply target.
+/// The shared enum stays convenient (same shape as envelope-level
+/// `ReplyTo.target`), at the cost of a dead `None` variant here.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ReplyEntry {
-    /// Reply routes over `HubOutbound` as a session-addressed frame.
-    Session(SessionToken),
-    /// Reply routes through the local `Mailer` as ordinary
-    /// component-to-component mail.
-    Component(MailboxId),
-    /// Reply routes over `HubOutbound` as
-    /// `EngineToHub::MailToEngineMailbox` (ADR-0037 Phase 2). The
-    /// hub forwards the frame to the target engine's connection as
-    /// `HubToEngine::MailById`; that engine's hub-client reader
-    /// resolves the mailbox id + kind locally and dispatches.
-    RemoteEngineMailbox {
-        engine_id: EngineId,
-        mailbox_id: u64,
-    },
+pub struct ReplyEntry {
+    pub target: ReplyTarget,
+    pub correlation_id: u64,
+}
+
+impl ReplyEntry {
+    /// Short constructor: `target` + `correlation_id`.
+    pub fn new(target: ReplyTarget, correlation_id: u64) -> Self {
+        Self {
+            target,
+            correlation_id,
+        }
+    }
+
+    /// Back-compat shim for call sites that used the pre-correlation
+    /// `ReplyEntry::Session(token)` form. Builds an entry with no
+    /// correlation.
+    pub fn session(token: SessionToken) -> Self {
+        Self::new(ReplyTarget::Session(token), 0)
+    }
+
+    /// Back-compat shim for `ReplyEntry::Component(mailbox)`.
+    pub fn component(mailbox: MailboxId) -> Self {
+        Self::new(ReplyTarget::Component(mailbox), 0)
+    }
 }
 
 /// Maintains the handle→entry map for one component instance.
@@ -101,13 +119,13 @@ mod tests {
     #[test]
     fn allocate_session_and_component_handles_roundtrip() {
         let mut t = ReplyTable::new();
-        let h_sess = t.allocate(ReplyEntry::Session(token(1)));
-        let h_comp = t.allocate(ReplyEntry::Component(MailboxId(42)));
+        let h_sess = t.allocate(ReplyEntry::session(token(1)));
+        let h_comp = t.allocate(ReplyEntry::component(MailboxId(42)));
         assert_ne!(h_sess, h_comp);
-        assert_eq!(t.resolve(h_sess), Some(ReplyEntry::Session(token(1))));
+        assert_eq!(t.resolve(h_sess), Some(ReplyEntry::session(token(1))));
         assert_eq!(
             t.resolve(h_comp),
-            Some(ReplyEntry::Component(MailboxId(42))),
+            Some(ReplyEntry::component(MailboxId(42)))
         );
     }
 
@@ -120,7 +138,7 @@ mod tests {
     #[test]
     fn resolve_unknown_handle_is_none() {
         let mut t = ReplyTable::new();
-        let _ = t.allocate(ReplyEntry::Session(token(7)));
+        let _ = t.allocate(ReplyEntry::session(token(7)));
         assert!(t.resolve(9999).is_none());
     }
 
@@ -128,10 +146,19 @@ mod tests {
     fn allocate_skips_sentinel_on_wrap() {
         let mut t = ReplyTable::new();
         t.next = NO_REPLY_HANDLE;
-        let h = t.allocate(ReplyEntry::Session(token(3)));
+        let h = t.allocate(ReplyEntry::session(token(3)));
         // First handle after the wrap is 0 — the sentinel is never
         // handed out.
         assert_eq!(h, 0);
         assert_ne!(h, NO_REPLY_HANDLE);
+    }
+
+    #[test]
+    fn allocate_preserves_correlation_id() {
+        let mut t = ReplyTable::new();
+        let entry = ReplyEntry::new(ReplyTarget::Session(token(5)), 0xCAFEBABE);
+        let h = t.allocate(entry);
+        let got = t.resolve(h).expect("resolves");
+        assert_eq!(got.correlation_id, 0xCAFEBABE);
     }
 }

--- a/crates/aether-substrate-desktop/src/capture.rs
+++ b/crates/aether-substrate-desktop/src/capture.rs
@@ -20,8 +20,6 @@
 use std::sync::{Arc, Mutex};
 
 use aether_substrate_core::{Mail, ReplyTo};
-#[cfg(test)]
-use aether_substrate_core::ReplyTarget;
 
 /// One pending capture request. Carries the reply handle so the
 /// render thread can reply once it has bytes, plus a resolved list
@@ -68,8 +66,10 @@ impl CaptureQueue {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_substrate_core::ReplyTarget;
+
+    use super::*;
 
     fn reply_to(u: u128) -> ReplyTo {
         ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))

--- a/crates/aether-substrate-desktop/src/capture.rs
+++ b/crates/aether-substrate-desktop/src/capture.rs
@@ -20,6 +20,8 @@
 use std::sync::{Arc, Mutex};
 
 use aether_substrate_core::{Mail, ReplyTo};
+#[cfg(test)]
+use aether_substrate_core::ReplyTarget;
 
 /// One pending capture request. Carries the reply handle so the
 /// render thread can reply once it has bytes, plus a resolved list
@@ -70,7 +72,7 @@ mod tests {
     use aether_hub_protocol::{SessionToken, Uuid};
 
     fn reply_to(u: u128) -> ReplyTo {
-        ReplyTo::Session(SessionToken(Uuid::from_u128(u)))
+        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))
     }
 
     fn pending(u: u128) -> PendingCapture {

--- a/crates/aether-substrate-desktop/src/lib.rs
+++ b/crates/aether-substrate-desktop/src/lib.rs
@@ -20,9 +20,10 @@ pub mod chassis;
 pub use aether_substrate_core::{
     AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,
     HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailboxEntry,
-    MailboxId, Mailer, Registry, ReplyTo, Scheduler, SinkHandler, SubstrateBoot, SubstrateCtx,
-    component, control, ctx, host_fns, hub_client, input, io, kind_manifest, log_capture, mail,
-    mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler, subscribers_for,
+    MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, Scheduler, SinkHandler, SubstrateBoot,
+    SubstrateCtx, component, control, ctx, host_fns, hub_client, input, io, kind_manifest,
+    log_capture, mail, mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler,
+    subscribers_for,
 };
 
 pub use capture::{CaptureQueue, PendingCapture};

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -32,7 +32,7 @@ use aether_substrate_desktop::{
     Scheduler, SubstrateBoot, UserEvent,
     audio::{self, AudioEvent, AudioEventSender},
     chassis_control_handler,
-    mail::{Mail, MailboxId, ReplyTo},
+    mail::{Mail, MailboxId, ReplyTarget, ReplyTo},
     subscribers_for,
 };
 use render::{Gpu, IDENTITY_VIEW_PROJ};
@@ -318,8 +318,8 @@ fn build_audio_pipeline() -> Option<audio::AudioPipeline> {
 /// audio sink in practice) collapse to id `0`, sharing one voice
 /// slot per (instrument, pitch).
 fn sender_mailbox_id(sender: ReplyTo) -> u64 {
-    match sender {
-        ReplyTo::EngineMailbox { mailbox_id, .. } => mailbox_id,
+    match sender.target {
+        ReplyTarget::EngineMailbox { mailbox_id, .. } => mailbox_id,
         _ => 0,
     }
 }

--- a/crates/aether-substrate-desktop/tests/hub_client.rs
+++ b/crates/aether-substrate-desktop/tests/hub_client.rs
@@ -14,7 +14,7 @@ use aether_hub_protocol::{
     SessionToken, Uuid, Welcome, read_frame, write_frame,
 };
 use aether_substrate_desktop::{
-    HubClient, HubOutbound, Mailer, Registry, ReplyTo, Scheduler, mail::MailboxId,
+    HubClient, HubOutbound, Mailer, Registry, ReplyTarget, ReplyTo, Scheduler, mail::MailboxId,
 };
 
 /// Start a mock hub on a random port. Returns the bound address and a
@@ -160,6 +160,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             payload: vec![1, 2, 3],
             count: 7,
             sender: alice,
+            correlation_id: 0,
         },
         MailFrame {
             recipient_name: "hello".into(),
@@ -167,6 +168,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             payload: vec![],
             count: 1,
             sender: SessionToken::NIL,
+            correlation_id: 0,
         },
         MailFrame {
             recipient_name: "hello".into(),
@@ -174,6 +176,7 @@ fn inbound_mail_lands_in_queue_after_resolution() {
             payload: vec![9],
             count: 1,
             sender: SessionToken::NIL,
+            correlation_id: 0,
         },
     ] {
         write_frame(&mut stream, &HubToEngine::Mail(frame)).unwrap();
@@ -196,7 +199,10 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     assert_eq!(s.payload_lens, vec![3, 1]);
     assert_eq!(
         s.senders,
-        vec![ReplyTo::Session(alice), ReplyTo::Session(SessionToken::NIL)],
+        vec![
+            ReplyTo::to(ReplyTarget::Session(alice)),
+            ReplyTo::to(ReplyTarget::Session(SessionToken::NIL)),
+        ],
     );
     assert_eq!(recipient, MailboxId::from_name("hello"));
 
@@ -348,6 +354,7 @@ fn outbound_sends_reach_the_hub_wire() {
         kind_name: "aether.observation.ping".into(),
         payload: vec![1, 2, 3],
         origin: Some("physics".into()),
+        correlation_id: 0,
     })));
 
     // Read it back on the server side. Heartbeats may arrive too —
@@ -378,6 +385,7 @@ fn outbound_send_without_attach_is_noop() {
         kind_name: "aether.tick".into(),
         payload: vec![],
         origin: None,
+        correlation_id: 0,
     }));
     assert!(!ok);
 }

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -118,7 +118,7 @@ fn dispatch<K: aether_mail::Kind + serde::Serialize>(plane: &ControlPlane, paylo
         K::ID,
         K::NAME,
         None,
-        aether_substrate_desktop::ReplyTo::None,
+        aether_substrate_desktop::ReplyTo::NONE,
         &bytes,
         0,
     );

--- a/crates/aether-substrate-hub/src/engine.rs
+++ b/crates/aether-substrate-hub/src/engine.rs
@@ -190,6 +190,9 @@ async fn read_loop(
                         kind_id: frame.kind_id,
                         payload: frame.payload,
                         count: frame.count,
+                        // ADR-0042: forward the correlation so the
+                        // target engine's `wait_reply_p32` can match it.
+                        correlation_id: frame.correlation_id,
                     });
                     if let Err(e) = record.mail_tx.try_send(by_id) {
                         eprintln!(
@@ -241,6 +244,7 @@ pub(crate) fn route_engine_mail(
         kind_name,
         payload,
         origin,
+        correlation_id: _,
     } = mail;
     match address {
         ClaudeAddress::Session(token) => match sessions.get(&token) {
@@ -361,6 +365,7 @@ mod tests {
             kind_name: "aether.observation.ping".into(),
             payload,
             origin: None,
+            correlation_id: 0,
         }
     }
 
@@ -370,6 +375,7 @@ mod tests {
             kind_name: "aether.observation.ping".into(),
             payload,
             origin: Some(origin.into()),
+            correlation_id: 0,
         }
     }
 

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -43,7 +43,7 @@ use aether_hub_protocol::{
 use aether_kinds::UnresolvedMail;
 use aether_mail::{Kind, mailbox_id_from_name};
 use aether_substrate_core::{
-    AETHER_DIAGNOSTICS, Mail, MailboxId, Mailer, Registry, ReplyTo, SubstrateBoot,
+    AETHER_DIAGNOSTICS, Mail, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
     dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
@@ -132,6 +132,7 @@ impl LoopbackHandle {
             payload,
             count,
             source_mailbox_id,
+            correlation_id,
         } = frame;
         // Kind lookup guards against an engine bubbling up a kind
         // the hub substrate doesn't know — without it the mail
@@ -163,11 +164,14 @@ impl LoopbackHandle {
             return;
         }
         let sender = match source_mailbox_id {
-            Some(mailbox_id) => ReplyTo::EngineMailbox {
-                engine_id: source_engine_id,
-                mailbox_id,
-            },
-            None => ReplyTo::None,
+            Some(mailbox_id) => ReplyTo::with_correlation(
+                ReplyTarget::EngineMailbox {
+                    engine_id: source_engine_id,
+                    mailbox_id,
+                },
+                correlation_id,
+            ),
+            None => ReplyTo::with_correlation(ReplyTarget::None, correlation_id),
         };
         self.queue.push(
             Mail::new(MailboxId(recipient_mailbox_id), kind_id, payload, count)
@@ -202,6 +206,7 @@ fn send_unresolved_diagnostic(
         kind_id: UnresolvedMail::ID,
         payload,
         count: 1,
+        correlation_id: 0,
     });
     if let Err(e) = record.mail_tx.try_send(frame) {
         eprintln!(
@@ -337,6 +342,7 @@ pub fn spawn_outbound_drainer(
                                 kind_id: frame.kind_id,
                                 payload: frame.payload,
                                 count: frame.count,
+                                correlation_id: frame.correlation_id,
                             });
                             if let Err(e) = record.mail_tx.try_send(by_id) {
                                 eprintln!(
@@ -426,6 +432,7 @@ mod tests {
                 kind_id: 42,
                 payload: vec![1, 2, 3],
                 count: 1,
+                correlation_id: 0,
             }))
             .expect("outbound send");
 
@@ -468,6 +475,7 @@ mod tests {
                 payload: vec![1, 2, 3],
                 count: 1,
                 source_mailbox_id: None,
+                correlation_id: 0,
             },
             &engines,
         );
@@ -515,6 +523,7 @@ mod tests {
                 payload: vec![],
                 count: 1,
                 source_mailbox_id: Some(0x5151),
+                correlation_id: 0,
             },
             &engines,
         );

--- a/crates/aether-substrate-hub/src/mcp/codecs.rs
+++ b/crates/aether-substrate-hub/src/mcp/codecs.rs
@@ -46,6 +46,12 @@ pub(super) async fn deliver_one(
         payload,
         count: spec.count,
         sender,
+        // ADR-0042: MCP `send_mail` doesn't expose correlation
+        // today — tooling can still invoke sync-like flows by
+        // manually matching on echoed namespace + path per
+        // ADR-0041, and we can widen MCP later when a concrete
+        // need surfaces.
+        correlation_id: 0,
     });
     record
         .mail_tx

--- a/docs/adr/0042-synchronous-mail-wait.md
+++ b/docs/adr/0042-synchronous-mail-wait.md
@@ -2,7 +2,8 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-23
-- **Amended:** 2026-04-24 — retired the filter-slot + oneshot mechanism in §1 / §4 / §6 in favour of a drain-and-buffer loop over the component's mpsc inbox. See _Amendment history_ below.
+- **Amended:** 2026-04-24 — retired the filter-slot + oneshot mechanism in §1 / §4 / §6 in favour of a drain-and-buffer loop over the component's mpsc inbox.
+- **Amended:** 2026-04-24 — added per-component correlation ids on `ReplyTo` + `prev_correlation_p32` host fn, so the drain loop can filter out stale replies of the same kind. See _Amendment history_ below.
 
 ## Context
 
@@ -47,37 +48,42 @@ This ADR commits to a synchronous-mail-wait primitive in the host FFI and the gu
 
 ## Decision
 
-### 1. Host fn: `wait_reply_p32`
+### 1. Host fns: `wait_reply_p32` + `prev_correlation_p32`
 
-One new import on the `aether` module, a sibling to `send_mail_p32` / `reply_mail_p32`:
+Two new imports on the `aether` module, siblings to `send_mail_p32` / `reply_mail_p32`:
 
 ```rust
-// Guest signature (Rust-side in aether-component::raw)
+// Guest signatures (Rust-side in aether-component::raw)
 pub fn wait_reply_p32(
-    expected_kind: u64,    // K::ID to wait for
-    out_ptr: u32,          // component-memory buffer to write the reply payload into
-    out_cap: u32,          // buffer capacity
-    timeout_ms: u32,       // 0 = return immediately if nothing matches; max clamped below
+    expected_kind: u64,             // K::ID to wait for
+    out_ptr: u32,                   // component-memory buffer to write the reply payload into
+    out_cap: u32,                   // buffer capacity
+    timeout_ms: u32,                // 0 = poll (try_recv only); max clamped below
+    expected_correlation: u64,      // 0 = kind-only match; nonzero = filter on reply_to.correlation_id
 ) -> i32;
+
+pub fn prev_correlation_p32() -> u64;
 ```
 
-Return value encoding:
+Return value encoding for `wait_reply_p32`:
 
 - `>= 0` — bytes written to `out_ptr`. Reply decoded against `expected_kind`.
 - `-1` — timeout elapsed with no matching reply.
 - `-2` — reply matched but the payload exceeded `out_cap` (bytes were dropped; caller retries with a larger buffer).
 - `-3` — substrate tore the component down while it was waiting (drop/replace during a wait); the guest treats this as "abort whatever you were doing."
 
-Substrate side (**drain + buffer**): the component's mpsc Receiver moves onto `SubstrateCtx` so the host fn can drive it directly. `wait_reply_p32` loops:
+`prev_correlation_p32` returns the correlation id the substrate auto-minted for this component's most recent `send_mail`. `0` before any send. Sync wrappers call it immediately after a send to capture the id, then pass it as `expected_correlation` on the matching `wait_reply_p32` — `(kind, correlation)` uniquely picks *our* reply out of the inbox rather than whatever `kind`-matching mail happens to be queued.
+
+Substrate side (**drain + buffer + correlation**): the component's mpsc Receiver moves onto `SubstrateCtx` so the host fn can drive it directly. `wait_reply_p32` loops:
 
 1. Pop a mail from the inbox mpsc (`recv_timeout(remaining)` or `try_recv` when `timeout_ms == 0`).
-2. If the mail's kind id matches `expected_kind`, decode the payload into the guest buffer and return the byte count.
+2. Match: `m.kind == expected_kind && (expected_correlation == 0 || m.reply_to.correlation_id == expected_correlation)`. On match, decode into the guest buffer and return the byte count.
 3. Otherwise, push the mail onto a per-component FIFO **overflow buffer** and loop again.
 4. On timeout, return `-1`. Buffered non-matching mail stays in overflow — the dispatcher drains it before pulling anything new from the mpsc on its next iteration.
 
 This means **no re-entrant deliver calls**. The component is one thread; that thread is parked inside the host fn's drain loop; non-match mail accumulates in the overflow buffer while the wait is live. When the wait returns (match, timeout, or disconnect), the dispatcher loop resumes, drains the overflow first (so FIFO order is preserved across the wait), and only then pulls new mail from the mpsc.
 
-Nothing new is needed on the send side: `SubstrateCtx::send` / `Mailer::push` / `ComponentEntry::send` all stay exactly as they were pre-wait. A reply to a sink-bound request arrives in the same mpsc that carries every other piece of mail; the host fn's drain loop picks it up. That removes the ordering trap an earlier version of this ADR introduced with a separate filter slot — a wait-bearing flow (`send` → sink replies synchronously → reply lands in mpsc → guest calls `wait_reply_p32`) works regardless of when the guest decides to park, because the mail is already sitting where the host fn reads from.
+Nothing new is needed on the send side from the guest's perspective: `raw::send_mail` keeps its 5-arg signature. What *did* change under the hood: `SubstrateCtx::send` now mints a fresh `correlation_id` on every call via a per-component `Cell<u64>` counter (single-threaded per ADR-0038, so no atomic), attaches it to the outgoing `ReplyTo`, and stores the value where `prev_correlation_p32` can read it. `Mailer::send_reply` auto-echoes the incoming correlation on the reply envelope. Sink authors never touch correlation — the mailer does it. A reply to a sink-bound request arrives in the same mpsc that carries every other piece of mail; the host fn's drain loop picks it up by matching the stashed correlation. That removes both the ordering trap an earlier version of this ADR introduced with a separate filter slot *and* the stale-reply trap where a sync call could consume a prior async reply of the same kind.
 
 ### 2. SDK surface: scoped to substrate sinks
 
@@ -191,3 +197,13 @@ On `timeout_ms = 0`, the guest uses `try_recv` instead of `recv_timeout` — sem
 **Why.** The filter-slot design's ordering invariant — filter must be installed before the mail it's meant to match arrives — didn't survive contact with ADR-0041's synchronous sink dispatch. A component calling `io::read` via `send_mail` dispatches the io sink inline on the dispatcher thread; the sink replies before `send_mail` returns, landing the reply in the mpsc. Any subsequent `wait_reply_p32` that both installs the filter and waits is too late — the match is already past. The clean fixes were (a) split install and wait into two host fns, or (b) drain the mpsc from the host fn. (b) is simpler and has no ordering trap: the host fn reads exactly where mail lives, so there's no "install before the race starts" step to get wrong.
 
 **Backward compatibility.** No guest SDK had shipped a `wait_reply` caller yet; no components were using the FFI. The retired `FilterSlot` type, `ComponentEntry.filter_slot` field, and `SubstrateCtx::with_filter_slot` builder are removed. `wait_reply_p32`'s wasm import name and return encoding are unchanged — guest code compiled against its signature still links correctly, only the body changed.
+
+### 2026-04-24 — per-component correlation ids on ReplyTo
+
+**What changed.** `ReplyTo` refactored from an enum to `struct ReplyTo { target: ReplyTarget, correlation_id: u64 }`. Every reply-bearing wire shape grows a `correlation_id: u64`: `EngineMailFrame`, `MailFrame`, `MailToEngineMailboxFrame`, `EngineMailToHubSubstrateFrame`, `MailByIdFrame`. Substrate-side, `SubstrateCtx` gains a `Cell<u64>` per-component counter minted on every `send` and auto-echoed on replies by `Mailer::send_reply`. `wait_reply_p32` grows a 5th arg `expected_correlation: u64` (0 = kind-only). New host fn `prev_correlation_p32() -> u64` reads the last-minted id.
+
+**Why.** The original drain+buffer design matched incoming mail by kind only. A component that fires an async `io::read` and *then* calls `io::read_sync` (of the same kind) would have the sync wait consume the prior async reply — silent cross-wiring. No queue-draining scheme fixes this in general: a prior async reply can land during the wait, and a kind-only match can't distinguish it from "ours." Correlating each request to its own reply fixes it cleanly. Making the substrate mint correlations automatically (rather than pushing the responsibility to the SDK) keeps the Rust-level `SubstrateCtx::send` signature unchanged — guests opt into filtering by calling `prev_correlation` + `wait_reply` with the returned id.
+
+**Per-component vs global.** Counter lives on `SubstrateCtx`, which is rebuilt per instance. Two components' correlation ids don't collide by accident (mail routes to separate inboxes) but more importantly the id-space is clean — each component starts at 1. On `replace_component`, the counter resets because the `SubstrateCtx` is rebuilt; in-flight correlations belong to the old instance, not the mailbox.
+
+**Backward compatibility.** Wire-level: all `correlation_id` fields derive `#[serde(default)]` so deserializing a pre-amendment frame yields `0` (the "no correlation" sentinel), matching kind-only behavior. `ReplyTo` API: enum variant matches become struct-with-target matches; a dozen call sites swept in the same PR. `ReplyEntry` (in the reply table) likewise grew a `correlation_id` field so `reply_mail_p32` echoes it on the outgoing reply. No components had shipped against the pre-correlation SDK; this amendment lands alongside the `*_sync` wrappers that first use it.


### PR DESCRIPTION
Closes #224. Fixes the silent-corruption bug where a component that mixes async + sync I/O on the same reply kind could have its sync wait consume a prior async reply as if it were the one it asked for.

## The bug

```rust
io::read("save", "a.bin");                       // async, fire-and-forget
// other work happens
let bytes = io::read_sync("save", "b.bin", 1000)?;  // returns a.bin's bytes
```

`wait_reply_p32` matched by kind only. First `ReadResult` in the mpsc wins, regardless of which request it was for. No amount of pre-send draining fixes it — a prior request's reply can arrive *during* the wait and be matched as ours.

## The fix

Attach a u64 correlation_id to every `ReplyTo` and filter on `(kind, correlation)` in the wait.

- **`ReplyTo` struct refactor.** Was an enum; now `struct ReplyTo { target: ReplyTarget, correlation_id: u64 }`. Stays `Copy` (u64 is Copy). Every envelope-level match on `ReplyTo` sweeps to match on `reply_to.target`.
- **Substrate auto-mints.** `SubstrateCtx` gains a `Cell<u64>` counter — **per-component, not global** (one `SubstrateCtx` per instance, single-threaded per ADR-0038, so no atomic needed). `SubstrateCtx::send` bumps + attaches the id on every send. Rust-level `send` signature stays unchanged.
- **`prev_correlation_p32` host fn.** Returns `counter.saturating_sub(1)` — the last-minted id. Sync wrappers call it right after `send_mail` to capture the id, then pass it as `expected_correlation` on the matching `wait_reply`.
- **Mailer auto-echoes.** `Mailer::send_reply` copies `sender.correlation_id` onto the reply envelope. Reply-bearing sinks (io today) inherit the behaviour — no per-sink code.
- **`wait_reply_p32` gets a 5th arg.** `expected_correlation: u64`. `0` = kind-only (backward compat); nonzero = `(kind, correlation)` filter.
- **Hub-protocol mail frames grow `correlation_id`.** `#[serde(default)]` for on-wire backward compat. Hub routing carries it across engine↔hub↔engine hops.
- **Guest SDK.** `raw::prev_correlation` import + host stub. `io::{read,write,delete,list}_sync` updated to capture + filter.

## Per-component, not global

Counter lives on `SubstrateCtx`, which is rebuilt per component instance. Two components' id-spaces don't collide (separate inboxes anyway), but more importantly each component starts fresh at 1. On `replace_component`, the counter resets because the `SubstrateCtx` is rebuilt — in-flight correlations belong to the old instance, not the mailbox.

## Regression test

`wait_reply_filters_by_correlation_not_just_kind`: seed two matching-kind replies (correlations 10 and 42), wait on 42, assert the 42 reply returned and the 10 reply landed in overflow for the dispatcher to deliver later.

## Wire compatibility

`#[serde(default)]` on every new `correlation_id` field means old-encoded frames decode with `correlation_id = 0` (the "no correlation" sentinel). A mixed-version cluster works: old substrate → new substrate → reply has 0; sync waits without correlation (expected=0) match kind-only and still work.

**Note for runtime use:** the MCP hub you're attached to was built before this PR. Wire layout changed on `MailFrame` / `EngineMailFrame` / etc. — the running hub would fail to decode frames from a post-merge engine and vice versa. Restart the hub after merging before trying the save-counter example.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` (137 tests pass; 1 new regression test)
- [ ] MCP smoke: skipped this round because the running hub is pre-refactor; will re-verify after hub restart