### PR TITLE
test(dsl-mesh): tier a csg primitive matrix harness (issue 344)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "pretty_assertions",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/aether-dsl-mesh/Cargo.toml
+++ b/crates/aether-dsl-mesh/Cargo.toml
@@ -11,3 +11,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1"
+tracing-subscriber = "0.3"

--- a/crates/aether-dsl-mesh/tests/csg_matrix.rs
+++ b/crates/aether-dsl-mesh/tests/csg_matrix.rs
@@ -1,0 +1,450 @@
+//! Tier A of the CSG completeness matrix (issue 344).
+//!
+//! Forces every primitive pair through every CSG op (9 × 9 × 3 = 243
+//! cells) at one canonical non-axis-aligned overlap position. Each cell
+//! is graded against four verdicts:
+//!
+//! 1. **non-empty** — `mesh()` succeeds and emits at least one triangle.
+//! 2. **manifold** — `validate_manifold` on the polygon-domain output is
+//!    empty (every directed edge twin-paired).
+//! 3. **invariants** — no `tracing::warn!` events fired during the run.
+//!    Issue 337's stage-boundary diagnostics are the verdict surface;
+//!    a clean matrix means the cleanup pipeline saw no surprises.
+//! 4. **tri-count** — output triangle count is within a generous sanity
+//!    band relative to the inputs' solo triangle counts. Catches BSP
+//!    explosions ("two cubes union → 50k triangles") without pinning
+//!    exact counts.
+//!
+//! On any cell failure, the test panics with a markdown failure matrix
+//! dumped to stdout — triage is one glance, not 243 stack traces.
+//!
+//! Tier B (seeded fuzz over translation/rotation per cell) is parked
+//! behind a follow-up PR per the issue.
+
+use aether_dsl_mesh::Polygon;
+use aether_dsl_mesh::debug::{ManifoldViolation, validate_manifold};
+use aether_dsl_mesh::{mesh_polygons, parse};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::time::Instant;
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+
+/// One cell of the curated matrix: a primitive pair under one op, at
+/// the canonical overlap offset.
+#[derive(Debug, Clone)]
+struct Cell {
+    op: &'static str,
+    a_name: &'static str,
+    b_name: &'static str,
+}
+
+/// Per-verdict result. `Skip` records that an upstream verdict (usually
+/// non-empty) made this one not-applicable — keeps the matrix readable
+/// when a cell errored before we could check manifoldness.
+#[derive(Debug, Clone)]
+enum Verdict {
+    Pass,
+    Fail(String),
+    Skip,
+}
+
+#[derive(Debug, Clone)]
+struct CellResult {
+    cell: Cell,
+    non_empty: Verdict,
+    manifold: Verdict,
+    invariants: Verdict,
+    tri_count: Verdict,
+}
+
+impl CellResult {
+    fn passed(&self) -> bool {
+        matches!(self.non_empty, Verdict::Pass)
+            && matches!(self.manifold, Verdict::Pass)
+            && matches!(self.invariants, Verdict::Pass)
+            && matches!(self.tri_count, Verdict::Pass)
+    }
+}
+
+/// 9 primitives. Each tuple: `(name, dsl-template)` where the
+/// `dsl-template` carries `{C}` for the `:color` slot.
+///
+/// All primitives are roughly half-extent 0.5 so the `(0.3, 0.15, 0.05)`
+/// offset (non-axis-aligned per cocircular-bias guidance) lands them in
+/// nontrivial overlap regardless of which pair fires.
+///
+/// Segment counts on curved primitives (cylinder, cone, sphere, lathe,
+/// torus) are kept low — Tier A is a coverage matrix, not a
+/// fidelity test, and BSP cost on heavy primitives explodes
+/// quadratically. Bumps belong in Tier B's seeded fuzz when we want
+/// stress-test runs.
+const PRIMITIVES: &[(&str, &str)] = &[
+    ("box", "(box 1 1 1 :color {C})"),
+    ("cylinder", "(cylinder 0.5 1.0 8 :color {C})"),
+    ("cone", "(cone 0.5 1.0 8 :color {C})"),
+    ("wedge", "(wedge 1 1 1 :color {C})"),
+    ("sphere", "(sphere 0.5 8 :color {C})"),
+    (
+        "lathe",
+        "(lathe ((0 -0.5) (0.5 -0.5) (0.5 0.5) (0 0.5)) 8 :color {C})",
+    ),
+    (
+        "extrude",
+        "(extrude ((-0.5 -0.5) (0.5 -0.5) (0.5 0.5) (-0.5 0.5)) 1.0 :color {C})",
+    ),
+    ("torus", "(torus 0.35 0.1 8 6 :color {C})"),
+    (
+        "sweep",
+        "(sweep ((-0.2 -0.2) (0.2 -0.2) (0.2 0.2) (-0.2 0.2)) ((0 -0.5 0) (0 0.5 0)) :color {C})",
+    ),
+];
+
+const OPS: &[&str] = &["union", "intersection", "difference"];
+
+/// Canonical overlap offset for the B primitive. Non-axis-aligned to
+/// avoid the cocircular bias that masked bugs in the existing axis-only
+/// regression corpus (memory: feedback_unit_tests_miss_cocircular_bias).
+const OFFSET: (f32, f32, f32) = (0.3, 0.15, 0.05);
+
+/// Tri-count sanity band: `[max(solo_a, solo_b) / LOWER, (solo_a + solo_b) * UPPER]`.
+/// Loose by design — the goal is to catch order-of-magnitude regressions
+/// (BSP explosions, unexpected empties from a non-empty input pair),
+/// not to pin counts.
+const TRI_COUNT_LOWER_DIVISOR: usize = 4;
+const TRI_COUNT_UPPER_FACTOR: usize = 10;
+
+/// Wallclock budget per cell. A cell that runs longer than this gets
+/// graded as `Fail("timeout")` and the matrix moves on. The runaway
+/// thread keeps running in the background until the test process
+/// exits — fine for a test harness, and the alternative (no timeout)
+/// is the original problem: one bad cell blocks the entire matrix.
+const PER_CELL_TIMEOUT_S: u64 = 10;
+
+/// Custom `tracing::Layer` that records every `WARN` event's formatted
+/// message. Each Tier A cell installs this as the default subscriber
+/// for the duration of its `mesh()` call so we can grade the
+/// invariants verdict without fighting global subscriber state.
+struct WarnCapture {
+    records: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S> tracing_subscriber::Layer<S> for WarnCapture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if *event.metadata().level() != tracing::Level::WARN {
+            return;
+        }
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.records.lock().unwrap().push(format!(
+            "{}: {}",
+            event.metadata().target(),
+            visitor.message
+        ));
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            if !self.message.is_empty() {
+                self.message.push_str(" | ");
+            }
+            self.message.push_str(&format!("{value:?}"));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            if !self.message.is_empty() {
+                self.message.push_str(" | ");
+            }
+            self.message.push_str(value);
+        }
+    }
+}
+
+fn build_dsl(op: &str, a_dsl: &str, b_dsl: &str) -> String {
+    let (ox, oy, oz) = OFFSET;
+    let b_translated = format!("(translate ({ox} {oy} {oz}) {b_dsl})");
+    format!("({op} {a_dsl} {b_translated})")
+}
+
+/// Estimate the post-tessellation triangle count from the cleanup
+/// pipeline's n-gon polygon output. Each polygon-with-holes contributes
+/// roughly `(outer_verts + sum(hole_verts) - 2)` triangles after CDT —
+/// close enough for the band check (which is order-of-magnitude, not
+/// exact). Lets the matrix grade tri-count without paying for a second
+/// full pipeline pass on top of `mesh_polygons`.
+fn estimate_tri_count(polys: &[Polygon]) -> usize {
+    polys
+        .iter()
+        .map(|p| {
+            let outer = p.vertices.len();
+            let holes_total: usize = p.holes.iter().map(|h| h.len()).sum();
+            let total = outer + holes_total;
+            total.saturating_sub(2)
+        })
+        .sum()
+}
+
+/// Run a primitive solo through the cleanup pipeline and return its
+/// estimated triangle count — the reference magnitude the per-cell band
+/// is built against.
+fn solo_tri_estimate(dsl: &str) -> Result<usize, String> {
+    let ast = parse(dsl).map_err(|e| format!("parse: {e}"))?;
+    let polys = mesh_polygons(&ast).map_err(|e| format!("mesh: {e}"))?;
+    Ok(estimate_tri_count(&polys))
+}
+
+/// Wrap [`run_cell_inner`] in a worker thread with a wallclock timeout.
+/// On timeout the thread keeps spinning in the background — we lose the
+/// ability to clean it up, but the test process exits at the end so it
+/// gets reaped. Trade-off: matrix coverage stays unblocked.
+fn run_cell(cell: &Cell, prim_a: (&str, usize), prim_b: (&str, usize)) -> CellResult {
+    let cell_owned = cell.clone();
+    let a_dsl = prim_a.0.to_string();
+    let b_dsl = prim_b.0.to_string();
+    let a_solo = prim_a.1;
+    let b_solo = prim_b.1;
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let r = run_cell_inner(&cell_owned, &a_dsl, a_solo, &b_dsl, b_solo);
+        let _ = tx.send(r);
+    });
+
+    match rx.recv_timeout(Duration::from_secs(PER_CELL_TIMEOUT_S)) {
+        Ok(r) => r,
+        Err(_) => CellResult {
+            cell: cell.clone(),
+            non_empty: Verdict::Fail(format!("wallclock timeout >{PER_CELL_TIMEOUT_S}s")),
+            manifold: Verdict::Skip,
+            invariants: Verdict::Skip,
+            tri_count: Verdict::Skip,
+        },
+    }
+}
+
+fn run_cell_inner(
+    cell: &Cell,
+    a_dsl: &str,
+    a_solo: usize,
+    b_dsl: &str,
+    b_solo: usize,
+) -> CellResult {
+    let a_dsl = a_dsl.replace("{C}", "0");
+    let b_dsl = b_dsl.replace("{C}", "1");
+    let cell_dsl = build_dsl(cell.op, &a_dsl, &b_dsl);
+
+    let warns: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(WarnCapture {
+        records: warns.clone(),
+    });
+
+    let parsed = match parse(&cell_dsl) {
+        Ok(node) => node,
+        Err(e) => {
+            return CellResult {
+                cell: cell.clone(),
+                non_empty: Verdict::Fail(format!("parse: {e}")),
+                manifold: Verdict::Skip,
+                invariants: Verdict::Skip,
+                tri_count: Verdict::Skip,
+            };
+        }
+    };
+
+    // Single pipeline pass per cell — `mesh_polygons` runs simplify +
+    // mesh + cleanup and stops at the n-gon boundary loops. We grade
+    // every verdict from the polygon output (manifold from
+    // validate_manifold, non-empty + tri-count via estimate_tri_count,
+    // invariants via the captured warn stream).
+    let polys_result = tracing::subscriber::with_default(subscriber, || mesh_polygons(&parsed));
+
+    let captured_warns = warns.lock().unwrap().clone();
+
+    let (non_empty, manifold, tri_count) = match &polys_result {
+        Ok(polys) => {
+            let tri_n = estimate_tri_count(polys);
+            let non_empty = if polys.is_empty() || tri_n == 0 {
+                Verdict::Fail("0 polygons".to_string())
+            } else {
+                Verdict::Pass
+            };
+            let violations = validate_manifold(polys);
+            let manifold = if violations.is_empty() {
+                Verdict::Pass
+            } else {
+                Verdict::Fail(format_violations(&violations))
+            };
+            let lower = std::cmp::max(a_solo, b_solo) / TRI_COUNT_LOWER_DIVISOR;
+            let upper = (a_solo + b_solo) * TRI_COUNT_UPPER_FACTOR;
+            let tri_count = if tri_n < lower || tri_n > upper {
+                Verdict::Fail(format!("{tri_n} not in [{lower}, {upper}]"))
+            } else {
+                Verdict::Pass
+            };
+            (non_empty, manifold, tri_count)
+        }
+        Err(e) => (
+            Verdict::Fail(format!("mesh err: {e}")),
+            Verdict::Skip,
+            Verdict::Skip,
+        ),
+    };
+
+    let invariants = if captured_warns.is_empty() {
+        Verdict::Pass
+    } else {
+        // First two warns is plenty for the failure report.
+        let preview: Vec<_> = captured_warns.iter().take(2).cloned().collect();
+        Verdict::Fail(preview.join("; "))
+    };
+
+    CellResult {
+        cell: cell.clone(),
+        non_empty,
+        manifold,
+        invariants,
+        tri_count,
+    }
+}
+
+fn format_violations(violations: &[ManifoldViolation]) -> String {
+    let count = violations.len();
+    let preview = violations
+        .iter()
+        .take(1)
+        .map(|v| format!("{v:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{count} violations (first: {preview})")
+}
+
+fn verdict_cell(v: &Verdict) -> String {
+    match v {
+        Verdict::Pass => "PASS".to_string(),
+        Verdict::Skip => "SKIP".to_string(),
+        Verdict::Fail(msg) => {
+            let truncated = if msg.len() > 60 {
+                format!("{}…", &msg[..60])
+            } else {
+                msg.clone()
+            };
+            format!("FAIL ({truncated})")
+        }
+    }
+}
+
+fn render_failure_report(failures: &[CellResult], total: usize) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\nCSG matrix verdict ({} cells): {} passed, {} failed\n\n",
+        total,
+        total - failures.len(),
+        failures.len()
+    ));
+    out.push_str(
+        "| op           | A         | B         | non-empty                  | manifold                   | invariants                 | tri-count                  |\n",
+    );
+    out.push_str(
+        "|--------------|-----------|-----------|----------------------------|----------------------------|----------------------------|----------------------------|\n",
+    );
+    for r in failures {
+        out.push_str(&format!(
+            "| {:<12} | {:<9} | {:<9} | {:<26} | {:<26} | {:<26} | {:<26} |\n",
+            r.cell.op,
+            r.cell.a_name,
+            r.cell.b_name,
+            verdict_cell(&r.non_empty),
+            verdict_cell(&r.manifold),
+            verdict_cell(&r.invariants),
+            verdict_cell(&r.tri_count),
+        ));
+    }
+    out
+}
+
+/// `#[ignore]` until the sphere/sweep manifold failures the matrix
+/// surfaces have follow-up issues filed against them — until then
+/// this would fail CI on bugs that are real but out-of-scope for the
+/// harness PR. Run locally with
+/// `cargo test --release -p aether-dsl-mesh --test csg_matrix -- \
+/// --ignored --nocapture` (release mode keeps the wall-clock
+/// reasonable; debug pays a ~10× tax through the BSP inner loops).
+/// Once the surfaced bugs are tracked, drop `#[ignore]` and the
+/// matrix becomes a CI-enforced verdict surface (issue 344).
+///
+/// The harness also depends on the BSP plane-identity fix from issue
+/// 345 — without it `union × sphere` cells hang BSP build instead of
+/// surfacing as manifold failures.
+#[test]
+#[ignore = "surfaces sphere/sweep manifold bugs awaiting follow-up issues (issue 344)"]
+fn csg_matrix_tier_a() {
+    // Sanity-check every solo primitive parses + meshes — both surfaces
+    // template typos before we hit 243 cells AND populates the per-
+    // primitive solo tri-count the band check is anchored against.
+    let solo_sizes: Vec<usize> = PRIMITIVES
+        .iter()
+        .map(|(name, dsl)| {
+            let solo_dsl = dsl.replace("{C}", "0");
+            let n = solo_tri_estimate(&solo_dsl)
+                .unwrap_or_else(|e| panic!("solo {name} failed to mesh: {e}"));
+            assert!(n > 0, "solo {name} produced 0 polygons (template broken)");
+            n
+        })
+        .collect();
+
+    let total = PRIMITIVES.len() * PRIMITIVES.len() * OPS.len();
+    let mut results = Vec::with_capacity(total);
+    let matrix_start = Instant::now();
+    let mut idx = 0usize;
+
+    for op in OPS {
+        for (i, (a_name, a_dsl)) in PRIMITIVES.iter().enumerate() {
+            for (j, (b_name, b_dsl)) in PRIMITIVES.iter().enumerate() {
+                idx += 1;
+                let cell_start = Instant::now();
+                eprint!("[{idx:>3}/{total}] {op:<13} {a_name:<8} × {b_name:<8} ... ");
+                let cell = Cell { op, a_name, b_name };
+                let r = run_cell(&cell, (a_dsl, solo_sizes[i]), (b_dsl, solo_sizes[j]));
+                let verdict = if r.passed() { "OK" } else { "FAIL" };
+                eprintln!("{verdict} ({:.2}s)", cell_start.elapsed().as_secs_f32());
+                results.push(r);
+            }
+        }
+    }
+
+    eprintln!(
+        "\n[matrix] {} cells in {:.1}s",
+        total,
+        matrix_start.elapsed().as_secs_f32()
+    );
+
+    let failures: Vec<_> = results.into_iter().filter(|r| !r.passed()).collect();
+
+    if !failures.is_empty() {
+        let report = render_failure_report(&failures, total);
+        // Print to stdout (visible via `cargo test -- --nocapture`) and
+        // also embed in the panic so failure CI logs are self-contained.
+        println!("{report}");
+        panic!(
+            "{} of {} CSG matrix cells failed:\n{}",
+            failures.len(),
+            total,
+            report
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `tests/csg_matrix.rs` — Tier A of the CSG completeness matrix per issue 344. 9 primitives × 9 primitives × 3 ops = 243 cells, each cell graded against four verdicts (non-empty, manifold, no invariant warns, tri-count sanity band). Failures aggregate into a markdown table dumped on panic.
- Marked `#[ignore]` until the sphere/sweep manifold cells the matrix surfaces have follow-up issues filed — CI runs everything else, the matrix stays a one-command local diagnostic.
- Adds `tracing-subscriber` as a dev-dependency for per-cell warn capture so the invariants verdict from issue 337 is graded inline.
- Depends on the BSP plane-identity fix from PR 346 (issue 345) — without it, `union × sphere` cells hang the build loop instead of surfacing as manifold failures.

## Local run

```
cargo test --release -p aether-dsl-mesh --test csg_matrix -- --ignored --nocapture
```

Release mode keeps wall-clock reasonable; debug pays a ~10× tax through BSP inner loops.

## Test plan

- [x] `cargo test -p aether-dsl-mesh` — 480+ tests green, matrix shows `0 passed; 0 failed; 1 ignored`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Manual local run with PR 346 applied — matrix completes in ~0.25s, surfaces ~30 sphere/sweep manifold cells (the next issues to triage)

## Follow-ups (out of scope)

- Sweep needs caps for CSG-eligibility — solo sweep emits 4 walls + no top/bottom (per spec, "no caps in v1"); every cell with sweep fails manifold.
- Sphere CSG produces manifold violations — distinct from PR 346's hang fix; the sphere cells now complete but with boundary edges in the cleanup output.
- Once those land, drop `#[ignore]` and the matrix becomes a CI-enforced verdict surface.
- Tier B (seeded fuzz over translation + rotation per cell) is the natural next iteration on this harness.

References issue 344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)