### PR TITLE
chore(substrate): bump vertex buffer cap to 4 MB

### DIFF
--- a/crates/aether-substrate-desktop/src/render.rs
+++ b/crates/aether-substrate-desktop/src/render.rs
@@ -38,7 +38,7 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 const VERTEX_STRIDE: u64 = 24; // 3 * f32 position + 3 * f32 color
-const VERTEX_BUFFER_BYTES: u64 = 64 * 1024;
+const VERTEX_BUFFER_BYTES: u64 = 4 * 1024 * 1024;
 const CAMERA_UNIFORM_BYTES: u64 = 64; // 4x4 f32 column-major
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 


### PR DESCRIPTION
## Summary

- Lifts the desktop chassis vertex buffer from 64 KB (~910 triangles) to 4 MB (~58k triangles).
- The 64 KB cap was a soft ceiling chosen for the single-quad-and-cursor era; the DSL-authored teapot already brushed it, and CSG output per ADR-0054 will eat budget faster from cut-edge fan triangulation.
- Drop-frame warn-log path is untouched — out-of-budget composers still get a loud failure rather than silent truncation.

First PR in the ADR-0054 implementation cascade. Standalone — does not depend on the rest of the cascade and unblocks current DSL iteration regardless of when CSG lands.

## Test plan

- [x] cargo build -p aether-substrate-desktop --release
- [ ] CI green