### PR TITLE
feat(dsl-mesh): wedge-decompose axis-closed lathes (fixes issue 300)

### DIFF
--- a/crates/aether-dsl-mesh/src/ast.rs
+++ b/crates/aether-dsl-mesh/src/ast.rs
@@ -41,6 +41,22 @@ pub enum Node {
         segments: u32,
         color: u32,
     },
+    /// One angular slice of a [`Node::Lathe`] revolved into a closed
+    /// solid: a wedge bounded by two radial walls (at the slice's start
+    /// and end angles) and the lathe's outer surface restricted to the
+    /// slice's angular range. Internal-only — emitted by the wedge-
+    /// decomposition rewrite in [`crate::simplify`] when a lathe's
+    /// profile is axis-closed (first and last profile points have
+    /// `x == 0`). Not parseable from DSL source.
+    ///
+    /// `segment_index` ranges over `0..segments`; the slice covers
+    /// `[segment_index · 2π/segments, (segment_index+1) · 2π/segments]`.
+    LatheSegment {
+        profile: Vec<[f32; 2]>,
+        segments: u32,
+        segment_index: u32,
+        color: u32,
+    },
     Extrude {
         profile: Vec<[f32; 2]>,
         depth: f32,

--- a/crates/aether-dsl-mesh/src/mesh.rs
+++ b/crates/aether-dsl-mesh/src/mesh.rs
@@ -81,6 +81,12 @@ fn mesh_into_polygons(
             segments,
             color,
         } => mesh_lathe(out, profile, *segments, *color, offset),
+        Node::LatheSegment {
+            profile,
+            segments,
+            segment_index,
+            color,
+        } => mesh_lathe_segment(out, profile, *segments, *segment_index, *color, offset),
         Node::Torus {
             major_radius,
             minor_radius,
@@ -284,6 +290,7 @@ pub(crate) fn is_csg_leaf(node: &Node) -> bool {
         | Node::Wedge { .. }
         | Node::Sphere { .. }
         | Node::Lathe { .. }
+        | Node::LatheSegment { .. }
         | Node::Extrude { .. }
         | Node::Torus { .. }
         | Node::Sweep { .. } => true,
@@ -525,6 +532,78 @@ fn mesh_lathe(
             push_polygon_from_f32(out, &[a, b, d, c], color)?;
         }
     }
+    Ok(())
+}
+
+/// Mesh one angular slice of a lathe as a closed solid (per
+/// [`Node::LatheSegment`]). The slice has `(profile.len() - 1)` outer
+/// quads (matching the existing lathe convention) plus two radial
+/// walls — one at `θ_start`, one at `θ_end` — that close the wedge
+/// off against the lathe axis.
+///
+/// Caller's contract: `profile.first().x == 0` AND `profile.last().x ==
+/// 0` (axis-closed). The simplify rewrite that creates `LatheSegment`
+/// nodes enforces this; constructing one directly from a non-closed
+/// profile silently produces a non-watertight mesh because the radial
+/// walls won't close at the axis.
+fn mesh_lathe_segment(
+    out: &mut Vec<CsgPolygon>,
+    profile: &[[f32; 2]],
+    segments: u32,
+    segment_index: u32,
+    color: u32,
+    offset: [f32; 3],
+) -> Result<(), MeshError> {
+    if profile.len() < 2 || segments < 3 || segment_index >= segments {
+        return Ok(());
+    }
+    let two_pi = std::f32::consts::TAU;
+    let theta_start = two_pi * (segment_index as f32) / (segments as f32);
+    let theta_end = two_pi * ((segment_index + 1) as f32) / (segments as f32);
+    let cos_s = theta_start.cos();
+    let sin_s = theta_start.sin();
+    let cos_e = theta_end.cos();
+    let sin_e = theta_end.sin();
+
+    let revolve = |r: f32, y: f32, cos_t: f32, sin_t: f32| -> [f32; 3] {
+        [offset[0] + r * cos_t, offset[1] + y, offset[2] + r * sin_t]
+    };
+
+    // Outer surface: one quad per profile edge, restricted to the
+    // angular slice [θ_start, θ_end]. Same (a, b, d, c) winding as
+    // mesh_lathe so the radial-outward normal points away from the axis.
+    for k in 0..profile.len() - 1 {
+        let r0 = profile[k][0];
+        let y0 = profile[k][1];
+        let r1 = profile[k + 1][0];
+        let y1 = profile[k + 1][1];
+        let a = revolve(r0, y0, cos_s, sin_s);
+        let b = revolve(r1, y1, cos_s, sin_s);
+        let c = revolve(r0, y0, cos_e, sin_e);
+        let d = revolve(r1, y1, cos_e, sin_e);
+        push_polygon_from_f32(out, &[a, b, d, c], color)?;
+    }
+
+    // Radial wall at θ_start: the profile rotated to that plane,
+    // walked in REVERSED order so the polygon's normal points in the
+    // -θ direction (away from the wedge volume). For axis-closed
+    // profiles, the first and last vertices coincide at the axis;
+    // push_polygon_from_f32 dedupes consecutive identical vertices and
+    // drops a trailing duplicate, so the polygon naturally closes.
+    let wall_start: Vec<[f32; 3]> = profile
+        .iter()
+        .rev()
+        .map(|p| revolve(p[0], p[1], cos_s, sin_s))
+        .collect();
+    push_polygon_from_f32(out, &wall_start, color)?;
+
+    // Radial wall at θ_end: forward profile order, normal points in the
+    // +θ direction.
+    let wall_end: Vec<[f32; 3]> = profile
+        .iter()
+        .map(|p| revolve(p[0], p[1], cos_e, sin_e))
+        .collect();
+    push_polygon_from_f32(out, &wall_end, color)?;
     Ok(())
 }
 
@@ -1076,5 +1155,55 @@ mod tests {
             from_union.len(),
             from_comp.len()
         );
+    }
+
+    /// Pin: a single LatheSegment meshes to a non-empty closed solid
+    /// when the profile is axis-closed. Per-segment basic correctness
+    /// — the wedge has outer quads + two radial walls.
+    #[test]
+    fn lathe_segment_meshes_to_closed_solid() {
+        let n = Node::LatheSegment {
+            profile: vec![[0.0, -0.5], [0.5, -0.5], [0.5, 0.5], [0.0, 0.5]],
+            segments: 16,
+            segment_index: 3,
+            color: 7,
+        };
+        let tris = mesh(&n).expect("lathe segment must mesh");
+        assert!(!tris.is_empty(), "wedge produced no triangles");
+        // Color preserved through the whole chain.
+        assert!(tris.iter().all(|t| t.color == 7));
+    }
+
+    /// End-to-end equivalence: a wedge-decomposed lathe must produce
+    /// the same logical surface (watertight, identical color) as the
+    /// non-decomposed lathe. We compare polygon counts loosely (the
+    /// BSP-union of segments may produce a slightly different
+    /// triangulation than the direct lathe), but the geometric
+    /// validators in `regression.rs` are the load-bearing equivalence
+    /// guarantee — pinning here just catches regressions where the
+    /// decomposed lathe collapses to nothing or doubles up.
+    #[test]
+    fn decomposed_lathe_meshes_to_non_empty_solid() {
+        use crate::parse;
+        let ast = parse("(lathe ((0 -0.5) (0.5 -0.5) (0.5 0.5) (0 0.5)) 16 :color 3)").unwrap();
+        let tris = mesh(&ast).expect("lathe must mesh");
+        assert!(!tris.is_empty(), "lathe produced no triangles");
+        assert!(tris.iter().all(|t| t.color == 3));
+    }
+
+    /// Pin: a non-axis-closed lathe profile (open ends) is NOT
+    /// decomposed — the wedge rewrite requires both endpoints at
+    /// `r == 0` to close the radial walls without an explicit cap.
+    /// The rewrite skips this case; the lathe still meshes via the
+    /// original whole-lathe path.
+    #[test]
+    fn open_profile_lathe_skips_decomposition_and_meshes() {
+        use crate::parse;
+        // Profile starts at (0.5, ...) — not axis-closed.
+        let ast = parse("(lathe ((0.5 -0.5) (0.5 0.5)) 16 :color 5)").unwrap();
+        let tris = mesh(&ast).expect("open-profile lathe must mesh");
+        // Open profile produces an open surface (not watertight) but
+        // should still emit triangles for the cylindrical band.
+        assert!(!tris.is_empty(), "open lathe produced no triangles");
     }
 }

--- a/crates/aether-dsl-mesh/src/serialize.rs
+++ b/crates/aether-dsl-mesh/src/serialize.rs
@@ -82,6 +82,19 @@ pub fn node_to_value(node: &Node) -> Value {
             kw("color"),
             uint(*color),
         ]),
+        Node::LatheSegment {
+            profile,
+            segments,
+            segment_index,
+            color,
+        } => list([
+            sym("lathe-segment"),
+            profile_to_value(profile),
+            uint(*segments),
+            uint(*segment_index),
+            kw("color"),
+            uint(*color),
+        ]),
         Node::Extrude {
             profile,
             depth,

--- a/crates/aether-dsl-mesh/src/simplify.rs
+++ b/crates/aether-dsl-mesh/src/simplify.rs
@@ -237,6 +237,20 @@ pub fn compute_aabb(node: &Node) -> Aabb {
         }
         Node::Wedge { x, y, z, .. } => Aabb::from_half_extents(*x * 0.5, *y * 0.5, *z * 0.5),
         Node::Sphere { radius, .. } => Aabb::from_half_extents(*radius, *radius, *radius),
+        Node::LatheSegment { profile, .. } => {
+            // Conservative: same bound as the parent lathe. A tighter
+            // per-wedge bound would let pairwise-disjoint segments
+            // route through the disjoint-union fast path, but adjacent
+            // segments share radial walls so they'd never partition
+            // out anyway. The win that matters — distribute-difference-
+            // over-union (PR 4) doing per-arm BSP on small inputs —
+            // doesn't depend on per-segment AABB tightness.
+            compute_aabb(&Node::Lathe {
+                profile: profile.clone(),
+                segments: 0,
+                color: 0,
+            })
+        }
         Node::Lathe { profile, .. } => {
             // Lathe revolves around Y axis. Radial extent is max |x| of
             // the profile; Y extent spans the profile's y range.
@@ -418,6 +432,17 @@ fn partition_disjoint_aabb(children: &[Node]) -> Vec<Vec<usize>> {
         .collect()
 }
 
+/// `true` when a lathe profile starts and ends at the axis (`r == 0`).
+/// Such profiles produce a closed solid when revolved, which is the
+/// precondition for wedge decomposition: each angular slice's radial
+/// walls collapse to single axis points at top and bottom, so the
+/// wall polygons close cleanly without an explicit cap.
+fn profile_axis_closed(profile: &[[f32; 2]]) -> bool {
+    profile.len() >= 2
+        && profile.first().unwrap()[0].abs() < f32::EPSILON
+        && profile.last().unwrap()[0].abs() < f32::EPSILON
+}
+
 /// `Some(+1.0)` when `a` and `b` point in the same direction,
 /// `Some(-1.0)` when opposite, `None` when skew (or either is the
 /// zero vector). Used to decide whether two `Rotate` nodes can fold:
@@ -501,6 +526,18 @@ fn parallel_axis_sign(a: [f32; 3], b: [f32; 3]) -> Option<f32> {
 ///   "bunch of parts minus one cutter" inputs to a flat composition
 ///   that skips BSP entirely.
 ///
+/// Wedge decomposition:
+/// - `(lathe profile segments color)` rewrites to
+///   `(union seg_0 seg_1 … seg_{n-1})` of [`Node::LatheSegment`]
+///   primitives when the profile is axis-closed (first and last
+///   profile points at `r == 0`). The decomposed lathe meshes
+///   identically to the original — adjacent segments share radial
+///   walls that the BSP-union (and root cleanup) merge — but each
+///   segment is a small convex-ish solid, so a CSG operation against
+///   the lathe distributes (via the rule above) into per-segment BSP
+///   work that's bounded per-pair instead of having one giant
+///   operation over all `segments × profile-edges` facets.
+///
 /// Identity rules for `Mirror` are intentionally absent — every mirror
 /// flips winding regardless of axis, so there's no zero-effect form.
 pub fn simplify(node: &Node) -> Node {
@@ -511,10 +548,36 @@ pub fn simplify(node: &Node) -> Node {
         | Node::Cone { .. }
         | Node::Wedge { .. }
         | Node::Sphere { .. }
-        | Node::Lathe { .. }
+        | Node::LatheSegment { .. }
         | Node::Extrude { .. }
         | Node::Torus { .. }
         | Node::Sweep { .. } => node.clone(),
+
+        Node::Lathe {
+            profile,
+            segments,
+            color,
+        } => {
+            // Wedge-decompose into a Union of LatheSegments when the
+            // profile is axis-closed and there's at least 3 segments.
+            // Non-axis-closed profiles can't form closed wedges (no
+            // radial-wall closure at the axis), so we leave them as a
+            // single Lathe and the caller's CSG ops bear the original
+            // fragmentation cost.
+            if *segments >= 3 && profile_axis_closed(profile) {
+                let children: Vec<Node> = (0..*segments)
+                    .map(|i| Node::LatheSegment {
+                        profile: profile.clone(),
+                        segments: *segments,
+                        segment_index: i,
+                        color: *color,
+                    })
+                    .collect();
+                Node::Union { children }
+            } else {
+                node.clone()
+            }
+        }
 
         Node::Composition(children) => {
             let simplified: Vec<Node> = children.iter().map(simplify).collect();
@@ -660,19 +723,50 @@ pub fn simplify(node: &Node) -> Node {
         },
         Node::Difference { base, subtract } => {
             let subtract: Vec<Node> = subtract.iter().map(simplify).collect();
+            let base = simplify(base);
 
-            // Distribution check happens on the *unsimplified* base —
-            // simplifying it first would convert a disjoint Union to a
-            // Composition, hiding the Union pattern from us.
-            if let Node::Union { children } = base.as_ref()
-                && children.iter().all(crate::mesh::is_csg_leaf)
-                && subtract.iter().all(crate::mesh::is_csg_leaf)
+            // Try distribution on the simplified base. Three eligible
+            // shapes — all preserve `(A ∪ B …) − Y = (A − Y) ∪ (B − Y) …`:
+            //
+            // 1. `Union { children }` with leaf children — the
+            //    set-algebra identity, restricted to leaves to avoid
+            //    amplifying composite-operand T-junctions/slivers.
+            // 2. `Composition(children)` with pairwise-disjoint leaf
+            //    children — Composition came from the disjoint-union
+            //    rewrite, so its children represent set-disjoint regions
+            //    and the same identity holds. Pairwise-disjoint check
+            //    via `partition_disjoint_aabb` returning N singleton
+            //    groups for N children.
+            //
+            // Subtractors must also be leaves (same safety guarantee).
+            //
+            // The Lathe wedge-decomposition rewrite makes this case
+            // load-bearing for issue 300: `(difference lathe cutter)`
+            // simplifies the Lathe into a Union of LatheSegments
+            // *during base simplification*, and distribution then turns
+            // it into N small per-segment differences instead of one
+            // catastrophically-fragmenting BSP composition.
+            let distributable_children: Option<&[Node]> = if subtract
+                .iter()
+                .all(crate::mesh::is_csg_leaf)
             {
-                // Each arm gets the full subtractor list (cloned) and
-                // is recursively simplified so per-arm AABB-prune and
-                // disjoint-union rewrites can fire on the smaller
-                // pieces. The wrapping Union is then simplified so
-                // disjoint arms collapse into a Composition.
+                match &base {
+                    Node::Union { children } if children.iter().all(crate::mesh::is_csg_leaf) => {
+                        Some(children.as_slice())
+                    }
+                    Node::Composition(children)
+                        if children.iter().all(crate::mesh::is_csg_leaf)
+                            && partition_disjoint_aabb(children).len() == children.len() =>
+                    {
+                        Some(children.as_slice())
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
+            if let Some(children) = distributable_children {
                 let arms: Vec<Node> = children
                     .iter()
                     .map(|c| {
@@ -682,11 +776,20 @@ pub fn simplify(node: &Node) -> Node {
                         })
                     })
                     .collect();
-                return simplify(&Node::Union { children: arms });
+                // Composition base → arms stay disjoint (each arm is a
+                // Difference whose AABB is bounded by its leaf base,
+                // and the original leaves were pairwise disjoint), so
+                // wrap in Composition directly. Union base → wrap in
+                // Union and re-simplify; the disjoint-union rewrite
+                // may further collapse it if the arms turn out
+                // pairwise-disjoint.
+                return match &base {
+                    Node::Composition(_) => Node::Composition(arms),
+                    _ => simplify(&Node::Union { children: arms }),
+                };
             }
 
-            // No distribution — simplify base, AABB-prune subtractors.
-            let base = simplify(base);
+            // No distribution — AABB-prune subtractors against the base.
             let base_aabb = compute_aabb(&base);
             let pruned: Vec<Node> = subtract
                 .into_iter()
@@ -2366,6 +2469,184 @@ mod difference_rewrite_tests {
                 z: 1.0,
                 color: 9,
             }],
+        };
+        let once = simplify(&n);
+        let twice = simplify(&once);
+        assert_eq!(once, twice);
+    }
+}
+
+#[cfg(test)]
+mod profile_axis_closed_tests {
+    use super::*;
+
+    #[test]
+    fn profile_starting_and_ending_at_axis_is_closed() {
+        assert!(profile_axis_closed(&[
+            [0.0, -0.5],
+            [0.5, -0.5],
+            [0.5, 0.5],
+            [0.0, 0.5]
+        ]));
+    }
+
+    #[test]
+    fn profile_open_at_start_is_not_closed() {
+        assert!(!profile_axis_closed(&[[0.5, -0.5], [0.5, 0.5], [0.0, 0.5]]));
+    }
+
+    #[test]
+    fn profile_open_at_end_is_not_closed() {
+        assert!(!profile_axis_closed(&[
+            [0.0, -0.5],
+            [0.5, -0.5],
+            [0.5, 0.5]
+        ]));
+    }
+
+    #[test]
+    fn empty_or_single_vertex_profile_is_not_closed() {
+        assert!(!profile_axis_closed(&[]));
+        assert!(!profile_axis_closed(&[[0.0, 0.0]]));
+    }
+}
+
+#[cfg(test)]
+mod lathe_decomp_tests {
+    use super::*;
+
+    fn closed_profile() -> Vec<[f32; 2]> {
+        vec![[0.0, -0.5], [0.5, -0.5], [0.5, 0.5], [0.0, 0.5]]
+    }
+
+    #[test]
+    fn axis_closed_lathe_rewrites_to_union_of_segments() {
+        let n = Node::Lathe {
+            profile: closed_profile(),
+            segments: 8,
+            color: 5,
+        };
+        let s = simplify(&n);
+        match s {
+            Node::Union { children } => {
+                assert_eq!(children.len(), 8);
+                for (i, child) in children.iter().enumerate() {
+                    match child {
+                        Node::LatheSegment {
+                            segments,
+                            segment_index,
+                            color,
+                            ..
+                        } => {
+                            assert_eq!(*segments, 8);
+                            assert_eq!(*segment_index, i as u32);
+                            assert_eq!(*color, 5);
+                        }
+                        other => panic!("expected LatheSegment, got {other:?}"),
+                    }
+                }
+            }
+            other => panic!("expected Union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_profile_lathe_is_unchanged() {
+        let n = Node::Lathe {
+            profile: vec![[0.5, -0.5], [0.5, 0.5]],
+            segments: 8,
+            color: 0,
+        };
+        assert_eq!(simplify(&n), n);
+    }
+
+    #[test]
+    fn lathe_with_too_few_segments_is_unchanged() {
+        let n = Node::Lathe {
+            profile: closed_profile(),
+            segments: 2,
+            color: 0,
+        };
+        assert_eq!(simplify(&n), n);
+    }
+
+    #[test]
+    fn lathe_segment_passes_through_simplify_unchanged() {
+        let n = Node::LatheSegment {
+            profile: closed_profile(),
+            segments: 8,
+            segment_index: 3,
+            color: 0,
+        };
+        assert_eq!(simplify(&n), n);
+    }
+
+    #[test]
+    fn lathe_segment_aabb_matches_lathe_aabb() {
+        // Conservative bound — same as parent lathe per the v1 design.
+        // Pinning so a future tighter per-wedge bound is a deliberate
+        // change.
+        let lathe_bound = compute_aabb(&Node::Lathe {
+            profile: closed_profile(),
+            segments: 16,
+            color: 0,
+        });
+        let segment_bound = compute_aabb(&Node::LatheSegment {
+            profile: closed_profile(),
+            segments: 16,
+            segment_index: 0,
+            color: 0,
+        });
+        assert_eq!(lathe_bound, segment_bound);
+    }
+
+    #[test]
+    fn difference_of_decomposed_lathe_distributes_through_pipeline() {
+        // The full chain: Lathe → Union<LatheSegment> via wedge
+        // decomp; then `Difference(Union, leaf_cutter)` distributes
+        // → Union of per-segment differences. Pin the final shape so
+        // a regression in any step shows up loudly — issue 300's fix
+        // load-bearing.
+        let n = Node::Difference {
+            base: Box::new(Node::Lathe {
+                profile: closed_profile(),
+                segments: 4,
+                color: 0,
+            }),
+            subtract: vec![Node::Box {
+                x: 0.5,
+                y: 2.0,
+                z: 0.5,
+                color: 1,
+            }],
+        };
+        let s = simplify(&n);
+        match s {
+            Node::Union { children } => {
+                assert_eq!(children.len(), 4, "expected 4 per-segment arms");
+                for child in children {
+                    match child {
+                        Node::Difference { base, subtract } => {
+                            assert!(
+                                matches!(*base, Node::LatheSegment { .. }),
+                                "arm base should be LatheSegment, got {base:?}"
+                            );
+                            assert_eq!(subtract.len(), 1);
+                        }
+                        other => panic!("arm should be Difference, got {other:?}"),
+                    }
+                }
+            }
+            other => panic!("expected Union of per-segment differences, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lathe_decomp_is_idempotent() {
+        let n = Node::Lathe {
+            profile: closed_profile(),
+            segments: 8,
+            color: 0,
         };
         let once = simplify(&n);
         let twice = simplify(&once);

--- a/crates/aether-dsl-mesh/tests/regression.rs
+++ b/crates/aether-dsl-mesh/tests/regression.rs
@@ -284,16 +284,17 @@ fn lathe_minus_box_is_geometric() {
     );
 }
 
-/// **Hangs (BSP runaway)**: ignored because BSP recursion exceeds
-/// 2 minutes at 100% CPU on this composition. Two facetted curved
-/// primitives with no axis alignment fragment past any reasonable
-/// budget. Un-ignore once BSP performance is bounded for off-axis
-/// curved×curved input.
+/// **Was**: hung indefinitely on the whole-lathe BSP composition
+/// (issue 300). The lathe wedge-decomposition rewrite in
+/// [`aether_dsl_mesh::simplify`] now expands the lathe into a
+/// `Union<LatheSegment>`; PR 4's distribute-difference-over-union
+/// rule then turns the difference into 16 small per-segment
+/// differences against the cylinder, which run in milliseconds
+/// instead of minutes.
 ///
 /// Lathe minus a tilted cylinder. Two curved-facet primitives with
 /// distinct axes — the worst case for cocircular fragmentation.
 #[test]
-#[ignore]
 fn lathe_minus_tilted_cylinder_is_geometric() {
     assert_geometric(
         "(difference \


### PR DESCRIPTION
## Summary

Closes the issue 300 sequence. The `lathe_minus_tilted_cylinder_is_geometric`
regression — which hung at 100% CPU for >2 minutes on the
whole-lathe BSP composition — now finishes in **10ms** release time.

The fix is at the AST level, not in BSP:

### `Node::LatheSegment` (new internal AST primitive)

Meshes one angular slice of a lathe as a closed solid:
per-edge outer quads restricted to the slice's angular range, plus
two radial walls (one at each angular boundary) closing the wedge to
the y-axis. Caller contract is axis-closed profile; the radial walls
collapse to single axis points at top and bottom, so the wall
polygons close cleanly without an explicit cap.

Internal-only — emitted by the simplify rewrite, not parseable from
DSL source. Serializer emits `(lathe-segment profile segments index
:color N)` for completeness but the parser doesn't accept it.

### Lathe → Union<LatheSegment> rewrite

The simplify Lathe arm rewrites axis-closed lathes (first and last
profile point at `r==0`, `segments ≥ 3`) into
`Union<LatheSegment_0…N-1>`. The decomposed lathe meshes equivalently
to the original — adjacent segments share radial walls that BSP-union
+ root cleanup merge — but the per-arm CSG work is bounded.

### Difference arm restructured

Distribution previously checked the *unsimplified* base (because the
disjoint-union rewrite would otherwise convert a literal Union to
Composition and hide the pattern). With the Lathe rewrite producing
a Union *during* base simplification, the check needed to fire after,
but only for two shapes: Union with leaf children, or Composition
with pairwise-disjoint leaf children (the only Composition shape the
disjoint-union rewrite produces). Both preserve the
`(A ∪ B …) − Y = (A − Y) ∪ (B − Y) …` set-algebra identity.

The Composition case is what catches user-authored disjoint-union
inputs that PR 4's distribution previously missed — a side benefit.

### Effect on issue 300

`(difference (lathe profile 16) (rotate (1 0 0) 0.4 (cylinder 0.3 1.5 16)))`:

1. Simplify: Lathe → `Union<LatheSegment[16]>`
2. Difference distributes: → `Union<Difference(seg_i, [rotate(cyl)])[16]>`
3. Each per-segment BSP works on ~6 polys vs cutter's ~50 — bounded
4. Final 15-step Union of small results — also bounded
5. **Total: 10ms vs 2+ minute hang**

### Coverage in five files

- `ast.rs`: `Node::LatheSegment` variant + docstring
- `mesh.rs`: `mesh_lathe_segment` + dispatch arm + `is_csg_leaf`
- `serialize.rs`: serializer arm
- `simplify.rs`: `compute_aabb` arm (conservative: matches parent
  lathe), `simplify` pass-through arm, Lathe rewrite,
  `profile_axis_closed` helper, restructured Difference arm
- `tests/regression.rs`: `lathe_minus_tilted_cylinder_is_geometric`
  un-ignored

### Tests (14 new)

- `mesh::tests` (3): per-segment meshes to closed solid,
  decomposed lathe meshes non-empty + color-preserving,
  open-profile lathe skips decomp.
- `profile_axis_closed_tests` (4): axis-closed, open-at-start,
  open-at-end, empty/single-vertex.
- `lathe_decomp_tests` (7): rewrite to `Union<LatheSegment>`,
  open-profile passthrough, too-few-segments passthrough,
  `LatheSegment` is primitive, AABB matches parent, full pipeline
  distributes through Difference, idempotence.

## Test plan
- [x] `cargo test -p aether-dsl-mesh --lib` — 358 pass (344 prior + 14 new), 9 ignored
- [x] `cargo test -p aether-dsl-mesh --tests --release` — 9 integration + **25 regression** (was 24 + 1 ignored), 0 ignored
- [x] `lathe_minus_tilted_cylinder_is_geometric` — passes in 10ms release (was: hung >2min)
- [x] `cargo clippy -p aether-dsl-mesh --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace` — all dependents compile

## Closes
Closes issue 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)