### PR TITLE
feat(component): unify send wire shape via Kind::encode_into_bytes (issue 240)

### DIFF
--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -17,8 +17,8 @@
 //!
 //! Mechanism check: the publish + broadcast sequence runs entirely
 //! through mail (`aether.handle.publish` to the `"aether.sink.handle"` sink,
-//! `wait_reply` for `HandlePublishResult`, then `send_postcard` to
-//! the broadcast sink). No host fns; the SDK's `Handle<K>` is a
+//! `wait_reply` for `HandlePublishResult`, then `send` to the
+//! broadcast sink). No host fns; the SDK's `Handle<K>` is a
 //! thin RAII wrapper over the same wire surface as `io::*` and
 //! `net::*`.
 
@@ -89,7 +89,7 @@ impl Component for HandleDemo {
         // been released and the entry could be evicted under
         // pressure — pin it so the cached bytes survive.
         let _ = handle.pin();
-        BROADCAST.send_postcard(&outer);
+        BROADCAST.send(&outer);
         // `handle` drops here → fire-and-forget HandleRelease;
         // the pin keeps the cached entry alive past release.
     }

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -44,8 +44,9 @@ const SAVE_PATH: &str = "counter.bin";
 /// would want a bigger budget.
 const IO_TIMEOUT_MS: u32 = 1_000;
 /// Broadcast sink — `hub.claude.broadcast` fans out to every
-/// attached Claude session. `Count` is postcard-shaped, so the send
-/// goes through `Sink::send_postcard`.
+/// attached Claude session. `Count` is postcard-shaped; the unified
+/// `Sink::send` routes through `Kind::encode_into_bytes`, which the
+/// derive specializes to postcard here (issue #240).
 const BROADCAST: Sink<Count> = resolve_sink::<Count>("hub.claude.broadcast");
 
 pub struct SaveCounter {
@@ -85,7 +86,7 @@ impl Component for SaveCounter {
             &next.to_le_bytes(),
             IO_TIMEOUT_MS,
         );
-        BROADCAST.send_postcard(&Count { count: next });
+        BROADCAST.send(&Count { count: next });
     }
 }
 

--- a/crates/aether-component/src/handle.rs
+++ b/crates/aether-component/src/handle.rs
@@ -27,7 +27,7 @@
 //!             held: handle.as_ref(),
 //!             ...
 //!         };
-//!         BROADCAST.send_postcard(&outer);
+//!         BROADCAST.send(&outer);
 //!         // `handle` drops here → fire-and-forget HandleRelease,
 //!         // refcount goes to zero, entry stays in the substrate's
 //!         // store subject to LRU eviction. Pin if the cached bytes
@@ -155,7 +155,7 @@ impl<K> Drop for Handle<K> {
         // The substrate's release dispatch is idempotent — calling
         // it on an already-released id saturates harmlessly.
         let req = HandleRelease { id: self.id };
-        resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send_postcard(&req);
+        resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send(&req);
     }
 }
 
@@ -172,7 +172,7 @@ pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleEr
         kind_id: K::ID,
         bytes,
     };
-    resolve_sink::<HandlePublish>(HANDLE_SINK_NAME).send_postcard(&req);
+    resolve_sink::<HandlePublish>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandlePublishResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
     match result {
@@ -186,7 +186,7 @@ pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleEr
 
 fn sync_release(id: u64) -> Result<(), SyncHandleError> {
     let req = HandleRelease { id };
-    resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send_postcard(&req);
+    resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandleReleaseResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
     match result {
@@ -197,7 +197,7 @@ fn sync_release(id: u64) -> Result<(), SyncHandleError> {
 
 fn sync_pin(id: u64) -> Result<(), SyncHandleError> {
     let req = HandlePin { id };
-    resolve_sink::<HandlePin>(HANDLE_SINK_NAME).send_postcard(&req);
+    resolve_sink::<HandlePin>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandlePinResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
     match result {
@@ -208,7 +208,7 @@ fn sync_pin(id: u64) -> Result<(), SyncHandleError> {
 
 fn sync_unpin(id: u64) -> Result<(), SyncHandleError> {
     let req = HandleUnpin { id };
-    resolve_sink::<HandleUnpin>(HANDLE_SINK_NAME).send_postcard(&req);
+    resolve_sink::<HandleUnpin>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandleUnpinResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
     match result {

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -46,7 +46,6 @@ use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
 use aether_mail::Kind;
-use serde::Serialize;
 
 use crate::{raw, resolve_sink};
 
@@ -106,8 +105,8 @@ pub fn list(namespace: &str, prefix: &str) {
     });
 }
 
-fn send<K: Kind + Serialize>(value: &K) -> u64 {
-    resolve_sink::<K>(IO_MAILBOX_NAME).send_postcard(value);
+fn send<K: Kind>(value: &K) -> u64 {
+    resolve_sink::<K>(IO_MAILBOX_NAME).send(value);
     // ADR-0042: capture the correlation the substrate just minted so
     // the sync wrappers can filter on it. For the async helpers
     // (`read` / `write` / `delete` / `list`), this is harmless noise —
@@ -260,6 +259,7 @@ mod tests {
     use aether_kinds::{
         Delete as DeleteKind, List as ListKind, Read as ReadKind, Write as WriteKind,
     };
+    use serde::Serialize;
 
     // The helpers' host-fn send path panics off-wasm (raw::send_mail
     // has a host-target stub). What we *can* test on host is the

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -180,11 +180,16 @@ impl<K: Kind> Sink<K> {
     }
 }
 
-impl<K: Kind + bytemuck::NoUninit> Sink<K> {
+impl<K: Kind> Sink<K> {
     /// Send a single typed payload. The substrate's `count` field is 1.
-    /// Bytemuck handles the `&K → &[u8]` cast.
+    ///
+    /// Issue #240: routes through `Kind::encode_into_bytes`, which the
+    /// derive specializes to either a bytemuck cast or a postcard
+    /// encode based on whether the type carries `#[repr(C)]`. One call
+    /// site for both wire shapes — the wire choice is the kind's, not
+    /// the call's.
     pub fn send(self, payload: &K) {
-        let bytes = bytemuck::bytes_of(payload);
+        let bytes = payload.encode_into_bytes();
         unsafe {
             raw::send_mail(
                 self.mailbox,
@@ -195,9 +200,16 @@ impl<K: Kind + bytemuck::NoUninit> Sink<K> {
             );
         }
     }
+}
 
+impl<K: Kind + bytemuck::NoUninit> Sink<K> {
     /// Send a slice of typed payloads as a contiguous buffer. The
     /// substrate's `count` field is `payloads.len()`.
+    ///
+    /// Cast-only — postcard has no efficient contiguous-batch wire
+    /// shape (ADR-0019 §6 fixes the batch wire as raw bytes). A
+    /// component that wants to fan out N postcard payloads calls
+    /// `send` in a loop.
     pub fn send_many(self, payloads: &[K]) {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         unsafe {
@@ -207,29 +219,6 @@ impl<K: Kind + bytemuck::NoUninit> Sink<K> {
                 bytes.as_ptr().addr() as u32,
                 bytes.len() as u32,
                 payloads.len() as u32,
-            );
-        }
-    }
-}
-
-impl<K: Kind + serde::Serialize> Sink<K> {
-    /// Send a single postcard-encoded payload. Sibling of [`Sink::send`]
-    /// for schema-shaped kinds (`#[derive(Schema, Serialize)]` — e.g.
-    /// `Count`, `SubscribeInput`, the `io::*` request kinds) that
-    /// aren't bytemuck-castable. The substrate's `count` field is 1.
-    ///
-    /// No `send_postcard_many` — postcard has no efficient contiguous
-    /// batch shape, so batch sends stay bytemuck-only. A component
-    /// that wants to fan out N postcard payloads calls this in a loop.
-    pub fn send_postcard(self, payload: &K) {
-        let bytes = postcard::to_allocvec(payload).expect("postcard encode to Vec is infallible");
-        unsafe {
-            raw::send_mail(
-                self.mailbox,
-                self.kind,
-                bytes.as_ptr().addr() as u32,
-                bytes.len() as u32,
-                1,
             );
         }
     }
@@ -403,7 +392,7 @@ impl InitCtx<'_> {
             stream,
             mailbox: self.mailbox,
         };
-        resolve_sink::<SubscribeInput>("aether.control").send_postcard(&payload);
+        resolve_sink::<SubscribeInput>("aether.control").send(&payload);
     }
 }
 
@@ -453,21 +442,16 @@ impl Ctx<'_> {
     /// Send a single payload to `sink`. Typed wrapper around
     /// `Sink::send` — having the same entry point through both
     /// `Ctx` and `Sink` is deliberate: `Ctx` is the receive-time
-    /// vocabulary, `Sink::send` is the universal one.
-    pub fn send<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payload: &K) {
+    /// vocabulary, `Sink::send` is the universal one. Wire shape
+    /// (cast or postcard) is the kind's, not the call's (issue #240).
+    pub fn send<K: Kind>(&self, sink: &Sink<K>, payload: &K) {
         sink.send(payload);
     }
 
-    /// Send a slice of payloads as a contiguous batch.
+    /// Send a slice of payloads as a contiguous batch. Cast-only —
+    /// see [`Sink::send_many`] for the wire-shape rationale.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
-    }
-
-    /// Send a postcard-encoded payload. Sibling of [`Ctx::send`] for
-    /// schema-shaped kinds — same dispatch discipline (receive-time
-    /// capability), different wire shape.
-    pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
-        sink.send_postcard(payload);
     }
 
     /// Publish `value` into the substrate's handle store. Returns
@@ -490,14 +474,11 @@ impl Ctx<'_> {
     ///
     /// Status of the underlying host call is dropped; reply is
     /// fire-and-forget on the guest side. If the session is gone the
-    /// hub silently discards the frame.
-    pub fn reply<K: Kind + bytemuck::NoUninit>(
-        &self,
-        sender: ReplyTo,
-        kind: KindId<K>,
-        payload: &K,
-    ) {
-        let bytes = bytemuck::bytes_of(payload);
+    /// hub silently discards the frame. Issue #240: wire shape (cast
+    /// or postcard) follows `Kind::encode_into_bytes` — the same
+    /// derive-time autodetect as `Ctx::send`.
+    pub fn reply<K: Kind>(&self, sender: ReplyTo, kind: KindId<K>, payload: &K) {
+        let bytes = payload.encode_into_bytes();
         unsafe {
             raw::reply_mail(
                 sender.raw,
@@ -570,20 +551,16 @@ impl DropCtx<'_> {
         }
     }
 
-    /// Send a single payload during a shutdown hook.
-    pub fn send<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payload: &K) {
+    /// Send a single payload during a shutdown hook. Wire shape (cast
+    /// or postcard) follows `Kind::encode_into_bytes`.
+    pub fn send<K: Kind>(&self, sink: &Sink<K>, payload: &K) {
         sink.send(payload);
     }
 
-    /// Send a slice of payloads during a shutdown hook.
+    /// Send a slice of payloads during a shutdown hook. Cast-only —
+    /// see [`Sink::send_many`] for the wire-shape rationale.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K>, payloads: &[K]) {
         sink.send_many(payloads);
-    }
-
-    /// Send a postcard-encoded payload during a shutdown hook. Sibling
-    /// of [`DropCtx::send`] for schema-shaped kinds.
-    pub fn send_postcard<K: Kind + serde::Serialize>(&self, sink: &Sink<K>, payload: &K) {
-        sink.send_postcard(payload);
     }
 
     /// Publish `value` into the substrate's handle store during a
@@ -1397,6 +1374,54 @@ mod tests {
         };
         let out = mail.decode_kind::<FakeCastKind>().expect("decode");
         assert_eq!(out, value);
+    }
+
+    // Issue #240 encode-side mirror. `Kind::encode_into_bytes` is the
+    // send-side counterpart to `decode_from_bytes`; the derive picks
+    // cast vs postcard based on the same `#[repr(C)]` flag. These two
+    // tests pin the symmetry: the encode output for each wire shape
+    // round-trips through the decode it pairs with.
+
+    #[test]
+    fn kind_encode_into_bytes_postcard_roundtrip() {
+        let value = FakePostcard {
+            tag: alloc::string::String::from("hello"),
+            ids: alloc::vec![10, 20, 30],
+        };
+        let bytes = value.encode_into_bytes();
+        // Wire-shape contract: postcard encode matches what the
+        // pre-#240 `Sink::send_postcard` path would have written.
+        assert_eq!(bytes, postcard::to_allocvec(&value).unwrap());
+        let decoded = FakePostcard::decode_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn kind_encode_into_bytes_cast_roundtrip() {
+        #[repr(C)]
+        #[derive(
+            Copy,
+            Clone,
+            Debug,
+            PartialEq,
+            bytemuck::Pod,
+            bytemuck::Zeroable,
+            aether_mail::Kind,
+            aether_mail::Schema,
+        )]
+        #[kind(name = "test.encode_cast")]
+        struct EncodeCast {
+            a: u32,
+            b: u32,
+        }
+
+        let value = EncodeCast { a: 11, b: 22 };
+        let bytes = value.encode_into_bytes();
+        // Wire-shape contract: cast encode matches `bytemuck::bytes_of`
+        // — what the pre-#240 `Sink::send` path wrote zero-copy.
+        assert_eq!(bytes.as_slice(), bytemuck::bytes_of(&value));
+        let decoded = EncodeCast::decode_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded, value);
     }
 
     #[test]

--- a/crates/aether-component/src/net.rs
+++ b/crates/aether-component/src/net.rs
@@ -125,7 +125,7 @@ pub enum SyncNetError {
 /// assert_eq!(resp.status, 200);
 /// ```
 pub fn fetch_blocking(fetch: &Fetch, timeout_ms: u32) -> Result<FetchResponse, SyncNetError> {
-    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send_postcard(fetch);
+    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(fetch);
     let correlation = unsafe { raw::prev_correlation() };
 
     let mut buf: Vec<u8> = alloc::vec![0u8; FETCH_REPLY_CAP];
@@ -171,7 +171,7 @@ pub fn fetch_blocking(fetch: &Fetch, timeout_ms: u32) -> Result<FetchResponse, S
 /// typed + named counterpart to [`fetch_blocking`]; `ctx.send` on a
 /// user-built `Sink<Fetch>` does the same thing.
 pub fn fetch(fetch: &Fetch) {
-    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send_postcard(fetch);
+    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(fetch);
 }
 
 /// Tiny constructor for the common "GET with no headers or body"

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -93,6 +93,15 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     } else {
         quote! { ::aether_mail::__derive_runtime::decode_postcard::<Self>(bytes) }
     };
+    // Issue #240: encode mirror. Same `#[repr(C)]` autodetect as
+    // `decode_body` — a single `Sink::send` call site routes through
+    // `Kind::encode_into_bytes`, picking cast or postcard at the
+    // kind's derive instead of at every send site.
+    let encode_body = if has_repr_c {
+        quote! { ::aether_mail::__derive_runtime::encode_cast::<Self>(self) }
+    } else {
+        quote! { ::aether_mail::__derive_runtime::encode_postcard::<Self>(self) }
+    };
 
     // ADR-0032 section emission goes through trait dispatch, not a
     // syntactic walker. `<Self as Schema>::SCHEMA` / `::LABEL_NODE`
@@ -127,6 +136,10 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
 
             fn decode_from_bytes(bytes: &[u8]) -> ::core::option::Option<Self> {
                 #decode_body
+            }
+
+            fn encode_into_bytes(&self) -> ::aether_mail::__derive_runtime::Vec<u8> {
+                #encode_body
             }
         }
 

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -60,6 +60,29 @@ pub trait Kind {
     {
         None
     }
+
+    /// Encode `self` into a fresh byte buffer in the wire shape this
+    /// kind was declared with. The `Kind` derive auto-implements this
+    /// using the same `#[repr(C)]` autodetect as `decode_from_bytes`
+    /// (cast for `#[repr(C)]` + `NoUninit`, postcard otherwise), so a
+    /// single `Sink::send` / `Ctx::reply` call site dispatches both
+    /// wire shapes without the caller picking the encoder.
+    ///
+    /// Default panics — sending a kind whose impl was hand-rolled
+    /// without an override is a contract violation, not "I have no
+    /// payload" (the symmetric `decode_from_bytes` default returns
+    /// `None`, which the dispatcher surfaces as `DISPATCH_UNKNOWN_KIND`;
+    /// silently shipping zero bytes here would write a garbled mail
+    /// rather than fail loud). Hand-rolled `Kind` impls that need to
+    /// send must override.
+    fn encode_into_bytes(&self) -> Vec<u8> {
+        panic!(
+            "aether-mail: Kind::encode_into_bytes called on `{}` whose impl does not override \
+             it. Use `#[derive(Kind)]` (which emits the body for cast or postcard kinds based \
+             on `#[repr(C)]`) or hand-roll an override before sending.",
+            Self::NAME,
+        );
+    }
 }
 
 /// Compile-time predicate: can this type's payload travel across the
@@ -321,6 +344,7 @@ pub mod __derive_runtime {
         canonical,
     };
     pub use alloc::borrow::Cow;
+    pub use alloc::vec::Vec;
 
     /// Cast-shape decode helper. Routes through `bytemuck::pod_read_unaligned`
     /// after a length check so the Kind derive can emit a uniform call
@@ -343,6 +367,22 @@ pub mod __derive_runtime {
     /// independent of `serde`.
     pub fn decode_postcard<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Option<T> {
         postcard::from_bytes(bytes).ok()
+    }
+
+    /// Cast-shape encode helper. Mirror of `decode_cast`. Routes
+    /// through `bytemuck::bytes_of` so the Kind derive emits a uniform
+    /// call without the user crate needing `bytemuck` in scope. The
+    /// `NoUninit` bound lives on the helper so non-cast kinds aren't
+    /// poisoned by a trait their `#[repr(C)]`-less layout can't satisfy.
+    pub fn encode_cast<T: bytemuck::NoUninit>(value: &T) -> alloc::vec::Vec<u8> {
+        ::bytemuck::bytes_of(value).to_vec()
+    }
+
+    /// Postcard-shape encode helper. Mirror of `decode_postcard`. The
+    /// `Serialize` bound lives here, not on `Kind`, so cast kinds stay
+    /// independent of `serde`.
+    pub fn encode_postcard<T: serde::Serialize>(value: &T) -> alloc::vec::Vec<u8> {
+        ::postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
     }
 }
 

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -16,7 +16,7 @@
 //! The dispatcher runs synchronously on the sink dispatch thread —
 //! fine for handle ops, which are sub-microsecond `RwLock`
 //! acquisitions on the store. Components publish via the SDK's
-//! `Ctx::publish` (encode + `send_postcard` + `wait_reply`); the
+//! `Ctx::publish` (encode + `Sink::send` + `wait_reply`); the
 //! `Drop` impl on `Handle<K>` mails `HandleRelease` fire-and-forget
 //! to keep teardown safe.
 


### PR DESCRIPTION
## Summary

- Mirror PR 239's receive-side `decode_from_bytes` on the encode side. The new default `Kind::encode_into_bytes(&self) -> Vec<u8>` is auto-implemented by the `Kind` derive with the same `#[repr(C)]` autodetect — cast for `#[repr(C)] + NoUninit`, postcard otherwise. Default panics on hand-rolled impls that send without overriding (the quieter "ship zero bytes" alternative would corrupt the wire silently).
- Collapse `Sink::send_postcard`, `Ctx::send_postcard`, `DropCtx::send_postcard`, and the cast-only `Ctx::reply` onto a single `K: Kind` API. `send_many` stays cast-only — ADR-0019 §6 fixes the batch wire as raw bytes; postcard has no contiguous-batch shape.
- Update every internal call site (handle publish/release/pin/unpin, io send, net fetch + fetch_blocking, the SDK init walker's subscribe_input, the `handle_demo` / `save_counter` examples) to drop the per-call wire choice.

Author experience: `sink.send(&payload)` regardless of wire shape, no `send_postcard` to remember.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` — 44 aether-component lib tests pass, including two new regression guards: `kind_encode_into_bytes_postcard_roundtrip` (asserts encode bytes equal `postcard::to_allocvec`) and `kind_encode_into_bytes_cast_roundtrip` (asserts encode bytes equal `bytemuck::bytes_of`). The contract: on-wire bytes stay byte-identical to the pre-#240 code paths.
- [x] `cargo check -p aether-{camera,mesh-editor,static-mesh,player,hello}-component --target wasm32-unknown-unknown` all clean

Closes issue 240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)