### PR TITLE
feat(mesh-editor): cylinder primitive + per-vertex scaling

### DIFF
--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -25,10 +25,10 @@ use crate::{
     NoteOn, OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget,
     OrbitSetYaw, Ping, PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode,
     PlayerSetPosition, PlayerSetVelocity, PlayerStepResult, Pong, Read, ReadResult,
-    ReplaceComponent, ReplaceResult, SetMasterGain, SetMasterGainResult, SetPrimitive,
-    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, SubscribeInput,
-    SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, TranslateVertices,
-    UnresolvedMail, UnsubscribeInput, WindowSize, Write, WriteResult,
+    ReplaceComponent, ReplaceResult, ScaleVertices, SetMasterGain, SetMasterGainResult,
+    SetPrimitive, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
+    SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent,
+    TranslateVertices, UnresolvedMail, UnsubscribeInput, WindowSize, Write, WriteResult,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -156,12 +156,13 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<HandleUnpin>(),
         schema::<HandleUnpinResult>(),
         // Mesh editor component vocabulary (Spike C). Postcard
-        // structs — `SetPrimitive` carries a tagged enum, and
-        // `TranslateVertices` carries a Vec of vertex ids. Both
-        // fire-and-forget; the editor re-emits its mesh as
-        // `DrawTriangle` mail every tick.
+        // structs — `SetPrimitive` carries a tagged `Primitive` enum
+        // with per-variant params, the others carry a `Vec` of vertex
+        // ids and per-op params. All fire-and-forget; the editor
+        // re-emits its mesh as `DrawTriangle` mail every tick.
         schema::<SetPrimitive>(),
         schema::<TranslateVertices>(),
+        schema::<ScaleVertices>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1438,29 +1438,37 @@ mod mesh {
 
     use serde::{Deserialize, Serialize};
 
-    /// Built-in primitive families the mesh editor knows how to
-    /// generate. Each replaces the editor's current mesh wholesale.
-    /// `Cube` is the only family implemented in v1; the others reserve
-    /// names so adding them later is a no-rename change.
-    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-    pub enum MeshPrimitive {
-        Cube,
-        Sphere,
-        Cylinder,
-        Plane,
+    /// Procedural primitive variants. Each variant carries the
+    /// parameters specific to its family — params don't share a
+    /// common shape across primitives, so a tagged enum keeps each
+    /// well-typed without optional-field weirdness.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub enum Primitive {
+        /// Axis-aligned cube centered at `center` with edge length
+        /// `size`. 8 vertices, 12 triangles.
+        Cube { center: [f32; 3], size: f32 },
+        /// Capped cylinder around the y axis with `segments` sides.
+        /// `2*segments + 2` vertices: bottom ring (0..N), top ring
+        /// (N..2N), bottom center (2N), top center (2N+1). `4*segments`
+        /// triangles: 2N for the side wall, N for each cap.
+        Cylinder {
+            center: [f32; 3],
+            radius: f32,
+            height: f32,
+            segments: u32,
+        },
     }
 
     /// `aether.mesh.set_primitive` — replace the editor's mesh with a
     /// procedurally generated primitive. Vertex and face ids are
     /// reassigned from zero so callers can address them deterministically
-    /// by index after a known primitive (e.g. cube vertices 4–7 are the
-    /// `+y` face). Fire-and-forget; the next tick renders the new mesh.
+    /// by index after a known primitive (see the mesh editor crate doc
+    /// for per-primitive layouts). Fire-and-forget; the next tick
+    /// renders the new mesh.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.mesh.set_primitive")]
     pub struct SetPrimitive {
-        pub primitive: MeshPrimitive,
-        pub center: [f32; 3],
-        pub size: f32,
+        pub primitive: Primitive,
     }
 
     /// `aether.mesh.translate_vertices` — shift the listed vertex ids
@@ -1473,6 +1481,18 @@ mod mesh {
     pub struct TranslateVertices {
         pub vertex_ids: Vec<u32>,
         pub delta: [f32; 3],
+    }
+
+    /// `aether.mesh.scale_vertices` — multiply each named vertex's
+    /// offset from `pivot` by `factor`, per axis. Non-uniform scale
+    /// (e.g., `[1.2, 1.0, 1.2]`) flares a horizontal ring without
+    /// changing its height. Unknown ids are ignored. Fire-and-forget.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.mesh.scale_vertices")]
+    pub struct ScaleVertices {
+        pub vertex_ids: Vec<u32>,
+        pub pivot: [f32; 3],
+        pub factor: [f32; 3],
     }
 }
 

--- a/crates/aether-mesh-editor-component/src/lib.rs
+++ b/crates/aether-mesh-editor-component/src/lib.rs
@@ -2,26 +2,48 @@
 //! `&mut self`, applies DSL ops via mail handlers, and re-emits the
 //! mesh as `DrawTriangle` to the `"render"` sink every tick.
 //!
-//! Stool tier (current): cube primitive + per-vertex translation.
-//! Other primitives, scale/rotate, extrude, recoloring, and OBJ
-//! export are scoped for follow-up once the iteration loop proves
-//! itself end-to-end (load → set_primitive → capture_frame → mutate
-//! → capture_frame).
+//! Current ops: `set_primitive` (Cube + Cylinder), `translate_vertices`,
+//! `scale_vertices`. Extrude / face deletion / new-vertex / OBJ export
+//! are scoped for follow-up — issue 241 tracks the v3 op set.
 //!
 //! # Vertex ids for cube primitive
 //!
-//! `SetPrimitive { primitive: Cube, center, size }` produces 8
-//! vertices in a deterministic layout. Index by sign on each axis,
-//! `0` = negative half, `1` = positive half:
+//! `Primitive::Cube { center, size }` produces 8 vertices in a
+//! deterministic layout. Index by sign on each axis, `0` = negative
+//! half, `1` = positive half:
 //!
 //! - `0` = `(-, -, -)` `1` = `(+, -, -)` `2` = `(+, -, +)` `3` = `(-, -, +)`
 //! - `4` = `(-, +, -)` `5` = `(+, +, -)` `6` = `(+, +, +)` `7` = `(-, +, +)`
 //!
-//! So vertices `4..=7` are the `+y` (top) face — translate them with
-//! `delta: [0, dy, 0]` to extrude / push the top up.
+//! Vertices `4..=7` are the `+y` (top) face — translate them with
+//! `delta: [0, dy, 0]` to push the top up.
+//!
+//! # Vertex ids for cylinder primitive
+//!
+//! `Primitive::Cylinder { center, radius, height, segments: N }`
+//! produces `2N + 2` vertices arranged as:
+//!
+//! - `0..N`     — bottom ring, CCW around the y axis. `i`-th vertex
+//!   is at angle `2π·i/N` (so vertex 0 sits on `+x`).
+//! - `N..2N`    — top ring, same angular positions as the bottom ring,
+//!   `height` units higher.
+//! - `2N`       — bottom center (cap fan apex).
+//! - `2N + 1`   — top center.
+//!
+//! Faces are `4N` triangles total: `2N` for the side wall (one quad
+//! per segment, triangulated), `N` for the top cap (fan from top
+//! center), `N` for the bottom cap.
+//!
+//! Useful selections for a 24-segment cylinder (N = 24):
+//! - top ring: `vertex_ids = (24..48).collect()`
+//! - bottom ring: `vertex_ids = (0..24).collect()`
+//! - flare the top: `scale_vertices` on top ring with
+//!   `factor: [1.2, 1, 1.2]` and `pivot: [center.x, top_y, center.z]`.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
-use aether_kinds::{DrawTriangle, MeshPrimitive, SetPrimitive, Tick, TranslateVertices, Vertex};
+use aether_kinds::{
+    DrawTriangle, Primitive, ScaleVertices, SetPrimitive, Tick, TranslateVertices, Vertex,
+};
 use aether_math::Vec3;
 
 /// One face of the editor's mesh. Stored as the three vertex indices
@@ -40,13 +62,17 @@ struct Face {
 ///
 /// # Agent
 /// Workflow: `set_primitive` to seed the mesh, then iterate with
-/// `translate_vertices` against known vertex ids (see crate doc for
-/// the cube-vertex layout). Use `capture_frame` between ops to verify.
+/// `translate_vertices` and `scale_vertices` against known vertex ids
+/// (see crate doc for the per-primitive layouts). Use `capture_frame`
+/// between ops to verify.
 ///
-/// - `SetPrimitive { primitive: Cube, center: [0, 0, 0], size: 1.0 }`
-///   — replace the mesh with a unit cube
-/// - `TranslateVertices { vertex_ids: [4, 5, 6, 7], delta: [0, 0.5, 0] }`
-///   — push the top face up by 0.5 units
+/// - `SetPrimitive { primitive: Cube { center, size } }` — replace
+///   the mesh with a cube
+/// - `SetPrimitive { primitive: Cylinder { center, radius, height,
+///   segments } }` — replace with a capped cylinder around the y axis
+/// - `TranslateVertices { vertex_ids, delta }` — shift listed vertices
+/// - `ScaleVertices { vertex_ids, pivot, factor }` — scale listed
+///   vertices around a pivot point, per axis
 pub struct MeshEditor {
     render: Sink<DrawTriangle>,
     vertices: Vec<Vec3>,
@@ -78,32 +104,47 @@ impl Component for MeshEditor {
     }
 
     /// Replace the mesh with a procedurally generated primitive.
-    /// `Cube` is the only family implemented today; others reply
-    /// implicitly (no-op) and log a warning — future work.
     ///
     /// # Agent
-    /// Use `Cube` with `size` in world units (1.0 fits the default
-    /// orbit camera nicely). `center` translates the whole primitive.
+    /// `Cube { center, size }` for axis-aligned boxes; `Cylinder
+    /// { center, radius, height, segments }` for cylinders around
+    /// the y axis. `segments` of 16–32 read as smooth at default
+    /// camera distance; lower for visible facets.
     #[handler]
     fn on_set_primitive(&mut self, _ctx: &mut Ctx<'_>, msg: SetPrimitive) {
         match msg.primitive {
-            MeshPrimitive::Cube => {
-                let center = Vec3::new(msg.center[0], msg.center[1], msg.center[2]);
-                build_cube(&mut self.vertices, &mut self.faces, center, msg.size);
-                self.rebuild_render_cache();
+            Primitive::Cube { center, size } => {
+                build_cube(
+                    &mut self.vertices,
+                    &mut self.faces,
+                    Vec3::new(center[0], center[1], center[2]),
+                    size,
+                );
             }
-            MeshPrimitive::Sphere | MeshPrimitive::Cylinder | MeshPrimitive::Plane => {
-                // Reserved primitive families; no-op until implemented.
+            Primitive::Cylinder {
+                center,
+                radius,
+                height,
+                segments,
+            } => {
+                build_cylinder(
+                    &mut self.vertices,
+                    &mut self.faces,
+                    Vec3::new(center[0], center[1], center[2]),
+                    radius,
+                    height,
+                    segments.max(3),
+                );
             }
         }
+        self.rebuild_render_cache();
     }
 
     /// Translate each named vertex by `delta`. Out-of-range ids are
     /// silently skipped so a partial-overlap selection still applies.
     ///
     /// # Agent
-    /// See the crate doc for the cube vertex layout. Selection is by
-    /// raw index in v1 — no `select_top_face` sugar yet.
+    /// See the crate doc for per-primitive vertex layouts.
     #[handler]
     fn on_translate_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: TranslateVertices) {
         let delta = Vec3::new(msg.delta[0], msg.delta[1], msg.delta[2]);
@@ -111,6 +152,36 @@ impl Component for MeshEditor {
         for id in &msg.vertex_ids {
             if let Some(v) = self.vertices.get_mut(*id as usize) {
                 *v += delta;
+                touched = true;
+            }
+        }
+        if touched {
+            self.rebuild_render_cache();
+        }
+    }
+
+    /// Scale each named vertex's offset from `pivot` by `factor`,
+    /// per axis. Non-uniform factors flare or flatten without
+    /// changing the unaffected axes.
+    ///
+    /// # Agent
+    /// To flare the top of a cylinder centered at the origin with
+    /// height 1.0, scale the top ring by `factor: [1.2, 1, 1.2]`
+    /// with `pivot: [0, 1, 0]`. Out-of-range ids skipped.
+    #[handler]
+    fn on_scale_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: ScaleVertices) {
+        let pivot = Vec3::new(msg.pivot[0], msg.pivot[1], msg.pivot[2]);
+        let factor = Vec3::new(msg.factor[0], msg.factor[1], msg.factor[2]);
+        let mut touched = false;
+        for id in &msg.vertex_ids {
+            if let Some(v) = self.vertices.get_mut(*id as usize) {
+                let offset = *v - pivot;
+                let scaled = Vec3::new(
+                    offset.x * factor.x,
+                    offset.y * factor.y,
+                    offset.z * factor.z,
+                );
+                *v = pivot + scaled;
                 touched = true;
             }
         }
@@ -244,6 +315,99 @@ fn build_cube(vertices: &mut Vec<Vec3>, faces: &mut Vec<Face>, center: Vec3, siz
             color: RIGHT,
         },
     ]);
+}
+
+/// Generate a capped cylinder around the y axis with `n` segments.
+/// See the crate doc for the vertex layout. `n` should be at least 3
+/// (caller clamps).
+///
+/// Side wall is two triangles per segment; the top cap is a fan
+/// of `n` triangles from the top center vertex (id `2n+1`); the
+/// bottom cap is the same fan from `2n`. Per-segment side hue
+/// alternates between two shades so adjacent segments are
+/// visually distinguishable in `capture_frame`.
+fn build_cylinder(
+    vertices: &mut Vec<Vec3>,
+    faces: &mut Vec<Face>,
+    center: Vec3,
+    radius: f32,
+    height: f32,
+    n: u32,
+) {
+    use core::f32::consts::TAU;
+
+    vertices.clear();
+    let bottom_y = center.y;
+    let top_y = center.y + height;
+
+    // Bottom ring (0..n) and top ring (n..2n).
+    for i in 0..n {
+        let theta = TAU * (i as f32) / (n as f32);
+        let x = center.x + radius * theta.cos();
+        let z = center.z + radius * theta.sin();
+        vertices.push(Vec3::new(x, bottom_y, z));
+    }
+    for i in 0..n {
+        let theta = TAU * (i as f32) / (n as f32);
+        let x = center.x + radius * theta.cos();
+        let z = center.z + radius * theta.sin();
+        vertices.push(Vec3::new(x, top_y, z));
+    }
+    // Bottom center (2n), top center (2n+1).
+    vertices.push(Vec3::new(center.x, bottom_y, center.z));
+    vertices.push(Vec3::new(center.x, top_y, center.z));
+
+    const SIDE_A: [f32; 3] = [0.30, 0.55, 0.85]; // mid blue
+    const SIDE_B: [f32; 3] = [0.40, 0.65, 0.92]; // light blue
+    const TOP_CAP: [f32; 3] = [0.95, 0.95, 0.95]; // white
+    const BOTTOM_CAP: [f32; 3] = [0.40, 0.40, 0.40]; // grey
+
+    faces.clear();
+    let bottom_center = 2 * n;
+    let top_center = 2 * n + 1;
+
+    // Side wall: for each segment i, vertices are
+    //   bot_a = i, bot_b = (i+1) % n, top_a = n + i, top_b = n + (i+1) % n
+    // Two triangles per segment, CCW when viewed from outside (+x at i=0).
+    for i in 0..n {
+        let next = (i + 1) % n;
+        let bot_a = i;
+        let bot_b = next;
+        let top_a = n + i;
+        let top_b = n + next;
+        let color = if i % 2 == 0 { SIDE_A } else { SIDE_B };
+        // Quad (bot_a, bot_b, top_b, top_a) split into two CCW tris.
+        faces.push(Face {
+            vertices: [bot_a, bot_b, top_b],
+            color,
+        });
+        faces.push(Face {
+            vertices: [bot_a, top_b, top_a],
+            color,
+        });
+    }
+
+    // Top cap: fan from top_center, CCW when viewed from +y looking down.
+    // Ring goes CCW around y axis when viewed from +y, so the fan
+    // triangles wind (top_center, top_a, top_b).
+    for i in 0..n {
+        let next = (i + 1) % n;
+        faces.push(Face {
+            vertices: [top_center, n + i, n + next],
+            color: TOP_CAP,
+        });
+    }
+
+    // Bottom cap: fan from bottom_center, CCW when viewed from -y.
+    // Ring goes CCW from +y view, which is CW from -y view, so the
+    // fan triangles wind (bottom_center, bot_b, bot_a) to face down.
+    for i in 0..n {
+        let next = (i + 1) % n;
+        faces.push(Face {
+            vertices: [bottom_center, next, i],
+            color: BOTTOM_CAP,
+        });
+    }
 }
 
 aether_component::export!(MeshEditor);


### PR DESCRIPTION
## Summary

- SetPrimitive's payload becomes a tagged Primitive enum (Cube, Cylinder) so each variant carries its own params. Wire-breaking but the only caller is the MCP harness; pre-1.0, low cost.
- Cylinder primitive: 2N+2 vertices around the y axis (bottom ring 0..N, top ring N..2N, bottom center 2N, top center 2N+1), 4N triangles. Side wall alternates two blue shades for visual segment readability.
- ScaleVertices op: per-axis scale around a pivot. Pairs with translate_vertices for body sculpting.
- Three ops (Cylinder, scale top ring outward, scale bottom ring inward) produce a recognizable teacup silhouette — Spike C teacup tier proven via MCP loop.
- Extrude still parked (issue 241); body sculpting was sufficient without it.

## Test plan

- [x] cargo fmt clean
- [x] cargo clippy --all-targets -D warnings clean on touched crates
- [x] cargo build --workspace succeeds
- [x] cargo test -p aether-kinds passes
- [x] wasm build of mesh editor succeeds
- [x] MCP loop verified end-to-end: spawn, load camera + mesh, pin camera, set_primitive Cylinder, scale_vertices flare top ring, scale_vertices taper bottom ring, capture between ops shows expected mutation; teacup silhouette readable in capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)