### PR TITLE
feat(mail): typed handle Ref wire type (ADR-0045)

### DIFF
--- a/crates/aether-hub-protocol/src/canonical/labels.rs
+++ b/crates/aether-hub-protocol/src/canonical/labels.rs
@@ -17,6 +17,7 @@ const LABEL_VEC: u8 = 2;
 const LABEL_ARRAY: u8 = 3;
 const LABEL_STRUCT: u8 = 4;
 const LABEL_ENUM: u8 = 5;
+const LABEL_REF: u8 = 6;
 
 const VARIANT_LABEL_UNIT: u8 = 0;
 const VARIANT_LABEL_TUPLE: u8 = 1;
@@ -71,6 +72,7 @@ const fn label_node_len(node: &LabelNode) -> usize {
             }
             total
         }
+        LabelNode::Ref(cell) => 1 + label_cell_len(cell),
     }
 }
 
@@ -192,6 +194,11 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
                 pos = write_variant_label(&vs[i], out, pos);
                 i += 1;
             }
+        }
+        LabelNode::Ref(cell) => {
+            out[pos] = LABEL_REF;
+            pos += 1;
+            pos = write_label_cell(cell, out, pos);
         }
     }
     pos

--- a/crates/aether-hub-protocol/src/canonical/mod.rs
+++ b/crates/aether-hub-protocol/src/canonical/mod.rs
@@ -265,6 +265,43 @@ mod tests {
         assert_eq!(&B1[..], &B2[..]);
     }
 
+    // ADR-0045 typed handle reference. The new `SchemaType::Ref`
+    // variant gets wire tag 10 (after `SCHEMA_ENUM = 9`); these
+    // tests pin both the canonical bytes and the `SchemaShape`
+    // round-trip so a future re-numbering of the variants can't
+    // silently shift bytes underneath shipped components.
+
+    static REF_F32: SchemaType = SchemaType::Ref(SchemaCell::Static(&F32));
+
+    #[test]
+    fn canonical_schema_ref_round_trips_as_shape() {
+        const N: usize = canonical_len_schema(&REF_F32);
+        const BYTES: [u8; N] = canonical_serialize_schema::<N>(&REF_F32);
+        // Tag 10 (SCHEMA_REF) followed by the inner schema's tag
+        // (Scalar = 2, F32 = 8).
+        assert_eq!(BYTES[0], 10);
+        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(
+            shape,
+            SchemaShape::Ref(Box::new(SchemaShape::Scalar(Primitive::F32)))
+        );
+    }
+
+    #[test]
+    fn canonical_schema_ref_differs_from_inline_kind() {
+        // A struct field flipping from `K` to `Ref<K>` MUST change
+        // the canonical bytes — that's how kind ids stay distinct
+        // for the inline-shaped and ref-shaped variants of an
+        // otherwise-equal kind. Pinned so a future bug that drops
+        // the SCHEMA_REF tag from the encoding would surface.
+        const INLINE_LEN: usize = canonical_len_schema(&F32);
+        const REF_LEN: usize = canonical_len_schema(&REF_F32);
+        const INLINE_BYTES: [u8; INLINE_LEN] = canonical_serialize_schema::<INLINE_LEN>(&F32);
+        const REF_BYTES: [u8; REF_LEN] = canonical_serialize_schema::<REF_LEN>(&REF_F32);
+        assert_ne!(&INLINE_BYTES[..], &REF_BYTES[..]);
+        assert_eq!(REF_BYTES.len(), INLINE_BYTES.len() + 1);
+    }
+
     // Labels tests — these exercise the full `KindLabels` round-trip.
 
     static VERTEX_LABELS: LabelNode = LabelNode::Struct {
@@ -319,6 +356,26 @@ mod tests {
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&RESULT_LABELS);
         let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, RESULT_LABELS);
+    }
+
+    // ADR-0045: `LabelNode::Ref` mirrors `SchemaType::Ref` in the
+    // labels sidecar tree. The label's own variant tag is 6 (after
+    // Enum = 5); the inner cell carries the wrapped kind's labels
+    // verbatim. Hub walks both trees in lockstep, so a missing tag
+    // on either side breaks `describe_kinds`.
+
+    static REF_VERTEX_LABELS: KindLabels = KindLabels {
+        kind_id: 0,
+        kind_label: Cow::Borrowed("my_crate::HeldVertex"),
+        root: LabelNode::Ref(LabelCell::Static(&VERTEX_LABELS)),
+    };
+
+    #[test]
+    fn canonical_labels_ref_round_trips() {
+        const N: usize = canonical_len_labels(&REF_VERTEX_LABELS);
+        const BYTES: [u8; N] = canonical_serialize_labels::<N>(&REF_VERTEX_LABELS);
+        let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(decoded, REF_VERTEX_LABELS);
     }
 
     // ADR-0033: handler/fallback/component record encoders. Round-trip

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -26,6 +26,7 @@ const SCHEMA_VEC: u8 = 6;
 const SCHEMA_ARRAY: u8 = 7;
 const SCHEMA_STRUCT: u8 = 8;
 const SCHEMA_ENUM: u8 = 9;
+const SCHEMA_REF: u8 = 10;
 
 const VARIANT_UNIT: u8 = 0;
 const VARIANT_TUPLE: u8 = 1;
@@ -75,6 +76,7 @@ pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
             }
             total
         }
+        SchemaType::Ref(cell) => 1 + canonical_len_cell(cell),
     }
 }
 
@@ -195,6 +197,7 @@ fn schema_to_shape(s: &SchemaType) -> crate::types::SchemaShape {
         SchemaType::Enum { variants } => SchemaShape::Enum {
             variants: variants.iter().map(variant_to_shape).collect(),
         },
+        SchemaType::Ref(cell) => SchemaShape::Ref(alloc::boxed::Box::new(schema_to_shape(cell))),
     }
 }
 
@@ -338,6 +341,11 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
                 pos = write_variant(&slice[i], out, pos);
                 i += 1;
             }
+        }
+        SchemaType::Ref(cell) => {
+            out[pos] = SCHEMA_REF;
+            pos += 1;
+            pos = write_cell(cell, out, pos);
         }
     }
     pos

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -94,6 +94,14 @@ pub enum SchemaType {
     Enum {
         variants: Cow<'static, [EnumVariant]>,
     },
+    /// ADR-0045 typed handle reference. A field whose type is
+    /// `Ref<K>` accepts either an inline `K` value or a
+    /// `Handle { id, kind_id }` pointing into the substrate's
+    /// handle store. The cell wraps the inner kind's schema —
+    /// recipients dispatch identically against the resolved
+    /// inline value, so existing decoders only need to learn
+    /// the new tag at the field-walk step.
+    Ref(SchemaCell),
 }
 
 /// Recursion-breaking indirection for nested `SchemaType` fields
@@ -273,6 +281,7 @@ pub enum SchemaShape {
     Enum {
         variants: Vec<VariantShape>,
     },
+    Ref(Box<SchemaShape>),
 }
 
 /// Positional enum variant — `VariantShape::Tuple { discriminant, fields }`
@@ -336,6 +345,7 @@ pub enum LabelNode {
         type_label: Option<Cow<'static, str>>,
         variants: Cow<'static, [VariantLabel]>,
     },
+    Ref(LabelCell),
 }
 
 /// Per-variant nominal info for `LabelNode::Enum`. `name` is the Rust
@@ -439,6 +449,7 @@ impl Clone for LabelNode {
                 type_label: type_label.clone(),
                 variants: variants.clone(),
             },
+            LabelNode::Ref(c) => LabelNode::Ref(c.clone()),
         }
     }
 }
@@ -472,6 +483,7 @@ impl PartialEq for LabelNode {
                     variants: vb,
                 },
             ) => la == lb && va == vb,
+            (LabelNode::Ref(a), LabelNode::Ref(b)) => a == b,
             _ => false,
         }
     }
@@ -523,6 +535,11 @@ impl Serialize for LabelNode {
                 s.serialize_field("variants", variants)?;
                 s.end()
             }
+            LabelNode::Ref(cell) => {
+                let mut s = serializer.serialize_tuple_variant("LabelNode", 6, "Ref", 1)?;
+                s.serialize_field(cell)?;
+                s.end()
+            }
         }
     }
 }
@@ -546,6 +563,7 @@ impl<'de> Deserialize<'de> for LabelNode {
                 type_label: Option<Cow<'static, str>>,
                 variants: Vec<VariantLabel>,
             },
+            Ref(LabelCell),
         }
         match LabelNodeDe::deserialize(deserializer)? {
             LabelNodeDe::Anonymous => Ok(LabelNode::Anonymous),
@@ -568,6 +586,7 @@ impl<'de> Deserialize<'de> for LabelNode {
                 type_label,
                 variants: Cow::Owned(variants),
             }),
+            LabelNodeDe::Ref(c) => Ok(LabelNode::Ref(c)),
         }
     }
 }

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -13,8 +13,8 @@
 //   - The `Vec<u8>` field-level specialization lands as `Bytes`, not
 //     `Vec(Scalar(U8))`.
 
-use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaType};
-use aether_mail::{CastEligible, Kind, Schema};
+use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaCell, SchemaType};
+use aether_mail::{CastEligible, Kind, Ref, Schema};
 
 #[derive(aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.tick")]
@@ -189,6 +189,105 @@ fn enum_emits_each_variant_shape_with_sequential_discriminants() {
             ty: SchemaType::String,
         }]
     );
+}
+
+// ADR-0045 typed handle: the derive doesn't have to know about
+// `Ref<K>` syntactically — the hand-rolled `Schema` impl in
+// aether-mail dispatches through the existing trait. These tests
+// pin that integration: a struct with a `Ref<K>` field gets a
+// `SchemaType::Ref` arm in its layout, the parent's CastEligible
+// flips to false (refs force postcard), and the wire roundtrips
+// for both Inline and Handle variants.
+
+#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.held_note")]
+#[allow(dead_code)]
+struct HeldNote {
+    body: Ref<Note>,
+    seq: u32,
+}
+
+#[test]
+fn ref_field_lands_as_schema_ref_pointing_at_inner_kind() {
+    let SchemaType::Struct { fields, repr_c } = &<HeldNote as Schema>::SCHEMA else {
+        panic!("expected Struct schema");
+    };
+    // Ref<K> forces postcard — a parent with a Ref field can't
+    // claim `repr_c: true` no matter how the rest of the fields
+    // look. ADR-0045 §1.
+    assert!(!*repr_c);
+    assert_eq!(fields.len(), 2);
+
+    let body = &fields[0];
+    assert_eq!(body.name, "body");
+    let SchemaType::Ref(inner_cell) = &body.ty else {
+        panic!("expected Ref schema for body field, got {:?}", body.ty);
+    };
+    let inner: &SchemaType = inner_cell;
+    // The cell points at <Note as Schema>::SCHEMA verbatim — same
+    // bytes the standalone Note would emit. Recipients dispatch
+    // against this after handle resolution lands inline.
+    assert_eq!(inner, &<Note as Schema>::SCHEMA);
+
+    // Sibling field unaffected.
+    let seq = &fields[1];
+    assert_eq!(seq.name, "seq");
+    assert_eq!(seq.ty, SchemaType::Scalar(Primitive::U32));
+}
+
+#[test]
+fn parent_with_ref_field_is_cast_ineligible() {
+    // Even though Ref<K>'s own ELIGIBLE is false, the AND-fold in
+    // the derive's emitted `ELIGIBLE` const propagates the false up
+    // to the parent. A future regression that forgets to mark
+    // Ref<K> ineligible would let parents claim repr_c, then break
+    // the cast-shaped wire encoder when it tries to emit a
+    // variable-length Inline body.
+    const { assert!(!<HeldNote as CastEligible>::ELIGIBLE) };
+}
+
+#[test]
+fn ref_inner_kind_id_is_carried_in_handle_arm() {
+    // `Ref::handle::<K>(id)` pulls `K::ID` automatically — pin the
+    // value so a future change to the kind's NAME or schema (which
+    // would reshuffle the FNV-derived id) is loud, not silent.
+    let r: Ref<Note> = Ref::handle(0xfeed_0000);
+    let Ref::Handle { id, kind_id } = r else {
+        panic!("expected Handle variant");
+    };
+    assert_eq!(id, 0xfeed_0000);
+    assert_eq!(kind_id, <Note as Kind>::ID);
+}
+
+#[test]
+fn ref_kind_id_differs_from_inline_kind_id() {
+    // The schema canonical bytes change when a field flips from
+    // `K` to `Ref<K>` — they pick up an extra `SCHEMA_REF` tag.
+    // This is intentional (a wire change at the kind boundary is
+    // a kind boundary change), but pin it explicitly so a refactor
+    // can't silently align the two ids and let mismatched
+    // recipients silently consume each other's mail.
+    #[derive(aether_mail::Kind, aether_mail::Schema)]
+    #[kind(name = "test.inline_note_field")]
+    #[allow(dead_code)]
+    struct Inlined {
+        body: Note,
+        seq: u32,
+    }
+    assert_ne!(<HeldNote as Kind>::ID, <Inlined as Kind>::ID);
+}
+
+#[test]
+fn ref_schema_cell_uses_static_pointer_for_const_construction() {
+    // ADR-0031: the Schema impl is a `const` so the derive can
+    // splat it as a literal. `SchemaType::Ref(SchemaCell::Static(_))`
+    // is what comes out of `<Ref<K> as Schema>::SCHEMA`; pin it
+    // here so a regression to `Owned` (which would force runtime
+    // allocation per-emit) is loud.
+    let SchemaType::Ref(cell) = &<Ref<Note> as Schema>::SCHEMA else {
+        panic!("expected Ref schema");
+    };
+    assert!(matches!(cell, SchemaCell::Static(_)));
 }
 
 #[test]

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -84,6 +84,9 @@ impl<T> CastEligible for alloc::vec::Vec<T> {
 impl<T> CastEligible for Option<T> {
     const ELIGIBLE: bool = false;
 }
+impl<K> CastEligible for Ref<K> {
+    const ELIGIBLE: bool = false;
+}
 
 /// Deterministic 64-bit hash of a mailbox name (ADR-0029). Both the
 /// substrate registry and the guest SDK compute mailbox ids from names
@@ -148,6 +151,83 @@ pub const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
         i += 1;
     }
     hash
+}
+
+/// ADR-0045 typed handle reference — wire form for fields that
+/// accept either an inline kind value or a handle pointing into the
+/// substrate's handle store.
+///
+/// `Ref<K>` lets a field carry one of two payloads on the wire:
+///
+/// - `Ref::Inline(K)` — the entire `K` value travels inline. The
+///   substrate dispatches identically to a non-`Ref` field after
+///   the field-walk step substitutes the inline value.
+/// - `Ref::Handle { id, kind_id }` — a reference into the
+///   substrate's handle store. On dispatch the substrate looks up
+///   `id` and either substitutes the resolved value or parks the
+///   mail until the handle resolves (ADR-0045 §4).
+///
+/// `kind_id` on the `Handle` arm MUST equal `<K as Kind>::ID`. The
+/// substrate validates this against the field's expected type
+/// before substitution; a mismatched id is a wire-corruption-class
+/// error, not a recoverable one. Use [`Ref::handle`] instead of
+/// constructing `Handle` directly to pull the id from the kind
+/// system rather than passing it by hand.
+///
+/// Phase 1 (this PR) ships the wire type and Schema integration
+/// only. The substrate-side dispatcher, handle store, and SDK
+/// `Handle<K>` newtype follow in subsequent PRs per the ADR's
+/// follow-up work plan.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Ref<K> {
+    /// Inline value — the whole `K` payload is on the wire.
+    Inline(K),
+    /// Handle reference into the substrate's handle store. `id`
+    /// addresses the entry; `kind_id` carries `<K as Kind>::ID` so
+    /// the substrate validates type compatibility before
+    /// substituting the resolved value.
+    Handle { id: u64, kind_id: u64 },
+}
+
+impl<K: Kind> Ref<K> {
+    /// Construct a `Ref::Handle` with `kind_id` pulled from
+    /// `K::ID`. Preferred over hand-constructing the variant —
+    /// callers can't pass a kind id that disagrees with the type
+    /// parameter.
+    pub const fn handle(id: u64) -> Self {
+        Ref::Handle { id, kind_id: K::ID }
+    }
+}
+
+impl<K> Ref<K> {
+    /// Wrap an owned value as `Ref::Inline`. Convenience for call
+    /// sites that have the value but want the field shape.
+    pub const fn inline(value: K) -> Self {
+        Ref::Inline(value)
+    }
+
+    /// Returns `true` for `Ref::Inline`, `false` for
+    /// `Ref::Handle`. Cheap predicate for call sites that branch
+    /// on resolution state.
+    pub const fn is_inline(&self) -> bool {
+        matches!(self, Ref::Inline(_))
+    }
+
+    /// Returns `true` for `Ref::Handle`, `false` for
+    /// `Ref::Inline`.
+    pub const fn is_handle(&self) -> bool {
+        matches!(self, Ref::Handle { .. })
+    }
+
+    /// The wire `id` if this is a `Ref::Handle`, `None` for
+    /// inline. `kind_id` is recoverable via `<K as Kind>::ID` so
+    /// no separate accessor is provided.
+    pub const fn handle_id(&self) -> Option<u64> {
+        match self {
+            Ref::Handle { id, .. } => Some(*id),
+            Ref::Inline(_) => None,
+        }
+    }
 }
 
 /// Re-exported derive macros from `aether-mail-derive`. Behind the
@@ -281,6 +361,20 @@ mod schema {
         };
         const LABEL: Option<&'static str> = None;
         const LABEL_NODE: LabelNode = LabelNode::Array(LabelCell::Static(&T::LABEL_NODE));
+    }
+
+    // ADR-0045 typed handle reference. `Ref<K>` exposes both the
+    // inline-value path and the handle-id path through one schema
+    // tag — recipients walk fields and dispatch identically once
+    // the substrate has substituted the resolved value. The bound
+    // is `Schema + 'static` (matching `Vec<T>` etc.) rather than
+    // `Kind` because the schema impl only needs the inner
+    // `K::SCHEMA` and `K::LABEL_NODE`; the `Kind` bound on `Ref<K>`
+    // helpers in lib.rs is for `K::ID` access at construction time.
+    impl<K: Schema + 'static> Schema for super::Ref<K> {
+        const SCHEMA: SchemaType = SchemaType::Ref(SchemaCell::Static(&K::SCHEMA));
+        const LABEL: Option<&'static str> = None;
+        const LABEL_NODE: LabelNode = LabelNode::Ref(LabelCell::Static(&K::LABEL_NODE));
     }
 }
 
@@ -504,6 +598,96 @@ mod tests {
             fnv1a_64_prefixed(MAILBOX_DOMAIN, &[]),
         );
         assert_ne!(mailbox_id_from_name(""), 0xcbf29ce484222325);
+    }
+
+    #[test]
+    fn ref_handle_pulls_kind_id_from_type_param() {
+        let r: Ref<TestStruct> = Ref::handle(42);
+        match r {
+            Ref::Handle { id, kind_id } => {
+                assert_eq!(id, 42);
+                assert_eq!(kind_id, TestStruct::ID);
+            }
+            _ => panic!("expected Handle variant"),
+        }
+    }
+
+    #[test]
+    fn ref_inline_wraps_value() {
+        let v = TestStruct {
+            tag: 7,
+            label: alloc::string::String::from("hi"),
+        };
+        let r = Ref::inline(v.clone());
+        match r {
+            Ref::Inline(inner) => assert_eq!(inner, v),
+            _ => panic!("expected Inline variant"),
+        }
+    }
+
+    #[test]
+    fn ref_predicates_and_handle_id() {
+        let inline: Ref<TestStruct> = Ref::Inline(TestStruct {
+            tag: 1,
+            label: alloc::string::String::from("a"),
+        });
+        let handle: Ref<TestStruct> = Ref::handle(99);
+        assert!(inline.is_inline());
+        assert!(!inline.is_handle());
+        assert_eq!(inline.handle_id(), None);
+        assert!(!handle.is_inline());
+        assert!(handle.is_handle());
+        assert_eq!(handle.handle_id(), Some(99));
+    }
+
+    #[test]
+    fn ref_inline_postcard_roundtrip() {
+        let v = TestStruct {
+            tag: 42,
+            label: alloc::string::String::from("hello"),
+        };
+        let r = Ref::Inline(v);
+        let bytes = postcard::to_allocvec(&r).unwrap();
+        let back: Ref<TestStruct> = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn ref_handle_postcard_roundtrip() {
+        let r: Ref<TestStruct> = Ref::Handle {
+            id: 0xdead_beef_cafe_babe,
+            kind_id: 0x1234_5678_9abc_def0,
+        };
+        let bytes = postcard::to_allocvec(&r).unwrap();
+        let back: Ref<TestStruct> = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn ref_inline_and_handle_have_distinct_wire_discriminants() {
+        // Pins the externally-tagged enum encoding: postcard writes
+        // a varint discriminant before the body, so Inline and
+        // Handle differ in their first byte. A regression that
+        // re-orders the Ref variants would silently flip what
+        // existing handle wires decode to.
+        let inline: Ref<TestStruct> = Ref::Inline(TestStruct {
+            tag: 1,
+            label: alloc::string::String::from("x"),
+        });
+        let handle: Ref<TestStruct> = Ref::Handle { id: 1, kind_id: 1 };
+        let inline_bytes = postcard::to_allocvec(&inline).unwrap();
+        let handle_bytes = postcard::to_allocvec(&handle).unwrap();
+        assert_eq!(inline_bytes[0], 0, "Inline discriminant must be 0");
+        assert_eq!(handle_bytes[0], 1, "Handle discriminant must be 1");
+    }
+
+    #[test]
+    fn ref_is_cast_ineligible() {
+        // A field typed `Ref<K>` forces postcard wire — cast-shaped
+        // structs can't contain refs because the Inline arm's
+        // payload size isn't fixed. The CastEligible impl encodes
+        // this so the derive emits `repr_c: false` for parents.
+        const { assert!(!<Ref<TestStruct> as CastEligible>::ELIGIBLE) };
     }
 
     #[test]

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -327,6 +327,13 @@ fn merge_schema(shape: &SchemaShape, label: Option<&LabelNode>) -> SchemaType {
                 variants: Cow::Owned(merged),
             }
         }
+        SchemaShape::Ref(inner) => {
+            let inner_label = match label {
+                Some(LabelNode::Ref(cell)) => Some(&**cell),
+                _ => None,
+            };
+            SchemaType::Ref(SchemaCell::owned(merge_schema(inner, inner_label)))
+        }
     }
 }
 

--- a/crates/aether-substrate-hub/src/decoder.rs
+++ b/crates/aether-substrate-hub/src/decoder.rs
@@ -183,7 +183,8 @@ fn decode_cast_field(
         | SchemaType::Option(_)
         | SchemaType::Vec(_)
         | SchemaType::Enum { .. }
-        | SchemaType::Unit => Err(DecodeError::UnsupportedSchema(
+        | SchemaType::Unit
+        | SchemaType::Ref(_) => Err(DecodeError::UnsupportedSchema(
             "non-cast field inside cast-shaped struct",
         )),
     }
@@ -321,6 +322,36 @@ fn decode_postcard(
                     discriminant: disc,
                 })?;
             decode_enum_body(cur, variant, path)
+        }
+        SchemaType::Ref(inner) => {
+            // ADR-0045 typed handle. Wire matches the postcard
+            // enum encoding: discriminant varint, then either the
+            // inner-kind body (Inline = 0) or two varints id +
+            // kind_id (Handle = 1). Render as externally-tagged
+            // JSON to match the encoder's input shape.
+            let disc = read_varint_u64(cur, path)? as u32;
+            match disc {
+                0 => {
+                    let inner_value = decode_postcard(cur, inner, path)?;
+                    let mut obj = Map::with_capacity(1);
+                    obj.insert("Inline".into(), inner_value);
+                    Ok(Value::Object(obj))
+                }
+                1 => {
+                    let id = read_varint_u64(cur, &format!("{path}.id"))?;
+                    let kind_id = read_varint_u64(cur, &format!("{path}.kind_id"))?;
+                    let mut handle_obj = Map::with_capacity(2);
+                    handle_obj.insert("id".into(), Value::from(id));
+                    handle_obj.insert("kind_id".into(), Value::from(kind_id));
+                    let mut obj = Map::with_capacity(1);
+                    obj.insert("Handle".into(), Value::Object(handle_obj));
+                    Ok(Value::Object(obj))
+                }
+                _ => Err(DecodeError::UnknownEnumDiscriminant {
+                    path: path.into(),
+                    discriminant: disc,
+                }),
+            }
         }
     }
 }

--- a/crates/aether-substrate-hub/src/encoder.rs
+++ b/crates/aether-substrate-hub/src/encoder.rs
@@ -261,6 +261,51 @@ fn encode_postcard(
             encode_enum_body(body, variant, path, out)?;
             Ok(())
         }
+        SchemaType::Ref(inner) => {
+            // ADR-0045 typed handle. Externally-tagged JSON matches
+            // the Rust enum: `{"Inline": <inner-K>}` chooses the
+            // inline arm; `{"Handle": {"id": u64, "kind_id": u64}}`
+            // chooses the handle arm. Wire is the postcard enum
+            // encoding — discriminant varint + body, where body is
+            // either the inner kind's postcard bytes (Inline = 0)
+            // or two varints (Handle = 1).
+            let (tag, body) = decode_enum_tag(value, path)?;
+            match tag {
+                "Inline" => {
+                    write_varint_u64(out, 0);
+                    encode_postcard(body, inner, path, out)
+                }
+                "Handle" => {
+                    write_varint_u64(out, 1);
+                    let obj = body.as_object().ok_or_else(|| EncodeError::TypeMismatch {
+                        field: path.to_owned(),
+                        expected: "Handle object",
+                    })?;
+                    for key in obj.keys() {
+                        if key != "id" && key != "kind_id" {
+                            return Err(EncodeError::UnexpectedField(format!("{path}.{key}")));
+                        }
+                    }
+                    let id_path = format!("{path}.id");
+                    let kind_id_path = format!("{path}.kind_id");
+                    let id_v = obj
+                        .get("id")
+                        .ok_or_else(|| EncodeError::MissingField(id_path.clone()))?;
+                    let kind_id_v = obj
+                        .get("kind_id")
+                        .ok_or_else(|| EncodeError::MissingField(kind_id_path.clone()))?;
+                    let id = as_unsigned(id_v, &id_path, "u64")?;
+                    let kind_id = as_unsigned(kind_id_v, &kind_id_path, "u64")?;
+                    write_varint_u64(out, id);
+                    write_varint_u64(out, kind_id);
+                    Ok(())
+                }
+                _ => Err(EncodeError::TypeMismatch {
+                    field: path.to_owned(),
+                    expected: "Inline or Handle variant",
+                }),
+            }
+        }
     }
 }
 
@@ -524,7 +569,8 @@ fn encode_field_value(
         | SchemaType::Option(_)
         | SchemaType::Vec(_)
         | SchemaType::Enum { .. }
-        | SchemaType::Unit => Err(EncodeError::UnsupportedSchema(
+        | SchemaType::Unit
+        | SchemaType::Ref(_) => Err(EncodeError::UnsupportedSchema(
             "non-cast field inside cast-shaped struct",
         )),
     }


### PR DESCRIPTION
## Summary
- ADR-0045 Phase 1, PR 1 of 4: wire foundation for typed handles. `Ref<K>` enum with `Inline(K) | Handle { id, kind_id }` variants, plus matching `SchemaType::Ref` / `SchemaShape::Ref` / `LabelNode::Ref` variants in the schema vocabulary.
- Canonical bytes get wire tag 10 (after `SCHEMA_ENUM = 9`); LabelNode tag 6. Postcard wire is the standard externally-tagged enum encoding (varint discriminant + body), so no custom serializer.
- Hand-rolled `impl<K: Schema + 'static> Schema for Ref<K>` follows the existing `Vec<T>` / `Option<T>` pattern — derive macro learns nothing new, fields typed `Ref<K>` flow through trait dispatch.
- Hub encoder + decoder ship the JSON roundtrip for both `{Inline: ...}` and `{Handle: { id, kind_id }}` shapes. Cast-shaped path rejects Ref (refs force postcard).
- `CastEligible::ELIGIBLE = false` for `Ref<K>` so any parent struct containing a Ref field flips to `repr_c: false` at derive time.

What is NOT in this PR (intentionally): substrate dispatch, handle store, parked-mail walk, SDK `Handle<K>` newtype, demonstrative kinds. Those land in PRs 2, 3, and 4 per the ADR-0045 follow-up work plan.

## Test plan
- [ ] `cargo test --workspace` — 15 new tests across aether-mail, aether-hub-protocol, aether-mail-derive
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)