### PR TITLE
feat(static-mesh): obj viewer component for inspecting generated meshes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-static-mesh-component"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-component",
+ "aether-kinds",
+]
+
+[[package]]
 name = "aether-substrate-core"
 version = "0.2.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/aether-hello-component",
     "crates/aether-mesh-editor-component",
     "crates/aether-player-component",
+    "crates/aether-static-mesh-component",
     "crates/aether-hub-protocol",
     "crates/aether-mail",
     "crates/aether-mail-derive",

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -22,7 +22,7 @@ use crate::{
     DrawTriangle, DropComponent, DropResult, ExtrudeFace, Fetch, FetchResult, FrameStats,
     HandlePin, HandlePinResult, HandlePublish, HandlePublishResult, HandleRelease,
     HandleReleaseResult, HandleUnpin, HandleUnpinResult, Key, KeyRelease, List, ListResult,
-    LoadComponent, LoadResult, MeshState, MouseButton, MouseMove, NoteOff, NoteOn,
+    LoadComponent, LoadResult, LoadStaticMesh, MeshState, MouseButton, MouseMove, NoteOff, NoteOn,
     OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping,
     PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition,
     PlayerSetVelocity, PlayerStepResult, Pong, Read, ReadResult, ReplaceComponent, ReplaceResult,
@@ -172,6 +172,11 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<DeleteFaces>(),
         schema::<Describe>(),
         schema::<MeshState>(),
+        // Static mesh viewer (developer tool). Loads an OBJ via the
+        // io sink and replays its triangle list as DrawTriangle each
+        // tick. ADR-0026's no-import-for-production-content rule does
+        // not apply — this is a dev viewer, not an asset path.
+        schema::<LoadStaticMesh>(),
     ]
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1586,6 +1586,35 @@ mod mesh {
     }
 }
 
+pub use static_mesh::*;
+
+/// Static mesh viewer vocabulary. The static-mesh component
+/// (`crates/aether-static-mesh-component/`) loads a Wavefront OBJ file
+/// from the substrate's I/O surface (ADR-0041 namespace + path), parses
+/// it once, and replays the triangle list as `DrawTriangle` mail every
+/// tick. It exists as a developer aid for inspecting the output of the
+/// `dsl-mesh-spike` mesher in the substrate's render path; ADR-0026's
+/// rejection of conventional asset import targets *production* content,
+/// not dev-tooling viewers.
+mod static_mesh {
+    use alloc::string::String;
+    use serde::{Deserialize, Serialize};
+
+    /// `aether.static_mesh.load` — instruct the static-mesh component to
+    /// load and display an OBJ file. The component sends a corresponding
+    /// `aether.io.read` to the substrate's `"io"` sink and parses the
+    /// reply. Subsequent `Load` mails replace the cached mesh.
+    /// Fire-and-forget; errors surface in `engine_logs`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.static_mesh.load")]
+    pub struct LoadStaticMesh {
+        /// Short namespace prefix (no `://`), e.g. `"save"`, `"assets"`.
+        pub namespace: String,
+        /// Relative path within the namespace.
+        pub path: String,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aether-static-mesh-component/Cargo.toml
+++ b/crates/aether-static-mesh-component/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aether-static-mesh-component"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aether-component = { path = "../aether-component" }
+aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-static-mesh-component/src/lib.rs
+++ b/crates/aether-static-mesh-component/src/lib.rs
@@ -1,0 +1,264 @@
+//! Static mesh viewer. Loads a Wavefront OBJ file from the substrate's
+//! I/O surface (ADR-0041), parses it into `DrawTriangle`s, and replays
+//! the cached list to the `"render"` sink every tick.
+//!
+//! Intended as a developer tool for inspecting `dsl-mesh-spike` output
+//! (or any other OBJ-producing tool) end-to-end through the substrate's
+//! render path. ADR-0026's no-import-for-production-content rule
+//! targets *asset content*; this is a viewer, not an authoring path.
+//!
+//! # Lifecycle
+//!
+//! 1. Send `aether.static_mesh.load { namespace, path }` to the
+//!    component. It fires an `aether.io.read` to the substrate's
+//!    `"io"` sink.
+//! 2. The substrate's I/O adapter resolves `namespace://path`, reads
+//!    the bytes, and replies with `aether.io.read_result`.
+//! 3. The component parses the OBJ text and caches the resulting
+//!    triangle list. Any prior cache is dropped.
+//! 4. On every `aether.tick` the cached triangles are re-emitted to
+//!    `"render"` so the mesh stays visible.
+//!
+//! Errors (parse failures, missing files, adapter rejection) silently
+//! drop the load. Visible symptom: no triangles render. Substrate-side
+//! errors (NotFound, Forbidden) surface via `engine_logs`. Per-component
+//! tracing is parked until the SDK exposes a logging facility.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers, io};
+use aether_kinds::{DrawTriangle, LoadStaticMesh, ReadResult, Tick, Vertex};
+
+/// Default soft-blue color applied to every vertex of every loaded
+/// triangle. OBJ doesn't carry per-face color in v1; per-group palette
+/// support is parked.
+const DEFAULT_COLOR: (f32, f32, f32) = (0.55, 0.7, 0.92);
+
+pub struct StaticMesh {
+    triangles: Vec<DrawTriangle>,
+    render: Sink<DrawTriangle>,
+}
+
+/// Static-mesh viewer component.
+///
+/// # Agent
+/// Workflow: `load_component` this binary, then send
+/// `aether.static_mesh.load { namespace, path }` pointing at an OBJ
+/// file inside one of the substrate's I/O namespaces (`save`, `assets`,
+/// `config`). After the substrate's read reply comes back the mesh
+/// renders every frame; capture_frame verifies. Send another `load`
+/// to swap the cached mesh.
+#[handlers]
+impl Component for StaticMesh {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        StaticMesh {
+            triangles: Vec::new(),
+            render: ctx.resolve_sink::<DrawTriangle>("render"),
+        }
+    }
+
+    /// Re-emits every cached triangle to the render sink.
+    ///
+    /// # Agent
+    /// Substrate-driven; do not send manually. If the rendered mesh
+    /// disappears the tick path stalled or the cache was cleared by
+    /// a failing reload.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
+        for tri in &self.triangles {
+            ctx.send(&self.render, tri);
+        }
+    }
+
+    /// Triggers an asynchronous OBJ load. Reply arrives as
+    /// `aether.io.read_result`.
+    ///
+    /// # Agent
+    /// `namespace` is the short prefix with no `://` — `"save"`,
+    /// `"assets"`, `"config"`. `path` is relative to the namespace
+    /// root; `..` and absolute prefixes are forbidden by the adapter.
+    #[handler]
+    fn on_load(&mut self, _ctx: &mut Ctx<'_>, msg: LoadStaticMesh) {
+        io::read(&msg.namespace, &msg.path);
+    }
+
+    /// Consumes the substrate's I/O reply. On success, parses the
+    /// bytes as OBJ and replaces the cached triangle list. On failure
+    /// or non-utf8 / parse-error bytes, silently leaves the previous
+    /// cache intact.
+    ///
+    /// # Agent
+    /// Not useful to send manually — the substrate emits this in
+    /// response to the component's `aether.io.read` request.
+    #[handler]
+    fn on_read_result(&mut self, _ctx: &mut Ctx<'_>, r: ReadResult) {
+        if let ReadResult::Ok { bytes, .. } = r
+            && let Ok(text) = core::str::from_utf8(&bytes)
+            && let Ok(tris) = parse_obj(text)
+        {
+            self.triangles = tris;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ObjParseError {
+    VertexIndexOutOfRange { index: usize, defined: usize },
+    DegenerateFace,
+}
+
+/// Minimal OBJ parser. Supports `v X Y Z` and `f V1 V2 V3 [V4 ...]`
+/// (n-gons triangulated fan-style). Ignores normals (`vn`), texcoords
+/// (`vt`), groups (`g`), materials (`mtllib`/`usemtl`), smoothing
+/// (`s`), and comments (`#`). Face refs may be `v`, `v/vt`, `v//vn`,
+/// or `v/vt/vn` — only the position index is used.
+pub fn parse_obj(text: &str) -> Result<Vec<DrawTriangle>, ObjParseError> {
+    let mut vertices: Vec<[f32; 3]> = Vec::new();
+    let mut triangles: Vec<DrawTriangle> = Vec::new();
+    let (cr, cg, cb) = DEFAULT_COLOR;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let mut parts = trimmed.split_whitespace();
+        let head = match parts.next() {
+            Some(h) => h,
+            None => continue,
+        };
+        match head {
+            "v" => {
+                let x: f32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let y: f32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let z: f32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                vertices.push([x, y, z]);
+            }
+            "f" => {
+                let indices: Vec<usize> = parts
+                    .filter_map(|tok| tok.split('/').next())
+                    .filter_map(|n| n.parse::<usize>().ok())
+                    .collect();
+                if indices.len() < 3 {
+                    return Err(ObjParseError::DegenerateFace);
+                }
+                for i in 1..indices.len() - 1 {
+                    let a = obj_idx(indices[0], vertices.len())?;
+                    let b = obj_idx(indices[i], vertices.len())?;
+                    let c = obj_idx(indices[i + 1], vertices.len())?;
+                    let va = vertices[a];
+                    let vb = vertices[b];
+                    let vc = vertices[c];
+                    triangles.push(DrawTriangle {
+                        verts: [
+                            Vertex {
+                                x: va[0],
+                                y: va[1],
+                                z: va[2],
+                                r: cr,
+                                g: cg,
+                                b: cb,
+                            },
+                            Vertex {
+                                x: vb[0],
+                                y: vb[1],
+                                z: vb[2],
+                                r: cr,
+                                g: cg,
+                                b: cb,
+                            },
+                            Vertex {
+                                x: vc[0],
+                                y: vc[1],
+                                z: vc[2],
+                                r: cr,
+                                g: cg,
+                                b: cb,
+                            },
+                        ],
+                    });
+                }
+            }
+            _ => {} // silently skip unknown directives
+        }
+    }
+    Ok(triangles)
+}
+
+fn obj_idx(one_based: usize, count: usize) -> Result<usize, ObjParseError> {
+    if one_based == 0 || one_based > count {
+        Err(ObjParseError::VertexIndexOutOfRange {
+            index: one_based,
+            defined: count,
+        })
+    } else {
+        Ok(one_based - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_box_obj() {
+        let obj = "\
+            v 0 0 0\n\
+            v 1 0 0\n\
+            v 1 1 0\n\
+            v 0 1 0\n\
+            f 1 2 3\n\
+            f 1 3 4\n";
+        let tris = parse_obj(obj).unwrap();
+        assert_eq!(tris.len(), 2);
+    }
+
+    #[test]
+    fn triangulates_quad_fan_style() {
+        let obj = "\
+            v 0 0 0\n\
+            v 1 0 0\n\
+            v 1 1 0\n\
+            v 0 1 0\n\
+            f 1 2 3 4\n";
+        let tris = parse_obj(obj).unwrap();
+        assert_eq!(tris.len(), 2, "quad should triangulate to 2 triangles");
+    }
+
+    #[test]
+    fn ignores_unknown_directives() {
+        let obj = "\
+            # comment\n\
+            mtllib foo.mtl\n\
+            v 0 0 0\n\
+            v 1 0 0\n\
+            v 1 1 0\n\
+            vn 0 0 1\n\
+            usemtl bar\n\
+            s off\n\
+            g group_name\n\
+            f 1 2 3\n";
+        let tris = parse_obj(obj).unwrap();
+        assert_eq!(tris.len(), 1);
+    }
+
+    #[test]
+    fn handles_face_refs_with_slashes() {
+        let obj = "\
+            v 0 0 0\n\
+            v 1 0 0\n\
+            v 1 1 0\n\
+            f 1/1/1 2/2/1 3/3/1\n";
+        let tris = parse_obj(obj).unwrap();
+        assert_eq!(tris.len(), 1);
+    }
+
+    #[test]
+    fn rejects_out_of_range_index() {
+        let obj = "\
+            v 0 0 0\n\
+            v 1 0 0\n\
+            f 1 2 99\n";
+        assert!(parse_obj(obj).is_err());
+    }
+}
+
+aether_component::export!(StaticMesh);


### PR DESCRIPTION
## Summary

New `aether-static-mesh-component` (cdylib) — a developer-tool component that loads a Wavefront OBJ from the substrate's I/O surface and replays its triangle list every tick.

**Lifecycle:**
1. Send `aether.static_mesh.load { namespace, path }` to the component.
2. The component fires `aether.io.read` to the `"io"` sink (ADR-0041).
3. On `aether.io.read_result::Ok`, parses the OBJ bytes and caches the triangle list (replaces any prior cache).
4. Every tick replays the cache to `"render"` via `DrawTriangle` mail.

**OBJ parser** (minimal, in-component): supports `v X Y Z` and `f V1 V2 V3 [V4 ...]` (triangulating n-gons fan-style). Face refs may be `v`, `v/vt`, `v//vn`, or `v/vt/vn`. Ignores `vn`, `vt`, `g`, `mtllib`, `usemtl`, `s`, and `#` comments.

**Adds** the `LoadStaticMesh` postcard kind (`aether.static_mesh.load` — `{ namespace: String, path: String }`) and registers it in the substrate descriptor list.

## Why

Lets the engine's render path serve as a viewer for any OBJ source — particularly, the output of forthcoming generative mesh tools (DSL parser spike, sculptor agents, etc.). Stacks naturally with the wireframe overlay (PR 254) for inspecting triangulation.

ADR-0026 explicitly rejects conventional mesh imports for **production asset content** because they break the structural-style-consistency property. A dev viewer that loads OBJ for inspection isn't the same thing — but worth naming the scope clearly so this doesn't drift toward becoming a production import path.

## Test plan

- [x] `cargo build --release -p aether-static-mesh-component --target wasm32-unknown-unknown` (wasm cdylib, full FFI exports verified)
- [x] `cargo test -p aether-static-mesh-component` (5 OBJ-parser tests: simple box, n-gon triangulation, ignored directives, face-ref slash variants, out-of-range index rejection)
- [x] `cargo clippy --all-targets -p aether-static-mesh-component -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manual end-to-end: spawn substrate with `AETHER_SAVE_DIR=/tmp/aether-test`, load camera + viewer components, write a `.obj` to that dir, send `aether.static_mesh.load { namespace: "save", path: "box.obj" }`, capture_frame returns the rendered geometry