### PR TITLE
fix(dsl-mesh): short-circuit Polygon::split via plane identity (issue 345)

### DIFF
--- a/crates/aether-dsl-mesh/src/csg/ops.rs
+++ b/crates/aether-dsl-mesh/src/csg/ops.rs
@@ -1041,4 +1041,53 @@ mod tests {
         let loops = difference(outer, cutter).unwrap();
         assert!(!loops.is_empty());
     }
+
+    /// Pre-fix: this case spun the BSP build loop indefinitely. The
+    /// third `BspTree::build` call in `union_raw` (the rebuild after
+    /// `nb.all_polygons()`) received polygons whose accumulated snap
+    /// drift from prior `clip → invert → clip → invert` passes had
+    /// pushed their vertices several grid units off their stored
+    /// `plane`. The per-vertex `coplanar_threshold` budget (≈ 1 grid
+    /// unit) misclassified the splitter polygon itself as FRONT, and
+    /// every other coplanar fragment routed forward identically, so
+    /// each iteration created one new node holding the same 36-polygon
+    /// list — a tower of single-child nodes growing without bound.
+    ///
+    /// The fix in `Polygon::split` short-circuits via `canonical_key`
+    /// plane equality before the per-vertex test: a polygon with a
+    /// stored plane structurally identical to the partitioner is
+    /// always coplanar regardless of vertex drift. This test pins the
+    /// case so a future regression here surfaces as a wallclock
+    /// failure, not as silent infinite work.
+    #[test]
+    fn union_box_offset_sphere_does_not_hang() {
+        use crate::ast::Node;
+        use aether_math::Vec3;
+
+        let box_polys = axis_aligned_box(0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0);
+        let sphere_node = Node::Translate {
+            offset: Vec3::new(0.3, 0.15, 0.05),
+            child: std::boxed::Box::new(Node::Sphere {
+                radius: 0.5,
+                subdivisions: 8,
+                color: 1,
+            }),
+        };
+        let sphere_tris = crate::mesh::mesh(&sphere_node).expect("sphere mesh should not fail");
+        let sphere_polys: Vec<Polygon> = sphere_tris
+            .into_iter()
+            .filter_map(|t| {
+                let v0 = Point3::from_f32(t.vertices[0]).ok()?;
+                let v1 = Point3::from_f32(t.vertices[1]).ok()?;
+                let v2 = Point3::from_f32(t.vertices[2]).ok()?;
+                Polygon::from_triangle(v0, v1, v2, t.color)
+            })
+            .collect();
+
+        let result = union(box_polys, sphere_polys).expect("union should not error");
+        assert!(
+            !result.is_empty(),
+            "box ∪ offset-sphere should produce non-empty geometry"
+        );
+    }
 }

--- a/crates/aether-dsl-mesh/src/csg/polygon.rs
+++ b/crates/aether-dsl-mesh/src/csg/polygon.rs
@@ -59,6 +59,32 @@ impl Polygon {
         front: &mut Vec<Polygon>,
         back: &mut Vec<Polygon>,
     ) {
+        // Plane-identity short-circuit: when this polygon's stored plane
+        // matches the partitioner structurally (same canonical key), the
+        // polygon IS on the partitioner plane regardless of any vertex
+        // drift accumulated by `compute_intersection` snap rounding
+        // across prior split passes. Skip the per-vertex side test and
+        // route directly to the coplanar bucket.
+        //
+        // Without this, multi-pass CSG (`union_raw`'s clip → invert →
+        // clip → invert → rebuild sequence) hits compounded snap drift:
+        // by the third `BspTree::build` call, fragment vertices have
+        // moved up to several grid units off their stored plane —
+        // beyond the per-pass `coplanar_threshold` budget. The vertex
+        // test misclassifies the splitter polygon itself as FRONT,
+        // every other coplanar fragment likewise routes forward, and
+        // the build loop spins indefinitely creating a tower of single-
+        // child nodes (CSG matrix issue 344, smoke test:
+        // `(union (box 1 1 1) (translate (0.3 0.15 0.05) (sphere 0.5 8)))`).
+        if self.plane.canonical_key() == partitioner.canonical_key() {
+            if partitioner.normal_dot_sign(&self.plane) > 0 {
+                coplanar_front.push(self.clone());
+            } else {
+                coplanar_back.push(self.clone());
+            }
+            return;
+        }
+
         // Snap-drift tolerance: a vertex within `coplanar_threshold()`
         // of the plane is treated as on it. This is what stops the
         // unbounded-recursion cascade where a split fragment's snapped


### PR DESCRIPTION
## Summary

- BSP build was looping forever on `(union (box 1 1 1) (translate (0.3 0.15 0.05) (sphere 0.5 8)))` because compounded snap drift from `clip → invert → clip → invert` pushed fragment vertices several grid units off their stored plane, the per-vertex `coplanar_threshold` misclassified the splitter polygon itself as `FRONT`, and the loop towered up one front child per iteration.
- Fix: `Polygon::split` now short-circuits via `Plane3::canonical_key` equality before the per-vertex test — same canonical key means same plane mathematically, so route to the coplanar bucket regardless of vertex drift.
- Surfaced by Tier A of the CSG matrix work for issue 344; full triage in issue 345.

## Test plan

- [x] `cargo test -p aether-dsl-mesh` — full suite (382 lib + 8 integration suites) green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] New regression test `csg::ops::tests::union_box_offset_sphere_does_not_hang` (would never terminate pre-fix)
- [x] Probe `(union box (translate (0.3 0.15 0.05) sphere))`: pre-fix hangs >30s, post-fix completes in 0.00s with 71 polygons

Closes issue 345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)