### PR TITLE
refactor(dsl-mesh): distribute difference over union + AABB-prune subtractors

### DIFF
--- a/crates/aether-dsl-mesh/src/mesh.rs
+++ b/crates/aether-dsl-mesh/src/mesh.rs
@@ -276,7 +276,7 @@ fn mesh_into_polygons(
 /// `true` when `node` is a CSG-leaf: contains no Union, Intersection,
 /// or Difference at any depth. Primitives, transforms of primitives,
 /// and compositions of leaves all qualify.
-fn is_csg_leaf(node: &Node) -> bool {
+pub(crate) fn is_csg_leaf(node: &Node) -> bool {
     match node {
         Node::Box { .. }
         | Node::Cylinder { .. }
@@ -1005,6 +1005,44 @@ mod tests {
         from_union.sort_by_key(key);
         from_comp.sort_by_key(key);
         assert_eq!(from_union, from_comp);
+    }
+
+    /// End-to-end equivalence for the difference-distribution rewrite:
+    /// a `(difference (union A B) Y)` where Y only touches A produces
+    /// the same triangle set as the hand-distributed
+    /// `(composition (difference A Y) B)`. Verifies the rewrite chain
+    /// (distribute → AABB-prune-arms → disjoint-union-to-composition)
+    /// preserves geometry.
+    #[test]
+    fn difference_over_disjoint_arm_union_matches_hand_distribution() {
+        use crate::parse;
+        let auto = parse(
+            "(difference \
+             (union (box 4 4 4 :color 0) (translate (20 0 0) (box 4 4 4 :color 1))) \
+             (box 1 1 1 :color 9))",
+        )
+        .unwrap();
+        let manual = parse(
+            "(composition \
+             (difference (box 4 4 4 :color 0) (box 1 1 1 :color 9)) \
+             (translate (20 0 0) (box 4 4 4 :color 1)))",
+        )
+        .unwrap();
+        let mut from_auto = mesh(&auto).unwrap();
+        let mut from_manual = mesh(&manual).unwrap();
+        let key = |t: &Triangle| {
+            let mut buf: Vec<u8> = Vec::with_capacity(40);
+            for v in &t.vertices {
+                for c in v {
+                    buf.extend_from_slice(&c.to_le_bytes());
+                }
+            }
+            buf.extend_from_slice(&t.color.to_le_bytes());
+            buf
+        };
+        from_auto.sort_by_key(key);
+        from_manual.sort_by_key(key);
+        assert_eq!(from_auto, from_manual);
     }
 
     /// Pin: an *overlapping* union still goes through the BSP path.

--- a/crates/aether-dsl-mesh/src/simplify.rs
+++ b/crates/aether-dsl-mesh/src/simplify.rs
@@ -484,6 +484,22 @@ fn parallel_axis_sign(a: [f32; 3], b: [f32; 3]) -> Option<f32> {
 ///   BSP, which is exact when the inputs share zero volume — the
 ///   resulting boundary loops are identical, and the root cleanup pass
 ///   handles welding the same way for either path.
+/// - `(difference X [Y_1 … Y_n])` drops any subtractor `Y_i` whose
+///   AABB doesn't touch the base's AABB — subtracting something
+///   geometrically separate is a no-op. If every subtractor gets
+///   pruned, the rewrite returns the bare base.
+///
+/// Algebraic distribution:
+/// - `(difference (union A B …) Y_1 … Y_n)` distributes to
+///   `(union (difference A Y_1 … Y_n) (difference B Y_1 … Y_n) …)`
+///   when both the union's children and every subtractor are
+///   CSG-leaves (per [`crate::mesh::is_csg_leaf`]). The set-algebra
+///   identity is exact; we restrict to leaves to avoid amplifying
+///   T-junctions/slivers from a composite operand. Distribution
+///   unlocks per-arm AABB pruning of the inner differences and the
+///   subsequent disjoint-union rewrite, which together collapse most
+///   "bunch of parts minus one cutter" inputs to a flat composition
+///   that skips BSP entirely.
 ///
 /// Identity rules for `Mirror` are intentionally absent — every mirror
 /// flips winding regardless of axis, so there's no zero-effect form.
@@ -642,10 +658,48 @@ pub fn simplify(node: &Node) -> Node {
         Node::Intersection { children } => Node::Intersection {
             children: children.iter().map(simplify).collect(),
         },
-        Node::Difference { base, subtract } => Node::Difference {
-            base: Box::new(simplify(base)),
-            subtract: subtract.iter().map(simplify).collect(),
-        },
+        Node::Difference { base, subtract } => {
+            let subtract: Vec<Node> = subtract.iter().map(simplify).collect();
+
+            // Distribution check happens on the *unsimplified* base —
+            // simplifying it first would convert a disjoint Union to a
+            // Composition, hiding the Union pattern from us.
+            if let Node::Union { children } = base.as_ref()
+                && children.iter().all(crate::mesh::is_csg_leaf)
+                && subtract.iter().all(crate::mesh::is_csg_leaf)
+            {
+                // Each arm gets the full subtractor list (cloned) and
+                // is recursively simplified so per-arm AABB-prune and
+                // disjoint-union rewrites can fire on the smaller
+                // pieces. The wrapping Union is then simplified so
+                // disjoint arms collapse into a Composition.
+                let arms: Vec<Node> = children
+                    .iter()
+                    .map(|c| {
+                        simplify(&Node::Difference {
+                            base: Box::new(c.clone()),
+                            subtract: subtract.clone(),
+                        })
+                    })
+                    .collect();
+                return simplify(&Node::Union { children: arms });
+            }
+
+            // No distribution — simplify base, AABB-prune subtractors.
+            let base = simplify(base);
+            let base_aabb = compute_aabb(&base);
+            let pruned: Vec<Node> = subtract
+                .into_iter()
+                .filter(|s| compute_aabb(s).intersects(&base_aabb))
+                .collect();
+            if pruned.is_empty() {
+                return base;
+            }
+            Node::Difference {
+                base: Box::new(base),
+                subtract: pruned,
+            }
+        }
     }
 }
 
@@ -1781,8 +1835,6 @@ mod fold_transform_tests {
         }
     }
 
-    // ---- Translate folding ----
-
     #[test]
     fn nested_translate_folds_to_one() {
         let n = Node::Translate {
@@ -1853,8 +1905,6 @@ mod fold_transform_tests {
         assert_eq!(simplify(&n), n);
     }
 
-    // ---- Scale folding ----
-
     #[test]
     fn nested_scale_folds_to_componentwise_product() {
         let n = Node::Scale {
@@ -1906,8 +1956,6 @@ mod fold_transform_tests {
             }
         );
     }
-
-    // ---- Rotate folding ----
 
     #[test]
     fn nested_rotate_same_axis_sums_angles() {
@@ -2010,8 +2058,6 @@ mod fold_transform_tests {
         }
     }
 
-    // ---- Cross-shape ----
-
     #[test]
     fn translate_does_not_fold_into_scale_or_vice_versa() {
         // (translate offset (scale s leaf)) cannot be expressed as
@@ -2042,6 +2088,284 @@ mod fold_transform_tests {
                     }),
                 }),
             }),
+        };
+        let once = simplify(&n);
+        let twice = simplify(&once);
+        assert_eq!(once, twice);
+    }
+}
+
+#[cfg(test)]
+mod difference_rewrite_tests {
+    use super::*;
+
+    fn unit_box() -> Node {
+        Node::Box {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            color: 0,
+        }
+    }
+
+    fn box_at(x: f32, y: f32, z: f32) -> Node {
+        let unit = unit_box();
+        if (x, y, z) == (0.0, 0.0, 0.0) {
+            unit
+        } else {
+            Node::Translate {
+                offset: [x, y, z],
+                child: Box::new(unit),
+            }
+        }
+    }
+
+    #[test]
+    fn single_disjoint_subtractor_drops_to_bare_base() {
+        let n = Node::Difference {
+            base: Box::new(unit_box()),
+            subtract: vec![box_at(10.0, 0.0, 0.0)],
+        };
+        assert_eq!(simplify(&n), unit_box());
+    }
+
+    #[test]
+    fn one_of_two_disjoint_subtractors_is_pruned() {
+        // First subtractor overlaps base, second doesn't — keep only first.
+        let n = Node::Difference {
+            base: Box::new(Node::Box {
+                x: 4.0,
+                y: 4.0,
+                z: 4.0,
+                color: 0,
+            }),
+            subtract: vec![box_at(0.0, 0.0, 0.0), box_at(20.0, 0.0, 0.0)],
+        };
+        let s = simplify(&n);
+        match s {
+            Node::Difference { subtract, .. } => {
+                assert_eq!(subtract.len(), 1);
+                assert_eq!(subtract[0], box_at(0.0, 0.0, 0.0));
+            }
+            other => panic!("expected Difference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_disjoint_subtractors_collapse_to_base() {
+        let n = Node::Difference {
+            base: Box::new(unit_box()),
+            subtract: vec![box_at(10.0, 0.0, 0.0), box_at(0.0, 10.0, 0.0)],
+        };
+        assert_eq!(simplify(&n), unit_box());
+    }
+
+    #[test]
+    fn no_subtractors_are_pruned_when_all_overlap() {
+        let n = Node::Difference {
+            base: Box::new(Node::Box {
+                x: 4.0,
+                y: 4.0,
+                z: 4.0,
+                color: 0,
+            }),
+            subtract: vec![box_at(0.0, 0.0, 0.0), box_at(0.5, 0.0, 0.0)],
+        };
+        let s = simplify(&n);
+        match s {
+            Node::Difference { subtract, .. } => assert_eq!(subtract.len(), 2),
+            other => panic!("expected Difference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn touching_face_subtractor_is_kept() {
+        // Pin: closed-set semantics from intersects mean shared-face
+        // counts as overlapping → don't prune.
+        let n = Node::Difference {
+            base: Box::new(Node::Box {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+                color: 0,
+            }),
+            subtract: vec![Node::Translate {
+                offset: [1.0, 0.0, 0.0],
+                child: Box::new(Node::Box {
+                    x: 1.0,
+                    y: 1.0,
+                    z: 1.0,
+                    color: 1,
+                }),
+            }],
+        };
+        let s = simplify(&n);
+        assert!(matches!(s, Node::Difference { .. }));
+    }
+
+    #[test]
+    fn difference_distributes_over_leaf_union_base() {
+        // (difference (union A B) Y) where A overlaps Y, B doesn't.
+        // Distribution + per-arm AABB-prune + disjoint-union rewrites
+        // collapse the whole thing to a composition.
+        let big_a = Node::Box {
+            x: 4.0,
+            y: 4.0,
+            z: 4.0,
+            color: 0,
+        };
+        let big_b = Node::Translate {
+            offset: [20.0, 0.0, 0.0],
+            child: Box::new(Node::Box {
+                x: 4.0,
+                y: 4.0,
+                z: 4.0,
+                color: 1,
+            }),
+        };
+        let cutter = Node::Box {
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+            color: 9,
+        };
+        let n = Node::Difference {
+            base: Box::new(Node::Union {
+                children: vec![big_a.clone(), big_b.clone()],
+            }),
+            subtract: vec![cutter.clone()],
+        };
+        let s = simplify(&n);
+        match s {
+            Node::Composition(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(
+                    matches!(&items[0], Node::Difference { .. }),
+                    "first arm should be Difference (A overlaps cutter), got {:?}",
+                    items[0]
+                );
+                assert_eq!(items[1], big_b);
+            }
+            other => panic!("expected Composition after full chain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn distribution_blocked_by_composite_subtractor() {
+        // Subtractor contains a Union → not a CSG-leaf → distribution
+        // skipped, structure preserved.
+        let composite_subtractor = Node::Union {
+            children: vec![
+                Node::Box {
+                    x: 1.0,
+                    y: 1.0,
+                    z: 1.0,
+                    color: 1,
+                },
+                Node::Translate {
+                    offset: [0.5, 0.0, 0.0],
+                    child: Box::new(Node::Box {
+                        x: 1.0,
+                        y: 1.0,
+                        z: 1.0,
+                        color: 2,
+                    }),
+                },
+            ],
+        };
+        let n = Node::Difference {
+            base: Box::new(Node::Union {
+                children: vec![
+                    Node::Box {
+                        x: 4.0,
+                        y: 4.0,
+                        z: 4.0,
+                        color: 0,
+                    },
+                    Node::Box {
+                        x: 4.0,
+                        y: 4.0,
+                        z: 4.0,
+                        color: 1,
+                    },
+                ],
+            }),
+            subtract: vec![composite_subtractor],
+        };
+        let s = simplify(&n);
+        assert!(
+            matches!(s, Node::Difference { .. }),
+            "expected Difference (composite subtractor blocks distribution), got {s:?}"
+        );
+    }
+
+    #[test]
+    fn distribution_blocked_when_union_child_is_composite() {
+        let composite_child = Node::Difference {
+            base: Box::new(Node::Box {
+                x: 4.0,
+                y: 4.0,
+                z: 4.0,
+                color: 0,
+            }),
+            subtract: vec![Node::Box {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+                color: 9,
+            }],
+        };
+        let n = Node::Difference {
+            base: Box::new(Node::Union {
+                children: vec![
+                    composite_child,
+                    Node::Box {
+                        x: 4.0,
+                        y: 4.0,
+                        z: 4.0,
+                        color: 1,
+                    },
+                ],
+            }),
+            subtract: vec![Node::Box {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+                color: 2,
+            }],
+        };
+        let s = simplify(&n);
+        assert!(matches!(s, Node::Difference { .. }));
+    }
+
+    #[test]
+    fn rewrite_is_idempotent() {
+        let n = Node::Difference {
+            base: Box::new(Node::Union {
+                children: vec![
+                    Node::Box {
+                        x: 4.0,
+                        y: 4.0,
+                        z: 4.0,
+                        color: 0,
+                    },
+                    Node::Translate {
+                        offset: [20.0, 0.0, 0.0],
+                        child: Box::new(Node::Box {
+                            x: 4.0,
+                            y: 4.0,
+                            z: 4.0,
+                            color: 1,
+                        }),
+                    },
+                ],
+            }),
+            subtract: vec![Node::Box {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+                color: 9,
+            }],
         };
         let once = simplify(&n);
         let twice = simplify(&once);


### PR DESCRIPTION
## Summary

Fourth PR in the issue 300 sequence. Two more rewrites on the `simplify`
pre-pass's Difference arm — together they turn the common
"scene-minus-cutter" shape into a flat composition that skips BSP for
every untouched part. Sets up the wedge-decomposition rewrite (planned
PR 5) by giving it the algebraic distribution it needs to be useful.

### What changes

**AABB-prune-subtractor.** Any subtractor whose AABB doesn't touch
the base's AABB is dropped — subtracting something geometrically
separate is a no-op. If every subtractor gets pruned, the rewrite
returns the bare base.

**Distribute-over-union.** `(difference (union A B …) Y_1 … Y_n)`
distributes to `(union (difference A Y_1 … Y_n) (difference B Y_1 …
Y_n) …)` when the union's children and every subtractor are CSG-leaves
(per `mesh::is_csg_leaf`, now bumped to `pub(crate)`). The
set-algebra identity is exact; the leaf restriction matches the
existing chained-difference rewrite's safety guarantee from
`feedback_csg_ast_rewrites_skip_composite.md`.

### Sequencing detail

The distribution check inspects the *unsimplified* base. Simplifying
first would let the disjoint-union rewrite collapse a Union into a
Composition, hiding the Union pattern. After distribution, each arm
is recursively simplified — that's where the per-arm AABB-prune fires
and where the wrapping Union may further collapse to a Composition.

Worked example: `(difference (union A_at_origin B_at_20) cutter_at_origin)`
1. Top-level: base is `Union`, all leaves, subtractor is leaf → distribute
2. Build `Union[Difference(A, [cutter]), Difference(B, [cutter])]`
3. Recursively simplify each arm:
   - `Difference(A, [cutter])` — cutter overlaps A → kept as Difference
   - `Difference(B, [cutter])` — cutter disjoint from B → pruned to bare B
4. Recursively simplify the wrapper: `Union[Difference(A, [cutter]), B]`
   has disjoint children → rewrites to `Composition[…]`

Final shape: `Composition[Difference(A, [cutter]), B]`. B never touches
BSP; A's difference is small.

### Test coverage (11 new)
- `difference_rewrite_tests` (10) — single + N-of-N + all-disjoint +
  no-prune cases for the AABB filter, touching-face-stays guard,
  basic distribution, composite-subtractor blocks distribution,
  composite-union-child blocks distribution, idempotence.
- `mesh::tests` (1) — end-to-end equivalence between
  `(difference (union A B) Y)` (auto-rewritten) and
  `(composition (difference A Y) B)` (hand-distributed). Sorted-equal
  triangle lists.

`is_csg_leaf` bumped to `pub(crate)` so simplify can call it (mirrors
the same convention used for `rotate_axis_angle` in PR 305).

### Drive-by cleanup
Removes four section-divider comments (`// ---- Translate folding ----`,
etc.) that I shouldn't have written in PR 307 — per
`feedback_no_divider_comments.md`, the codebase splits into modules
when visual structure is needed instead of using banner comments.

## Test plan
- [x] `cargo test -p aether-dsl-mesh --lib` — 344 pass (334 prior + 10 new), 9 ignored
- [x] `cargo test -p aether-dsl-mesh --tests --release` — 9 integration + 24 regression pass
- [x] `cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)