### PR TITLE
feat(substrate): postcard receive path for #[handlers] (ADR-0033)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,10 @@ version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
  "aether-mail",
+ "bytemuck",
  "proc-macro2",
  "quote",
+ "serde",
  "syn",
 ]
 

--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -64,3 +64,12 @@ crate-type = ["cdylib"]
 [[example]]
 name = "handle_demo"
 crate-type = ["cdylib"]
+
+# Postcard receive smoke test (sibling of `echoer.rs`). Demonstrates
+# `#[handler(postcard)]` dispatching through `Mail::decode_postcard`
+# for kinds whose schema isn't bytemuck-castable (here: `String` +
+# `Vec<u8>` fields). Closes the gap in ADR-0033's design intent that
+# `#[handlers]` accepts any declared kind regardless of wire shape.
+[[example]]
+name = "postcard_echoer"
+crate-type = ["cdylib"]

--- a/crates/aether-component/examples/postcard_echoer.rs
+++ b/crates/aether-component/examples/postcard_echoer.rs
@@ -1,0 +1,70 @@
+//! Smoke-test component for the postcard receive path. Receives
+//! `demo.postcard_request { tag, payload }` (a struct with a `String`
+//! and `Vec<u8>` — postcard-shaped, not bytemuck-castable) via the
+//! same bare `#[handler]` attribute that cast-shaped components use,
+//! and broadcasts a `demo.postcard_observed` cast-shaped acknowledgement
+//! so the receive landed observably.
+//!
+//! Pairs with the cast-shaped `echoer.rs` example to demonstrate that
+//! `#[handlers]` dispatches both wire shapes from the same impl block
+//! with no per-handler annotation — wire shape is picked at the kind's
+//! `Kind` derive site (cast for `#[repr(C)]` + `Pod`, postcard
+//! otherwise) and routed through `Kind::decode_from_bytes`. Compiles
+//! to wasm; load via `mcp__aether-hub__load_component` and send
+//! `demo.postcard_request` to verify the dispatch.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
+use aether_mail::{Kind, Schema};
+use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Serialize};
+
+/// Postcard-shaped request: contains a `String` and `Vec<u8>` so the
+/// derive can't generate a `bytemuck::Pod` impl. Decoding goes through
+/// `Mail::decode_postcard`, selected by `#[handler(postcard)]`.
+#[derive(Debug, Clone, Kind, Schema, Serialize, Deserialize)]
+#[kind(name = "demo.postcard_request")]
+pub struct PostcardRequest {
+    pub tag: String,
+    pub payload: Vec<u8>,
+}
+
+/// Cast-shaped acknowledgement: empty payload, broadcast to confirm
+/// the postcard request was received and decoded. Stays cast so the
+/// observation path doesn't depend on the same code path it's testing.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable, Kind, Schema)]
+#[kind(name = "demo.postcard_observed")]
+pub struct PostcardObserved {
+    pub tag_len: u32,
+    pub payload_len: u32,
+}
+
+pub struct PostcardEchoer {
+    broadcast: Sink<PostcardObserved>,
+}
+
+#[handlers]
+impl Component for PostcardEchoer {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        PostcardEchoer {
+            broadcast: ctx.resolve_sink::<PostcardObserved>("hub.claude.broadcast"),
+        }
+    }
+
+    /// Decoded postcard payload arrives as the third parameter. No
+    /// per-handler annotation needed — `Kind::decode_from_bytes`
+    /// (synthesised by the Kind derive on `PostcardRequest` based on
+    /// the absence of `#[repr(C)]`) already knows the wire shape.
+    #[handler]
+    fn on_request(&mut self, ctx: &mut Ctx<'_>, req: PostcardRequest) {
+        ctx.send(
+            &self.broadcast,
+            &PostcardObserved {
+                tag_len: req.tag.len() as u32,
+                payload_len: req.payload.len() as u32,
+            },
+        );
+    }
+}
+
+aether_component::export!(PostcardEchoer);

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -739,6 +739,14 @@ pub struct Mail<'a> {
     // incoming `u32` address. On wasm32 `usize == u32` so this is a
     // no-op; on 64-bit hosts it lets us unit-test with real pointers.
     ptr: usize,
+    // Total payload bytes valid at `ptr` for this delivery. Substrate
+    // sources from `mail.payload.len()` and threads through the
+    // receive ABI as a frame parameter (sibling of `kind`/`count`/
+    // `sender`). Cast decoders sanity-check against
+    // `size_of::<K>() * count`; postcard decoders use it as the
+    // exact slice length so the parser can't run past the substrate-
+    // written bytes into adjacent linear memory.
+    byte_len: u32,
     count: u32,
     sender: u32,
     _borrow: PhantomData<&'a [u8]>,
@@ -748,10 +756,11 @@ impl<'a> Mail<'a> {
     /// Not part of the public API; called only by `export!`. The FFI
     /// delivers `ptr` as a wasm32 offset (`u32`); this widens it.
     #[doc(hidden)]
-    pub unsafe fn __from_raw(kind: u64, ptr: u32, count: u32, sender: u32) -> Self {
+    pub unsafe fn __from_raw(kind: u64, ptr: u32, byte_len: u32, count: u32, sender: u32) -> Self {
         Mail {
             kind,
             ptr: ptr as usize,
+            byte_len,
             count,
             sender,
             _borrow: PhantomData,
@@ -762,10 +771,17 @@ impl<'a> Mail<'a> {
     /// from a host pointer go through here so 64-bit addresses survive.
     #[doc(hidden)]
     #[cfg(test)]
-    unsafe fn __from_ptr_test(kind: u64, ptr: usize, count: u32, sender: u32) -> Self {
+    unsafe fn __from_ptr_test(
+        kind: u64,
+        ptr: usize,
+        byte_len: u32,
+        count: u32,
+        sender: u32,
+    ) -> Self {
         Mail {
             kind,
             ptr,
+            byte_len,
             count,
             sender,
             _borrow: PhantomData,
@@ -783,6 +799,15 @@ impl<'a> Mail<'a> {
     /// payload send, N for a batch send of N elements.
     pub fn count(&self) -> u32 {
         self.count
+    }
+
+    /// Total bytes the substrate placed at `ptr` for this delivery.
+    /// Cast decoders treat this as a sanity check
+    /// (`size_of::<K>() * count`); postcard decoders use it as the
+    /// exact slice length so the parser is bounded by the substrate-
+    /// written region rather than reading into adjacent memory.
+    pub fn byte_len(&self) -> u32 {
+        self.byte_len
     }
 
     /// Reply handle for the session that originated this mail. `None`
@@ -837,7 +862,9 @@ impl<'a> Mail<'a> {
     /// Type-driven sibling of `decode`: takes `K` as a type parameter
     /// and uses `<K as Kind>::ID` directly (ADR-0030 compile-time hash),
     /// so no `KindId<K>` thread-through is needed. Returns `None` if
-    /// the inbound kind doesn't match `K::ID` or if `count != 1`.
+    /// the inbound kind doesn't match `K::ID`, if `count != 1`, or
+    /// if `byte_len` doesn't equal `size_of::<K>()` (a sender/receiver
+    /// schema-skew guard the substrate's frame metadata makes free).
     /// Copies rather than borrows so alignment of the underlying bytes
     /// doesn't matter — same semantics as `decode`.
     pub fn decode_typed<K: Kind + bytemuck::AnyBitPattern>(&self) -> Option<K> {
@@ -845,6 +872,9 @@ impl<'a> Mail<'a> {
             return None;
         }
         let byte_len = core::mem::size_of::<K>();
+        if self.byte_len as usize != byte_len {
+            return None;
+        }
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         Some(bytemuck::pod_read_unaligned(bytes))
     }
@@ -856,8 +886,38 @@ impl<'a> Mail<'a> {
             return None;
         }
         let byte_len = core::mem::size_of::<K>() * self.count as usize;
+        if self.byte_len as usize != byte_len {
+            return None;
+        }
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         bytemuck::try_cast_slice(bytes).ok()
+    }
+
+    /// Decode a single inbound `K` via the wire shape `K`'s `Kind`
+    /// derive baked into `Kind::decode_from_bytes` — cast for
+    /// `#[repr(C)]` + `Pod` types, postcard for schema-shaped types.
+    /// This is the canonical receive-side decode and what the
+    /// `#[handlers]` dispatcher calls on every typed handler;
+    /// `decode` / `decode_typed` / `decode_slice` / `decode_slice_typed`
+    /// remain as low-level escape hatches for fallback handlers that
+    /// want explicit wire-shape control.
+    ///
+    /// Hands `K::decode_from_bytes` exactly `byte_len` bytes from
+    /// `ptr` so the decoder is bounded by the substrate-written
+    /// frame and can't read past it into adjacent linear memory.
+    /// Returns `None` on kind mismatch, on `count != 1` (batch
+    /// receives go through `decode_slice_typed`), or when
+    /// `K::decode_from_bytes` itself returns `None` — which can be
+    /// either the default body for hand-rolled `Kind` impls that
+    /// didn't override, a cast-size mismatch, or a postcard decode
+    /// error.
+    pub fn decode_kind<K: Kind>(&self) -> Option<K> {
+        if self.kind != K::ID || self.count != 1 {
+            return None;
+        }
+        let bytes =
+            unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
+        K::decode_from_bytes(bytes)
     }
 }
 
@@ -957,22 +1017,32 @@ macro_rules! export {
         }
 
         /// # Safety
-        /// Called by the substrate with `(kind, ptr, count, sender)`
-        /// matching the FFI contract in
-        /// `aether-substrate/src/host_fns.rs`. `sender` is the per-
-        /// instance reply-to handle (ADR-0013) or `NO_REPLY_HANDLE` for
-        /// mail with no meaningful reply target. Exported under the
-        /// `_p32` suffix per ADR-0024 Phase 1. Returns the `u32` the
+        /// Called by the substrate with `(kind, ptr, byte_len, count,
+        /// sender)` matching the FFI contract in
+        /// `aether-substrate/src/host_fns.rs`. `byte_len` is the
+        /// total payload size the substrate wrote at `ptr`
+        /// (sourced from `mail.payload.len()`); cast decoders sanity-
+        /// check it, postcard decoders use it as the exact slice
+        /// length. `sender` is the per-instance reply-to handle
+        /// (ADR-0013) or `NO_REPLY_HANDLE` for mail with no
+        /// meaningful reply target. Exported under the `_p32` suffix
+        /// per ADR-0024 Phase 1. Returns the `u32` the
         /// `#[handlers]`-synthesized `__aether_dispatch` produces —
         /// `DISPATCH_HANDLED` on match, `DISPATCH_UNKNOWN_KIND` on a
         /// strict-receiver miss (ADR-0033 §Strict receivers).
         #[unsafe(export_name = "receive_p32")]
-        pub unsafe extern "C" fn receive(kind: u64, ptr: u32, count: u32, sender: u32) -> u32 {
+        pub unsafe extern "C" fn receive(
+            kind: u64,
+            ptr: u32,
+            byte_len: u32,
+            count: u32,
+            sender: u32,
+        ) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
             let mut ctx = $crate::Ctx::__new();
-            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, count, sender) };
+            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
             instance.__aether_dispatch(&mut ctx, mail)
         }
 
@@ -1100,7 +1170,8 @@ mod tests {
         // has to arrange for that address to point at valid bytes.
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, NO_REPLY_HANDLE) };
+        let byte_len = core::mem::size_of::<FakePod>() as u32;
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -1113,7 +1184,8 @@ mod tests {
     fn mail_decode_wrong_kind_returns_none() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 1, NO_REPLY_HANDLE) };
+        let byte_len = core::mem::size_of::<FakePod>() as u32;
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let wrong: KindId<FakePod> = KindId {
             raw: 8,
             _k: PhantomData,
@@ -1125,7 +1197,8 @@ mod tests {
     fn mail_decode_wrong_count_returns_none() {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, NO_REPLY_HANDLE) };
+        let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -1138,7 +1211,8 @@ mod tests {
     fn mail_decode_slice_roundtrip() {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, 2, NO_REPLY_HANDLE) };
+        let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        let mail = unsafe { Mail::__from_ptr_test(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId {
             raw: 7,
             _k: PhantomData,
@@ -1149,13 +1223,13 @@ mod tests {
 
     #[test]
     fn mail_sender_none_for_sentinel_handle() {
-        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.reply_to().is_none());
     }
 
     #[test]
     fn mail_sender_some_for_real_handle() {
-        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, 42) };
+        let mail = unsafe { Mail::__from_ptr_test(0, 0, 0, 0, 42) };
         let s = mail.reply_to().expect("non-sentinel handle yields Some");
         assert_eq!(s.raw(), 42);
     }
@@ -1206,7 +1280,7 @@ mod tests {
 
     #[test]
     fn mail_is_typed_matches_kind_id() {
-        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, 0, 0, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, 0, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.is::<FakeKind>());
         assert!(!mail.is::<FakePod>());
     }
@@ -1215,7 +1289,9 @@ mod tests {
     fn mail_decode_typed_roundtrip() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 1, NO_REPLY_HANDLE) };
+        let byte_len = core::mem::size_of::<FakePod>() as u32;
+        let mail =
+            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let out = mail.decode_typed::<FakePod>().unwrap();
         assert_eq!(out, value);
     }
@@ -1224,8 +1300,10 @@ mod tests {
     fn mail_decode_typed_wrong_kind_returns_none() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&value as *const FakePod).addr();
+        let byte_len = core::mem::size_of::<FakePod>() as u32;
         // Kind id deliberately mismatched (FakeKind instead of FakePod).
-        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, ptr_raw, 1, NO_REPLY_HANDLE) };
+        let mail =
+            unsafe { Mail::__from_ptr_test(FakeKind::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1233,7 +1311,9 @@ mod tests {
     fn mail_decode_typed_wrong_count_returns_none() {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, NO_REPLY_HANDLE) };
+        let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        let mail =
+            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1241,9 +1321,171 @@ mod tests {
     fn mail_decode_slice_typed_roundtrip() {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
-        let mail = unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, 2, NO_REPLY_HANDLE) };
+        let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        let mail =
+            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let out = mail.decode_slice_typed::<FakePod>().unwrap();
         assert_eq!(out, &values);
+    }
+
+    // `Mail::decode_kind` coverage. Routes through `K::decode_from_bytes`
+    // — the Kind derive picks cast vs postcard based on `#[repr(C)]`,
+    // so these tests exercise both arms via two fixture types.
+
+    #[derive(
+        aether_mail::Kind,
+        aether_mail::Schema,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[kind(name = "test.fake_postcard")]
+    struct FakePostcard {
+        tag: alloc::string::String,
+        ids: alloc::vec::Vec<u32>,
+    }
+
+    #[test]
+    fn mail_decode_kind_postcard_roundtrip() {
+        let value = FakePostcard {
+            tag: alloc::string::String::from("greet"),
+            ids: alloc::vec![1, 2, 3, 4],
+        };
+        let bytes = postcard::to_allocvec(&value).unwrap();
+        let mail = unsafe {
+            Mail::__from_ptr_test(
+                FakePostcard::ID,
+                bytes.as_ptr().addr(),
+                bytes.len() as u32,
+                1,
+                NO_REPLY_HANDLE,
+            )
+        };
+        let out = mail.decode_kind::<FakePostcard>().expect("decode");
+        assert_eq!(out, value);
+    }
+
+    #[test]
+    fn mail_decode_kind_cast_roundtrip() {
+        // Cast arm — Kind derive on a `#[repr(C)] + Pod` type emits
+        // `decode_cast` as the body, so `decode_kind` lands on the
+        // bytemuck reader without any per-handler annotation.
+        #[repr(C)]
+        #[derive(
+            Copy,
+            Clone,
+            Debug,
+            PartialEq,
+            bytemuck::Pod,
+            bytemuck::Zeroable,
+            aether_mail::Kind,
+            aether_mail::Schema,
+        )]
+        #[kind(name = "test.fake_cast_kind")]
+        struct FakeCastKind {
+            a: u32,
+            b: u32,
+        }
+
+        let value = FakeCastKind { a: 5, b: 9 };
+        let ptr_raw = (&value as *const FakeCastKind).addr();
+        let byte_len = core::mem::size_of::<FakeCastKind>() as u32;
+        let mail = unsafe {
+            Mail::__from_ptr_test(FakeCastKind::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE)
+        };
+        let out = mail.decode_kind::<FakeCastKind>().expect("decode");
+        assert_eq!(out, value);
+    }
+
+    #[test]
+    fn mail_decode_kind_wrong_kind_returns_none() {
+        let value = FakePostcard {
+            tag: alloc::string::String::from("x"),
+            ids: alloc::vec![],
+        };
+        let bytes = postcard::to_allocvec(&value).unwrap();
+        let mail = unsafe {
+            Mail::__from_ptr_test(
+                FakeKind::ID,
+                bytes.as_ptr().addr(),
+                bytes.len() as u32,
+                1,
+                NO_REPLY_HANDLE,
+            )
+        };
+        assert!(mail.decode_kind::<FakePostcard>().is_none());
+    }
+
+    #[test]
+    fn mail_decode_kind_wrong_count_returns_none() {
+        let value = FakePostcard {
+            tag: alloc::string::String::from("x"),
+            ids: alloc::vec![],
+        };
+        let bytes = postcard::to_allocvec(&value).unwrap();
+        let mail = unsafe {
+            Mail::__from_ptr_test(
+                FakePostcard::ID,
+                bytes.as_ptr().addr(),
+                bytes.len() as u32,
+                2,
+                NO_REPLY_HANDLE,
+            )
+        };
+        assert!(mail.decode_kind::<FakePostcard>().is_none());
+    }
+
+    #[test]
+    fn mail_decode_kind_truncated_bytes_returns_none() {
+        let value = FakePostcard {
+            tag: alloc::string::String::from("longer"),
+            ids: alloc::vec![1, 2, 3],
+        };
+        let bytes = postcard::to_allocvec(&value).unwrap();
+        // Pretend the substrate only wrote the first 2 bytes —
+        // `decode_from_bytes` (postcard arm) gets the truncated slice
+        // and surfaces the parse error as `None`.
+        let mail = unsafe {
+            Mail::__from_ptr_test(
+                FakePostcard::ID,
+                bytes.as_ptr().addr(),
+                2,
+                1,
+                NO_REPLY_HANDLE,
+            )
+        };
+        assert!(mail.decode_kind::<FakePostcard>().is_none());
+    }
+
+    #[test]
+    fn mail_decode_kind_default_body_returns_none_for_handrolled_kind() {
+        // FakeKind is a hand-rolled Kind with no `decode_from_bytes`
+        // override, so the default trait body returns None — dispatch
+        // surfaces this as DISPATCH_UNKNOWN_KIND in real components.
+        // Use a real (empty) buffer — `slice::from_raw_parts(NULL, 0)`
+        // is UB even when the length is zero.
+        let buf: [u8; 1] = [0];
+        let mail = unsafe {
+            Mail::__from_ptr_test(FakeKind::ID, buf.as_ptr().addr(), 0, 1, NO_REPLY_HANDLE)
+        };
+        assert!(mail.decode_kind::<FakeKind>().is_none());
+    }
+
+    #[test]
+    fn mail_decode_typed_byte_len_mismatch_returns_none() {
+        // Cast decode now sanity-checks byte_len against
+        // `size_of::<K>() * count`. If the substrate ever delivers a
+        // mail whose declared byte_len doesn't match the kind's size,
+        // decode bails rather than reading the wrong window.
+        let value = FakePod { a: 5, b: 9 };
+        let ptr_raw = (&value as *const FakePod).addr();
+        let bogus_byte_len = (core::mem::size_of::<FakePod>() + 4) as u32;
+        let mail = unsafe {
+            Mail::__from_ptr_test(FakePod::ID, ptr_raw, bogus_byte_len, 1, NO_REPLY_HANDLE)
+        };
+        assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
     // ADR-0040 typed-state framing. `DropCtx::save_state_kind` can't be

--- a/crates/aether-mail-derive/Cargo.toml
+++ b/crates/aether-mail-derive/Cargo.toml
@@ -17,3 +17,10 @@ syn = { version = "2", features = ["full"] }
 # available now.
 aether-mail = { path = "../aether-mail", features = ["derive"] }
 aether-hub-protocol = { path = "../aether-hub-protocol" }
+# ADR-0033 wire-shape autodetect: the Kind derive emits
+# `decode_from_bytes` bodies that bound on either `bytemuck::AnyBitPattern`
+# (cast arm) or `serde::de::DeserializeOwned` (postcard arm). Test
+# fixtures here mirror real components by satisfying whichever bound
+# matches their wire shape.
+bytemuck = { version = "1.19", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -79,6 +79,21 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         quote! {}
     };
 
+    // ADR-0033 wire-shape autodetect: `#[repr(C)]` on the type means
+    // the substrate carried it as raw cast bytes (and the user has
+    // `#[derive(Pod, Zeroable)]`); anything else is postcard-shaped
+    // (and the user has `#[derive(Serialize, Deserialize)]`). The
+    // dispatcher in `#[handlers]` calls `Kind::decode_from_bytes` via
+    // `Mail::decode_kind::<K>()`; emitting the body per-impl here is
+    // what lets that one call site compile against types whose Pod /
+    // Deserialize bounds are disjoint.
+    let has_repr_c = struct_has_repr_c(&input.attrs);
+    let decode_body = if has_repr_c {
+        quote! { ::aether_mail::__derive_runtime::decode_cast::<Self>(bytes) }
+    } else {
+        quote! { ::aether_mail::__derive_runtime::decode_postcard::<Self>(bytes) }
+    };
+
     // ADR-0032 section emission goes through trait dispatch, not a
     // syntactic walker. `<Self as Schema>::SCHEMA` / `::LABEL_NODE`
     // resolve at const-eval after every consumer-side impl is in
@@ -109,6 +124,10 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 &#canonical_bytes_ident,
             );
             #is_input_item
+
+            fn decode_from_bytes(bytes: &[u8]) -> ::core::option::Option<Self> {
+                #decode_body
+            }
         }
 
         // Intermediate `static` holds the schema value — reading
@@ -847,12 +866,13 @@ fn validate_fallback_sig(sig: &Signature) -> syn::Result<()> {
 
 /// Synthesized body of `__aether_dispatch`. Compares `mail.kind()`
 /// against each `<K as Kind>::ID` const (ADR-0030 Phase 2); on match,
-/// decodes via `Mail::decode_typed::<K>()` (now a pure `K::ID`
-/// compare + byte read, no `KindTable`) and calls the inherent-impl
-/// handler method. Returns `DISPATCH_HANDLED` on a match or when the
-/// `#[fallback]` ran; returns `DISPATCH_UNKNOWN_KIND` on strict-
-/// receiver miss so the substrate's scheduler logs the drop (issue
-/// #142).
+/// decodes via `Mail::decode_kind::<K>()` and calls the inherent-impl
+/// handler method. Wire shape (cast vs postcard) is picked at K's
+/// `Kind` derive site, not here — `Kind::decode_from_bytes` carries
+/// the per-K body — so this dispatcher never sees the wire choice.
+/// Returns `DISPATCH_HANDLED` on a match or when the `#[fallback]`
+/// ran; returns `DISPATCH_UNKNOWN_KIND` on strict-receiver miss so
+/// the substrate's scheduler logs the drop (issue #142).
 fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) -> TokenStream2 {
     let arms = handlers.iter().map(|h| {
         let k = &h.kind_ty;
@@ -860,7 +880,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
         quote! {
             if __aether_kind == <#k as ::aether_component::__macro_internals::Kind>::ID {
                 if let ::core::option::Option::Some(__aether_decoded) =
-                    __aether_mail.decode_typed::<#k>()
+                    __aether_mail.decode_kind::<#k>()
                 {
                     self.#method(__aether_ctx, __aether_decoded);
                 }

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -15,20 +15,23 @@
 
 use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaCell, SchemaType};
 use aether_mail::{CastEligible, Kind, Ref, Schema};
+use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Serialize};
 
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.tick")]
 struct Tick;
 
 #[repr(C)]
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.key")]
 struct Key {
     code: u32,
 }
 
 #[repr(C)]
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.vertex")]
 struct Vertex {
     x: f32,
@@ -36,13 +39,13 @@ struct Vertex {
 }
 
 #[repr(C)]
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.triangle")]
 struct Triangle {
     verts: [Vertex; 3],
 }
 
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.note")]
 #[allow(dead_code)]
 struct Note {
@@ -52,12 +55,12 @@ struct Note {
     blob: Vec<u8>,
 }
 
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.tuple")]
 #[allow(dead_code)]
 struct TupleStruct(u32, bool);
 
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.result")]
 #[allow(dead_code)]
 enum Outcome {
@@ -199,7 +202,7 @@ fn enum_emits_each_variant_shape_with_sequential_discriminants() {
 // flips to false (refs force postcard), and the wire roundtrips
 // for both Inline and Handle variants.
 
-#[derive(aether_mail::Kind, aether_mail::Schema)]
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
 #[kind(name = "test.held_note")]
 #[allow(dead_code)]
 struct HeldNote {
@@ -267,7 +270,7 @@ fn ref_kind_id_differs_from_inline_kind_id() {
     // a kind boundary change), but pin it explicitly so a refactor
     // can't silently align the two ids and let mismatched
     // recipients silently consume each other's mail.
-    #[derive(aether_mail::Kind, aether_mail::Schema)]
+    #[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
     #[kind(name = "test.inline_note_field")]
     #[allow(dead_code)]
     struct Inlined {
@@ -295,9 +298,14 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
     // A struct with `#[repr(C)]` but a non-eligible field type must
     // still report `ELIGIBLE = false`. Catching this is what stops
     // the substrate from misclassifying a postcard kind as cast-able.
+    //
+    // Kind derive is intentionally omitted here — the autodetect rule
+    // (cast iff `#[repr(C)]`) would emit a `decode_cast` body that
+    // can't satisfy `AnyBitPattern` against a `String` field, and that
+    // user-side compile error is the correct outcome. This fixture
+    // exercises Schema's AND-fold in isolation.
     #[repr(C)]
-    #[derive(aether_mail::Kind, aether_mail::Schema)]
-    #[kind(name = "test.repr_c_with_string")]
+    #[derive(aether_mail::Schema)]
     #[allow(dead_code)]
     struct ReprCButStrung {
         seq: u32,

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -40,6 +40,26 @@ pub trait Kind {
     const NAME: &'static str;
     const ID: u64;
     const IS_INPUT: bool = false;
+
+    /// Decode a single instance from substrate-supplied bytes. The
+    /// `Kind` derive auto-implements this with the right body for the
+    /// type's wire shape (cast for `#[repr(C)]` + `Pod`, postcard
+    /// otherwise). Hand-rolled `Kind` impls that don't participate in
+    /// `#[handlers]` receive dispatch can leave the default — it
+    /// returns `None`, which the SDK surfaces as a strict-receiver
+    /// miss (`DISPATCH_UNKNOWN_KIND`).
+    ///
+    /// The dispatcher synthesised by `#[handlers]` calls this through
+    /// `Mail::decode_kind::<K>()`, which hands `bytes` already sliced
+    /// to the substrate-supplied `byte_len` so the decoder is bounded
+    /// by the actual frame and can't read past the substrate-written
+    /// payload into adjacent linear memory.
+    fn decode_from_bytes(_bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 /// Compile-time predicate: can this type's payload travel across the
@@ -266,6 +286,29 @@ pub mod __derive_runtime {
         canonical,
     };
     pub use alloc::borrow::Cow;
+
+    /// Cast-shape decode helper. Routes through `bytemuck::pod_read_unaligned`
+    /// after a length check so the Kind derive can emit a uniform call
+    /// without the user crate needing `bytemuck` in scope. `T` satisfies
+    /// `AnyBitPattern` via the user's `#[derive(Pod)]`; the bound is
+    /// enforced at the impl site rather than on `Kind` itself so non-
+    /// cast kinds aren't poisoned by a trait they can't satisfy.
+    pub fn decode_cast<T: bytemuck::AnyBitPattern>(bytes: &[u8]) -> Option<T> {
+        if bytes.len() != core::mem::size_of::<T>() {
+            return None;
+        }
+        Some(bytemuck::pod_read_unaligned(bytes))
+    }
+
+    /// Postcard-shape decode helper. Sibling of `decode_cast` for
+    /// schema-shaped kinds (anything carrying `Vec` / `String` /
+    /// `Option` / a tagged enum). `T` satisfies `DeserializeOwned`
+    /// via the user's `#[derive(Deserialize)]`; the bound lives on
+    /// this helper rather than on `Kind` so cast kinds stay
+    /// independent of `serde`.
+    pub fn decode_postcard<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+        postcard::from_bytes(bytes).ok()
+    }
 }
 
 mod schema {

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -31,11 +31,18 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 const STATE_OFFSET: u32 = 8192;
 
 /// Contract with the guest: it exports a
-/// `receive(kind, ptr, count, sender) -> u32` entrypoint and a `memory`
-/// named `memory`. ADR-0013 widened the receive ABI with a fourth
-/// `sender: u32` parameter — a per-instance handle the guest can pass
-/// back to `reply_mail`, or `NO_REPLY_HANDLE` for component-originated
-/// mail. ADR-0015 adds optional `on_replace`, `on_drop`, and
+/// `receive(kind, ptr, byte_len, count, sender) -> u32` entrypoint
+/// and a `memory` named `memory`. ADR-0013 widened the receive ABI
+/// with a `sender: u32` parameter — a per-instance handle the guest
+/// can pass back to `reply_mail`, or `NO_REPLY_HANDLE` for
+/// component-originated mail. The `byte_len: u32` parameter (added
+/// to support postcard-shaped receivers per ADR-0033's "any declared
+/// kind" intent) is the total payload size the substrate wrote at
+/// `ptr`, sourced from `mail.payload.len()`. Cast decoders sanity-
+/// check it against `size_of::<K>() * count`; postcard decoders use
+/// it as the exact slice length so a parser bug or a corrupted frame
+/// can't read past the substrate-written bytes into adjacent linear
+/// memory. ADR-0015 adds optional `on_replace`, `on_drop`, and
 /// `on_rehydrate` exports; the substrate calls them at the right
 /// lifecycle moments when present and silently skips when absent
 /// (no-op trait defaults compile down to no symbol under LTO, so
@@ -43,7 +50,7 @@ const STATE_OFFSET: u32 = 8192;
 pub struct Component {
     store: Store<SubstrateCtx>,
     memory: Memory,
-    receive: TypedFunc<(u64, u32, u32, u32), u32>,
+    receive: TypedFunc<(u64, u32, u32, u32, u32), u32>,
     on_replace: Option<TypedFunc<(), u32>>,
     on_drop: Option<TypedFunc<(), u32>>,
     on_rehydrate: Option<TypedFunc<(u32, u32, u32), u32>>,
@@ -65,7 +72,7 @@ impl Component {
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
         let receive =
-            instance.get_typed_func::<(u64, u32, u32, u32), u32>(&mut store, "receive_p32")?;
+            instance.get_typed_func::<(u64, u32, u32, u32, u32), u32>(&mut store, "receive_p32")?;
 
         // Optional `init(mailbox_id) -> u32` export: called once before
         // the first `receive`, handed the component's own mailbox id so
@@ -157,9 +164,10 @@ impl Component {
         };
         self.memory
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
+        let byte_len = mail.payload.len() as u32;
         self.receive.call(
             &mut self.store,
-            (mail.kind, MAIL_OFFSET, mail.count, handle),
+            (mail.kind, MAIL_OFFSET, byte_len, mail.count, handle),
         )
     }
 
@@ -321,7 +329,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -338,14 +346,14 @@ mod tests {
     const WAT_NO_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
     const WAT_TRAP_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -359,7 +367,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -377,7 +385,7 @@ mod tests {
             (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -394,7 +402,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 ;; *(u32*)396 = version
@@ -414,9 +422,9 @@ mod tests {
     const WAT_STORES_SENDER: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 500
-                local.get 3
+                local.get 4
                 i32.store
                 i32.const 0))
     "#;
@@ -433,9 +441,9 @@ mod tests {
             (import "aether" "reply_mail_p32"
                 (func $reply_mail (param i32 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 (drop (call $reply_mail
-                    (local.get 3) ;; sender handle from receive param
+                    (local.get 4) ;; sender handle from receive param
                     (i64.const {kind_id}) ;; hashed kind id of "test.pong"
                     (i32.const 0) ;; ptr
                     (i32.const 0) ;; len
@@ -792,13 +800,13 @@ mod tests {
             (import "aether" "wait_reply_p32"
                 (func $wait (param i64 i32 i32 i32 i64) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 700
                 (call $wait
                     (i64.const -6148914691236517206) ;; 0xAAAA_AAAA_AAAA_AAAA reinterpreted as i64
                     (i32.const 600)                  ;; out_ptr
                     (i32.const 64)                   ;; out_cap
-                    (local.get 2)                    ;; timeout_ms = count
+                    (local.get 3)                    ;; timeout_ms = count (param 3 after byte_len shifted in at 2)
                     (i64.const 0))                   ;; expected_correlation = 0 (kind-only filter)
                 i32.store
                 i32.const 0))
@@ -979,7 +987,7 @@ mod tests {
                 (import "aether" "wait_reply_p32"
                     (func $wait (param i64 i32 i32 i32 i64) (result i32)))
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                     i32.const 700
                     (call $wait
                         (i64.const -6148914691236517206) ;; expected_kind = 0xAAAA...

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -605,7 +605,7 @@ mod tests {
     const WAT: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 
@@ -616,7 +616,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 i32.const 200
@@ -635,7 +635,7 @@ mod tests {
     const WAT_TRAPS_ON_DROP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_drop") (result i32)
                 unreachable))
@@ -650,7 +650,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -668,7 +668,7 @@ mod tests {
             (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_replace") (result i32)
                 (drop (call $save_state
@@ -685,7 +685,7 @@ mod tests {
     const WAT_REHYDRATES: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 i32.const 396
@@ -822,7 +822,7 @@ mod tests {
                 (@custom "aether.kinds" "{}")
                 (@custom "aether.kinds.labels" "{}")
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                     i32.const 0))"#,
             esc(&canonical),
             esc(&labels_bytes),
@@ -899,7 +899,7 @@ mod tests {
                 (@custom "aether.kinds" "{}")
                 (@custom "aether.kinds.labels" "{}")
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                     i32.const 0))"#,
             esc(&canonical),
             esc(&labels_bytes),
@@ -1253,7 +1253,7 @@ mod tests {
                 (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (func (export "receive_p32")
-                (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
+                (param $kind i64) (param $ptr i32) (param $byte_len i32) (param $count i32) (param $sender i32)
                 (result i32)
                 ;; Payload: [sink_id:u64]. Forward memory[396..404] to it.
                 (drop (call $send_mail
@@ -1946,7 +1946,7 @@ mod tests {
                 (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (func (export "receive_p32")
-                (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
+                (param $kind i64) (param $ptr i32) (param $byte_len i32) (param $count i32) (param $sender i32)
                 (result i32)
                 (drop (call $send_mail
                     (i64.load (local.get $ptr))

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -1061,7 +1061,7 @@ mod tests {
         const WAT_RECORDS_KIND: &str = r#"
             (module
                 (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                     i32.const 200
                     local.get 0
                     i32.wrap_i64

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -359,7 +359,7 @@ mod tests {
     const WAT_NOOP: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0))
     "#;
 

--- a/crates/aether-substrate-desktop/tests/end_to_end.rs
+++ b/crates/aether-substrate-desktop/tests/end_to_end.rs
@@ -34,7 +34,7 @@ fn forwards_to_sink_wat(sink_id: MailboxId) -> String {
     (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
-    (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
+    (param $kind i64) (param $ptr i32) (param $byte_len i32) (param $count i32) (param $sender i32)
     (result i32)
     i64.const {sink_id}
     i64.const 99

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -37,7 +37,7 @@ fn tally_forwarding_wat(tally_id: u64) -> String {
     (func $send_mail (param i64 i64 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (func (export "receive_p32")
-    (param $kind i64) (param $ptr i32) (param $count i32) (param $sender i32)
+    (param $kind i64) (param $ptr i32) (param $byte_len i32) (param $count i32) (param $sender i32)
     (result i32)
     (drop (call $send_mail
         (i64.const {tally_id}) (i64.const 99) (i32.const 0) (i32.const 0) (i32.const 1)))

--- a/docs/adr/0033-handler-driven-inputs-manifest.md
+++ b/docs/adr/0033-handler-driven-inputs-manifest.md
@@ -11,7 +11,7 @@ After ADR-0027, ADR-0028, and ADR-0030 the per-component shape is:
 - **Received kinds** are declared twice: once in `type Kinds = (Tick, Key, ...)` (ADR-0027) which the SDK walks at init to populate a runtime `KindTable`, and a second time inside `fn receive` as a chain of `mail.is::<K>()` / `mail.decode_typed::<K>()` checks.
 - **Introduced kinds** (everything `#[derive(Kind)]` reaches) ride in the `aether.kinds` wasm custom section (ADR-0028) and are visible to the substrate and hub at load time without executing the component.
 - **Kind identity** is compile-time: `K::ID = fnv1a_64(KIND_DOMAIN ++ canonical(name, schema))` (ADR-0030, ADR-0032; domain prefix added in issue #186). The substrate trusts these ids once registered.
-- **FFI dispatch** is a single generic `receive_p32(kind_id, ptr, len, sender) -> u32` export per component; the SDK's per-component runtime consults the `KindTable` and routes.
+- **FFI dispatch** is a single generic `receive_p32(kind_id, ptr, byte_len, count, sender) -> u32` export per component; the SDK's per-component runtime consults the `KindTable` and routes. (At the time this ADR shipped the ABI was `(kind, ptr, count, sender)` — `byte_len` was added later when wiring the postcard receive path; see *Wire-shape selection* in §Decision.)
 
 Three problems compound under this shape:
 
@@ -69,7 +69,18 @@ impl Component for InputLogger {
 }
 ```
 
-`#[handler]` takes no arguments. The handled kind is inferred from the method's third parameter type (after `&mut self` and `&mut Ctx<'_>`) — the parameter is the decoded `K`, same shape as `Mail::decode_typed::<K>()` today. `#[fallback]` takes no arguments either; its third parameter must be `Mail<'_>`. Components that omit `#[fallback]` are strict receivers.
+`#[handler]` takes no arguments. The handled kind is inferred from the method's third parameter type (after `&mut self` and `&mut Ctx<'_>`) — the parameter is the decoded `K`. `#[fallback]` takes no arguments either; its third parameter must be `Mail<'_>`. Components that omit `#[fallback]` are strict receivers.
+
+#### Wire-shape selection
+
+Receive-side decode is uniform: the dispatcher always emits `mail.decode_kind::<K>()`, which calls `Kind::decode_from_bytes(bytes)`. Wire shape (cast vs postcard) is picked once at the kind's `Kind` derive site, not at every handler:
+
+- A type with `#[repr(C)]` (and the user's existing `#[derive(Pod, Zeroable)]`) gets a cast-shape body that calls `bytemuck::pod_read_unaligned`.
+- Anything else (the user's `#[derive(Serialize, Deserialize)]` already in place) gets a postcard-shape body that calls `postcard::from_bytes`.
+
+`Kind::decode_from_bytes` carries no trait bounds — the per-K body uses whichever crate the type's existing derives satisfy, so cast and postcard kinds can share one trait method even though their decode bounds (`AnyBitPattern` vs `DeserializeOwned`) are disjoint. Hand-rolled `Kind` impls inherit a default body that returns `None`; if such a kind needs `#[handlers]` dispatch, the impl overrides `decode_from_bytes` directly.
+
+The receive ABI is `receive_p32(kind, ptr, byte_len, count, sender)`. `byte_len` is the substrate-supplied total payload size (sourced from `mail.payload.len()`); `decode_kind` hands `K::decode_from_bytes` exactly that slice so postcard parsing is bounded by the actual frame and can't read past it into adjacent linear memory. The cast helper (`__derive_runtime::decode_cast`) cross-checks the slice length against `size_of::<K>()` for free.
 
 ### Agent documentation extraction
 


### PR DESCRIPTION
## Summary

- **Closes ADR-0033's design gap**: today `#[handlers]` only emits `Mail::decode_typed` (cast wire), so postcard-shaped kinds (anything carrying `Vec`, `String`, `Option`, or a tagged enum) can't be received via the macro at all. The first component that needed this — a content-authoring spike whose mesh ops naturally take `Vec<u32>` selections and tagged-enum primitives — surfaced the wall.
- **Three-layer fix, no per-handler annotation.** The wire-shape choice is made once at the kind's `Kind` derive site (cast iff `#[repr(C)]`), not at every handler call site. Authors write `#[handler]` regardless of wire shape; the derive picks the right decode body based on the type's existing `Pod` or `Deserialize` derives.
- **No new ADR needed.** This is implementation parity with what ADR-0033 already specified ("any declared kind"). The ADR grows a *Wire-shape selection* subsection documenting the autodetect rule and an updated sentence on the receive ABI.

## Architecture

Three layers, bottom up:

1. **Receive ABI gains `byte_len`.** `receive_p32` grows from `(kind, ptr, count, sender)` to `(kind, ptr, byte_len, count, sender)`. Substrate sources `byte_len` from `mail.payload.len()` — the value was already known there, just not threaded through. Cast decoders sanity-check it (`size_of::<K>() * count` must match) as a free schema-skew guard; postcard decoders use it as the parser's safety boundary so a corrupted frame can't read past the substrate-written payload into adjacent linear memory.
2. **`Kind` trait gains `decode_from_bytes` with a default `None` body.** The `Kind` derive auto-implements it per type based on the existing `#[repr(C)]` attribute the `Schema` derive already inspects. The trait method itself carries no bounds — each impl uses whichever crate the user's existing derives satisfy (cast → `bytemuck::pod_read_unaligned`; postcard → `postcard::from_bytes`). Hand-rolled `Kind` impls inherit the default `None` body and surface as `DISPATCH_UNKNOWN_KIND` if dispatched against, matching the existing strict-receiver shape.
3. **`#[handlers]` always emits `mail.decode_kind::<K>()`.** `Mail::decode_kind` hands `K::decode_from_bytes` exactly `byte_len` bytes from `ptr`. No per-handler annotation, no wire-shape bookkeeping at the call site — handler signatures are identical regardless of the kind's wire shape.

## What's where

- `crates/aether-mail/src/lib.rs` — `Kind` trait grows `decode_from_bytes` default; `__derive_runtime` gains `decode_cast` / `decode_postcard` helpers with the right per-arm bounds.
- `crates/aether-mail-derive/src/lib.rs` — `Kind` derive emits `decode_from_bytes` body picking cast vs postcard from `#[repr(C)]`. `#[handlers]` dispatcher emits `mail.decode_kind` always (the `(postcard)` arg + `HandlerWire` enum + `parse_handler_wire` helper from the earlier iteration are gone).
- `crates/aether-component/src/lib.rs` — `Mail` gains `byte_len` field + accessor; new `Mail::decode_kind<K: Kind>` as the canonical entry the macro calls; existing `decode_typed` sanity-checks `byte_len` as a free schema-skew guard. `__from_raw` / `__from_ptr_test` grow the `byte_len` param.
- `crates/aether-substrate-core/src/component.rs` — `TypedFunc<(u64, u32, u32, u32, u32), u32>`; `deliver` threads `payload.len()` through.
- 22 wat fixtures across substrate-core / substrate-desktop tests updated for the new param shape (3 positional `local.get N` references shifted: sender 3→4, count 2→3 since `byte_len` slid in at index 2).
- `crates/aether-component/examples/postcard_echoer.rs` — worked example mirroring `echoer.rs`; uses bare `#[handler]` on a postcard-shaped `PostcardRequest` with no per-handler annotation.
- `crates/aether-mail-derive/tests/derive.rs` — fixtures updated to satisfy the new bounds (cast fixtures derive `Pod`/`Zeroable`; postcard fixtures derive `Serialize`/`Deserialize`). The `CastEligible` regression fixture (`#[repr(C)]` + `String` field) drops the `Kind` derive — that combo is the correct compile error under the autodetect contract, and the test now exercises `Schema`'s AND-fold in isolation.
- `docs/adr/0033-handler-driven-inputs-manifest.md` — *Wire-shape selection* subsection plus updated FFI-dispatch sentence noting `byte_len` was added when wiring the postcard receive path.

## Author experience

```rust
// Cast-shaped kind
#[repr(C)]
#[derive(Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
#[kind(name = "demo.cast")]
struct CastReq { seq: u32 }

// Postcard-shaped kind
#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
#[kind(name = "demo.postcard")]
struct PostcardReq { tag: String, ids: Vec<u32> }

#[handlers]
impl Component for X {
    fn init(_ctx: &mut InitCtx) -> Self { ... }

    // Same #[handler] both ways. Wire shape is picked at the kind, not here.
    #[handler] fn on_cast(&mut self, _ctx: &mut Ctx, _req: CastReq) {}
    #[handler] fn on_postcard(&mut self, _ctx: &mut Ctx, _req: PostcardReq) {}
}
```

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests green (full suite, including new `decode_kind` coverage on both cast + postcard arms, the default-body case for hand-rolled `Kind` impls, and existing substrate-core dispatch tests against the new ABI shape)
- [x] `cargo build -p aether-component --example postcard_echoer --target wasm32-unknown-unknown` — postcard handler compiles into a loadable cdylib via bare `#[handler]`
- [ ] Once merged, rebase the mesh-editor-component spike branch on top and verify postcard handlers compile + dispatch in a real component context.

## Notes

- **ABI churn** is genuinely additive (one new param) but does mean every existing component recompiles against the new SDK. No backwards-compat shim — wasmtime `TypedFunc` arity is strict. All in-tree components and fixtures are updated in this PR; out-of-tree components would need to rebuild.
- **Hand-rolled `Kind` impls** that need `#[handlers]` dispatch must override `decode_from_bytes` to pick a wire shape. Default `None` body is correct for test fixtures and Kind impls that only participate in the send side. None of the in-tree hand-rolled impls (test fixtures in `aether-mail`, `aether-component`, and `aether-substrate-core`) currently dispatch through `#[handlers]`, so they all stay on the default.
- **Encode-side symmetry** is the obvious follow-up — `Sink::send` / `Sink::send_postcard` / `Ctx::reply` should collapse to one call routed through `Kind::encode_into_bytes`. Filing as a separate issue: it touches more call sites and `send_many` (cast batch) has no postcard equivalent so unification has to decide what "batch" means there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)