### PR TITLE
feat(substrate): guest-side logging via mail sink (issue 317)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "inventory",
  "postcard",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -155,6 +156,7 @@ dependencies = [
  "aether-dsl-mesh",
  "aether-kinds",
  "aether-math",
+ "tracing",
 ]
 
 [[package]]
@@ -182,6 +184,7 @@ dependencies = [
  "aether-mail",
  "bytemuck",
  "dirs",
+ "log",
  "postcard",
  "serde",
  "tracing",

--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -21,6 +21,12 @@ postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 # the typed state path on `serde::Serialize` / `DeserializeOwned`, and
 # the framing goes through postcard which is serde-driven end-to-end.
 serde = { version = "1", default-features = false, features = ["alloc"] }
+# ADR-0060: the SDK installs a `tracing::Subscriber` (`MailSubscriber`)
+# at component boot that turns `tracing::warn!` / `error!` / `info!`
+# inside the wasm sandbox into `aether.log` mail. The facade itself is
+# `no_std`-friendly with `default-features = false`; we don't pull
+# `tracing-subscriber`.
+tracing = { version = "0.1", default-features = false }
 
 # Examples are standalone wasm cdylibs loaded via the substrate's
 # `load_component` control plane. Their dev-deps don't propagate to

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -69,6 +69,7 @@ use aether_mail::{Kind, Schema, mailbox_id_from_name};
 
 pub mod handle;
 pub mod io;
+pub mod log;
 pub mod net;
 pub mod raw;
 
@@ -982,9 +983,12 @@ macro_rules! export {
         /// Receives the component's own mailbox id (ADR-0030 Phase 2)
         /// so `#[handlers]`'s synthesized `init` prologue can self-
         /// address `subscribe_input` for every `K::IS_INPUT` handler
-        /// kind.
+        /// kind. ADR-0060: also installs `MailSubscriber` as the global
+        /// `tracing` default before user `init` runs, so logging from
+        /// inside `init` reaches the substrate's `aether.sink.log` sink.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
+            $crate::log::install_global_default();
             let mut ctx = $crate::InitCtx::__new(mailbox_id);
             let instance = <$component as $crate::Component>::init(&mut ctx);
             unsafe {

--- a/crates/aether-component/src/log.rs
+++ b/crates/aether-component/src/log.rs
@@ -1,0 +1,255 @@
+//! ADR-0060 guest-side logging via mail sink.
+//!
+//! `MailSubscriber` implements `tracing::Subscriber` so existing
+//! `tracing::warn!` / `error!` / `info!` calls in component code emit
+//! mail to the substrate-owned `aether.sink.log` mailbox. The chassis
+//! sink decodes and re-emits through the host-side `tracing` subscriber
+//! so events land in `engine_logs` (ADR-0023).
+//!
+//! The macro short-circuits at `enabled()` for events below the
+//! configured max level (default `INFO`) — debug/trace calls in tight
+//! loops cost a vtable dispatch and return, no FFI. v1 hardcodes the
+//! level; per-component dynamic filtering rides on a future
+//! `aether.control.set_log_level` mail (ADR-0060 §Default level and
+//! per-component filter).
+//!
+//! Spans are no-ops in v1. The wire kind carries pre-formatted message
+//! strings, so structured span context is not propagated; flat events
+//! (`tracing::warn!(...)`) are the supported shape.
+//!
+//! Production builds that need truly-zero-cost trace/debug elimination
+//! set `tracing/release_max_level_info` (or similar) in their own
+//! `Cargo.toml` — the `STATIC_MAX_LEVEL` check happens at the macro
+//! call site before the subscriber is consulted.
+
+use core::fmt::Write as _;
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use alloc::string::{String, ToString};
+
+use aether_kinds::LogEvent;
+use tracing::{
+    Event, Level, Metadata, Subscriber,
+    field::{Field, Visit},
+    span,
+};
+
+use crate::resolve_sink;
+
+/// Hard cap on the mail payload's `message` field. Protects the queue
+/// from a misbehaving component flooding multi-megabyte log frames; the
+/// `" [truncated]"` suffix tells a `engine_logs` reader the original was
+/// longer.
+const MAX_MESSAGE_BYTES: usize = 4096;
+const TRUNCATED_SUFFIX: &str = " [truncated]";
+
+/// Default max level — events strictly above this (numerically lower
+/// in `tracing::Level`) are dropped at `enabled()`. `Level::INFO`
+/// emits info / warn / error and skips debug / trace, matching the
+/// substrate's `log_capture` default (ADR-0060 §Default level).
+const MAX_LEVEL: Level = Level::INFO;
+
+pub struct MailSubscriber {
+    next_span: AtomicU64,
+}
+
+impl MailSubscriber {
+    pub const fn new() -> Self {
+        MailSubscriber {
+            next_span: AtomicU64::new(1),
+        }
+    }
+}
+
+impl Default for MailSubscriber {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Subscriber for MailSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        *metadata.level() <= MAX_LEVEL
+    }
+
+    fn new_span(&self, _attrs: &span::Attributes<'_>) -> span::Id {
+        // Spans are observed but not transmitted in v1. Hand out a
+        // monotonic id so `tracing` invariants hold.
+        let id = self.next_span.fetch_add(1, Ordering::Relaxed);
+        span::Id::from_u64(id.max(1))
+    }
+
+    fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let metadata = event.metadata();
+        let level = level_to_u8(*metadata.level());
+        let target = metadata.target().to_string();
+
+        let mut visitor = MessageBuilder::new();
+        event.record(&mut visitor);
+        let message = visitor.finish();
+
+        let payload = LogEvent {
+            level,
+            target,
+            message,
+        };
+        resolve_sink::<LogEvent>("aether.sink.log").send(&payload);
+    }
+}
+
+fn level_to_u8(level: Level) -> u8 {
+    match level {
+        Level::TRACE => 0,
+        Level::DEBUG => 1,
+        Level::INFO => 2,
+        Level::WARN => 3,
+        Level::ERROR => 4,
+    }
+}
+
+/// Walks an `Event`'s fields and renders them in fields-first order:
+/// `key1=val1 key2=val2 message_body`. Matches `tracing-subscriber`'s
+/// default fmt layer so a reader of `engine_logs` sees the same shape
+/// whether the event was emitted host- or guest-side.
+struct MessageBuilder {
+    fields: String,
+    message: String,
+}
+
+impl MessageBuilder {
+    fn new() -> Self {
+        Self {
+            fields: String::new(),
+            message: String::new(),
+        }
+    }
+
+    fn finish(mut self) -> String {
+        if !self.fields.is_empty() && !self.message.is_empty() {
+            self.fields.push(' ');
+        }
+        self.fields.push_str(&self.message);
+        truncate(self.fields)
+    }
+
+    fn append_field(&mut self, name: &str, separator: &str, value: core::fmt::Arguments<'_>) {
+        if !self.fields.is_empty() {
+            self.fields.push(' ');
+        }
+        let _ = write!(&mut self.fields, "{}{}{}", name, separator, value);
+    }
+}
+
+impl Visit for MessageBuilder {
+    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(&mut self.message, "{:?}", value);
+        } else {
+            self.append_field(field.name(), "=", format_args!("{:?}", value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            self.append_field(field.name(), "=", format_args!("{}", value));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.append_field(field.name(), "=", format_args!("{}", value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.append_field(field.name(), "=", format_args!("{}", value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.append_field(field.name(), "=", format_args!("{}", value));
+    }
+}
+
+fn truncate(mut s: String) -> String {
+    if s.len() <= MAX_MESSAGE_BYTES {
+        return s;
+    }
+    let mut cap = MAX_MESSAGE_BYTES.saturating_sub(TRUNCATED_SUFFIX.len());
+    while cap > 0 && !s.is_char_boundary(cap) {
+        cap -= 1;
+    }
+    s.truncate(cap);
+    s.push_str(TRUNCATED_SUFFIX);
+    s
+}
+
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// Installs `MailSubscriber` as `tracing`'s global default. Idempotent;
+/// repeated calls (e.g. across `replace_component` cycles in the same
+/// linear memory) are a no-op.
+///
+/// Called by the `export!` macro before the user's `Component::init`
+/// runs so logging from inside `init` works.
+pub fn install_global_default() {
+    if INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let _ = tracing::dispatcher::set_global_default(tracing::dispatcher::Dispatch::new(
+        MailSubscriber::new(),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn level_mapping() {
+        assert_eq!(level_to_u8(Level::TRACE), 0);
+        assert_eq!(level_to_u8(Level::DEBUG), 1);
+        assert_eq!(level_to_u8(Level::INFO), 2);
+        assert_eq!(level_to_u8(Level::WARN), 3);
+        assert_eq!(level_to_u8(Level::ERROR), 4);
+    }
+
+    #[test]
+    fn truncate_preserves_short_messages() {
+        let s = String::from("short message");
+        let out = truncate(s);
+        assert_eq!(out, "short message");
+    }
+
+    #[test]
+    fn truncate_appends_suffix_when_oversize() {
+        let s = "a".repeat(MAX_MESSAGE_BYTES + 100);
+        let out = truncate(s);
+        assert!(out.ends_with(TRUNCATED_SUFFIX));
+        assert!(out.len() <= MAX_MESSAGE_BYTES);
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        // Force the naive cut inside a multi-byte char.
+        let mut s = String::with_capacity(MAX_MESSAGE_BYTES + 4);
+        for _ in 0..(MAX_MESSAGE_BYTES / 4 + 5) {
+            s.push('🦀'); // 4 bytes per char
+        }
+        let out = truncate(s);
+        // Round-tripping back through `String::from_utf8` would panic
+        // on a torn boundary; the assertion is implicit in not panicking
+        // and producing a valid suffix.
+        assert!(out.ends_with(TRUNCATED_SUFFIX));
+    }
+
+    // The Visit/format path is exercised end-to-end by the substrate
+    // integration test (sink decode roundtrip) — `tracing::field::Field`
+    // can't be hand-constructed without a real `FieldSet` + callsite, so
+    // unit-testing `MessageBuilder` in isolation buys little over what
+    // the integration coverage already proves.
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1450,6 +1450,31 @@ mod control_plane {
         Ok { id: u64 },
         Err { id: u64, error: HandleError },
     }
+
+    // ADR-0060 guest-side logging via mail sink. One postcard kind on
+    // the substrate-owned `"aether.sink.log"` mailbox. The SDK installs
+    // a `tracing::Subscriber` that formats events into this shape and
+    // sends them; chassis sinks decode and re-emit through the host
+    // `tracing` subscriber so `engine_logs` (ADR-0023) sees them.
+
+    /// `aether.log` — a single tracing event the guest emitted, ready
+    /// for the substrate to re-emit into its own subscriber. Mailed to
+    /// the `"aether.sink.log"` sink; fire-and-forget (no reply).
+    /// `level` maps to a `tracing::Level` substrate-side
+    /// (`0 = trace`, `1 = debug`, `2 = info`, `3 = warn`, `4 = error`).
+    /// `target` is a module-style string the chassis's `EnvFilter`
+    /// matches against; the SDK defaults it to the guest's crate name.
+    /// `message` is pre-formatted with structured fields collapsed into
+    /// the message body in fields-first form (e.g.
+    /// `"error=<Display> count=3 parse failed"`), capped at 4096 bytes
+    /// by the SDK with a `" [truncated]"` suffix on overflow.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.log")]
+    pub struct LogEvent {
+        pub level: u8,
+        pub target: String,
+        pub message: String,
+    }
 }
 
 pub use dsl_mesh::*;

--- a/crates/aether-mesh-editor-component/Cargo.toml
+++ b/crates/aether-mesh-editor-component/Cargo.toml
@@ -11,3 +11,7 @@ aether-component = { path = "../aether-component" }
 aether-dsl-mesh = { path = "../aether-dsl-mesh" }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }
+# ADR-0060: tracing facade reaches the substrate's `aether.sink.log`
+# via the SDK's `MailSubscriber` (installed by `export!`). The crate
+# itself stays no_std-friendly via `default-features = false`.
+tracing = { version = "0.1", default-features = false }

--- a/crates/aether-mesh-editor-component/src/lib.rs
+++ b/crates/aether-mesh-editor-component/src/lib.rs
@@ -155,11 +155,27 @@ impl DslMeshEditor {
     /// the per-tick render path stays cheap (one cached triangle list,
     /// no re-tessellation per frame).
     fn try_replace(&mut self, dsl: &str) {
-        let Ok(ast) = aether_dsl_mesh::parse(dsl) else {
-            return;
+        let ast = match aether_dsl_mesh::parse(dsl) {
+            Ok(ast) => ast,
+            Err(error) => {
+                tracing::warn!(
+                    target: "aether_mesh_editor",
+                    error = %error,
+                    "DSL parse failed; keeping prior mesh",
+                );
+                return;
+            }
         };
-        let Ok(polygons) = aether_dsl_mesh::mesh_polygons(&ast) else {
-            return;
+        let polygons = match aether_dsl_mesh::mesh_polygons(&ast) {
+            Ok(p) => p,
+            Err(error) => {
+                tracing::warn!(
+                    target: "aether_mesh_editor",
+                    error = %error,
+                    "DSL mesh build failed; keeping prior mesh",
+                );
+                return;
+            }
         };
         let mut out = Vec::new();
         for polygon in &polygons {

--- a/crates/aether-static-mesh-component/src/lib.rs
+++ b/crates/aether-static-mesh-component/src/lib.rs
@@ -21,8 +21,10 @@
 //!
 //! Errors (parse failures, missing files, adapter rejection) silently
 //! drop the load. Visible symptom: no triangles render. Substrate-side
-//! errors (NotFound, Forbidden) surface via `engine_logs`. Per-component
-//! tracing is parked until the SDK exposes a logging facility.
+//! errors (NotFound, Forbidden) surface via `engine_logs`. The SDK now
+//! exposes a `tracing`-based logging facility (ADR-0060) so per-
+//! component warns can surface the parse-side too — left as a focused
+//! follow-up rather than scoped into the ADR-0060 implementation PR.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers, io};
 use aether_kinds::{DrawTriangle, LoadStaticMesh, ReadResult, Tick, Vertex};

--- a/crates/aether-substrate-core/Cargo.toml
+++ b/crates/aether-substrate-core/Cargo.toml
@@ -19,6 +19,13 @@ postcard = { version = "1.1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# ADR-0060 guest-side logging: the `aether.sink.log` handler bridges
+# decoded `LogEvent` payloads back into the host tracing pipeline.
+# `log::log!(target: dyn, lvl, ...)` accepts a dynamic target the
+# `tracing-log` integration in `tracing-subscriber` (default feature)
+# lifts into a tracing event, so the chassis EnvFilter sees the
+# guest's reported target without us hand-rolling a Metadata cache.
+log = "0.4"
 # ADR-0041 I/O namespace defaults. `dirs` resolves XDG on Linux,
 # Application Support on macOS, AppData on Windows without reimple-
 # menting platform-specific path logic per chassis.

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod input;
 pub mod io;
 pub mod kind_manifest;
 pub mod log_capture;
+pub mod log_sink;
 pub mod mail;
 pub mod mailer;
 pub mod net;

--- a/crates/aether-substrate-core/src/log_sink.rs
+++ b/crates/aether-substrate-core/src/log_sink.rs
@@ -1,0 +1,117 @@
+// ADR-0060 guest-side logging via mail sink. Counterpart to the
+// `MailSubscriber` in `aether-component`: decodes `aether.log` mail
+// the guest sent to `"aether.sink.log"` and re-emits the event through
+// the host's existing tracing pipeline so it shows up in `engine_logs`
+// (ADR-0023) and on stderr alongside native-side logs.
+//
+// We bridge via the `log` crate facade rather than `tracing::event!`
+// because `tracing::event!` requires a `&'static str` target — the
+// guest-supplied target is dynamic. `log::log!(target: <dyn>, lvl, ...)`
+// accepts an expression target, and `tracing-subscriber`'s default
+// `tracing-log` feature lifts every log record into a tracing event
+// with that target preserved. The chassis `EnvFilter` (built in
+// `log_capture::init`) then sees the guest's target verbatim and
+// applies the operator's `AETHER_LOG_FILTER` directives without us
+// maintaining a leaked-target cache.
+//
+// The handler is intentionally chassis-agnostic — desktop and
+// headless wire the same closure. Hub doesn't (no shipped chassis
+// hosts components on the hub today; the kinds bubble back to the
+// child substrate via ADR-0037 if a guest-bound component were ever
+// loaded there).
+
+use std::sync::Arc;
+
+use aether_kinds::LogEvent;
+
+use crate::mail::ReplyTo;
+use crate::registry::{Registry, SinkHandler};
+
+/// Build the `SinkHandler` closure that decodes `LogEvent` mail and
+/// emits the event through the `log` facade. Caller registers it
+/// against `"aether.sink.log"`.
+pub fn log_sink_handler() -> SinkHandler {
+    Arc::new(
+        move |_kind_id: u64,
+              _kind_name: &str,
+              _origin: Option<&str>,
+              _sender: ReplyTo,
+              bytes: &[u8],
+              _count: u32| {
+            handle_log_mail(bytes);
+        },
+    )
+}
+
+fn handle_log_mail(bytes: &[u8]) {
+    let event: LogEvent = match postcard::from_bytes(bytes) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::warn!(
+                target: "aether_substrate::log_sink",
+                error = %err,
+                bytes = bytes.len(),
+                "log sink: failed to decode LogEvent, dropping",
+            );
+            return;
+        }
+    };
+    let level = match event.level {
+        0 => log::Level::Trace,
+        1 => log::Level::Debug,
+        2 => log::Level::Info,
+        3 => log::Level::Warn,
+        4 => log::Level::Error,
+        other => {
+            tracing::warn!(
+                target: "aether_substrate::log_sink",
+                level = other,
+                "log sink: unknown level, treating as Info",
+            );
+            log::Level::Info
+        }
+    };
+    log::log!(target: event.target.as_str(), level, "{}", event.message);
+}
+
+/// Convenience: register the log sink against the canonical mailbox
+/// name `"aether.sink.log"`. Returned `MailboxId` is normally ignored;
+/// callers keep it only to assert against in tests.
+pub fn register_log_sink(registry: &Registry) {
+    registry.register_sink("aether.sink.log", log_sink_handler());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_mail::Kind;
+
+    #[test]
+    fn log_event_kind_name_matches() {
+        // The component-side subscriber sends to "aether.sink.log" with
+        // kind name "aether.log"; if either side renames in isolation
+        // this test catches the divergence without needing a live wire.
+        assert_eq!(LogEvent::NAME, "aether.log");
+    }
+
+    #[test]
+    fn handler_decodes_and_dispatches_without_panic() {
+        // No subscriber installed in tests => log records get dropped
+        // silently by the log facade. This test is a smoke check that
+        // the postcard decode + level dispatch path doesn't panic on a
+        // valid payload.
+        let event = LogEvent {
+            level: 3,
+            target: "aether_test_guest".into(),
+            message: "parse failed: missing close paren".into(),
+        };
+        let bytes = postcard::to_allocvec(&event).expect("encode");
+        handle_log_mail(&bytes);
+    }
+
+    #[test]
+    fn handler_drops_garbage_bytes() {
+        // Out-of-band bytes should warn-and-return rather than panic.
+        handle_log_mail(&[0xff, 0xff, 0xff, 0xff, 0xff]);
+    }
+}

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -1176,6 +1176,13 @@ fn main() -> wasmtime::Result<()> {
         aether_substrate_core::net::net_sink_handler(net_adapter, Arc::clone(&boot.queue)),
     );
 
+    // `aether.sink.log`: ADR-0060 guest-side logging. Decode `LogEvent`
+    // mail and re-emit through the host `log` facade; the existing
+    // `tracing-log` bridge in `log_capture::init` lifts the record back
+    // into the chassis EnvFilter + capture ring so guest events land
+    // in `engine_logs` alongside native logs.
+    aether_substrate_core::log_sink::register_log_sink(&boot.registry);
+
     tracing::info!(
         target: "aether_substrate::boot",
         workers = WORKERS,

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -230,6 +230,11 @@ fn main() -> wasmtime::Result<()> {
         aether_substrate_core::net::net_sink_handler(net_adapter, Arc::clone(&boot.queue)),
     );
 
+    // `aether.sink.log`: ADR-0060. Same handler as desktop — guest
+    // log mail is independent of GPU / windowing, so headless wires
+    // it identically.
+    aether_substrate_core::log_sink::register_log_sink(&boot.registry);
+
     let tick_hz = parse_tick_hz_env();
     let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
     tracing::info!(


### PR DESCRIPTION
## Summary
- Implements ADR-0060: SDK MailSubscriber ships guest tracing::*! calls to substrate via an aether.sink.log mailbox; chassis re-emits through the host tracing pipeline so events land in engine_logs.
- Mesh-editor canary: parse / mesh failure surfaces a tracing::warn! instead of silently dropping (issue 317's original ask, now actually wired up).
- Static-mesh: removes the "tracing is parked" comment now that the SDK exposes the facility.

## What's in the diff
- aether-kinds: new postcard kind LogEvent { level, target, message } (aether.log).
- aether-component: new log module — MailSubscriber impls tracing::Subscriber, formats fields-first to match tracing-subscriber's default fmt layer, caps messages at 4 KiB with a [truncated] suffix, short-circuits below INFO at enabled(). Installed as global default by the export! macro before user init runs.
- aether-substrate-core: new log_sink module — decodes LogEvent and bridges through the log facade so tracing-log lifts the record back into a tracing event with the guest's target preserved for EnvFilter.
- Desktop + headless chassis register the sink. Hub doesn't (matches the io / audio / render policy).
- aether-mesh-editor-component: replaces the silent let Ok(...) else { return; } chain in try_replace with match + tracing::warn! carrying the parser / mesher error.

## Test plan
- [x] cargo check --workspace --all-targets clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean
- [x] cargo test --workspace clean
- [x] cargo check --target wasm32-unknown-unknown clean for aether-component, aether-mesh-editor-component, aether-static-mesh-component
- [x] Live MCP smoke: spawned headless substrate, loaded mesh-editor wasm, sent (box 1 1 1 :color (truncated), confirmed engine_logs --level warn returned the parser's EOF while parsing a list error with log.target=aether_mesh_editor preserved as a field.

Closes #317