### PR TITLE
feat(mesh-editor): rewrite as DSL hot-loader (ADR-0052)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,8 +155,8 @@ name = "aether-mesh-editor-component"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-component",
+ "aether-dsl-mesh",
  "aether-kinds",
- "aether-math",
 ]
 
 [[package]]

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -18,18 +18,17 @@ use aether_hub_protocol::KindDescriptor;
 use aether_mail::{Kind, Schema};
 
 use crate::{
-    Camera, CaptureFrame, CaptureFrameResult, Delete, DeleteFaces, DeleteResult, Describe,
-    DrawTriangle, DropComponent, DropResult, ExtrudeFace, Fetch, FetchResult, FrameStats,
-    HandlePin, HandlePinResult, HandlePublish, HandlePublishResult, HandleRelease,
-    HandleReleaseResult, HandleUnpin, HandleUnpinResult, Key, KeyRelease, List, ListResult,
-    LoadComponent, LoadResult, LoadStaticMesh, MeshState, MouseButton, MouseMove, NoteOff, NoteOn,
-    OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed, OrbitSetTarget, OrbitSetYaw, Ping,
-    PlatformInfo, PlatformInfoResult, PlayerRequestStep, PlayerSetMode, PlayerSetPosition,
-    PlayerSetVelocity, PlayerStepResult, Pong, Read, ReadResult, ReplaceComponent, ReplaceResult,
-    RotateVertices, ScaleVertices, SetMasterGain, SetMasterGainResult, SetPrimitive, SetWindowMode,
-    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, SubscribeInput,
-    SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, TranslateVertices,
-    UnresolvedMail, UnsubscribeInput, WindowSize, Write, WriteResult,
+    Camera, CaptureFrame, CaptureFrameResult, Delete, DeleteResult, DrawTriangle, DropComponent,
+    DropResult, Fetch, FetchResult, FrameStats, HandlePin, HandlePinResult, HandlePublish,
+    HandlePublishResult, HandleRelease, HandleReleaseResult, HandleUnpin, HandleUnpinResult, Key,
+    KeyRelease, List, ListResult, LoadComponent, LoadResult, LoadStaticMesh, MouseButton,
+    MouseMove, NoteOff, NoteOn, OrbitSetDistance, OrbitSetFov, OrbitSetPitch, OrbitSetSpeed,
+    OrbitSetTarget, OrbitSetYaw, Ping, PlatformInfo, PlatformInfoResult, PlayerRequestStep,
+    PlayerSetMode, PlayerSetPosition, PlayerSetVelocity, PlayerStepResult, Pong, Read, ReadResult,
+    ReplaceComponent, ReplaceResult, SetMasterGain, SetMasterGainResult, SetPath, SetText,
+    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, SubscribeInput,
+    SubscribeInputResult, Tick, TopdownSetCenter, TopdownSetExtent, UnresolvedMail,
+    UnsubscribeInput, WindowSize, Write, WriteResult,
 };
 
 /// Every kind the substrate exposes, in the order the `Registry` will
@@ -156,22 +155,13 @@ pub fn all() -> Vec<KindDescriptor> {
         schema::<HandlePinResult>(),
         schema::<HandleUnpin>(),
         schema::<HandleUnpinResult>(),
-        // Mesh editor component vocabulary (Spike C). Postcard
-        // structs — `SetPrimitive` carries a tagged `Primitive` enum
-        // with per-variant params, the others carry a `Vec` of vertex
-        // ids and per-op params. All fire-and-forget; the editor
-        // re-emits its mesh as `DrawTriangle` mail every tick. The
-        // `Describe` request is answered by broadcasting `MeshState`
-        // to `hub.claude.broadcast` so MCP harness consumers can see
-        // the editor's current vertex/face inventory.
-        schema::<SetPrimitive>(),
-        schema::<TranslateVertices>(),
-        schema::<ScaleVertices>(),
-        schema::<RotateVertices>(),
-        schema::<ExtrudeFace>(),
-        schema::<DeleteFaces>(),
-        schema::<Describe>(),
-        schema::<MeshState>(),
+        // DSL mesh editor component vocabulary (ADR-0052). The editor
+        // hot-loads DSL source (per ADR-0026 + ADR-0051) and replays
+        // the meshed triangles as `DrawTriangle` mail every tick. Two
+        // input kinds: `SetText` for inline DSL, `SetPath` for
+        // namespace+path-loaded DSL via the `"io"` sink.
+        schema::<SetText>(),
+        schema::<SetPath>(),
         // Static mesh viewer (developer tool). Loads an OBJ via the
         // io sink and replays its triangle list as DrawTriangle each
         // tick. ADR-0026's no-import-for-production-content rule does

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1425,164 +1425,49 @@ mod control_plane {
     }
 }
 
-pub use mesh::*;
+pub use dsl_mesh::*;
 
-/// Mesh editor component vocabulary (Spike C). Postcard-shaped because
-/// every kind here either carries a `Vec` of vertex ids or a tagged
-/// enum that bytemuck can't represent. The mesh editor component
-/// (`crates/aether-mesh-editor-component/`) is the sole receiver; mail
-/// is fire-and-forget for v1 — state changes become visible the next
-/// tick when the editor re-emits `DrawTriangle` for every face.
-mod mesh {
-    use alloc::vec::Vec;
-
+/// DSL mesh editor component vocabulary (ADR-0052). The editor accepts
+/// a `.dsl` source (per ADR-0026 + ADR-0051), parses + meshes it, and
+/// replays the triangle list as `DrawTriangle` mail every tick. Hot
+/// reload is by-replacement: each `SetText` / successful `SetPath` reply
+/// drops the prior cache wholesale and installs the new triangles.
+///
+/// The editor that previously held a stateful vertex/face graph and
+/// accepted `aether.mesh.set_primitive` / `translate_vertices` /
+/// `scale_vertices` / `rotate_vertices` / `extrude_face` /
+/// `delete_faces` / `describe` was retired in ADR-0052. Edits happen
+/// by rewriting DSL text, not by mutating an off-screen state graph.
+mod dsl_mesh {
+    use alloc::string::String;
     use serde::{Deserialize, Serialize};
 
-    /// Procedural primitive variants. Each variant carries the
-    /// parameters specific to its family — params don't share a
-    /// common shape across primitives, so a tagged enum keeps each
-    /// well-typed without optional-field weirdness.
-    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    pub enum Primitive {
-        /// Axis-aligned cube centered at `center` with edge length
-        /// `size`. 8 vertices, 12 triangles.
-        Cube { center: [f32; 3], size: f32 },
-        /// Capped cylinder around the y axis with `segments` sides.
-        /// `2*segments + 2` vertices: bottom ring (0..N), top ring
-        /// (N..2N), bottom center (2N), top center (2N+1). `4*segments`
-        /// triangles: 2N for the side wall, N for each cap.
-        Cylinder {
-            center: [f32; 3],
-            radius: f32,
-            height: f32,
-            segments: u32,
-        },
-    }
-
-    /// `aether.mesh.set_primitive` — replace the editor's mesh with a
-    /// procedurally generated primitive. Vertex and face ids are
-    /// reassigned from zero so callers can address them deterministically
-    /// by index after a known primitive (see the mesh editor crate doc
-    /// for per-primitive layouts). Fire-and-forget; the next tick
-    /// renders the new mesh.
+    /// `aether.dsl_mesh.set_text` — replace the editor's cached mesh
+    /// with the result of parsing + meshing the supplied DSL text.
+    /// Inline; no I/O. Fire-and-forget; the next tick renders the new
+    /// mesh. Parse or mesh failures silently keep the prior cache;
+    /// errors surface via `engine_logs`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.set_primitive")]
-    pub struct SetPrimitive {
-        pub primitive: Primitive,
+    #[kind(name = "aether.dsl_mesh.set_text")]
+    pub struct SetText {
+        /// The DSL source text. See `crates/aether-dsl-mesh/examples/`
+        /// for shipped examples (box, lamp_post, teapot).
+        pub dsl: String,
     }
 
-    /// `aether.mesh.translate_vertices` — shift the listed vertex ids
-    /// by `delta` in world space. Unknown ids are ignored (warned, not
-    /// rejected) so a partial-overlap selection still applies cleanly
-    /// to the ids that exist. Fire-and-forget; next tick reflects the
-    /// move.
+    /// `aether.dsl_mesh.set_path` — instruct the editor to load DSL
+    /// text from the substrate's I/O surface (ADR-0041 namespace +
+    /// path), then parse + mesh + replace the cached triangles. The
+    /// editor fires an `aether.io.read` to the `"io"` sink and
+    /// processes the reply when it arrives. Fire-and-forget on the
+    /// caller's side; the load is asynchronous.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.translate_vertices")]
-    pub struct TranslateVertices {
-        pub vertex_ids: Vec<u32>,
-        pub delta: [f32; 3],
-    }
-
-    /// `aether.mesh.scale_vertices` — multiply each named vertex's
-    /// offset from `pivot` by `factor`, per axis. Non-uniform scale
-    /// (e.g., `[1.2, 1.0, 1.2]`) flares a horizontal ring without
-    /// changing its height. Unknown ids are ignored. Fire-and-forget.
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.scale_vertices")]
-    pub struct ScaleVertices {
-        pub vertex_ids: Vec<u32>,
-        pub pivot: [f32; 3],
-        pub factor: [f32; 3],
-    }
-
-    /// `aether.mesh.describe` — request a snapshot of the editor's
-    /// current mesh state. The editor responds by publishing
-    /// `MeshState` to the broadcast sink (`hub.claude.broadcast`),
-    /// from which MCP harness consumers read it via `receive_mail`.
-    /// Fire-and-forget; the snapshot flows on the broadcast path,
-    /// not as a typed reply (Ctx::reply is cast-only today, issue 240).
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.describe")]
-    pub struct Describe;
-
-    /// `aether.mesh.state` — snapshot of the editor's mesh, broadcast
-    /// in response to `Describe`. Tombstoned (deleted) vertex/face ids
-    /// are excluded; the agent sees only what's currently live. Ids
-    /// are monotonic and never reused — a missing id from a previous
-    /// snapshot means that vertex or face was deleted.
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.state")]
-    pub struct MeshState {
-        pub vertices: Vec<VertexInfo>,
-        pub faces: Vec<FaceInfo>,
-    }
-
-    /// One live vertex in a `MeshState` snapshot.
-    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    pub struct VertexInfo {
-        pub id: u32,
-        pub x: f32,
-        pub y: f32,
-        pub z: f32,
-    }
-
-    /// One live face in a `MeshState` snapshot. `vertex_ids` are
-    /// indices into the editor's vertex space (NOT positions in the
-    /// `MeshState.vertices` Vec, since the Vec excludes tombstones).
-    /// To resolve, look up each id in the vertex list by `id` field.
-    #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    pub struct FaceInfo {
-        pub id: u32,
-        pub vertex_ids: [u32; 3],
-        pub color: [f32; 3],
-    }
-
-    /// `aether.mesh.extrude_face` — region-extrude the listed faces
-    /// along their averaged normal by `distance`. Standard mesh-editor
-    /// semantics: the input faces become the bottom of the extrusion
-    /// (tombstoned), a new face is created at the offset position for
-    /// each input face (preserving original color), and side quads
-    /// stitch boundary edges (edges used by exactly one input face)
-    /// from old to new positions. Interior edges (shared between two
-    /// input faces) get no side quad.
-    ///
-    /// New ids are appended monotonically: vertices first (one new
-    /// vertex per unique input vertex, in ascending input-id order),
-    /// then top faces (one per input face, in input order), then side
-    /// quads (two triangles per boundary edge). Send `describe`
-    /// afterward to learn the new ids — this op produces enough new
-    /// geometry that mental tracking is fragile.
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.extrude_face")]
-    pub struct ExtrudeFace {
-        pub face_ids: Vec<u32>,
-        pub distance: f32,
-    }
-
-    /// `aether.mesh.delete_faces` — tombstone the listed face ids.
-    /// Tombstoned faces never reappear in `describe` output, never
-    /// render, and their ids are never reused (per the editor's
-    /// monotonic-id rule). Vertices referenced only by deleted faces
-    /// are NOT cascaded — they stay live until explicitly translated,
-    /// scaled, or removed by a future `delete_vertices` op.
-    /// Out-of-range and already-tombstoned ids are silently skipped.
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.delete_faces")]
-    pub struct DeleteFaces {
-        pub face_ids: Vec<u32>,
-    }
-
-    /// `aether.mesh.rotate_vertices` — rotate each named vertex
-    /// around the axis through `pivot` by `angle` radians. `axis`
-    /// is normalized internally; a zero-length axis is treated as
-    /// a no-op rotation. Out-of-range and tombstoned ids skipped.
-    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.mesh.rotate_vertices")]
-    pub struct RotateVertices {
-        pub vertex_ids: Vec<u32>,
-        pub pivot: [f32; 3],
-        pub axis: [f32; 3],
-        pub angle: f32,
+    #[kind(name = "aether.dsl_mesh.set_path")]
+    pub struct SetPath {
+        /// Short namespace prefix (no `://`), e.g. `"save"`, `"assets"`.
+        pub namespace: String,
+        /// Relative path within the namespace.
+        pub path: String,
     }
 }
 

--- a/crates/aether-mesh-editor-component/Cargo.toml
+++ b/crates/aether-mesh-editor-component/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 aether-component = { path = "../aether-component" }
+aether-dsl-mesh = { path = "../aether-dsl-mesh" }
 aether-kinds = { path = "../aether-kinds" }
-aether-math = { path = "../aether-math" }

--- a/crates/aether-mesh-editor-component/src/lib.rs
+++ b/crates/aether-mesh-editor-component/src/lib.rs
@@ -1,707 +1,178 @@
-//! Mesh editor component (Spike C). Holds a triangulated mesh in
-//! `&mut self`, applies DSL ops via mail handlers, and re-emits the
-//! mesh as `DrawTriangle` to the `"render"` sink every tick.
+//! DSL mesh editor component (ADR-0052). Accepts a `.dsl` source per
+//! ADR-0026 + ADR-0051, parses + meshes it via `aether-dsl-mesh`, and
+//! replays the cached triangle list to the `"render"` sink every tick.
+//! Hot reload is by-replacement: each `SetText` (or successful
+//! `SetPath`-driven I/O reply) drops the prior cache and installs the
+//! new triangles atomically — partial parse or mesh failures keep the
+//! previous mesh visible.
 //!
-//! Current ops: `set_primitive` (Cube + Cylinder), `translate_vertices`,
-//! `scale_vertices`, `rotate_vertices`, `extrude_face`, `delete_faces`,
-//! `describe`. New-vertex / new-face authoring and OBJ export are
-//! scoped for follow-up.
+//! Supersedes the Spike C vertex/face stateful editor. The
+//! `aether.mesh.set_primitive` / `translate_vertices` / `scale_vertices`
+//! / `rotate_vertices` / `extrude_face` / `delete_faces` / `describe`
+//! mail kinds were removed in the same PR; agents now edit DSL text
+//! and re-send it.
 //!
-//! # Identity rules — read first
+//! # Workflow
 //!
-//! Vertex and face ids are **monotonic and never reused**. A
-//! `set_primitive` resets the mesh wholesale and starts ids at zero;
-//! after that, every new vertex or face gets the next unused id (=
-//! `len()` of the underlying sparse vec). When delete arrives in a
-//! later PR, deleted slots become tombstones — the id is permanently
-//! gone, future allocations skip past it.
-//!
-//! Why: agents (and humans) iterating against this editor over
-//! multiple captures can't tolerate id renumbering. "Vertex 17 is
-//! gone" is a stable fact; "vertex 17 was renumbered to 12 because
-//! 5 was deleted" is a context disaster.
-//!
-//! # Inspecting the current mesh
-//!
-//! Mail `aether.mesh.describe` to the editor; it publishes
-//! `aether.mesh.state` to `hub.claude.broadcast`. The MCP harness
-//! reads it via `receive_mail`. Tombstoned ids are excluded from
-//! the snapshot — a missing id from a previous snapshot means it
-//! was deleted (or never existed).
-//!
-//! # Vertex ids for cube primitive (at primitive creation)
-//!
-//! `Primitive::Cube { center, size }` produces 8 vertices in a
-//! deterministic layout. Index by sign on each axis, `0` = negative
-//! half, `1` = positive half:
-//!
-//! - `0` = `(-, -, -)` `1` = `(+, -, -)` `2` = `(+, -, +)` `3` = `(-, -, +)`
-//! - `4` = `(-, +, -)` `5` = `(+, +, -)` `6` = `(+, +, +)` `7` = `(-, +, +)`
-//!
-//! Vertices `4..=7` are the `+y` (top) face — translate them with
-//! `delta: [0, dy, 0]` to push the top up. Layout is stable AT primitive
-//! creation; after any mutation, prefer `describe` over assumed indices.
-//!
-//! # Vertex ids for cylinder primitive (at primitive creation)
-//!
-//! `Primitive::Cylinder { center, radius, height, segments: N }`
-//! produces `2N + 2` vertices arranged as:
-//!
-//! - `0..N`     — bottom ring, CCW around the y axis. `i`-th vertex
-//!   is at angle `2π·i/N` (so vertex 0 sits on `+x`).
-//! - `N..2N`    — top ring, same angular positions as the bottom ring,
-//!   `height` units higher.
-//! - `2N`       — bottom center (cap fan apex).
-//! - `2N + 1`   — top center.
-//!
-//! Faces are `4N` triangles total: `2N` for the side wall (one quad
-//! per segment, triangulated), `N` for the top cap (fan from top
-//! center), `N` for the bottom cap. Same caveat as cube: layout
-//! stable AT creation, prefer `describe` after edits.
+//! 1. `load_component` this binary.
+//! 2. Send either:
+//!    - `aether.dsl_mesh.set_text { dsl }` with the source inline, or
+//!    - `aether.dsl_mesh.set_path { namespace, path }` to load from
+//!      the substrate's I/O surface (ADR-0041).
+//! 3. The editor parses, meshes, and caches the triangles. The next
+//!    tick (and every tick after) re-emits them to `"render"`.
+//! 4. To iterate, modify the DSL text and re-send `set_text` (or
+//!    re-write the file and re-send `set_path`).
 
-use std::collections::{BTreeMap, BTreeSet};
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers, io};
+use aether_dsl_mesh::Triangle;
+use aether_kinds::{DrawTriangle, ReadResult, SetPath, SetText, Tick, Vertex};
 
-use aether_component::{Component, Ctx, InitCtx, Sink, handlers};
-use aether_kinds::{
-    DeleteFaces, Describe, DrawTriangle, ExtrudeFace, FaceInfo, MeshState, Primitive,
-    RotateVertices, ScaleVertices, SetPrimitive, Tick, TranslateVertices, Vertex, VertexInfo,
-};
-use aether_math::{Quat, Vec3};
+/// Built-in palette mapping DSL `:color N` indices to RGB. The DSL's
+/// color is a `u32` palette reference; the substrate renderer needs
+/// floating-point RGB. Indices wrap modulo `PALETTE.len()` so any
+/// non-negative integer is a valid color.
+const PALETTE: &[(f32, f32, f32)] = &[
+    (0.55, 0.70, 0.92), // 0 — soft blue (default)
+    (0.85, 0.40, 0.30), // 1 — terracotta
+    (0.45, 0.75, 0.45), // 2 — sage green
+    (0.95, 0.85, 0.40), // 3 — mustard
+    (0.80, 0.55, 0.85), // 4 — lilac
+    (0.65, 0.50, 0.35), // 5 — wood brown
+    (0.95, 0.95, 0.95), // 6 — white
+    (0.30, 0.30, 0.35), // 7 — slate
+];
 
-/// One face of the editor's mesh. Stored as the three vertex indices
-/// into `MeshEditor::vertices` plus an RGB color used for every vertex
-/// of the emitted `DrawTriangle`. Triangulated only — quads/n-gons are
-/// pre-split when a primitive is generated.
-#[derive(Clone, Copy)]
-struct Face {
-    vertices: [u32; 3],
-    color: [f32; 3],
+pub struct DslMeshEditor {
+    triangles: Vec<DrawTriangle>,
+    render: Sink<DrawTriangle>,
 }
 
-/// Mesh editor component. Holds the current mesh in sparse vertex
-/// and face vectors (`Vec<Option<T>>` indexed by id; tombstones for
-/// deleted entries). Rebuilds a `DrawTriangle` cache on mutation and
-/// replays it every tick.
+/// DSL mesh editor component.
 ///
 /// # Agent
-/// Workflow: `set_primitive` to seed the mesh, then iterate with
-/// `translate_vertices`, `scale_vertices`. Send `describe` to get a
-/// `MeshState` snapshot back via the broadcast channel. Use
-/// `capture_frame` between ops to verify visually.
-///
-/// - `SetPrimitive { primitive: Cube { center, size } }` — replace
-///   the mesh with a cube
-/// - `SetPrimitive { primitive: Cylinder { center, radius, height,
-///   segments } }` — replace with a capped cylinder around the y axis
-/// - `TranslateVertices { vertex_ids, delta }` — shift listed vertices
-/// - `ScaleVertices { vertex_ids, pivot, factor }` — scale listed
-///   vertices around a pivot point, per axis
-/// - `RotateVertices { vertex_ids, pivot, axis, angle }` — rotate
-///   listed vertices around an axis through a pivot
-/// - `ExtrudeFace { face_ids, distance }` — region-extrude faces
-///   along their averaged normal; old faces tombstoned, new faces
-///   appended at the offset position with side quads on boundary edges
-/// - `DeleteFaces { face_ids }` — tombstone faces (vertices left
-///   live; lazy invalidation in render and describe)
-/// - `Describe { }` — request a mesh-state snapshot. Reply lands on
-///   the broadcast channel as `MeshState`; consume via `receive_mail`.
-pub struct MeshEditor {
-    render: Sink<DrawTriangle>,
-    broadcast: Sink<MeshState>,
-    vertices: Vec<Option<Vec3>>,
-    faces: Vec<Option<Face>>,
-    rendered: Vec<DrawTriangle>,
-}
-
+/// Send `aether.dsl_mesh.set_text { dsl: "(box 1 1 1 :color 0)" }` for
+/// inline DSL, or `aether.dsl_mesh.set_path { namespace: "assets",
+/// path: "teapot.dsl" }` to load from disk. Iterate by re-sending
+/// `set_text` with the modified source — the editor swaps the mesh
+/// atomically and the next frame reflects the change. Parse / mesh
+/// failures silently retain the previous cache; check `engine_logs`
+/// or capture a frame to confirm the new mesh rendered.
 #[handlers]
-impl Component for MeshEditor {
+impl Component for DslMeshEditor {
     fn init(ctx: &mut InitCtx<'_>) -> Self {
-        MeshEditor {
+        DslMeshEditor {
+            triangles: Vec::new(),
             render: ctx.resolve_sink::<DrawTriangle>("render"),
-            broadcast: ctx.resolve_sink::<MeshState>("hub.claude.broadcast"),
-            vertices: Vec::new(),
-            faces: Vec::new(),
-            rendered: Vec::new(),
         }
     }
 
-    /// Replay the current mesh as `DrawTriangle` mail every tick.
-    /// Empty mesh emits nothing.
+    /// Re-emits every cached triangle to the render sink.
     ///
     /// # Agent
-    /// Tick-driven; not useful to send manually.
+    /// Substrate-driven; do not send manually. If no triangles render
+    /// after a `set_text`, the source failed to parse or mesh — the
+    /// cache stayed empty (or kept its previous contents).
     #[handler]
     fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
-        if !self.rendered.is_empty() {
-            ctx.send_many(&self.render, &self.rendered);
+        if !self.triangles.is_empty() {
+            ctx.send_many(&self.render, &self.triangles);
         }
     }
 
-    /// Replace the mesh with a procedurally generated primitive.
-    /// Vertex and face ids reset to zero (fresh mesh, no inherited
-    /// tombstones from the previous one).
+    /// Parse + mesh the supplied DSL text inline; on success replace
+    /// the cached triangles wholesale. On parse or mesh failure the
+    /// previous cache stays intact (silent drop).
     ///
     /// # Agent
-    /// `Cube { center, size }` for axis-aligned boxes; `Cylinder
-    /// { center, radius, height, segments }` for cylinders around
-    /// the y axis. `segments` of 16–32 read as smooth at default
-    /// camera distance; lower for visible facets.
+    /// The full DSL grammar is documented in ADR-0026 and ADR-0051;
+    /// `crates/aether-dsl-mesh/examples/` has worked examples
+    /// (box.dsl, lamp_post.dsl, teapot.dsl).
     #[handler]
-    fn on_set_primitive(&mut self, _ctx: &mut Ctx<'_>, msg: SetPrimitive) {
-        match msg.primitive {
-            Primitive::Cube { center, size } => {
-                build_cube(
-                    &mut self.vertices,
-                    &mut self.faces,
-                    Vec3::new(center[0], center[1], center[2]),
-                    size,
-                );
-            }
-            Primitive::Cylinder {
-                center,
-                radius,
-                height,
-                segments,
-            } => {
-                build_cylinder(
-                    &mut self.vertices,
-                    &mut self.faces,
-                    Vec3::new(center[0], center[1], center[2]),
-                    radius,
-                    height,
-                    segments.max(3),
-                );
-            }
-        }
-        self.rebuild_render_cache();
+    fn on_set_text(&mut self, _ctx: &mut Ctx<'_>, msg: SetText) {
+        self.try_replace(&msg.dsl);
     }
 
-    /// Translate each named vertex by `delta`. Out-of-range ids and
-    /// tombstoned ids are silently skipped so a partial-overlap
-    /// selection still applies cleanly to the live ids.
+    /// Issue an `aether.io.read` to the substrate for `namespace://path`.
+    /// The reply lands on `on_read_result` and triggers the same
+    /// parse-mesh-replace path as `set_text`.
     ///
     /// # Agent
-    /// See the crate doc for per-primitive vertex layouts. After any
-    /// edit, prefer a fresh `describe` over assumed indices.
+    /// `namespace` is the short prefix (no `://`) — `"save"`,
+    /// `"assets"`, `"config"`. `path` is relative to the namespace
+    /// root; `..` and absolute prefixes are rejected by the substrate.
     #[handler]
-    fn on_translate_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: TranslateVertices) {
-        let delta = Vec3::new(msg.delta[0], msg.delta[1], msg.delta[2]);
-        let mut touched = false;
-        for id in &msg.vertex_ids {
-            if let Some(slot) = self.vertices.get_mut(*id as usize)
-                && let Some(v) = slot.as_mut()
-            {
-                *v += delta;
-                touched = true;
-            }
-        }
-        if touched {
-            self.rebuild_render_cache();
-        }
+    fn on_set_path(&mut self, _ctx: &mut Ctx<'_>, msg: SetPath) {
+        io::read(&msg.namespace, &msg.path);
     }
 
-    /// Scale each named vertex's offset from `pivot` by `factor`,
-    /// per axis. Non-uniform factors flare or flatten without
-    /// changing the unaffected axes. Out-of-range and tombstoned
-    /// ids skipped.
+    /// Consume the substrate's I/O reply for a prior `set_path`. On
+    /// success, decode the bytes as UTF-8 DSL text and run the same
+    /// parse-mesh-replace path. On any failure (I/O error, non-utf8,
+    /// parse error, mesh error) the previous cache is retained.
     ///
     /// # Agent
-    /// To flare the top of a cylinder centered at the origin with
-    /// height 1.0, scale the top ring by `factor: [1.2, 1, 1.2]`
-    /// with `pivot: [0, 1, 0]`.
+    /// Substrate-driven; do not send manually. If a `set_path` doesn't
+    /// take effect, the I/O error surfaces in `engine_logs`.
     #[handler]
-    fn on_scale_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: ScaleVertices) {
-        let pivot = Vec3::new(msg.pivot[0], msg.pivot[1], msg.pivot[2]);
-        let factor = Vec3::new(msg.factor[0], msg.factor[1], msg.factor[2]);
-        let mut touched = false;
-        for id in &msg.vertex_ids {
-            if let Some(slot) = self.vertices.get_mut(*id as usize)
-                && let Some(v) = slot.as_mut()
-            {
-                let offset = *v - pivot;
-                let scaled = Vec3::new(
-                    offset.x * factor.x,
-                    offset.y * factor.y,
-                    offset.z * factor.z,
-                );
-                *v = pivot + scaled;
-                touched = true;
-            }
-        }
-        if touched {
-            self.rebuild_render_cache();
+    fn on_read_result(&mut self, _ctx: &mut Ctx<'_>, r: ReadResult) {
+        if let ReadResult::Ok { bytes, .. } = r
+            && let Ok(text) = core::str::from_utf8(&bytes)
+        {
+            self.try_replace(text);
         }
     }
+}
 
-    /// Rotate each named vertex around the axis through `pivot` by
-    /// `angle` radians. `axis` is normalized internally; a zero-length
-    /// axis is a no-op. Out-of-range and tombstoned ids skipped.
-    ///
-    /// # Agent
-    /// To bend an extruded ring, rotate its vertices around an axis
-    /// perpendicular to both the ring's tangent and the bend
-    /// direction. Common case: bending around world `z` to curve
-    /// geometry along the y axis — `axis: [0, 0, 1]`, pivot at the
-    /// hinge point.
-    #[handler]
-    fn on_rotate_vertices(&mut self, _ctx: &mut Ctx<'_>, msg: RotateVertices) {
-        let axis = Vec3::new(msg.axis[0], msg.axis[1], msg.axis[2]).normalize();
-        if axis.length_squared() == 0.0 {
+impl DslMeshEditor {
+    /// Parse DSL text and (on success) replace the cached triangle
+    /// list. Atomic: failures leave the prior cache untouched, so a
+    /// bad reload doesn't blank the render.
+    fn try_replace(&mut self, dsl: &str) {
+        let Ok(ast) = aether_dsl_mesh::parse(dsl) else {
             return;
-        }
-        let pivot = Vec3::new(msg.pivot[0], msg.pivot[1], msg.pivot[2]);
-        let q = Quat::from_axis_angle(axis, msg.angle);
-        let mut touched = false;
-        for id in &msg.vertex_ids {
-            if let Some(slot) = self.vertices.get_mut(*id as usize)
-                && let Some(v) = slot.as_mut()
-            {
-                *v = pivot + q.rotate_vec3(*v - pivot);
-                touched = true;
-            }
-        }
-        if touched {
-            self.rebuild_render_cache();
-        }
-    }
-
-    /// Region-extrude the listed faces along their averaged normal
-    /// by `distance`. The input faces become the bottom of the
-    /// extrusion (tombstoned), each input face gets a corresponding
-    /// new face at the offset position with the original color, and
-    /// boundary edges (edges in exactly one input face) get side
-    /// quads stitching old to new. Interior edges (shared between
-    /// two input faces) get no side quad.
-    ///
-    /// # Agent
-    /// Send `describe` afterward to learn the new vertex/face ids.
-    /// New ids are appended monotonically: vertices first (one per
-    /// unique input vertex, in ascending input id order), then top
-    /// faces (one per input face, in input order), then side-quad
-    /// pairs in input-face / edge-walk order.
-    #[handler]
-    fn on_extrude_face(&mut self, _ctx: &mut Ctx<'_>, msg: ExtrudeFace) {
-        self.extrude_faces(&msg.face_ids, msg.distance);
-    }
-
-    /// Tombstone the listed face ids. Vertices stay live (lazy
-    /// invalidation; the agent can clean up unused vertices later).
-    /// Out-of-range and already-tombstoned ids skipped.
-    ///
-    /// # Agent
-    /// Use to hollow a region — e.g., delete the top cap of a
-    /// cylinder before extruding the rim inward.
-    #[handler]
-    fn on_delete_faces(&mut self, _ctx: &mut Ctx<'_>, msg: DeleteFaces) {
-        let mut touched = false;
-        for id in &msg.face_ids {
-            if let Some(slot) = self.faces.get_mut(*id as usize)
-                && slot.is_some()
-            {
-                *slot = None;
-                touched = true;
-            }
-        }
-        if touched {
-            self.rebuild_render_cache();
-        }
-    }
-
-    /// Publish the current mesh as `MeshState` to the broadcast sink.
-    /// Tombstoned (deleted) ids are excluded; the snapshot only
-    /// includes live vertices and faces. The MCP harness reads the
-    /// reply via `receive_mail`.
-    ///
-    /// # Agent
-    /// Empty payload: `Describe { }`. Watch for an `aether.mesh.state`
-    /// item in the next `receive_mail` drain.
-    #[handler]
-    fn on_describe(&mut self, ctx: &mut Ctx<'_>, _msg: Describe) {
-        let mut vertices = Vec::with_capacity(self.vertices.len());
-        for (id, slot) in self.vertices.iter().enumerate() {
-            if let Some(v) = slot {
-                vertices.push(VertexInfo {
-                    id: id as u32,
-                    x: v.x,
-                    y: v.y,
-                    z: v.z,
-                });
-            }
-        }
-        let mut faces = Vec::with_capacity(self.faces.len());
-        for (id, slot) in self.faces.iter().enumerate() {
-            if let Some(f) = slot {
-                faces.push(FaceInfo {
-                    id: id as u32,
-                    vertex_ids: f.vertices,
-                    color: f.color,
-                });
-            }
-        }
-        ctx.send_postcard(&self.broadcast, &MeshState { vertices, faces });
-    }
-}
-
-impl MeshEditor {
-    /// Region-extrude implementation. See the `ExtrudeFace` kind doc
-    /// for semantics; see `on_extrude_face` for the handler that
-    /// dispatches into this.
-    fn extrude_faces(&mut self, face_ids: &[u32], distance: f32) {
-        // 1. Filter to live, in-range face ids; snapshot their data.
-        struct InputFace {
-            verts: [u32; 3],
-            color: [f32; 3],
-        }
-        let mut inputs: Vec<InputFace> = Vec::new();
-        for &fid in face_ids {
-            if let Some(Some(face)) = self.faces.get(fid as usize) {
-                inputs.push(InputFace {
-                    verts: face.vertices,
-                    color: face.color,
-                });
-            }
-        }
-        if inputs.is_empty() {
+        };
+        let Ok(triangles) = aether_dsl_mesh::mesh(&ast) else {
             return;
+        };
+        let mut out = Vec::with_capacity(triangles.len());
+        for tri in &triangles {
+            out.push(to_draw_triangle(tri));
         }
-
-        // 2. Compute averaged normal across input faces. Skip faces
-        //    whose normal is degenerate (zero-area triangle).
-        let mut normal_sum = Vec3::ZERO;
-        for f in &inputs {
-            let (Some(Some(va)), Some(Some(vb)), Some(Some(vc))) = (
-                self.vertices.get(f.verts[0] as usize),
-                self.vertices.get(f.verts[1] as usize),
-                self.vertices.get(f.verts[2] as usize),
-            ) else {
-                continue;
-            };
-            let n = (*vb - *va).cross(*vc - *va).normalize();
-            normal_sum += n;
-        }
-        let avg = normal_sum.normalize();
-        if avg.length_squared() == 0.0 {
-            return;
-        }
-        let offset = avg * distance;
-
-        // 3. Collect unique input vertex ids; duplicate each at
-        //    `original + offset`, recording the old->new id map.
-        let mut input_vertex_ids: BTreeSet<u32> = BTreeSet::new();
-        for f in &inputs {
-            for &v in &f.verts {
-                input_vertex_ids.insert(v);
-            }
-        }
-        let mut old_to_new: BTreeMap<u32, u32> = BTreeMap::new();
-        for &vid in &input_vertex_ids {
-            let Some(Some(orig)) = self.vertices.get(vid as usize) else {
-                continue;
-            };
-            let new_pos = *orig + offset;
-            let new_id = self.vertices.len() as u32;
-            self.vertices.push(Some(new_pos));
-            old_to_new.insert(vid, new_id);
-        }
-
-        // 4. Count canonical edge appearances across input faces.
-        //    Boundary == count == 1.
-        let mut edge_count: BTreeMap<(u32, u32), u32> = BTreeMap::new();
-        for f in &inputs {
-            for &(a, b) in &[
-                (f.verts[0], f.verts[1]),
-                (f.verts[1], f.verts[2]),
-                (f.verts[2], f.verts[0]),
-            ] {
-                let key = if a < b { (a, b) } else { (b, a) };
-                *edge_count.entry(key).or_insert(0) += 1;
-            }
-        }
-
-        // 5. Tombstone the input faces in-place (preserves their ids
-        //    as permanently-gone) and emit one new top face per input
-        //    using the new (offset) vertex ids.
-        for &fid in face_ids {
-            if let Some(slot) = self.faces.get_mut(fid as usize)
-                && slot.is_some()
-            {
-                *slot = None;
-            }
-        }
-        for f in &inputs {
-            let Some(&a) = old_to_new.get(&f.verts[0]) else {
-                continue;
-            };
-            let Some(&b) = old_to_new.get(&f.verts[1]) else {
-                continue;
-            };
-            let Some(&c) = old_to_new.get(&f.verts[2]) else {
-                continue;
-            };
-            self.faces.push(Some(Face {
-                vertices: [a, b, c],
-                color: f.color,
-            }));
-        }
-
-        // 6. Side quads on boundary edges. Walk each input face's
-        //    edges in directed order; for each edge in the boundary
-        //    set, emit two triangles bridging the original edge to
-        //    its new copy, CCW from outside (consistent with the
-        //    host face's winding).
-        for f in &inputs {
-            for &(a, b) in &[
-                (f.verts[0], f.verts[1]),
-                (f.verts[1], f.verts[2]),
-                (f.verts[2], f.verts[0]),
-            ] {
-                let key = if a < b { (a, b) } else { (b, a) };
-                if edge_count.get(&key).copied() != Some(1) {
-                    continue;
-                }
-                let (Some(&a_new), Some(&b_new)) = (old_to_new.get(&a), old_to_new.get(&b)) else {
-                    continue;
-                };
-                self.faces.push(Some(Face {
-                    vertices: [a, b, b_new],
-                    color: f.color,
-                }));
-                self.faces.push(Some(Face {
-                    vertices: [a, b_new, a_new],
-                    color: f.color,
-                }));
-            }
-        }
-
-        self.rebuild_render_cache();
-    }
-
-    fn rebuild_render_cache(&mut self) {
-        self.rendered.clear();
-        self.rendered.reserve(self.faces.len());
-        for face_slot in &self.faces {
-            let Some(face) = face_slot else { continue };
-            let [a, b, c] = face.vertices;
-            let (Some(Some(va)), Some(Some(vb)), Some(Some(vc))) = (
-                self.vertices.get(a as usize),
-                self.vertices.get(b as usize),
-                self.vertices.get(c as usize),
-            ) else {
-                continue;
-            };
-            let [r, g, b_] = face.color;
-            self.rendered.push(DrawTriangle {
-                verts: [
-                    Vertex {
-                        x: va.x,
-                        y: va.y,
-                        z: va.z,
-                        r,
-                        g,
-                        b: b_,
-                    },
-                    Vertex {
-                        x: vb.x,
-                        y: vb.y,
-                        z: vb.z,
-                        r,
-                        g,
-                        b: b_,
-                    },
-                    Vertex {
-                        x: vc.x,
-                        y: vc.y,
-                        z: vc.z,
-                        r,
-                        g,
-                        b: b_,
-                    },
-                ],
-            });
-        }
+        self.triangles = out;
     }
 }
 
-/// Generate a unit-axis-aligned cube centered at `center` with edge
-/// length `size`. Replaces `vertices` and `faces` wholesale (clears
-/// the sparse vecs before populating; ids start at 0). Vertex layout
-/// matches the crate doc.
-fn build_cube(
-    vertices: &mut Vec<Option<Vec3>>,
-    faces: &mut Vec<Option<Face>>,
-    center: Vec3,
-    size: f32,
-) {
-    let h = size * 0.5;
-    vertices.clear();
-    vertices.extend([
-        Some(Vec3::new(center.x - h, center.y - h, center.z - h)), // 0
-        Some(Vec3::new(center.x + h, center.y - h, center.z - h)), // 1
-        Some(Vec3::new(center.x + h, center.y - h, center.z + h)), // 2
-        Some(Vec3::new(center.x - h, center.y - h, center.z + h)), // 3
-        Some(Vec3::new(center.x - h, center.y + h, center.z - h)), // 4
-        Some(Vec3::new(center.x + h, center.y + h, center.z - h)), // 5
-        Some(Vec3::new(center.x + h, center.y + h, center.z + h)), // 6
-        Some(Vec3::new(center.x - h, center.y + h, center.z + h)), // 7
-    ]);
-
-    // Distinct hue per face so the agent can read orientation directly
-    // from a `capture_frame` without needing wireframe overlays.
-    const BOTTOM: [f32; 3] = [0.40, 0.40, 0.40]; // grey
-    const TOP: [f32; 3] = [0.95, 0.95, 0.95]; // white
-    const FRONT: [f32; 3] = [0.85, 0.20, 0.20]; // red    (+z)
-    const BACK: [f32; 3] = [0.20, 0.30, 0.85]; // blue   (-z)
-    const LEFT: [f32; 3] = [0.20, 0.75, 0.30]; // green  (-x)
-    const RIGHT: [f32; 3] = [0.95, 0.85, 0.20]; // yellow (+x)
-
-    // Faces wound CCW from outside, so each triangle's
-    // (b - a) × (c - a) cross product points outward. extrude_face
-    // depends on this convention to push faces away from the body
-    // when distance is positive. Render-side culling is off today
-    // (PR-A merged with culling-off intact), but the math here is
-    // what extrude / future culling work will rely on.
-    faces.clear();
-    faces.extend([
-        Some(Face {
-            vertices: [0, 1, 2],
-            color: BOTTOM,
-        }),
-        Some(Face {
-            vertices: [0, 2, 3],
-            color: BOTTOM,
-        }),
-        Some(Face {
-            vertices: [4, 6, 5],
-            color: TOP,
-        }),
-        Some(Face {
-            vertices: [4, 7, 6],
-            color: TOP,
-        }),
-        Some(Face {
-            vertices: [3, 2, 6],
-            color: FRONT,
-        }),
-        Some(Face {
-            vertices: [3, 6, 7],
-            color: FRONT,
-        }),
-        Some(Face {
-            vertices: [0, 4, 5],
-            color: BACK,
-        }),
-        Some(Face {
-            vertices: [0, 5, 1],
-            color: BACK,
-        }),
-        Some(Face {
-            vertices: [0, 3, 7],
-            color: LEFT,
-        }),
-        Some(Face {
-            vertices: [0, 7, 4],
-            color: LEFT,
-        }),
-        Some(Face {
-            vertices: [1, 5, 6],
-            color: RIGHT,
-        }),
-        Some(Face {
-            vertices: [1, 6, 2],
-            color: RIGHT,
-        }),
-    ]);
-}
-
-/// Generate a capped cylinder around the y axis with `n` segments.
-/// See the crate doc for the vertex layout. `n` should be at least 3
-/// (caller clamps).
-///
-/// Side wall is two triangles per segment; the top cap is a fan of
-/// `n` triangles from the top center vertex (id `2n+1`); the bottom
-/// cap is the same fan from `2n`. Per-segment side hue alternates
-/// between two shades so adjacent segments are visually
-/// distinguishable in `capture_frame`.
-fn build_cylinder(
-    vertices: &mut Vec<Option<Vec3>>,
-    faces: &mut Vec<Option<Face>>,
-    center: Vec3,
-    radius: f32,
-    height: f32,
-    n: u32,
-) {
-    use core::f32::consts::TAU;
-
-    vertices.clear();
-    let bottom_y = center.y;
-    let top_y = center.y + height;
-
-    // Bottom ring (0..n) and top ring (n..2n).
-    for i in 0..n {
-        let theta = TAU * (i as f32) / (n as f32);
-        let x = center.x + radius * theta.cos();
-        let z = center.z + radius * theta.sin();
-        vertices.push(Some(Vec3::new(x, bottom_y, z)));
-    }
-    for i in 0..n {
-        let theta = TAU * (i as f32) / (n as f32);
-        let x = center.x + radius * theta.cos();
-        let z = center.z + radius * theta.sin();
-        vertices.push(Some(Vec3::new(x, top_y, z)));
-    }
-    // Bottom center (2n), top center (2n+1).
-    vertices.push(Some(Vec3::new(center.x, bottom_y, center.z)));
-    vertices.push(Some(Vec3::new(center.x, top_y, center.z)));
-
-    const SIDE_A: [f32; 3] = [0.30, 0.55, 0.85]; // mid blue
-    const SIDE_B: [f32; 3] = [0.40, 0.65, 0.92]; // light blue
-    const TOP_CAP: [f32; 3] = [0.95, 0.95, 0.95]; // white
-    const BOTTOM_CAP: [f32; 3] = [0.40, 0.40, 0.40]; // grey
-
-    faces.clear();
-    let bottom_center = 2 * n;
-    let top_center = 2 * n + 1;
-
-    // All faces wound CCW from outside (radially outward for the
-    // side wall, +y for the top cap, -y for the bottom cap), so
-    // each triangle's (b - a) × (c - a) cross product points outward.
-    // Same convention as build_cube — extrude_face depends on it.
-
-    // Side wall.
-    for i in 0..n {
-        let next = (i + 1) % n;
-        let bot_a = i;
-        let bot_b = next;
-        let top_a = n + i;
-        let top_b = n + next;
-        let color = if i % 2 == 0 { SIDE_A } else { SIDE_B };
-        faces.push(Some(Face {
-            vertices: [bot_a, top_a, top_b],
-            color,
-        }));
-        faces.push(Some(Face {
-            vertices: [bot_a, top_b, bot_b],
-            color,
-        }));
-    }
-
-    // Top cap (fan from top_center, outward = +y).
-    for i in 0..n {
-        let next = (i + 1) % n;
-        faces.push(Some(Face {
-            vertices: [top_center, n + next, n + i],
-            color: TOP_CAP,
-        }));
-    }
-
-    // Bottom cap (fan from bottom_center, outward = -y).
-    for i in 0..n {
-        let next = (i + 1) % n;
-        faces.push(Some(Face {
-            vertices: [bottom_center, i, next],
-            color: BOTTOM_CAP,
-        }));
+fn to_draw_triangle(tri: &Triangle) -> DrawTriangle {
+    let (r, g, b) = PALETTE[(tri.color as usize) % PALETTE.len()];
+    DrawTriangle {
+        verts: [
+            Vertex {
+                x: tri.vertices[0][0],
+                y: tri.vertices[0][1],
+                z: tri.vertices[0][2],
+                r,
+                g,
+                b,
+            },
+            Vertex {
+                x: tri.vertices[1][0],
+                y: tri.vertices[1][1],
+                z: tri.vertices[1][2],
+                r,
+                g,
+                b,
+            },
+            Vertex {
+                x: tri.vertices[2][0],
+                y: tri.vertices[2][1],
+                z: tri.vertices[2][2],
+                r,
+                g,
+                b,
+            },
+        ],
     }
 }
 
-aether_component::export!(MeshEditor);
+aether_component::export!(DslMeshEditor);


### PR DESCRIPTION
## Summary

Replaces the Spike C vertex/face stateful editor with a DSL hot-loader per ADR-0052. The crate name stays; the abstraction inside changes.

**Component (crates/aether-mesh-editor-component):**
- Two input handlers: aether.dsl_mesh.set_text { dsl } for inline DSL, aether.dsl_mesh.set_path { namespace, path } for substrate I/O loads. Plus an aether.io.read_result handler that wires set_path's reply into the same parse-mesh-replace path.
- Hot reload by-replacement: parse + mesh atomically, swap the triangle cache only on success. Failures keep the prior cache so a bad reload doesn't blank the render.
- aether-dsl-mesh dep added; aether-math dep dropped.
- Built-in 8-color palette maps DSL :color N indices to RGB.

**Kinds (crates/aether-kinds):**
- Drops the entire mesh module and its descriptor entries: Primitive, SetPrimitive, TranslateVertices, ScaleVertices, RotateVertices, ExtrudeFace, DeleteFaces, Describe, MeshState, VertexInfo, FaceInfo. ADR-0052 retired this whole surface.
- Adds dsl_mesh module with SetText (postcard, carries a String) and SetPath (postcard, namespace + path). Both fire-and-forget; the editor reflects the change on the next tick.

## Test plan

- [x] cargo build --workspace — clean
- [x] cargo build -p aether-mesh-editor-component --target wasm32-unknown-unknown --release — clean (verifies aether-dsl-mesh + lexpr work in wasm32)
- [x] cargo test --workspace — clean
- [x] cargo clippy --all-targets -- -D warnings — clean
- [x] cargo fmt -- --check — clean
- [x] End-to-end MCP harness: spawn_substrate + load_component + send aether.dsl_mesh.set_text with the teapot DSL → recognizable teapot rendered via capture_frame. Inline (box 1 1 1 :color 1) also rendered correctly with the new palette.

Co-Authored-By: Claude Opus 4.7 (1M context)