### PR TITLE
feat(spike): finish v1 mesh vocab — cylinder, cone, wedge, sphere, extrude, mirror, array

### DIFF
--- a/spikes/dsl-mesh-spike/src/mesh.rs
+++ b/spikes/dsl-mesh-spike/src/mesh.rs
@@ -1,17 +1,18 @@
 //! Mesh a typed AST into a triangle list.
 //!
-//! Implemented: `box`, `lathe`, `torus`, `sweep` (with optional
-//! per-waypoint `:scales` and parallel-transport framing),
-//! `composition`, `translate`, `rotate`, `scale`. Unsupported nodes
-//! return `MeshError::NotYetImplemented` so the DSL fails loudly
-//! rather than silently producing wrong geometry. `cylinder`, `cone`,
-//! `wedge`, `sphere`, `extrude`, `mirror`, `array` are still pending.
+//! Full v1 vocabulary per ADR-0026 + ADR-0051: primitives `box`,
+//! `cylinder`, `cone`, `wedge`, `sphere`, `lathe`, `extrude`, `torus`,
+//! `sweep` (with optional per-waypoint `:scales` and parallel-transport
+//! framing); structural ops `composition`, `translate`, `rotate`,
+//! `scale`, `mirror`, `array`. The `MeshError::NotYetImplemented`
+//! variant is retained as an escape hatch for future vocabulary
+//! additions but is unreachable from any v1 input.
 //!
 //! Convention: every primitive winds CCW from outside (normal =
-//! `(b - a) × (c - a)` points outward). Verified by the
-//! face-normal-direction test for each primitive.
+//! `(b - a) × (c - a)` points outward). Verified by per-primitive
+//! face-normal-direction tests.
 
-use crate::ast::Node;
+use crate::ast::{Axis, Node};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Triangle {
@@ -124,13 +125,89 @@ fn mesh_into(out: &mut Vec<Triangle>, node: &Node, offset: [f32; 3]) -> Result<(
             }
             Ok(())
         }
-        Node::Cylinder { .. } => Err(MeshError::NotYetImplemented("cylinder")),
-        Node::Cone { .. } => Err(MeshError::NotYetImplemented("cone")),
-        Node::Wedge { .. } => Err(MeshError::NotYetImplemented("wedge")),
-        Node::Sphere { .. } => Err(MeshError::NotYetImplemented("sphere")),
-        Node::Extrude { .. } => Err(MeshError::NotYetImplemented("extrude")),
-        Node::Mirror { .. } => Err(MeshError::NotYetImplemented("mirror")),
-        Node::Array { .. } => Err(MeshError::NotYetImplemented("array")),
+        Node::Cylinder {
+            radius,
+            height,
+            segments,
+            color,
+        } => {
+            mesh_cylinder(out, *radius, *height, *segments, *color, offset);
+            Ok(())
+        }
+        Node::Cone {
+            radius,
+            height,
+            segments,
+            color,
+        } => {
+            mesh_cone(out, *radius, *height, *segments, *color, offset);
+            Ok(())
+        }
+        Node::Wedge { x, y, z, color } => {
+            mesh_wedge(out, *x, *y, *z, *color, offset);
+            Ok(())
+        }
+        Node::Sphere {
+            radius,
+            subdivisions,
+            color,
+        } => {
+            mesh_sphere(out, *radius, *subdivisions, *color, offset);
+            Ok(())
+        }
+        Node::Extrude {
+            profile,
+            depth,
+            color,
+        } => {
+            mesh_extrude(out, profile, *depth, *color, offset);
+            Ok(())
+        }
+        Node::Mirror { axis, child } => {
+            let mut local = Vec::new();
+            mesh_into(&mut local, child, [0.0, 0.0, 0.0])?;
+            for mut tri in local {
+                for v in tri.vertices.iter_mut() {
+                    match axis {
+                        Axis::X => v[0] = -v[0],
+                        Axis::Y => v[1] = -v[1],
+                        Axis::Z => v[2] = -v[2],
+                    }
+                    v[0] += offset[0];
+                    v[1] += offset[1];
+                    v[2] += offset[2];
+                }
+                // Reflection inverts orientation — swap two vertices to
+                // restore CCW-from-outside winding.
+                tri.vertices.swap(1, 2);
+                out.push(tri);
+            }
+            Ok(())
+        }
+        Node::Array {
+            count,
+            spacing,
+            child,
+        } => {
+            let mut local = Vec::new();
+            mesh_into(&mut local, child, [0.0, 0.0, 0.0])?;
+            for i in 0..*count {
+                let f = i as f32;
+                let dx = offset[0] + spacing[0] * f;
+                let dy = offset[1] + spacing[1] * f;
+                let dz = offset[2] + spacing[2] * f;
+                for tri in &local {
+                    let mut copy = *tri;
+                    for v in copy.vertices.iter_mut() {
+                        v[0] += dx;
+                        v[1] += dy;
+                        v[2] += dz;
+                    }
+                    out.push(copy);
+                }
+            }
+            Ok(())
+        }
     }
 }
 
@@ -473,4 +550,149 @@ fn rotate_axis_angle(v: [f32; 3], n: [f32; 3], angle: f32) -> [f32; 3] {
         v[1] * c + kx[1] * s + n[1] * dot * (1.0 - c),
         v[2] * c + kx[2] * s + n[2] * dot * (1.0 - c),
     ]
+}
+
+/// Cylinder of `radius` and total `height`, centered on the Y axis at
+/// `offset`. Implemented as a lathe of a 4-point profile so the side
+/// + cap winding matches the rest of the lathed primitives.
+fn mesh_cylinder(
+    out: &mut Vec<Triangle>,
+    radius: f32,
+    height: f32,
+    segments: u32,
+    color: u32,
+    offset: [f32; 3],
+) {
+    let h = height * 0.5;
+    let profile = [[0.0, -h], [radius, -h], [radius, h], [0.0, h]];
+    mesh_lathe(out, &profile, segments, color, offset);
+}
+
+/// Cone of `radius` and total `height`, base on the -Y side and apex
+/// on the +Y side, centered at `offset`. Implemented as a lathe.
+fn mesh_cone(
+    out: &mut Vec<Triangle>,
+    radius: f32,
+    height: f32,
+    segments: u32,
+    color: u32,
+    offset: [f32; 3],
+) {
+    let h = height * 0.5;
+    let profile = [[0.0, -h], [radius, -h], [0.0, h]];
+    mesh_lathe(out, &profile, segments, color, offset);
+}
+
+/// UV sphere of `radius`, centered at `offset`. `subdivisions` controls
+/// both the number of latitude rings (between poles, exclusive) and the
+/// number of longitude segments. Implemented as a lathe of a half-circle
+/// profile from south pole to north pole; pole quads degenerate naturally.
+fn mesh_sphere(
+    out: &mut Vec<Triangle>,
+    radius: f32,
+    subdivisions: u32,
+    color: u32,
+    offset: [f32; 3],
+) {
+    if subdivisions < 3 {
+        return;
+    }
+    let n = subdivisions as usize;
+    let mut profile: Vec<[f32; 2]> = Vec::with_capacity(n + 1);
+    for i in 0..=n {
+        let theta = -std::f32::consts::FRAC_PI_2 + (i as f32) * std::f32::consts::PI / (n as f32);
+        profile.push([radius * theta.cos(), radius * theta.sin()]);
+    }
+    mesh_lathe(out, &profile, subdivisions, color, offset);
+}
+
+/// Right-triangular prism (ramp) with extents `(x, y, z)` centered at
+/// `offset`. The hypotenuse face slopes from the front-bottom edge
+/// (`+z/2, -y/2`) up to the back-top edge (`-z/2, +y/2`). Six vertices,
+/// five faces (bottom quad, back quad, hypotenuse quad, two triangular
+/// sides). Faces wound CCW from outside.
+fn mesh_wedge(out: &mut Vec<Triangle>, x: f32, y: f32, z: f32, color: u32, offset: [f32; 3]) {
+    let hx = x * 0.5;
+    let hy = y * 0.5;
+    let hz = z * 0.5;
+    let [ox, oy, oz] = offset;
+    let a = [ox - hx, oy - hy, oz - hz]; // back-bottom-left
+    let b = [ox + hx, oy - hy, oz - hz]; // back-bottom-right
+    let c = [ox - hx, oy - hy, oz + hz]; // front-bottom-left
+    let d = [ox + hx, oy - hy, oz + hz]; // front-bottom-right
+    let e = [ox - hx, oy + hy, oz - hz]; // back-top-left
+    let f = [ox + hx, oy + hy, oz - hz]; // back-top-right
+
+    let push = |out: &mut Vec<Triangle>, p, q, r| {
+        out.push(Triangle {
+            vertices: [p, q, r],
+            color,
+        });
+    };
+
+    // Bottom (-Y): a, b, d, c going CCW viewed from -Y
+    push(out, a, b, d);
+    push(out, a, d, c);
+    // Back (-Z): a, e, f, b going CCW viewed from -Z
+    push(out, a, e, f);
+    push(out, a, f, b);
+    // Left side (-X): a, c, e
+    push(out, a, c, e);
+    // Right side (+X): b, f, d
+    push(out, b, f, d);
+    // Hypotenuse (+Y/+Z): c, d, f, e
+    push(out, c, d, f);
+    push(out, c, f, e);
+}
+
+/// Extrude a 2D `profile` polygon along Z by `depth`. Generates side-wall
+/// quads + two cap polygons triangulated by a fan from vertex 0.
+///
+/// The profile is interpreted as listed CCW when viewed from +Z. The back
+/// cap (at `z = depth`) keeps the original winding (normal +Z); the
+/// front cap (at `z = 0`) reverses the winding (normal -Z). Side walls
+/// stitch each profile edge `p_i → p_{i+1}` between the two cap planes.
+///
+/// **Caller's contract**: `profile` must be convex for the fan
+/// triangulation to produce a correct cap. Concave profiles will tile
+/// the cap with overlapping triangles — a future ear-clipping pass
+/// would lift this restriction. The v1 vocabulary is convex-only by
+/// convention (per ADR-0026's primitive set).
+fn mesh_extrude(
+    out: &mut Vec<Triangle>,
+    profile: &[[f32; 2]],
+    depth: f32,
+    color: u32,
+    offset: [f32; 3],
+) {
+    if profile.len() < 3 || depth <= 0.0 {
+        return;
+    }
+    let n = profile.len();
+    let [ox, oy, oz] = offset;
+    let base = |i: usize| -> [f32; 3] { [ox + profile[i][0], oy + profile[i][1], oz] };
+    let top = |i: usize| -> [f32; 3] { [ox + profile[i][0], oy + profile[i][1], oz + depth] };
+
+    // Side walls. For edge p_i → p_{i+1}, the quad corners CCW from
+    // outside are (base i, base i+1, top i+1, top i). Triangulate as
+    // (a, b, c) + (a, c, d) — outward normal verified for CCW profiles.
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let a = base(i);
+        let b = base(j);
+        let c = top(j);
+        let d = top(i);
+        push_unless_degenerate(out, a, b, c, color);
+        push_unless_degenerate(out, a, c, d, color);
+    }
+
+    // Back cap (z = depth, normal +Z): fan from vertex 0 in original
+    // winding.
+    for i in 1..n - 1 {
+        push_unless_degenerate(out, top(0), top(i), top(i + 1), color);
+    }
+    // Front cap (z = 0, normal -Z): reverse winding.
+    for i in 1..n - 1 {
+        push_unless_degenerate(out, base(0), base(i + 1), base(i), color);
+    }
 }

--- a/spikes/dsl-mesh-spike/tests/mesh_box.rs
+++ b/spikes/dsl-mesh-spike/tests/mesh_box.rs
@@ -94,13 +94,3 @@ fn box_face_normals_point_outward() {
         );
     }
 }
-
-#[test]
-fn unsupported_primitive_returns_error() {
-    let ast = parse("(sphere 1 2 :color 0)").unwrap();
-    let result = mesh(&ast);
-    assert!(
-        result.is_err(),
-        "sphere mesher not yet implemented should error"
-    );
-}

--- a/spikes/dsl-mesh-spike/tests/mesh_v1_remaining.rs
+++ b/spikes/dsl-mesh-spike/tests/mesh_v1_remaining.rs
@@ -1,0 +1,332 @@
+//! Tests for the v1 vocabulary completion: cylinder, cone, wedge,
+//! sphere, extrude, mirror, array. Promoted alongside ADR-0051's
+//! formalization of the v1 vocabulary.
+//!
+//! Each mesher gets a triangle-count check + an outward-winding check
+//! (where the centroid-vs-normal test is well-defined for the shape).
+
+use dsl_mesh_spike::{mesh, parse};
+
+fn tri_normal(tri: &dsl_mesh_spike::Triangle) -> [f32; 3] {
+    let a = tri.vertices[0];
+    let b = tri.vertices[1];
+    let c = tri.vertices[2];
+    let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    [
+        ab[1] * ac[2] - ab[2] * ac[1],
+        ab[2] * ac[0] - ab[0] * ac[2],
+        ab[0] * ac[1] - ab[1] * ac[0],
+    ]
+}
+
+fn tri_centroid(tri: &dsl_mesh_spike::Triangle) -> [f32; 3] {
+    let a = tri.vertices[0];
+    let b = tri.vertices[1];
+    let c = tri.vertices[2];
+    [
+        (a[0] + b[0] + c[0]) / 3.0,
+        (a[1] + b[1] + c[1]) / 3.0,
+        (a[2] + b[2] + c[2]) / 3.0,
+    ]
+}
+
+// ---------- cylinder ----------
+
+#[test]
+fn cylinder_has_4n_triangles() {
+    // Lathed from a 4-point profile with two pole edges + one side
+    // edge: each segment yields 1 (bottom cap) + 2 (side) + 1 (top
+    // cap) = 4 triangles.
+    let ast = parse("(cylinder 1 2 8 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 4 * 8);
+}
+
+#[test]
+fn cylinder_outward_normals() {
+    // For a cylinder centered at origin, side-face normals point away
+    // from the Y axis; cap normals point along ±Y. The centroid-vs-
+    // normal test works because the centroid of every face has a
+    // strictly positive component in the outward direction.
+    let ast = parse("(cylinder 1 2 12 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        // Pick the dominant axis component of the centroid as the
+        // expected outward direction.
+        let radial_len = (c[0] * c[0] + c[2] * c[2]).sqrt();
+        let outward = if c[1].abs() > radial_len {
+            [0.0, c[1].signum(), 0.0]
+        } else {
+            [c[0], 0.0, c[2]]
+        };
+        let dot = n[0] * outward[0] + n[1] * outward[1] + n[2] * outward[2];
+        assert!(
+            dot > 0.0,
+            "cylinder face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+// ---------- cone ----------
+
+#[test]
+fn cone_has_2n_triangles() {
+    // 3-point profile, two pole edges (first edge from axis to base
+    // ring is the bottom cap; last edge from rim to apex is the
+    // sloped sides). 1 + 1 = 2 triangles per segment.
+    let ast = parse("(cone 1 2 6 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 2 * 6);
+}
+
+#[test]
+fn cone_outward_normals() {
+    // Use a known deeply-interior reference point and check
+    // (centroid - interior) · normal > 0 for every face. For a cone
+    // with base at y=-1 and apex at y=+1, (0, -0.9, 0) is inside.
+    let ast = parse("(cone 1 2 12 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    let interior = [0.0, -0.9, 0.0];
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        let v = [c[0] - interior[0], c[1] - interior[1], c[2] - interior[2]];
+        let dot = n[0] * v[0] + n[1] * v[1] + n[2] * v[2];
+        assert!(
+            dot > 0.0,
+            "cone face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+// ---------- wedge ----------
+
+#[test]
+fn wedge_has_eight_triangles() {
+    // Two quads (bottom, back, hypotenuse) → 6 tris; two triangles
+    // (left, right side) → 2 tris; total 8.
+    let ast = parse("(wedge 2 1 1 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 8);
+}
+
+#[test]
+fn wedge_outward_normals() {
+    // The wedge's geometric centroid lies on the hypotenuse face plane,
+    // so a centroid-as-interior test is degenerate. Use a known point
+    // strictly inside (low-Y, low-Z corner of the wedge volume).
+    let ast = parse("(wedge 2 2 2 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    let interior = [0.0, -0.5, -0.5];
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        let v = [c[0] - interior[0], c[1] - interior[1], c[2] - interior[2]];
+        let dot = n[0] * v[0] + n[1] * v[1] + n[2] * v[2];
+        assert!(
+            dot > 0.0,
+            "wedge face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+#[test]
+fn wedge_uses_six_unique_vertices() {
+    let ast = parse("(wedge 2 2 2 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    let mut seen = std::collections::BTreeSet::<[i32; 3]>::new();
+    for tri in &tris {
+        for v in tri.vertices {
+            seen.insert([v[0] as i32, v[1] as i32, v[2] as i32]);
+        }
+    }
+    assert_eq!(seen.len(), 6, "expected 6 unique corners, got {seen:?}");
+}
+
+// ---------- sphere ----------
+
+#[test]
+fn sphere_triangle_count_matches_lathe_pole_collapse() {
+    // n+1 profile points, n profile edges. Two pole edges (first +
+    // last) emit 1 tri/segment; the remaining n-2 edges emit
+    // 2 tris/segment. Total = (2*(n-2) + 2) * segments = (2n - 2) * n.
+    // For subdivisions = 8: (16 - 2) * 8 = 112.
+    let ast = parse("(sphere 1 8 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), (2 * 8 - 2) * 8);
+}
+
+#[test]
+fn sphere_vertices_lie_on_radius() {
+    let radius: f32 = 1.5;
+    let ast = parse("(sphere 1.5 12 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        for v in tri.vertices {
+            let r = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+            assert!(
+                (r - radius).abs() < 1e-4,
+                "sphere vertex off-radius: r={r}, expected {radius}"
+            );
+        }
+    }
+}
+
+#[test]
+fn sphere_outward_normals() {
+    let ast = parse("(sphere 1 12 :color 0)").unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        // Centroid is inside the sphere shell; outward = c (radial).
+        let dot = n[0] * c[0] + n[1] * c[1] + n[2] * c[2];
+        assert!(
+            dot > 0.0,
+            "sphere face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+// ---------- extrude ----------
+
+#[test]
+fn extrude_square_produces_walls_and_caps() {
+    // 4-edge square profile, depth 1: 4 side quads (8 tris) + 2 caps,
+    // each fan-triangulated into n-2 = 2 tris. Total 8 + 4 = 12.
+    let ast = parse(
+        "(extrude
+            ((-0.5 -0.5) (0.5 -0.5) (0.5 0.5) (-0.5 0.5))
+            1
+            :color 0)",
+    )
+    .unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 12);
+}
+
+#[test]
+fn extrude_cap_normals_face_along_z() {
+    // For a square extruded by depth 1, all triangles should be
+    // axis-aligned faces. Verify outward direction by centroid sign.
+    let ast = parse(
+        "(extrude
+            ((-0.5 -0.5) (0.5 -0.5) (0.5 0.5) (-0.5 0.5))
+            1
+            :color 0)",
+    )
+    .unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        // Front cap z=0 (centroid z=0) faces -Z; back cap z=1
+        // (centroid z=1) faces +Z; sides (centroid z=0.5) face
+        // outward in XY.
+        let outward = if c[2] < 0.01 {
+            [0.0, 0.0, -1.0]
+        } else if c[2] > 0.99 {
+            [0.0, 0.0, 1.0]
+        } else {
+            [c[0], c[1], 0.0]
+        };
+        let dot = n[0] * outward[0] + n[1] * outward[1] + n[2] * outward[2];
+        assert!(
+            dot > 0.0,
+            "extrude face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+#[test]
+fn extrude_with_under_three_profile_points_emits_nothing() {
+    let ast = parse("(extrude ((0 0) (1 0)) 1 :color 0)").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+// ---------- mirror ----------
+
+#[test]
+fn mirror_x_reflects_box_across_yz_plane() {
+    // Box centered at (5, 0, 0), mirrored across YZ plane → centered
+    // at (-5, 0, 0).
+    let ast = parse("(mirror x (translate (5 0 0) (box 1 1 1 :color 0)))").unwrap();
+    let tris = mesh(&ast).unwrap();
+    assert_eq!(tris.len(), 12);
+    for tri in &tris {
+        for v in tri.vertices {
+            assert!(
+                v[0] >= -5.51 && v[0] <= -4.49,
+                "mirror-x vertex x out of range: {v:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn mirror_preserves_outward_winding() {
+    // After reflection + winding swap, normals should still point
+    // outward of the reflected box (toward the new centroid at -5).
+    let ast = parse("(mirror x (translate (5 0 0) (box 2 2 2 :color 0)))").unwrap();
+    let tris = mesh(&ast).unwrap();
+    for tri in &tris {
+        let n = tri_normal(tri);
+        let c = tri_centroid(tri);
+        // Reflected box center is at (-5, 0, 0); outward = c - center.
+        let outward = [c[0] + 5.0, c[1], c[2]];
+        let dot = n[0] * outward[0] + n[1] * outward[1] + n[2] * outward[2];
+        assert!(
+            dot > 0.0,
+            "mirror face normal points inward for triangle {tri:?}"
+        );
+    }
+}
+
+// ---------- array ----------
+
+#[test]
+fn array_produces_count_copies() {
+    let ast = parse("(array 4 (2 0 0) (box 1 1 1 :color 0))").unwrap();
+    let tris = mesh(&ast).unwrap();
+    assert_eq!(tris.len(), 12 * 4);
+}
+
+#[test]
+fn array_copies_are_translated_correctly() {
+    // 3 copies of a unit box at spacing (2, 0, 0): copies sit at
+    // x=0, x=2, x=4.
+    let ast = parse("(array 3 (2 0 0) (box 1 1 1 :color 0))").unwrap();
+    let tris = mesh(&ast).unwrap();
+    let mut x_centers = std::collections::BTreeSet::<i32>::new();
+    for tri in &tris {
+        let c = tri_centroid(tri);
+        x_centers.insert(c[0].round() as i32);
+    }
+    assert!(x_centers.contains(&0));
+    assert!(x_centers.contains(&2));
+    assert!(x_centers.contains(&4));
+}
+
+#[test]
+fn array_zero_count_emits_nothing() {
+    let ast = parse("(array 0 (1 0 0) (box 1 1 1 :color 0))").unwrap();
+    assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+// ---------- round-trip across the full v1 vocabulary ----------
+
+#[test]
+fn round_trip_full_v1_vocab() {
+    let text = "(composition
+        (cylinder 1 2 12 :color 0)
+        (cone 0.5 1 8 :color 1)
+        (wedge 1 1 1 :color 2)
+        (sphere 0.7 8 :color 3)
+        (extrude ((-1 -1) (1 -1) (1 1) (-1 1)) 0.5 :color 4)
+        (mirror x (translate (2 0 0) (box 1 1 1 :color 5)))
+        (array 3 (1.5 0 0) (box 0.5 0.5 0.5 :color 6)))";
+    let ast1 = parse(text).unwrap();
+    let serialized = dsl_mesh_spike::serialize(&ast1);
+    let ast2 = parse(&serialized).unwrap();
+    assert_eq!(ast1, ast2);
+    // And the whole composition meshes without error.
+    let _ = mesh(&ast1).unwrap();
+}


### PR DESCRIPTION
## Summary

Implements the seven remaining v1 primitives that the spike previously returned NotYetImplemented for. ADR-0051 promoted these to v1 status; this fills in the meshers so the claim is true.

- **cylinder, cone, sphere**: delegate to mesh_lathe with synthesized profiles. The pole-collapse via the existing degenerate-triangle filter handles caps without a separate pass.
- **wedge**: right-triangular prism (ramp shape) with hypotenuse sloping from front-bottom to back-top edge. Five faces, six vertices.
- **extrude**: side-wall quads + two fan-triangulated cap polygons. Convex-only by contract (documented in the function comment); ear-clipping stays parked until a concave profile forces it.
- **mirror**: mesh child, flip the named axis, swap two vertices to restore CCW-from-outside winding (reflection inverts orientation).
- **array**: mesh child once, emit count copies translated by spacing*i.

The MeshError::NotYetImplemented variant is retained as a future escape hatch but is unreachable from any v1 input.

Sets up the next step in the in-flight cascade per ADR-0053: the spike now meshes everything v1 promises, so the promotion to crates/aether-dsl-mesh becomes a mechanical move.

## Test plan

- [x] cargo test in spikes/dsl-mesh-spike — 47 tests pass (19 new in tests/mesh_v1_remaining.rs)
- [x] cargo clippy --all-targets -- -D warnings — clean
- [x] cargo fmt -- --check — clean
- [x] Each new primitive has a triangle-count check + outward-normal check
- [x] Full-vocab round-trip test ensures parse/serialize symmetry across all v1 nodes

Co-Authored-By: Claude Opus 4.7 (1M context)