### PR TITLE
feat(component): sink::send_postcard for schema-shaped kinds

### DIFF
--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -21,9 +21,8 @@
 //! 3. `terminate_substrate`, spawn another, observe the count
 //!    bumped by one.
 
-use aether_component::{Component, Ctx, InitCtx, handlers, io, raw};
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers, io, resolve_sink};
 use aether_kinds::{IoError, Tick};
-use aether_mail::{Kind, mailbox_id_from_name};
 
 /// Broadcast payload the Claude session (or any component listening
 /// on `hub.claude.broadcast`) reads to track counter progress. The
@@ -107,19 +106,10 @@ fn write_counter(value: u64) {
 }
 
 /// Emit `Count { count }` to `hub.claude.broadcast` so every
-/// attached Claude session observes the new value. Goes through
-/// `raw::send_mail` rather than `Sink::send` because the `Count`
-/// schema is postcard-shaped, not bytemuck-castable.
+/// attached Claude session observes the new value. `Count` is
+/// schema-shaped (postcard), so the send goes through
+/// `Sink::send_postcard` rather than `Sink::send`.
 fn broadcast_count(count: u64) {
-    let payload =
-        postcard::to_allocvec(&Count { count }).expect("postcard encode Count is infallible");
-    unsafe {
-        raw::send_mail(
-            mailbox_id_from_name("hub.claude.broadcast"),
-            <Count as Kind>::ID,
-            payload.as_ptr().addr() as u32,
-            payload.len() as u32,
-            1,
-        );
-    }
+    const BROADCAST: Sink<Count> = resolve_sink::<Count>("hub.claude.broadcast");
+    BROADCAST.send_postcard(&Count { count });
 }

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -43,6 +43,10 @@ const SAVE_PATH: &str = "counter.bin";
 /// should complete in sub-ms; larger backends (future cloud adapter)
 /// would want a bigger budget.
 const IO_TIMEOUT_MS: u32 = 1_000;
+/// Broadcast sink — `hub.claude.broadcast` fans out to every
+/// attached Claude session. `Count` is postcard-shaped, so the send
+/// goes through `Sink::send_postcard`.
+const BROADCAST: Sink<Count> = resolve_sink::<Count>("hub.claude.broadcast");
 
 pub struct SaveCounter {
     initialized: bool,
@@ -75,8 +79,13 @@ impl Component for SaveCounter {
 
         let current = read_counter_or_zero();
         let next = current.saturating_add(1);
-        write_counter(next);
-        broadcast_count(next);
+        let _ = io::write_sync(
+            SAVE_NAMESPACE,
+            SAVE_PATH,
+            &next.to_le_bytes(),
+            IO_TIMEOUT_MS,
+        );
+        BROADCAST.send_postcard(&Count { count: next });
     }
 }
 
@@ -98,18 +107,4 @@ fn read_counter_or_zero() -> u64 {
         Err(io::SyncIoError::Io(IoError::NotFound)) => 0,
         Err(_) => 0,
     }
-}
-
-fn write_counter(value: u64) {
-    let bytes = value.to_le_bytes();
-    let _ = io::write_sync(SAVE_NAMESPACE, SAVE_PATH, &bytes, IO_TIMEOUT_MS);
-}
-
-/// Emit `Count { count }` to `hub.claude.broadcast` so every
-/// attached Claude session observes the new value. `Count` is
-/// schema-shaped (postcard), so the send goes through
-/// `Sink::send_postcard` rather than `Sink::send`.
-fn broadcast_count(count: u64) {
-    const BROADCAST: Sink<Count> = resolve_sink::<Count>("hub.claude.broadcast");
-    BROADCAST.send_postcard(&Count { count });
 }

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -44,10 +44,10 @@ use alloc::vec::Vec;
 use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
-use aether_mail::{Kind, mailbox_id_from_name};
+use aether_mail::Kind;
 use serde::Serialize;
 
-use crate::raw;
+use crate::{raw, resolve_sink};
 
 /// Short mailbox name the substrate registers its I/O sink under
 /// (ADR-0041). Exposed so components that want to bypass the
@@ -106,29 +106,12 @@ pub fn list(namespace: &str, prefix: &str) {
 }
 
 fn send<K: Kind + Serialize>(value: &K) -> u64 {
-    let bytes = encode_postcard(value);
-    unsafe {
-        raw::send_mail(
-            mailbox_id_from_name(IO_MAILBOX_NAME),
-            K::ID,
-            bytes.as_ptr().addr() as u32,
-            bytes.len() as u32,
-            1,
-        );
-        // ADR-0042: capture the correlation the substrate just
-        // minted so the sync wrappers can filter on it. For the
-        // async helpers (`read` / `write` / `delete` / `list`),
-        // this is harmless noise — they don't wait.
-        raw::prev_correlation()
-    }
-}
-
-fn encode_postcard<K: Serialize>(value: &K) -> Vec<u8> {
-    // postcard encode to Vec is infallible for well-formed serde
-    // impls — the kinds here all derive Serialize via
-    // `#[derive(Serialize)]`, so the `expect` is a "this can't
-    // fail" guard, not a recoverable branch.
-    postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
+    resolve_sink::<K>(IO_MAILBOX_NAME).send_postcard(value);
+    // ADR-0042: capture the correlation the substrate just minted so
+    // the sync wrappers can filter on it. For the async helpers
+    // (`read` / `write` / `delete` / `list`), this is harmless noise —
+    // they don't wait.
+    unsafe { raw::prev_correlation() }
 }
 
 /// ADR-0042: errors surfaced by the `*_sync` wrappers. The first three
@@ -284,9 +267,20 @@ mod tests {
     // That proves the wire shape stays identical to what the ADR-0041
     // substrate dispatcher decodes.
 
+    // The request kinds derive `Serialize`/`Deserialize`, so postcard
+    // roundtrip is what the substrate dispatcher observes on the wire.
+    // Off-wasm we can't exercise the host fn, but we can prove the
+    // encode shape survives a decode — a canary against an accidental
+    // schema drift between what the guest builds and what the adapter
+    // parses in `SinkHandler::handle`.
+
+    fn postcard_bytes<T: Serialize>(value: &T) -> Vec<u8> {
+        postcard::to_allocvec(value).unwrap()
+    }
+
     #[test]
     fn read_encodes_to_postcard_read() {
-        let encoded = encode_postcard(&ReadKind {
+        let encoded = postcard_bytes(&ReadKind {
             namespace: "save".to_string(),
             path: "slot.bin".to_string(),
         });
@@ -297,7 +291,7 @@ mod tests {
 
     #[test]
     fn write_encodes_to_postcard_write() {
-        let encoded = encode_postcard(&WriteKind {
+        let encoded = postcard_bytes(&WriteKind {
             namespace: "save".to_string(),
             path: "state.bin".to_string(),
             bytes: alloc::vec![1, 2, 3, 4],
@@ -308,7 +302,7 @@ mod tests {
 
     #[test]
     fn delete_encodes_to_postcard_delete() {
-        let encoded = encode_postcard(&DeleteKind {
+        let encoded = postcard_bytes(&DeleteKind {
             namespace: "save".to_string(),
             path: "ghost.bin".to_string(),
         });
@@ -318,7 +312,7 @@ mod tests {
 
     #[test]
     fn list_encodes_to_postcard_list() {
-        let encoded = encode_postcard(&ListKind {
+        let encoded = postcard_bytes(&ListKind {
             namespace: "save".to_string(),
             prefix: "".to_string(),
         });

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -208,6 +208,29 @@ impl<K: Kind + bytemuck::NoUninit> Sink<K> {
     }
 }
 
+impl<K: Kind + serde::Serialize> Sink<K> {
+    /// Send a single postcard-encoded payload. Sibling of [`Sink::send`]
+    /// for schema-shaped kinds (`#[derive(Schema, Serialize)]` — e.g.
+    /// `Count`, `SubscribeInput`, the `io::*` request kinds) that
+    /// aren't bytemuck-castable. The substrate's `count` field is 1.
+    ///
+    /// No `send_postcard_many` — postcard has no efficient contiguous
+    /// batch shape, so batch sends stay bytemuck-only. A component
+    /// that wants to fan out N postcard payloads calls this in a loop.
+    pub fn send_postcard(self, payload: &K) {
+        let bytes = postcard::to_allocvec(payload).expect("postcard encode to Vec is infallible");
+        unsafe {
+            raw::send_mail(
+                self.mailbox,
+                self.kind,
+                bytes.as_ptr().addr() as u32,
+                bytes.len() as u32,
+                1,
+            );
+        }
+    }
+}
+
 /// Resolve a kind, producing a typed id from the `const ID` the derive
 /// emits on the `Kind` impl. ADR-0030 Phase 2 made kind ids a pure
 /// function of `(name, schema)` at compile time — no host-fn round
@@ -366,17 +389,7 @@ impl InitCtx<'_> {
             stream,
             mailbox: self.mailbox,
         };
-        let bytes = postcard::to_allocvec(&payload).expect("SubscribeInput encode infallible");
-        let recipient = mailbox_id_from_name("aether.control");
-        unsafe {
-            raw::send_mail(
-                recipient,
-                <SubscribeInput as Kind>::ID,
-                bytes.as_ptr().addr() as u32,
-                bytes.len() as u32,
-                1,
-            );
-        }
+        resolve_sink::<SubscribeInput>("aether.control").send_postcard(&payload);
     }
 }
 
@@ -434,6 +447,13 @@ impl Ctx<'_> {
     /// Send a slice of payloads as a contiguous batch.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
+    }
+
+    /// Send a postcard-encoded payload. Sibling of [`Ctx::send`] for
+    /// schema-shaped kinds — same dispatch discipline (receive-time
+    /// capability), different wire shape.
+    pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
+        sink.send_postcard(payload);
     }
 
     /// Reply to the Claude session that originated the inbound mail
@@ -532,6 +552,12 @@ impl DropCtx<'_> {
     /// Send a slice of payloads during a shutdown hook.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
+    }
+
+    /// Send a postcard-encoded payload during a shutdown hook. Sibling
+    /// of [`DropCtx::send`] for schema-shaped kinds.
+    pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
+        sink.send_postcard(payload);
     }
 
     /// Deposit a migration bundle for the substrate to hand to the


### PR DESCRIPTION
## Summary

Closes #223. Add `Sink::send_postcard` and rewrite the three call-sites that were hand-rolling `unsafe raw::send_mail` to get postcard-encoded mail through the FFI.

- `Sink::send_postcard(&payload)` keyed on `K: Kind + serde::Serialize`, sibling of the existing `bytemuck`-gated `Sink::send`.
- `Ctx::send_postcard` / `DropCtx::send_postcard` mirror the existing `send` pair.
- No `send_postcard_many` — postcard has no efficient batch shape (spelled out in the rustdoc).

Call-sites migrated:
- `InitCtx::subscribe_input` — `resolve_sink::<SubscribeInput>(\"aether.control\").send_postcard(&payload)`.
- `io::send` — resolves the `\"io\"` sink per-request (all `const fn`, zero runtime cost); `encode_postcard` helper dropped. `raw::prev_correlation()` still captures the ADR-0042 correlation for the `*_sync` wrappers.
- `save_counter` example — `broadcast_count` caches the sink in a `const` and sends through `send_postcard`.

Post-change `grep -rn 'raw::send_mail'` reports only the SDK-internal paths (`Sink::send` / `Sink::send_many` / `Sink::send_postcard`), which is the invariant #223 wanted.

## Test plan
- [x] `cargo test` — all 29 component tests pass (existing `encode_postcard` unit tests swapped to a local `postcard_bytes` helper since the prod helper is gone).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo build --target wasm32-unknown-unknown -p aether-component --examples` — all examples (echoer/caller/input_logger/save_counter) still compile, confirming the `subscribe_input` rewrite didn't break input-subscribing components.