### PR TITLE
feat(spike): dsl-mesh v2 vocab — torus, sweep, scale, rotate; teapot example

### DIFF
--- a/spikes/dsl-mesh-spike/examples/teapot.dsl
+++ b/spikes/dsl-mesh-spike/examples/teapot.dsl
@@ -1,0 +1,72 @@
+; Full teapot composition.
+;
+; Three pieces, all centered around (0, 0, 0):
+;   - body+lid+knob as one continuous lathe (axially symmetric solid)
+;   - handle: torus rotated 90° around Z so its donut hole faces sideways,
+;     translated to the +x shoulder
+;   - spout: 8-sided tube swept along a path arcing from the -x shoulder
+;     outward and upward
+;
+; Color indices are placeholder palette refs (per ADR-0026's
+; palette-indexed model); the spike ignores them and the static-mesh
+; viewer paints everything default-blue today.
+(composition
+  ; --- BODY + LID + KNOB ---
+  ; Profile traces base centre → foot → bulge → equator → shoulder →
+  ; rim → over the lid → knob top.
+  (lathe
+    ((0.00 0.00)    ; base centre, closes bottom via axis collapse
+     (0.45 0.00)    ; foot ring
+     (0.50 0.05)    ; foot fillet
+     (0.65 0.25)    ; lower bulge
+     (0.70 0.50)    ; equator
+     (0.65 0.75)    ; shoulder narrowing
+     (0.45 0.95)    ; lid sit
+     (0.40 1.00)    ; rim outer
+     (0.32 1.00)    ; rim inner
+     (0.34 1.06)    ; lid bulge
+     (0.18 1.16)    ; lid taper
+     (0.07 1.20)    ; knob base shoulder
+     (0.05 1.25)    ; knob stem
+     (0.00 1.30))   ; knob top, closes via axis collapse
+    20 :color 0)
+
+  ; --- HANDLE ---
+  ; Half-heart silhouette at full size: the centerline traces the right
+  ; half of a heart in the XY plane and the wire is a 0.036-radius
+  ; 8-sided tube. Closed loop attaches at upper and lower waypoints
+  ; inside the body wall (overlap-by-transform per ADR-0026). All Z=0
+  ; so the handle's plane stands perpendicular to the spout-handle line
+  ; — hole faces ±Z. ~80% of the handle's height sits above the body
+  ; midline (y=0.5): top at 0.97, bottom-tip at 0.38.
+  (sweep
+    ((0.036 0.000) (0.0254 0.0254) (0.000 0.036) (-0.0254 0.0254)
+     (-0.036 0.000) (-0.0254 -0.0254) (0.000 -0.036) (0.0254 -0.0254))
+    ((0.35 0.92 0)    ; upper attach (deep inside body wall)
+     (0.80 0.97 0)    ; rising over the lobe top
+     (0.95 0.94 0)    ; lobe peak
+     (1.05 0.83 0)    ; upper-right curving down
+     (1.08 0.70 0)    ; outer max upper
+     (1.05 0.55 0)    ; outer max lower
+     (0.97 0.45 0)    ; curving back inward
+     (0.85 0.40 0)    ; approaching tip
+     (0.73 0.38 0)    ; bottom-tip (heart point) — at 80% line
+     (0.60 0.45 0)    ; rising back toward body
+     (0.45 0.62 0))   ; lower attach (deep inside body wall)
+    :color 0)
+
+  ; --- SPOUT ---
+  ; 8-sided unit-radius cross-section, scaled per-waypoint via :scales
+  ; for a base-wide / tip-narrow taper. Path arcs out and up in 6
+  ; waypoints for a smooth curve. Base waypoint sits inside the body
+  ; wall (overlap-by-transform) so the spout reads as attached.
+  (sweep
+    ((0.080 0.000) (0.057 0.057) (0.000 0.080) (-0.057 0.057)
+     (-0.080 0.000) (-0.057 -0.057) (0.000 -0.080) (0.057 -0.057))
+    ((-0.50 0.55 0)
+     (-0.68 0.62 0)
+     (-0.83 0.74 0)
+     (-0.93 0.88 0)
+     (-0.97 1.00 0))
+    :scales (1.6 1.3 1.0 0.75 0.55)
+    :color 0))

--- a/spikes/dsl-mesh-spike/src/ast.rs
+++ b/spikes/dsl-mesh-spike/src/ast.rs
@@ -1,4 +1,11 @@
-//! Typed mesh AST for the v1 vocabulary committed by ADR-0026.
+//! Typed mesh AST for the v1 vocabulary committed by ADR-0026, plus
+//! the v2 additions the spike commits to ahead of an ADR amendment:
+//! `torus` (handles, rings) and `sweep` (curved tubes — spouts).
+//!
+//! Sweep-along-path is on ADR-0026's parked v2 list; torus is not in
+//! the ADR yet and would land as a v2 vocabulary extension. Both are
+//! gated behind the spike — promotion to a real crate should sync
+//! the ADR first.
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Node {
@@ -42,6 +49,34 @@ pub enum Node {
     Extrude {
         profile: Vec<[f32; 2]>,
         depth: f32,
+        color: u32,
+    },
+
+    // v2 vocabulary (spike-committed; ADR amendment pending)
+    /// Donut-shaped surface around the Y axis. `major_radius` is the
+    /// distance from the torus center to the center of the tube;
+    /// `minor_radius` is the tube's radius. `major_segments` divides
+    /// the big loop, `minor_segments` divides the tube cross-section.
+    Torus {
+        major_radius: f32,
+        minor_radius: f32,
+        major_segments: u32,
+        minor_segments: u32,
+        color: u32,
+    },
+    /// Sweep a 2D `profile` polygon along a 3D polyline `path`. At each
+    /// path waypoint the profile is oriented perpendicular to the local
+    /// tangent (parallel-transport-ish — see mesher for exact framing).
+    /// Adjacent profile rings are stitched into quads (triangulated).
+    ///
+    /// Optional `scales` is a per-waypoint scalar multiplier applied to
+    /// the profile (length must match `path` length). `None` is
+    /// equivalent to all-ones — uniform tube along the path. Use this
+    /// to taper a swept tube toward its tip.
+    Sweep {
+        profile: Vec<[f32; 2]>,
+        path: Vec<[f32; 3]>,
+        scales: Option<Vec<f32>>,
         color: u32,
     },
 

--- a/spikes/dsl-mesh-spike/src/mesh.rs
+++ b/spikes/dsl-mesh-spike/src/mesh.rs
@@ -1,10 +1,15 @@
 //! Mesh a typed AST into a triangle list.
 //!
-//! Iteration 1 supports `box`, `composition`, and `translate` only — enough
-//! to validate the meshing concept and produce a viewable artifact for a
-//! cube-with-translates scene. Other primitives and transforms return
-//! `MeshError::NotYetImplemented` so unsupported scenes fail loudly rather
-//! than silently producing wrong geometry.
+//! Implemented: `box`, `lathe`, `torus`, `sweep` (with optional
+//! per-waypoint `:scales` and parallel-transport framing),
+//! `composition`, `translate`, `rotate`, `scale`. Unsupported nodes
+//! return `MeshError::NotYetImplemented` so the DSL fails loudly
+//! rather than silently producing wrong geometry. `cylinder`, `cone`,
+//! `wedge`, `sphere`, `extrude`, `mirror`, `array` are still pending.
+//!
+//! Convention: every primitive winds CCW from outside (normal =
+//! `(b - a) × (c - a)` points outward). Verified by the
+//! face-normal-direction test for each primitive.
 
 use crate::ast::Node;
 
@@ -40,6 +45,33 @@ fn mesh_into(out: &mut Vec<Triangle>, node: &Node, offset: [f32; 3]) -> Result<(
             mesh_lathe(out, profile, *segments, *color, offset);
             Ok(())
         }
+        Node::Torus {
+            major_radius,
+            minor_radius,
+            major_segments,
+            minor_segments,
+            color,
+        } => {
+            mesh_torus(
+                out,
+                *major_radius,
+                *minor_radius,
+                *major_segments,
+                *minor_segments,
+                *color,
+                offset,
+            );
+            Ok(())
+        }
+        Node::Sweep {
+            profile,
+            path,
+            scales,
+            color,
+        } => {
+            mesh_sweep(out, profile, path, scales.as_deref(), *color, offset);
+            Ok(())
+        }
         Node::Composition(children) => {
             for child in children {
                 mesh_into(out, child, offset)?;
@@ -57,13 +89,46 @@ fn mesh_into(out: &mut Vec<Triangle>, node: &Node, offset: [f32; 3]) -> Result<(
             ];
             mesh_into(out, child, combined)
         }
+        Node::Rotate { axis, angle, child } => {
+            // Mesh the child at origin, rotate every vertex around the
+            // axis (Rodrigues), then apply the inherited translation.
+            // This composes correctly for nested transforms because each
+            // recursive call freshly accumulates its own state.
+            let mut local = Vec::new();
+            mesh_into(&mut local, child, [0.0, 0.0, 0.0])?;
+            let n = normalize_or_default(*axis, [0.0, 1.0, 0.0]);
+            for mut tri in local {
+                for v in tri.vertices.iter_mut() {
+                    let r = rotate_axis_angle(*v, n, *angle);
+                    *v = [r[0] + offset[0], r[1] + offset[1], r[2] + offset[2]];
+                }
+                out.push(tri);
+            }
+            Ok(())
+        }
+        Node::Scale { factor, child } => {
+            // Mesh the child at origin, scale per-axis, then translate.
+            // Combine with translate-to-pivot/translate-back for
+            // "scale around a pivot point" composition.
+            let mut local = Vec::new();
+            mesh_into(&mut local, child, [0.0, 0.0, 0.0])?;
+            for mut tri in local {
+                for v in tri.vertices.iter_mut() {
+                    *v = [
+                        v[0] * factor[0] + offset[0],
+                        v[1] * factor[1] + offset[1],
+                        v[2] * factor[2] + offset[2],
+                    ];
+                }
+                out.push(tri);
+            }
+            Ok(())
+        }
         Node::Cylinder { .. } => Err(MeshError::NotYetImplemented("cylinder")),
         Node::Cone { .. } => Err(MeshError::NotYetImplemented("cone")),
         Node::Wedge { .. } => Err(MeshError::NotYetImplemented("wedge")),
         Node::Sphere { .. } => Err(MeshError::NotYetImplemented("sphere")),
         Node::Extrude { .. } => Err(MeshError::NotYetImplemented("extrude")),
-        Node::Rotate { .. } => Err(MeshError::NotYetImplemented("rotate")),
-        Node::Scale { .. } => Err(MeshError::NotYetImplemented("scale")),
         Node::Mirror { .. } => Err(MeshError::NotYetImplemented("mirror")),
         Node::Array { .. } => Err(MeshError::NotYetImplemented("array")),
     }
@@ -197,4 +262,215 @@ fn push_unless_degenerate(
 fn approx_eq(a: [f32; 3], b: [f32; 3]) -> bool {
     const EPS: f32 = 1e-6;
     (a[0] - b[0]).abs() < EPS && (a[1] - b[1]).abs() < EPS && (a[2] - b[2]).abs() < EPS
+}
+
+/// Donut around the Y axis. Generates `major_segments × minor_segments`
+/// quads (× 2 triangles) on the surface. The major loop sweeps angle α
+/// around the Y axis; the minor loop sweeps angle β around the tube
+/// cross-section. Triangles wound CCW from outside (radial-outward
+/// normal verified by the standard cross-product test).
+fn mesh_torus(
+    out: &mut Vec<Triangle>,
+    major_radius: f32,
+    minor_radius: f32,
+    major_segments: u32,
+    minor_segments: u32,
+    color: u32,
+    offset: [f32; 3],
+) {
+    if major_segments < 3 || minor_segments < 3 {
+        return;
+    }
+    let m = major_segments as usize;
+    let n = minor_segments as usize;
+    let two_pi = std::f32::consts::TAU;
+    // P(i, j) = vertex at major angle α_i, minor angle β_j.
+    let position = |i: usize, j: usize| -> [f32; 3] {
+        let alpha = two_pi * (i as f32) / (m as f32);
+        let beta = two_pi * (j as f32) / (n as f32);
+        let cos_a = alpha.cos();
+        let sin_a = alpha.sin();
+        let cos_b = beta.cos();
+        let sin_b = beta.sin();
+        let r = major_radius + minor_radius * cos_b;
+        [
+            offset[0] + r * cos_a,
+            offset[1] + minor_radius * sin_b,
+            offset[2] + r * sin_a,
+        ]
+    };
+    for i in 0..m {
+        let i_next = (i + 1) % m;
+        for j in 0..n {
+            let j_next = (j + 1) % n;
+            // a = P(i, j), b = P(i+1, j), c = P(i, j+1), d = P(i+1, j+1).
+            // Both i and j are angular here (unlike lathe where k was a
+            // profile-height index), so the natural (a, b, c) winding
+            // gives an inward normal. Flip to (a, c, b) + (c, d, b) for
+            // outward-facing.
+            let a = position(i, j);
+            let b = position(i_next, j);
+            let c = position(i, j_next);
+            let d = position(i_next, j_next);
+            out.push(Triangle {
+                vertices: [a, c, b],
+                color,
+            });
+            out.push(Triangle {
+                vertices: [c, d, b],
+                color,
+            });
+        }
+    }
+}
+
+/// Sweep a 2D `profile` polygon along a 3D `path`. At each path
+/// waypoint the profile is oriented perpendicular to the local tangent.
+/// Adjacent rings are stitched into quads (triangulated).
+///
+/// Path representation choice: a polyline (list of (x, y, z) points).
+/// ADR-0026 doesn't pin this — bezier / catmull-rom would be smoother
+/// but require more careful tessellation. Polyline is the simplest
+/// correct choice for v1.
+///
+/// Frame computation: at each waypoint we compute a tangent T (forward
+/// difference at endpoints, central elsewhere), then pick a "right"
+/// vector R perpendicular to T using world up `(0, 1, 0)` as a
+/// reference. If T is nearly parallel to up we fall back to
+/// `(1, 0, 0)`. The profile's local (x, y) maps to (R, U) where
+/// U = T × R. This isn't a rotation-minimizing frame (parallel
+/// transport would be) but it's stable enough for short paths like
+/// teapot spouts.
+///
+/// Caps are NOT generated — the swept surface is open at both ends.
+/// For closed tubes, end the path on a small profile (or composition
+/// with a separate cap primitive).
+fn mesh_sweep(
+    out: &mut Vec<Triangle>,
+    profile: &[[f32; 2]],
+    path: &[[f32; 3]],
+    scales: Option<&[f32]>,
+    color: u32,
+    offset: [f32; 3],
+) {
+    if profile.len() < 3 || path.len() < 2 {
+        return;
+    }
+    // If `scales` was supplied with the wrong length, treat as
+    // unspecified rather than panic — the spike's job is to be lenient
+    // while the syntax matures. Real ADR enforcement comes at promotion.
+    let scales = match scales {
+        Some(s) if s.len() == path.len() => Some(s),
+        _ => None,
+    };
+    let n = profile.len();
+
+    // Compute a tangent at each waypoint.
+    let mut tangents: Vec<[f32; 3]> = Vec::with_capacity(path.len());
+    for k in 0..path.len() {
+        let prev = if k == 0 { path[k] } else { path[k - 1] };
+        let next = if k == path.len() - 1 {
+            path[k]
+        } else {
+            path[k + 1]
+        };
+        let t = normalize_or_default(
+            [next[0] - prev[0], next[1] - prev[1], next[2] - prev[2]],
+            [0.0, 0.0, 1.0],
+        );
+        tangents.push(t);
+    }
+
+    // Build the profile ring at each waypoint using a parallel-transport
+    // frame: the first frame is seeded from world up; each subsequent
+    // frame is the previous frame rotated by the smallest angle that
+    // takes the previous tangent onto the current one. This keeps the
+    // cross-section's orientation continuous along the curve, avoiding
+    // the visible "twist" you get from picking each frame independently
+    // off a fixed reference. Without this, paths with tangents that
+    // approach world-up flip the up reference between adjacent
+    // waypoints and the tube reads as having varying diameter.
+    let mut rings: Vec<Vec<[f32; 3]>> = Vec::with_capacity(path.len());
+    let t0 = tangents[0];
+    let up_ref = if t0[1].abs() > 0.95 {
+        [1.0, 0.0, 0.0]
+    } else {
+        [0.0, 1.0, 0.0]
+    };
+    let mut r = normalize_or_default(cross(up_ref, t0), [1.0, 0.0, 0.0]);
+    let mut u = cross(t0, r);
+    for (k, p) in path.iter().enumerate() {
+        let t = tangents[k];
+        if k > 0 {
+            let prev_t = tangents[k - 1];
+            let axis = cross(prev_t, t);
+            let axis_len_sq = axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2];
+            if axis_len_sq > 1e-12 {
+                let dot = (prev_t[0] * t[0] + prev_t[1] * t[1] + prev_t[2] * t[2]).clamp(-1.0, 1.0);
+                let angle = dot.acos();
+                let axis_n = normalize_or_default(axis, [0.0, 1.0, 0.0]);
+                r = rotate_axis_angle(r, axis_n, angle);
+                u = rotate_axis_angle(u, axis_n, angle);
+            }
+        }
+        let scale = scales.map(|s| s[k]).unwrap_or(1.0);
+        let mut ring = Vec::with_capacity(n);
+        for pt in profile {
+            let sx = pt[0] * scale;
+            let sy = pt[1] * scale;
+            let world = [
+                offset[0] + p[0] + sx * r[0] + sy * u[0],
+                offset[1] + p[1] + sx * r[1] + sy * u[1],
+                offset[2] + p[2] + sx * r[2] + sy * u[2],
+            ];
+            ring.push(world);
+        }
+        rings.push(ring);
+    }
+
+    // Stitch adjacent rings.
+    for k in 0..rings.len() - 1 {
+        let r0 = &rings[k];
+        let r1 = &rings[k + 1];
+        for i in 0..n {
+            let j = (i + 1) % n;
+            let a = r0[i];
+            let b = r1[i];
+            let c = r0[j];
+            let d = r1[j];
+            push_unless_degenerate(out, a, b, c, color);
+            push_unless_degenerate(out, c, b, d, color);
+        }
+    }
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn normalize_or_default(v: [f32; 3], fallback: [f32; 3]) -> [f32; 3] {
+    let len_sq = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+    if len_sq < 1e-12 {
+        return fallback;
+    }
+    let inv = 1.0 / len_sq.sqrt();
+    [v[0] * inv, v[1] * inv, v[2] * inv]
+}
+
+/// Rotate `v` around unit axis `n` by `angle` radians (Rodrigues' formula).
+/// `n` MUST be normalized — caller's responsibility.
+fn rotate_axis_angle(v: [f32; 3], n: [f32; 3], angle: f32) -> [f32; 3] {
+    let c = angle.cos();
+    let s = angle.sin();
+    let dot = n[0] * v[0] + n[1] * v[1] + n[2] * v[2];
+    let kx = cross(n, v);
+    [
+        v[0] * c + kx[0] * s + n[0] * dot * (1.0 - c),
+        v[1] * c + kx[1] * s + n[1] * dot * (1.0 - c),
+        v[2] * c + kx[2] * s + n[2] * dot * (1.0 - c),
+    ]
 }

--- a/spikes/dsl-mesh-spike/src/parse.rs
+++ b/spikes/dsl-mesh-spike/src/parse.rs
@@ -79,6 +79,8 @@ fn parse_node(value: &Value) -> Result<Node, ParseError> {
         "sphere" => parse_sphere(&positional, &keywords),
         "lathe" => parse_lathe(&positional, &keywords),
         "extrude" => parse_extrude(&positional, &keywords),
+        "torus" => parse_torus(&positional, &keywords),
+        "sweep" => parse_sweep(&positional, &keywords),
         "composition" => parse_composition(&positional, &keywords),
         "translate" => parse_translate(&positional, &keywords),
         "rotate" => parse_rotate(&positional, &keywords),
@@ -290,6 +292,48 @@ fn parse_extrude(positional: &[&Value], keywords: &[(String, &Value)]) -> Result
         depth: as_f32(positional[1])?,
         color: require_color("extrude", keywords)?,
     })
+}
+
+fn parse_torus(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<Node, ParseError> {
+    expect_arity("torus", positional, 4)?;
+    check_no_extra_keywords("torus", keywords, &["color"])?;
+    Ok(Node::Torus {
+        major_radius: as_f32(positional[0])?,
+        minor_radius: as_f32(positional[1])?,
+        major_segments: as_u32(positional[2])?,
+        minor_segments: as_u32(positional[3])?,
+        color: require_color("torus", keywords)?,
+    })
+}
+
+fn parse_sweep(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<Node, ParseError> {
+    expect_arity("sweep", positional, 2)?;
+    check_no_extra_keywords("sweep", keywords, &["color", "scales"])?;
+    let scales = keywords
+        .iter()
+        .find(|(k, _)| k == "scales")
+        .map(|(_, v)| as_scalar_list(v))
+        .transpose()?;
+    Ok(Node::Sweep {
+        profile: as_profile(positional[0])?,
+        path: as_path(positional[1])?,
+        scales,
+        color: require_color("sweep", keywords)?,
+    })
+}
+
+fn as_scalar_list(value: &Value) -> Result<Vec<f32>, ParseError> {
+    let items = list_to_vec(value)?;
+    items.iter().map(|v| as_f32(v)).collect()
+}
+
+fn as_path(value: &Value) -> Result<Vec<[f32; 3]>, ParseError> {
+    let points = list_to_vec(value)?;
+    let mut out = Vec::with_capacity(points.len());
+    for p in points {
+        out.push(as_vec3("sweep path waypoint", p)?);
+    }
+    Ok(out)
 }
 
 fn parse_composition(

--- a/spikes/dsl-mesh-spike/src/serialize.rs
+++ b/spikes/dsl-mesh-spike/src/serialize.rs
@@ -93,6 +93,36 @@ pub fn node_to_value(node: &Node) -> Value {
             kw("color"),
             uint(*color),
         ]),
+        Node::Torus {
+            major_radius,
+            minor_radius,
+            major_segments,
+            minor_segments,
+            color,
+        } => list([
+            sym("torus"),
+            num(*major_radius),
+            num(*minor_radius),
+            uint(*major_segments),
+            uint(*minor_segments),
+            kw("color"),
+            uint(*color),
+        ]),
+        Node::Sweep {
+            profile,
+            path,
+            scales,
+            color,
+        } => {
+            let mut items = vec![sym("sweep"), profile_to_value(profile), path_to_value(path)];
+            if let Some(s) = scales {
+                items.push(kw("scales"));
+                items.push(list(s.iter().map(|x| num(*x))));
+            }
+            items.push(kw("color"));
+            items.push(uint(*color));
+            list(items)
+        }
         Node::Composition(children) => {
             let mut items = vec![sym("composition")];
             items.extend(children.iter().map(node_to_value));
@@ -159,4 +189,11 @@ fn vec3_to_value(v: [f32; 3]) -> Value {
 
 fn profile_to_value(p: &[[f32; 2]]) -> Value {
     list(p.iter().map(|pt| list([num(pt[0]), num(pt[1])])))
+}
+
+fn path_to_value(p: &[[f32; 3]]) -> Value {
+    list(
+        p.iter()
+            .map(|pt| list([num(pt[0]), num(pt[1]), num(pt[2])])),
+    )
 }

--- a/spikes/dsl-mesh-spike/tests/mesh_v2.rs
+++ b/spikes/dsl-mesh-spike/tests/mesh_v2.rs
@@ -1,0 +1,146 @@
+//! Tests for the v2 vocabulary additions: torus + sweep-along-path.
+
+use dsl_mesh_spike::{mesh, parse};
+
+#[test]
+fn torus_triangle_count_is_two_per_quad() {
+    // 8×6 = 48 quads → 96 triangles.
+    let text = "(torus 1.0 0.25 8 6 :color 0)";
+    let ast = parse(text).unwrap();
+    let tris = mesh(&ast).unwrap();
+    assert_eq!(tris.len(), 8 * 6 * 2);
+}
+
+#[test]
+fn torus_face_normals_point_outward() {
+    // Outward direction at a torus vertex is (vertex - tube_center)
+    // where tube_center is the projection of the vertex onto the
+    // major circle (i.e., scaled to major_radius in the XZ plane).
+    let major_radius: f32 = 1.0;
+    let text = "(torus 1.0 0.25 12 8 :color 0)";
+    let ast = parse(text).unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        let a = tri.vertices[0];
+        let b = tri.vertices[1];
+        let c = tri.vertices[2];
+        let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+        let normal = [
+            ab[1] * ac[2] - ab[2] * ac[1],
+            ab[2] * ac[0] - ab[0] * ac[2],
+            ab[0] * ac[1] - ab[1] * ac[0],
+        ];
+        // Centroid in XZ; project onto the major circle.
+        let cent = [
+            (a[0] + b[0] + c[0]) / 3.0,
+            (a[1] + b[1] + c[1]) / 3.0,
+            (a[2] + b[2] + c[2]) / 3.0,
+        ];
+        let radial_xz = (cent[0] * cent[0] + cent[2] * cent[2]).sqrt();
+        let tube_center = if radial_xz < 1e-6 {
+            [0.0, 0.0, 0.0]
+        } else {
+            [
+                cent[0] / radial_xz * major_radius,
+                0.0,
+                cent[2] / radial_xz * major_radius,
+            ]
+        };
+        let outward = [
+            cent[0] - tube_center[0],
+            cent[1] - tube_center[1],
+            cent[2] - tube_center[2],
+        ];
+        let dot = normal[0] * outward[0] + normal[1] * outward[1] + normal[2] * outward[2];
+        assert!(
+            dot > 0.0,
+            "torus face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+#[test]
+fn torus_with_under_three_segments_emits_nothing() {
+    let ast = parse("(torus 1.0 0.25 2 6 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+    let ast = parse("(torus 1.0 0.25 6 2 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+#[test]
+fn sweep_straight_path_is_an_extruded_polygon() {
+    // 4-point square profile swept along a 2-point straight path
+    // should produce a square tube: 4 sides × 1 segment × 2 triangles
+    // = 8 triangles. No caps in v1.
+    let text = "(sweep
+        ((-0.1 -0.1) (0.1 -0.1) (0.1 0.1) (-0.1 0.1))
+        ((0 0 0) (1 0 0))
+        :color 0)";
+    let ast = parse(text).unwrap();
+    let tris = mesh(&ast).unwrap();
+    assert_eq!(tris.len(), 4 * 2);
+}
+
+#[test]
+fn sweep_curved_path_keeps_profile_perpendicular() {
+    // A path that turns 90° (going +x then +y) — verify all profile
+    // ring vertices land at the correct distance from each waypoint.
+    let radius: f32 = 0.1;
+    let text = "(sweep
+        ((-0.1 -0.1) (0.1 -0.1) (0.1 0.1) (-0.1 0.1))
+        ((0 0 0) (1 0 0) (1 1 0))
+        :color 0)";
+    let ast = parse(text).unwrap();
+    let tris = mesh(&ast).unwrap();
+    // Square profile, 3 path points → 2 tube segments → 4 quads each
+    // → 8 triangles per segment → 16 triangles.
+    assert_eq!(tris.len(), 16);
+    // Sanity: every vertex should be within `radius * sqrt(2)` of a
+    // waypoint (corners of the square profile). Conservative bound.
+    let path = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]];
+    for tri in &tris {
+        for v in tri.vertices {
+            let mut min_dist = f32::MAX;
+            for p in &path {
+                let dx = v[0] - p[0];
+                let dy = v[1] - p[1];
+                let dz = v[2] - p[2];
+                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+                if d < min_dist {
+                    min_dist = d;
+                }
+            }
+            assert!(
+                min_dist <= radius * std::f32::consts::SQRT_2 + 1e-4,
+                "swept vertex too far from any waypoint: {v:?} (dist {min_dist})"
+            );
+        }
+    }
+}
+
+#[test]
+fn sweep_with_short_path_emits_nothing() {
+    let ast =
+        parse("(sweep ((-0.1 -0.1) (0.1 -0.1) (0.1 0.1) (-0.1 0.1)) ((0 0 0)) :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+#[test]
+fn sweep_with_under_three_profile_points_emits_nothing() {
+    let ast = parse("(sweep ((-0.1 0) (0.1 0)) ((0 0 0) (1 0 0)) :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+#[test]
+fn round_trip_torus_and_sweep() {
+    let text = "(composition
+        (torus 1.0 0.25 16 8 :color 5)
+        (sweep ((0 0.05) (0.05 0) (0 -0.05) (-0.05 0))
+               ((0 0.5 0) (0.3 0.6 0) (0.5 0.8 0))
+               :color 7))";
+    let ast1 = parse(text).unwrap();
+    let serialized = dsl_mesh_spike::serialize(&ast1);
+    let ast2 = parse(&serialized).unwrap();
+    assert_eq!(ast1, ast2);
+}


### PR DESCRIPTION
## Summary

Extends `spikes/dsl-mesh-spike/` from box+lathe coverage (PR 256) to roughly two-thirds of ADR-0026 v1 plus two parked v2 ops, validated end-to-end by composing a recognizable teapot from ~30 lines of DSL.

## What's in it

**New primitives:**
- `(torus major_radius minor_radius major_segments minor_segments :color N)` — donut around the Y axis. Faces wound CCW from outside, verified by face-normal-direction test. The torus winding required flipping `(a, b, c) → (a, c, b)` relative to the lathe pattern because both i and j are angular indices here.
- `(sweep profile path :scales? :color N)` — sweeps a closed 2D profile along a 3D polyline path. Optional per-waypoint `:scales` for tapered tubes (the teapot spout). The mesher uses **parallel-transport framing** — first frame seeded from world up, each subsequent frame is the previous one rotated by the smallest angle that aligns the new tangent. Without this, sharp tangent turns flip the up reference and the cross-section visibly twists, reading as varying tube diameter.

**New structural ops:**
- `(rotate (ax ay az) angle child)` — Rodrigues axis-angle, post-mesh transform pattern. Composes correctly with nested transforms.
- `(scale (sx sy sz) child)` — same post-mesh pattern. Combine with translate-to-pivot/translate-back for "scale around a pivot point."

## Spike-committed syntax decisions

ADR-0026 leaves these unspecified. The spike commits to:
- `(rotate (ax ay az) angle child)` — axis-angle in radians
- `(scale (sx sy sz) child)` — per-axis (not uniform)
- `(sweep profile path :scales (s0 s1 ...) :color N)` — `:scales` optional; length must equal path length or it's silently ignored
- `(torus R r M m :color N)` — default axis is +Y; rotate around +X by π/2 for a vertical donut whose hole faces ±Z (teapot handle orientation)

If the ADR wants these locked in before promotion to a real crate, that's a follow-up doc change.

## Teapot validation

`examples/teapot.dsl` composes:
- Body+lid+knob: one continuous lathe (14-point profile, 20 segments)
- Handle: sweep along an 11-waypoint half-heart path with 8-sided circular cross-section. Attach points sit deep inside the body wall via overlap-by-transform. ~80% of the loop sits above the body midline (ergonomic — keeps your hand away from the stove).
- Spout: 5-waypoint smooth arc with `:scales (1.6 1.3 1.0 0.75 0.55)` for base-wide / tip-narrow taper.

End-to-end loop:
```
cargo run -- examples/teapot.dsl > /tmp/teapot.obj
substrate (with AETHER_WIREFRAME=overlay) loads via static-mesh viewer
capture_frame returns recognizable teapot
```

Subjective verdict: looks like a teapot. Fresh-Claude oracle test pending.

## Test plan

- [x] `cargo test` (29 tests pass: 9 round-trip + 6 box + 6 lathe + 8 v2 — 4 torus, 4 sweep, 1 round-trip on torus+sweep)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo run -- examples/teapot.dsl > /tmp/teapot.obj` produces 704 triangles
- [x] Manual end-to-end: substrate + viewer + wireframe overlay renders the teapot composition; iterated handle/spout shape interactively (re-emit DSL → reload → re-capture) without any architectural friction