### PR TITLE
fix(dsl-mesh): mesh_polygons skips triangle round-trip; un-ignore protruding_sphere

### DIFF
--- a/crates/aether-dsl-mesh/src/csg/cleanup/weld.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/weld.rs
@@ -44,19 +44,22 @@ use std::collections::HashMap;
 /// rounding step. Two same-true-point intersections each independently
 /// snapped can land up to 1 unit apart in Chebyshev distance.
 ///
-/// We use `2` (not `1`) to absorb the accumulated drift across BSP
-/// passes for compositions with deeply overlapping cuts (e.g.,
-/// `three_cut_box_is_watertight`). The per-line
-/// [`crate::csg::vertex_pool::SharedVertexPool`] catches all
-/// single-pass snap-drift duplicates that share a line key; the
-/// remaining ≤2-unit gaps come from cross-pass drift between
-/// non-line-key-sharing computations and need to be welded here.
+/// We use `4` (not `1`) to absorb accumulated drift across BSP passes
+/// for compositions with multi-facet cuts (sphere/cylinder vs cube).
+/// Under the polygon-throughout pipeline (PR 292) cleanup runs once at
+/// the end of an entire CSG composition, so the cleanup sees drift
+/// accumulated over every BSP partitioner the cube fragments survived
+/// — a 12-facet sphere on a cube face accumulates up to ~3 units in
+/// Chebyshev distance per face fragment. Tolerance `4` catches that
+/// without colliding distinct vertices: the next-nearest distinct-point
+/// spacing in practical CSG inputs (sphere/cylinder facet spacing,
+/// typically 0.05+ float = 3000+ fixed units) is well above the bound.
 ///
-/// The next-nearest distinct-point spacing in practical CSG inputs
-/// (sphere/cylinder facet vertex spacing on a cube face, typically
-/// 0.05+ float = 3000+ fixed units) is far above 2, so there are no
-/// false positives.
-const WELD_TOLERANCE_FIXED_UNITS: i32 = 2;
+/// Raised from `2` to `4` (2026-04-26) after un-ignoring
+/// `box_minus_protruding_sphere_is_watertight` exposed 3- and 4-unit
+/// duplicate vertex pairs on the x=-0.75 cube face that the previous
+/// tolerance missed.
+const WELD_TOLERANCE_FIXED_UNITS: i32 = 4;
 
 /// Spatial-bucket cell size: 2 × tolerance so any two points within
 /// tolerance land in the same or adjacent buckets.

--- a/crates/aether-dsl-mesh/src/polygon.rs
+++ b/crates/aether-dsl-mesh/src/polygon.rs
@@ -23,7 +23,7 @@
 
 use crate::csg;
 use crate::csg::point::Point3;
-use crate::mesh::{MeshError, Triangle};
+use crate::mesh::MeshError;
 use std::collections::HashMap;
 
 /// N-gon polygonal face — the canonical mesh form (ADR-0057).
@@ -40,30 +40,18 @@ pub struct Polygon {
 
 /// Mesh `node` and return the result as n-gon polygons.
 ///
-/// Internally calls [`crate::mesh::mesh`] to get triangles, then runs
-/// the cleanup pipeline's loop-extraction pass (skipping triangulation)
-/// to recover the boundary loops, then groups by plane + color into
-/// outer + holes via signed-area orientation. The triangle round-trip
-/// is wasteful but correct; ADR-0057 PR 3 will replace it with a
-/// polygon-domain CSG path.
+/// Goes directly through [`crate::mesh::mesh_polygons_internal`] —
+/// the polygon-domain mesh evaluator that operates polygon-in /
+/// polygon-out throughout (no triangle round-trip). This is the fix
+/// for the protruding_sphere SingularEdges: the previous path went
+/// `mesh → Vec<Triangle> → from_triangle (re-derives plane via cross
+/// product) → polygons`, and `from_triangle` flips `n_z` sign on
+/// CDT-output sliver triangles. Skipping the triangle hop avoids the
+/// re-derivation entirely — n-gon loops travel from CSG cleanup
+/// straight into [`group_loops`].
 pub fn mesh_polygons(node: &crate::ast::Node) -> Result<Vec<Polygon>, MeshError> {
-    let triangles = crate::mesh::mesh(node)?;
-    Ok(triangles_to_polygons(&triangles))
-}
-
-fn triangles_to_polygons(triangles: &[Triangle]) -> Vec<Polygon> {
-    let csg_polys: Vec<csg::polygon::Polygon> = triangles
-        .iter()
-        .filter_map(|t| {
-            let v0 = Point3::from_f32(t.vertices[0]).ok()?;
-            let v1 = Point3::from_f32(t.vertices[1]).ok()?;
-            let v2 = Point3::from_f32(t.vertices[2]).ok()?;
-            csg::polygon::Polygon::from_triangle(v0, v1, v2, t.color)
-        })
-        .collect();
-
-    let loops = csg::cleanup::run_to_loops(csg_polys);
-    group_loops(loops)
+    let loops = crate::mesh::mesh_polygons_internal(node)?;
+    Ok(group_loops(loops))
 }
 
 type GroupKey = (i64, i64, i64, i128, u32);

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -62,22 +62,14 @@ fn box_minus_enclosed_sphere_is_watertight() {
     assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (sphere 0.5 12 :color 1))");
 }
 
-/// **Known-failing — blocked on polygon-throughout migration.** The two
-/// SingularEdges (forward=2, reverse=2) on the cube's z=-0.75 face are
-/// caused by the triangle round-trip in `mesh_polygons`: BSP CSG output
-/// is correct (zero reversed-orientation cube fragments), but the wire
-/// `Vec<Triangle>` boundary fan-triangulates n-gons and `from_triangle`
-/// re-derives each plane from three vertices via cross product. For
-/// CDT-output sliver triangles (near-collinear vertices), the cross
-/// product is dominated by sub-fixed-point noise and `n_z` flips sign
-/// on ~20 cube-color triangles per protruding face. Those reversed
-/// triangles re-enter cleanup as a separate coplanar bucket and emit
-/// as a real second mesh layer — the visible singular edges. The fix
-/// is the polygon-throughout migration: skip the triangle round-trip
-/// entirely (n-gon loops travel from CSG cleanup straight into
-/// `mesh_polygons`, no plane re-derivation). Tracked separately.
+/// **Regression**: the protruding sphere previously surfaced two
+/// SingularEdges on the cube's z=-0.75 face caused by the triangle
+/// round-trip in `mesh_polygons` re-deriving plane normals via cross
+/// product on CDT-output sliver triangles (`n_z` flipped sign on ~20
+/// cube-color triangles per face). The polygon-throughout migration
+/// (`crate::mesh::mesh_polygons_internal`) skips the round-trip — n-gon
+/// loops travel from CSG cleanup straight into `mesh_polygons`.
 #[test]
-#[ignore = "blocked on polygon-throughout migration — triangle round-trip flips sliver normals"]
 fn box_minus_protruding_sphere_is_watertight() {
     assert_watertight("(difference (box 1.5 1.5 1.5 :color 0) (sphere 0.95 12 :color 1))");
 }


### PR DESCRIPTION
## Summary

PR C of the polygon-throughout migration — the architectural fix the whole cluster has been pointing at.

`crate::polygon::mesh_polygons` now goes directly through `crate::mesh::mesh_polygons_internal` (added in PR 292), bypassing the `mesh → Vec<Triangle> → Polygon::from_triangle` round-trip that flipped `n_z` sign on CDT-output sliver triangles. n-gon loops travel from CSG cleanup straight into `group_loops`, no plane re-derivation.

`box_minus_protruding_sphere_is_watertight` un-ignored — the bug it pinned is gone.

## Weld tolerance bump

The un-ignore exposed three residual SingularEdges on the cube's x=-0.75 face — duplicate vertex pairs 3-4 fixed units apart that the previous `WELD_TOLERANCE_FIXED_UNITS=2` missed. Bumped to 4 to absorb multi-facet-Boolean drift accumulation: under cleanup-once-at-end (PR 292), a 12-facet sphere on a cube face accumulates ~3 units per fragment in Chebyshev distance. The next-nearest distinct-point spacing in practical CSG inputs (sphere/cylinder facet spacing, typically 3000+ fixed units) is well above 4, so no false welds.

## Side effect

three_cut_box (still ignored) goes from 6 to 8 violations — same residual sliver near the center-box-cutter `z=-0.2` corner, just two more weld-induced extra fragments. Net win for the cluster: one fewer ignored regression test (protruding_sphere now passing).

## Test plan
- [x] cargo test -p aether-dsl-mesh — 223 lib + all integration green; 9 ignored (one fewer than before)
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)