### PR TITLE
feat(dsl-mesh): csg cleanup pipeline scaffolding + vertex welding (ADR-0055)

### DIFF
--- a/crates/aether-dsl-mesh/src/csg.rs
+++ b/crates/aether-dsl-mesh/src/csg.rs
@@ -29,6 +29,7 @@
 //! mesher can stay agnostic of integer arithmetic.
 
 pub mod bsp;
+pub mod cleanup;
 pub mod fixed;
 pub mod ops;
 pub mod plane;

--- a/crates/aether-dsl-mesh/src/csg/cleanup.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup.rs
@@ -1,0 +1,34 @@
+//! Post-CSG mesh cleanup pipeline (ADR-0055).
+//!
+//! Runs on the polygon stream produced by `ops::{union, intersection,
+//! difference}` before triangulation back to the wire `Vec<Triangle>`
+//! format. The pipeline operates in the same fixed-point integer domain
+//! as the BSP CSG core; passes are pure and exact.
+//!
+//! Three passes (composed in order):
+//!
+//! 1. **Vertex welding** — converts owned-vertex polygons into an
+//!    indexed-mesh representation, deduplicating vertices by exact
+//!    integer equality. Foundation for the other two passes; on its
+//!    own it is semantically a no-op for the wire output.
+//! 2. **Coplanar polygon merging** — *not yet implemented.*
+//! 3. **T-junction removal** — *not yet implemented.*
+//!
+//! [`run`] is the single entry point — `csg::ops` calls it on every
+//! boolean operation's result so callers see cleaned polygons
+//! unconditionally.
+
+mod mesh;
+mod weld;
+
+use crate::csg::polygon::Polygon;
+
+/// Run the cleanup pipeline on a polygon list.
+///
+/// Currently only Pass 1 (vertex welding) is wired up; subsequent PRs
+/// extend this entry point with coplanar merging and T-junction repair.
+/// The wire-format output is unchanged in this PR — welding is an
+/// internal-representation pass.
+pub fn run(polygons: Vec<Polygon>) -> Vec<Polygon> {
+    mesh::IndexedMesh::weld(polygons).into_polygons()
+}

--- a/crates/aether-dsl-mesh/src/csg/cleanup/mesh.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/mesh.rs
@@ -1,0 +1,47 @@
+//! Indexed-mesh intermediate representation used by the cleanup pipeline.
+//!
+//! Polygons own indices into a shared vertex pool rather than vertex
+//! coordinates. Two adjacent polygons that share a corner share the
+//! same `VertexId` — coplanar merging (Pass 2) detects shared edges by
+//! `VertexId` equality, T-junction repair (Pass 3) detects collinear
+//! interior vertices by walking the pool. Both rely on canonical vertex
+//! identity that the welding pass establishes.
+//!
+//! Module-private; callers see only the `Vec<Polygon>` round-trip
+//! through `cleanup::run`.
+
+use crate::csg::plane::Plane3;
+use crate::csg::point::Point3;
+use crate::csg::polygon::Polygon;
+
+pub(super) type VertexId = usize;
+
+pub(super) struct IndexedMesh {
+    pub(super) vertices: Vec<Point3>,
+    pub(super) polygons: Vec<IndexedPolygon>,
+}
+
+pub(super) struct IndexedPolygon {
+    pub(super) vertices: Vec<VertexId>,
+    pub(super) plane: Plane3,
+    pub(super) color: u32,
+}
+
+impl IndexedMesh {
+    /// Convert back to the owned-vertex polygon form for the wire output.
+    /// Polygon order, vertex order within each polygon, plane, and color
+    /// are preserved exactly.
+    pub(super) fn into_polygons(self) -> Vec<Polygon> {
+        let IndexedMesh { vertices, polygons } = self;
+        let mut out = Vec::with_capacity(polygons.len());
+        for poly in polygons {
+            let verts = poly.vertices.iter().map(|&i| vertices[i]).collect();
+            out.push(Polygon {
+                vertices: verts,
+                plane: poly.plane,
+                color: poly.color,
+            });
+        }
+        out
+    }
+}

--- a/crates/aether-dsl-mesh/src/csg/cleanup/weld.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/weld.rs
@@ -1,0 +1,188 @@
+//! Pass 1: vertex welding — owned-vertex polygons → indexed mesh.
+//!
+//! Hashes vertices by exact `Point3` integer equality and replaces
+//! polygon vertex lists with indices into a shared pool. Polygons that
+//! collapse to fewer than three distinct vertices after welding are
+//! dropped — they were degenerate slivers from a CSG split that
+//! produced near-coincident edges (the snap-to-grid round-trip in
+//! `compute_intersection` occasionally produces these).
+//!
+//! Determinism: the vertex pool is built in input traversal order, so
+//! identical input polygon lists produce identical pools and identical
+//! indexed-polygon lists across runs / platforms / threads.
+
+use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
+use crate::csg::point::Point3;
+use crate::csg::polygon::Polygon;
+use std::collections::HashMap;
+
+impl IndexedMesh {
+    pub(super) fn weld(polygons: Vec<Polygon>) -> Self {
+        let mut vertex_pool: Vec<Point3> = Vec::new();
+        let mut vertex_index: HashMap<Point3, VertexId> = HashMap::new();
+        let mut indexed = Vec::with_capacity(polygons.len());
+
+        for poly in polygons {
+            let mut ids: Vec<VertexId> = Vec::with_capacity(poly.vertices.len());
+            for v in &poly.vertices {
+                let id = *vertex_index.entry(*v).or_insert_with(|| {
+                    let next = vertex_pool.len();
+                    vertex_pool.push(*v);
+                    next
+                });
+                if ids.last() != Some(&id) {
+                    ids.push(id);
+                }
+            }
+            // Wrap-around duplicate: last vertex equal to first (an explicit
+            // closed-polygon form, or a sliver where the loop folds back).
+            if ids.len() >= 2 && ids.first() == ids.last() {
+                ids.pop();
+            }
+            if ids.len() < 3 {
+                continue;
+            }
+            indexed.push(IndexedPolygon {
+                vertices: ids,
+                plane: poly.plane,
+                color: poly.color,
+            });
+        }
+
+        IndexedMesh {
+            vertices: vertex_pool,
+            polygons: indexed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csg::fixed::f32_to_fixed;
+    use crate::csg::plane::Plane3;
+
+    fn pt(x: f32, y: f32, z: f32) -> Point3 {
+        Point3 {
+            x: f32_to_fixed(x).unwrap(),
+            y: f32_to_fixed(y).unwrap(),
+            z: f32_to_fixed(z).unwrap(),
+        }
+    }
+
+    #[test]
+    fn empty_input_produces_empty_mesh() {
+        let mesh = IndexedMesh::weld(vec![]);
+        assert!(mesh.vertices.is_empty());
+        assert!(mesh.polygons.is_empty());
+    }
+
+    #[test]
+    fn single_triangle_keeps_three_distinct_vertices() {
+        let tri =
+            Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(0.0, 1.0, 0.0), 5)
+                .unwrap();
+        let mesh = IndexedMesh::weld(vec![tri]);
+        assert_eq!(mesh.vertices.len(), 3);
+        assert_eq!(mesh.polygons.len(), 1);
+        assert_eq!(mesh.polygons[0].vertices.len(), 3);
+        assert_eq!(mesh.polygons[0].color, 5);
+    }
+
+    #[test]
+    fn two_triangles_sharing_an_edge_share_two_vertices() {
+        // Quad split into two triangles along the (0,0)-(1,1) diagonal.
+        let t1 = Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(1.0, 1.0, 0.0), 0)
+            .unwrap();
+        let t2 = Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 1.0, 0.0), pt(0.0, 1.0, 0.0), 0)
+            .unwrap();
+        let mesh = IndexedMesh::weld(vec![t1, t2]);
+        // 4 distinct corners, not 6.
+        assert_eq!(mesh.vertices.len(), 4);
+        assert_eq!(mesh.polygons.len(), 2);
+    }
+
+    #[test]
+    fn polygon_collapsing_to_fewer_than_three_distinct_vertices_is_dropped() {
+        // Degenerate: same point twice + one other → a collapsing sliver.
+        // We can't go through `Polygon::from_triangle` (it rejects degenerate
+        // planes), so build the polygon directly with a bogus plane — weld
+        // doesn't inspect the plane, only the vertex list.
+        let bogus_plane = Plane3 {
+            n_x: 0,
+            n_y: 0,
+            n_z: 1,
+            d: 0,
+        };
+        let degenerate = Polygon {
+            vertices: vec![pt(0.0, 0.0, 0.0), pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0)],
+            plane: bogus_plane,
+            color: 0,
+        };
+        let mesh = IndexedMesh::weld(vec![degenerate]);
+        assert!(mesh.polygons.is_empty());
+    }
+
+    #[test]
+    fn explicit_closed_loop_is_unwound() {
+        // Polygon expressed with a wraparound duplicate (last == first).
+        let bogus_plane = Plane3 {
+            n_x: 0,
+            n_y: 0,
+            n_z: 1,
+            d: 0,
+        };
+        let closed = Polygon {
+            vertices: vec![
+                pt(0.0, 0.0, 0.0),
+                pt(1.0, 0.0, 0.0),
+                pt(0.0, 1.0, 0.0),
+                pt(0.0, 0.0, 0.0),
+            ],
+            plane: bogus_plane,
+            color: 0,
+        };
+        let mesh = IndexedMesh::weld(vec![closed]);
+        assert_eq!(mesh.polygons.len(), 1);
+        assert_eq!(mesh.polygons[0].vertices.len(), 3);
+    }
+
+    #[test]
+    fn round_trip_preserves_vertex_coords_planes_and_colors() {
+        let tri_a =
+            Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(0.0, 1.0, 0.0), 7)
+                .unwrap();
+        let tri_b =
+            Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(0.0, 1.0, 0.0), pt(0.0, 0.0, 1.0), 9)
+                .unwrap();
+        let original = vec![tri_a.clone(), tri_b.clone()];
+        let round_tripped = IndexedMesh::weld(original.clone()).into_polygons();
+
+        assert_eq!(round_tripped.len(), original.len());
+        for (a, b) in original.iter().zip(round_tripped.iter()) {
+            assert_eq!(a.vertices, b.vertices);
+            assert_eq!(a.color, b.color);
+            assert_eq!(a.plane.n_x, b.plane.n_x);
+            assert_eq!(a.plane.n_y, b.plane.n_y);
+            assert_eq!(a.plane.n_z, b.plane.n_z);
+            assert_eq!(a.plane.d, b.plane.d);
+        }
+    }
+
+    #[test]
+    fn welding_is_deterministic_across_runs() {
+        let tri_a =
+            Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(1.0, 1.0, 0.0), 0)
+                .unwrap();
+        let tri_b =
+            Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(1.0, 1.0, 0.0), pt(0.0, 1.0, 0.0), 0)
+                .unwrap();
+        let m1 = IndexedMesh::weld(vec![tri_a.clone(), tri_b.clone()]);
+        let m2 = IndexedMesh::weld(vec![tri_a, tri_b]);
+        assert_eq!(m1.vertices, m2.vertices);
+        assert_eq!(m1.polygons.len(), m2.polygons.len());
+        for (p, q) in m1.polygons.iter().zip(m2.polygons.iter()) {
+            assert_eq!(p.vertices, q.vertices);
+        }
+    }
+}

--- a/crates/aether-dsl-mesh/src/csg/ops.rs
+++ b/crates/aether-dsl-mesh/src/csg/ops.rs
@@ -14,6 +14,7 @@
 
 use super::CsgError;
 use super::bsp::BspTree;
+use super::cleanup;
 use super::polygon::Polygon;
 
 pub fn union(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, CsgError> {
@@ -28,7 +29,7 @@ pub fn union(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, CsgError>
     nb.invert();
     let extra = nb.all_polygons();
     na.build(extra)?;
-    Ok(na.all_polygons())
+    Ok(cleanup::run(na.all_polygons()))
 }
 
 pub fn intersection(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, CsgError> {
@@ -44,7 +45,7 @@ pub fn intersection(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, Cs
     let extra = nb.all_polygons();
     na.build(extra)?;
     na.invert();
-    Ok(na.all_polygons())
+    Ok(cleanup::run(na.all_polygons()))
 }
 
 pub fn difference(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, CsgError> {
@@ -61,7 +62,7 @@ pub fn difference(a: Vec<Polygon>, b: Vec<Polygon>) -> Result<Vec<Polygon>, CsgE
     let extra = nb.all_polygons();
     na.build(extra)?;
     na.invert();
-    Ok(na.all_polygons())
+    Ok(cleanup::run(na.all_polygons()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Pass 1 of the ADR-0055 cleanup pipeline (3-PR series). Adds `csg::cleanup` as a module with a single `run(Vec<Polygon>) -> Vec<Polygon>` entry point that `csg::ops::{union, intersection, difference}` calls on every boolean op result.
- Implements vertex welding: hashes vertices by exact `Point3` integer equality, deduplicates them into a shared pool, drops polygons that collapse to fewer than 3 distinct vertices, and unwinds explicit closed-polygon forms (last == first).
- The `IndexedMesh` / `IndexedPolygon` intermediate is module-private; callers still see `Vec<Polygon>` in / out. Welding is semantically a no-op for the wire output — the visible quality wins land in the next two PRs (coplanar merging, T-junction removal) under the same entry point.

## Test plan
- [x] CI green
- [x] All existing CSG ops tests still pass (welding round-trip preserves vertex coords / planes / colors)
- [x] New welding unit tests cover: empty input, single triangle, shared-edge dedup (4 vertices not 6), degenerate polygon drop, closed-loop unwind, round-trip preservation, determinism

🤖 Generated with [Claude Code](https://claude.com/claude-code)