### PR TITLE
fix(dsl-mesh): raise t-junction collinearity tolerance for cascaded snap drift

### DIFF
--- a/crates/aether-dsl-mesh/src/csg/cleanup/tjunctions.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/tjunctions.rs
@@ -105,19 +105,25 @@ impl IndexedMesh {
 
 /// Snap-drift bound for the collinearity check: a vertex within this
 /// many fixed units of perpendicular distance from the edge is treated
-/// as collinear. **This is not a magic number** — it's the
-/// mathematically derived bound from
-/// [`crate::csg::polygon`]'s `compute_intersection` rounding step.
+/// as collinear.
 ///
-/// Derivation: each `compute_intersection` snaps the result by up to
-/// 0.5 fixed units per axis. Two intersection points on the same true
-/// line, each independently snapped, can land up to 0.5 + 0.5 = 1
-/// fixed unit apart in perpendicular direction. Even with the
-/// per-line [`crate::csg::vertex_pool::SharedVertexPool`] catching
-/// near-duplicates, distinct points on the same line each accumulate
-/// up to 0.5 units of drift, so checking collinearity between two
-/// pool entries needs to allow up to 1 unit of perpendicular slack.
-const COLLINEAR_TOLERANCE_FIXED_UNITS: i128 = 1;
+/// Derivation matches [`super::weld::WELD_TOLERANCE_FIXED_UNITS`] —
+/// each `compute_intersection` snaps by up to 0.5 fixed units per
+/// axis, and under the polygon-throughout pipeline (PR 292) cleanup
+/// runs once at the end of an entire CSG composition, so a single
+/// vertex can accumulate snap drift from every BSP partitioner the
+/// fragment survived. Empirically (off-axis CSG corpus, PR 298): a
+/// 16-facet tilted cylinder cut through a cube produces T-junction
+/// vertices up to ~3.5 fixed units perpendicular to the host edge.
+/// Tolerance `4` catches every observed case with margin and stays
+/// well below the next-nearest distinct-point spacing in practical
+/// CSG inputs (sphere/cylinder facet spacing ≥ 3000+ fixed units).
+///
+/// Raised from `1` to `4` (2026-04-26) after the geometric-validator
+/// corpus showed off-axis CSG produces T-junctions at perpendicular
+/// distances of 1.0 to 3.5 fixed units that the prior tolerance
+/// silently dropped, leaving render-visible cracks. See issue #299.
+const COLLINEAR_TOLERANCE_FIXED_UNITS: i128 = 4;
 
 /// Between-ness test in 3D fixed-point: returns `true` iff `p` lies
 /// on the open segment from `a` to `b`, within
@@ -414,6 +420,42 @@ mod tests {
         let mesh = IndexedMesh { vertices, polygons };
         let repaired = mesh.repair_tjunctions();
         assert_eq!(repaired.polygons[0].vertices, vec![0, 3, 1, 4, 2]);
+    }
+
+    /// Off-axis CSG accumulates snap drift across cascaded BSP cuts;
+    /// the failing T-junction from `box_minus_tilted_cylinder_is_geometric`
+    /// (PR 298) sits 2.05 fixed units perpendicular to its host edge.
+    /// Pinned with the actual fixed-point coords so a regression in
+    /// `COLLINEAR_TOLERANCE_FIXED_UNITS` re-exposes the bug at the unit
+    /// level rather than only via the integration corpus.
+    #[test]
+    fn off_axis_t_junction_within_cascaded_snap_drift_is_detected() {
+        // Coords lifted from validate_no_t_junctions on the failing
+        // case: vertex at (-0.0961, -0.75, -0.7010), edge endpoints
+        // (-0.1824, -0.75, -0.7009) → (0, -0.75, -0.7010). Snapped
+        // to 16:16 fixed:
+        let a = Point3 {
+            x: -11951,
+            y: -49152,
+            z: -45936,
+        };
+        let b = Point3 {
+            x: 0,
+            y: -49152,
+            z: -45938,
+        };
+        let v = Point3 {
+            x: -6299,
+            y: -49152,
+            z: -45939,
+        };
+        // Perpendicular distance: ~2.05 fixed units, within the
+        // post-fix collinearity tolerance.
+        assert!(
+            is_strictly_between(v, a, b),
+            "off-axis T-junction at ~2 fixed units perpendicular drift \
+             must be classified as collinear (issue #299)"
+        );
     }
 
     #[test]

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -154,20 +154,17 @@ fn translated_sphere_is_geometric() {
     assert_geometric("(translate (0.37 0.41 -0.23) (sphere 0.5 12 :color 0))");
 }
 
-/// **Ignored (off-axis T-junction class)**: the cleanup pipeline
-/// produces a vertex on the cube's −Y face from the tilted cylinder's
-/// facet intersection, but doesn't insert that vertex into the
-/// abutting cylinder facet's loop. The abutting loop "skips" the new
-/// vertex, leaving a tiny boundary triangle (3 BoundaryEdges) and the
-/// validator flags the offending vertex as a TJunction within 3e-5 of
-/// the long edge. Un-ignore once the off-axis cleanup vertex
-/// insertion is fixed (see follow-up issue).
+/// **Regression**: the off-axis T-junction repair fix (issue #299) —
+/// `COLLINEAR_TOLERANCE_FIXED_UNITS` raised from 1 to 4 to absorb
+/// snap-drift accumulated across cascaded BSP cuts. Pre-fix this
+/// composition produced 3 BoundaryEdges on the cube's −Y face plus a
+/// TJunction at ~2.05 fixed units perpendicular drift; the prior
+/// 1-unit collinearity bound silently dropped the vertex insertion.
 ///
 /// Box with a 30°-rotated cylinder cutter through it. Off-axis cutter
 /// vs. axis-aligned solid — exercises the cube-face-clipped-by-non-
 /// orthogonal-cylinder-facet path that axis-aligned tests skip.
 #[test]
-#[ignore]
 fn box_minus_tilted_cylinder_is_geometric() {
     assert_geometric(
         "(difference \
@@ -209,15 +206,14 @@ fn two_rotated_boxes_union_is_geometric() {
     );
 }
 
-/// **Ignored (off-axis T-junction class)**: same root cause as
-/// `box_minus_tilted_cylinder_is_geometric`. The composition produces
-/// 3 BoundaryEdges on the +Y cube face plus a TJunction within 1.6e-5
-/// of the long edge.
+/// **Regression**: same off-axis T-junction repair fix as
+/// `box_minus_tilted_cylinder_is_geometric` (issue #299). Pre-fix this
+/// composition produced 3 BoundaryEdges on the +Y cube face plus a
+/// TJunction at ~1.05 fixed units perpendicular drift.
 ///
 /// Mixed primitives: union of sphere and box, intersected with a
 /// cylinder. Three distinct facet topologies in one BSP composition.
 #[test]
-#[ignore]
 fn sphere_or_box_and_cylinder_is_geometric() {
     assert_geometric(
         "(intersection \
@@ -226,13 +222,14 @@ fn sphere_or_box_and_cylinder_is_geometric() {
     );
 }
 
-/// **Ignored (off-axis T-junction class, severe)**: amplifies the
-/// pattern across three sequential cutters — 6 BoundaryEdges and 2
-/// TJunctions plus one ExtremeAspectRatio (~2516:1) and one SliverEdge
-/// (~4e-4). The slivers + aspect ratio are the same root cause: BSP
-/// fragmentation snapped a sphere/cylinder facet edge close to but not
-/// exactly onto the cube face, leaving a vertex pair the snap-rounding
-/// can't merge.
+/// **Ignored (sliver-edge class)**: the off-axis T-junction fix
+/// (issue #299) eliminated the boundary-edge cracks here, but the
+/// composition still produces 2 SliverEdges (~4e-4) and 2
+/// ExtremeAspectRatios (~2516:1) on a cylinder/cube near-coincident
+/// facet pair. The root cause is a different bug: BSP produces two
+/// distinct vertices ~9 fixed units apart in one axis (above the
+/// `WELD_TOLERANCE_FIXED_UNITS = 4` weld bound, so they survive
+/// cleanup as separate vertices that bound a sliver edge).
 ///
 /// Multiple rotated cutters at distinct angles through one box. The
 /// closest analogue to the live-substrate three_cut_box but with each
@@ -249,12 +246,12 @@ fn box_minus_three_rotated_cutters_is_geometric() {
     );
 }
 
-/// **Ignored (sliver-only)**: the mesh is watertight (0 manifold
-/// violations) but produces 2 SliverEdges (~9e-4, just under the 1e-3
-/// sliver threshold). A sphere facet snapped close to a cube edge but
-/// not onto it, leaving a tiny edge fragment. Catches the
-/// shape-quality-only failure mode that watertight asserts miss
-/// entirely.
+/// **Ignored (sliver-edge class)**: same root cause as
+/// `box_minus_three_rotated_cutters_is_geometric` — mesh is watertight
+/// (0 manifold violations) but BSP left a near-duplicate vertex pair
+/// that bounds a 2-SliverEdge sequence (~9e-4). Pre-existing before
+/// the issue #299 fix; un-ignore once near-duplicate elimination
+/// (separate issue) lands.
 ///
 /// Non-uniform scale on an otherwise axis-aligned scene. Scale changes
 /// edge lengths asymmetrically — a corner-case for the aspect-ratio
@@ -310,11 +307,15 @@ fn lathe_minus_tilted_cylinder_is_geometric() {
     );
 }
 
-/// **Ignored (worst-case off-axis manifestation)**: 13 BoundaryEdges,
-/// 6 TJunctions, 7 SliverEdges, and 2 ExtremeAspectRatios. Curved-on-
-/// curved CSG with no axis alignment exposes every snap-drift failure
-/// mode the BSP has at once. Useful as a stress oracle once
-/// un-ignored: any fix that reduces this count is a forward step.
+/// **Ignored (sliver-edge class, severe)**: the off-axis T-junction
+/// fix (issue #299) reduced manifold violations from 13 to 3, but the
+/// composition still produces a SingularEdge plus 2 BoundaryEdges
+/// rooted in the same near-duplicate-vertex bug as
+/// `box_minus_three_rotated_cutters_is_geometric` (BSP leaves vertices
+/// ~9 fixed units apart in one axis, above the weld bound). The
+/// remaining geometry violations (slivers, extreme aspect ratios) are
+/// downstream of the same near-duplicate pair. Useful as a stress
+/// oracle: any fix that reduces this count is a forward step.
 ///
 /// Two intersecting tilted cylinders. Pure curved-on-curved CSG,
 /// fully off-axis. The polygon-throughout migration's most demanding


### PR DESCRIPTION
## Summary
- `repair_tjunctions` used `COLLINEAR_TOLERANCE_FIXED_UNITS = 1`, derived for a single `compute_intersection` snap. Off-axis CSG accumulates drift across cascaded BSP cuts; the T-junction validators added in PR 298 caught vertices 1.0-3.5 fixed units perpendicular off the host edge that the prior 1-unit bound silently dropped, leaving render-visible cracks.
- Raises the tolerance to 4, matching `weld.rs`'s tolerance which was bumped for the same accumulated-drift reason on 2026-04-26. Next-nearest distinct-point spacing in practical CSG inputs is ~3000+ fixed units, so no false-positive risk.
- Pinned with a unit test using the actual failing fixed-point coords from `box_minus_tilted_cylinder_is_geometric` (~2.05 fixed units perpendicular drift) so a regression in the constant re-exposes the bug at the unit level.
- Un-ignores 2 of the 4 T-junction-class corpus tests (`box_minus_tilted_cylinder_is_geometric`, `sphere_or_box_and_cylinder_is_geometric`). The other 3 ignored cases (3-rotated-cutters, 2-tilted-cylinders, nonuniform-scaled-box-minus-sphere) still fail on a separate near-duplicate-vertex bug class — docstrings updated to reflect the distinction; follow-up issue to track.

Resolves issue 299.

## Test plan
- [x] `cargo test -p aether-dsl-mesh --lib` — 229 pass (1 new tjunction unit test)
- [x] `cargo test -p aether-dsl-mesh --test regression --release` — 21 pass (was 19), 0 fail, 4 ignored (was 6)
- [x] `cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>