### PR TITLE
fix(dsl-mesh): error on trailing top-level forms in parse (issue 361)

### DIFF
--- a/crates/aether-dsl-mesh/src/parse.rs
+++ b/crates/aether-dsl-mesh/src/parse.rs
@@ -59,6 +59,8 @@ pub enum ParseError {
         min: usize,
         got: usize,
     },
+    #[error("trailing top-level form after first node: {trailing}")]
+    TrailingInput { trailing: String },
 }
 
 pub fn parse(text: &str) -> Result<Node, ParseError> {
@@ -68,7 +70,13 @@ pub fn parse(text: &str) -> Result<Node, ParseError> {
     let value = parser
         .next_value()?
         .ok_or_else(|| ParseError::NotAList("empty input".into()))?;
-    parse_node(&value)
+    let node = parse_node(&value)?;
+    if let Some(extra) = parser.next_value()? {
+        return Err(ParseError::TrailingInput {
+            trailing: format!("{extra}"),
+        });
+    }
+    Ok(node)
 }
 
 fn parse_node(value: &Value) -> Result<Node, ParseError> {

--- a/crates/aether-dsl-mesh/tests/round_trip.rs
+++ b/crates/aether-dsl-mesh/tests/round_trip.rs
@@ -87,3 +87,31 @@ fn parse_errors_on_invalid_axis() {
     let result = parse("(mirror w (box 1 1 1 :color 0))");
     assert!(result.is_err(), "invalid axis should fail");
 }
+
+#[test]
+fn parse_errors_on_trailing_top_level_form() {
+    let result = parse("(box 1 1 1 :color 0) (box 2 2 2 :color 1)");
+    let err = result.expect_err("trailing top-level form should fail");
+    assert!(
+        matches!(err, aether_dsl_mesh::ParseError::TrailingInput { .. }),
+        "expected TrailingInput, got {err:?}"
+    );
+}
+
+#[test]
+fn parse_allows_trailing_comment() {
+    let result = parse("(box 1 1 1 :color 0)\n; trailing comment\n");
+    assert!(
+        result.is_ok(),
+        "trailing comment should not trigger TrailingInput, got {result:?}"
+    );
+}
+
+#[test]
+fn parse_allows_trailing_whitespace() {
+    let result = parse("(box 1 1 1 :color 0)   ");
+    assert!(
+        result.is_ok(),
+        "trailing whitespace should be OK, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `ParseError::TrailingInput { trailing }` and checks that the lexpr parser yields no additional top-level value after the first node.
- Trailing whitespace and lexpr comments still parse cleanly (lexpr consumes them before `next_value` returns).
- Adds three tests covering the failure case plus the two no-op-trailing cases called out in the issue.

Closes issue 361

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`