### PR TITLE
chore(adr): accept dsl-mesh cluster (0026, 0051, 0052, 0053)

### DIFF
--- a/crates/aether-dsl-mesh/src/mesh.rs
+++ b/crates/aether-dsl-mesh/src/mesh.rs
@@ -433,9 +433,10 @@ fn mesh_sweep(
     if profile.len() < 3 || path.len() < 2 {
         return;
     }
-    // If `scales` was supplied with the wrong length, treat as
-    // unspecified rather than panic — the spike's job is to be lenient
-    // while the syntax matures. Real ADR enforcement comes at promotion.
+    // ADR-0051 requires `:scales` length to equal `path` length; the
+    // parser enforces it (`SweepScalesLengthMismatch`). The defensive
+    // length check here is a backstop in case a caller constructs the
+    // `Node::Sweep` AST directly.
     let scales = match scales {
         Some(s) if s.len() == path.len() => Some(s),
         _ => None,

--- a/crates/aether-dsl-mesh/src/parse.rs
+++ b/crates/aether-dsl-mesh/src/parse.rs
@@ -50,6 +50,8 @@ pub enum ParseError {
     InvalidAxis(String),
     #[error("profile point must be (x y), got list of length {0}")]
     InvalidProfilePoint(usize),
+    #[error("sweep: :scales length ({scales_len}) must equal path length ({path_len})")]
+    SweepScalesLengthMismatch { scales_len: usize, path_len: usize },
 }
 
 pub fn parse(text: &str) -> Result<Node, ParseError> {
@@ -314,9 +316,18 @@ fn parse_sweep(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
         .find(|(k, _)| k == "scales")
         .map(|(_, v)| as_scalar_list(v))
         .transpose()?;
+    let path = as_path(positional[1])?;
+    if let Some(s) = scales.as_ref()
+        && s.len() != path.len()
+    {
+        return Err(ParseError::SweepScalesLengthMismatch {
+            scales_len: s.len(),
+            path_len: path.len(),
+        });
+    }
     Ok(Node::Sweep {
         profile: as_profile(positional[0])?,
-        path: as_path(positional[1])?,
+        path,
         scales,
         color: require_color("sweep", keywords)?,
     })

--- a/crates/aether-dsl-mesh/tests/mesh_v2.rs
+++ b/crates/aether-dsl-mesh/tests/mesh_v2.rs
@@ -1,6 +1,6 @@
 //! Tests for the v2 vocabulary additions: torus + sweep-along-path.
 
-use aether_dsl_mesh::{mesh, parse};
+use aether_dsl_mesh::{ParseError, mesh, parse};
 
 #[test]
 fn torus_triangle_count_is_two_per_quad() {
@@ -130,6 +130,26 @@ fn sweep_with_short_path_emits_nothing() {
 fn sweep_with_under_three_profile_points_emits_nothing() {
     let ast = parse("(sweep ((-0.1 0) (0.1 0)) ((0 0 0) (1 0 0)) :color 0)").unwrap();
     assert_eq!(mesh(&ast).unwrap().len(), 0);
+}
+
+#[test]
+fn sweep_scales_length_must_equal_path_length() {
+    // ADR-0051 normative: scales-length-mismatched sweeps are a parse-time error.
+    let text = "(sweep ((-0.1 -0.1) (0.1 -0.1) (0.1 0.1) (-0.1 0.1))
+                       ((0 0 0) (1 0 0) (2 0 0))
+                       :scales (1.0 0.5)
+                       :color 0)";
+    let err = parse(text).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ParseError::SweepScalesLengthMismatch {
+                scales_len: 2,
+                path_len: 3
+            }
+        ),
+        "expected SweepScalesLengthMismatch, got {err:?}"
+    );
 }
 
 #[test]

--- a/docs/adr/0026-primitive-composition-dsl.md
+++ b/docs/adr/0026-primitive-composition-dsl.md
@@ -1,6 +1,6 @@
 # ADR-0026: Primitive-composition DSL as native mesh representation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-19
 
 ## Context

--- a/docs/adr/0051-dsl-mesh-vocabulary-v1-pinning.md
+++ b/docs/adr/0051-dsl-mesh-vocabulary-v1-pinning.md
@@ -1,6 +1,6 @@
 # ADR-0051: DSL mesh vocabulary v1 — pin syntax, promote torus + sweep
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-26
 - **Amends:** ADR-0026
 

--- a/docs/adr/0052-mesh-editor-is-the-dsl.md
+++ b/docs/adr/0052-mesh-editor-is-the-dsl.md
@@ -1,6 +1,6 @@
 # ADR-0052: The mesh editor is the DSL — text + hot reload, not vertex/face state
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-26
 - **Supersedes mesh-editor abstraction in:** Spike C (`aether-mesh-editor-component` v0.1) — the cube/cylinder/extrude/translate-vertices stateful editor introduced in PR 235 / 250 / 252 / 253. The crate name stays; the abstraction inside it changes.
 

--- a/docs/adr/0053-promote-dsl-mesh-spike-to-crate.md
+++ b/docs/adr/0053-promote-dsl-mesh-spike-to-crate.md
@@ -1,6 +1,6 @@
 # ADR-0053: Promote `dsl-mesh-spike` to `aether-dsl-mesh` library crate
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-26
 - **Implements:** ADR-0026, ADR-0051, ADR-0052
 


### PR DESCRIPTION
## Summary

- Flips ADR-0026 / 0051 / 0052 / 0053 from Proposed to Accepted. The cluster is implementation-complete in main.
- Closes the one remaining normative gap on ADR-0051: the parser now enforces sweep `:scales` length == path length (`ParseError::SweepScalesLengthMismatch`), with a negative test. The mesher's defensive length check is retained as a backstop for callers constructing the AST directly.

## Test plan

- [x] `cargo test -p aether-dsl-mesh --tests` (all 9 v2 tests pass including the new negative test)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings`