### PR TITLE
feat(substrate): panic hook + dispatcher trap survival (issue 321 phase 1)

### DIFF
--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -175,6 +175,12 @@ impl<'a> SubstrateBootBuilder<'a> {
     /// `boot.connect_hub_from_env()` once it's done registering its
     /// sinks (issue #262).
     pub fn build(self) -> wasmtime::Result<SubstrateBoot> {
+        // Issue #321: route panics through tracing so dispatcher-thread
+        // crashes surface in `engine_logs` instead of vanishing to
+        // stderr. Idempotent — chassis re-entries / repeated builds in
+        // tests are safe.
+        crate::panic_hook::init_panic_hook();
+
         let outbound = HubOutbound::disconnected();
         log_capture::init(Arc::clone(&outbound));
 

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -546,7 +546,7 @@ impl ControlPlane {
     }
 
     fn insert_component(&self, id: MailboxId, component: Component) {
-        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry));
+        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry), id);
         self.components.write().unwrap().insert(id, Arc::new(entry));
     }
 

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -1109,7 +1109,11 @@ mod tests {
         );
         let component =
             Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate");
-        let entry = Arc::new(ComponentEntry::spawn(component, Arc::clone(&registry)));
+        let entry = Arc::new(ComponentEntry::spawn(
+            component,
+            Arc::clone(&registry),
+            caller_mailbox,
+        ));
         components
             .write()
             .unwrap()

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod log_capture;
 pub mod mail;
 pub mod mailer;
 pub mod net;
+pub mod panic_hook;
 pub mod registry;
 pub mod reply_table;
 pub mod scheduler;
@@ -51,6 +52,7 @@ pub use hub_client::{
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
+pub use panic_hook::init_panic_hook;
 pub use registry::{MailboxEntry, Registry, SinkHandler};
 pub use scheduler::Scheduler;
 

--- a/crates/aether-substrate-core/src/panic_hook.rs
+++ b/crates/aether-substrate-core/src/panic_hook.rs
@@ -1,0 +1,319 @@
+// Substrate panic-hook plumbing (issue #321 Phase 1).
+//
+// Installs a process-global panic hook that routes panics through
+// `tracing::error!` so they surface in `engine_logs` via the existing
+// ADR-0023 capture path. Without this, panics on dispatcher threads
+// (`std::thread::Builder::spawn` in `scheduler.rs`) print to stderr
+// only — and stderr is not what the capture layer reads.
+//
+// Chains the previous hook (`take_hook` -> closure-wraps it ->
+// `set_hook`) so the test harness's panic formatter, color_eyre /
+// human_panic prettifiers, and any embedder hook keep working. The
+// runtime only ever invokes one hook per panic; chaining is a manual
+// pattern, not a runtime feature.
+//
+// Backtrace capture is gated on `AETHER_BACKTRACE` (mirrors the
+// `RUST_BACKTRACE` ergonomic without flipping the global Rust knob).
+// Falls through to `Backtrace::capture()` otherwise, which respects
+// `RUST_BACKTRACE` if set — so existing toolchain conventions still
+// work.
+
+use std::backtrace::{Backtrace, BacktraceStatus};
+use std::panic::{self, PanicHookInfo};
+use std::sync::OnceLock;
+
+/// Env var that forces backtrace capture without flipping
+/// `RUST_BACKTRACE` for the whole process (which would change every
+/// other crate's panic output).
+pub const ENV_BACKTRACE: &str = "AETHER_BACKTRACE";
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Install the substrate panic hook globally. Idempotent — only the
+/// first call wires the hook; subsequent calls are no-ops, so chassis
+/// boot, tests, and embedders can call freely without ordering
+/// constraints.
+///
+/// Call early in process startup (substrate `boot::build` is the
+/// canonical site). Installing later is fine — the hook only fires on
+/// future panics — but earlier means more of the process is covered.
+pub fn init_panic_hook() {
+    INIT.get_or_init(|| {
+        let prev = panic::take_hook();
+        panic::set_hook(make_hook(prev));
+    });
+}
+
+/// Wrap `prev` so the returned hook emits a structured tracing event
+/// before invoking `prev`. Factored out of `init_panic_hook` so the
+/// chaining and event-emit mechanics are testable without touching
+/// the global hook slot.
+fn make_hook(
+    prev: Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>,
+) -> Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static> {
+    Box::new(move |info| {
+        emit_event(info);
+        prev(info);
+    })
+}
+
+fn emit_event(info: &PanicHookInfo<'_>) {
+    let thread = std::thread::current();
+    let thread_name = thread.name().unwrap_or("<unnamed>");
+    let location = info
+        .location()
+        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let payload = payload_string(info.payload());
+    let backtrace = capture_backtrace();
+
+    // The current `tracing::Span` is auto-captured by the dispatcher
+    // (subscriber-side concern), so component / mailbox / kind ride
+    // along when the panic happens inside `dispatcher_loop` without
+    // having to thread them in here.
+    if let Some(bt) = backtrace {
+        tracing::error!(
+            target: "aether_substrate::panic",
+            thread = %thread_name,
+            location = %location,
+            payload = %payload,
+            backtrace = %bt,
+            "panic on substrate thread",
+        );
+    } else {
+        tracing::error!(
+            target: "aether_substrate::panic",
+            thread = %thread_name,
+            location = %location,
+            payload = %payload,
+            "panic on substrate thread",
+        );
+    }
+}
+
+/// Stringify the panic payload. Std supports two common shapes —
+/// `&'static str` (from `panic!("literal")`) and `String` (from
+/// `panic!("{}", thing)`) — and falls back to a `TypeId` mention for
+/// anything else. Mirrors the default hook's behaviour without
+/// duplicating its full dance.
+fn payload_string(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("<non-string panic payload type_id={:?}>", payload.type_id())
+    }
+}
+
+fn capture_backtrace() -> Option<Backtrace> {
+    capture_backtrace_with(std::env::var_os(ENV_BACKTRACE).is_some())
+}
+
+/// Pure-fn factor of `capture_backtrace` so tests can exercise both
+/// branches without racing on env-var mutations.
+fn capture_backtrace_with(forced: bool) -> Option<Backtrace> {
+    if forced {
+        return Some(Backtrace::force_capture());
+    }
+    let bt = Backtrace::capture();
+    matches!(bt.status(), BacktraceStatus::Captured).then_some(bt)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use tracing::Subscriber;
+    use tracing::field::{Field, Visit};
+
+    use super::*;
+
+    /// `&'static str` payload (the common `panic!("literal")` case).
+    #[test]
+    fn payload_string_handles_static_str() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("static reason");
+        assert_eq!(payload_string(payload.as_ref()), "static reason");
+    }
+
+    /// `String` payload (the common `panic!("{}", x)` case).
+    #[test]
+    fn payload_string_handles_owned_string() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("owned reason"));
+        assert_eq!(payload_string(payload.as_ref()), "owned reason");
+    }
+
+    /// Anything else falls through to a TypeId mention so the message
+    /// at least identifies the payload shape.
+    #[test]
+    fn payload_string_handles_unknown_type() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let out = payload_string(payload.as_ref());
+        assert!(
+            out.starts_with("<non-string panic payload"),
+            "unexpected: {out}",
+        );
+    }
+
+    /// Forced branch returns a captured backtrace regardless of env.
+    #[test]
+    fn capture_backtrace_with_forced_returns_some() {
+        let bt = capture_backtrace_with(true);
+        assert!(bt.is_some(), "forced=true must always capture");
+        assert!(matches!(
+            bt.unwrap().status(),
+            BacktraceStatus::Captured | BacktraceStatus::Unsupported
+        ));
+    }
+
+    /// Unforced branch defers to `Backtrace::capture()` which respects
+    /// `RUST_BACKTRACE`. We don't assert on the result (the test env
+    /// might or might not have it set) — we just verify the function
+    /// doesn't panic and returns a Backtrace value of some shape.
+    #[test]
+    fn capture_backtrace_with_unforced_does_not_panic() {
+        let _ = capture_backtrace_with(false);
+    }
+
+    /// `init_panic_hook` is idempotent — calling it many times must
+    /// not double-install or panic. The OnceLock guard is the
+    /// load-bearing piece; this test makes regressions loud.
+    #[test]
+    fn init_is_idempotent() {
+        init_panic_hook();
+        init_panic_hook();
+        init_panic_hook();
+    }
+
+    /// The wrapped hook calls the previous hook exactly once per
+    /// panic. Tests the chaining mechanic directly. `set_hook` is
+    /// process-global, so other tests panicking concurrently could
+    /// fire our sentinel too — we filter on `thread::current().id()`
+    /// to count only panics from this test's thread, keeping the
+    /// assertion stable under parallel test execution.
+    #[test]
+    fn make_hook_chains_to_previous() {
+        let test_thread = std::thread::current().id();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_prev = Arc::clone(&counter);
+        let prev: Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static> =
+            Box::new(move |_info| {
+                if std::thread::current().id() == test_thread {
+                    counter_for_prev.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        let hook = make_hook(prev);
+
+        // Drive the hook with a real PanicHookInfo by triggering a
+        // panic inside `catch_unwind` while our hook is the global
+        // hook. We have to install it (briefly) to get a real info.
+        let saved = panic::take_hook();
+        panic::set_hook(hook);
+        let _ = panic::catch_unwind(|| {
+            panic!("chain probe");
+        });
+        let _ = panic::take_hook();
+        panic::set_hook(saved);
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "previous hook must run exactly once per panic on this thread",
+        );
+    }
+
+    /// End-to-end: installing the global hook, driving a panic,
+    /// observing a structured tracing event with the expected fields.
+    /// Uses a thread-local subscriber so the assertion only sees the
+    /// panic this test triggered (other parallel tests' panics route
+    /// to whatever subscriber is active on their threads).
+    #[test]
+    fn global_hook_emits_panic_event() {
+        init_panic_hook();
+
+        let captured: Arc<Mutex<Vec<CapturedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = CapturingSubscriber {
+            events: Arc::clone(&captured),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _ = panic::catch_unwind(|| {
+                panic!("e2e probe 8e3a");
+            });
+        });
+
+        let events = captured.lock().unwrap();
+        let panic_events: Vec<&CapturedEvent> = events
+            .iter()
+            .filter(|e| e.target == "aether_substrate::panic")
+            .collect();
+        assert!(
+            !panic_events.is_empty(),
+            "no panic event captured (got {} non-panic events)",
+            events.len(),
+        );
+        let merged: String = panic_events
+            .iter()
+            .map(|e| e.fields.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            merged.contains("e2e probe 8e3a"),
+            "panic payload missing from event: {merged}",
+        );
+        assert!(
+            merged.contains("location"),
+            "location field missing from event: {merged}",
+        );
+        assert!(
+            merged.contains("thread"),
+            "thread field missing from event: {merged}",
+        );
+    }
+
+    struct CapturedEvent {
+        target: String,
+        fields: String,
+    }
+
+    /// Minimal in-tree tracing subscriber that captures event target +
+    /// formatted fields into a Vec for test assertions. Avoids pulling
+    /// `tracing-test` as a dev-dep just to do this one thing.
+    struct CapturingSubscriber {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl Subscriber for CapturingSubscriber {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut buf = String::new();
+            let mut visitor = StringVisit(&mut buf);
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                target: event.metadata().target().to_string(),
+                fields: buf,
+            });
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    struct StringVisit<'a>(&'a mut String);
+
+    impl Visit for StringVisit<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0.push_str(&format!("{}={:?};", field.name(), value));
+        }
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0.push_str(&format!("{}={};", field.name(), value));
+        }
+    }
+}

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -66,6 +66,12 @@ pub struct ComponentEntry {
     /// to the whole entry (which would create a cycle through the
     /// `JoinHandle`).
     gate: Arc<PendingGate>,
+    /// Stable identity for this entry (issue #321). Carried so
+    /// `splice_inbox` can rewire a fresh dispatcher under the same
+    /// thread name + dispatch span without the caller threading the id
+    /// back through, and so panic-hook events have a structured field
+    /// for the failing mailbox.
+    mailbox: MailboxId,
 }
 
 impl ComponentEntry {
@@ -75,21 +81,34 @@ impl ComponentEntry {
     /// that both the dispatcher and the `wait_reply_p32` host fn —
     /// which runs on the same dispatcher thread, nested under
     /// `deliver` — can drain the same inbox. The `Arc<Registry>` is
-    /// used by the dispatcher to format warn-logs for unknown kinds.
-    pub fn spawn(mut component: Component, registry: Arc<Registry>) -> Self {
+    /// used by the dispatcher to format warn-logs for unknown kinds
+    /// and to resolve `mailbox` to a human-readable name when naming
+    /// the dispatcher thread (issue #321) — a panic on the dispatcher
+    /// then surfaces in `engine_logs` with `thread="aether-component-
+    /// {name}-{mailbox_short}"` instead of an opaque thread label.
+    pub fn spawn(mut component: Component, registry: Arc<Registry>, mailbox: MailboxId) -> Self {
         let (tx, rx) = mpsc::channel();
         component.install_inbox_rx(rx);
         let gate: Arc<PendingGate> = Arc::new(PendingGate::default());
         let gate_for_thread = Arc::clone(&gate);
+        let thread_name = dispatcher_thread_name(&registry, mailbox);
         let handle = thread::Builder::new()
-            .name("aether-component-dispatch".into())
-            .spawn(move || dispatcher_loop(component, registry, gate_for_thread))
+            .name(thread_name)
+            .spawn(move || dispatcher_loop(component, registry, gate_for_thread, mailbox))
             .expect("spawn component dispatcher");
         Self {
             sender: Mutex::new(Some(tx)),
             handle: Mutex::new(Some(handle)),
             gate,
+            mailbox,
         }
+    }
+
+    /// Mailbox id this entry was registered under. Stable across a
+    /// `splice_inbox` (replace) — the dispatcher swaps but the entry
+    /// stays put.
+    pub fn mailbox(&self) -> MailboxId {
+        self.mailbox
     }
 
     /// Forward `mail` to this component's inbox. Returns `false` if
@@ -214,35 +233,84 @@ pub fn spawn_dispatcher_on(
 ) {
     component.install_inbox_rx(rx);
     let gate = Arc::clone(&entry.gate);
+    let mailbox = entry.mailbox;
+    let thread_name = dispatcher_thread_name(&registry, mailbox);
     let handle = thread::Builder::new()
-        .name("aether-component-dispatch".into())
-        .spawn(move || dispatcher_loop(component, registry, gate))
+        .name(thread_name)
+        .spawn(move || dispatcher_loop(component, registry, gate, mailbox))
         .expect("spawn component dispatcher");
     let prev = entry.handle.lock().unwrap().replace(handle);
     debug_assert!(prev.is_none(), "entry handle slot must be empty");
+}
+
+/// Build the dispatcher-thread name. Issue #321: panic-hook events
+/// carry `thread.name` as a structured field, and naming threads after
+/// their mailbox makes "what crashed?" answerable from one log line.
+/// Format: `aether-component-{name}-{mailbox_short}` where
+/// `mailbox_short` is the low 16 hex digits of the 64-bit id (full id
+/// is too long for `top` / `ps`). Falls back to `"?"` for unnamed
+/// mailboxes — sinks-only lookups would already have surfaced a
+/// different error before getting here, but the fallback keeps the
+/// thread-name path infallible.
+fn dispatcher_thread_name(registry: &Registry, mailbox: MailboxId) -> String {
+    let name = registry
+        .mailbox_name(mailbox)
+        .unwrap_or_else(|| "?".to_string());
+    format!("aether-component-{}-{:016x}", name, mailbox.0)
 }
 
 fn dispatcher_loop(
     mut component: Component,
     registry: Arc<Registry>,
     gate: Arc<PendingGate>,
+    mailbox: MailboxId,
 ) -> Component {
     // ADR-0042: the receiver lives on `SubstrateCtx`; `next_mail`
     // drains the overflow buffer (any non-match mail set aside by a
     // completed `wait_reply_p32` call) ahead of the mpsc. `None`
     // means both are empty and the inbox is closed — our exit.
     while let Some(mail) = component.next_mail() {
-        let rc = component.deliver(&mail).expect("component.deliver failed");
-        if rc == DISPATCH_UNKNOWN_KIND {
-            let kind_name = registry
-                .kind_name(mail.kind)
-                .unwrap_or_else(|| format!("kind#{:#x}", mail.kind));
-            tracing::warn!(
-                target: "aether_substrate::scheduler",
-                mailbox = ?mail.recipient,
-                kind = %kind_name,
-                "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
-            );
+        // Issue #321: open a `dispatch` span around `deliver` so the
+        // panic hook auto-captures the mailbox + kind context if the
+        // guest (or our host code) panics. Pre-resolve `kind_name`
+        // once and reuse it both as a span field and (if we hit the
+        // unknown-kind path) the warn message.
+        let kind_name = registry
+            .kind_name(mail.kind)
+            .unwrap_or_else(|| format!("kind#{:#x}", mail.kind));
+        let span = tracing::info_span!(
+            "dispatch",
+            mailbox = mailbox.0,
+            kind = %kind_name,
+        );
+        let _enter = span.enter();
+        // Issue #321: replace `.expect("component.deliver failed")`
+        // with a logged Err. A wasmtime trap (guest unreachable, host-
+        // fn panic caught by wasmtime, etc.) used to take the whole
+        // dispatcher thread down silently; now it surfaces as a
+        // structured event and the dispatcher continues draining.
+        // Phase 2 (mailbox-Dead transitions, component_died broadcast)
+        // ships separately.
+        match component.deliver(&mail) {
+            Ok(rc) => {
+                if rc == DISPATCH_UNKNOWN_KIND {
+                    tracing::warn!(
+                        target: "aether_substrate::scheduler",
+                        mailbox = ?mail.recipient,
+                        kind = %kind_name,
+                        "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "aether_substrate::scheduler",
+                    mailbox = ?mail.recipient,
+                    kind = %kind_name,
+                    error = %e,
+                    "component deliver failed: wasmtime returned Err (likely guest trap)",
+                );
+            }
         }
         decrement_and_notify(&gate);
     }
@@ -301,7 +369,7 @@ impl Scheduler {
     /// `id` — replacement is an ADR-0010 primitive in its own right,
     /// handled by `ControlPlane::handle_replace`.
     pub fn add_component(&self, id: MailboxId, component: Component) {
-        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry));
+        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry), id);
         self.components.write().unwrap().insert(id, Arc::new(entry));
     }
 }
@@ -363,11 +431,27 @@ mod tests {
                 i32.const 0))
     "#;
 
-    fn minimal_component() -> Component {
+    /// Issue #321: guest unreachables on every `receive_p32` call.
+    /// Wasmtime translates the WASM `unreachable` opcode into a trap
+    /// that surfaces as `Err(wasmtime::Error)` from `Component::deliver`.
+    /// Pre-issue-321 the dispatcher's `.expect("component.deliver
+    /// failed")` turned that Err into a panic that killed the actor
+    /// thread silently — `drain` then deadlocked because the pending
+    /// counter never decremented. With the fix, `deliver` errs cleanly,
+    /// the dispatcher logs a `tracing::error!` and continues to the
+    /// next mail.
+    const WAT_TRAPS_IN_RECEIVE: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+                unreachable))
+    "#;
+
+    fn component_from_wat(wat: &str) -> Component {
         let engine = Engine::default();
         let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
         crate::host_fns::register(&mut linker).expect("register host fns");
-        let wasm = wat::parse_str(WAT_NOOP).expect("compile WAT");
+        let wasm = wat::parse_str(wat).expect("compile WAT");
         let module = Module::new(&engine, &wasm).expect("compile module");
         let ctx = SubstrateCtx::new(
             MailboxId(0),
@@ -379,10 +463,15 @@ mod tests {
         Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate")
     }
 
+    fn minimal_component() -> Component {
+        component_from_wat(WAT_NOOP)
+    }
+
     fn spawn_entry() -> Arc<ComponentEntry> {
         Arc::new(ComponentEntry::spawn(
             minimal_component(),
             Arc::new(Registry::new()),
+            MailboxId(0),
         ))
     }
 
@@ -428,5 +517,95 @@ mod tests {
     fn splice_inbox_joins_old_dispatcher() {
         let entry = spawn_entry();
         let (_old_component, _new_rx) = splice_inbox(&entry);
+    }
+
+    /// Issue #321: thread name carries the resolved mailbox name plus a
+    /// 16-hex-char suffix derived from the 64-bit mailbox id. The panic
+    /// hook's `thread.name` field is what makes a dispatcher panic
+    /// answerable from one log line, so the format is load-bearing.
+    #[test]
+    fn dispatcher_thread_name_includes_mailbox_name_and_id() {
+        let registry = Registry::new();
+        let mbox = registry.register_component("test-comp");
+        let name = dispatcher_thread_name(&registry, mbox);
+        assert!(
+            name.starts_with("aether-component-test-comp-"),
+            "unexpected prefix: {name}",
+        );
+        // 16-hex-char id suffix.
+        let suffix = &name[name.len() - 16..];
+        assert_eq!(suffix.len(), 16);
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "id suffix not hex: {suffix}",
+        );
+    }
+
+    /// Falls back to `?` when the mailbox isn't registered. Real
+    /// substrate paths register the mailbox before spawning, but the
+    /// fallback keeps the thread-name path infallible — a missing name
+    /// must never crash a dispatcher spawn.
+    #[test]
+    fn dispatcher_thread_name_falls_back_when_unnamed() {
+        let registry = Registry::new();
+        let name = dispatcher_thread_name(&registry, MailboxId(0xABCDEF1234567890));
+        assert_eq!(name, "aether-component-?-abcdef1234567890");
+    }
+
+    /// Load-bearing regression for issue #321: a guest that traps on
+    /// every `receive_p32` (the post-fix behaviour we're relying on)
+    /// no longer kills the dispatcher thread. Pre-fix this test would
+    /// deadlock in `drain` because `.expect("component.deliver
+    /// failed")` panicked the dispatcher before it could decrement the
+    /// pending counter.
+    #[test]
+    fn trap_in_receive_does_not_kill_dispatcher() {
+        let entry = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::new(Registry::new()),
+            MailboxId(0),
+        ));
+
+        // First mail: guest traps. With the fix, dispatcher logs Err
+        // and decrements the gate; without the fix, drain blocks
+        // forever (pending stays at 1 because the panicked dispatcher
+        // never ran `decrement_and_notify`).
+        assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![1], 1)));
+        entry.drain();
+        assert_eq!(
+            entry.gate.pending.load(Ordering::Acquire),
+            0,
+            "dispatcher must decrement pending even when deliver returns Err",
+        );
+
+        // Second mail: dispatcher should still be alive (proof: drain
+        // returns) and processing. Pre-fix this would also deadlock
+        // because the thread died on mail #1.
+        assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![2], 1)));
+        entry.drain();
+        assert_eq!(entry.gate.pending.load(Ordering::Acquire), 0);
+
+        // Clean shutdown: close the channel, dispatcher exits,
+        // close_and_join recovers the Component without panicking.
+        let _component = close_and_join(entry);
+    }
+
+    /// Repeated traps don't leak state or accumulate pending counts.
+    /// Strict regression check for the decrement_and_notify path
+    /// running on every iteration of the dispatcher loop, not just
+    /// the Ok arm.
+    #[test]
+    fn repeated_traps_drain_independently() {
+        let entry = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::new(Registry::new()),
+            MailboxId(0),
+        ));
+        for i in 0..16u32 {
+            assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![i as u8], 1)));
+        }
+        entry.drain();
+        assert_eq!(entry.gate.pending.load(Ordering::Acquire), 0);
+        let _component = close_and_join(entry);
     }
 }


### PR DESCRIPTION
Phase 1 of issue 321 — pure visibility. Closes the panic-vanishing and silent-trap-death gaps; recovery semantics (`MailboxState::Dead`, component_died broadcast, `catch_unwind` on the dispatcher loop body) ship as Phase 2.

## What changes

- **`crates/aether-substrate-core/src/panic_hook.rs` (new).** `init_panic_hook()` installs a process-global panic hook via `take_hook` + `set_hook`, idempotent under `OnceLock`. Hook emits a `tracing::error!` event with thread name, panic location (file:line:col), payload, and (env-gated) backtrace, then invokes the previous hook so the test harness's panic formatter and any embedder hook keep working.
- **`boot.rs::build()`.** Calls `init_panic_hook()` before `log_capture::init` so all three chassis (desktop / headless / hub) get the hook through one insertion point — chassis mains stay untouched.
- **`scheduler.rs`.** Dispatcher threads named `aether-component-{mailbox_name}-{mailbox_short_hex}` instead of the opaque `aether-component-dispatch`. `dispatcher_loop` opens a `dispatch` span carrying mailbox + kind around each `deliver` call, so the panic hook's auto-captured span context says which mailbox was servicing which kind when it died. `.expect("component.deliver failed")` becomes a `match` that logs `Err` via `tracing::error!` and continues — a wasmtime trap during deliver no longer kills the dispatcher thread silently.
- **`ComponentEntry`** carries its `MailboxId` so `splice_inbox` can rewire a fresh dispatcher under the same identity without callers re-threading the id.
- **Backtrace gating.** `AETHER_BACKTRACE=1` mirrors the `RUST_BACKTRACE` ergonomic without flipping the global Rust knob (so other crates' panic output is unaffected).

## Tests

- **`panic_hook` unit tests:** payload formatting (static str / String / unknown type), backtrace env-gating (forced + default branches), `init_panic_hook` idempotency, chaining mechanic via `make_hook` (sentinel-counted, thread-id-filtered to survive parallel test execution), and end-to-end "panic to tracing event captured" via a thread-local subscriber.
- **`scheduler` tests:** thread-name format (mailbox-named + fallback to `?` for unnamed), and the load-bearing regression — `WAT_TRAPS_IN_RECEIVE` fixture + `trap_in_receive_does_not_kill_dispatcher` and `repeated_traps_drain_independently`. Pre-fix these would deadlock in `drain` because the panicked dispatcher thread never decremented the pending counter; post-fix they pass.

Tier-4 end-to-end (full `SubstrateBoot` + a trapping component + `engine_logs` polling) is deferred to Phase 2 — that PR adds the `aether.observation.component_died` broadcast, which gives a cleaner assertion target than tracing-event polling does today.

## Test plan
- [x] `cargo test --workspace` — all green (no regressions; 8 new tests added)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs issue 321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)