### PR TITLE
feat(schema): add Map type to kind vocabulary (issue 232)

### DIFF
--- a/crates/aether-hub-protocol/src/canonical/labels.rs
+++ b/crates/aether-hub-protocol/src/canonical/labels.rs
@@ -18,6 +18,7 @@ const LABEL_ARRAY: u8 = 3;
 const LABEL_STRUCT: u8 = 4;
 const LABEL_ENUM: u8 = 5;
 const LABEL_REF: u8 = 6;
+const LABEL_MAP: u8 = 7;
 
 const VARIANT_LABEL_UNIT: u8 = 0;
 const VARIANT_LABEL_TUPLE: u8 = 1;
@@ -73,6 +74,7 @@ const fn label_node_len(node: &LabelNode) -> usize {
             total
         }
         LabelNode::Ref(cell) => 1 + label_cell_len(cell),
+        LabelNode::Map { key, value } => 1 + label_cell_len(key) + label_cell_len(value),
     }
 }
 
@@ -199,6 +201,12 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
             out[pos] = LABEL_REF;
             pos += 1;
             pos = write_label_cell(cell, out, pos);
+        }
+        LabelNode::Map { key, value } => {
+            out[pos] = LABEL_MAP;
+            pos += 1;
+            pos = write_label_cell(key, out, pos);
+            pos = write_label_cell(value, out, pos);
         }
     }
     pos

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -27,6 +27,7 @@ const SCHEMA_ARRAY: u8 = 7;
 const SCHEMA_STRUCT: u8 = 8;
 const SCHEMA_ENUM: u8 = 9;
 const SCHEMA_REF: u8 = 10;
+const SCHEMA_MAP: u8 = 11;
 
 const VARIANT_UNIT: u8 = 0;
 const VARIANT_TUPLE: u8 = 1;
@@ -77,6 +78,7 @@ pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
             total
         }
         SchemaType::Ref(cell) => 1 + canonical_len_cell(cell),
+        SchemaType::Map { key, value } => 1 + canonical_len_cell(key) + canonical_len_cell(value),
     }
 }
 
@@ -198,6 +200,10 @@ fn schema_to_shape(s: &SchemaType) -> crate::types::SchemaShape {
             variants: variants.iter().map(variant_to_shape).collect(),
         },
         SchemaType::Ref(cell) => SchemaShape::Ref(alloc::boxed::Box::new(schema_to_shape(cell))),
+        SchemaType::Map { key, value } => SchemaShape::Map {
+            key: alloc::boxed::Box::new(schema_to_shape(key)),
+            value: alloc::boxed::Box::new(schema_to_shape(value)),
+        },
     }
 }
 
@@ -346,6 +352,12 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
             out[pos] = SCHEMA_REF;
             pos += 1;
             pos = write_cell(cell, out, pos);
+        }
+        SchemaType::Map { key, value } => {
+            out[pos] = SCHEMA_MAP;
+            pos += 1;
+            pos = write_cell(key, out, pos);
+            pos = write_cell(value, out, pos);
         }
     }
     pos

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -624,6 +624,71 @@ mod tests {
         assert_eq!(postcard::from_bytes::<InputsRecord>(&bytes).unwrap(), rec);
     }
 
+    // Issue #232 — `SchemaType::Map` wire-format tests. The Map arm
+    // describes `BTreeMap<K, V>` payloads; canonical bytes must be
+    // stable so `Kind::ID` doesn't drift across runs/builds.
+
+    #[test]
+    fn schema_map_string_keys_roundtrip() {
+        let desc = KindDescriptor {
+            name: "demo.headers".into(),
+            schema: SchemaType::Struct {
+                repr_c: false,
+                fields: vec![NamedField {
+                    name: "headers".into(),
+                    ty: SchemaType::Map {
+                        key: SchemaCell::owned(SchemaType::String),
+                        value: SchemaCell::owned(SchemaType::String),
+                    },
+                }]
+                .into(),
+            },
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_map_integer_keys_roundtrip() {
+        // Integer-keyed map — Map<u32, String>. Wire shape unaffected
+        // by key type; only encoder/decoder JSON projection cares.
+        let desc = KindDescriptor {
+            name: "demo.lookup".into(),
+            schema: SchemaType::Map {
+                key: SchemaCell::owned(SchemaType::Scalar(Primitive::U32)),
+                value: SchemaCell::owned(SchemaType::String),
+            },
+        };
+        let bytes = postcard::to_allocvec(&desc).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<KindDescriptor>(&bytes).unwrap(),
+            desc
+        );
+    }
+
+    #[test]
+    fn schema_map_canonical_bytes_deterministic() {
+        // `Kind::ID` derives from `fnv1a_64_prefixed(KIND_DOMAIN,
+        // canonical_kind_bytes(name, schema))`. Two calls with the same
+        // schema must produce byte-identical canonical bytes — otherwise
+        // the same kind would hash to different ids across builds. Pins
+        // the Map arm against the stability invariant ADR-0030 set up.
+        let schema = SchemaType::Map {
+            key: SchemaCell::owned(SchemaType::String),
+            value: SchemaCell::owned(SchemaType::Scalar(Primitive::U64)),
+        };
+        let bytes_a = canonical::canonical_kind_bytes("demo.counters", &schema);
+        let bytes_b = canonical::canonical_kind_bytes("demo.counters", &schema);
+        assert_eq!(bytes_a, bytes_b);
+        // Also pin the id derivation — it's the load-bearing call.
+        let id_a = canonical::kind_id_from_parts("demo.counters", &schema);
+        let id_b = canonical::kind_id_from_parts("demo.counters", &schema);
+        assert_eq!(id_a, id_b);
+    }
+
     #[test]
     fn inputs_section_concatenated_records_streaming_decode() {
         // Walk-the-section pattern the substrate reader will use:

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -66,7 +66,8 @@ pub struct KindDescriptor {
 /// the wire format): only legal when every field is itself
 /// cast-eligible — `Scalar`, `Array` of cast-eligible elements, or a
 /// nested `Struct { repr_c: true, .. }`. `String`, `Bytes`, `Vec`,
-/// `Option`, and `Enum` fields disqualify a struct from `repr_c`.
+/// `Option`, `Map`, and `Enum` fields disqualify a struct from
+/// `repr_c`.
 ///
 /// ADR-0031: every recursive field uses `SchemaCell` (static-or-owned)
 /// and every collection/string uses `Cow<'static, _>` so the whole type
@@ -102,6 +103,19 @@ pub enum SchemaType {
     /// inline value, so existing decoders only need to learn
     /// the new tag at the field-walk step.
     Ref(SchemaCell),
+    /// Issue #232: keyed lookup table. Wire form is postcard's
+    /// `BTreeMap<K, V>` — `varint(len) + (k, v)` pairs in
+    /// key-sorted order. Key types are restricted to `String`,
+    /// integer `Scalar`s, and `Bool` (proto3-style stringify
+    /// rule); the Rust-level `BTreeMap<K: Ord, V>` bound makes
+    /// `f32`/`f64`/`Vec`/`Option` unreachable at the type level
+    /// and the codec rejects them defensively. Disqualifies a
+    /// parent struct from `repr_c` — variable-length data has
+    /// no fixed `#[repr(C)]` layout.
+    Map {
+        key: SchemaCell,
+        value: SchemaCell,
+    },
 }
 
 /// Recursion-breaking indirection for nested `SchemaType` fields
@@ -282,6 +296,10 @@ pub enum SchemaShape {
         variants: Vec<VariantShape>,
     },
     Ref(Box<SchemaShape>),
+    Map {
+        key: Box<SchemaShape>,
+        value: Box<SchemaShape>,
+    },
 }
 
 /// Positional enum variant — `VariantShape::Tuple { discriminant, fields }`
@@ -346,6 +364,14 @@ pub enum LabelNode {
         variants: Cow<'static, [VariantLabel]>,
     },
     Ref(LabelCell),
+    /// Issue #232: parallel labels for `SchemaType::Map`. Both
+    /// key and value carry their own cell because either side may
+    /// be a struct/enum whose nominal info needs preserving for
+    /// `describe_kinds` rendering.
+    Map {
+        key: LabelCell,
+        value: LabelCell,
+    },
 }
 
 /// Per-variant nominal info for `LabelNode::Enum`. `name` is the Rust
@@ -450,6 +476,10 @@ impl Clone for LabelNode {
                 variants: variants.clone(),
             },
             LabelNode::Ref(c) => LabelNode::Ref(c.clone()),
+            LabelNode::Map { key, value } => LabelNode::Map {
+                key: key.clone(),
+                value: value.clone(),
+            },
         }
     }
 }
@@ -484,6 +514,9 @@ impl PartialEq for LabelNode {
                 },
             ) => la == lb && va == vb,
             (LabelNode::Ref(a), LabelNode::Ref(b)) => a == b,
+            (LabelNode::Map { key: ka, value: va }, LabelNode::Map { key: kb, value: vb }) => {
+                ka == kb && va == vb
+            }
             _ => false,
         }
     }
@@ -540,6 +573,12 @@ impl Serialize for LabelNode {
                 s.serialize_field(cell)?;
                 s.end()
             }
+            LabelNode::Map { key, value } => {
+                let mut s = serializer.serialize_struct_variant("LabelNode", 7, "Map", 2)?;
+                s.serialize_field("key", key)?;
+                s.serialize_field("value", value)?;
+                s.end()
+            }
         }
     }
 }
@@ -564,6 +603,10 @@ impl<'de> Deserialize<'de> for LabelNode {
                 variants: Vec<VariantLabel>,
             },
             Ref(LabelCell),
+            Map {
+                key: LabelCell,
+                value: LabelCell,
+            },
         }
         match LabelNodeDe::deserialize(deserializer)? {
             LabelNodeDe::Anonymous => Ok(LabelNode::Anonymous),
@@ -587,6 +630,7 @@ impl<'de> Deserialize<'de> for LabelNode {
                 variants: Cow::Owned(variants),
             }),
             LabelNodeDe::Ref(c) => Ok(LabelNode::Ref(c)),
+            LabelNodeDe::Map { key, value } => Ok(LabelNode::Map { key, value }),
         }
     }
 }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -386,6 +386,10 @@ fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
         return Ok(quote! { ::aether_mail::__derive_runtime::SchemaType::Unit });
     }
 
+    for f in fields {
+        reject_hashmap(&f.ty)?;
+    }
+
     let entries = fields.iter().enumerate().map(|(idx, f)| {
         let name = match &f.ident {
             Some(id) => id.to_string(),
@@ -412,6 +416,12 @@ fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
 }
 
 fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
+    for v in &data.variants {
+        for f in v.fields.iter() {
+            reject_hashmap(&f.ty)?;
+        }
+    }
+
     let variant_entries = data.variants.iter().enumerate().map(|(idx, v)| {
         let name = v.ident.to_string();
         let discriminant = idx as u32;
@@ -492,6 +502,45 @@ fn is_vec_u8(ty: &Type) -> bool {
         return false;
     };
     inner.path.is_ident("u8")
+}
+
+/// Walk a field-type syntactic tree and reject `HashMap` anywhere
+/// inside it (issue #232). `HashMap`'s iteration order is hash-state-
+/// dependent, which would let two builds of the same kind hash to
+/// different `Kind::ID`s — kind ids are derived from canonical schema
+/// bytes, so platform-dependent encoding is a wire-correctness bug.
+/// `BTreeMap` (sorted by key) is the deterministic alternative; the
+/// error message names it explicitly so the fix is one substitution.
+///
+/// Recurses through `AngleBracketed` generic args so nested forms like
+/// `Vec<HashMap<String, String>>` and `Option<HashMap<...>>` are
+/// caught too — the nested case would otherwise pass through trait
+/// dispatch and emit a less actionable "trait `Schema` not
+/// implemented" error pointing at the inner `HashMap`.
+fn reject_hashmap(ty: &Type) -> syn::Result<()> {
+    if let Type::Path(tp) = ty {
+        if let Some(seg) = tp.path.segments.last()
+            && seg.ident == "HashMap"
+        {
+            return Err(syn::Error::new_spanned(
+                ty,
+                "HashMap is not allowed in derived kind schemas — its iteration order is \
+                 platform-dependent and would diverge canonical schema bytes (and Kind::ID) \
+                 across builds. Use `std::collections::BTreeMap` instead, which sorts by key. \
+                 See https://github.com/iamacoffeepot/aether/issues/232",
+            ));
+        }
+        for seg in &tp.path.segments {
+            if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                for arg in &args.args {
+                    if let GenericArgument::Type(inner) = arg {
+                        reject_hashmap(inner)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 struct KindAttr {
@@ -1367,5 +1416,81 @@ fn extract_agent_doc(attrs: &[Attribute]) -> Option<String> {
         if s.is_empty() { None } else { Some(s) }
     } else {
         Some(full_trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reject_hashmap;
+    use syn::parse_str;
+
+    // Issue #232: pin the HashMap rejection so a future field-walker
+    // refactor can't silently drop the check (the user-visible
+    // failure mode would be a confusing "Schema not implemented"
+    // error pointing at HashMap rather than the actionable
+    // "use BTreeMap" message). Each fixture covers one shape we
+    // expect the rejection to catch — direct, nested in Vec, nested
+    // in Option, and inside a fully-qualified path.
+
+    fn err(ty: &str) -> String {
+        let parsed: syn::Type = parse_str(ty).expect("test fixture parses");
+        reject_hashmap(&parsed)
+            .err()
+            .unwrap_or_else(|| panic!("expected reject_hashmap to error on {ty}"))
+            .to_string()
+    }
+
+    #[test]
+    fn rejects_direct_hashmap_field() {
+        let msg = err("HashMap<String, String>");
+        assert!(
+            msg.contains("BTreeMap"),
+            "error must point to BTreeMap fix, got: {msg}"
+        );
+        assert!(
+            msg.contains("232"),
+            "error must reference issue 232, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_fully_qualified_hashmap() {
+        let msg = err("std::collections::HashMap<String, u32>");
+        assert!(msg.contains("BTreeMap"));
+    }
+
+    #[test]
+    fn rejects_hashmap_nested_in_vec() {
+        let msg = err("Vec<HashMap<String, String>>");
+        assert!(msg.contains("BTreeMap"));
+    }
+
+    #[test]
+    fn rejects_hashmap_nested_in_option() {
+        let msg = err("Option<HashMap<String, String>>");
+        assert!(msg.contains("BTreeMap"));
+    }
+
+    #[test]
+    fn allows_btreemap_field() {
+        let parsed: syn::Type = parse_str("BTreeMap<String, String>").unwrap();
+        assert!(reject_hashmap(&parsed).is_ok());
+    }
+
+    #[test]
+    fn allows_plain_types() {
+        for ty in [
+            "u32",
+            "String",
+            "Vec<u8>",
+            "Option<String>",
+            "BTreeSet<u64>",
+        ] {
+            let parsed: syn::Type = parse_str(ty).unwrap();
+            assert!(
+                reject_hashmap(&parsed).is_ok(),
+                "rejected {ty} unexpectedly"
+            );
+        }
     }
 }

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -319,3 +319,71 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
     };
     assert!(!*repr_c);
 }
+
+// Issue #232 — `BTreeMap<K, V>` is the deterministic map type for
+// derived kind schemas. The Schema impl in `aether-mail` lands a
+// `SchemaType::Map`; the derive does no special-casing, so this is
+// trait-dispatch end-to-end.
+
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.headers")]
+#[allow(dead_code)]
+struct Headers {
+    headers: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.lookup")]
+#[allow(dead_code)]
+struct Lookup {
+    counters: std::collections::BTreeMap<u32, u64>,
+}
+
+#[test]
+fn btreemap_field_lands_as_schema_map() {
+    let SchemaType::Struct { fields, .. } = &<Headers as Schema>::SCHEMA else {
+        panic!("expected Struct schema");
+    };
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "headers");
+    let SchemaType::Map { key, value } = &fields[0].ty else {
+        panic!("expected Map schema, got {:?}", fields[0].ty);
+    };
+    assert_eq!(&**key, &SchemaType::String);
+    assert_eq!(&**value, &SchemaType::String);
+}
+
+#[test]
+fn btreemap_with_integer_keys_lands_as_schema_map() {
+    let SchemaType::Struct { fields, .. } = &<Lookup as Schema>::SCHEMA else {
+        panic!("expected Struct schema");
+    };
+    let SchemaType::Map { key, value } = &fields[0].ty else {
+        panic!("expected Map schema");
+    };
+    assert_eq!(&**key, &SchemaType::Scalar(Primitive::U32));
+    assert_eq!(&**value, &SchemaType::Scalar(Primitive::U64));
+}
+
+#[test]
+fn btreemap_field_disqualifies_repr_c() {
+    // BTreeMap is variable-length — same constraint as Vec/String/
+    // Option. A `#[repr(C)]` struct with a BTreeMap field must report
+    // `ELIGIBLE = false` so the wire layer doesn't try to cast bytes.
+    const { assert!(!<Headers as CastEligible>::ELIGIBLE) };
+    const { assert!(!<Lookup as CastEligible>::ELIGIBLE) };
+}
+
+#[test]
+fn btreemap_kind_id_stable_across_invocations() {
+    // `Kind::ID` is `fnv1a_64_prefixed(KIND_DOMAIN, canonical_bytes)`.
+    // Two reads of the same const must agree byte-for-byte; this is
+    // the canonical-stability invariant ADR-0030 + ADR-0032 lock in
+    // for the new Map arm.
+    let id_a = <Headers as Kind>::ID;
+    let id_b = <Headers as Kind>::ID;
+    assert_eq!(id_a, id_b);
+    // And different schemas → different ids (collision-resistance
+    // sanity, not an exhaustive test of FNV-1a).
+    assert_ne!(<Headers as Kind>::ID, <Lookup as Kind>::ID);
+}

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -130,6 +130,11 @@ impl<T> CastEligible for Option<T> {
 impl<K> CastEligible for Ref<K> {
     const ELIGIBLE: bool = false;
 }
+// Issue #232: `BTreeMap<K, V>` is variable-length and disqualifies a
+// parent struct from `repr_c`, same as `Vec`/`String`/`Option`.
+impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
+    const ELIGIBLE: bool = false;
+}
 
 /// Deterministic 64-bit hash of a mailbox name (ADR-0029). Both the
 /// substrate registry and the guest SDK compute mailbox ids from names
@@ -493,6 +498,26 @@ mod schema {
         const SCHEMA: SchemaType = SchemaType::Ref(SchemaCell::Static(&K::SCHEMA));
         const LABEL: Option<&'static str> = None;
         const LABEL_NODE: LabelNode = LabelNode::Ref(LabelCell::Static(&K::LABEL_NODE));
+    }
+
+    // Issue #232: `BTreeMap<K, V>` lands as `SchemaType::Map`. The
+    // `Ord` bound is what proto3-style stringify-and-canonicalize
+    // relies on at the codec layer — sorted iteration makes the
+    // wire bytes deterministic without a runtime sort, and
+    // `Vec`/`Option`/`f32`/`f64` are unreachable as keys at the
+    // type level. `HashMap<K, V>` is rejected at the derive layer
+    // (mail-derive) because its iteration order is platform-
+    // dependent and would diverge canonical bytes across builds.
+    impl<K: Schema + Ord + 'static, V: Schema + 'static> Schema for alloc::collections::BTreeMap<K, V> {
+        const SCHEMA: SchemaType = SchemaType::Map {
+            key: SchemaCell::Static(&K::SCHEMA),
+            value: SchemaCell::Static(&V::SCHEMA),
+        };
+        const LABEL: Option<&'static str> = None;
+        const LABEL_NODE: LabelNode = LabelNode::Map {
+            key: LabelCell::Static(&K::LABEL_NODE),
+            value: LabelCell::Static(&V::LABEL_NODE),
+        };
     }
 }
 

--- a/crates/aether-substrate-core/src/handle_store.rs
+++ b/crates/aether-substrate-core/src/handle_store.rs
@@ -399,6 +399,11 @@ pub fn schema_contains_ref(schema: &SchemaType) -> bool {
             EnumVariant::Tuple { fields, .. } => fields.iter().any(schema_contains_ref),
             EnumVariant::Struct { fields, .. } => fields.iter().any(|f| schema_contains_ref(&f.ty)),
         }),
+        // Issue #232: keys are restricted to `String`/integer/`Bool`
+        // (none of which can carry a `Ref`), but the codec rejects
+        // those defensively rather than the type system, so be
+        // conservative and walk both sides.
+        SchemaType::Map { key, value } => schema_contains_ref(key) || schema_contains_ref(value),
     }
 }
 
@@ -596,6 +601,25 @@ fn walk(
                     Ok(None)
                 }
             }
+        }
+        SchemaType::Map { key, value } => {
+            // Wire is `varint(len) + (k, v)` pairs. Same descent
+            // pattern as `Vec<(K, V)>` — walk every key and every
+            // value; bail out on the first `Ref::Handle` that doesn't
+            // resolve. Keys can't carry `Ref`s under the v1 codec
+            // rules, but the walker treats them uniformly so a
+            // hand-rolled `Schema` impl that lands a `Ref` key here
+            // doesn't silently corrupt the wire.
+            let len = state.read_varint()? as usize;
+            for _ in 0..len {
+                if let Some(parked) = walk(key, state, store)? {
+                    return Ok(Some(parked));
+                }
+                if let Some(parked) = walk(value, state, store)? {
+                    return Ok(Some(parked));
+                }
+            }
+            Ok(None)
         }
         SchemaType::Ref(inner) => {
             let ref_disc_start = state.pos;

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -334,6 +334,21 @@ fn merge_schema(shape: &SchemaShape, label: Option<&LabelNode>) -> SchemaType {
             };
             SchemaType::Ref(SchemaCell::owned(merge_schema(inner, inner_label)))
         }
+        SchemaShape::Map { key, value } => {
+            // Issue #232: parallel-walk the labels Map arm so any
+            // nominal info inside key/value types (struct field
+            // names etc.) survives the shape→type rebuild. Mismatched
+            // labels (or no labels at all) collapse to anonymous on
+            // each side independently — the schema arm always wins.
+            let (key_label, value_label) = match label {
+                Some(LabelNode::Map { key: kc, value: vc }) => (Some(&**kc), Some(&**vc)),
+                _ => (None, None),
+            };
+            SchemaType::Map {
+                key: SchemaCell::owned(merge_schema(key, key_label)),
+                value: SchemaCell::owned(merge_schema(value, value_label)),
+            }
+        }
     }
 }
 

--- a/crates/aether-substrate-hub/src/decoder.rs
+++ b/crates/aether-substrate-hub/src/decoder.rs
@@ -184,7 +184,8 @@ fn decode_cast_field(
         | SchemaType::Vec(_)
         | SchemaType::Enum { .. }
         | SchemaType::Unit
-        | SchemaType::Ref(_) => Err(DecodeError::UnsupportedSchema(
+        | SchemaType::Ref(_)
+        | SchemaType::Map { .. } => Err(DecodeError::UnsupportedSchema(
             "non-cast field inside cast-shaped struct",
         )),
     }
@@ -323,6 +324,28 @@ fn decode_postcard(
                 })?;
             decode_enum_body(cur, variant, path)
         }
+        SchemaType::Map {
+            key: key_schema,
+            value: value_schema,
+        } => {
+            // Issue #232 + proto3-style JSON mapping. Wire is
+            // postcard's `BTreeMap<K, V>` shape — varint(len) followed
+            // by `(k, v)` pairs in key-sorted order. We emit a JSON
+            // object with the proto3 stringify rule: integer keys as
+            // decimal-string keys, bool keys as `"true"`/`"false"`,
+            // string keys identity. Order in the emitted object isn't
+            // load-bearing for decoders that compare by value.
+            let len = read_varint_u64(cur, path)? as usize;
+            let mut obj = Map::with_capacity(len);
+            for i in 0..len {
+                let entry_path = format!("{path}[{i}]");
+                let key_value = decode_postcard(cur, key_schema, &entry_path)?;
+                let val_value = decode_postcard(cur, value_schema, &entry_path)?;
+                let key_string = render_map_key(&key_value, key_schema, &entry_path)?;
+                obj.insert(key_string, val_value);
+            }
+            Ok(Value::Object(obj))
+        }
         SchemaType::Ref(inner) => {
             // ADR-0045 typed handle. Wire matches the postcard
             // enum encoding: discriminant varint, then either the
@@ -431,6 +454,46 @@ fn decode_enum_body(
             let mut obj = Map::with_capacity(1);
             obj.insert(name, Value::Object(body));
             Ok(Value::Object(obj))
+        }
+    }
+}
+
+/// Stringify a decoded map key into its proto3-JSON form (issue #232).
+/// Mirrors the encoder's `parse_map_key`: string identity, integer
+/// scalars to decimal digits, bool to `"true"`/`"false"`. Anything else
+/// is `UnsupportedSchema` — the BTreeMap<K: Ord, V> bound at the Rust
+/// layer makes those unreachable, but the codec rejects them defensively
+/// in case a descriptor lands here from an external source.
+fn render_map_key(
+    key_value: &Value,
+    key_schema: &SchemaType,
+    path: &str,
+) -> Result<String, DecodeError> {
+    match (key_schema, key_value) {
+        (SchemaType::String, Value::String(s)) => Ok(s.clone()),
+        (SchemaType::Bool, Value::Bool(b)) => Ok(if *b { "true".into() } else { "false".into() }),
+        (SchemaType::Scalar(p), Value::Number(n)) => match p {
+            Primitive::U8 | Primitive::U16 | Primitive::U32 | Primitive::U64 => Ok(n
+                .as_u64()
+                .ok_or(DecodeError::UnsupportedSchema(
+                    "decoded unsigned key value out of u64 range",
+                ))?
+                .to_string()),
+            Primitive::I8 | Primitive::I16 | Primitive::I32 | Primitive::I64 => Ok(n
+                .as_i64()
+                .ok_or(DecodeError::UnsupportedSchema(
+                    "decoded signed key value out of i64 range",
+                ))?
+                .to_string()),
+            Primitive::F32 | Primitive::F64 => {
+                Err(DecodeError::UnsupportedSchema("float as Map key (no Ord)"))
+            }
+        },
+        _ => {
+            let _ = path;
+            Err(DecodeError::UnsupportedSchema(
+                "Map key must be String, integer scalar, or Bool",
+            ))
         }
     }
 }
@@ -867,5 +930,83 @@ mod tests {
         for n in [0.0, 1.5, -123.456, f64::MIN_POSITIVE, f64::MAX] {
             roundtrip(json!({"x": n}), &schema);
         }
+    }
+
+    // Issue #232 — `SchemaType::Map` decode tests. Each pins JSON
+    // round-trip equivalence: encoder takes a JSON object, decoder
+    // produces the same shape (key strings stringified per proto3).
+
+    fn map_schema(key: SchemaType, value: SchemaType) -> SchemaType {
+        SchemaType::Map {
+            key: SchemaCell::owned(key),
+            value: SchemaCell::owned(value),
+        }
+    }
+
+    #[test]
+    fn map_string_keys_roundtrip() {
+        roundtrip(
+            json!({"content-type": "application/json", "x-trace": "abc123"}),
+            &map_schema(SchemaType::String, SchemaType::String),
+        );
+    }
+
+    #[test]
+    fn map_u32_keys_roundtrip() {
+        // Decoder emits integer keys as decimal-string JSON keys —
+        // matches the encoder's input shape, so round-trip is exact.
+        roundtrip(
+            json!({"1": "one", "42": "answer", "255": "max"}),
+            &map_schema(SchemaType::Scalar(Primitive::U32), SchemaType::String),
+        );
+    }
+
+    #[test]
+    fn map_i64_keys_roundtrip() {
+        roundtrip(
+            json!({"-1": "neg", "0": "zero", "9223372036854775807": "max"}),
+            &map_schema(SchemaType::Scalar(Primitive::I64), SchemaType::String),
+        );
+    }
+
+    #[test]
+    fn map_bool_keys_roundtrip() {
+        roundtrip(
+            json!({"false": 0u32, "true": 1u32}),
+            &map_schema(SchemaType::Bool, SchemaType::Scalar(Primitive::U32)),
+        );
+    }
+
+    #[test]
+    fn map_inside_struct_field_roundtrip() {
+        // The expected shape for the named v1 use case: a map field
+        // inside a postcard struct (HTTP-header-style descriptor).
+        let schema = pc_struct(vec![NamedField {
+            name: "headers".into(),
+            ty: map_schema(SchemaType::String, SchemaType::String),
+        }]);
+        roundtrip(
+            json!({"headers": {"x-foo": "bar", "x-baz": "qux"}}),
+            &schema,
+        );
+    }
+
+    #[test]
+    fn map_empty_roundtrip() {
+        roundtrip(
+            json!({}),
+            &map_schema(SchemaType::String, SchemaType::String),
+        );
+    }
+
+    #[test]
+    fn map_inside_cast_struct_rejected() {
+        let schema = cast_struct(vec![NamedField {
+            name: "headers".into(),
+            ty: map_schema(SchemaType::String, SchemaType::String),
+        }]);
+        // 1-byte payload is enough to fail at the field-walk step.
+        let err = decode_schema(&[0], &schema).unwrap_err();
+        assert!(matches!(err, DecodeError::UnsupportedSchema(_)));
     }
 }

--- a/crates/aether-substrate-hub/src/encoder.rs
+++ b/crates/aether-substrate-hub/src/encoder.rs
@@ -261,6 +261,38 @@ fn encode_postcard(
             encode_enum_body(body, variant, path, out)?;
             Ok(())
         }
+        SchemaType::Map {
+            key: key_schema,
+            value: value_schema,
+        } => {
+            // Issue #232 + proto3-style JSON mapping. Input is a JSON
+            // object: keys live as strings on the wire-side regardless
+            // of declared key type. We parse each JSON-string key
+            // through the key schema, then sort by the parsed value
+            // so the wire bytes match what `postcard::to_allocvec`
+            // would produce on a `BTreeMap` with the same contents
+            // (sorted by key). Sender-order independence keeps two
+            // tools producing byte-identical payloads from
+            // semantically-equal inputs.
+            let json_map = value.as_object().ok_or_else(|| EncodeError::TypeMismatch {
+                field: path.to_owned(),
+                expected: "object",
+            })?;
+            let mut entries: Vec<(ParsedMapKey, Value, &Value)> =
+                Vec::with_capacity(json_map.len());
+            for (k_str, v_json) in json_map {
+                let entry_path = format!("{path}.{k_str}");
+                let (parsed, key_json) = parse_map_key(k_str, key_schema, &entry_path)?;
+                entries.push((parsed, key_json, v_json));
+            }
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            write_varint_u64(out, entries.len() as u64);
+            for (_pk, k_json, v_json) in &entries {
+                encode_postcard(k_json, key_schema, path, out)?;
+                encode_postcard(v_json, value_schema, path, out)?;
+            }
+            Ok(())
+        }
         SchemaType::Ref(inner) => {
             // ADR-0045 typed handle. Externally-tagged JSON matches
             // the Rust enum: `{"Inline": <inner-K>}` chooses the
@@ -306,6 +338,71 @@ fn encode_postcard(
                 }),
             }
         }
+    }
+}
+
+/// Normalized map-key form for sorting (issue #232). Cross-variant
+/// ordering is irrelevant — every key in a single map shares the
+/// declared key schema, so all `ParsedMapKey` values produced for one
+/// encode call land in the same arm. The derived `Ord` keeps the type
+/// total so callers don't need a custom comparator.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum ParsedMapKey<'a> {
+    Bool(bool),
+    UInt(u64),
+    SInt(i64),
+    Str(&'a str),
+}
+
+/// Parse a JSON-string map key per the declared key schema and produce
+/// (a) a sortable normalized form and (b) a `serde_json::Value` shaped
+/// for `encode_postcard` so the actual wire bytes flow through the
+/// existing scalar/string/bool encoders. Proto3 stringify rule —
+/// integer keys land as JSON-string digits, bool keys as `"true"` /
+/// `"false"`, string keys identity. Any other key shape is
+/// `UnsupportedSchema`; the `BTreeMap<K: Ord, V>` bound at the Rust
+/// layer makes most of these unreachable, but the codec rejects them
+/// defensively.
+fn parse_map_key<'a>(
+    k_str: &'a str,
+    schema: &SchemaType,
+    path: &str,
+) -> Result<(ParsedMapKey<'a>, Value), EncodeError> {
+    match schema {
+        SchemaType::String => Ok((ParsedMapKey::Str(k_str), Value::String(k_str.to_owned()))),
+        SchemaType::Bool => match k_str {
+            "true" => Ok((ParsedMapKey::Bool(true), Value::Bool(true))),
+            "false" => Ok((ParsedMapKey::Bool(false), Value::Bool(false))),
+            _ => Err(EncodeError::TypeMismatch {
+                field: path.to_owned(),
+                expected: "\"true\" or \"false\" (bool map key)",
+            }),
+        },
+        SchemaType::Scalar(p) => match p {
+            Primitive::U8 | Primitive::U16 | Primitive::U32 | Primitive::U64 => {
+                let n: u64 = k_str.parse().map_err(|_| EncodeError::TypeMismatch {
+                    field: path.to_owned(),
+                    expected: "unsigned integer (map key as decimal string)",
+                })?;
+                // Range-check happens at the scalar-write step via
+                // `as_unsigned`; storing as u64 here is lossless for
+                // every supported key width.
+                Ok((ParsedMapKey::UInt(n), Value::Number(n.into())))
+            }
+            Primitive::I8 | Primitive::I16 | Primitive::I32 | Primitive::I64 => {
+                let n: i64 = k_str.parse().map_err(|_| EncodeError::TypeMismatch {
+                    field: path.to_owned(),
+                    expected: "signed integer (map key as decimal string)",
+                })?;
+                Ok((ParsedMapKey::SInt(n), Value::Number(n.into())))
+            }
+            Primitive::F32 | Primitive::F64 => {
+                Err(EncodeError::UnsupportedSchema("float as Map key (no Ord)"))
+            }
+        },
+        _ => Err(EncodeError::UnsupportedSchema(
+            "Map key must be String, integer scalar, or Bool",
+        )),
     }
 }
 
@@ -570,7 +667,8 @@ fn encode_field_value(
         | SchemaType::Vec(_)
         | SchemaType::Enum { .. }
         | SchemaType::Unit
-        | SchemaType::Ref(_) => Err(EncodeError::UnsupportedSchema(
+        | SchemaType::Ref(_)
+        | SchemaType::Map { .. } => Err(EncodeError::UnsupportedSchema(
             "non-cast field inside cast-shaped struct",
         )),
     }
@@ -1164,5 +1262,125 @@ mod tests {
             let theirs = postcard::to_allocvec(&n).unwrap();
             assert_eq!(ours, theirs, "zigzag mismatch for {n}");
         }
+    }
+
+    // Issue #232 — `SchemaType::Map` encode tests. proto3-style JSON:
+    // object input always, integer/bool keys stringified.
+
+    fn map_schema(key: SchemaType, value: SchemaType) -> SchemaType {
+        SchemaType::Map {
+            key: SchemaCell::owned(key),
+            value: SchemaCell::owned(value),
+        }
+    }
+
+    #[test]
+    fn map_string_keys_matches_postcard_btreemap() {
+        // Reference value is a `BTreeMap<String, String>` postcarded by
+        // serde — that's the wire shape every receiving substrate will
+        // decode into. Sender input is unsorted to lock in the
+        // sort-after-parse step.
+        let schema = postcard_struct(vec![NamedField {
+            name: "headers".into(),
+            ty: map_schema(SchemaType::String, SchemaType::String),
+        }]);
+
+        let mut reference: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
+        reference.insert("content-type".into(), "application/json".into());
+        reference.insert("x-trace".into(), "abc123".into());
+
+        let expected = postcard::to_allocvec(&reference).unwrap();
+
+        let bytes = encode_schema(
+            &json!({"headers": {"x-trace": "abc123", "content-type": "application/json"}}),
+            &schema,
+        )
+        .unwrap();
+
+        // Strip the schema-struct field-prefix bytes — there are none
+        // here since the field's value is the whole map. The encoded
+        // payload is exactly the BTreeMap postcard bytes.
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn map_string_keys_sender_order_independent() {
+        // Two callers produce the same wire bytes regardless of JSON
+        // input order. Pins the sort-by-parsed-key step.
+        let schema = map_schema(SchemaType::String, SchemaType::Scalar(Primitive::U32));
+        let a = encode_schema(&json!({"alpha": 1, "beta": 2, "gamma": 3}), &schema).unwrap();
+        let b = encode_schema(&json!({"gamma": 3, "alpha": 1, "beta": 2}), &schema).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn map_u32_keys_match_postcard_btreemap() {
+        let schema = map_schema(SchemaType::Scalar(Primitive::U32), SchemaType::String);
+
+        let mut reference: std::collections::BTreeMap<u32, String> =
+            std::collections::BTreeMap::new();
+        reference.insert(1, "one".into());
+        reference.insert(42, "answer".into());
+        reference.insert(255, "max-u8".into());
+
+        let expected = postcard::to_allocvec(&reference).unwrap();
+
+        let bytes = encode_schema(
+            &json!({"42": "answer", "1": "one", "255": "max-u8"}),
+            &schema,
+        )
+        .unwrap();
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn map_bool_keys_match_postcard_btreemap() {
+        let schema = map_schema(SchemaType::Bool, SchemaType::Scalar(Primitive::U32));
+        let mut reference: std::collections::BTreeMap<bool, u32> =
+            std::collections::BTreeMap::new();
+        reference.insert(false, 0);
+        reference.insert(true, 1);
+        let expected = postcard::to_allocvec(&reference).unwrap();
+        let bytes = encode_schema(&json!({"true": 1, "false": 0}), &schema).unwrap();
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn map_rejects_non_object_input() {
+        let schema = map_schema(SchemaType::String, SchemaType::String);
+        let err = encode_schema(&json!([["k", "v"]]), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn map_rejects_unparsable_integer_key() {
+        let schema = map_schema(SchemaType::Scalar(Primitive::U32), SchemaType::String);
+        let err = encode_schema(&json!({"not-a-number": "v"}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn map_rejects_invalid_bool_key() {
+        let schema = map_schema(SchemaType::Bool, SchemaType::Scalar(Primitive::U32));
+        let err = encode_schema(&json!({"yes": 1}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn map_inside_cast_struct_rejected() {
+        // A `Map` field inside a `repr_c: true` parent has no fixed
+        // layout — must surface as `UnsupportedSchema`, not silently
+        // produce garbled bytes.
+        let schema = SchemaType::Struct {
+            repr_c: true,
+            fields: vec![NamedField {
+                name: "headers".into(),
+                ty: map_schema(SchemaType::String, SchemaType::String),
+            }]
+            .into(),
+        };
+        let err = encode_schema(&json!({"headers": {"k": "v"}}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::UnsupportedSchema(_)));
     }
 }


### PR DESCRIPTION
## Summary

- New `SchemaType::Map { key, value }` (and parallel `SchemaShape::Map`, `LabelNode::Map`) — the deterministic map shape for kind payloads. Wire format = postcard's `BTreeMap<K, V>` encoding: varint(len) + (k, v) pairs in key-sorted order.
- `Schema` blanket on `BTreeMap<K: Ord, V>` in aether-mail; trait dispatch covers any user struct that lands a BTreeMap field. `CastEligible::ELIGIBLE = false` so a `#[repr(C)]` parent with a BTreeMap field correctly disqualifies itself.
- Hub MCP encoder/decoder follow proto3's JSON-mapping rule: input is always a JSON object, integer keys parsed from decimal-string form (`{"42": "answer"}`), bool keys as `"true"`/`"false"`, string keys identity. Encoder sorts entries by parsed key so two senders producing the same logical map emit byte-identical wire bytes.
- HashMap is rejected at derive time with an error pointing at BTreeMap as the fix. The walker catches direct uses, fully-qualified paths, and nested forms (`Vec<HashMap<...>>`, `Option<HashMap<...>>`).

## Why

Closes issue 232. The HTTP-header use case (ADR-0043's `Vec<HttpHeader>` shape) is the named v1 driver; future config-dict / response-header / query-string kinds reach for the same shape and now have a primitive instead of a `Vec<KvPair>` workaround. Migrating existing kinds is intentionally **out of scope** here.

## Design notes

- **Why BTreeMap and not HashMap.** `Kind::ID` derives from canonical schema bytes (ADR-0030). HashMap iteration order is platform/hash-state dependent — two builds of the same kind would hash to different ids, which is a wire-correctness bug. BTreeMap's `Ord` bound + sorted iteration removes the divergence at the type level.
- **Why proto3-style stringified keys.** JSON has no map type. Three options surfaced (array-of-pairs, object-when-string-else-array, object-always-with-stringify); proto3's choice (object always, integer/bool keys stringified) gives uniform UX, lines up with the `Ord` bound naturally (`f32`/`f64`/`Vec`/`Option` all excluded as keys), and matches a well-trodden industry convention.
- **Cast-shape rejection.** Maps inside a `repr_c: true` parent surface as `UnsupportedSchema` — variable-length data has no fixed `#[repr(C)]` layout, same constraint as `Vec`/`Option`/`String`.

## Test plan

- [x] `cargo test --workspace --all-targets` (387 tests, all green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Protocol crate: 3 tests covering Map descriptor postcard round-trip + canonical-byte stability across two evaluations
- [x] Hub encoder: 7 tests covering String/integer/bool key roundtrips against `postcard::to_allocvec(BTreeMap<...>)`, sender-order independence, malformed-key rejection, cast-parent rejection
- [x] Hub decoder: 7 round-trip tests for each key shape including empty maps and Map-inside-Struct
- [x] Mail-derive integration: 4 tests pinning that BTreeMap fields land as `SchemaType::Map`, disqualify `repr_c`, and produce stable `Kind::ID` across reads
- [x] Derive unit tests: 6 tests on `reject_hashmap` covering direct/fully-qualified/Vec-nested/Option-nested HashMap forms plus BTreeMap allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)