### PR TITLE
feat(dsl-mesh): csg ast + parser + mesher dispatch stub (ADR-0054)

### DIFF
--- a/crates/aether-dsl-mesh/src/ast.rs
+++ b/crates/aether-dsl-mesh/src/ast.rs
@@ -98,6 +98,27 @@ pub enum Node {
         spacing: [f32; 3],
         child: std::boxed::Box<Node>,
     },
+
+    // Boolean (CSG) operators per ADR-0054. The mesher routes these
+    // through `crate::csg`; the v1 algorithm is BSP-CSG with internal
+    // fixed-point predicates.
+    /// N-ary union: result is the union of all children's solid regions.
+    /// Requires at least two children (one-child union is a parse error).
+    Union {
+        children: Vec<Node>,
+    },
+    /// N-ary intersection: result is the intersection of all children's
+    /// solid regions. Requires at least two children. Empty-result is a
+    /// valid empty mesh, not an error.
+    Intersection {
+        children: Vec<Node>,
+    },
+    /// First child minus the union of the remaining children. Requires
+    /// `base` plus at least one subtractor.
+    Difference {
+        base: std::boxed::Box<Node>,
+        subtract: Vec<Node>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/aether-dsl-mesh/src/csg.rs
+++ b/crates/aether-dsl-mesh/src/csg.rs
@@ -1,0 +1,25 @@
+//! BSP-CSG mesher for the `union` / `intersection` / `difference`
+//! operators added by ADR-0054.
+//!
+//! Per ADR-0054, the algorithm is single-threaded BSP-CSG (Thibault &
+//! Naylor 1980) with **internal fixed-point coordinates** and **exact
+//! integer-determinant predicates** — the wire `Vertex` format stays
+//! `f32`, but classification ("which side of plane Q is point P on?"),
+//! edge intersection, and topology decisions all run as `i32 × i32 →
+//! i64` arithmetic against snapped 16:16 fixed-point coordinates.
+//!
+//! Coordinates entering the CSG core must satisfy `|coord| ≤ 256`; the
+//! `fixed::f32_to_fixed` conversion returns `Err` outside that range so
+//! out-of-range geometry is a loud failure rather than a silent
+//! precision degradation.
+//!
+//! This module is currently a scaffolding placeholder. The
+//! implementation lands in PR 4 of the ADR-0054 cascade:
+//!
+//! - PR 3: `fixed` submodule with `f32_to_fixed` / `fixed_to_f32`.
+//! - PR 4: `plane`, `polygon`, `bsp`, and the three operations.
+//!
+//! Until then, mailing a `Node::Union` / `Intersection` / `Difference`
+//! through the mesher silently produces an empty triangle list (the AST
+//! parses, round-trips, and composes structurally — there's just no
+//! geometry yet).

--- a/crates/aether-dsl-mesh/src/lib.rs
+++ b/crates/aether-dsl-mesh/src/lib.rs
@@ -7,6 +7,7 @@
 //! Wavefront OBJ for inspection in any external viewer.
 
 pub mod ast;
+pub mod csg;
 pub mod mesh;
 pub mod obj;
 pub mod parse;

--- a/crates/aether-dsl-mesh/src/mesh.rs
+++ b/crates/aether-dsl-mesh/src/mesh.rs
@@ -184,6 +184,18 @@ fn mesh_into(out: &mut Vec<Triangle>, node: &Node, offset: [f32; 3]) -> Result<(
             }
             Ok(())
         }
+        Node::Union { children: _ }
+        | Node::Intersection { children: _ }
+        | Node::Difference {
+            base: _,
+            subtract: _,
+        } => {
+            // TODO(ADR-0054, PR 4): route through `crate::csg` once the
+            // BSP-CSG core lands. Until then these meshes silently emit
+            // an empty triangle list — the AST parses, round-trips, and
+            // composes structurally, but produces no geometry.
+            Ok(())
+        }
         Node::Array {
             count,
             spacing,

--- a/crates/aether-dsl-mesh/src/parse.rs
+++ b/crates/aether-dsl-mesh/src/parse.rs
@@ -52,6 +52,12 @@ pub enum ParseError {
     InvalidProfilePoint(usize),
     #[error("sweep: :scales length ({scales_len}) must equal path length ({path_len})")]
     SweepScalesLengthMismatch { scales_len: usize, path_len: usize },
+    #[error("{node}: requires at least {min} children, got {got}")]
+    CsgArityTooFew {
+        node: &'static str,
+        min: usize,
+        got: usize,
+    },
 }
 
 pub fn parse(text: &str) -> Result<Node, ParseError> {
@@ -89,6 +95,9 @@ fn parse_node(value: &Value) -> Result<Node, ParseError> {
         "scale" => parse_scale(&positional, &keywords),
         "mirror" => parse_mirror(&positional, &keywords),
         "array" => parse_array(&positional, &keywords),
+        "union" => parse_union(&positional, &keywords),
+        "intersection" => parse_intersection(&positional, &keywords),
+        "difference" => parse_difference(&positional, &keywords),
         other => Err(ParseError::UnknownNode(other.to_string())),
     }
 }
@@ -411,5 +420,63 @@ fn parse_array(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
         count: as_u32(positional[0])?,
         spacing: as_vec3("array", positional[1])?,
         child: std::boxed::Box::new(parse_node(positional[2])?),
+    })
+}
+
+fn parse_union(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<Node, ParseError> {
+    check_no_extra_keywords("union", keywords, &[])?;
+    if positional.len() < 2 {
+        return Err(ParseError::CsgArityTooFew {
+            node: "union",
+            min: 2,
+            got: positional.len(),
+        });
+    }
+    let children = positional
+        .iter()
+        .map(|v| parse_node(v))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Node::Union { children })
+}
+
+fn parse_intersection(
+    positional: &[&Value],
+    keywords: &[(String, &Value)],
+) -> Result<Node, ParseError> {
+    check_no_extra_keywords("intersection", keywords, &[])?;
+    if positional.len() < 2 {
+        return Err(ParseError::CsgArityTooFew {
+            node: "intersection",
+            min: 2,
+            got: positional.len(),
+        });
+    }
+    let children = positional
+        .iter()
+        .map(|v| parse_node(v))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Node::Intersection { children })
+}
+
+fn parse_difference(
+    positional: &[&Value],
+    keywords: &[(String, &Value)],
+) -> Result<Node, ParseError> {
+    check_no_extra_keywords("difference", keywords, &[])?;
+    if positional.len() < 2 {
+        return Err(ParseError::CsgArityTooFew {
+            node: "difference",
+            min: 2,
+            got: positional.len(),
+        });
+    }
+    let base = parse_node(positional[0])?;
+    let subtract = positional[1..]
+        .iter()
+        .map(|v| parse_node(v))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Node::Difference {
+        base: std::boxed::Box::new(base),
+        subtract,
     })
 }

--- a/crates/aether-dsl-mesh/src/serialize.rs
+++ b/crates/aether-dsl-mesh/src/serialize.rs
@@ -155,6 +155,21 @@ pub fn node_to_value(node: &Node) -> Value {
             vec3_to_value(*spacing),
             node_to_value(child),
         ]),
+        Node::Union { children } => {
+            let mut items = vec![sym("union")];
+            items.extend(children.iter().map(node_to_value));
+            list(items)
+        }
+        Node::Intersection { children } => {
+            let mut items = vec![sym("intersection")];
+            items.extend(children.iter().map(node_to_value));
+            list(items)
+        }
+        Node::Difference { base, subtract } => {
+            let mut items = vec![sym("difference"), node_to_value(base)];
+            items.extend(subtract.iter().map(node_to_value));
+            list(items)
+        }
     }
 }
 

--- a/crates/aether-dsl-mesh/tests/csg_scaffolding.rs
+++ b/crates/aether-dsl-mesh/tests/csg_scaffolding.rs
@@ -1,0 +1,198 @@
+//! Parser, serializer, and mesher-stub tests for the CSG operators
+//! added by ADR-0054. The mesher itself is a stub — these tests cover
+//! AST shape, arity rules, round-tripping, and that mesher dispatch
+//! does not error on the new variants (it just emits no triangles).
+
+use aether_dsl_mesh::parse::ParseError;
+use aether_dsl_mesh::{Node, mesh, parse, serialize};
+use pretty_assertions::assert_eq;
+
+fn assert_round_trip(text: &str) {
+    let ast = parse(text).expect("parse should succeed");
+    let reserialized = serialize(&ast);
+    let ast2 = parse(&reserialized).expect("re-parse should succeed");
+    assert_eq!(
+        ast, ast2,
+        "round-trip not equal — reserialized text:\n{reserialized}"
+    );
+}
+
+#[test]
+fn parse_union_two_children() {
+    let ast = parse("(union (box 1 1 1 :color 0) (box 1 1 1 :color 1))")
+        .expect("union with two children should parse");
+    let Node::Union { children } = ast else {
+        panic!("expected Node::Union");
+    };
+    assert_eq!(children.len(), 2);
+}
+
+#[test]
+fn parse_intersection_three_children() {
+    let ast = parse(
+        "(intersection (sphere 0.5 2 :color 0) (box 1 1 1 :color 1) (cylinder 0.4 1 8 :color 2))",
+    )
+    .expect("intersection with three children should parse");
+    let Node::Intersection { children } = ast else {
+        panic!("expected Node::Intersection");
+    };
+    assert_eq!(children.len(), 3);
+}
+
+#[test]
+fn parse_difference_base_plus_one() {
+    let ast = parse("(difference (cylinder 0.5 1 12 :color 0) (box 0.2 0.2 1.5 :color 1))")
+        .expect("difference with base + one subtractor should parse");
+    let Node::Difference { subtract, .. } = ast else {
+        panic!("expected Node::Difference");
+    };
+    assert_eq!(subtract.len(), 1);
+}
+
+#[test]
+fn parse_difference_base_plus_many() {
+    let ast = parse(
+        "(difference
+            (cylinder 0.5 1 12 :color 0)
+            (box 0.2 0.2 1.5 :color 1)
+            (box 1.5 0.2 0.2 :color 1)
+            (box 0.2 1.5 0.2 :color 1))",
+    )
+    .expect("difference with multiple subtractors should parse");
+    let Node::Difference { subtract, .. } = ast else {
+        panic!("expected Node::Difference");
+    };
+    assert_eq!(subtract.len(), 3);
+}
+
+#[test]
+fn union_requires_at_least_two_children() {
+    let err = parse("(union (box 1 1 1 :color 0))").unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ParseError::CsgArityTooFew {
+                node: "union",
+                min: 2,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn intersection_requires_at_least_two_children() {
+    let err = parse("(intersection (box 1 1 1 :color 0))").unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ParseError::CsgArityTooFew {
+                node: "intersection",
+                min: 2,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn difference_requires_base_plus_at_least_one_subtractor() {
+    let err = parse("(difference (cylinder 0.5 1 12 :color 0))").unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ParseError::CsgArityTooFew {
+                node: "difference",
+                min: 2,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn empty_csg_node_fails() {
+    assert!(parse("(union)").is_err());
+    assert!(parse("(intersection)").is_err());
+    assert!(parse("(difference)").is_err());
+}
+
+#[test]
+fn csg_rejects_unknown_keyword() {
+    let err = parse("(union (box 1 1 1 :color 0) (box 1 1 1 :color 1) :foo bar)").unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnknownKeyword { node: "union", .. }
+    ));
+}
+
+#[test]
+fn round_trip_union() {
+    assert_round_trip("(union (box 1 1 1 :color 0) (box 1 1 1 :color 1) (box 1 1 1 :color 2))");
+}
+
+#[test]
+fn round_trip_intersection() {
+    assert_round_trip("(intersection (sphere 0.5 2 :color 0) (box 0.8 0.8 0.8 :color 1))");
+}
+
+#[test]
+fn round_trip_difference() {
+    assert_round_trip(
+        "(difference (cylinder 0.5 1 12 :color 0) (box 0.2 0.2 1.5 :color 1) (box 1.5 0.2 0.2 :color 1))",
+    );
+}
+
+#[test]
+fn round_trip_csg_inside_transforms() {
+    assert_round_trip(
+        "(translate (0 1 0)
+           (rotate (0 1 0) 0.785
+             (difference
+               (cylinder 0.5 1 12 :color 0)
+               (box 0.2 0.2 1.5 :color 1))))",
+    );
+}
+
+#[test]
+fn round_trip_csg_inside_csg() {
+    assert_round_trip(
+        "(difference
+           (union (box 1 1 1 :color 0) (sphere 0.7 2 :color 0))
+           (intersection (box 0.5 0.5 1.5 :color 1) (cylinder 0.4 1.5 8 :color 1)))",
+    );
+}
+
+#[test]
+fn mesher_stub_emits_empty_for_csg_nodes() {
+    // Until PR 4 lands, the CSG arms in mesh.rs return an empty Vec.
+    // This test pins that contract so PR 4 obviously breaks it (and the
+    // test then becomes a real geometric check).
+    let ast = parse("(union (box 1 1 1 :color 0) (box 1 1 1 :color 1))").unwrap();
+    let tris = mesh(&ast).expect("CSG mesher stub should not error");
+    assert!(
+        tris.is_empty(),
+        "CSG mesher stub must emit no triangles until PR 4; got {} tris",
+        tris.len()
+    );
+}
+
+#[test]
+fn mesher_traverses_into_csg_children_for_other_nodes() {
+    // A composition wrapping a CSG node still meshes its non-CSG
+    // siblings — verifying the dispatch doesn't shortcut the whole tree.
+    let ast = parse(
+        "(composition
+           (box 1 1 1 :color 0)
+           (union (sphere 0.5 2 :color 0) (sphere 0.5 2 :color 1)))",
+    )
+    .unwrap();
+    let tris = mesh(&ast).expect("composition with CSG inside should not error");
+    assert!(
+        !tris.is_empty(),
+        "the box sibling should still emit triangles even though the union stub does not"
+    );
+}


### PR DESCRIPTION
## Summary

- Lands the scaffolding for ADR-0054's three CSG operators: `union`, `intersection`, `difference`. AST variants, parser arms with arity checks, serializer round-trip, mesher stub that emits an empty triangle list with a TODO pointing at the BSP core PR.
- Adds an empty `csg` module skeleton documenting the planned shape (internal fixed-point coordinates, exact integer-determinant predicates, ±256 unit input range) — the BSP core lands in PR 4 of the cascade after the fixed-point conversion utilities (PR 3).
- New `ParseError::CsgArityTooFew` variant: `union`/`intersection` require ≥2 children; `difference` requires base + ≥1 subtractor.

Until PR 4 lands, parsing/serializing/composing CSG nodes works end-to-end; mailing one through the mesher silently produces no geometry. A test pins that contract so PR 4 obviously breaks it (and the test then becomes a real geometric check).

Second PR in the ADR-0054 implementation cascade. Builds on PR 269 (vertex buffer cap bump).

## Test plan

- [x] cargo test -p aether-dsl-mesh — 16 new tests, all green
- [x] cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings
- [x] cargo fmt --check
- [ ] CI green