### PR TITLE
docs(adr): dsl-mesh cluster (0051 v1 vocab, 0052 editor-is-dsl, 0053 promote spike)

### DIFF
--- a/docs/adr/0051-dsl-mesh-vocabulary-v1-pinning.md
+++ b/docs/adr/0051-dsl-mesh-vocabulary-v1-pinning.md
@@ -1,0 +1,80 @@
+# ADR-0051: DSL mesh vocabulary v1 — pin syntax, promote torus + sweep
+
+- **Status:** Proposed
+- **Date:** 2026-04-26
+- **Amends:** ADR-0026
+
+## Context
+
+ADR-0026 committed the engine to a Lisp-syntactic primitive-composition DSL as the only mesh authoring path and listed a v1 vocabulary plus structural operators. That ADR was deliberately light on detail in two places:
+
+- The **exact syntax** of `translate` / `rotate` / `scale` was left to "sub-grammar decisions inside the spike." Only `translate` appeared by example; rotate and scale were implied but not pinned.
+- **Torus** and **sweep-along-path** were called out as parked v2 vocabulary extensions, deferred until a demo needed them.
+
+The dsl-mesh spike (PR 256, PR 257) implemented the v1 vocabulary plus torus and sweep, validated end-to-end through the substrate's render path, and produced a recognizable teapot from a single composition node tree. The spike's work surfaced two facts:
+
+1. The syntax for `translate` / `rotate` / `scale` / `mirror` / `array` is now load-bearing — the spike wrote it, the example models depend on it, and any second implementation needs to match. It belongs in the ADR.
+2. **A teapot needs torus and sweep.** Both are widely useful beyond the teapot (rings, tubes, pipes, decorative bands, character fingers, vegetation stems). Keeping them parked while we ship the DSL implementation creates a vocabulary cliff: v1 is technically usable but visibly lacks the primitives most LLM-emitted designs would reach for.
+
+A second forcing function: the spike's sweep mesher needed **parallel-transport framing** to avoid visible cross-section twist at sharp tangent turns. The naive "pick a perpendicular each time off world up" approach produced visibly varying tube diameter on the teapot handle. Without naming this requirement in the ADR, a future re-implementation could re-introduce the bug.
+
+## Decision
+
+Amend ADR-0026's primitive vocabulary and structural-operator section with the following pins.
+
+### Structural operator syntax (v1, pinned)
+
+- `(translate (x y z) child)` — translate child by `(x, y, z)`. Already pinned by ADR-0026's example.
+- `(rotate (ax ay az) angle child)` — axis-angle rotation in radians. The axis is normalized internally; the angle uses the right-hand rule.
+- `(scale (sx sy sz) child)` — per-axis scale. **Not** uniform; uniform scale is composable as `(scale (s s s) ...)`.
+- `(mirror axis child)` where `axis` is the symbol `x`, `y`, or `z` — reflect across the named axis-plane (e.g. `(mirror x ...)` reflects across the YZ plane). Faces in the mirrored copy MUST be re-wound so their normals continue to face outward.
+- `(array n (sx sy sz) child)` — `n` copies of child, each translated by `i * (sx, sy, sz)` for `i ∈ [0, n)`. `n` is `u32`.
+- `(composition child1 child2 ...)` — group node, each child rendered in the group's local frame (which is the parent's frame for the group itself).
+
+### Primitive vocabulary additions (v1, promoted from v2 parked)
+
+- `(torus major_radius minor_radius major_segments minor_segments :color N)` — donut around the Y axis. `major_radius` is the distance from the torus center to the center of the tube; `minor_radius` is the tube's radius. Default axis is `+Y` — rotate around `+X` by `π/2` to make a vertical donut whose hole faces `±Z`.
+- `(sweep profile path :scales? :color N)` — sweep a closed 2D `profile` polygon along a 3D `path` polyline. `:scales` is an optional list of per-waypoint scalar multipliers (length must equal `path` length); when present, the profile at waypoint `i` is multiplied by `scales[i]`. When absent, the tube has uniform diameter.
+
+### Sweep framing requirement (v1, normative)
+
+The sweep mesher MUST use a **parallel-transport frame**: the first frame is seeded from world up (with a fallback to world `+x` when the first tangent is nearly vertical), and each subsequent frame is the previous frame rotated by the smallest angle that aligns the previous tangent with the current one. The naive "pick a perpendicular per waypoint off a fixed up reference" approach is **not** acceptable because it visibly twists the cross-section at sharp tangent changes and reads as varying tube diameter.
+
+This requirement is normative because a sweep is a load-bearing primitive (teapot spouts, lamp pipes, character limbs) and the wrong framing produces visibly broken geometry that a downstream consumer cannot fix without re-meshing.
+
+### Path representation choice (v1)
+
+`sweep`'s `path` is a **polyline** — a list of `(x, y, z)` waypoints with linear interpolation between them. Bezier and Catmull-Rom interpolation are **not** committed by this ADR; if a future use case needs smooth-curve paths, it lands as a separate ADR amendment with a distinct primitive (e.g. `(sweep-bezier ...)`) rather than modifying `sweep`'s semantics.
+
+## Consequences
+
+### Positive
+
+- **Two implementations of the DSL produce byte-identical meshes** for the same input. Without pinned syntax for `rotate`/`scale`/`mirror`/`array`, two implementers would diverge.
+- **Teapot-class objects are expressible in v1.** Bodies, lids, knobs (lathe), handles (torus or sweep), spouts (sweep with `:scales`). The vocabulary cliff that would have surrounded "you can author a cup but not a teapot" is removed before it bites.
+- **Parallel-transport framing is documented as load-bearing.** A re-implementation can't accidentally re-introduce the twist bug.
+- **`:scales` is a small, additive extension to sweep** that unlocks all tapered-tube use cases (teapot spouts, character limbs that thicken at the joint, decorative banister spindles) without committing to a more complex per-waypoint API.
+
+### Negative
+
+- **The v1 vocabulary is one node larger** (torus added). Implementations have one more primitive to mesh. Cost is small — torus meshing is well-understood and the spike's implementation is ~40 lines.
+- **`array` does not support per-copy rotation.** A spiral staircase or a row of progressively-rotated petals needs a `(composition (rotate ... (translate ...)) ...)` unrolling rather than a single `array` node. This is intentional — array is for the cheap, common case; arbitrary per-copy transforms compose with existing structural operators.
+
+### Neutral
+
+- **CSG boolean operators remain parked.** Overlap-by-transform is still the v1 fusion pattern; CSG enters when a forcing function appears (per the parked-design memory).
+- **Bezier/spline paths remain unspecified.** Polyline paths are sufficient for the teapot use case and the validation set.
+
+## Alternatives considered
+
+- **Defer torus + sweep to a v2 ADR.** Rejected: the spike already implements them, the teapot already uses them, and shipping v1 without them creates a vocabulary cliff that contradicts ADR-0026's "LLM-friendly" thesis. The ADR cluster shipping today should include them.
+- **Add a `(sweep-bezier ...)` primitive instead of polyline-only `sweep`.** Rejected for v1: bezier tessellation is a separate problem with its own design surface (control-point density, parameterization, C¹ continuity at joins). Polyline is the simplest correct choice. Bezier lands as its own primitive when needed.
+- **Make `scale` accept a single uniform factor.** Rejected: `(scale (s s s) ...)` is one extra symbol per call and avoids a syntactic special case. The DSL prefers uniform shapes over convenient shorthands.
+- **Make sweep's framing the implementer's choice (don't require parallel transport).** Rejected: the wrong choice produces visibly broken meshes, and the spike already paid the cost of discovering this. Naming it in the ADR saves the next implementer.
+- **Add per-copy rotation to `array`.** Rejected for v1: composition + rotate handles the case at the cost of slightly more verbose DSL. v1 stays small.
+
+## Follow-up work
+
+- Implement remaining v1 meshers in the spike: cylinder, cone, wedge, sphere, extrude, mirror, array. (PR follow-up.)
+- Promote `spikes/dsl-mesh-spike/` to a real workspace crate. (See ADR-0053.)
+- Replace the existing vertex/face mesh editor with a DSL hot-loader. (See ADR-0052.)

--- a/docs/adr/0052-mesh-editor-is-the-dsl.md
+++ b/docs/adr/0052-mesh-editor-is-the-dsl.md
@@ -1,0 +1,94 @@
+# ADR-0052: The mesh editor is the DSL — text + hot reload, not vertex/face state
+
+- **Status:** Proposed
+- **Date:** 2026-04-26
+- **Supersedes mesh-editor abstraction in:** Spike C (`aether-mesh-editor-component` v0.1) — the cube/cylinder/extrude/translate-vertices stateful editor introduced in PR 235 / 250 / 252 / 253. The crate name stays; the abstraction inside it changes.
+
+## Context
+
+The substrate currently ships an `aether-mesh-editor-component` whose API treats the mesh as a **stateful vertex-and-face graph**: agents send `aether.mesh.set_primitive` to seed a cube or cylinder, then iterate via `aether.mesh.translate_vertices`, `aether.mesh.scale_vertices`, `aether.mesh.rotate_vertices`, `aether.mesh.extrude_face`, `aether.mesh.delete_faces`, with `aether.mesh.describe` to introspect. Vertex and face IDs are monotonic + tombstoned for stability across sessions (per the mesh-editor-id-shape memory).
+
+This was a useful spike — it validated the substrate render path, the hub MCP harness, and the agent-driving-substrate-via-mail loop. It produced a working bowl and (eventually) a wing-handled cup.
+
+It also surfaced a clear failure mode: **the abstraction is wrong for the agent-driven authoring use case ADR-0026 commits to.** Specifically:
+
+- The agent has to track vertex IDs across many operations to know what to manipulate next. A 100-vertex mesh has a 100-element ID space the agent must keep in working memory.
+- The agent has to mentally simulate the mesh's geometry to predict what an op will produce. "Extrude face 47" has different meaning depending on the mesh's current state.
+- Topology changes invalidate the agent's mental model. After an extrude, "vertex 50" exists where there was none before; after a delete, "face 47" is a tombstone the agent might still have in memory.
+- Many edits later, the mesh is the result of a long history that exists nowhere as a single artifact. The asset is "the substrate's current state," not a file the agent (or a reviewer) can read.
+- The teacup oracle test (PR-related discussion 2026-04-25) failed largely because the agent's mental model of the vertex graph couldn't track topology changes well enough to construct a recognizable teacup.
+
+ADR-0026 made the architectural call that mesh content is authored as a primitive-composition DSL parsed at load time. The dsl-mesh spike (PRs 256, 257) then proved the inverse claim: an agent emitting **30 lines of DSL text** can produce a recognizable teapot in one shot, with no intermediate state to track. The DSL *is* the asset, the asset *is* the agent's working memory, and editing is rewriting text — exactly what LLMs are good at.
+
+The two abstractions are not compatible. We can ship one or the other but not both as the load-bearing mesh editor.
+
+## Decision
+
+**The mesh editor is the DSL.** Agents author meshes by emitting DSL text and sending it to the editor; the editor parses, meshes, caches, and replays the result every tick. Iteration is rewriting the text and re-sending it; the editor hot-reloads on receipt.
+
+Specifically:
+
+- **Component crate `aether-mesh-editor-component` is rewritten** to be a DSL hot-loader. Crate name unchanged; internals replaced.
+- **New mail vocabulary** (proposed details left to ADR-0053):
+  - `aether.dsl_mesh.set_text { dsl }` — agent supplies inline DSL text. Component parses, meshes, replaces cache.
+  - `aether.dsl_mesh.set_path { namespace, path }` — agent supplies a path; component fires `aether.io.read` to load the DSL from disk, then parses + meshes + replaces cache.
+- **Old mail vocabulary is removed** from the component and from `aether-kinds`:
+  - `aether.mesh.set_primitive`, `aether.mesh.translate_vertices`, `aether.mesh.scale_vertices`, `aether.mesh.rotate_vertices`, `aether.mesh.extrude_face`, `aether.mesh.delete_faces`, `aether.mesh.describe`, plus the response shape `aether.mesh.state`.
+- **Hot reload semantics are by-replacement.** Each `set_text` or successful `set_path` reload drops the prior cache wholesale and installs the new triangle list. There is no diff/patch surface in v1.
+- **The editor is stateless beyond the cache.** It does not retain DSL history, undo, or a "current edit position." History is the user's responsibility (git, file timestamps, agent transcripts).
+
+### What "edit" means under this model
+
+The agent's edit loop is:
+
+1. Read the current DSL (from a file via `aether.io.read`, from agent memory, or from a fresh prompt).
+2. Modify the text — change a profile point, add a `(translate ...)` wrapper, swap a torus for a sweep.
+3. Send `aether.dsl_mesh.set_text` (or write the file and send `set_path`).
+4. Capture a frame to verify.
+5. Iterate or commit.
+
+This is the workflow the spike validated for the teapot. The editor's job is to make step 3 → 4 fast (substrate hot-reloads in one tick).
+
+### What this ADR does not do
+
+- It does not specify the DSL grammar — that's ADR-0026 + ADR-0051.
+- It does not specify the parser/mesher implementation crate layout — that's ADR-0053.
+- It does not commit to a file format for `set_path`. The DSL text format defined by ADR-0026 IS the file format; no envelope.
+- It does not commit to introspection mail (a `describe`-equivalent for the DSL). The agent already has the source text — there's nothing to introspect that the agent didn't just send. If a use case for "inspect the meshed result" appears, it lands as a separate ADR.
+
+## Consequences
+
+### Positive
+
+- **The asset is the DSL text.** Git-versionable, diffable, reviewable, search-grep-able. No "the substrate's current state" as a hidden source of truth.
+- **The agent's working memory matches what's on disk.** No vertex-ID tracking, no topology mental model. The agent edits text, exactly what it's good at.
+- **The component is dramatically simpler.** No sparse vertex/face vectors, no tombstones, no monotonic ID allocator. Two handlers (`set_text`, `set_path`), one cache, one tick replayer.
+- **One asset format across all mesh consumers.** The DSL editor and a future "load this scene at startup" path read the same files.
+- **Iteration is fast and reversible.** Rewrite text, hot-reload, capture, repeat. Reverting is reverting the file.
+- **Composition is free.** A scene with multiple meshes is one DSL document with one `(composition ...)` at the root, or several files loaded into separate component instances. Either works without new infrastructure.
+
+### Negative
+
+- **The retired vertex-editor API can no longer be used.** Any spike, demo, or external script that drove `aether.mesh.set_primitive` / `translate_vertices` / `extrude_face` / etc. via MCP must be rewritten to emit DSL instead. The mesh-editor-id-shape memory and related discussion artifacts are now historical context, not active guidance. Documented in the migration notes shipped with the implementing PR.
+- **Local fine-grained edits cost a full re-mesh.** Tweaking one profile point re-meshes the whole DSL. For our teapot-class scale this is fast (sub-millisecond meshing for ~700 triangles), but a future complex scene might want diff-based reloads. Deferred until pressure shows up.
+- **No incremental introspection.** The agent can't ask "what's the current vertex at id 47" because there is no id 47 — there's just text. If introspection becomes useful (e.g. "where is the bottom-tip of the handle in world coords?"), it needs a new query mail kind that walks the AST.
+- **Existing memory entries about the mesh editor become partially stale.** Specifically `project_mesh_editor_spike_planned.md`, `project_mesh_editor_id_shape.md`, `project_teacup_oracle_test.md` all refer to the retired API. They remain useful as historical context but should not be read as active guidance after this ADR lands. Updates to those memories will reflect the supersession.
+
+### Neutral
+
+- **Multiple mesh editors per scene** are still supported — load the component multiple times under different names, drive each with different DSL. Works the same as the static-mesh viewer pattern.
+- **The DSL parser/mesher lives in a library crate**, not the component, so other consumers (a DSL linter, a one-off CLI for OBJ export, future agents that want to mesh without going through the editor) can use it directly.
+
+## Alternatives considered
+
+- **Keep both abstractions side-by-side.** Rejected: ADR-0026's positioning is "the DSL is the only mesh authoring path." Shipping a parallel vertex-editor contradicts that and creates a "which path do I use?" question for every new component author. Two paths means neither is the path.
+- **Keep the vertex editor as the editor; treat the DSL as an export format only.** Rejected: it inverts cause and effect. The DSL is the asset format per ADR-0026; the editor must therefore edit assets. An "edit a different format and export to assets" workflow is exactly the conventional-tool authoring pipeline ADR-0026 rejects.
+- **Add a `compile_to_dsl` op to the vertex editor.** Rejected: vertex-graph → DSL inverse-mapping is hard (the DSL is structural; the vertex graph is geometric) and produces ugly machine-generated DSL that the agent can't easily edit further. The DSL is most useful when it's hand- or LLM-authored at the structural level.
+- **Defer the editor rewrite until ADR-0053's promotion lands.** Rejected: the rewrite IS the implementation of ADR-0053's editor crate. They land together (or the editor lands second once the library is there).
+- **Diff-based reload (send only the changed subtree).** Rejected for v1: full re-mesh is fast at our scale, and a diff protocol adds significant agent-side bookkeeping. Re-evaluate if scenes get large enough for full re-mesh to feel slow.
+
+## Follow-up work
+
+- ADR-0053 lands the promotion of the spike to a library crate plus the editor rewrite as one or two coordinated PRs.
+- Update `project_mesh_editor_spike_planned.md`, `project_mesh_editor_id_shape.md`, `project_teacup_oracle_test.md` memories to reflect supersession after the editor PR lands.
+- The `mcp__aether-hub__describe_component` MCP tool still surfaces the editor's input handlers. After the rewrite, it will show `set_text` and `set_path` instead of `set_primitive` / `translate_vertices` / etc. — agents that read the capabilities surface adapt automatically.

--- a/docs/adr/0053-promote-dsl-mesh-spike-to-crate.md
+++ b/docs/adr/0053-promote-dsl-mesh-spike-to-crate.md
@@ -1,0 +1,143 @@
+# ADR-0053: Promote `dsl-mesh-spike` to `aether-dsl-mesh` library crate
+
+- **Status:** Proposed
+- **Date:** 2026-04-26
+- **Implements:** ADR-0026, ADR-0051, ADR-0052
+
+## Context
+
+ADR-0026 committed the engine to a Lisp-syntactic primitive-composition DSL as the only mesh authoring path. ADR-0051 pinned the v1 vocabulary syntax and promoted torus + sweep from parked v2 into v1. ADR-0052 retired the vertex/face stateful mesh editor in favour of a DSL hot-loader that lives in the existing `aether-mesh-editor-component` crate.
+
+The implementation of all three ADRs currently lives in `spikes/dsl-mesh-spike/` — its own standalone Cargo workspace per ADR-0003's spike convention. The spike has shipped:
+
+- A typed AST (`src/ast.rs`) covering the full v1 vocabulary plus structural operators.
+- A parser (`src/parse.rs`) and serializer (`src/serialize.rs`) over `lexpr` s-expressions, with round-trip tests.
+- A mesher (`src/mesh.rs`) that handles `box`, `lathe`, `torus`, `sweep` (with `:scales` and parallel-transport framing), `composition`, `translate`, `rotate`, `scale`. The remaining v1 nodes (`cylinder`, `cone`, `wedge`, `sphere`, `extrude`, `mirror`, `array`) return `MeshError::NotYetImplemented`.
+- An OBJ exporter (`src/obj.rs`) used by the spike's CLI binary (`src/main.rs`) and consumed by the `aether-static-mesh-component` viewer for end-to-end validation through the substrate render path.
+- The `examples/teapot.dsl` model that ADR-0052's case study cites.
+
+The spike has paid off: the abstraction is right, the wire surface is right, and the teapot validates the end-to-end loop. To use it from the rewritten mesh editor (per ADR-0052), it must live somewhere the workspace can `path = "..."` into. Spikes are structurally ineligible for that — they're standalone workspaces by ADR-0003 to keep their dependency graph isolated from the engine's.
+
+This ADR pins the promotion plan so it doesn't accidentally drag in shape decisions that don't belong (a CLI binary the engine ships, a render dependency, a host-fn surface). The spike's CLI is useful for development but is not engine code.
+
+## Decision
+
+Promote `spikes/dsl-mesh-spike/` to `crates/aether-dsl-mesh/` as a **library-only** workspace member. The component rewrite per ADR-0052 lands as a separate change that depends on this crate.
+
+### Crate scope
+
+`aether-dsl-mesh` exposes three layers, each from a separate module:
+
+- `ast` — the typed `Node` enum and helper types (`Axis`, etc.).
+- `parse` — `parse(text: &str) -> Result<Node, ParseError>`. s-expression → typed AST.
+- `serialize` — `serialize(node: &Node) -> String`. Typed AST → s-expression text. Round-trip with `parse`.
+- `mesh` — `mesh(node: &Node) -> Result<Vec<Triangle>, MeshError>`. Typed AST → flat triangle list. The exposed `Triangle` is `{ vertices: [[f32; 3]; 3], color: u32 }` — same shape the spike already ships.
+- `obj` — `to_obj(triangles: &[Triangle]) -> String`. Optional convenience for tooling/tests; doesn't depend on the substrate render path.
+
+### What the crate does NOT contain
+
+- **No CLI binary.** The spike's `src/main.rs` (DSL-text → OBJ-on-stdout) is useful for one-off development and stays available as `examples/dsl_to_obj.rs` so `cargo run --example dsl_to_obj -- examples/teapot.dsl` still works. It is not an engine artefact.
+- **No rendering.** The crate produces triangles. Whoever consumes them owns the render path. The mesh editor component ships triangles as `aether.draw_triangle` mail per the existing pattern.
+- **No host-fn surface, no MCP tool surface, no mail kinds.** Those live in `aether-kinds` and the component crates. This crate is a pure library.
+- **No async, no I/O.** Reading DSL from a file is the component's job (via the `aether.io.read` sink per ADR-0041). Parsing and meshing are CPU-only synchronous calls.
+- **No incremental re-meshing API.** ADR-0052 commits to by-replacement hot reload in v1. The crate exposes `mesh(node)` only; no `mesh_diff(old, new)`.
+
+### Dependencies
+
+Carries forward the spike's two: `lexpr` and `thiserror`. Both already vetted against the engine's dep policy (small, pure-Rust, no transitive surprises). Dev-dependency `pretty_assertions` likewise carries forward.
+
+### Layout
+
+```
+crates/aether-dsl-mesh/
+  Cargo.toml          # workspace member, library only
+  src/
+    lib.rs            # re-exports ast, parse, serialize, mesh, obj
+    ast.rs
+    parse.rs
+    serialize.rs
+    mesh.rs
+    obj.rs
+  examples/
+    dsl_to_obj.rs     # the spike's CLI moved here verbatim
+    teapot.dsl        # moved from spike examples/, used by tests
+  tests/
+    # spike's existing tests/ moved here verbatim
+```
+
+The spike directory `spikes/dsl-mesh-spike/` is deleted in the same PR so there is no parallel-source confusion. The teapot DSL becomes the crate's authoritative example.
+
+### Cargo.toml shape
+
+```toml
+[package]
+name = "aether-dsl-mesh"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+lexpr = "0.2"
+thiserror = "2"
+
+[dev-dependencies]
+pretty_assertions = "1"
+```
+
+Workspace root `Cargo.toml` adds `crates/aether-dsl-mesh` to its `members` list. No new workspace dependencies; the two used here are crate-local.
+
+### Sequencing relative to ADR-0051's leftover meshers
+
+ADR-0051's "promoted to v1" claim is currently aspirational for `cylinder`, `cone`, `wedge`, `sphere`, `extrude`, `mirror`, `array` — the spike returns `NotYetImplemented` for all of them. This ADR's promotion happens **before** those meshers are filled in, for two reasons:
+
+1. The crate-shape decision is independent of which mesher functions are populated. Promoting now means the editor rewrite per ADR-0052 can begin in parallel with the remaining meshers.
+2. Filling in meshers inside the spike produces a larger move PR, with diff noise that obscures the promotion itself. Two small PRs (promote, then complete v1) review more cleanly than one large one.
+
+The remaining meshers land as a follow-up PR against the new crate, not against the spike.
+
+### Sequencing relative to the editor rewrite (ADR-0052)
+
+The editor rewrite lands as a **separate** PR after this promotion. It needs `aether-dsl-mesh` as a path dependency, so the promotion must merge first. The two PRs are coordinated but distinct because:
+
+- The promotion is a mechanical move + workspace wire-up. It should review fast.
+- The editor rewrite removes mail kinds (`aether.mesh.set_primitive`, `translate_vertices`, etc.), adds new kinds (`aether.dsl_mesh.set_text`, `aether.dsl_mesh.set_path`), and restructures the component internals. It needs more careful review.
+
+Bundling them risks the editor rewrite's review burden gating the promotion.
+
+## Consequences
+
+### Positive
+
+- **The mesh editor (per ADR-0052) becomes implementable.** A workspace `path = "..."` dependency on `aether-dsl-mesh` is the only thing standing between today's spike and a real component.
+- **The DSL is reusable beyond the editor.** A future scene loader, asset linter, or one-off OBJ-export tool depends on `aether-dsl-mesh` directly without going through a component or mail. The spike's "is this the right abstraction?" question is settled in favour of "yes, ship it as a library."
+- **Spike directory disappears.** No long-lived parallel source tree where someone might fix a bug in one place but not the other. The crate is the source of truth.
+- **Crate boundary forces a clean library API.** The spike's CLI was free to dip into `mesh::*` internals; the library has to expose its surface deliberately. The decision to keep the API to `parse` / `serialize` / `mesh` / `to_obj` is the contract.
+
+### Negative
+
+- **The spike's CI artefact (the standalone `Cargo.lock`) is gone.** That `Cargo.lock` was incidentally useful for catching dep-graph regressions in isolation; rolled into the workspace lock, regressions in `lexpr` or `thiserror` would surface workspace-wide rather than spike-local. The cost is small — both deps are stable — but worth naming.
+- **Workspace member count goes up by one.** Build times for `cargo build` (no `-p`) get marginally longer. Negligible in practice; mentioned for completeness.
+- **Spike-as-experiment status is consumed.** Promotion is the spike claiming the engine's stability bar. Future breaking changes to the AST or mesher API are now PR-reviewed engine changes, not spike iteration.
+
+### Neutral
+
+- **The teapot DSL moves with the crate.** It's the canonical example regardless of where it lives; the move is a path update for the OBJ-export workflow, nothing else.
+- **`aether-static-mesh-component` is unaffected.** It loads OBJ from the io sink, not DSL. It will continue to consume the OBJ output of `cargo run --example dsl_to_obj` exactly as it does today.
+
+## Alternatives considered
+
+- **Promote and finish v1 meshers in one PR.** Rejected: bundles a mechanical move with semantic implementation work. Splits cleanly; the move PR reviews on "is the new crate shape right?", the meshers PR reviews on "is each new mesher correct?". Different review questions, different PRs.
+- **Promote and rewrite the editor in one PR.** Rejected: see sequencing above. The editor rewrite is the larger semantic change and shouldn't gate the promotion.
+- **Keep the spike, copy needed modules into the editor crate.** Rejected: produces two diverging copies of the parser/AST/mesher. ADR-0026 and ADR-0052 both depend on the DSL being one canonical thing across the engine. A library crate is the correct factoring; a vendored copy is not.
+- **Split parser/AST/serialize into one crate and mesher into another.** Rejected for v1: the mesher depends on the AST and nothing else, and the AST is no use without the parser. Splitting now is premature factoring against a problem that doesn't exist (no consumer wants AST without mesher or mesher without AST). Revisit if a consumer wants only the parser (e.g. a syntax-highlighting LSP) and the dep weight bothers them.
+- **Move the CLI into a separate `aether-dsl-mesh-cli` crate.** Rejected for v1: it's one short file (`dsl_to_obj.rs`) used during development. `cargo run --example dsl_to_obj` is the same ergonomics with one fewer crate.
+- **Delay promotion until v1 meshers are complete.** Rejected: the editor rewrite per ADR-0052 needs the crate to exist as a path-importable library. Blocking that on filling in mesher stubs would idle the editor rewrite for no benefit; the partial mesher set already meshes the teapot.
+
+## Follow-up work
+
+- This ADR's PR cluster includes ADR-0051 and ADR-0052. After the cluster lands, the implementation cascade is:
+  1. Promote `spikes/dsl-mesh-spike/` → `crates/aether-dsl-mesh/` per this ADR. (Mechanical move PR.)
+  2. Finish v1 meshers (`cylinder`, `cone`, `wedge`, `sphere`, `extrude`, `mirror`, `array`) inside the new crate. (Implementation PR.)
+  3. Rewrite `aether-mesh-editor-component` per ADR-0052 to depend on `aether-dsl-mesh` and expose `aether.dsl_mesh.set_text` / `set_path`. (Editor PR.)
+  4. Wire-in PR: update demos, examples, MCP harness section in `CLAUDE.md`, and stale memory entries.
+- The retired vertex-editor mail kinds (`aether.mesh.set_primitive`, `translate_vertices`, `scale_vertices`, `rotate_vertices`, `extrude_face`, `delete_faces`, `describe`, `state`) are deleted from `aether-kinds` in step 3. Anything in-tree that referenced them is updated in step 4.


### PR DESCRIPTION
## Summary

Three coordinated ADRs setting up the implementation cascade for the DSL as the mesh editor.

- **ADR-0051** amends ADR-0026. Pins translate/rotate/scale/mirror/array syntax. Promotes torus + sweep from v2 parked to v1. Makes parallel-transport framing normative for sweep (the spike discovered the naive framing twists visibly on sharp tangent turns).
- **ADR-0052** supersedes the Spike C vertex/face editor abstraction inside aether-mesh-editor-component. The mesh editor IS the DSL — agents emit text, hot-reload happens by replacement. Retires set_primitive / translate_vertices / scale_vertices / rotate_vertices / extrude_face / delete_faces / describe / state. New mail vocab is aether.dsl_mesh.set_text and aether.dsl_mesh.set_path.
- **ADR-0053** specifies the promotion of spikes/dsl-mesh-spike/ to crates/aether-dsl-mesh/ as a library-only workspace member. No CLI in the engine, no rendering, no host-fn surface. Two-PR sequencing: promote first, then fill in remaining v1 meshers.

Validated end-to-end by the teapot (PR 257, ~30 lines of DSL, recognizable through the substrate render path) before drafting.

## Test plan

- [ ] Read ADR-0051. Does the pinned syntax match what is already shipped in the spike?
- [ ] Read ADR-0052. Does the supersession of the vertex editor scope correctly to the existing crate name?
- [ ] Read ADR-0053. Does the library-only scope match the engine's needs (no CLI, no render dep)?
- [ ] Cluster reads as one decision in three pieces, not three independent decisions.

Docs-only; per the self-merge rule for ADRs.

Co-Authored-By: Claude Opus 4.7 (1M context)