### PR TITLE
test(dsl-mesh): manifold validator + regression suite for CSG output (ADR-0057)

### DIFF
--- a/crates/aether-dsl-mesh/src/csg/cleanup/merge.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/merge.rs
@@ -39,6 +39,10 @@ use std::collections::HashMap;
 
 type PlaneKey = (i64, i64, i64, i128);
 
+fn plane_key(p: &Plane3) -> PlaneKey {
+    (p.n_x, p.n_y, p.n_z, p.d)
+}
+
 impl IndexedMesh {
     pub(super) fn merge_coplanar(self) -> Self {
         let IndexedMesh { vertices, polygons } = self;
@@ -61,10 +65,6 @@ impl IndexedMesh {
             polygons: merged,
         }
     }
-}
-
-fn plane_key(p: &Plane3) -> PlaneKey {
-    (p.n_x, p.n_y, p.n_z, p.d)
 }
 
 fn group_by_plane(polygons: &[IndexedPolygon]) -> HashMap<PlaneKey, Vec<usize>> {
@@ -356,18 +356,13 @@ mod tests {
         ];
         // Plane keys differ across the fan because each triangle has its
         // own cross-product magnitude. The middle two share a plane key
-        // (both have the same edge magnitudes from bl) and a shared edge
-        // bl→mid, so they merge into one 4-vertex loop. The first and
-        // last stay as singletons. 4 in → 3 out.
+        // and a shared edge bl→mid, so they merge into one 4-vertex
+        // loop. The first and last stay as singletons. 4 in → 3 out.
         let out = weld_then_merge(polys);
         assert_eq!(out.len(), 3);
         let lens: std::collections::BTreeSet<usize> =
             out.iter().map(|p| p.vertices.len()).collect();
-        assert_eq!(
-            lens,
-            [3, 4].into_iter().collect(),
-            "expected two 3-vert singletons and one 4-vert merged loop"
-        );
+        assert_eq!(lens, [3, 4].into_iter().collect());
     }
 
     #[test]

--- a/crates/aether-dsl-mesh/src/csg/plane.rs
+++ b/crates/aether-dsl-mesh/src/csg/plane.rs
@@ -14,6 +14,21 @@
 
 use super::point::Point3;
 
+fn gcd_u128(a: u128, b: u128) -> u128 {
+    let mut a = a;
+    let mut b = b;
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+fn gcd_4(a: u128, b: u128, c: u128, d: u128) -> u128 {
+    gcd_u128(gcd_u128(gcd_u128(a, b), c), d)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Plane3 {
     pub n_x: i64,
@@ -89,6 +104,39 @@ impl Plane3 {
         }
     }
 
+    /// GCD-normalized canonical key for plane equality.
+    ///
+    /// Two coplanar polygons with parallel normals can have `Plane3`
+    /// fields differing by a positive scalar (e.g. two triangles on the
+    /// same face whose cross products differ in magnitude because the
+    /// triangles themselves have different shapes). The canonical key
+    /// divides `(n_x, n_y, n_z, d)` by their absolute GCD, collapsing
+    /// proportional planes to the same key while preserving sign
+    /// (so opposite-facing coplanar planes stay distinct).
+    ///
+    /// Used by the cleanup pipeline's coplanar grouping per ADR-0057
+    /// — without it, CDT-triangulated faces re-emerge with one plane
+    /// key per output triangle and never re-merge into n-gon faces.
+    pub fn canonical_key(&self) -> (i64, i64, i64, i128) {
+        let g = gcd_4(
+            self.n_x.unsigned_abs() as u128,
+            self.n_y.unsigned_abs() as u128,
+            self.n_z.unsigned_abs() as u128,
+            self.d.unsigned_abs(),
+        );
+        if g == 0 {
+            // Fully zero plane (degenerate); leave as-is.
+            return (self.n_x, self.n_y, self.n_z, self.d);
+        }
+        let g = g as i128;
+        (
+            (self.n_x as i128 / g) as i64,
+            (self.n_y as i128 / g) as i64,
+            (self.n_z as i128 / g) as i64,
+            self.d / g,
+        )
+    }
+
     /// Sign of `dot(self.normal, other.normal)`. Used to distinguish
     /// coplanar-front from coplanar-back when classifying a polygon
     /// against a partitioner whose plane it shares.
@@ -153,6 +201,26 @@ mod tests {
         let down = up.invert();
         assert!(up.normal_dot_sign(&up) > 0);
         assert!(up.normal_dot_sign(&down) < 0);
+    }
+
+    #[test]
+    fn canonical_key_collapses_proportional_planes() {
+        // Two triangles on the same physical plane (z = 0 in fixed
+        // point), with different cross-product magnitudes — different
+        // raw plane fields but the same canonical key.
+        let small = Plane3::from_points(p(0.0, 0.0, 0.0), p(1.0, 0.0, 0.0), p(0.0, 1.0, 0.0));
+        let large = Plane3::from_points(p(0.0, 0.0, 0.0), p(2.0, 0.0, 0.0), p(0.0, 2.0, 0.0));
+        // Raw normals differ by factor 4 (cross product scales with edge length).
+        assert_ne!(small.n_z, large.n_z);
+        // But canonical keys match.
+        assert_eq!(small.canonical_key(), large.canonical_key());
+    }
+
+    #[test]
+    fn canonical_key_distinguishes_opposite_normals() {
+        let up = Plane3::from_points(p(0.0, 0.0, 0.0), p(1.0, 0.0, 0.0), p(0.0, 1.0, 0.0));
+        let down = up.invert();
+        assert_ne!(up.canonical_key(), down.canonical_key());
     }
 
     #[test]

--- a/crates/aether-dsl-mesh/src/debug.rs
+++ b/crates/aether-dsl-mesh/src/debug.rs
@@ -64,22 +64,21 @@ pub enum ManifoldViolation {
 pub fn validate_manifold(polygons: &[Polygon]) -> Vec<ManifoldViolation> {
     let mut directed: HashMap<(VertKey, VertKey), usize> = HashMap::new();
 
-    let record_loop =
-        |loop_: &[[f32; 3]], directed: &mut HashMap<(VertKey, VertKey), usize>| {
-            let n = loop_.len();
-            if n < 2 {
-                return;
+    let record_loop = |loop_: &[[f32; 3]], directed: &mut HashMap<(VertKey, VertKey), usize>| {
+        let n = loop_.len();
+        if n < 2 {
+            return;
+        }
+        for i in 0..n {
+            let a = vert_key(loop_[i]);
+            let b = vert_key(loop_[(i + 1) % n]);
+            if a == b {
+                // Degenerate edge (same vertex); skip.
+                continue;
             }
-            for i in 0..n {
-                let a = vert_key(loop_[i]);
-                let b = vert_key(loop_[(i + 1) % n]);
-                if a == b {
-                    // Degenerate edge (same vertex); skip.
-                    continue;
-                }
-                *directed.entry((a, b)).or_insert(0) += 1;
-            }
-        };
+            *directed.entry((a, b)).or_insert(0) += 1;
+        }
+    };
 
     for poly in polygons {
         record_loop(&poly.vertices, &mut directed);

--- a/crates/aether-dsl-mesh/src/debug.rs
+++ b/crates/aether-dsl-mesh/src/debug.rs
@@ -1,0 +1,341 @@
+//! Debug + invariant-checking tools for the polygon-domain mesh
+//! pipeline (ADR-0057). Used by regression tests and on-demand from
+//! the editor to diagnose topology issues without round-tripping
+//! through the renderer.
+//!
+//! The most useful one is [`validate_manifold`]: a closed manifold
+//! mesh has every directed edge appearing exactly once, with its
+//! reverse appearing exactly once in an adjacent face. Boundary edges
+//! (count=1) mean the mesh has holes (CSG output is broken).
+//! Singular edges (count>2) mean non-manifold topology (multiple
+//! faces meet at the same edge in the same direction).
+//!
+//! `validate_manifold` is the single best invariant-check for the
+//! end-to-end pipeline: any CSG bug that drops a face, double-emits
+//! a face, or produces inconsistent winding will show up as a
+//! violation with concrete vertex coords pointing at the failure.
+
+use crate::polygon::Polygon;
+use std::collections::HashMap;
+
+/// A grid-snapped 3D vertex used as a stable hash key. f32 coords get
+/// snapped to the same 16:16 fixed-point grid the CSG core uses, so
+/// vertices that should be identical (e.g. two faces meeting at an
+/// edge) hash to the same key even after f32 round-tripping.
+type VertKey = (i32, i32, i32);
+
+fn vert_key(v: [f32; 3]) -> VertKey {
+    use crate::csg::fixed::f32_to_fixed;
+    (
+        f32_to_fixed(v[0]).unwrap_or(0),
+        f32_to_fixed(v[1]).unwrap_or(0),
+        f32_to_fixed(v[2]).unwrap_or(0),
+    )
+}
+
+fn from_key(k: VertKey) -> [f32; 3] {
+    use crate::csg::fixed::fixed_to_f32;
+    [fixed_to_f32(k.0), fixed_to_f32(k.1), fixed_to_f32(k.2)]
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ManifoldViolation {
+    /// Edge appears in only one direction with no reverse twin —
+    /// the mesh has a hole (boundary) where this edge sits. For CSG
+    /// output (which should be closed), this means a face is missing.
+    BoundaryEdge { v0: [f32; 3], v1: [f32; 3] },
+    /// Edge (or its reverse) appears more than 2 times total —
+    /// non-manifold topology. Multiple faces share this edge.
+    SingularEdge {
+        v0: [f32; 3],
+        v1: [f32; 3],
+        forward_count: usize,
+        reverse_count: usize,
+    },
+    /// Edge appears the right number of times (2 total) but both in
+    /// the same direction — adjacent faces don't have opposite
+    /// winding, so the surface orientation is inconsistent.
+    InconsistentWinding { v0: [f32; 3], v1: [f32; 3] },
+}
+
+/// Walk every directed edge across every polygon (outer + holes) and
+/// flag manifold violations. A closed manifold mesh should produce an
+/// empty Vec.
+pub fn validate_manifold(polygons: &[Polygon]) -> Vec<ManifoldViolation> {
+    let mut directed: HashMap<(VertKey, VertKey), usize> = HashMap::new();
+
+    let record_loop =
+        |loop_: &[[f32; 3]], directed: &mut HashMap<(VertKey, VertKey), usize>| {
+            let n = loop_.len();
+            if n < 2 {
+                return;
+            }
+            for i in 0..n {
+                let a = vert_key(loop_[i]);
+                let b = vert_key(loop_[(i + 1) % n]);
+                if a == b {
+                    // Degenerate edge (same vertex); skip.
+                    continue;
+                }
+                *directed.entry((a, b)).or_insert(0) += 1;
+            }
+        };
+
+    for poly in polygons {
+        record_loop(&poly.vertices, &mut directed);
+        for hole in &poly.holes {
+            record_loop(hole, &mut directed);
+        }
+    }
+
+    let mut violations = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for &(a, b) in directed.keys() {
+        let canonical = if a < b { (a, b) } else { (b, a) };
+        if !seen.insert(canonical) {
+            continue;
+        }
+        let forward = directed.get(&(a, b)).copied().unwrap_or(0);
+        let reverse = directed.get(&(b, a)).copied().unwrap_or(0);
+        let total = forward + reverse;
+        let v0 = from_key(canonical.0);
+        let v1 = from_key(canonical.1);
+        if total == 1 {
+            violations.push(ManifoldViolation::BoundaryEdge { v0, v1 });
+        } else if total > 2 {
+            violations.push(ManifoldViolation::SingularEdge {
+                v0,
+                v1,
+                forward_count: forward,
+                reverse_count: reverse,
+            });
+        } else if forward != 1 || reverse != 1 {
+            // Total is 2 but not 1+1 — both same direction.
+            violations.push(ManifoldViolation::InconsistentWinding { v0, v1 });
+        }
+    }
+    // Sort for deterministic output order.
+    violations.sort_by(|a, b| format!("{:?}", a).cmp(&format!("{:?}", b)));
+    violations
+}
+
+/// Aggregate stats about a polygon mesh. Useful for spotting
+/// gross differences between baseline and broken pipelines.
+#[derive(Debug, Clone)]
+pub struct Summary {
+    pub polygon_count: usize,
+    pub triangle_count_after_fan: usize,
+    pub vertex_count_min: usize,
+    pub vertex_count_max: usize,
+    pub vertex_count_avg: f32,
+    pub hole_count_total: usize,
+    /// Polygons grouped by canonical plane direction signature.
+    /// (sign(n_x), sign(n_y), sign(n_z)) → count. For axis-aligned
+    /// meshes like cubes, expect 6 distinct entries.
+    pub by_plane_direction: HashMap<(i8, i8, i8), usize>,
+}
+
+pub fn summary(polygons: &[Polygon]) -> Summary {
+    let polygon_count = polygons.len();
+    let triangle_count_after_fan = polygons
+        .iter()
+        .map(|p| {
+            // Outer fan: n - 2. Each hole adds n - 2.
+            let outer_tri = p.vertices.len().saturating_sub(2);
+            let hole_tri: usize = p.holes.iter().map(|h| h.len().saturating_sub(2)).sum();
+            outer_tri + hole_tri
+        })
+        .sum();
+    let (vmin, vmax, vsum) =
+        polygons
+            .iter()
+            .fold((usize::MAX, 0usize, 0usize), |(mn, mx, sum), p| {
+                let n = p.vertices.len();
+                (mn.min(n), mx.max(n), sum + n)
+            });
+    let avg = if polygon_count == 0 {
+        0.0
+    } else {
+        vsum as f32 / polygon_count as f32
+    };
+    let hole_count_total = polygons.iter().map(|p| p.holes.len()).sum();
+    let mut by_plane_direction: HashMap<(i8, i8, i8), usize> = HashMap::new();
+    for p in polygons {
+        let key = (
+            p.plane_normal[0].signum() as i8,
+            p.plane_normal[1].signum() as i8,
+            p.plane_normal[2].signum() as i8,
+        );
+        *by_plane_direction.entry(key).or_insert(0) += 1;
+    }
+    Summary {
+        polygon_count,
+        triangle_count_after_fan,
+        vertex_count_min: if polygon_count == 0 { 0 } else { vmin },
+        vertex_count_max: vmax,
+        vertex_count_avg: avg,
+        hole_count_total,
+        by_plane_direction,
+    }
+}
+
+/// Human-readable per-polygon dump. One line per polygon: index,
+/// color, plane normal, vertex count, hole count, centroid.
+pub fn dump(polygons: &[Polygon]) -> String {
+    let mut out = String::new();
+    for (i, p) in polygons.iter().enumerate() {
+        let cx: f32 = p.vertices.iter().map(|v| v[0]).sum::<f32>() / p.vertices.len() as f32;
+        let cy: f32 = p.vertices.iter().map(|v| v[1]).sum::<f32>() / p.vertices.len() as f32;
+        let cz: f32 = p.vertices.iter().map(|v| v[2]).sum::<f32>() / p.vertices.len() as f32;
+        out.push_str(&format!(
+            "[{:>3}] color={} normal=({:+.3},{:+.3},{:+.3}) verts={:>2} holes={} centroid=({:+.3},{:+.3},{:+.3})\n",
+            i, p.color,
+            p.plane_normal[0], p.plane_normal[1], p.plane_normal[2],
+            p.vertices.len(), p.holes.len(),
+            cx, cy, cz,
+        ));
+    }
+    out
+}
+
+/// Pretty-printed assertion helper. Use at the call site:
+///
+/// ```ignore
+/// assert!(
+///     validate_manifold(&polys).is_empty(),
+///     "{}",
+///     report(&polys)
+/// );
+/// ```
+pub fn report(polygons: &[Polygon]) -> String {
+    let violations = validate_manifold(polygons);
+    let summ = summary(polygons);
+    let mut out = String::new();
+    out.push_str(&format!(
+        "polygon mesh report: {} polygons, {} triangles after fan-tessellate, {} holes total\n",
+        summ.polygon_count, summ.triangle_count_after_fan, summ.hole_count_total
+    ));
+    out.push_str(&format!(
+        "  vertices/poly: min={} max={} avg={:.1}\n",
+        summ.vertex_count_min, summ.vertex_count_max, summ.vertex_count_avg
+    ));
+    let mut keys: Vec<&(i8, i8, i8)> = summ.by_plane_direction.keys().collect();
+    keys.sort();
+    out.push_str("  by plane direction (sign x,y,z → count):\n");
+    for k in keys {
+        out.push_str(&format!(
+            "    ({:+},{:+},{:+}) → {}\n",
+            k.0, k.1, k.2, summ.by_plane_direction[k]
+        ));
+    }
+    if violations.is_empty() {
+        out.push_str("  manifold: OK (closed, consistent winding)\n");
+    } else {
+        out.push_str(&format!("  manifold: {} VIOLATIONS:\n", violations.len()));
+        for v in &violations {
+            out.push_str(&format!("    {:?}\n", v));
+        }
+    }
+    out.push_str("\nfull dump:\n");
+    out.push_str(&dump(polygons));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Polygon;
+
+    fn quad(verts: [[f32; 3]; 4], normal: [f32; 3]) -> Polygon {
+        Polygon {
+            vertices: verts.to_vec(),
+            holes: vec![],
+            plane_normal: normal,
+            color: 0,
+        }
+    }
+
+    #[test]
+    fn closed_unit_cube_passes_manifold_check() {
+        // 6 quad faces with consistent CCW-from-outside winding.
+        let h = 0.5;
+        let polys = vec![
+            // -X
+            quad(
+                [[-h, -h, -h], [-h, -h, h], [-h, h, h], [-h, h, -h]],
+                [-1.0, 0.0, 0.0],
+            ),
+            // +X
+            quad(
+                [[h, -h, -h], [h, h, -h], [h, h, h], [h, -h, h]],
+                [1.0, 0.0, 0.0],
+            ),
+            // -Y
+            quad(
+                [[-h, -h, -h], [h, -h, -h], [h, -h, h], [-h, -h, h]],
+                [0.0, -1.0, 0.0],
+            ),
+            // +Y
+            quad(
+                [[-h, h, -h], [-h, h, h], [h, h, h], [h, h, -h]],
+                [0.0, 1.0, 0.0],
+            ),
+            // -Z
+            quad(
+                [[-h, -h, -h], [-h, h, -h], [h, h, -h], [h, -h, -h]],
+                [0.0, 0.0, -1.0],
+            ),
+            // +Z
+            quad(
+                [[-h, -h, h], [h, -h, h], [h, h, h], [-h, h, h]],
+                [0.0, 0.0, 1.0],
+            ),
+        ];
+        let violations = validate_manifold(&polys);
+        assert!(
+            violations.is_empty(),
+            "unit cube should be watertight; got {:#?}",
+            violations
+        );
+    }
+
+    #[test]
+    fn cube_with_one_face_missing_reports_boundary_edges() {
+        let h = 0.5;
+        // Same as above but drop the +Z face.
+        let polys = vec![
+            quad(
+                [[-h, -h, -h], [-h, -h, h], [-h, h, h], [-h, h, -h]],
+                [-1.0, 0.0, 0.0],
+            ),
+            quad(
+                [[h, -h, -h], [h, h, -h], [h, h, h], [h, -h, h]],
+                [1.0, 0.0, 0.0],
+            ),
+            quad(
+                [[-h, -h, -h], [h, -h, -h], [h, -h, h], [-h, -h, h]],
+                [0.0, -1.0, 0.0],
+            ),
+            quad(
+                [[-h, h, -h], [-h, h, h], [h, h, h], [h, h, -h]],
+                [0.0, 1.0, 0.0],
+            ),
+            quad(
+                [[-h, -h, -h], [-h, h, -h], [h, h, -h], [h, -h, -h]],
+                [0.0, 0.0, -1.0],
+            ),
+            // +Z face removed.
+        ];
+        let violations = validate_manifold(&polys);
+        // The 4 edges around where the +Z face would have been are now boundary.
+        let boundary_count = violations
+            .iter()
+            .filter(|v| matches!(v, ManifoldViolation::BoundaryEdge { .. }))
+            .count();
+        assert_eq!(
+            boundary_count, 4,
+            "expected 4 boundary edges around missing face, got {}: {:#?}",
+            boundary_count, violations
+        );
+    }
+}

--- a/crates/aether-dsl-mesh/src/lib.rs
+++ b/crates/aether-dsl-mesh/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod ast;
 pub mod csg;
+pub mod debug;
 pub mod mesh;
 pub mod obj;
 pub mod parse;

--- a/crates/aether-dsl-mesh/src/polygon.rs
+++ b/crates/aether-dsl-mesh/src/polygon.rs
@@ -71,13 +71,10 @@ type GroupKey = (i64, i64, i64, i128, u32);
 fn group_loops(loops: Vec<csg::polygon::Polygon>) -> Vec<Polygon> {
     let mut groups: HashMap<GroupKey, Vec<csg::polygon::Polygon>> = HashMap::new();
     for poly in loops {
-        let key = (
-            poly.plane.n_x,
-            poly.plane.n_y,
-            poly.plane.n_z,
-            poly.plane.d,
-            poly.color,
-        );
+        // Use the GCD-canonical plane key so re-derived planes from
+        // CDT-output triangles match the original face plane.
+        let (kx, ky, kz, kd) = poly.plane.canonical_key();
+        let key = (kx, ky, kz, kd, poly.color);
         groups.entry(key).or_default().push(poly);
     }
 

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -1,0 +1,105 @@
+//! Regression test suite for the polygon-domain mesh pipeline
+//! (ADR-0057). Every visual bug we've caught becomes a fixture here
+//! so a future change that re-introduces it fails `cargo test`
+//! instead of needing a live MCP capture to spot.
+//!
+//! The pattern: parse a DSL string, mesh it via `mesh_polygons`, run
+//! `validate_manifold` against the output, fail with `report` if any
+//! invariant is violated. Each test docstring records the bug it
+//! pins down.
+
+use aether_dsl_mesh::debug::{report, validate_manifold};
+use aether_dsl_mesh::{mesh_polygons, parse};
+
+fn assert_watertight(dsl: &str) {
+    let ast = parse(dsl).expect("parse failed");
+    let polys = mesh_polygons(&ast).expect("mesh failed");
+    let violations = validate_manifold(&polys);
+    assert!(
+        violations.is_empty(),
+        "DSL `{}` produced a non-watertight mesh:\n\n{}",
+        dsl,
+        report(&polys)
+    );
+}
+
+#[test]
+fn plain_box_is_watertight() {
+    assert_watertight("(box 1.5 1.5 1.5 :color 0)");
+}
+
+#[test]
+fn plain_cylinder_is_watertight() {
+    assert_watertight("(cylinder 0.5 1.5 12 :color 0)");
+}
+
+#[test]
+fn plain_sphere_is_watertight() {
+    assert_watertight("(sphere 0.5 12 :color 0)");
+}
+
+/// **Regression**: cube with a fully-enclosed inner box should be
+/// a hollow cube — the outer cube surface intact, an inner cubical
+/// cavity. Every edge of every polygon should be shared by exactly
+/// two polygons. (Caught visually 2026-04-26: the broken pipeline
+/// rendered the inner geometry visible from outside.)
+#[test]
+fn box_minus_enclosed_box_is_watertight() {
+    assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (box 0.6 0.6 0.6 :color 1))");
+}
+
+/// **Known-failing regression**: BSP CSG produces ~36 boundary edges
+/// on cube face planes when a sphere is subtracted. Surfaced
+/// 2026-04-26 by the new manifold validator. The visual symptom
+/// (sphere visible through cube faces) appeared only when paired
+/// with canonical_key in cleanup, but the underlying boundary edges
+/// exist regardless — likely a `Plane3::coplanar_threshold` issue
+/// where sphere vertices near a cube face plane get classified
+/// COPLANAR and the triangle gets mis-routed instead of split.
+#[test]
+#[ignore = "BSP CSG sphere-cut non-manifold output (pre-existing); investigate coplanar_threshold"]
+fn box_minus_enclosed_sphere_is_watertight() {
+    assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (sphere 0.5 12 :color 1))");
+}
+
+/// **Known-failing**: same root cause as enclosed_sphere — the
+/// protruding sphere case adds visible holes (pierced cube faces)
+/// on top of the underlying boundary-edge problem.
+#[test]
+#[ignore = "BSP CSG sphere-cut non-manifold output (pre-existing); investigate coplanar_threshold"]
+fn box_minus_protruding_sphere_is_watertight() {
+    assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (sphere 0.95 12 :color 1))");
+}
+
+/// **Known-failing**: same root cause — cylinder side facets
+/// near-cube-face planes trigger the same coplanar_threshold
+/// misclassification.
+#[test]
+#[ignore = "BSP CSG cylinder-cut non-manifold output (pre-existing); investigate coplanar_threshold"]
+fn box_minus_cylinder_is_watertight() {
+    assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (cylinder 0.3 2.0 16 :color 1))");
+}
+
+/// **Known-failing**: the 3-cut box compounds two cylinder cuts —
+/// same coplanar_threshold issue as the single-cylinder case.
+#[test]
+#[ignore = "BSP CSG cylinder-cut non-manifold output (pre-existing); investigate coplanar_threshold"]
+fn three_cut_box_is_watertight() {
+    assert_watertight(
+        "(difference \
+         (box 3.0 1.0 1.5 :color 0) \
+         (translate (-0.9 0 0) (cylinder 0.3 1.5 16 :color 1)) \
+         (translate (0 0 0) (box 0.4 1.5 0.4 :color 2)) \
+         (translate (0.9 0 0) (cylinder 0.3 1.5 16 :color 3)))",
+    );
+}
+
+#[test]
+fn union_of_disjoint_boxes_is_watertight() {
+    assert_watertight("(union (box 1 1 1 :color 0) (translate (3 0 0) (box 1 1 1 :color 1)))");
+}
+
+#[test]
+fn union_of_overlapping_boxes_is_watertight() {
+    assert_watertight("(union (box 1 1 1 :color 0) (translate (0.5 0 0) (box 1 1 1 :color 1)))");
+}

--- a/crates/aether-mesh-editor-component/src/lib.rs
+++ b/crates/aether-mesh-editor-component/src/lib.rs
@@ -31,8 +31,22 @@
 //!    re-write the file and re-send `set_path`).
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers, io};
-use aether_dsl_mesh::tessellate_polygon;
+use aether_dsl_mesh::{Polygon, tessellate_polygon};
 use aether_kinds::{DrawTriangle, ReadResult, SetPath, SetText, Tick, Vertex};
+
+/// Outline edges are emitted as thin in-plane quads. Width is in world
+/// units; matches the box/sphere scale we typically demo against
+/// (~0.5 to 3 unit primitives).
+const OUTLINE_WIDTH: f32 = 0.012;
+
+/// Lift outlines slightly along the polygon's plane normal so they
+/// don't z-fight with the filled triangles underneath.
+const OUTLINE_LIFT: f32 = 0.002;
+
+/// Outline color. Hardcoded slate (matches PALETTE[7]) for "DCC mode"
+/// readability against any fill color. Not a DSL color — outlines are
+/// a render decoration, not part of the source mesh.
+const OUTLINE_RGB: (f32, f32, f32) = (0.12, 0.12, 0.16);
 
 /// Built-in palette mapping DSL `:color N` indices to RGB. The DSL's
 /// color is a `u32` palette reference; the substrate renderer needs
@@ -148,16 +162,95 @@ impl DslMeshEditor {
         };
         let mut out = Vec::new();
         for polygon in &polygons {
+            // Filled face triangles.
             for tri in tessellate_polygon(polygon) {
-                out.push(to_draw_triangle(tri, polygon.color));
+                out.push(to_draw_triangle_palette(tri, polygon.color));
+            }
+            // Polygon-edge outlines (per ADR-0057's "polygon-edge wireframe"
+            // — show the n-gon boundary, never the tessellator's diagonals).
+            for tri in polygon_outline_triangles(polygon) {
+                out.push(to_draw_triangle_rgb(tri, OUTLINE_RGB));
             }
         }
         self.triangles = out;
     }
 }
 
-fn to_draw_triangle(tri: [[f32; 3]; 3], color: u32) -> DrawTriangle {
-    let (r, g, b) = PALETTE[(color as usize) % PALETTE.len()];
+/// Generate thin in-plane outline quads for every outer + hole edge of
+/// a polygon. Each edge becomes a 2-triangle strip of width
+/// [`OUTLINE_WIDTH`], lifted [`OUTLINE_LIFT`] units along the plane
+/// normal so it sits cleanly above the filled face. Returns flat
+/// triangles (no internal grouping) ready for `DrawTriangle` emission.
+///
+/// World-space thickness — outlines stay the same size in world units
+/// regardless of camera distance. They look thinner edge-on, which is
+/// the right behavior for face boundaries (a face viewed edge-on is
+/// itself a line).
+fn polygon_outline_triangles(polygon: &Polygon) -> Vec<[[f32; 3]; 3]> {
+    let mut tris = Vec::new();
+    let n = polygon.plane_normal;
+    outline_loop(&polygon.vertices, n, &mut tris);
+    for hole in &polygon.holes {
+        outline_loop(hole, n, &mut tris);
+    }
+    tris
+}
+
+fn outline_loop(loop_: &[[f32; 3]], normal: [f32; 3], out: &mut Vec<[[f32; 3]; 3]>) {
+    let count = loop_.len();
+    if count < 2 {
+        return;
+    }
+    let lift = [
+        normal[0] * OUTLINE_LIFT,
+        normal[1] * OUTLINE_LIFT,
+        normal[2] * OUTLINE_LIFT,
+    ];
+    for i in 0..count {
+        let v0 = loop_[i];
+        let v1 = loop_[(i + 1) % count];
+        let edge = [v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]];
+        let perp = cross(normal, edge);
+        let perp_len = (perp[0] * perp[0] + perp[1] * perp[1] + perp[2] * perp[2]).sqrt();
+        if perp_len < 1e-6 {
+            continue;
+        }
+        let scale = OUTLINE_WIDTH * 0.5 / perp_len;
+        let off = [perp[0] * scale, perp[1] * scale, perp[2] * scale];
+        let v0_in = sub_lift_off(v0, lift, off, -1.0);
+        let v0_out = sub_lift_off(v0, lift, off, 1.0);
+        let v1_in = sub_lift_off(v1, lift, off, -1.0);
+        let v1_out = sub_lift_off(v1, lift, off, 1.0);
+        // CCW around the plane normal (matches face winding) so culling
+        // and lighting future-friendly.
+        out.push([v0_in, v1_in, v1_out]);
+        out.push([v0_in, v1_out, v0_out]);
+    }
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn sub_lift_off(base: [f32; 3], lift: [f32; 3], off: [f32; 3], sign: f32) -> [f32; 3] {
+    [
+        base[0] + lift[0] + off[0] * sign,
+        base[1] + lift[1] + off[1] * sign,
+        base[2] + lift[2] + off[2] * sign,
+    ]
+}
+
+fn to_draw_triangle_palette(tri: [[f32; 3]; 3], color: u32) -> DrawTriangle {
+    let rgb = PALETTE[(color as usize) % PALETTE.len()];
+    to_draw_triangle_rgb(tri, rgb)
+}
+
+fn to_draw_triangle_rgb(tri: [[f32; 3]; 3], rgb: (f32, f32, f32)) -> DrawTriangle {
+    let (r, g, b) = rgb;
     DrawTriangle {
         verts: [
             Vertex {


### PR DESCRIPTION
## Summary
- New aether_dsl_mesh::debug module: validate_manifold, summary, dump, report. Checks "every directed edge appears once with its reverse appearing once" — the closed-manifold invariant.
- New tests/regression.rs converts every CSG visual smoke we've hit into a parse + assert_watertight fixture. 6 pass, 4 ignored documenting a pre-existing BSP CSG bug the validator surfaced.
- New Plane3::canonical_key (GCD-normalized plane equality) used by polygon::group_loops to merge CDT-output triangles into n-gons in the public API path.
- Editor-side polygon-edge wireframe: thin in-plane outline triangles per polygon edge, lifted along plane normal to avoid z-fight. Clean for primitives; shows per-triangle edges for sphere/cylinder CSG until the underlying manifold bug is fixed.

## Validator finding
The 4 ignored fixtures all hit the same pattern: 36 boundary edges on cube face planes in sphere/cylinder cuts, present regardless of canonical_key. Likely a Plane3::coplanar_threshold issue — sphere/cylinder vertices near a cube face plane get classified COPLANAR and the triangle gets mis-routed instead of split. Test docstrings record the hypothesis. Follow-up PR.

## Test plan
- [x] cargo test --workspace green; 6 regression fixtures pass.
- [x] cargo test -- --ignored runs the 4 known-failing ones with full report output.
- [x] cargo clippy --all-targets -- -D warnings clean.
- [x] cargo fmt clean.
- [x] Live MCP capture: plain box renders with clean polygon-edge wireframe (12 cube edges, no diagonals).