### PR TITLE
feat(dsl-mesh): geometric validators and off-axis CSG regression corpus

### DIFF
--- a/crates/aether-dsl-mesh/src/debug.rs
+++ b/crates/aether-dsl-mesh/src/debug.rs
@@ -16,7 +16,42 @@
 //! violation with concrete vertex coords pointing at the failure.
 
 use crate::polygon::Polygon;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+/// Default tolerances for geometric validators. All in world units.
+///
+/// The CSG core snaps coordinates to a 16:16 fixed-point grid (`1 unit
+/// ≈ 1.5e-5`, see [`crate::csg::fixed`]); these defaults sit a few snap
+/// units above that floor so f32 reconstruction noise and plane
+/// re-derivation drift don't trip the validators on legitimate output.
+pub mod tol {
+    /// Vertex-to-stored-plane distance allowed in [`validate_planarity`].
+    /// ~33 fixed-point units — enough for f32 round-trip drift on cleanup
+    /// output, tight enough to catch a polygon that legitimately bends.
+    pub const PLANARITY: f32 = 5e-4;
+
+    /// Edge length below which an edge is "sliver" in
+    /// [`validate_polygon_quality`]. ~65 fixed-point units — smaller
+    /// than any usable face edge but well above snap noise.
+    pub const SLIVER_EDGE: f32 = 1e-3;
+
+    /// Polygon area below which the polygon is degenerate.
+    pub const DEGENERATE_AREA: f32 = 1e-6;
+
+    /// Edge-length aspect ratio (longest / shortest) above which the
+    /// polygon is shape-pathological.
+    pub const ASPECT_RATIO: f32 = 1000.0;
+
+    /// Cosine of the fold angle between adjacent face normals below
+    /// which they're "flipped." `-1.0` is a 180° fold (back-to-back
+    /// faces — a CSG sign error). `-0.99` is ~8° from full inversion,
+    /// which still leaves headroom for sharp concave dihedrals.
+    pub const FOLD_COS: f32 = -0.99;
+
+    /// Distance from a vertex to a non-incident edge below which the
+    /// vertex sits *on* the edge — a T-junction.
+    pub const T_JUNCTION: f32 = 1e-4;
+}
 
 /// A grid-snapped 3D vertex used as a stable hash key. f32 coords get
 /// snapped to the same 16:16 fixed-point grid the CSG core uses, so
@@ -116,6 +151,350 @@ pub fn validate_manifold(polygons: &[Polygon]) -> Vec<ManifoldViolation> {
     // Sort for deterministic output order.
     violations.sort_by(|a, b| format!("{:?}", a).cmp(&format!("{:?}", b)));
     violations
+}
+
+/// Geometric (non-topological) violations: shape, planarity, normal
+/// continuity, T-junctions. These slip past [`validate_manifold`]
+/// because they don't break edge counts — they break the *shape* of
+/// the surface, which `tessellate_polygon` and the renderer notice.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GeometryViolation {
+    /// A polygon vertex sits more than `tol::PLANARITY` from the
+    /// polygon's stored plane. Catches a polygon whose stored normal
+    /// disagrees with its actual vertex layout (cleanup failure, plane
+    /// re-derivation bug, or a genuinely non-planar n-gon).
+    NonPlanar {
+        polygon_index: usize,
+        vertex: [f32; 3],
+        distance: f32,
+    },
+    /// A polygon's projected signed area is below `tol::DEGENERATE_AREA`
+    /// — it tessellates to ~zero pixels and is a likely source of
+    /// downstream NaNs.
+    DegenerateArea { polygon_index: usize, area: f32 },
+    /// A polygon edge is shorter than `tol::SLIVER_EDGE`. Slivers slip
+    /// through CSG cleanup and trigger CDT pathologies.
+    SliverEdge {
+        polygon_index: usize,
+        v0: [f32; 3],
+        v1: [f32; 3],
+        length: f32,
+    },
+    /// A polygon's longest:shortest edge ratio exceeds `tol::ASPECT_RATIO`.
+    ExtremeAspectRatio { polygon_index: usize, ratio: f32 },
+    /// Two polygons share an edge but their stored normals point nearly
+    /// opposite (`dot < tol::FOLD_COS`) — a folded surface, almost
+    /// always a CSG sign error.
+    FoldedNormals {
+        v0: [f32; 3],
+        v1: [f32; 3],
+        cos_angle: f32,
+    },
+    /// A vertex lies on the open interior of a non-incident edge — a
+    /// T-junction. Cleanup should have inserted this vertex into the
+    /// edge's owning loop; missing it produces render-visible cracks.
+    TJunction {
+        vertex: [f32; 3],
+        edge_v0: [f32; 3],
+        edge_v1: [f32; 3],
+        distance: f32,
+    },
+}
+
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn sub(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn length(v: [f32; 3]) -> f32 {
+    dot(v, v).sqrt()
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+/// Build a 2D basis (u, v) on the plane normal to `n` so a polygon can
+/// be projected for shoelace area. Picks the world axis least aligned
+/// with `n` to avoid degenerate cross products.
+fn plane_basis(n: [f32; 3]) -> ([f32; 3], [f32; 3]) {
+    let abs = [n[0].abs(), n[1].abs(), n[2].abs()];
+    let helper = if abs[0] <= abs[1] && abs[0] <= abs[2] {
+        [1.0, 0.0, 0.0]
+    } else if abs[1] <= abs[2] {
+        [0.0, 1.0, 0.0]
+    } else {
+        [0.0, 0.0, 1.0]
+    };
+    let u_raw = cross(n, helper);
+    let u_len = length(u_raw);
+    let u = if u_len > 0.0 {
+        [u_raw[0] / u_len, u_raw[1] / u_len, u_raw[2] / u_len]
+    } else {
+        [1.0, 0.0, 0.0]
+    };
+    let v = cross(n, u);
+    (u, v)
+}
+
+fn projected_area(verts: &[[f32; 3]], n: [f32; 3]) -> f32 {
+    if verts.len() < 3 {
+        return 0.0;
+    }
+    let (u, v) = plane_basis(n);
+    let projected: Vec<(f32, f32)> = verts.iter().map(|p| (dot(*p, u), dot(*p, v))).collect();
+    let mut sum = 0.0;
+    for i in 0..projected.len() {
+        let (x0, y0) = projected[i];
+        let (x1, y1) = projected[(i + 1) % projected.len()];
+        sum += x0 * y1 - x1 * y0;
+    }
+    0.5 * sum
+}
+
+/// Each polygon vertex (outer + holes) must lie within `tol::PLANARITY`
+/// of the polygon's stored plane. Plane is taken from the stored
+/// `plane_normal` plus the centroid of the outer loop as the in-plane
+/// reference point — both are what downstream rendering trusts.
+pub fn validate_planarity(polygons: &[Polygon]) -> Vec<GeometryViolation> {
+    let mut out = Vec::new();
+    for (i, poly) in polygons.iter().enumerate() {
+        if poly.vertices.is_empty() {
+            continue;
+        }
+        let n = poly.plane_normal;
+        // Use a vertex as the in-plane reference (any vertex works if
+        // the polygon is genuinely planar; centroid would mask a single
+        // out-of-plane vertex by averaging it in).
+        let p0 = poly.vertices[0];
+        let check = |v: [f32; 3], out: &mut Vec<GeometryViolation>| {
+            let d = dot(sub(v, p0), n).abs();
+            if d > tol::PLANARITY {
+                out.push(GeometryViolation::NonPlanar {
+                    polygon_index: i,
+                    vertex: v,
+                    distance: d,
+                });
+            }
+        };
+        for &v in &poly.vertices {
+            check(v, &mut out);
+        }
+        for hole in &poly.holes {
+            for &v in hole {
+                check(v, &mut out);
+            }
+        }
+    }
+    out
+}
+
+/// Polygon shape sanity: signed-area degeneracy, sliver edges, and
+/// extreme aspect ratio. These don't break manifoldness on paper but
+/// they're failure modes for `tessellate_polygon` and the BSP core.
+pub fn validate_polygon_quality(polygons: &[Polygon]) -> Vec<GeometryViolation> {
+    let mut out = Vec::new();
+    for (i, poly) in polygons.iter().enumerate() {
+        let area = projected_area(&poly.vertices, poly.plane_normal).abs();
+        if area < tol::DEGENERATE_AREA {
+            out.push(GeometryViolation::DegenerateArea {
+                polygon_index: i,
+                area,
+            });
+        }
+        let mut min_edge = f32::INFINITY;
+        let mut max_edge: f32 = 0.0;
+        let n = poly.vertices.len();
+        for j in 0..n {
+            let a = poly.vertices[j];
+            let b = poly.vertices[(j + 1) % n];
+            let len = length(sub(b, a));
+            if len < tol::SLIVER_EDGE {
+                out.push(GeometryViolation::SliverEdge {
+                    polygon_index: i,
+                    v0: a,
+                    v1: b,
+                    length: len,
+                });
+            }
+            if len > 0.0 {
+                if len < min_edge {
+                    min_edge = len;
+                }
+                if len > max_edge {
+                    max_edge = len;
+                }
+            }
+        }
+        if min_edge.is_finite() && min_edge > 0.0 {
+            let ratio = max_edge / min_edge;
+            if ratio > tol::ASPECT_RATIO {
+                out.push(GeometryViolation::ExtremeAspectRatio {
+                    polygon_index: i,
+                    ratio,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// For each manifold-shared edge (exactly two adjacent polygons in
+/// opposing directions), the two stored normals must not be nearly
+/// antiparallel (`dot < tol::FOLD_COS`). Antiparallel = the surface is
+/// folded back on itself at this edge, which means CSG misclassified
+/// inside vs outside on one of the two faces.
+pub fn validate_normal_coherence(polygons: &[Polygon]) -> Vec<GeometryViolation> {
+    // Map: canonical (snapped) edge → list of (polygon_index, normal).
+    type EdgeIncidents = HashMap<(VertKey, VertKey), Vec<(usize, [f32; 3])>>;
+    let mut edges: EdgeIncidents = HashMap::new();
+    for (i, poly) in polygons.iter().enumerate() {
+        let walk = |loop_: &[[f32; 3]], edges: &mut EdgeIncidents| {
+            let n = loop_.len();
+            for j in 0..n {
+                let a = vert_key(loop_[j]);
+                let b = vert_key(loop_[(j + 1) % n]);
+                if a == b {
+                    continue;
+                }
+                let canonical = if a < b { (a, b) } else { (b, a) };
+                edges
+                    .entry(canonical)
+                    .or_default()
+                    .push((i, poly.plane_normal));
+            }
+        };
+        walk(&poly.vertices, &mut edges);
+        for hole in &poly.holes {
+            walk(hole, &mut edges);
+        }
+    }
+    let mut out = Vec::new();
+    let mut seen: HashSet<(usize, usize)> = HashSet::new();
+    for ((a, b), incidents) in edges.iter() {
+        if incidents.len() != 2 {
+            continue;
+        }
+        let (i0, n0) = incidents[0];
+        let (i1, n1) = incidents[1];
+        if i0 == i1 {
+            continue;
+        }
+        let pair = if i0 < i1 { (i0, i1) } else { (i1, i0) };
+        if !seen.insert(pair) {
+            continue;
+        }
+        let cos = dot(n0, n1);
+        if cos < tol::FOLD_COS {
+            out.push(GeometryViolation::FoldedNormals {
+                v0: from_key(*a),
+                v1: from_key(*b),
+                cos_angle: cos,
+            });
+        }
+    }
+    out.sort_by(|a, b| format!("{:?}", a).cmp(&format!("{:?}", b)));
+    out
+}
+
+/// For every polygon edge (A, B) and every vertex V (across all
+/// polygons), if V is not a snap-key endpoint of (A, B) but lies within
+/// `tol::T_JUNCTION` of the open segment interior, flag a T-junction.
+/// Cleanup should have inserted V as an explicit vertex of (A, B)'s
+/// owning loop; missing it produces render-visible cracks.
+pub fn validate_no_t_junctions(polygons: &[Polygon]) -> Vec<GeometryViolation> {
+    // Collect every distinct vertex (snap-key + f32 coords for reporting).
+    let mut all_verts: HashMap<VertKey, [f32; 3]> = HashMap::new();
+    for poly in polygons {
+        for &v in &poly.vertices {
+            all_verts.insert(vert_key(v), v);
+        }
+        for hole in &poly.holes {
+            for &v in hole {
+                all_verts.insert(vert_key(v), v);
+            }
+        }
+    }
+
+    // Collect every directed edge once (canonicalized).
+    let mut edges: HashSet<(VertKey, VertKey)> = HashSet::new();
+    for poly in polygons {
+        let walk = |loop_: &[[f32; 3]], edges: &mut HashSet<(VertKey, VertKey)>| {
+            let n = loop_.len();
+            for j in 0..n {
+                let a = vert_key(loop_[j]);
+                let b = vert_key(loop_[(j + 1) % n]);
+                if a == b {
+                    continue;
+                }
+                let canonical = if a < b { (a, b) } else { (b, a) };
+                edges.insert(canonical);
+            }
+        };
+        walk(&poly.vertices, &mut edges);
+        for hole in &poly.holes {
+            walk(hole, &mut edges);
+        }
+    }
+
+    let mut out = Vec::new();
+    let tol_sq = tol::T_JUNCTION * tol::T_JUNCTION;
+    for (a_key, b_key) in &edges {
+        let a = from_key(*a_key);
+        let b = from_key(*b_key);
+        let ab = sub(b, a);
+        let ab_len_sq = dot(ab, ab);
+        if ab_len_sq <= 0.0 {
+            continue;
+        }
+        for (v_key, v) in &all_verts {
+            if *v_key == *a_key || *v_key == *b_key {
+                continue;
+            }
+            let av = sub(*v, a);
+            let t = dot(av, ab) / ab_len_sq;
+            // Open interior — exclude endpoints by a small parametric margin
+            // proportional to the snap tolerance vs. edge length.
+            let margin = (tol::T_JUNCTION / ab_len_sq.sqrt()).min(0.5);
+            if t <= margin || t >= 1.0 - margin {
+                continue;
+            }
+            // Perpendicular distance from V to line AB.
+            let proj = [a[0] + t * ab[0], a[1] + t * ab[1], a[2] + t * ab[2]];
+            let d = sub(*v, proj);
+            let d_sq = dot(d, d);
+            if d_sq <= tol_sq {
+                out.push(GeometryViolation::TJunction {
+                    vertex: *v,
+                    edge_v0: a,
+                    edge_v1: b,
+                    distance: d_sq.sqrt(),
+                });
+            }
+        }
+    }
+    out.sort_by(|x, y| format!("{:?}", x).cmp(&format!("{:?}", y)));
+    out
+}
+
+/// Run [`validate_manifold`] plus all four geometric validators.
+/// Returned tuple keeps manifold and geometric violations separate so
+/// callers can attribute failures cleanly.
+pub fn validate_geometry(polygons: &[Polygon]) -> (Vec<ManifoldViolation>, Vec<GeometryViolation>) {
+    let manifold = validate_manifold(polygons);
+    let mut geom = Vec::new();
+    geom.extend(validate_planarity(polygons));
+    geom.extend(validate_polygon_quality(polygons));
+    geom.extend(validate_normal_coherence(polygons));
+    geom.extend(validate_no_t_junctions(polygons));
+    (manifold, geom)
 }
 
 /// Aggregate stats about a polygon mesh. Useful for spotting
@@ -232,6 +611,24 @@ pub fn report(polygons: &[Polygon]) -> String {
     } else {
         out.push_str(&format!("  manifold: {} VIOLATIONS:\n", violations.len()));
         for v in &violations {
+            out.push_str(&format!("    {:?}\n", v));
+        }
+    }
+    let planarity = validate_planarity(polygons);
+    let quality = validate_polygon_quality(polygons);
+    let normals = validate_normal_coherence(polygons);
+    let tjunctions = validate_no_t_junctions(polygons);
+    let total_geom = planarity.len() + quality.len() + normals.len() + tjunctions.len();
+    if total_geom == 0 {
+        out.push_str("  geometry: OK (planar, well-shaped, coherent, no T-junctions)\n");
+    } else {
+        out.push_str(&format!("  geometry: {} VIOLATIONS:\n", total_geom));
+        for v in planarity
+            .iter()
+            .chain(&quality)
+            .chain(&normals)
+            .chain(&tjunctions)
+        {
             out.push_str(&format!("    {:?}\n", v));
         }
     }
@@ -373,6 +770,121 @@ mod tests {
         assert_eq!(s.hole_count_total, 0);
         assert_eq!(s.vertex_count_min, 4);
         assert_eq!(s.vertex_count_max, 4);
+    }
+
+    #[test]
+    fn validate_planarity_flags_off_plane_vertex() {
+        // Quad whose 4th vertex is lifted 0.01 off the z=0 plane —
+        // well above the 5e-4 PLANARITY tolerance. Stored normal is
+        // +Z, so the lifted vertex's distance is exactly the lift.
+        let polys = vec![Polygon {
+            vertices: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.01],
+            ],
+            holes: vec![],
+            plane_normal: [0.0, 0.0, 1.0],
+            color: 0,
+        }];
+        let v = validate_planarity(&polys);
+        assert_eq!(v.len(), 1, "expected 1 NonPlanar violation, got {v:#?}");
+        assert!(matches!(v[0], GeometryViolation::NonPlanar { .. }));
+    }
+
+    #[test]
+    fn validate_polygon_quality_flags_sliver_edge() {
+        // Triangle with one edge 1e-4 long — well below the 1e-3
+        // SLIVER threshold.
+        let polys = vec![Polygon {
+            vertices: vec![[0.0, 0.0, 0.0], [1e-4, 0.0, 0.0], [0.5, 1.0, 0.0]],
+            holes: vec![],
+            plane_normal: [0.0, 0.0, 1.0],
+            color: 0,
+        }];
+        let v = validate_polygon_quality(&polys);
+        assert!(
+            v.iter()
+                .any(|g| matches!(g, GeometryViolation::SliverEdge { .. })),
+            "expected at least one SliverEdge, got {v:#?}"
+        );
+    }
+
+    #[test]
+    fn validate_normal_coherence_flags_folded_pair() {
+        // Two coplanar quads sharing edge (a,b) but with opposite
+        // stored normals (+Z and −Z). They wind opposing around the
+        // shared edge so manifold check passes — only normal
+        // coherence catches the fold.
+        let a = [0.0, 0.0, 0.0];
+        let b = [1.0, 0.0, 0.0];
+        let c = [1.0, 1.0, 0.0];
+        let d = [0.0, 1.0, 0.0];
+        let e = [1.0, -1.0, 0.0];
+        let f = [0.0, -1.0, 0.0];
+        let polys = vec![
+            Polygon {
+                vertices: vec![a, b, c, d],
+                holes: vec![],
+                plane_normal: [0.0, 0.0, 1.0],
+                color: 0,
+            },
+            Polygon {
+                vertices: vec![b, a, f, e],
+                holes: vec![],
+                plane_normal: [0.0, 0.0, -1.0],
+                color: 0,
+            },
+        ];
+        let v = validate_normal_coherence(&polys);
+        assert!(
+            v.iter()
+                .any(|g| matches!(g, GeometryViolation::FoldedNormals { .. })),
+            "expected at least one FoldedNormals, got {v:#?}"
+        );
+    }
+
+    #[test]
+    fn validate_no_t_junctions_flags_vertex_on_edge_interior() {
+        // Triangle (a,b,c) plus a smaller triangle whose vertex sits
+        // exactly on edge (a,b) but is not in (a,b)'s loop. Classic
+        // T-junction.
+        let a = [0.0, 0.0, 0.0];
+        let b = [1.0, 0.0, 0.0];
+        let c = [0.5, 1.0, 0.0];
+        let mid_ab = [0.5, 0.0, 0.0]; // on edge a→b interior
+        let d = [0.5, -1.0, 0.0];
+        let polys = vec![
+            Polygon {
+                vertices: vec![a, b, c],
+                holes: vec![],
+                plane_normal: [0.0, 0.0, 1.0],
+                color: 0,
+            },
+            Polygon {
+                // walks a → mid_ab → d, then mid_ab → b → d (two
+                // adjacent triangles sharing mid_ab) so mid_ab is a
+                // legitimate vertex elsewhere — but NOT in the first
+                // polygon's loop.
+                vertices: vec![a, mid_ab, d],
+                holes: vec![],
+                plane_normal: [0.0, 0.0, -1.0],
+                color: 0,
+            },
+            Polygon {
+                vertices: vec![mid_ab, b, d],
+                holes: vec![],
+                plane_normal: [0.0, 0.0, -1.0],
+                color: 0,
+            },
+        ];
+        let v = validate_no_t_junctions(&polys);
+        assert!(
+            v.iter()
+                .any(|g| matches!(g, GeometryViolation::TJunction { .. })),
+            "expected at least one TJunction on edge (a,b), got {v:#?}"
+        );
     }
 
     #[test]

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -4,11 +4,17 @@
 //! instead of needing a live MCP capture to spot.
 //!
 //! The pattern: parse a DSL string, mesh it via `mesh_polygons`, run
-//! `validate_manifold` against the output, fail with `report` if any
-//! invariant is violated. Each test docstring records the bug it
-//! pins down.
+//! `validate_manifold` (or the stricter `validate_geometry`) against
+//! the output, fail with `report` if any invariant is violated. Each
+//! test docstring records the bug it pins down.
+//!
+//! Two assertion strengths: `assert_watertight` checks topology only;
+//! `assert_geometric` also runs the planarity, polygon-quality,
+//! normal-coherence, and T-junction validators. The off-axis tests
+//! lower in the file use the stronger one because tessellation-domain
+//! bugs slip past topology when geometry isn't axis-aligned.
 
-use aether_dsl_mesh::debug::{report, validate_manifold};
+use aether_dsl_mesh::debug::{report, validate_geometry, validate_manifold};
 use aether_dsl_mesh::{mesh_polygons, parse};
 
 fn assert_watertight(dsl: &str) {
@@ -18,6 +24,22 @@ fn assert_watertight(dsl: &str) {
     assert!(
         violations.is_empty(),
         "DSL `{}` produced a non-watertight mesh:\n\n{}",
+        dsl,
+        report(&polys)
+    );
+}
+
+/// Stronger than `assert_watertight`: also requires the geometric
+/// validators (planarity, polygon quality, normal coherence,
+/// T-junctions) to pass. Use for the off-axis corpus where shape
+/// failures (slivers, fold-flips, cracks) matter as much as topology.
+fn assert_geometric(dsl: &str) {
+    let ast = parse(dsl).expect("parse failed");
+    let polys = mesh_polygons(&ast).expect("mesh failed");
+    let (manifold, geom) = validate_geometry(&polys);
+    assert!(
+        manifold.is_empty() && geom.is_empty(),
+        "DSL `{}` produced an invalid mesh:\n\n{}",
         dsl,
         report(&polys)
     );
@@ -109,4 +131,205 @@ fn union_of_disjoint_boxes_is_watertight() {
 #[test]
 fn union_of_overlapping_boxes_is_watertight() {
     assert_watertight("(union (box 1 1 1 :color 0) (translate (0.5 0 0) (box 1 1 1 :color 1)))");
+}
+
+/// Box rotated 30° around Y — same topology as the axis-aligned box,
+/// but every face plane is now off-grid. Catches BSP plane-snap drift
+/// on the primitive itself.
+#[test]
+fn rotated_box_is_geometric() {
+    assert_geometric("(rotate (0 1 0) 0.5236 (box 1.5 1.5 1.5 :color 0))");
+}
+
+/// Cylinder tilted 30° from vertical — sides are no longer axis-parallel.
+#[test]
+fn tilted_cylinder_is_geometric() {
+    assert_geometric("(rotate (1 0 0) 0.5236 (cylinder 0.5 1.5 16 :color 0))");
+}
+
+/// Sphere on a non-axis-aligned position. Sphere mesher is rotation-
+/// invariant; this catches downstream snap drift only if it appears.
+#[test]
+fn translated_sphere_is_geometric() {
+    assert_geometric("(translate (0.37 0.41 -0.23) (sphere 0.5 12 :color 0))");
+}
+
+/// **Known-failing**: catches the T-junction → boundary-crack class
+/// of bug. The cleanup pipeline produces a vertex on the cube's −Y
+/// face from the tilted cylinder's facet intersection, but doesn't
+/// insert that vertex into the abutting cylinder facet's loop. The
+/// abutting loop then "skips" the new vertex, leaving a tiny boundary
+/// triangle (3 BoundaryEdges) and the validator flags the offending
+/// vertex as a TJunction within 3e-5 of the long edge. Same root cause
+/// as `box_minus_enclosed_sphere_is_watertight` and friends — the
+/// polygon-throughout migration fixed the axis-aligned case but not
+/// the off-axis one.
+///
+/// Box with a 30°-rotated cylinder cutter through it. Off-axis cutter
+/// vs. axis-aligned solid — exercises the cube-face-clipped-by-non-
+/// orthogonal-cylinder-facet path that axis-aligned tests skip.
+#[test]
+fn box_minus_tilted_cylinder_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (box 1.5 1.5 1.5 :color 0) \
+         (rotate (1 0 0) 0.5236 (cylinder 0.3 2.0 16 :color 1)))",
+    );
+}
+
+/// 45°-rotated box vs. axis-aligned sphere. Both off-grid faces and
+/// curved facet faces in the same scene.
+#[test]
+fn rotated_box_minus_sphere_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (rotate (0 1 0) 0.7854 (box 1.5 1.5 1.5 :color 0)) \
+         (sphere 0.5 12 :color 1))",
+    );
+}
+
+/// 45°-rotated box vs. 30°-rotated box. No two face planes share an
+/// axis — every BSP partition edge is off-grid.
+#[test]
+fn two_rotated_boxes_difference_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (rotate (0 1 0) 0.7854 (box 1.5 1.5 1.5 :color 0)) \
+         (rotate (0 0 1) 0.5236 (box 0.6 0.6 1.5 :color 1)))",
+    );
+}
+
+/// Two rotated boxes union. Catches the dual of the difference case
+/// — fold-flip bugs in union are usually distinct from difference.
+#[test]
+fn two_rotated_boxes_union_is_geometric() {
+    assert_geometric(
+        "(union \
+         (rotate (0 1 0) 0.5236 (box 1 1 1 :color 0)) \
+         (translate (0.5 0 0) (rotate (0 0 1) 0.5236 (box 1 1 1 :color 1))))",
+    );
+}
+
+/// **Known-failing**: same T-junction → boundary-crack pattern as
+/// `box_minus_tilted_cylinder_is_geometric`. The composition produces
+/// 3 BoundaryEdges on the +Y cube face plus a TJunction within 1.6e-5
+/// of the long edge.
+///
+/// Mixed primitives: union of sphere and box, intersected with a
+/// cylinder. Three distinct facet topologies in one BSP composition.
+#[test]
+fn sphere_or_box_and_cylinder_is_geometric() {
+    assert_geometric(
+        "(intersection \
+         (union (sphere 0.6 12 :color 0) (box 1 1 1 :color 1)) \
+         (cylinder 0.45 2.0 16 :color 2))",
+    );
+}
+
+/// **Known-failing**: amplifies the off-axis T-junction pattern across
+/// three sequential cutters — 6 BoundaryEdges and 2 TJunctions plus
+/// one ExtremeAspectRatio (~2516:1) and one SliverEdge (~4e-4). The
+/// slivers + aspect ratio are the same root cause: BSP fragmentation
+/// snapped a sphere/cylinder facet edge close to but not exactly onto
+/// the cube face, leaving a vertex pair the snap-rounding can't merge.
+///
+/// Multiple rotated cutters at distinct angles through one box. The
+/// closest analogue to the live-substrate three_cut_box but with each
+/// cutter coming in at its own off-axis orientation.
+#[test]
+fn box_minus_three_rotated_cutters_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (box 3.0 1.0 1.5 :color 0) \
+         (translate (-0.9 0 0) (rotate (1 0 0) 0.3 (cylinder 0.3 1.5 16 :color 1))) \
+         (translate (0 0 0) (rotate (0 0 1) 0.5236 (box 0.5 1.5 0.5 :color 2))) \
+         (translate (0.9 0 0) (rotate (0 1 0) 0.3 (cylinder 0.3 1.5 16 :color 3))))",
+    );
+}
+
+/// **Known-failing**: the mesh is watertight (0 manifold violations)
+/// but produces 2 SliverEdges (~9e-4, just under the 1e-3 sliver
+/// threshold). A sphere facet snapped close to a cube edge but not
+/// onto it, leaving a tiny edge fragment. Catches the
+/// shape-quality-only failure mode that watertight asserts miss
+/// entirely.
+///
+/// Non-uniform scale on an otherwise axis-aligned scene. Scale changes
+/// edge lengths asymmetrically — a corner-case for the aspect-ratio
+/// validator and for any BSP code that assumes near-unit edges.
+#[test]
+fn nonuniform_scaled_box_minus_sphere_is_geometric() {
+    assert_geometric(
+        "(scale (2.5 0.6 1.0) \
+         (difference (box 1 1 1 :color 0) (sphere 0.4 12 :color 1)))",
+    );
+}
+
+/// A rotated CSG result wrapped in another rotation. Tests that the
+/// outer transform doesn't introduce numerical error on top of an
+/// already-fragile BSP output.
+#[test]
+fn rotated_csg_then_rotated_again_is_geometric() {
+    assert_geometric(
+        "(rotate (0 0 1) 0.4 \
+         (rotate (1 0 0) 0.4 \
+         (difference (box 1.5 1.5 1.5 :color 0) (box 0.6 0.6 0.6 :color 1))))",
+    );
+}
+
+/// Lathe (curved revolution surface) minus a box. Lathe is the canonical
+/// off-axis-facet primitive — every side facet is rotated by 360/segs
+/// from the previous one, none are world-axis-aligned.
+#[test]
+fn lathe_minus_box_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (lathe ((0 -0.5) (0.5 -0.5) (0.5 0.5) (0 0.5)) 16 :color 0) \
+         (box 0.4 0.4 1.5 :color 1))",
+    );
+}
+
+/// **Hangs (BSP runaway)**: ignored because BSP recursion exceeds
+/// 2 minutes at 100% CPU on this composition. Two facetted curved
+/// primitives with no axis alignment fragment past any reasonable
+/// budget. Un-ignore once BSP performance is bounded for off-axis
+/// curved×curved input.
+///
+/// Lathe minus a tilted cylinder. Two curved-facet primitives with
+/// distinct axes — the worst case for cocircular fragmentation.
+#[test]
+#[ignore]
+fn lathe_minus_tilted_cylinder_is_geometric() {
+    assert_geometric(
+        "(difference \
+         (lathe ((0 -0.5) (0.5 -0.5) (0.5 0.5) (0 0.5)) 16 :color 0) \
+         (rotate (1 0 0) 0.4 (cylinder 0.3 1.5 16 :color 1)))",
+    );
+}
+
+/// **Known-failing (severe)**: the worst-case manifestation of the
+/// off-axis T-junction pattern — 13 BoundaryEdges, 6 TJunctions, 7
+/// SliverEdges, and 2 ExtremeAspectRatios. Curved-on-curved CSG with
+/// no axis alignment exposes every snap-drift failure mode the BSP
+/// has at once. Useful as a stress oracle: any fix that reduces this
+/// count is a forward step.
+///
+/// Two intersecting tilted cylinders. Pure curved-on-curved CSG,
+/// fully off-axis. The polygon-throughout migration's most demanding
+/// shape-quality test.
+#[test]
+fn two_tilted_cylinders_union_is_geometric() {
+    assert_geometric(
+        "(union \
+         (rotate (1 0 0) 0.5 (cylinder 0.4 1.5 16 :color 0)) \
+         (rotate (0 0 1) 0.5 (cylinder 0.4 1.5 16 :color 1)))",
+    );
+}
+
+/// 45° box rotation viewed as a *baseline* for the planarity validator —
+/// no CSG, just a rotated primitive. If this fails, the tolerance is
+/// too tight for legitimate f32 reconstruction noise on rotated input.
+#[test]
+fn rotated_box_no_csg_is_geometric() {
+    assert_geometric("(rotate (0 1 0) 0.7854 (box 1 1 1 :color 0))");
 }

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -154,21 +154,20 @@ fn translated_sphere_is_geometric() {
     assert_geometric("(translate (0.37 0.41 -0.23) (sphere 0.5 12 :color 0))");
 }
 
-/// **Known-failing**: catches the T-junction → boundary-crack class
-/// of bug. The cleanup pipeline produces a vertex on the cube's −Y
-/// face from the tilted cylinder's facet intersection, but doesn't
-/// insert that vertex into the abutting cylinder facet's loop. The
-/// abutting loop then "skips" the new vertex, leaving a tiny boundary
-/// triangle (3 BoundaryEdges) and the validator flags the offending
-/// vertex as a TJunction within 3e-5 of the long edge. Same root cause
-/// as `box_minus_enclosed_sphere_is_watertight` and friends — the
-/// polygon-throughout migration fixed the axis-aligned case but not
-/// the off-axis one.
+/// **Ignored (off-axis T-junction class)**: the cleanup pipeline
+/// produces a vertex on the cube's −Y face from the tilted cylinder's
+/// facet intersection, but doesn't insert that vertex into the
+/// abutting cylinder facet's loop. The abutting loop "skips" the new
+/// vertex, leaving a tiny boundary triangle (3 BoundaryEdges) and the
+/// validator flags the offending vertex as a TJunction within 3e-5 of
+/// the long edge. Un-ignore once the off-axis cleanup vertex
+/// insertion is fixed (see follow-up issue).
 ///
 /// Box with a 30°-rotated cylinder cutter through it. Off-axis cutter
 /// vs. axis-aligned solid — exercises the cube-face-clipped-by-non-
 /// orthogonal-cylinder-facet path that axis-aligned tests skip.
 #[test]
+#[ignore]
 fn box_minus_tilted_cylinder_is_geometric() {
     assert_geometric(
         "(difference \
@@ -210,7 +209,7 @@ fn two_rotated_boxes_union_is_geometric() {
     );
 }
 
-/// **Known-failing**: same T-junction → boundary-crack pattern as
+/// **Ignored (off-axis T-junction class)**: same root cause as
 /// `box_minus_tilted_cylinder_is_geometric`. The composition produces
 /// 3 BoundaryEdges on the +Y cube face plus a TJunction within 1.6e-5
 /// of the long edge.
@@ -218,6 +217,7 @@ fn two_rotated_boxes_union_is_geometric() {
 /// Mixed primitives: union of sphere and box, intersected with a
 /// cylinder. Three distinct facet topologies in one BSP composition.
 #[test]
+#[ignore]
 fn sphere_or_box_and_cylinder_is_geometric() {
     assert_geometric(
         "(intersection \
@@ -226,17 +226,19 @@ fn sphere_or_box_and_cylinder_is_geometric() {
     );
 }
 
-/// **Known-failing**: amplifies the off-axis T-junction pattern across
-/// three sequential cutters — 6 BoundaryEdges and 2 TJunctions plus
-/// one ExtremeAspectRatio (~2516:1) and one SliverEdge (~4e-4). The
-/// slivers + aspect ratio are the same root cause: BSP fragmentation
-/// snapped a sphere/cylinder facet edge close to but not exactly onto
-/// the cube face, leaving a vertex pair the snap-rounding can't merge.
+/// **Ignored (off-axis T-junction class, severe)**: amplifies the
+/// pattern across three sequential cutters — 6 BoundaryEdges and 2
+/// TJunctions plus one ExtremeAspectRatio (~2516:1) and one SliverEdge
+/// (~4e-4). The slivers + aspect ratio are the same root cause: BSP
+/// fragmentation snapped a sphere/cylinder facet edge close to but not
+/// exactly onto the cube face, leaving a vertex pair the snap-rounding
+/// can't merge.
 ///
 /// Multiple rotated cutters at distinct angles through one box. The
 /// closest analogue to the live-substrate three_cut_box but with each
 /// cutter coming in at its own off-axis orientation.
 #[test]
+#[ignore]
 fn box_minus_three_rotated_cutters_is_geometric() {
     assert_geometric(
         "(difference \
@@ -247,10 +249,10 @@ fn box_minus_three_rotated_cutters_is_geometric() {
     );
 }
 
-/// **Known-failing**: the mesh is watertight (0 manifold violations)
-/// but produces 2 SliverEdges (~9e-4, just under the 1e-3 sliver
-/// threshold). A sphere facet snapped close to a cube edge but not
-/// onto it, leaving a tiny edge fragment. Catches the
+/// **Ignored (sliver-only)**: the mesh is watertight (0 manifold
+/// violations) but produces 2 SliverEdges (~9e-4, just under the 1e-3
+/// sliver threshold). A sphere facet snapped close to a cube edge but
+/// not onto it, leaving a tiny edge fragment. Catches the
 /// shape-quality-only failure mode that watertight asserts miss
 /// entirely.
 ///
@@ -258,6 +260,7 @@ fn box_minus_three_rotated_cutters_is_geometric() {
 /// edge lengths asymmetrically — a corner-case for the aspect-ratio
 /// validator and for any BSP code that assumes near-unit edges.
 #[test]
+#[ignore]
 fn nonuniform_scaled_box_minus_sphere_is_geometric() {
     assert_geometric(
         "(scale (2.5 0.6 1.0) \
@@ -307,17 +310,17 @@ fn lathe_minus_tilted_cylinder_is_geometric() {
     );
 }
 
-/// **Known-failing (severe)**: the worst-case manifestation of the
-/// off-axis T-junction pattern — 13 BoundaryEdges, 6 TJunctions, 7
-/// SliverEdges, and 2 ExtremeAspectRatios. Curved-on-curved CSG with
-/// no axis alignment exposes every snap-drift failure mode the BSP
-/// has at once. Useful as a stress oracle: any fix that reduces this
-/// count is a forward step.
+/// **Ignored (worst-case off-axis manifestation)**: 13 BoundaryEdges,
+/// 6 TJunctions, 7 SliverEdges, and 2 ExtremeAspectRatios. Curved-on-
+/// curved CSG with no axis alignment exposes every snap-drift failure
+/// mode the BSP has at once. Useful as a stress oracle once
+/// un-ignored: any fix that reduces this count is a forward step.
 ///
 /// Two intersecting tilted cylinders. Pure curved-on-curved CSG,
 /// fully off-axis. The polygon-throughout migration's most demanding
 /// shape-quality test.
 #[test]
+#[ignore]
 fn two_tilted_cylinders_union_is_geometric() {
     assert_geometric(
         "(union \


### PR DESCRIPTION
## Summary
- Adds four geometric validators to `aether-dsl-mesh::debug` covering shape/quality failures the existing `validate_manifold` (topology only) misses: planarity, polygon quality (sliver edges, degenerate area, aspect ratio), normal coherence, T-junctions. `validate_geometry` composes them with `validate_manifold`.
- Extends the regression corpus with 15 off-axis cases (rotated / scaled / mixed-primitive CSG) using a stronger `assert_geometric` helper. The existing axis-aligned tests are cocircular-biased and miss tessellation-domain bugs; the new corpus surfaces them.
- Triage: 9 of the 15 new cases pass; 5 fail with the same root-cause family (off-axis cleanup misses a vertex insertion, leaving a T-junction within ~2-5e-5 of the boundary edge it should have been on); 1 hits a BSP perf cliff (>2 min at 100% CPU on facetted-curved x facetted-curved off-axis input). The 6 failing/hanging cases are marked `#[ignore]` with un-ignore pointers in their docstrings; follow-up issues will track each.

## Test plan
- [x] `cargo test -p aether-dsl-mesh --lib` — 228 pass (4 new validator unit tests added)
- [x] `cargo test -p aether-dsl-mesh --test regression --release` — 19 pass, 0 fail, 6 ignored (the corpus's deliverable failures, gated until fixed)
- [x] `cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

To run the ignored cases locally and observe the catches: `cargo test -p aether-dsl-mesh --test regression --release -- --ignored`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>