### PR TITLE
feat(component): typed Handle SDK + handle host-fns (ADR-0045)

### DIFF
--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -57,3 +57,11 @@ crate-type = ["cdylib"]
 [[example]]
 name = "save_counter"
 crate-type = ["cdylib"]
+
+# ADR-0045 typed-handle SDK demo. Publishes a `Note`, sends a
+# `HeldNote` whose `held: Ref<Note>` field carries the handle's
+# wire reference; the substrate's dispatch path resolves the
+# handle to its inline form before broadcast.
+[[example]]
+name = "handle_demo"
+crate-type = ["cdylib"]

--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -1,0 +1,88 @@
+//! ADR-0045 typed-handle SDK demo. Publishes a `Note` value into the
+//! substrate's handle store on the first tick, then broadcasts a
+//! `HeldNote` whose `held: Ref<Note>` field is the handle's wire
+//! reference. The substrate's dispatch path resolves the handle to
+//! its inline form before forwarding through `hub.claude.broadcast`,
+//! so attached Claude sessions see a fully-inline `HeldNote`.
+//!
+//! Run via MCP:
+//!
+//! 1. `spawn_substrate` a desktop / headless chassis with this
+//!    component preloaded.
+//! 2. `receive_mail` — one `demo.handle.held_note` frame surfaces
+//!    on the first tick, with `held` arriving as the `Inline`
+//!    variant even though the wire reference was a `Handle`.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers, resolve_sink};
+use aether_kinds::Tick;
+use aether_mail::Ref;
+
+#[derive(
+    aether_mail::Kind, aether_mail::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "demo.handle.note")]
+pub struct Note {
+    pub body: String,
+    pub seq: u32,
+}
+
+#[derive(
+    aether_mail::Kind, aether_mail::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "demo.handle.held_note")]
+pub struct HeldNote {
+    pub held: Ref<Note>,
+    pub seq: u32,
+}
+
+const BROADCAST: Sink<HeldNote> = resolve_sink::<HeldNote>("hub.claude.broadcast");
+
+pub struct HandleDemo {
+    fired: bool,
+}
+
+#[handlers]
+impl Component for HandleDemo {
+    fn init(_ctx: &mut InitCtx<'_>) -> Self {
+        HandleDemo { fired: false }
+    }
+
+    /// First-tick demo: publish a `Note`, broadcast a `HeldNote`
+    /// whose `held` is a `Ref::Handle`, pin the entry so it
+    /// outlives the local guard.
+    ///
+    /// # Agent
+    /// Not typically sent manually; the substrate's tick loop fires
+    /// this. Watch `receive_mail` for a `demo.handle.held_note`
+    /// frame. The `held` field arrives as `{"Inline": { ... }}`
+    /// because the substrate resolved the handle on dispatch.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        if self.fired {
+            return;
+        }
+        self.fired = true;
+
+        let inner = Note {
+            body: String::from("from a handle"),
+            seq: 7,
+        };
+        let Some(handle) = ctx.publish(&inner) else {
+            return;
+        };
+        let outer = HeldNote {
+            held: handle.as_ref(),
+            seq: 11,
+        };
+        // Broadcast is fire-and-forget. By the time the hub forwards
+        // to a Claude session the local guard would have been
+        // released and the entry could be evicted under pressure —
+        // pin it so the cached bytes survive.
+        handle.pin();
+        BROADCAST.send_postcard(&outer);
+        // `handle` drops here; the pin keeps the cached entry alive
+        // past release.
+    }
+}
+
+aether_component::export!(HandleDemo);

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -65,7 +65,7 @@ extern crate alloc;
 use core::any::TypeId;
 use core::marker::PhantomData;
 
-use aether_mail::{Kind, Schema, mailbox_id_from_name};
+use aether_mail::{Kind, Ref, Schema, mailbox_id_from_name};
 
 pub mod io;
 pub mod net;
@@ -232,6 +232,112 @@ impl<K: Kind + serde::Serialize> Sink<K> {
     }
 }
 
+/// ADR-0045 typed-handle wrapper around a substrate-side handle id.
+/// Created by [`Ctx::publish`] and friends; carries an RAII drop-
+/// release to drop the publisher's refcount when the handle goes out
+/// of scope. `K` is phantom — the id-as-bytes representation is
+/// type-agnostic, but `as_ref` pulls `K::ID` to construct a
+/// type-aligned `Ref::Handle`.
+///
+/// Not `Copy`. Cloning a refcounted handle without inc-ref'ing
+/// would cause a double-release on drop; if a component genuinely
+/// needs multiple references it pins the handle and reads the raw
+/// id.
+///
+/// Sending: build the wire-shaped value with [`Handle::as_ref`] in
+/// the `Ref<K>` field of an outgoing kind, then send the parent
+/// kind through any existing `Sink<_>::send_postcard`. The handle
+/// itself stays in the sender's hands until drop / explicit
+/// release; the substrate's dispatch path resolves the wire ref
+/// against the cached bytes before delivery.
+pub struct Handle<K> {
+    id: u64,
+    _k: PhantomData<fn() -> K>,
+}
+
+impl<K> Handle<K> {
+    /// Raw handle id. Exposed for hand-rolled callers that need to
+    /// pass the id to a host fn the SDK doesn't yet wrap, or to
+    /// detach it from the RAII guard via [`core::mem::forget`].
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Pin against LRU eviction. Useful when the publisher wants to
+    /// release its local guard (drop the `Handle`) without losing
+    /// the cached bytes — pin first, then drop.
+    pub fn pin(&self) {
+        unsafe {
+            raw::handle_pin(self.id);
+        }
+    }
+
+    /// Clear the pinned flag.
+    pub fn unpin(&self) {
+        unsafe {
+            raw::handle_unpin(self.id);
+        }
+    }
+
+    /// Drop the publisher's reference and consume the handle.
+    /// Equivalent to `drop(handle)` but explicit. Returns the
+    /// underlying id so callers that pinned first can keep using
+    /// it after release.
+    pub fn release(self) -> u64 {
+        let id = self.id;
+        // Capture the id, suppress the Drop impl, call release
+        // once. The Drop impl would otherwise double-release.
+        core::mem::forget(self);
+        unsafe {
+            raw::handle_release(id);
+        }
+        id
+    }
+}
+
+impl<K: Kind> Handle<K> {
+    /// Wire-shaped reference to this handle. Embed in a `Ref<K>`
+    /// field on an outgoing kind so the substrate's dispatch path
+    /// resolves the inline bytes before delivery. The handle keeps
+    /// its refcount on the publisher side — `as_ref` is a borrow,
+    /// not a transfer.
+    pub fn as_ref(&self) -> Ref<K> {
+        Ref::Handle {
+            id: self.id,
+            kind_id: K::ID,
+        }
+    }
+}
+
+impl<K> Drop for Handle<K> {
+    fn drop(&mut self) {
+        // dec_ref saturates at zero on the substrate side — calling
+        // release on an already-released handle is a no-op success.
+        // Failures (no store wired, unknown id) are silent because a
+        // panicking Drop is poison for ADR-0015 trap containment.
+        unsafe {
+            raw::handle_release(self.id);
+        }
+    }
+}
+
+/// Postcard-encode `value` and call the `handle_publish` host fn.
+/// Shared by `InitCtx::publish` / `Ctx::publish` / `DropCtx::publish`.
+/// Returns `None` when the substrate signals failure via the `0`
+/// sentinel (no store wired, OOB pointer, eviction-failed).
+fn publish_value<K: Kind + serde::Serialize>(value: &K) -> Option<Handle<K>> {
+    let bytes = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
+    let id =
+        unsafe { raw::handle_publish(K::ID, bytes.as_ptr().addr() as u32, bytes.len() as u32) };
+    if id == 0 {
+        return None;
+    }
+    Some(Handle {
+        id,
+        _k: PhantomData,
+    })
+}
+
 /// Resolve a kind, producing a typed id from the `const ID` the derive
 /// emits on the `Kind` impl. ADR-0030 Phase 2 made kind ids a pure
 /// function of `(name, schema)` at compile time — no host-fn round
@@ -355,6 +461,12 @@ impl InitCtx<'_> {
         resolve_sink::<K>(name)
     }
 
+    /// Publish `value` into the substrate's handle store at init.
+    /// See [`Ctx::publish`] for semantics.
+    pub fn publish<K: Kind + serde::Serialize>(&self, value: &K) -> Option<Handle<K>> {
+        publish_value::<K>(value)
+    }
+
     /// Send `aether.control.subscribe_input` with this component's
     /// mailbox as the subscriber for `K`'s stream. Called by
     /// `KindList::resolve_all` for every `K::IS_INPUT` kind — ADR-0030
@@ -455,6 +567,15 @@ impl Ctx<'_> {
     /// capability), different wire shape.
     pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
         sink.send_postcard(payload);
+    }
+
+    /// Publish `value` into the substrate's handle store and return
+    /// a typed [`Handle<K>`]. The publisher holds an initial
+    /// refcount; dropping the handle releases it. Returns `None` on
+    /// substrate-side failure (no store wired, OOB pointer,
+    /// eviction-failed).
+    pub fn publish<K: Kind + serde::Serialize>(&self, value: &K) -> Option<Handle<K>> {
+        publish_value::<K>(value)
     }
 
     /// Reply to the Claude session that originated the inbound mail
@@ -559,6 +680,16 @@ impl DropCtx<'_> {
     /// of [`DropCtx::send`] for schema-shaped kinds.
     pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
         sink.send_postcard(payload);
+    }
+
+    /// Publish `value` into the substrate's handle store during a
+    /// shutdown hook. See [`Ctx::publish`] for semantics — the
+    /// returned handle's RAII drop releases the publisher refcount,
+    /// which on `on_replace` typically means "pin first, then drop"
+    /// so the cached entry survives the hand-off to the next
+    /// instance.
+    pub fn publish<K: Kind + serde::Serialize>(&self, value: &K) -> Option<Handle<K>> {
+        publish_value::<K>(value)
     }
 
     /// Deposit a migration bundle for the substrate to hand to the

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -47,6 +47,29 @@ unsafe extern "C" {
     /// of this kind."
     #[link_name = "prev_correlation_p32"]
     pub fn prev_correlation() -> u64;
+    /// ADR-0045: copy `len` bytes at `ptr` (in the guest's linear
+    /// memory) into the substrate's handle store under `kind_id` and
+    /// return a fresh ephemeral handle id. Returns `0` on failure
+    /// (out-of-bounds pointer, no store wired, eviction-failed).
+    /// The publishing component holds an initial refcount on the
+    /// returned handle — call `handle_release` to drop it.
+    #[link_name = "handle_publish_p32"]
+    pub fn handle_publish(kind_id: u64, ptr: u32, len: u32) -> u64;
+    /// ADR-0045: drop one reference on `id`. Returns `0` on success,
+    /// non-zero status codes for unknown handle (`1`) or no store
+    /// wired (`2`). `dec_ref` saturates at zero so calling release
+    /// on an already-released handle is a no-op success.
+    #[link_name = "handle_release_p32"]
+    pub fn handle_release(id: u64) -> u32;
+    /// ADR-0045: pin `id` against LRU eviction. Pinned entries stay
+    /// in the store regardless of refcount. Same return codes as
+    /// `handle_release`.
+    #[link_name = "handle_pin_p32"]
+    pub fn handle_pin(id: u64) -> u32;
+    /// ADR-0045: clear the pinned flag on `id`. Same return codes
+    /// as `handle_release`.
+    #[link_name = "handle_unpin_p32"]
+    pub fn handle_unpin(id: u64) -> u32;
 }
 
 /// # Safety
@@ -93,4 +116,36 @@ pub unsafe fn wait_reply(
 #[cfg(not(target_arch = "wasm32"))]
 pub unsafe fn prev_correlation() -> u64 {
     panic!("aether-component: prev_correlation called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::handle_publish` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn handle_publish(_kind_id: u64, _ptr: u32, _len: u32) -> u64 {
+    panic!("aether-component: handle_publish called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::handle_release` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn handle_release(_id: u64) -> u32 {
+    panic!("aether-component: handle_release called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::handle_pin` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn handle_pin(_id: u64) -> u32 {
+    panic!("aether-component: handle_pin called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::handle_unpin` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn handle_unpin(_id: u64) -> u32 {
+    panic!("aether-component: handle_unpin called on non-wasm target");
 }

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -55,6 +55,21 @@ pub const WAIT_CANCELLED: i32 = -3;
 /// `WAIT_TIMEOUT`.
 pub const MAX_WAIT_TIMEOUT_MS: u32 = 30_000;
 
+/// Status codes returned by `handle_release_p32`, `handle_pin_p32`,
+/// `handle_unpin_p32` (ADR-0045). `handle_publish_p32` returns the
+/// minted handle id directly — `0` is the sentinel for failure (no
+/// memory exported, OOB pointer, no store wired, eviction-failed).
+pub const HANDLE_OK: u32 = 0;
+pub const HANDLE_UNKNOWN: u32 = 1;
+pub const HANDLE_NO_STORE: u32 = 2;
+
+/// Sentinel return value from `handle_publish_p32` indicating the
+/// publish failed. Matches `0` because the store's `next_ephemeral`
+/// counter starts at `1`, so `0` cannot collide with a real handle
+/// id. The SDK wraps this in `Option<Handle<K>>` so callers see the
+/// failure as `None` rather than a magic-zero handle.
+pub const HANDLE_PUBLISH_FAILED: u64 = 0;
+
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
 /// function has been called on.
@@ -390,5 +405,346 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         |caller: Caller<'_, SubstrateCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
+    // ADR-0045 typed-handle SDK: `publish` copies guest bytes into
+    // the substrate-side handle store and returns a fresh ephemeral
+    // id. The publisher's initial reference is recorded immediately
+    // (refcount=1 after put), so a subsequent `release` from the
+    // same component dec-refs it back to 0 and the entry becomes
+    // LRU-eligible. `0` is the failure sentinel (matches the
+    // store's `next_ephemeral` reservation of `0` as the no-handle
+    // id).
+    linker.func_wrap(
+        "aether",
+        "handle_publish_p32",
+        |mut caller: Caller<'_, SubstrateCtx>, kind_id: u64, ptr: u32, len: u32| -> u64 {
+            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                Some(m) => m,
+                None => return HANDLE_PUBLISH_FAILED,
+            };
+            let data = memory.data(&caller);
+            let start = ptr as usize;
+            let end = match start.checked_add(len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return HANDLE_PUBLISH_FAILED,
+            };
+            let bytes = data[start..end].to_vec();
+
+            let ctx = caller.data();
+            let Some(store) = ctx.queue.handle_store() else {
+                return HANDLE_PUBLISH_FAILED;
+            };
+            let id = store.next_ephemeral();
+            if let Err(e) = store.put(id, kind_id, bytes) {
+                tracing::warn!(
+                    target: "aether_substrate::handle_store",
+                    kind_id = format_args!("{kind_id:#x}"),
+                    error = ?e,
+                    "handle_publish failed",
+                );
+                return HANDLE_PUBLISH_FAILED;
+            }
+            // Hold a reference on behalf of the publishing
+            // component. Drop / explicit `release` decrements; on
+            // zero the entry stays in the store (subject to LRU
+            // eviction under pressure).
+            store.inc_ref(id);
+            id
+        },
+    )?;
+
+    // ADR-0045: drop the publisher's reference. `dec_ref` saturates
+    // at zero so calling release on an already-released handle is
+    // a no-op success rather than a panic.
+    linker.func_wrap(
+        "aether",
+        "handle_release_p32",
+        |caller: Caller<'_, SubstrateCtx>, id: u64| -> u32 {
+            let ctx = caller.data();
+            let Some(store) = ctx.queue.handle_store() else {
+                return HANDLE_NO_STORE;
+            };
+            if store.dec_ref(id) {
+                HANDLE_OK
+            } else {
+                HANDLE_UNKNOWN
+            }
+        },
+    )?;
+
+    // ADR-0045: pin / unpin let a component shield a handle from
+    // LRU eviction even when its refcount drops to zero. Useful for
+    // cross-frame caching where the publisher wants to release the
+    // local guard without losing the entry.
+    linker.func_wrap(
+        "aether",
+        "handle_pin_p32",
+        |caller: Caller<'_, SubstrateCtx>, id: u64| -> u32 {
+            let ctx = caller.data();
+            let Some(store) = ctx.queue.handle_store() else {
+                return HANDLE_NO_STORE;
+            };
+            if store.pin(id) {
+                HANDLE_OK
+            } else {
+                HANDLE_UNKNOWN
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "aether",
+        "handle_unpin_p32",
+        |caller: Caller<'_, SubstrateCtx>, id: u64| -> u32 {
+            let ctx = caller.data();
+            let Some(store) = ctx.queue.handle_store() else {
+                return HANDLE_NO_STORE;
+            };
+            if store.unpin(id) {
+                HANDLE_OK
+            } else {
+                HANDLE_UNKNOWN
+            }
+        },
+    )?;
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use wasmtime::{Engine, Linker, Module, Store, TypedFunc};
+
+    use super::*;
+    use crate::handle_store::HandleStore;
+    use crate::hub_client::HubOutbound;
+    use crate::input::new_subscribers;
+    use crate::mail::MailboxId;
+    use crate::mailer::Mailer;
+    use crate::registry::Registry;
+
+    /// WAT module exposing thin wrappers over the four ADR-0045
+    /// host fns. Each `(func (export ...))` matches the host-fn
+    /// signature so the tests can call them through `TypedFunc`
+    /// without indirection.
+    const WAT_HANDLE_HOST_FNS: &str = r#"
+        (module
+          (import "aether" "handle_publish_p32"
+            (func $publish (param i64 i32 i32) (result i64)))
+          (import "aether" "handle_release_p32"
+            (func $release (param i64) (result i32)))
+          (import "aether" "handle_pin_p32"
+            (func $pin (param i64) (result i32)))
+          (import "aether" "handle_unpin_p32"
+            (func $unpin (param i64) (result i32)))
+          (memory (export "memory") 1)
+          ;; 5 bytes at offset 100, used as the `publish` payload.
+          (data (i32.const 100) "\01\02\03\04\05")
+
+          (func (export "publish") (param i64) (result i64)
+            (call $publish (local.get 0) (i32.const 100) (i32.const 5)))
+          (func (export "publish_oob") (param i64) (result i64)
+            (call $publish (local.get 0) (i32.const 99999999) (i32.const 5)))
+          (func (export "release") (param i64) (result i32)
+            (call $release (local.get 0)))
+          (func (export "pin") (param i64) (result i32)
+            (call $pin (local.get 0)))
+          (func (export "unpin") (param i64) (result i32)
+            (call $unpin (local.get 0)))
+        )
+    "#;
+
+    struct Harness {
+        store: Store<SubstrateCtx>,
+        publish: TypedFunc<i64, i64>,
+        publish_oob: TypedFunc<i64, i64>,
+        release: TypedFunc<i64, i32>,
+        pin_fn: TypedFunc<i64, i32>,
+        unpin: TypedFunc<i64, i32>,
+        handle_store: Arc<HandleStore>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            Self::with_store(Arc::new(HandleStore::new(4096)))
+        }
+
+        fn with_store(handle_store: Arc<HandleStore>) -> Self {
+            let registry = Arc::new(Registry::new());
+            let queue = Arc::new(Mailer::new());
+            queue.wire_handle_store(Arc::clone(&handle_store));
+            // Wire registry+components so `Mailer::push` doesn't
+            // panic; route_mail isn't called in these tests but
+            // accessing `Mailer::handle_store` via the ctx still
+            // wants the rest of the wiring sane.
+            queue.wire(
+                Arc::clone(&registry),
+                Arc::new(std::sync::RwLock::new(Default::default())),
+            );
+            let outbound = HubOutbound::disconnected();
+
+            let ctx = SubstrateCtx::new(
+                MailboxId(0),
+                registry,
+                Arc::clone(&queue),
+                outbound,
+                new_subscribers(),
+            );
+
+            let engine = Engine::default();
+            let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+            register(&mut linker).expect("register host fns");
+            let wasm = wat::parse_str(WAT_HANDLE_HOST_FNS).expect("compile WAT");
+            let module = Module::new(&engine, &wasm).expect("compile module");
+            let mut store = Store::new(&engine, ctx);
+            let instance = linker
+                .instantiate(&mut store, &module)
+                .expect("instantiate");
+
+            let publish = instance
+                .get_typed_func::<i64, i64>(&mut store, "publish")
+                .unwrap();
+            let publish_oob = instance
+                .get_typed_func::<i64, i64>(&mut store, "publish_oob")
+                .unwrap();
+            let release = instance
+                .get_typed_func::<i64, i32>(&mut store, "release")
+                .unwrap();
+            let pin_fn = instance
+                .get_typed_func::<i64, i32>(&mut store, "pin")
+                .unwrap();
+            let unpin = instance
+                .get_typed_func::<i64, i32>(&mut store, "unpin")
+                .unwrap();
+
+            Harness {
+                store,
+                publish,
+                publish_oob,
+                release,
+                pin_fn,
+                unpin,
+                handle_store,
+            }
+        }
+    }
+
+    #[test]
+    fn handle_publish_copies_guest_bytes_into_store_with_initial_refcount() {
+        let mut h = Harness::new();
+        let id = h
+            .publish
+            .call(&mut h.store, 0xCAFE_u64 as i64)
+            .expect("publish call");
+        assert_ne!(
+            id, 0,
+            "publish must mint a real id, not the failure sentinel"
+        );
+        let id = id as u64;
+        // The handle store should now hold the bytes we baked into
+        // the WAT data segment.
+        let (kind, bytes) = h.handle_store.get(id).expect("entry present");
+        assert_eq!(kind, 0xCAFE);
+        assert_eq!(bytes, vec![1, 2, 3, 4, 5]);
+        // Initial refcount is 1 — release once must drop it to 0
+        // and clear the saturating floor without surfacing
+        // UNKNOWN.
+        let status = h
+            .release
+            .call(&mut h.store, id as i64)
+            .expect("release call");
+        assert_eq!(status, HANDLE_OK as i32);
+    }
+
+    #[test]
+    fn handle_publish_oob_returns_failure_sentinel() {
+        let mut h = Harness::new();
+        let id = h
+            .publish_oob
+            .call(&mut h.store, 0xCAFE_u64 as i64)
+            .expect("publish_oob call");
+        assert_eq!(id, HANDLE_PUBLISH_FAILED as i64);
+        // Nothing landed in the store.
+        assert_eq!(h.handle_store.entry_count(), 0);
+    }
+
+    #[test]
+    fn handle_release_unknown_id_returns_unknown_status() {
+        let mut h = Harness::new();
+        let status = h
+            .release
+            .call(&mut h.store, 0x1234_u64 as i64)
+            .expect("release call");
+        assert_eq!(status, HANDLE_UNKNOWN as i32);
+    }
+
+    #[test]
+    fn handle_pin_then_unpin_round_trips() {
+        let mut h = Harness::new();
+        let id = h
+            .publish
+            .call(&mut h.store, 0xCAFE_u64 as i64)
+            .expect("publish");
+
+        let pin_status = h.pin_fn.call(&mut h.store, id).expect("pin");
+        assert_eq!(pin_status, HANDLE_OK as i32);
+        let unpin_status = h.unpin.call(&mut h.store, id).expect("unpin");
+        assert_eq!(unpin_status, HANDLE_OK as i32);
+
+        // Pinning an unknown id must surface as UNKNOWN — pin/unpin
+        // shouldn't quietly succeed against a missing entry.
+        let bad = h
+            .pin_fn
+            .call(&mut h.store, 0xBADBAD_u64 as i64)
+            .expect("pin");
+        assert_eq!(bad, HANDLE_UNKNOWN as i32);
+    }
+
+    #[test]
+    fn handle_publish_with_unwired_store_returns_failure_sentinel() {
+        // Set up a Mailer with no handle store wired. Every host
+        // fn that needs the store should surface NO_STORE / the
+        // failure sentinel and leave guest memory alone.
+        let registry = Arc::new(Registry::new());
+        let queue = Arc::new(Mailer::new());
+        queue.wire(
+            Arc::clone(&registry),
+            Arc::new(std::sync::RwLock::new(Default::default())),
+        );
+        // No wire_handle_store call.
+        let outbound = HubOutbound::disconnected();
+        let ctx = SubstrateCtx::new(
+            MailboxId(0),
+            registry,
+            Arc::clone(&queue),
+            outbound,
+            new_subscribers(),
+        );
+
+        let engine = Engine::default();
+        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        register(&mut linker).expect("register");
+        let wasm = wat::parse_str(WAT_HANDLE_HOST_FNS).unwrap();
+        let module = Module::new(&engine, &wasm).unwrap();
+        let mut store = Store::new(&engine, ctx);
+        let instance = linker.instantiate(&mut store, &module).unwrap();
+
+        let publish = instance
+            .get_typed_func::<i64, i64>(&mut store, "publish")
+            .unwrap();
+        let release = instance
+            .get_typed_func::<i64, i32>(&mut store, "release")
+            .unwrap();
+        let pin_fn = instance
+            .get_typed_func::<i64, i32>(&mut store, "pin")
+            .unwrap();
+
+        assert_eq!(
+            publish.call(&mut store, 0xCAFE_u64 as i64).unwrap(),
+            HANDLE_PUBLISH_FAILED as i64,
+        );
+        assert_eq!(release.call(&mut store, 1).unwrap(), HANDLE_NO_STORE as i32,);
+        assert_eq!(pin_fn.call(&mut store, 1).unwrap(), HANDLE_NO_STORE as i32);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds four ADR-0045 host-fns to the substrate: `handle_publish_p32`, `handle_release_p32`, `handle_pin_p32`, `handle_unpin_p32`. Publish copies guest bytes into the handle store and returns a fresh ephemeral id (with the publisher's initial refcount); the others are direct passthroughs to the store API from PR 235.
- Adds the guest-side `Handle<K>` newtype: id + PhantomData, RAII Drop that releases the refcount, `pin`/`unpin`/`release` methods, and `as_ref()` to produce the wire-shaped `Ref::Handle`.
- Wires `publish<K>(&K) -> Option<Handle<K>>` onto `InitCtx`, `Ctx`, and `DropCtx` so components can publish at any lifecycle phase.
- Adds the `handle_demo` example: publishes a `Note`, broadcasts a `HeldNote { held: Ref<Note> }` whose handle the substrate resolves inline before the broadcast sink ships it.

## Scope
PR 3 of ADR-0045 Phase 1, on top of 234 (`Ref<K>` wire type) and 235 (substrate handle store + ref-walking dispatch). No new wire types, no new schema arms — just the publish/release surface that lets components actually mint refs and the typed wrapper that makes the SDK ergonomic.

**Out of scope:** the hub `describe_handles` MCP tool (PR 4), wait-for-resolution (deferred until a real use case forces it), content-addressed handle ids (Phase 3 per ADR-0045 follow-up).

## Test plan
- [x] 5 host-fn unit tests in `host_fns::tests` (publish copies bytes + initial refcount, OOB rejected, unknown release, pin/unpin round-trip, unwired-store sentinels)
- [x] `cargo test --workspace` — 350+ tests pass
- [x] `cargo build -p aether-component --example handle_demo --target wasm32-unknown-unknown` — wasm guest builds with the new SDK surface
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
