### PR TITLE
feat(substrate): mark dead + component_died broadcast (issue 321 phase 2)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -528,6 +528,31 @@ pub struct FrameStats {
     pub triangles: u64,
 }
 
+/// Substrate broadcast on actor death (issue 321 Phase 2). The
+/// dispatcher emits one of these to `hub.claude.broadcast` when a
+/// component's actor thread is marked dead — either because the guest
+/// trapped during `deliver` or a host-side panic was caught around the
+/// loop body. External monitor components (or a Claude session in MCP)
+/// observe this kind via `receive_mail` and decide what to do —
+/// `replace_component` for hot-recovery, page a human, or just leave
+/// the mailbox dead. The substrate itself takes no recovery action;
+/// policy lives outside.
+///
+/// `last_kind` carries the kind name being delivered when the actor
+/// died. `reason` is a human-readable string describing the failure
+/// (panic payload, trap message). String fields make this postcard-
+/// shaped on the wire (cast eligibility is false for non-`Pod` types).
+#[derive(
+    aether_mail::Kind, aether_mail::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.observation.component_died")]
+pub struct ComponentDied {
+    pub mailbox_id: u64,
+    pub mailbox_name: alloc::string::String,
+    pub last_kind: alloc::string::String,
+    pub reason: alloc::string::String,
+}
+
 /// Diagnostic the hub emits back to an originating engine when mail
 /// that engine bubbled up (ADR-0037) doesn't resolve at the hub
 /// either. Lands on the engine's `aether.diagnostics` sink, which

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -473,6 +473,7 @@ impl ControlPlane {
                 old_component,
                 new_rx,
                 Arc::clone(&self.registry),
+                Arc::clone(&self.queue),
             );
             return ReplaceResult::Err { error: err };
         }
@@ -505,6 +506,7 @@ impl ControlPlane {
                         old_component,
                         new_rx,
                         Arc::clone(&self.registry),
+                        Arc::clone(&self.queue),
                     );
                     return ReplaceResult::Err {
                         error: format!("wasm instantiation failed: {e}"),
@@ -524,6 +526,7 @@ impl ControlPlane {
                 old_component,
                 new_rx,
                 Arc::clone(&self.registry),
+                Arc::clone(&self.queue),
             );
             return ReplaceResult::Err {
                 error: format!("on_rehydrate failed: {e}"),
@@ -539,6 +542,7 @@ impl ControlPlane {
             new_component,
             new_rx,
             Arc::clone(&self.registry),
+            Arc::clone(&self.queue),
         );
 
         self.announce_kinds();
@@ -546,7 +550,12 @@ impl ControlPlane {
     }
 
     fn insert_component(&self, id: MailboxId, component: Component) {
-        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry), id);
+        let entry = ComponentEntry::spawn(
+            component,
+            Arc::clone(&self.registry),
+            Arc::clone(&self.queue),
+            id,
+        );
         self.components.write().unwrap().insert(id, Arc::new(entry));
     }
 

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -1112,6 +1112,7 @@ mod tests {
         let entry = Arc::new(ComponentEntry::spawn(
             component,
             Arc::clone(&registry),
+            Arc::clone(&mailer),
             caller_mailbox,
         ));
         components

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -295,11 +295,24 @@ fn route_mail(
             let entry = components.read().unwrap().get(&recipient).map(Arc::clone);
             match entry {
                 Some(entry) => {
-                    if !entry.send(mail) {
+                    // Issue 321 Phase 2: differentiate "actor died
+                    // (panic / trap)" from "shutdown closed". The
+                    // dead-state check happens before send so the
+                    // warn message is unambiguous; otherwise both
+                    // failure modes collapsed into the same line and
+                    // dead-actor diagnoses became "why is mail being
+                    // dropped?" detective work.
+                    if entry.is_dead() {
                         tracing::warn!(
                             target: "aether_substrate::queue",
                             mailbox = ?recipient,
-                            "component inbox closed; mail discarded",
+                            "mail to dead mailbox (actor panicked or trapped); discarded — see component_died broadcast",
+                        );
+                    } else if !entry.send(mail) {
+                        tracing::warn!(
+                            target: "aether_substrate::queue",
+                            mailbox = ?recipient,
+                            "component inbox closed (shutdown); mail discarded",
                         );
                     }
                 }

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -24,15 +24,28 @@
 // per-mailbox drains.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
 
+use aether_kinds::ComponentDied;
+use aether_mail::Kind;
+
 use crate::component::{Component, DISPATCH_UNKNOWN_KIND};
-use crate::mail::{Mail, MailboxId};
+use crate::mail::{Mail, MailboxId, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::Registry;
+
+/// MailboxState tag stored in `ComponentEntry::state` (issue 321
+/// Phase 2). The dispatcher transitions Live → Dead before exiting on
+/// a panic / trap; `send` and the mailer's routing path read this on
+/// the fast path so mail to a dead mailbox warn-drops with the
+/// distinct "actor died" reason instead of queuing on a Sender
+/// nobody is reading.
+const STATE_LIVE: u8 = 0;
+const STATE_DEAD: u8 = 1;
 
 /// Per-entry quiescence counter + condvar, shared with the dispatcher
 /// thread. `send` increments `pending` before forwarding to the inbox;
@@ -72,6 +85,14 @@ pub struct ComponentEntry {
     /// back through, and so panic-hook events have a structured field
     /// for the failing mailbox.
     mailbox: MailboxId,
+    /// Issue 321 Phase 2: actor liveness flag. Shared with the
+    /// dispatcher loop so a panic / trap detected during `deliver`
+    /// transitions the entry to `STATE_DEAD` before the actor thread
+    /// exits — `send` / mailer routing then warn-drop subsequent mail
+    /// with the dead-actor reason instead of queuing on a Sender no
+    /// one is reading. Reset to `STATE_LIVE` on a successful replace
+    /// (`spawn_dispatcher_on`'s caller takes care of that path).
+    state: Arc<AtomicU8>,
 }
 
 impl ComponentEntry {
@@ -86,21 +107,38 @@ impl ComponentEntry {
     /// the dispatcher thread (issue #321) — a panic on the dispatcher
     /// then surfaces in `engine_logs` with `thread="aether-component-
     /// {name}-{mailbox_short}"` instead of an opaque thread label.
-    pub fn spawn(mut component: Component, registry: Arc<Registry>, mailbox: MailboxId) -> Self {
+    pub fn spawn(
+        mut component: Component,
+        registry: Arc<Registry>,
+        mailer: Arc<Mailer>,
+        mailbox: MailboxId,
+    ) -> Self {
         let (tx, rx) = mpsc::channel();
         component.install_inbox_rx(rx);
         let gate: Arc<PendingGate> = Arc::new(PendingGate::default());
+        let state: Arc<AtomicU8> = Arc::new(AtomicU8::new(STATE_LIVE));
         let gate_for_thread = Arc::clone(&gate);
+        let state_for_thread = Arc::clone(&state);
         let thread_name = dispatcher_thread_name(&registry, mailbox);
         let handle = thread::Builder::new()
             .name(thread_name)
-            .spawn(move || dispatcher_loop(component, registry, gate_for_thread, mailbox))
+            .spawn(move || {
+                dispatcher_loop(
+                    component,
+                    registry,
+                    mailer,
+                    gate_for_thread,
+                    state_for_thread,
+                    mailbox,
+                )
+            })
             .expect("spawn component dispatcher");
         Self {
             sender: Mutex::new(Some(tx)),
             handle: Mutex::new(Some(handle)),
             gate,
             mailbox,
+            state,
         }
     }
 
@@ -111,13 +149,27 @@ impl ComponentEntry {
         self.mailbox
     }
 
+    /// Issue 321 Phase 2: `true` if the dispatcher transitioned this
+    /// mailbox to Dead after a panic or trap during deliver. Mail
+    /// routed to a dead mailbox is warn-dropped at the mailer with a
+    /// distinct reason instead of being queued on a Sender no one
+    /// reads.
+    pub fn is_dead(&self) -> bool {
+        self.state.load(Ordering::Acquire) == STATE_DEAD
+    }
+
     /// Forward `mail` to this component's inbox. Returns `false` if
-    /// the inbox is closed (caller should warn-and-drop). On success,
-    /// increments the per-entry quiescence counter before sending; the
-    /// dispatcher decrements after `deliver` returns. On closed-inbox,
-    /// the counter is left untouched (nothing to deliver, nothing to
+    /// the inbox is closed OR the mailbox transitioned to Dead
+    /// (issue 321 Phase 2; callers that want to differentiate use
+    /// `is_dead()` first). On success, increments the per-entry
+    /// quiescence counter before sending; the dispatcher decrements
+    /// after `deliver` returns. On the dead / closed paths the
+    /// counter is left untouched (nothing to deliver, nothing to
     /// drain).
     pub fn send(&self, mail: Mail) -> bool {
+        if self.is_dead() {
+            return false;
+        }
         let guard = self.sender.lock().unwrap();
         let Some(tx) = guard.as_ref() else {
             return false;
@@ -230,14 +282,22 @@ pub fn spawn_dispatcher_on(
     mut component: Component,
     rx: Receiver<Mail>,
     registry: Arc<Registry>,
+    mailer: Arc<Mailer>,
 ) {
     component.install_inbox_rx(rx);
     let gate = Arc::clone(&entry.gate);
+    let state = Arc::clone(&entry.state);
+    // Replace resets liveness — a successful swap brings a fresh
+    // instance up under the same entry, so a prior panic on the old
+    // dispatcher shouldn't leave the entry permanently Dead. ADR-0022
+    // freeze-drain-swap takes the failure-path policy elsewhere
+    // (replace returns Err and the old instance stays bound).
+    state.store(STATE_LIVE, Ordering::Release);
     let mailbox = entry.mailbox;
     let thread_name = dispatcher_thread_name(&registry, mailbox);
     let handle = thread::Builder::new()
         .name(thread_name)
-        .spawn(move || dispatcher_loop(component, registry, gate, mailbox))
+        .spawn(move || dispatcher_loop(component, registry, mailer, gate, state, mailbox))
         .expect("spawn component dispatcher");
     let prev = entry.handle.lock().unwrap().replace(handle);
     debug_assert!(prev.is_none(), "entry handle slot must be empty");
@@ -262,7 +322,9 @@ fn dispatcher_thread_name(registry: &Registry, mailbox: MailboxId) -> String {
 fn dispatcher_loop(
     mut component: Component,
     registry: Arc<Registry>,
+    mailer: Arc<Mailer>,
     gate: Arc<PendingGate>,
+    state: Arc<AtomicU8>,
     mailbox: MailboxId,
 ) -> Component {
     // ADR-0042: the receiver lives on `SubstrateCtx`; `next_mail`
@@ -270,29 +332,45 @@ fn dispatcher_loop(
     // completed `wait_reply_p32` call) ahead of the mpsc. `None`
     // means both are empty and the inbox is closed — our exit.
     while let Some(mail) = component.next_mail() {
-        // Issue #321: open a `dispatch` span around `deliver` so the
-        // panic hook auto-captures the mailbox + kind context if the
-        // guest (or our host code) panics. Pre-resolve `kind_name`
-        // once and reuse it both as a span field and (if we hit the
-        // unknown-kind path) the warn message.
+        // Issue 321: pre-resolve `kind_name` once and reuse it both as
+        // a span field and (if we hit the unknown / trap / panic
+        // paths) the warn / error / broadcast payloads.
         let kind_name = registry
             .kind_name(mail.kind)
             .unwrap_or_else(|| format!("kind#{:#x}", mail.kind));
-        let span = tracing::info_span!(
-            "dispatch",
-            mailbox = mailbox.0,
-            kind = %kind_name,
-        );
-        let _enter = span.enter();
-        // Issue #321: replace `.expect("component.deliver failed")`
-        // with a logged Err. A wasmtime trap (guest unreachable, host-
-        // fn panic caught by wasmtime, etc.) used to take the whole
-        // dispatcher thread down silently; now it surfaces as a
-        // structured event and the dispatcher continues draining.
-        // Phase 2 (mailbox-Dead transitions, component_died broadcast)
-        // ships separately.
-        match component.deliver(&mail) {
-            Ok(rc) => {
+
+        // Issue 321 Phase 2: wrap `deliver` in `catch_unwind` so a
+        // host-side Rust panic (a panicking host fn, a poisoned
+        // mutex unwrap, etc.) doesn't kill the dispatcher silently.
+        // Wasmtime traps from the guest — an `unreachable` opcode,
+        // OOB memory access, a panicked Rust guest under the SDK's
+        // default panic handler — already surface as `Err` from
+        // `deliver`, so they don't need `catch_unwind`; they're
+        // handled in the inner `Ok(Err(e))` arm below. The two paths
+        // are folded into one `kill_actor` disposition (issue 321
+        // question C: "same disposition for traps and panics") that
+        // marks the entry Dead and emits a `component_died`
+        // broadcast.
+        //
+        // `AssertUnwindSafe` is required because the closure captures
+        // `&mut component`, and `Component`'s wasmtime `Store` is not
+        // `RefUnwindSafe` by default. The contract we promise: after
+        // a panic the component's Store may be in an inconsistent
+        // state — that's fine, because we drop the actor entirely
+        // (mark Dead, exit the loop). We never touch the mid-panic
+        // Store again.
+        let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let span = tracing::info_span!(
+                "dispatch",
+                mailbox = mailbox.0,
+                kind = %kind_name,
+            );
+            let _enter = span.enter();
+            component.deliver(&mail)
+        }));
+
+        match outcome {
+            Ok(Ok(rc)) => {
                 if rc == DISPATCH_UNKNOWN_KIND {
                     tracing::warn!(
                         target: "aether_substrate::scheduler",
@@ -301,20 +379,127 @@ fn dispatcher_loop(
                         "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
                     );
                 }
+                decrement_and_notify(&gate);
             }
-            Err(e) => {
+            Ok(Err(trap)) => {
                 tracing::error!(
                     target: "aether_substrate::scheduler",
                     mailbox = ?mail.recipient,
                     kind = %kind_name,
-                    error = %e,
-                    "component deliver failed: wasmtime returned Err (likely guest trap)",
+                    error = %trap,
+                    "component deliver returned Err (wasmtime trap); marking mailbox dead",
                 );
+                kill_actor(
+                    &state,
+                    &mailer,
+                    &registry,
+                    mailbox,
+                    &kind_name,
+                    format!("wasmtime trap: {trap}"),
+                );
+                decrement_and_notify(&gate);
+                return component;
+            }
+            Err(payload) => {
+                let payload_msg = panic_payload_string(&payload);
+                tracing::error!(
+                    target: "aether_substrate::scheduler",
+                    mailbox = ?mail.recipient,
+                    kind = %kind_name,
+                    payload = %payload_msg,
+                    "host-side panic during deliver; marking mailbox dead",
+                );
+                kill_actor(
+                    &state,
+                    &mailer,
+                    &registry,
+                    mailbox,
+                    &kind_name,
+                    format!("host panic: {payload_msg}"),
+                );
+                decrement_and_notify(&gate);
+                return component;
             }
         }
-        decrement_and_notify(&gate);
     }
     component
+}
+
+/// Issue 321 Phase 2: transition `state` to Dead, then emit a
+/// `aether.observation.component_died` broadcast through the mailer
+/// so external monitor components (or a Claude session in MCP) can
+/// observe the death without polling `engine_logs`. Same disposition
+/// for both wasmtime traps (`Ok(Err)` from `deliver`) and host-side
+/// Rust panics caught by `catch_unwind` — recovery policy is out of
+/// scope for the substrate (issue 321 question D).
+///
+/// The broadcast emission is itself wrapped in `catch_unwind` —
+/// pushing through the mailer involves a registered sink handler,
+/// and we don't want a panic in that handler to escape on top of an
+/// already-failing dispatcher. Worst case: the broadcast is silently
+/// dropped and the death is only visible via `engine_logs`.
+fn kill_actor(
+    state: &AtomicU8,
+    mailer: &Mailer,
+    registry: &Registry,
+    mailbox: MailboxId,
+    last_kind: &str,
+    reason: String,
+) {
+    state.store(STATE_DEAD, Ordering::Release);
+
+    let mailbox_name = registry
+        .mailbox_name(mailbox)
+        .unwrap_or_else(|| "?".to_string());
+    let died = ComponentDied {
+        mailbox_id: mailbox.0,
+        mailbox_name,
+        last_kind: last_kind.to_string(),
+        reason,
+    };
+    let payload = match postcard::to_allocvec(&died) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(
+                target: "aether_substrate::scheduler",
+                error = %e,
+                "failed to encode component_died broadcast; death visible only in logs",
+            );
+            return;
+        }
+    };
+
+    let broadcast_mbox = MailboxId::from_name(crate::HUB_CLAUDE_BROADCAST);
+    let mail = Mail {
+        recipient: broadcast_mbox,
+        kind: ComponentDied::ID,
+        payload,
+        count: 1,
+        from_component: Some(mailbox),
+        reply_to: ReplyTo::NONE,
+    };
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| mailer.push(mail)));
+    if result.is_err() {
+        tracing::error!(
+            target: "aether_substrate::scheduler",
+            "panic while emitting component_died broadcast; death visible only in logs",
+        );
+    }
+}
+
+/// Best-effort stringify a panic payload caught by `catch_unwind`.
+/// Std supports `&'static str` (from `panic!("literal")`) and
+/// `String` (from `panic!("{}", x)`); falls back to a `TypeId`
+/// mention. Mirrors `panic_hook::payload_string` but takes a `Box`
+/// since `catch_unwind`'s Err is `Box<dyn Any + Send>`.
+fn panic_payload_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("<non-string panic payload type_id={:?}>", payload.type_id())
+    }
 }
 
 /// Shared, runtime-mutable table of bound components. Cloned into the
@@ -369,7 +554,12 @@ impl Scheduler {
     /// `id` — replacement is an ADR-0010 primitive in its own right,
     /// handled by `ControlPlane::handle_replace`.
     pub fn add_component(&self, id: MailboxId, component: Component) {
-        let entry = ComponentEntry::spawn(component, Arc::clone(&self.registry), id);
+        let entry = ComponentEntry::spawn(
+            component,
+            Arc::clone(&self.registry),
+            Arc::clone(&self.queue),
+            id,
+        );
         self.components.write().unwrap().insert(id, Arc::new(entry));
     }
 }
@@ -471,6 +661,7 @@ mod tests {
         Arc::new(ComponentEntry::spawn(
             minimal_component(),
             Arc::new(Registry::new()),
+            Arc::new(Mailer::new()),
             MailboxId(0),
         ))
     }
@@ -552,60 +743,199 @@ mod tests {
         assert_eq!(name, "aether-component-?-abcdef1234567890");
     }
 
-    /// Load-bearing regression for issue #321: a guest that traps on
-    /// every `receive_p32` (the post-fix behaviour we're relying on)
-    /// no longer kills the dispatcher thread. Pre-fix this test would
-    /// deadlock in `drain` because `.expect("component.deliver
-    /// failed")` panicked the dispatcher before it could decrement the
-    /// pending counter.
+    /// Issue 321 Phase 2 (replaces Phase 1's
+    /// `trap_in_receive_does_not_kill_dispatcher`): a guest trap during
+    /// `deliver` now marks the mailbox Dead and exits the dispatcher.
+    /// Pre-Phase-1 this test would deadlock in `drain` because the
+    /// panicked dispatcher never decremented the pending counter.
+    /// Post-Phase-1 the dispatcher logged the Err and continued. Phase 2
+    /// changes the disposition again: same as a host panic, the actor
+    /// is killed (issue 321 question C: "same disposition for traps and
+    /// panics"). Recovery (replace_component) is policy that lives
+    /// outside the substrate.
     #[test]
-    fn trap_in_receive_does_not_kill_dispatcher() {
+    fn trap_in_receive_marks_mailbox_dead() {
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new());
+        // Install the broadcast sink so the dispatcher's death push
+        // doesn't bubble up as "unknown mailbox" — a side effect of
+        // having no broadcast in test setup. Counter is plumbed
+        // through to verify the broadcast actually fired.
+        let broadcast_count = Arc::new(AtomicU32::new(0));
+        let bc = Arc::clone(&broadcast_count);
+        registry.register_sink(
+            crate::HUB_CLAUDE_BROADCAST,
+            Arc::new(move |_, _, _, _, _, _| {
+                bc.fetch_add(1, Ordering::SeqCst);
+            }),
+        );
+        // Wire the mailer with a fresh ComponentTable so push routing
+        // hits the registered sink.
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
         let entry = Arc::new(ComponentEntry::spawn(
             component_from_wat(WAT_TRAPS_IN_RECEIVE),
-            Arc::new(Registry::new()),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
             MailboxId(0),
         ));
 
-        // First mail: guest traps. With the fix, dispatcher logs Err
-        // and decrements the gate; without the fix, drain blocks
-        // forever (pending stays at 1 because the panicked dispatcher
-        // never ran `decrement_and_notify`).
+        // Send mail; guest traps on receive_p32. Phase 2 dispatcher
+        // marks state Dead, emits ComponentDied broadcast, exits.
         assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![1], 1)));
         entry.drain();
         assert_eq!(
             entry.gate.pending.load(Ordering::Acquire),
             0,
-            "dispatcher must decrement pending even when deliver returns Err",
+            "dispatcher must decrement pending before exiting",
+        );
+        assert!(
+            entry.is_dead(),
+            "trap during deliver must transition mailbox to Dead",
+        );
+        assert_eq!(
+            broadcast_count.load(Ordering::SeqCst),
+            1,
+            "exactly one component_died broadcast must be emitted",
         );
 
-        // Second mail: dispatcher should still be alive (proof: drain
-        // returns) and processing. Pre-fix this would also deadlock
-        // because the thread died on mail #1.
-        assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![2], 1)));
-        entry.drain();
+        // Send to dead mailbox: returns false, doesn't queue, doesn't
+        // increment pending.
+        assert!(
+            !entry.send(Mail::new(MailboxId(0), 0xDD, vec![2], 1)),
+            "send to dead mailbox must fail-fast",
+        );
         assert_eq!(entry.gate.pending.load(Ordering::Acquire), 0);
 
-        // Clean shutdown: close the channel, dispatcher exits,
-        // close_and_join recovers the Component without panicking.
+        // close_and_join still recovers cleanly — dispatcher already
+        // exited via the kill_actor path, so the JoinHandle is ready.
         let _component = close_and_join(entry);
     }
 
-    /// Repeated traps don't leak state or accumulate pending counts.
-    /// Strict regression check for the decrement_and_notify path
-    /// running on every iteration of the dispatcher loop, not just
-    /// the Ok arm.
+    /// Issue 321 Phase 2: the ComponentDied broadcast carries the
+    /// expected structured fields (mailbox_id, mailbox_name, last_kind,
+    /// reason) so external monitors can act on the failure without
+    /// polling logs.
     #[test]
-    fn repeated_traps_drain_independently() {
+    fn component_died_broadcast_carries_expected_fields() {
+        let registry = Arc::new(Registry::new());
+        // Register the dispatcher's mailbox under a known name so the
+        // broadcast's `mailbox_name` field has something to resolve.
+        let mailbox = registry.register_component("crashy");
+        let mailer = Arc::new(Mailer::new());
+
+        let captured: Arc<Mutex<Vec<ComponentDied>>> = Arc::new(Mutex::new(Vec::new()));
+        let cap = Arc::clone(&captured);
+        registry.register_sink(
+            crate::HUB_CLAUDE_BROADCAST,
+            Arc::new(move |kind_id, _, _, _, bytes, _| {
+                if kind_id == ComponentDied::ID
+                    && let Ok(d) = postcard::from_bytes::<ComponentDied>(bytes)
+                {
+                    cap.lock().unwrap().push(d);
+                }
+            }),
+        );
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
         let entry = Arc::new(ComponentEntry::spawn(
             component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox,
+        ));
+
+        assert!(entry.send(Mail::new(mailbox, 0xDD, vec![], 1)));
+        entry.drain();
+
+        let died = captured.lock().unwrap();
+        assert_eq!(died.len(), 1, "exactly one death broadcast expected");
+        let d = &died[0];
+        assert_eq!(d.mailbox_id, mailbox.0);
+        assert_eq!(d.mailbox_name, "crashy");
+        assert!(
+            d.reason.starts_with("wasmtime trap:"),
+            "expected wasmtime trap reason, got: {}",
+            d.reason,
+        );
+        // last_kind is the registry-resolved or hex-fallback name; this
+        // mailbox's send used kind 0xDD which has no registered name.
+        assert!(
+            d.last_kind.contains("0xdd") || d.last_kind == "kind#0xdd",
+            "expected hex fallback for unregistered kind, got: {}",
+            d.last_kind,
+        );
+
+        let _component = close_and_join(entry);
+    }
+
+    /// Issue 321 Phase 2: `is_dead` defaults to false on a freshly
+    /// spawned entry, transitions to true only after a kill_actor
+    /// path. Tests the AtomicU8 visibility guarantee — Acquire load
+    /// must see the dispatcher's Release store.
+    #[test]
+    fn is_dead_starts_false_and_transitions_after_trap() {
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new());
+        registry.register_sink(crate::HUB_CLAUDE_BROADCAST, Arc::new(|_, _, _, _, _, _| {}));
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
+        let entry = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        assert!(!entry.is_dead(), "freshly spawned entry must be Live");
+
+        assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![], 1)));
+        entry.drain();
+        assert!(entry.is_dead(), "post-trap entry must be Dead");
+
+        let _component = close_and_join(entry);
+    }
+
+    /// Issue 321 Phase 2: a healthy component (no trap) stays Live
+    /// across many mails. Negative regression — kill_actor must not
+    /// fire on Ok deliveries.
+    #[test]
+    fn healthy_component_stays_live_across_many_mails() {
+        let entry = Arc::new(ComponentEntry::spawn(
+            minimal_component(),
             Arc::new(Registry::new()),
+            Arc::new(Mailer::new()),
             MailboxId(0),
         ));
         for i in 0..16u32 {
-            assert!(entry.send(Mail::new(MailboxId(0), 0xDD, vec![i as u8], 1)));
+            assert!(entry.send(Mail::new(MailboxId(0), 0xCC, vec![i as u8], 1)));
         }
         entry.drain();
+        assert!(!entry.is_dead());
         assert_eq!(entry.gate.pending.load(Ordering::Acquire), 0);
         let _component = close_and_join(entry);
+    }
+
+    /// Issue 321 Phase 2: `panic_payload_string` mirrors the
+    /// `panic_hook::payload_string` shapes for `&'static str`,
+    /// `String`, and unknown payload types. Pure-fn coverage so a
+    /// future regression in formatting shows up at the unit level
+    /// rather than only via the integration trap path.
+    #[test]
+    fn panic_payload_string_handles_common_shapes() {
+        let s_static: Box<dyn std::any::Any + Send> = Box::new("literal");
+        assert_eq!(panic_payload_string(&s_static), "literal");
+
+        let s_owned: Box<dyn std::any::Any + Send> = Box::new(String::from("formatted"));
+        assert_eq!(panic_payload_string(&s_owned), "formatted");
+
+        let other: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let out = panic_payload_string(&other);
+        assert!(
+            out.starts_with("<non-string panic payload"),
+            "unexpected: {out}",
+        );
     }
 }


### PR DESCRIPTION
Phase 2 of issue 321 — recovery semantics. Phase 1 made panics and traps visible; Phase 2 gives them a defined disposition. A wasmtime trap or host-side Rust panic during `deliver` now marks the mailbox Dead, emits a structured `aether.observation.component_died` broadcast, and exits the dispatcher cleanly.

## Behavioural change from Phase 1

Traps used to be logged-and-continue (Phase 1 dispatcher: `match component.deliver { Err(e) => tracing::error!(...) }`). Phase 2 funnels traps through the same `kill_actor` path as host panics — they're both "this actor crashed" (issue 321 question C: same disposition for traps and panics). Recovery policy (replace_component, page a human, leave it dead) is explicitly out-of-scope for the substrate (question D); the broadcast hands that off to external monitors.

## What changes

- **`aether-kinds`**: new `aether.observation.component_died` kind with fields `{ mailbox_id, mailbox_name, last_kind, reason }`. Postcard-shaped (string fields). Routed through `hub.claude.broadcast` per ADR-0008, symmetric with `aether.observation.frame_stats`.
- **`ComponentEntry`** carries a shared `Arc<AtomicU8>` state with the dispatcher. `STATE_LIVE` / `STATE_DEAD`; the dispatcher `Release`-stores Dead before exiting on a panic / trap, callers `Acquire`-load via `is_dead()`. `send` short-circuits Dead before touching the mpsc. `spawn_dispatcher_on` resets state to Live so a successful replace brings a fresh instance up under the same entry.
- **`dispatcher_loop`**: wraps `deliver` in `catch_unwind(AssertUnwindSafe(...))`. `Ok(Ok(rc))` continues. `Ok(Err(trap))` and `Err(panic_payload)` both call `kill_actor`, which marks state Dead, postcard-encodes a `ComponentDied`, and pushes through the mailer to `hub.claude.broadcast`. The broadcast emission itself is `catch_unwind`-wrapped so a panic in a registered sink handler doesn't cascade on top of the already-failing dispatcher — worst case the death is visible in `engine_logs` only.
- **`mailer.rs`**: differentiates `is_dead()` warn ("mail to dead mailbox; actor panicked or trapped — see component_died broadcast") from the prior closed-Sender warn ("component inbox closed; mail discarded"). Diagnoses become unambiguous instead of "why is mail being dropped?" detective work.
- **API surface**: `ComponentEntry::spawn` and `spawn_dispatcher_on` gain an `Arc<Mailer>` parameter. Internal call sites (`Scheduler::add_component`, `ControlPlane::handle_load` / `handle_replace`, the `io.rs` test fixture) all updated.

## Tests

- **`trap_in_receive_marks_mailbox_dead`** — replaces Phase 1's `trap_in_receive_does_not_kill_dispatcher`. Asserts `is_dead()` after a guest `unreachable`, the broadcast counter incremented exactly once, and a follow-up `send` to the Dead mailbox returns false without queuing.
- **`component_died_broadcast_carries_expected_fields`** — registers a broadcast sink that postcard-decodes the `ComponentDied` payload; asserts `mailbox_id` / `mailbox_name` resolve correctly, `reason` starts with `"wasmtime trap:"`, `last_kind` falls back to the hex form for unregistered kinds.
- **`is_dead_starts_false_and_transitions_after_trap`** — covers the AtomicU8 visibility (Acquire load sees the dispatcher's Release store).
- **`healthy_component_stays_live_across_many_mails`** — negative regression: `kill_actor` must not fire on the Ok arm.
- **`panic_payload_string_handles_common_shapes`** — pure-fn coverage of the panic-payload formatter (`&'static str` / `String` / unknown).

Phase 1's `repeated_traps_drain_independently` was retired since the first trap now ends the dispatcher.

## Smoke test
Spawned `aether-substrate-headless` with the hello component preloaded, sent `aether.ping` and an unhandled `aether.audio.set_master_gain`, observed:
- Boot path through `init_panic_hook` + new `ComponentDied` kind registration: clean
- Frame-loop dispatch with `catch_unwind` wrapper: ~1s of ticks, no error events
- Unknown-kind warn still surfaces with correct mailbox + kind fields
- Termination clean (no SIGKILL escalation)

Inducing a real wasmtime trap end-to-end via MCP would need a "traps on receive" wasm fixture component; the unit test (`trap_in_receive_marks_mailbox_dead` with the inline `WAT_TRAPS_IN_RECEIVE` fixture) covers that path deterministically. Worth filing a follow-up to ship a trapping fixture as a tier-4 integration test if the user wants belt-and-suspenders coverage.

## Test plan
- [x] `cargo test --workspace` — all green (4 new scheduler tests + 1 new pure-fn test, Phase 1's retired test removed)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] MCP smoke test against fresh substrate

Refs issue 321. Closes the recovery work; the deferred extensions (host-fn-level spans, COW transactional handlers, render-sink mutex freeze fix) stay parked per their forcing-function notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)