### PR TITLE
chore(claude): pre-flight hooks for pr text and host-fn additions

### DIFF
--- a/.claude/hooks/check-host-fn-additions.sh
+++ b/.claude/hooks/check-host-fn-additions.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Pre-flight check for new host-fn additions. The substrate's host-fn
+# surface is privileged (ADR-0002): every new fn becomes reachable by
+# every component that links against this surface. Most new substrate
+# capabilities should land as a mail sink instead — see
+# `crates/aether-substrate-core/src/io.rs` and `net.rs` for the
+# precedent: substrate-owned sink + paired request/result kinds in
+# `aether-kinds` + SDK wraps via `send_postcard` + `wait_reply`.
+#
+# This hook fires on Edit/Write to `host_fns.rs` and rejects diffs
+# that add a `linker.func_wrap(` call. To deliberately add a host fn
+# (e.g. for a wasmtime-specific capability that genuinely needs FFI),
+# include `// HOST_FN_OK: <reason>` adjacent to the new
+# `linker.func_wrap` and the hook will yield.
+#
+# Reads the Edit/Write tool call JSON from stdin (Claude Code
+# PreToolUse hook protocol), exits 2 (block) on match.
+
+set -u
+
+input=$(cat)
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+
+case "$file_path" in
+    */host_fns.rs) ;;
+    *) exit 0 ;;
+esac
+
+count_funcs() {
+    printf '%s' "$1" | grep -cE 'linker\.func_wrap\(' || true
+}
+
+emit_message() {
+    local added=$1
+    {
+        printf 'host_fns.rs: this change adds %d new linker.func_wrap call(s).\n' "$added"
+        printf '\n'
+        printf 'Adding a host fn is a deliberate capability decision (ADR-0002).\n'
+        printf 'Most new substrate capabilities should land as a mail sink instead.\n'
+        printf 'See crates/aether-substrate-core/src/io.rs and net.rs for the\n'
+        printf 'precedent: sink owns the resource, paired request/result kinds in\n'
+        printf 'aether-kinds, SDK wraps via send_postcard + wait_reply for sync.\n'
+        printf '\n'
+        printf 'If a host fn is genuinely the right tool, override by including\n'
+        printf '`// HOST_FN_OK: <reason>` in the new code.\n'
+    } >&2
+}
+
+case "$tool_name" in
+    Edit)
+        old_string=$(printf '%s' "$input" | jq -r '.tool_input.old_string // ""')
+        new_string=$(printf '%s' "$input" | jq -r '.tool_input.new_string // ""')
+        old_count=$(count_funcs "$old_string")
+        new_count=$(count_funcs "$new_string")
+        added=$((new_count - old_count))
+        if (( added > 0 )); then
+            if printf '%s' "$new_string" | grep -qE 'HOST_FN_OK:'; then
+                exit 0
+            fi
+            emit_message "$added"
+            exit 2
+        fi
+        ;;
+    Write)
+        content=$(printf '%s' "$input" | jq -r '.tool_input.content // ""')
+        old_count=0
+        if [[ -f "$file_path" ]]; then
+            old_count=$(count_funcs "$(cat "$file_path")")
+        fi
+        new_count=$(count_funcs "$content")
+        added=$((new_count - old_count))
+        if (( added > 0 )); then
+            if printf '%s' "$content" | grep -qE 'HOST_FN_OK:'; then
+                exit 0
+            fi
+            emit_message "$added"
+            exit 2
+        fi
+        ;;
+esac
+exit 0

--- a/.claude/hooks/check-pr-body.sh
+++ b/.claude/hooks/check-pr-body.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Pre-flight check for `gh pr create` / `gh pr edit` / `gh issue
+# create` / `gh issue edit` body and title content. Catches the four
+# recurring failure modes documented in the user's auto-memory file
+# `feedback_heredoc_no_backtick_escape.md`.
+#
+# Reads the Bash tool call JSON from stdin (Claude Code PreToolUse
+# hook protocol), filters to only `gh` commands that publish text,
+# runs the regex check, exits 2 (block) on match. Body extraction
+# also handles `--body-file PATH` by reading the file directly.
+#
+# To deliberately submit a body that looks like one of the patterns
+# (rare — usually the pattern means the body really is broken),
+# include `# pr-body-ok: <reason>` somewhere in the command and the
+# hook will yield.
+
+set -u
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+case "$command" in
+    *"gh pr create"*|*"gh pr edit"*|*"gh issue create"*|*"gh issue edit"*) ;;
+    *) exit 0 ;;
+esac
+
+if printf '%s' "$command" | grep -qE 'pr-body-ok:'; then
+    exit 0
+fi
+
+# Body-file content joins the search corpus alongside the command
+# itself so heredoc + --body-file paths are both covered.
+body_file=$(printf '%s' "$command" | grep -oE -- '--body-file[ =]+[^ ]+' | sed -E 's/^--body-file[ =]+//' | tr -d '"' | tr -d "'")
+body_content=""
+if [[ -n "$body_file" && -f "$body_file" ]]; then
+    body_content=$(cat "$body_file")
+fi
+search_text="$command"$'\n'"$body_content"
+
+issues=()
+
+# Pattern A: \` or \$ — escaped backticks/dollars are literal in
+# quoted heredocs and render as broken text on GitHub. Drop the
+# backslash.
+if printf '%s' "$search_text" | grep -qE '\\[`$]'; then
+    issues+=("Pattern A: backslash-escaped backtick or dollar — drop the backslash; quoted heredocs (<<'EOF') pass them through literally")
+fi
+
+# Pattern B: bare #NNN auto-link. GitHub renders any standalone
+# `#<digits>` as a cross-ref. Allow `owner/repo#NNN` (preceded by
+# `/`); allow ADR-0045-style refs (preceded by an alphanum or `-`).
+# Allow occurrences inside obvious URL paths (preceded by digits via
+# the `[A-Za-z0-9_/-]` exclusion).
+if printf '%s' "$search_text" | grep -qE '(^|[^A-Za-z0-9_/-])#[0-9]+'; then
+    issues+=("Pattern B: bare #NNN auto-links — write 'PR 235' instead of '#235', or 'owner/repo#NNN' for cross-repo refs")
+fi
+
+# Pattern D: $...$ inline math span. GitHub treats `$foo$` as LaTeX.
+# Exclude `$(...)` (shell expansion) and `$ ` (variable form) by
+# requiring the byte after the opening `$` to be neither space, paren,
+# nor digit.
+if printf '%s' "$search_text" | grep -qE '\$[^ \(0-9][^$]*\$'; then
+    issues+=("Pattern D: \$...\$ renders as LaTeX math on GitHub — switch inline code to backticks")
+fi
+
+# Pattern C: PR title subject must start lowercase. CI runs
+# amannn/action-semantic-pull-request with subjectPattern
+# `^(?![A-Z]).+$`. Extract --title argument; works for both single
+# and double-quoted forms.
+title_match=$(printf '%s' "$command" | grep -oE -- "--title[ =]+(\"[^\"]*\"|'[^']*')" || true)
+if [[ -n "$title_match" ]]; then
+    title=${title_match#*--title}
+    title=${title# }
+    title=${title#=}
+    title=${title%\'}
+    title=${title#\'}
+    title=${title%\"}
+    title=${title#\"}
+    if [[ "$title" == *:* ]]; then
+        subject=${title#*:}
+        subject=${subject# }
+        first=${subject:0:1}
+        if [[ "$first" =~ [A-Z] ]]; then
+            issues+=("Pattern C: PR title subject starts uppercase ('$first') — CI rejects, rephrase ('adr-0045 ...' not 'ADR-0045 ...')")
+        fi
+    fi
+fi
+
+if (( ${#issues[@]} )); then
+    {
+        printf 'PR/issue text pre-flight failed:\n'
+        for i in "${issues[@]}"; do
+            printf '  - %s\n' "$i"
+        done
+        printf '\nSee feedback_heredoc_no_backtick_escape.md (auto-memory) for context.\n'
+        printf 'To override deliberately, include `# pr-body-ok: <reason>` in the command.\n'
+    } >&2
+    exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo test *)",
+      "Bash(cargo check *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo fmt -- --check*)",
+      "mcp__aether-hub__receive_mail",
+      "mcp__aether-hub__list_engines",
+      "mcp__aether-hub__describe_kinds",
+      "mcp__aether-hub__engine_logs"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-pr-body.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-host-fn-additions.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@
 # Spike crates under spikes/ are standalone Cargo workspaces with
 # their own target dirs (per ADR-0003 §Consequences).
 spikes/*/target/
-# Claude Code session-local state (scheduled tasks, etc.).
-.claude/
+# Claude Code session-local state. The base `settings.json` and
+# `hooks/` are shippable (project-wide permissions + pre-flight
+# checks); everything else is per-user / runtime.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/skills/


### PR DESCRIPTION
## Summary
- Adds two `PreToolUse` hooks for the Claude Code session, scoped to this project via `.claude/settings.json`.
- `check-pr-body.sh` fires on `gh pr|issue create|edit` and rejects bodies/titles that hit the four recurring failure modes from my feedback memory file: escaped backticks/dollars, bare `#NNN` auto-links, dollar-delimited spans that GitHub renders as LaTeX, and uppercase title subjects. Override via `# pr-body-ok: <reason>` in the command.
- `check-host-fn-additions.sh` fires on Edit/Write to `host_fns.rs` and rejects diffs that add a `linker.func_wrap(` call without a `// HOST_FN_OK: <reason>` justification. Steers new substrate capabilities toward the io/net/handle sink pattern instead of growing the privileged FFI surface.
- `.gitignore` now excludes only per-user / runtime state under `.claude/` so the hooks and project-level settings ride with the repo.

## Why
Both hooks codify failure modes that have already cost this project review round-trips. The PR-body one I have a memory file for and still tripped on PR 236 last hour. The host-fn one would have caught the host-fn vs sink architectural detour I just took on PR 236 before any Rust got written. Mechanical pre-submission checks beat "be more careful next time."

## Test plan
- [x] All four PR-body patterns surface their named issue and exit 2: Pattern A (escape), Pattern B (bare hash-NNN), Pattern C (uppercase subject), Pattern D (LaTeX) — verified locally
- [x] Override marker `pr-body-ok:` skips the check
- [x] Clean body passes (exit 0)
- [x] Non-PR Bash commands skip the check entirely
- [x] Host-fn hook on `Edit` adding `linker.func_wrap` blocks; with `HOST_FN_OK:` it passes; on non-`host_fns.rs` paths it skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
