### PR TITLE
chore(claude): pre-flight hook to block section-divider comments

### DIFF
--- a/.claude/hooks/check-no-divider-comments.sh
+++ b/.claude/hooks/check-no-divider-comments.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Pre-flight check for section-divider comments. The user dislikes
+# decorative banners like `// ---- foo ----` in source files (per
+# auto-memory `feedback_no_divider_comments.md`): module structure
+# should come from items + file splits, not ASCII art.
+#
+# This hook fires on Edit / Write / MultiEdit against source-extension
+# files and rejects diffs that ADD a comment line matching
+#   ^\s*(//|#)\s*[-=*]{3,}
+# (a `//` or `#` comment opener followed by 3+ marker characters).
+# Pre-existing dividers in legacy code don't trigger — only new ones
+# introduced by the diff. To deliberately add a banner (rare),
+# include `// DIVIDER_OK: <reason>` (or `# DIVIDER_OK: <reason>`) in
+# the new content and the hook yields.
+#
+# Reads the tool call JSON from stdin (Claude Code PreToolUse hook
+# protocol), exits 2 (block) on match.
+
+set -u
+
+input=$(cat)
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+
+case "$file_path" in
+    *.rs|*.ts|*.tsx|*.js|*.py|*.sh|*.go|*.c|*.cpp|*.h) ;;
+    *) exit 0 ;;
+esac
+
+DIVIDER_RE='^[[:space:]]*(\/\/|#)[[:space:]]*[-=*]{3,}'
+
+count_dividers() {
+    printf '%s' "$1" | grep -cE "$DIVIDER_RE" || true
+}
+
+has_override() {
+    printf '%s' "$1" | grep -qE '(\/\/|#) ?DIVIDER_OK:'
+}
+
+emit_message() {
+    local added=$1
+    {
+        printf 'no-divider-comments: this change adds %d new section-divider comment line(s).\n' "$added"
+        printf '\n'
+        printf 'User feedback (auto-memory `feedback_no_divider_comments.md`):\n'
+        printf 'do not write decorative banners like `// ---- foo ----` in source\n'
+        printf 'files. The items below the banner already say what they are; if a\n'
+        printf 'file genuinely needs visual structure, that is a signal to split it\n'
+        printf 'into modules, not to add ASCII art.\n'
+        printf '\n'
+        printf 'If a banner is genuinely the right tool, override by including\n'
+        printf '`// DIVIDER_OK: <reason>` (or `# DIVIDER_OK: <reason>`) in the new code.\n'
+    } >&2
+}
+
+case "$tool_name" in
+    Edit)
+        old_string=$(printf '%s' "$input" | jq -r '.tool_input.old_string // ""')
+        new_string=$(printf '%s' "$input" | jq -r '.tool_input.new_string // ""')
+        old_count=$(count_dividers "$old_string")
+        new_count=$(count_dividers "$new_string")
+        added=$((new_count - old_count))
+        if (( added > 0 )); then
+            if has_override "$new_string"; then
+                exit 0
+            fi
+            emit_message "$added"
+            exit 2
+        fi
+        ;;
+    Write)
+        content=$(printf '%s' "$input" | jq -r '.tool_input.content // ""')
+        old_count=0
+        if [[ -f "$file_path" ]]; then
+            old_count=$(count_dividers "$(cat "$file_path")")
+        fi
+        new_count=$(count_dividers "$content")
+        added=$((new_count - old_count))
+        if (( added > 0 )); then
+            if has_override "$content"; then
+                exit 0
+            fi
+            emit_message "$added"
+            exit 2
+        fi
+        ;;
+    MultiEdit)
+        edit_count=$(printf '%s' "$input" | jq -r '.tool_input.edits | length // 0')
+        total_added=0
+        any_override=0
+        for ((i=0; i<edit_count; i++)); do
+            old_string=$(printf '%s' "$input" | jq -r ".tool_input.edits[$i].old_string // \"\"")
+            new_string=$(printf '%s' "$input" | jq -r ".tool_input.edits[$i].new_string // \"\"")
+            old_count=$(count_dividers "$old_string")
+            new_count=$(count_dividers "$new_string")
+            added=$((new_count - old_count))
+            if (( added > 0 )); then
+                total_added=$((total_added + added))
+                if has_override "$new_string"; then
+                    any_override=1
+                fi
+            fi
+        done
+        if (( total_added > 0 )); then
+            if (( any_override == 1 )); then
+                exit 0
+            fi
+            emit_message "$total_added"
+            exit 2
+        fi
+        ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,15 @@
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-host-fn-additions.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-no-divider-comments.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/check-no-divider-comments.sh`, a `PreToolUse` hook on `Edit` / `Write` / `MultiEdit` that rejects any source-file diff that adds a banner-style comment line matching `^\s*(//|#)\s*[-=*]{3,}` (e.g. `// ---- foo ----`, `# ==== bar ====`, `//****`).
- Diff-aware: counts NEW dividers per call (Edit: new minus old; Write: new content minus current file; MultiEdit: summed across edits) so pre-existing banners in legacy code don't trigger; only newly-added ones do.
- Override is `// DIVIDER_OK: <reason>` (or `# DIVIDER_OK: <reason>`) adjacent in the new content for the rare legitimate case.
- Scope is source extensions only (`.rs`, `.ts`, `.tsx`, `.js`, `.py`, `.sh`, `.go`, `.c`, `.cpp`, `.h`); `.md` frontmatter and `.toml` separators pass through.

Mirrors `check-host-fn-additions.sh` in shape: stdin JSON parse via jq, exit 2 on block with a diagnostic pointing at the auto-memory rule and the override escape hatch.

Closes issue 309.

## Test plan

Smoke-tested against 18 hand-built tool-call payloads (all PASS):

- [x] Edit adding a `// ---- foo ----` banner blocks
- [x] Edit adding plain code passes
- [x] Edit on `.md` containing `---` frontmatter passes (extension filter)
- [x] Edit replacing a divider line with itself passes (diff-aware: zero new)
- [x] Edit with `// DIVIDER_OK: <reason>` passes
- [x] Edit adding `///` doc comment passes (not a banner)
- [x] Edit adding `#[derive(...)]` passes (attribute, not comment)
- [x] Edit adding `# ---- helpers ----` to `.py` blocks
- [x] Edit adding `#!/usr/bin/env python` to `.py` passes (shebang, no markers)
- [x] Write to a new `.rs` containing `// ==== top ====` blocks
- [x] Write to `.toml` containing `# ---- core ----` passes (extension filter)
- [x] MultiEdit with one banner-adding edit blocks; clean MultiEdit passes
- [x] Two-dash banner (`// -- foo --`) passes (below 3-char threshold)
- [x] No-space `//------` blocks
- [x] `//!` module doc passes
- [x] `// ====` and `// ****` markers both block