### PR TITLE
fix(dsl-mesh): split polygon at pinch on unsafe t-junction insertion

### DIFF
--- a/crates/aether-dsl-mesh/src/csg/cleanup/merge.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/merge.rs
@@ -351,11 +351,13 @@ fn collapse_unbacked_boundary_runs(
 
 /// Normalize a possibly non-simple loop into a list of simple loops.
 ///
-/// `extract_loops` walks an X-junction by smallest-turn continuation
-/// and tracks visited *edges*, not vertices. With pinch-point topology
-/// (figure-8) the walker can re-enter a vertex via a different edge,
-/// emitting a single loop with a repeated vertex id. The post-merge
-/// invariant (issue 337) catches these as `NonSimpleLoopViolation`.
+/// Used both inside this module (after `extract_loops` /
+/// `collapse_unbacked_boundary_runs` produce a loop with a vertex
+/// re-entered via a different edge at an X-junction pinch) and from
+/// `super::tjunctions` (where unsafe subdivision insertion would
+/// repeat a vertex already in the polygon's loop). The post-merge
+/// invariant (issue 337) catches surviving non-simple loops as
+/// `NonSimpleLoopViolation`.
 ///
 /// Strategy: strip adjacent duplicates (including the wrap), then while
 /// a non-adjacent repeat exists at indices `i < j` split at the pinch:
@@ -368,13 +370,13 @@ fn collapse_unbacked_boundary_runs(
 /// All edges of the original loop are preserved; only the grouping
 /// changes. Branches with fewer than 3 vertices are dropped — they
 /// represent antennae (e.g. `[a, b, a]`) whose contributing edges
-/// twin-cancel and shouldn't have survived the bucket-wide pass.
+/// twin-cancel.
 ///
 /// Recurses to handle multiply-pinched loops. Pinch detection is the
 /// HashMap-based first-repeat scan, which is O(n) per call; recursion
 /// depth is bounded by the number of pinches (typically 1-2 in BSP
 /// output).
-fn normalize_loop(loop_verts: &[VertexId]) -> Vec<Vec<VertexId>> {
+pub(super) fn normalize_loop(loop_verts: &[VertexId]) -> Vec<Vec<VertexId>> {
     let mut verts: Vec<VertexId> = Vec::with_capacity(loop_verts.len());
     for &v in loop_verts {
         if verts.last() == Some(&v) {

--- a/crates/aether-dsl-mesh/src/csg/cleanup/tjunctions.rs
+++ b/crates/aether-dsl-mesh/src/csg/cleanup/tjunctions.rs
@@ -20,7 +20,8 @@
 //! bucketing is the Phase 2 optimization mentioned in ADR-0055 if
 //! profiling shows cleanup time dominates mesh authoring.
 
-use super::mesh::{IndexedMesh, VertexId};
+use super::merge::normalize_loop;
+use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
 use crate::csg::point::Point3;
 use std::collections::{HashMap, HashSet};
 
@@ -80,22 +81,18 @@ impl IndexedMesh {
                 break;
             }
 
-            for (poly_idx, poly) in polygons.iter_mut().enumerate() {
+            // Insert subdivisions unconditionally; if an insertion would
+            // produce a non-simple loop (same pool vertex was already in
+            // this polygon, or is the subdivision for two adjacent edges
+            // of one polygon — the spike pattern from PR 371), feed the
+            // result through `normalize_loop` to split at the pinch into
+            // simple loops. This preserves both contracts: every
+            // subdivision is inserted (no unrepaired T-junctions) and
+            // every emitted polygon is simple. A polygon that fully
+            // collapses (every branch is degenerate) is dropped.
+            let mut next_polygons: Vec<IndexedPolygon> = Vec::with_capacity(polygons.len());
+            for poly in &polygons {
                 let n = poly.vertices.len();
-                // Skip insertion when `v` already appears in this polygon's
-                // loop — either originally, or inserted earlier in the
-                // current pass through this polygon. Inserting `v` twice
-                // produces a non-simple loop `[..., v, x, v, ...]` (the
-                // spike pattern): happens when the same pool vertex is the
-                // subdivision for two different edges of the same polygon,
-                // e.g. when an off-axis cutter snap-drifts a rim vertex
-                // onto two adjacent host edges. Downstream the merge stage
-                // reads the spike as an internal twin edge `(v,x)+(x,v)`
-                // and the post-merge invariant fires. The T-junction at
-                // `v` is left unrepaired in this polygon; loop splitting
-                // (auditor's deeper fix) is the right thing if a manifold
-                // crack remains. Box × sphere is the canonical repro.
-                let mut existing: HashSet<VertexId> = poly.vertices.iter().copied().collect();
                 let mut new_verts: Vec<VertexId> = Vec::with_capacity(n + subdivisions.len());
                 for i in 0..n {
                     let a = poly.vertices[i];
@@ -106,21 +103,18 @@ impl IndexedMesh {
                         && v != a
                         && v != b
                     {
-                        if existing.contains(&v) {
-                            tracing::trace!(
-                                poly_idx,
-                                edge = ?canon,
-                                vertex_id = v,
-                                "tjunction insert skipped to preserve simple loop (issue 350 family)"
-                            );
-                        } else {
-                            new_verts.push(v);
-                            existing.insert(v);
-                        }
+                        new_verts.push(v);
                     }
                 }
-                poly.vertices = new_verts;
+                for verts in normalize_loop(&new_verts) {
+                    next_polygons.push(IndexedPolygon {
+                        vertices: verts,
+                        plane: poly.plane,
+                        color: poly.color,
+                    });
+                }
             }
+            polygons = next_polygons;
         }
 
         IndexedMesh { vertices, polygons }
@@ -527,6 +521,71 @@ mod tests {
             "off-axis T-junction at ~2 fixed units perpendicular drift \
              must be classified as collinear (issue #299)"
         );
+    }
+
+    /// Loop-splitting regression. When a subdivision `w` for edge
+    /// `(a, b)` is already present in the polygon's loop at a different
+    /// position, inserting blindly would emit `[..., a, w, b, ..., w, ...]`
+    /// — non-simple. Skipping (PR 371's containment) leaves an
+    /// unrepaired T-junction and trips the post-tjunctions invariant.
+    /// The fix splits at `w` into two simple loops sharing the vertex.
+    /// Box × sphere was the canonical matrix repro.
+    #[test]
+    fn unsafe_subdivision_splits_polygon_into_two_simple_loops() {
+        // Polygon under test is a 7-gon `[A, B, C, w, D, E, F]` where
+        // `w` already sits at index 3 and is also collinear-strictly-
+        // between the polygon's first edge `A → B`. Inserting `w` into
+        // `(A, B)` produces `[A, w, B, C, w, D, E, F]` — w at indices
+        // 1 and 4. `normalize_loop` splits at the pinch:
+        //   outer = verts[..=1] + verts[5..] = [A, w, D, E, F]
+        //   inner = verts[1..4]              = [w, B, C]
+        let plane = xy_plane();
+        let vertices = vec![
+            pt(0.0, 0.0, 0.0),  // 0: A
+            pt(4.0, 0.0, 0.0),  // 1: B
+            pt(3.0, 1.0, 0.0),  // 2: C
+            pt(2.0, 0.0, 0.0),  // 3: w (on edge A→B, also in poly loop)
+            pt(1.0, 2.0, 0.0),  // 4: D
+            pt(0.0, 2.0, 0.0),  // 5: E
+            pt(-1.0, 1.0, 0.0), // 6: F
+        ];
+        let polygons = vec![
+            // Source polygon to keep w referenced.
+            poly(vec![0, 3, 4], plane, 0),
+            // Polygon under test.
+            poly(vec![0, 1, 2, 3, 4, 5, 6], plane, 0),
+        ];
+        let mesh = IndexedMesh { vertices, polygons };
+        let repaired = mesh.repair_tjunctions();
+
+        // Every emitted polygon must be simple (no repeated vertex).
+        for p in &repaired.polygons {
+            let mut seen = std::collections::HashSet::new();
+            for &v in &p.vertices {
+                assert!(
+                    seen.insert(v),
+                    "polygon {:?} contains repeated vertex {v}",
+                    p.vertices
+                );
+            }
+        }
+
+        // The 7-gon split — the source polygon (3 verts) plus two
+        // simple loops sharing w. Compare loops as multisets to
+        // tolerate rotation / order-of-emission differences.
+        assert_eq!(repaired.polygons.len(), 3);
+        let actual_loops: std::collections::BTreeSet<std::collections::BTreeSet<VertexId>> =
+            repaired
+                .polygons
+                .iter()
+                .map(|p| p.vertices.iter().copied().collect())
+                .collect();
+        let expected_loops: std::collections::BTreeSet<std::collections::BTreeSet<VertexId>> =
+            [vec![0, 3, 4], vec![0, 3, 4, 5, 6], vec![3, 1, 2]]
+                .into_iter()
+                .map(|v| v.into_iter().collect())
+                .collect();
+        assert_eq!(actual_loops, expected_loops);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- PR 371 contained the spike pattern in t-junction repair by **skipping** subdivision insertions that would repeat a vertex already in the polygon — but skipping leaves an unrepaired interior vertex, which the post-tjunctions invariant from PR 372 then catches. The 5 box×sphere / sweep×sphere matrix cells were the canonical repro.
- This PR replaces the skip with **loop splitting**: insert unconditionally, then run `normalize_loop` (added in PR 373) on the result. A non-simple loop gets split at the pinch into two simple loops sharing the vertex. Both contracts hold — every subdivision is inserted, every emitted polygon is simple.
- `normalize_loop` was already in place; promoted from private to `pub(super)` so both merge and tjunctions stages share it.
- Matrix moves from 226/243 → 231/243 passing. The remaining 12 are pure curved × sphere boundary-edge mismatches (issue 370).

## Test plan
- [x] New unit test `unsafe_subdivision_splits_polygon_into_two_simple_loops` (7-gon with subdivision-vertex already in the loop → splits into 5-gon + triangle, both simple)
- [x] All 17 existing tjunctions tests still pass
- [x] `cargo test -p aether-dsl-mesh` (413 unit tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Tier A CSG matrix: 231/243 passing (up from 226)

# pr-body-ok: matrix counts use slashes, not bare #NNN

🤖 Generated with [Claude Code](https://claude.com/claude-code)