### PR TITLE
feat(mesh-editor): describe op + monotonic+tombstone vertex/face ids

### DIFF
--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -18,17 +18,18 @@ use aether_hub_protocol::KindDescriptor;
 use aether_mail::{Kind, Schema};
 
 use crate::{
-    Camera, CaptureFrame, CaptureFrameResult, Delete, DeleteResult, DrawTriangle, DropComponent,
-    DropResult, Fetch, FetchResult, FrameStats, HandlePin, HandlePinResult, HandlePublish,
-    HandlePublishResult, HandleRelease, HandleReleaseResult, HandleUnpin, HandleUnpinResult, Key,
-    KeyRelease, List, ListResult, LoadComponent, LoadResult, MouseButton, MouseMove, NoteOff,
-    NoteOn, OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget,
-    OrbitSetYaw, Ping, PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode,
-    PlayerSetPosition, PlayerSetVelocity, PlayerStepResult, Pong, Read, ReadResult,
-    ReplaceComponent, ReplaceResult, ScaleVertices, SetMasterGain, SetMasterGainResult,
-    SetPrimitive, SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
-    SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent,
-    TranslateVertices, UnresolvedMail, UnsubscribeInput, WindowSize, Write, WriteResult,
+    Camera, CaptureFrame, CaptureFrameResult, Delete, DeleteResult, Describe, DrawTriangle,
+    DropComponent, DropResult, Fetch, FetchResult, FrameStats, HandlePin, HandlePinResult,
+    HandlePublish, HandlePublishResult, HandleRelease, HandleReleaseResult, HandleUnpin,
+    HandleUnpinResult, Key, KeyRelease, List, ListResult, LoadComponent, LoadResult, MeshState,
+    MouseButton, MouseMove, NoteOff, NoteOn, OrbitSetDistance, OrbitSetFov, OrbitSetPitch,
+    OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo, PlatformInfoResult,
+    PlayerRequestStep, PlayerSetMode, PlayerSetPosition, PlayerSetVelocity, PlayerStepResult, Pong,
+    Read, ReadResult, ReplaceComponent, ReplaceResult, ScaleVertices, SetMasterGain,
+    SetMasterGainResult, SetPrimitive, SetWindowMode, SetWindowModeResult, SetWindowTitle,
+    SetWindowTitleResult, SubscribeInput, SubscribeInputResult, Tick, TopdownSetCenter,
+    TopdownSetExtent, TranslateVertices, UnresolvedMail, UnsubscribeInput, WindowSize, Write,
+    WriteResult,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -159,10 +160,15 @@ pub fn all() -> Vec<KindDescriptor> {
         // structs — `SetPrimitive` carries a tagged `Primitive` enum
         // with per-variant params, the others carry a `Vec` of vertex
         // ids and per-op params. All fire-and-forget; the editor
-        // re-emits its mesh as `DrawTriangle` mail every tick.
+        // re-emits its mesh as `DrawTriangle` mail every tick. The
+        // `Describe` request is answered by broadcasting `MeshState`
+        // to `hub.claude.broadcast` so MCP harness consumers can see
+        // the editor's current vertex/face inventory.
         schema::<SetPrimitive>(),
         schema::<TranslateVertices>(),
         schema::<ScaleVertices>(),
+        schema::<Describe>(),
+        schema::<MeshState>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1494,6 +1494,48 @@ mod mesh {
         pub pivot: [f32; 3],
         pub factor: [f32; 3],
     }
+
+    /// `aether.mesh.describe` — request a snapshot of the editor's
+    /// current mesh state. The editor responds by publishing
+    /// `MeshState` to the broadcast sink (`hub.claude.broadcast`),
+    /// from which MCP harness consumers read it via `receive_mail`.
+    /// Fire-and-forget; the snapshot flows on the broadcast path,
+    /// not as a typed reply (Ctx::reply is cast-only today, issue 240).
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.mesh.describe")]
+    pub struct Describe;
+
+    /// `aether.mesh.state` — snapshot of the editor's mesh, broadcast
+    /// in response to `Describe`. Tombstoned (deleted) vertex/face ids
+    /// are excluded; the agent sees only what's currently live. Ids
+    /// are monotonic and never reused — a missing id from a previous
+    /// snapshot means that vertex or face was deleted.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.mesh.state")]
+    pub struct MeshState {
+        pub vertices: Vec<VertexInfo>,
+        pub faces: Vec<FaceInfo>,
+    }
+
+    /// One live vertex in a `MeshState` snapshot.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct VertexInfo {
+        pub id: u32,
+        pub x: f32,
+        pub y: f32,
+        pub z: f32,
+    }
+
+    /// One live face in a `MeshState` snapshot. `vertex_ids` are
+    /// indices into the editor's vertex space (NOT positions in the
+    /// `MeshState.vertices` Vec, since the Vec excludes tombstones).
+    /// To resolve, look up each id in the vertex list by `id` field.
+    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct FaceInfo {
+        pub id: u32,
+        pub vertex_ids: [u32; 3],
+        pub color: [f32; 3],
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-mesh-editor-component/src/lib.rs
+++ b/crates/aether-mesh-editor-component/src/lib.rs
@@ -3,10 +3,33 @@
 //! mesh as `DrawTriangle` to the `"render"` sink every tick.
 //!
 //! Current ops: `set_primitive` (Cube + Cylinder), `translate_vertices`,
-//! `scale_vertices`. Extrude / face deletion / new-vertex / OBJ export
-//! are scoped for follow-up — issue 241 tracks the v3 op set.
+//! `scale_vertices`, `describe`. Extrude / face deletion / new-vertex
+//! / OBJ export are scoped for follow-up — issue 241 tracks the v3
+//! op set.
 //!
-//! # Vertex ids for cube primitive
+//! # Identity rules — read first
+//!
+//! Vertex and face ids are **monotonic and never reused**. A
+//! `set_primitive` resets the mesh wholesale and starts ids at zero;
+//! after that, every new vertex or face gets the next unused id (=
+//! `len()` of the underlying sparse vec). When delete arrives in a
+//! later PR, deleted slots become tombstones — the id is permanently
+//! gone, future allocations skip past it.
+//!
+//! Why: agents (and humans) iterating against this editor over
+//! multiple captures can't tolerate id renumbering. "Vertex 17 is
+//! gone" is a stable fact; "vertex 17 was renumbered to 12 because
+//! 5 was deleted" is a context disaster.
+//!
+//! # Inspecting the current mesh
+//!
+//! Mail `aether.mesh.describe` to the editor; it publishes
+//! `aether.mesh.state` to `hub.claude.broadcast`. The MCP harness
+//! reads it via `receive_mail`. Tombstoned ids are excluded from
+//! the snapshot — a missing id from a previous snapshot means it
+//! was deleted (or never existed).
+//!
+//! # Vertex ids for cube primitive (at primitive creation)
 //!
 //! `Primitive::Cube { center, size }` produces 8 vertices in a
 //! deterministic layout. Index by sign on each axis, `0` = negative
@@ -16,9 +39,10 @@
 //! - `4` = `(-, +, -)` `5` = `(+, +, -)` `6` = `(+, +, +)` `7` = `(-, +, +)`
 //!
 //! Vertices `4..=7` are the `+y` (top) face — translate them with
-//! `delta: [0, dy, 0]` to push the top up.
+//! `delta: [0, dy, 0]` to push the top up. Layout is stable AT primitive
+//! creation; after any mutation, prefer `describe` over assumed indices.
 //!
-//! # Vertex ids for cylinder primitive
+//! # Vertex ids for cylinder primitive (at primitive creation)
 //!
 //! `Primitive::Cylinder { center, radius, height, segments: N }`
 //! produces `2N + 2` vertices arranged as:
@@ -32,17 +56,13 @@
 //!
 //! Faces are `4N` triangles total: `2N` for the side wall (one quad
 //! per segment, triangulated), `N` for the top cap (fan from top
-//! center), `N` for the bottom cap.
-//!
-//! Useful selections for a 24-segment cylinder (N = 24):
-//! - top ring: `vertex_ids = (24..48).collect()`
-//! - bottom ring: `vertex_ids = (0..24).collect()`
-//! - flare the top: `scale_vertices` on top ring with
-//!   `factor: [1.2, 1, 1.2]` and `pivot: [center.x, top_y, center.z]`.
+//! center), `N` for the bottom cap. Same caveat as cube: layout
+//! stable AT creation, prefer `describe` after edits.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
 use aether_kinds::{
-    DrawTriangle, Primitive, ScaleVertices, SetPrimitive, Tick, TranslateVertices, Vertex,
+    Describe, DrawTriangle, FaceInfo, MeshState, Primitive, ScaleVertices, SetPrimitive, Tick,
+    TranslateVertices, Vertex, VertexInfo,
 };
 use aether_math::Vec3;
 
@@ -56,15 +76,16 @@ struct Face {
     color: [f32; 3],
 }
 
-/// Mesh editor component. Holds the current mesh in `vertices` +
-/// `faces`; rebuilds a `DrawTriangle` cache on mutation and replays it
-/// every tick.
+/// Mesh editor component. Holds the current mesh in sparse vertex
+/// and face vectors (`Vec<Option<T>>` indexed by id; tombstones for
+/// deleted entries). Rebuilds a `DrawTriangle` cache on mutation and
+/// replays it every tick.
 ///
 /// # Agent
 /// Workflow: `set_primitive` to seed the mesh, then iterate with
-/// `translate_vertices` and `scale_vertices` against known vertex ids
-/// (see crate doc for the per-primitive layouts). Use `capture_frame`
-/// between ops to verify.
+/// `translate_vertices`, `scale_vertices`. Send `describe` to get a
+/// `MeshState` snapshot back via the broadcast channel. Use
+/// `capture_frame` between ops to verify visually.
 ///
 /// - `SetPrimitive { primitive: Cube { center, size } }` — replace
 ///   the mesh with a cube
@@ -73,10 +94,13 @@ struct Face {
 /// - `TranslateVertices { vertex_ids, delta }` — shift listed vertices
 /// - `ScaleVertices { vertex_ids, pivot, factor }` — scale listed
 ///   vertices around a pivot point, per axis
+/// - `Describe { }` — request a mesh-state snapshot. Reply lands on
+///   the broadcast channel as `MeshState`; consume via `receive_mail`.
 pub struct MeshEditor {
     render: Sink<DrawTriangle>,
-    vertices: Vec<Vec3>,
-    faces: Vec<Face>,
+    broadcast: Sink<MeshState>,
+    vertices: Vec<Option<Vec3>>,
+    faces: Vec<Option<Face>>,
     rendered: Vec<DrawTriangle>,
 }
 
@@ -85,6 +109,7 @@ impl Component for MeshEditor {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         MeshEditor {
             render: ctx.resolve_sink::<DrawTriangle>("render"),
+            broadcast: ctx.resolve_sink::<MeshState>("hub.claude.broadcast"),
             vertices: Vec::new(),
             faces: Vec::new(),
             rendered: Vec::new(),
@@ -104,6 +129,8 @@ impl Component for MeshEditor {
     }
 
     /// Replace the mesh with a procedurally generated primitive.
+    /// Vertex and face ids reset to zero (fresh mesh, no inherited
+    /// tombstones from the previous one).
     ///
     /// # Agent
     /// `Cube { center, size }` for axis-aligned boxes; `Cylinder
@@ -140,17 +167,21 @@ impl Component for MeshEditor {
         self.rebuild_render_cache();
     }
 
-    /// Translate each named vertex by `delta`. Out-of-range ids are
-    /// silently skipped so a partial-overlap selection still applies.
+    /// Translate each named vertex by `delta`. Out-of-range ids and
+    /// tombstoned ids are silently skipped so a partial-overlap
+    /// selection still applies cleanly to the live ids.
     ///
     /// # Agent
-    /// See the crate doc for per-primitive vertex layouts.
+    /// See the crate doc for per-primitive vertex layouts. After any
+    /// edit, prefer a fresh `describe` over assumed indices.
     #[handler]
     fn on_translate_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: TranslateVertices) {
         let delta = Vec3::new(msg.delta[0], msg.delta[1], msg.delta[2]);
         let mut touched = false;
         for id in &msg.vertex_ids {
-            if let Some(v) = self.vertices.get_mut(*id as usize) {
+            if let Some(slot) = self.vertices.get_mut(*id as usize)
+                && let Some(v) = slot.as_mut()
+            {
                 *v += delta;
                 touched = true;
             }
@@ -162,19 +193,22 @@ impl Component for MeshEditor {
 
     /// Scale each named vertex's offset from `pivot` by `factor`,
     /// per axis. Non-uniform factors flare or flatten without
-    /// changing the unaffected axes.
+    /// changing the unaffected axes. Out-of-range and tombstoned
+    /// ids skipped.
     ///
     /// # Agent
     /// To flare the top of a cylinder centered at the origin with
     /// height 1.0, scale the top ring by `factor: [1.2, 1, 1.2]`
-    /// with `pivot: [0, 1, 0]`. Out-of-range ids skipped.
+    /// with `pivot: [0, 1, 0]`.
     #[handler]
     fn on_scale_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: ScaleVertices) {
         let pivot = Vec3::new(msg.pivot[0], msg.pivot[1], msg.pivot[2]);
         let factor = Vec3::new(msg.factor[0], msg.factor[1], msg.factor[2]);
         let mut touched = false;
         for id in &msg.vertex_ids {
-            if let Some(v) = self.vertices.get_mut(*id as usize) {
+            if let Some(slot) = self.vertices.get_mut(*id as usize)
+                && let Some(v) = slot.as_mut()
+            {
                 let offset = *v - pivot;
                 let scaled = Vec3::new(
                     offset.x * factor.x,
@@ -189,15 +223,50 @@ impl Component for MeshEditor {
             self.rebuild_render_cache();
         }
     }
+
+    /// Publish the current mesh as `MeshState` to the broadcast sink.
+    /// Tombstoned (deleted) ids are excluded; the snapshot only
+    /// includes live vertices and faces. The MCP harness reads the
+    /// reply via `receive_mail`.
+    ///
+    /// # Agent
+    /// Empty payload: `Describe { }`. Watch for an `aether.mesh.state`
+    /// item in the next `receive_mail` drain.
+    #[handler]
+    fn on_describe(&mut self, ctx: &mut Ctx<'_>, _msg: Describe) {
+        let mut vertices = Vec::with_capacity(self.vertices.len());
+        for (id, slot) in self.vertices.iter().enumerate() {
+            if let Some(v) = slot {
+                vertices.push(VertexInfo {
+                    id: id as u32,
+                    x: v.x,
+                    y: v.y,
+                    z: v.z,
+                });
+            }
+        }
+        let mut faces = Vec::with_capacity(self.faces.len());
+        for (id, slot) in self.faces.iter().enumerate() {
+            if let Some(f) = slot {
+                faces.push(FaceInfo {
+                    id: id as u32,
+                    vertex_ids: f.vertices,
+                    color: f.color,
+                });
+            }
+        }
+        ctx.send_postcard(&self.broadcast, &MeshState { vertices, faces });
+    }
 }
 
 impl MeshEditor {
     fn rebuild_render_cache(&mut self) {
         self.rendered.clear();
         self.rendered.reserve(self.faces.len());
-        for face in &self.faces {
+        for face_slot in &self.faces {
+            let Some(face) = face_slot else { continue };
             let [a, b, c] = face.vertices;
-            let (Some(va), Some(vb), Some(vc)) = (
+            let (Some(Some(va)), Some(Some(vb)), Some(Some(vc))) = (
                 self.vertices.get(a as usize),
                 self.vertices.get(b as usize),
                 self.vertices.get(c as usize),
@@ -238,21 +307,26 @@ impl MeshEditor {
 }
 
 /// Generate a unit-axis-aligned cube centered at `center` with edge
-/// length `size`. Replaces `vertices` and `faces` wholesale. Vertex
-/// layout matches the crate doc: bit `x = id & 1`, `y = (id >> 2) & 1`,
-/// `z = (id >> 1) & 1` with `0` = negative half, `1` = positive half.
-fn build_cube(vertices: &mut Vec<Vec3>, faces: &mut Vec<Face>, center: Vec3, size: f32) {
+/// length `size`. Replaces `vertices` and `faces` wholesale (clears
+/// the sparse vecs before populating; ids start at 0). Vertex layout
+/// matches the crate doc.
+fn build_cube(
+    vertices: &mut Vec<Option<Vec3>>,
+    faces: &mut Vec<Option<Face>>,
+    center: Vec3,
+    size: f32,
+) {
     let h = size * 0.5;
     vertices.clear();
-    vertices.extend_from_slice(&[
-        Vec3::new(center.x - h, center.y - h, center.z - h), // 0 (-, -, -)
-        Vec3::new(center.x + h, center.y - h, center.z - h), // 1 (+, -, -)
-        Vec3::new(center.x + h, center.y - h, center.z + h), // 2 (+, -, +)
-        Vec3::new(center.x - h, center.y - h, center.z + h), // 3 (-, -, +)
-        Vec3::new(center.x - h, center.y + h, center.z - h), // 4 (-, +, -)
-        Vec3::new(center.x + h, center.y + h, center.z - h), // 5 (+, +, -)
-        Vec3::new(center.x + h, center.y + h, center.z + h), // 6 (+, +, +)
-        Vec3::new(center.x - h, center.y + h, center.z + h), // 7 (-, +, +)
+    vertices.extend([
+        Some(Vec3::new(center.x - h, center.y - h, center.z - h)), // 0
+        Some(Vec3::new(center.x + h, center.y - h, center.z - h)), // 1
+        Some(Vec3::new(center.x + h, center.y - h, center.z + h)), // 2
+        Some(Vec3::new(center.x - h, center.y - h, center.z + h)), // 3
+        Some(Vec3::new(center.x - h, center.y + h, center.z - h)), // 4
+        Some(Vec3::new(center.x + h, center.y + h, center.z - h)), // 5
+        Some(Vec3::new(center.x + h, center.y + h, center.z + h)), // 6
+        Some(Vec3::new(center.x - h, center.y + h, center.z + h)), // 7
     ]);
 
     // Distinct hue per face so the agent can read orientation directly
@@ -265,55 +339,55 @@ fn build_cube(vertices: &mut Vec<Vec3>, faces: &mut Vec<Face>, center: Vec3, siz
     const RIGHT: [f32; 3] = [0.95, 0.85, 0.20]; // yellow (+x)
 
     faces.clear();
-    faces.extend_from_slice(&[
-        Face {
+    faces.extend([
+        Some(Face {
             vertices: [0, 2, 1],
             color: BOTTOM,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [0, 3, 2],
             color: BOTTOM,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [4, 5, 6],
             color: TOP,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [4, 6, 7],
             color: TOP,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [3, 6, 2],
             color: FRONT,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [3, 7, 6],
             color: FRONT,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [0, 1, 5],
             color: BACK,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [0, 5, 4],
             color: BACK,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [0, 4, 7],
             color: LEFT,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [0, 7, 3],
             color: LEFT,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [1, 2, 6],
             color: RIGHT,
-        },
-        Face {
+        }),
+        Some(Face {
             vertices: [1, 6, 5],
             color: RIGHT,
-        },
+        }),
     ]);
 }
 
@@ -321,14 +395,14 @@ fn build_cube(vertices: &mut Vec<Vec3>, faces: &mut Vec<Face>, center: Vec3, siz
 /// See the crate doc for the vertex layout. `n` should be at least 3
 /// (caller clamps).
 ///
-/// Side wall is two triangles per segment; the top cap is a fan
-/// of `n` triangles from the top center vertex (id `2n+1`); the
-/// bottom cap is the same fan from `2n`. Per-segment side hue
-/// alternates between two shades so adjacent segments are
-/// visually distinguishable in `capture_frame`.
+/// Side wall is two triangles per segment; the top cap is a fan of
+/// `n` triangles from the top center vertex (id `2n+1`); the bottom
+/// cap is the same fan from `2n`. Per-segment side hue alternates
+/// between two shades so adjacent segments are visually
+/// distinguishable in `capture_frame`.
 fn build_cylinder(
-    vertices: &mut Vec<Vec3>,
-    faces: &mut Vec<Face>,
+    vertices: &mut Vec<Option<Vec3>>,
+    faces: &mut Vec<Option<Face>>,
     center: Vec3,
     radius: f32,
     height: f32,
@@ -345,17 +419,17 @@ fn build_cylinder(
         let theta = TAU * (i as f32) / (n as f32);
         let x = center.x + radius * theta.cos();
         let z = center.z + radius * theta.sin();
-        vertices.push(Vec3::new(x, bottom_y, z));
+        vertices.push(Some(Vec3::new(x, bottom_y, z)));
     }
     for i in 0..n {
         let theta = TAU * (i as f32) / (n as f32);
         let x = center.x + radius * theta.cos();
         let z = center.z + radius * theta.sin();
-        vertices.push(Vec3::new(x, top_y, z));
+        vertices.push(Some(Vec3::new(x, top_y, z)));
     }
     // Bottom center (2n), top center (2n+1).
-    vertices.push(Vec3::new(center.x, bottom_y, center.z));
-    vertices.push(Vec3::new(center.x, top_y, center.z));
+    vertices.push(Some(Vec3::new(center.x, bottom_y, center.z)));
+    vertices.push(Some(Vec3::new(center.x, top_y, center.z)));
 
     const SIDE_A: [f32; 3] = [0.30, 0.55, 0.85]; // mid blue
     const SIDE_B: [f32; 3] = [0.40, 0.65, 0.92]; // light blue
@@ -366,9 +440,7 @@ fn build_cylinder(
     let bottom_center = 2 * n;
     let top_center = 2 * n + 1;
 
-    // Side wall: for each segment i, vertices are
-    //   bot_a = i, bot_b = (i+1) % n, top_a = n + i, top_b = n + (i+1) % n
-    // Two triangles per segment, CCW when viewed from outside (+x at i=0).
+    // Side wall.
     for i in 0..n {
         let next = (i + 1) % n;
         let bot_a = i;
@@ -376,37 +448,32 @@ fn build_cylinder(
         let top_a = n + i;
         let top_b = n + next;
         let color = if i % 2 == 0 { SIDE_A } else { SIDE_B };
-        // Quad (bot_a, bot_b, top_b, top_a) split into two CCW tris.
-        faces.push(Face {
+        faces.push(Some(Face {
             vertices: [bot_a, bot_b, top_b],
             color,
-        });
-        faces.push(Face {
+        }));
+        faces.push(Some(Face {
             vertices: [bot_a, top_b, top_a],
             color,
-        });
+        }));
     }
 
-    // Top cap: fan from top_center, CCW when viewed from +y looking down.
-    // Ring goes CCW around y axis when viewed from +y, so the fan
-    // triangles wind (top_center, top_a, top_b).
+    // Top cap.
     for i in 0..n {
         let next = (i + 1) % n;
-        faces.push(Face {
+        faces.push(Some(Face {
             vertices: [top_center, n + i, n + next],
             color: TOP_CAP,
-        });
+        }));
     }
 
-    // Bottom cap: fan from bottom_center, CCW when viewed from -y.
-    // Ring goes CCW from +y view, which is CW from -y view, so the
-    // fan triangles wind (bottom_center, bot_b, bot_a) to face down.
+    // Bottom cap.
     for i in 0..n {
         let next = (i + 1) % n;
-        faces.push(Face {
+        faces.push(Some(Face {
             vertices: [bottom_center, next, i],
             color: BOTTOM_CAP,
-        });
+        }));
     }
 }
 


### PR DESCRIPTION
## Summary

- New `aether.mesh.describe` request publishes a `MeshState` snapshot to `hub.claude.broadcast`. Reply-via-broadcast pattern matches frame_stats; typed reply is gated on issue 240 (postcard reply path on Ctx::reply).
- Storage refactored from `Vec<T>` to `Vec<Option<T>>` for both vertices and faces. Ids are monotonic and never reused. Tombstoned slots stay None forever; new allocations push past the high-water mark.
- translate_vertices and scale_vertices skip None slots — partial selections still apply.
- describe output excludes tombstones. A missing id from a prior snapshot means the entry was deleted (or never existed).

## Why monotonic + tombstone

Agents iterating against the editor across multiple captures can't tolerate id renumbering. "Vertex 17 is gone" is a stable fact; "vertex 17 was renumbered to 12 because 5 was deleted" is a context disaster. Cheap implementation cost (sparse vec) for clean LLM-consumer ergonomics. Decision documented in the user's auto-memory.

## Test plan

- [x] cargo fmt clean
- [x] cargo clippy --all-targets -D warnings clean on touched crates
- [x] cargo build --workspace succeeds
- [x] cargo test -p aether-kinds passes
- [x] wasm build succeeds
- [x] MCP loop verified: spawn substrate, load camera + mesh, set_primitive Cube, describe — MeshState lands on broadcast with 8 vertices + 12 faces, all ids decoded correctly
- [x] After translate_vertices [4,5,6,7] delta [0,0.5,0], describe shows updated y values for those vertices and unchanged for the others — sparse storage round-trip works

## Follow-up (next PR)

PR-B will add extrude_face, delete_faces, and rotate_vertices on top of this storage shape. Tombstones will be exercised first by delete_faces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)