### PR TITLE
feat(substrate): fail-fast on abnormal component lifecycle (issue 383)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -461,6 +461,26 @@ pub struct ComponentDied {
     pub reason: alloc::string::String,
 }
 
+/// Final broadcast emitted by the substrate before `lifecycle::
+/// fatal_abort` calls `std::process::exit` (ADR-0063). Tells attached
+/// hub sessions that the substrate is going down on purpose, with a
+/// human-readable reason. Distinct from `ComponentDied`: the latter
+/// fires per dying component while the substrate keeps running;
+/// `SubstrateDying` fires once, immediately before exit, regardless of
+/// whether the cause was a component death or a wedged dispatcher.
+///
+/// `reason` is the same string that lands in `engine_logs` (e.g.
+/// `"component died: <kind> ..."` or `"dispatcher wedged: mailbox=...
+/// waited=5s"`). Receivers should treat this as the engine's last
+/// word — the TCP connection drops moments later.
+#[derive(
+    aether_mail::Kind, aether_mail::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.observation.substrate_dying")]
+pub struct SubstrateDying {
+    pub reason: alloc::string::String,
+}
+
 /// Diagnostic the hub emits back to an originating engine when mail
 /// that engine bubbled up (ADR-0037) doesn't resolve at the hub
 /// either. Lands on the engine's `aether.diagnostics` sink, which

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod hub_client;
 pub mod input;
 pub mod io;
 pub mod kind_manifest;
+pub mod lifecycle;
 pub mod log_capture;
 pub mod log_sink;
 pub mod mail;

--- a/crates/aether-substrate-core/src/lifecycle.rs
+++ b/crates/aether-substrate-core/src/lifecycle.rs
@@ -1,0 +1,65 @@
+//! Substrate lifecycle helpers (ADR-0063).
+//!
+//! `fatal_abort` is the chassis-facing exit path for abnormal
+//! component lifecycle events: a wasm trap or host panic during
+//! `deliver`, or a `drain_with_budget` returning `Wedged`. The
+//! function logs the abort reason, emits a final `SubstrateDying`
+//! broadcast to attached hub sessions, synchronously flushes the
+//! capture ring (so the abort log lands in `engine_logs`), and
+//! exits the process with code `2`.
+//!
+//! The function is `-> !`. It does not unwind — by the time we're
+//! here we've already decided the substrate is going down, and any
+//! caller-side cleanup would race the hub's reaping of the engine
+//! anyway.
+
+use aether_hub_protocol::{ClaudeAddress, EngineMailFrame, EngineToHub};
+use aether_kinds::SubstrateDying;
+
+use crate::hub_client::HubOutbound;
+
+/// Process exit code on fatal abort. Distinct from `0` (clean exit)
+/// and `1` (which Rust uses for panics from `main`).
+pub const FATAL_EXIT_CODE: i32 = 2;
+
+/// Emit a final `SubstrateDying` broadcast and exit the process. The
+/// reason string is what lands in `engine_logs` — make it specific
+/// enough that an operator reading the logs knows what triggered the
+/// abort (e.g. `"component died: <kind> ..."` vs. `"dispatcher
+/// wedged: mailbox=... waited=5s"`).
+///
+/// The broadcast uses `outbound` directly (bypassing the mailer) so
+/// it works even when the abort cause is an in-mailer wedge. Send is
+/// best-effort: a closed connection silently drops the frame, which
+/// is the right disposition during abort.
+pub fn fatal_abort(outbound: &HubOutbound, reason: String) -> ! {
+    tracing::error!(
+        target: "aether_substrate::lifecycle",
+        reason = %reason,
+        "substrate fatal abort",
+    );
+
+    // SubstrateDying carries the same reason; postcard-encode and
+    // ship as a broadcast frame on the engine TCP. Encoding is
+    // infallible for `String`-only structs; the `if let` is just
+    // defensive against a future schema change.
+    if let Ok(payload) = postcard::to_allocvec(&SubstrateDying {
+        reason: reason.clone(),
+    }) {
+        outbound.send(EngineToHub::Mail(EngineMailFrame {
+            address: ClaudeAddress::Broadcast,
+            kind_name: <SubstrateDying as aether_mail::Kind>::NAME.to_owned(),
+            payload,
+            origin: None,
+            correlation_id: 0,
+        }));
+    }
+
+    // Drain whatever's in the capture ring onto the engine TCP
+    // before we go. The 250 ms background flusher in `log_capture`
+    // can't be relied on during abort — we exit the process below
+    // and the flusher's loop never sees the next tick.
+    crate::log_capture::flush_now();
+
+    std::process::exit(FATAL_EXIT_CODE);
+}

--- a/crates/aether-substrate-core/src/log_capture.rs
+++ b/crates/aether-substrate-core/src/log_capture.rs
@@ -22,7 +22,7 @@
 use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -52,6 +52,13 @@ const BATCH_TRIGGER_INTERVAL: Duration = Duration::from_millis(250);
 /// Env var name for overriding the default filter.
 const FILTER_ENV: &str = "AETHER_LOG_FILTER";
 
+/// Process-lifetime handle to the capture ring, populated by `init`.
+/// `flush_now` reads this so `lifecycle::fatal_abort` can drain the
+/// ring synchronously before the substrate exits (ADR-0063); the
+/// background flush thread on a 250 ms timer can't be relied on when
+/// the process is about to call `std::process::exit`.
+static CAPTURE: OnceLock<Arc<Inner>> = OnceLock::new();
+
 /// Install the global tracing subscriber and spawn the flush thread.
 ///
 /// `outbound` is the same handle the hub client populates; this lets
@@ -80,11 +87,45 @@ pub fn init(outbound: Arc<HubOutbound>) {
         .is_ok();
 
     if registered {
+        // Publish the ring handle for `flush_now`. Set on first init
+        // only; subsequent inits (chassis re-entry / tests) are no-ops
+        // because `try_init` already returned false above.
+        let _ = CAPTURE.set(Arc::clone(&inner));
+
         let flusher = Arc::clone(&inner);
         thread::Builder::new()
             .name("aether-log-flush".into())
             .spawn(move || flush_loop(flusher))
             .expect("spawn flush thread");
+    }
+}
+
+/// Synchronously drain the capture ring and push it through the
+/// configured `HubOutbound` on the calling thread. Used by
+/// `lifecycle::fatal_abort` (ADR-0063) immediately before
+/// `std::process::exit` so the abort log lands in `engine_logs`
+/// instead of being lost with the process.
+///
+/// No-op if `init` was never called (e.g. unit tests that don't boot
+/// the global subscriber). Safe to call from any thread.
+pub fn flush_now() {
+    if let Some(inner) = CAPTURE.get() {
+        flush_into(inner);
+    }
+}
+
+/// Inner half of `flush_now` — does the synchronous take + send
+/// against an explicit `Inner`. Pulled out so tests can drive the
+/// drain path against a test channel without touching the
+/// process-global `CAPTURE` static (which `init` populates exactly
+/// once for the substrate's lifetime).
+fn flush_into(inner: &Inner) {
+    let batch = {
+        let mut s = inner.state.lock().unwrap();
+        take_batch(&mut s)
+    };
+    if !batch.is_empty() {
+        inner.outbound.send(EngineToHub::LogBatch(batch));
     }
 }
 
@@ -343,6 +384,34 @@ mod tests {
         assert_eq!(batch[1].message, "kept");
         // Counter resets after flush.
         assert_eq!(s.dropped_since_last_flush, 0);
+    }
+
+    /// ADR-0063: `flush_into` (the inner half of `flush_now`) drains
+    /// the ring on the calling thread — no background flusher
+    /// involvement, so a `fatal_abort` flushing immediately before
+    /// `process::exit` actually lands the abort log on the engine
+    /// TCP. Subsequent flushes are no-ops because the ring is empty.
+    #[test]
+    fn flush_into_drains_synchronously_on_calling_thread() {
+        let (inner, rx) = make_inner();
+        inner.push(LogLevel::Error, "lifecycle".into(), "abort msg".into());
+        inner.push(LogLevel::Warn, "lifecycle".into(), "secondary".into());
+
+        flush_into(&inner);
+
+        let frame = rx.try_recv().expect("flush_into should send a batch");
+        let EngineToHub::LogBatch(batch) = frame else {
+            panic!("unexpected frame variant: {frame:?}");
+        };
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].message, "abort msg");
+        assert_eq!(batch[1].message, "secondary");
+
+        // Re-flushing an empty ring is a no-op — no extra frame on
+        // the channel, ring stays empty.
+        flush_into(&inner);
+        assert!(rx.try_recv().is_err());
+        assert_eq!(inner.state.lock().unwrap().entries.len(), 0);
     }
 
     #[test]

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -210,6 +210,18 @@ impl Mailer {
         let components = self.components.get().expect("Mailer not wired");
         crate::scheduler::drain_all(components);
     }
+
+    /// Budget-aware variant of `drain_all` (ADR-0063). Returns a
+    /// `DrainSummary` the chassis matches on to detect dispatcher
+    /// deaths and wedges; on either, the chassis routes through
+    /// `lifecycle::fatal_abort`.
+    pub fn drain_all_with_budget(
+        &self,
+        budget: std::time::Duration,
+    ) -> crate::scheduler::DrainSummary {
+        let components = self.components.get().expect("Mailer not wired");
+        crate::scheduler::drain_all_with_budget(components, budget)
+    }
 }
 
 impl Default for Mailer {

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -29,6 +29,7 @@ use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use aether_kinds::ComponentDied;
 use aether_mail::Kind;
@@ -50,14 +51,58 @@ const STATE_DEAD: u8 = 1;
 /// Per-entry quiescence counter + condvar, shared with the dispatcher
 /// thread. `send` increments `pending` before forwarding to the inbox;
 /// the dispatcher decrements after each `deliver` and signals when the
-/// counter reaches zero. `drain` waits on the condvar for that signal,
-/// giving callers a per-mailbox barrier equivalent to the Phase-2
-/// global `Mailer::wait_idle`.
+/// counter reaches zero. `drain_with_budget` waits on the condvar for
+/// that signal, giving callers a per-mailbox barrier with a deadline.
+///
+/// `death` is populated by `kill_actor` before it calls
+/// `decrement_and_notify`, so a `drain_with_budget` waking on the same
+/// notify reads a fully-formed `DrainDeath` and can report
+/// `DrainOutcome::Died` instead of `Quiesced` (ADR-0063).
 #[derive(Default)]
 struct PendingGate {
     pending: AtomicU32,
     lock: Mutex<()>,
     cv: Condvar,
+    death: Mutex<Option<DrainDeath>>,
+}
+
+/// Structured information about a dispatcher death — recorded by
+/// `kill_actor` and surfaced through `drain_with_budget` /
+/// `drain_all_with_budget` so the chassis can fail-fast (ADR-0063)
+/// without scraping log text.
+#[derive(Debug, Clone)]
+pub struct DrainDeath {
+    pub mailbox: MailboxId,
+    pub mailbox_name: String,
+    pub last_kind: String,
+    pub reason: String,
+}
+
+/// Result of a single per-entry `drain_with_budget` call.
+#[derive(Debug)]
+pub enum DrainOutcome {
+    /// Pending counter reached zero with the entry still live.
+    Quiesced,
+    /// The dispatcher transitioned to Dead during the wait. The
+    /// `DrainDeath` carries the mailbox identity and trap / panic
+    /// reason recorded by `kill_actor`.
+    Died(DrainDeath),
+    /// The budget expired with `pending > 0`. The dispatcher is
+    /// either mid-trap or wedged in host code; the chassis treats
+    /// this as a fatal substrate event.
+    Wedged { waited: Duration },
+}
+
+/// Aggregate outcome of `drain_all_with_budget` across the whole
+/// component table. The chassis matches on this each frame and routes
+/// abnormal cases through `lifecycle::fatal_abort` (ADR-0063).
+#[derive(Debug, Default)]
+pub struct DrainSummary {
+    pub deaths: Vec<DrainDeath>,
+    /// First wedged entry encountered. Walking stops on the first
+    /// wedge — the substrate is going down regardless, so collecting
+    /// further state isn't useful.
+    pub wedged: Option<(MailboxId, Duration)>,
 }
 
 /// Per-mailbox scheduler state. The `Component` (and its wasmtime
@@ -190,10 +235,53 @@ impl ComponentEntry {
     /// arriving during the wait re-raise the counter and extend the
     /// wait; callers that need a single-frame barrier should ensure
     /// no concurrent sends target this mailbox.
+    ///
+    /// Has no upper bound on wait time — chassis callers that need a
+    /// fail-fast policy on stuck dispatchers use `drain_with_budget`
+    /// instead (ADR-0063).
     pub fn drain(&self) {
         let mut guard = self.gate.lock.lock().unwrap();
         while self.gate.pending.load(Ordering::Acquire) > 0 {
             guard = self.gate.cv.wait(guard).unwrap();
+        }
+    }
+
+    /// Budget-aware drain (ADR-0063). Same wait semantics as `drain`
+    /// but with a deadline; returns a structured outcome the chassis
+    /// can match on:
+    ///
+    /// - `Quiesced` — the entry is live and its inbox drained cleanly.
+    /// - `Died(...)` — the dispatcher transitioned to Dead during the
+    ///   wait; the `DrainDeath` carries the trap / panic reason
+    ///   recorded by `kill_actor`.
+    /// - `Wedged { waited }` — the budget elapsed with `pending > 0`.
+    ///
+    /// The death-vs-quiesce distinction reads from `gate.death` (a
+    /// slot `kill_actor` populates before notifying the condvar), not
+    /// from the `STATE_DEAD` flag. The slot is the structured signal;
+    /// the state flag is for the `send`-side fast path.
+    pub fn drain_with_budget(&self, budget: Duration) -> DrainOutcome {
+        let deadline = Instant::now() + budget;
+        let mut guard = self.gate.lock.lock().unwrap();
+        while self.gate.pending.load(Ordering::Acquire) > 0 {
+            let now = Instant::now();
+            if now >= deadline {
+                return DrainOutcome::Wedged { waited: budget };
+            }
+            let remaining = deadline - now;
+            let (next, timeout) = self.gate.cv.wait_timeout(guard, remaining).unwrap();
+            guard = next;
+            if timeout.timed_out() && self.gate.pending.load(Ordering::Acquire) > 0 {
+                return DrainOutcome::Wedged { waited: budget };
+            }
+        }
+        // pending == 0. The death slot is the source of truth: if
+        // `kill_actor` ran, it populated the slot before
+        // `decrement_and_notify`, and that notify is what woke us.
+        if let Some(d) = self.gate.death.lock().unwrap().clone() {
+            DrainOutcome::Died(d)
+        } else {
+            DrainOutcome::Quiesced
         }
     }
 }
@@ -293,6 +381,10 @@ pub fn spawn_dispatcher_on(
     // freeze-drain-swap takes the failure-path policy elsewhere
     // (replace returns Err and the old instance stays bound).
     state.store(STATE_LIVE, Ordering::Release);
+    // ADR-0063: clear the prior death record so a post-replace
+    // `drain_with_budget` doesn't see stale `Died` from the dispatcher
+    // we just replaced.
+    *gate.death.lock().unwrap() = None;
     let mailbox = entry.mailbox;
     let thread_name = dispatcher_thread_name(&registry, mailbox);
     let handle = thread::Builder::new()
@@ -391,6 +483,7 @@ fn dispatcher_loop(
                 );
                 kill_actor(
                     &state,
+                    &gate,
                     &mailer,
                     &registry,
                     mailbox,
@@ -411,6 +504,7 @@ fn dispatcher_loop(
                 );
                 kill_actor(
                     &state,
+                    &gate,
                     &mailer,
                     &registry,
                     mailbox,
@@ -440,17 +534,34 @@ fn dispatcher_loop(
 /// dropped and the death is only visible via `engine_logs`.
 fn kill_actor(
     state: &AtomicU8,
+    gate: &PendingGate,
     mailer: &Mailer,
     registry: &Registry,
     mailbox: MailboxId,
     last_kind: &str,
     reason: String,
 ) {
-    state.store(STATE_DEAD, Ordering::Release);
-
     let mailbox_name = registry
         .mailbox_name(mailbox)
         .unwrap_or_else(|| "?".to_string());
+
+    // ADR-0063: record the structured death into the gate's slot
+    // *before* `decrement_and_notify` (called immediately after we
+    // return). A `drain_with_budget` waking on that notify reads this
+    // slot and reports `DrainOutcome::Died` instead of `Quiesced`,
+    // which is what lets the chassis fail-fast without scraping logs.
+    {
+        let mut slot = gate.death.lock().unwrap();
+        *slot = Some(DrainDeath {
+            mailbox,
+            mailbox_name: mailbox_name.clone(),
+            last_kind: last_kind.to_string(),
+            reason: reason.clone(),
+        });
+    }
+
+    state.store(STATE_DEAD, Ordering::Release);
+
     let died = ComponentDied {
         mailbox_id: mailbox.0,
         mailbox_name,
@@ -596,6 +707,46 @@ pub fn drain_all(components: &ComponentTable) {
         }
     }
 }
+
+/// Budget-aware variant of `drain_all` (ADR-0063). Walks the component
+/// table, collecting structured outcomes from each per-entry drain.
+/// Returns a `DrainSummary` the chassis matches on — non-empty
+/// `deaths` or any `wedged` triggers `lifecycle::fatal_abort`.
+///
+/// Stops iteration on the first wedged entry: the substrate is going
+/// down regardless, so collecting further state isn't useful and may
+/// itself be slow if other entries are also stuck.
+///
+/// Re-iterates after a clean pass if any entry's pending counter has
+/// risen again — a delivered mail can dispatch fresh mail to another
+/// mailbox we already drained, same way the no-budget `drain_all`
+/// handles that case. The budget applies per-entry-per-pass; a
+/// single chassis call can wait up to `budget * passes` in pathological
+/// cross-component send loops, but in practice quiesces in one pass.
+pub fn drain_all_with_budget(components: &ComponentTable, budget: Duration) -> DrainSummary {
+    let mut summary = DrainSummary::default();
+    loop {
+        let entries: Vec<Arc<ComponentEntry>> =
+            components.read().unwrap().values().cloned().collect();
+        for entry in &entries {
+            match entry.drain_with_budget(budget) {
+                DrainOutcome::Quiesced => {}
+                DrainOutcome::Died(d) => summary.deaths.push(d),
+                DrainOutcome::Wedged { waited } => {
+                    summary.wedged = Some((entry.mailbox, waited));
+                    return summary;
+                }
+            }
+        }
+        let still_busy = entries
+            .iter()
+            .any(|e| e.gate.pending.load(Ordering::Acquire) > 0);
+        if !still_busy {
+            return summary;
+        }
+    }
+}
+
 // Per-component dispatcher threads exit when their `ComponentEntry`
 // Arc drops (the `Sender` drops with it, the inbox closes, `recv()`
 // returns `None`). The scheduler no longer owns a router thread, so
@@ -937,5 +1088,178 @@ mod tests {
             out.starts_with("<non-string panic payload"),
             "unexpected: {out}",
         );
+    }
+
+    /// ADR-0063: a clean delivery cycle ends with the entry still
+    /// live, so `drain_with_budget` returns `Quiesced`.
+    #[test]
+    fn drain_with_budget_returns_quiesced_on_clean_delivery() {
+        let entry = spawn_entry();
+        assert!(entry.send(Mail::new(MailboxId(0), 0xBB, vec![1], 1)));
+        match entry.drain_with_budget(Duration::from_secs(1)) {
+            DrainOutcome::Quiesced => {}
+            other => panic!("expected Quiesced, got {other:?}"),
+        }
+        let _component = close_and_join(entry);
+    }
+
+    /// ADR-0063: a guest trap during deliver records a `DrainDeath`
+    /// in the gate, and `drain_with_budget` reads it on wake to
+    /// return `Died`. Mirrors the existing `trap_in_receive_marks_
+    /// mailbox_dead` test but exercises the new budget-aware path.
+    #[test]
+    fn drain_with_budget_returns_died_after_trap() {
+        let registry = Arc::new(Registry::new());
+        let mailbox = registry.register_component("trappy");
+        let mailer = Arc::new(Mailer::new());
+
+        // Broadcast sink: the dispatcher's death push goes through
+        // it; without a registered sink the broadcast warn-drops as
+        // an unknown mailbox, harmless but noisy.
+        registry.register_sink(crate::HUB_CLAUDE_BROADCAST, Arc::new(|_, _, _, _, _, _| {}));
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
+        let entry = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox,
+        ));
+
+        assert!(entry.send(Mail::new(mailbox, 0xDD, vec![], 1)));
+        let outcome = entry.drain_with_budget(Duration::from_secs(2));
+        match outcome {
+            DrainOutcome::Died(d) => {
+                assert_eq!(d.mailbox, mailbox);
+                assert_eq!(d.mailbox_name, "trappy");
+                assert!(
+                    d.reason.starts_with("wasmtime trap:"),
+                    "expected wasmtime trap reason, got: {}",
+                    d.reason,
+                );
+            }
+            other => panic!("expected Died, got {other:?}"),
+        }
+
+        let _component = close_and_join(entry);
+    }
+
+    /// ADR-0063: a dispatcher that doesn't decrement pending within
+    /// the budget triggers `Wedged`. Simulated by bumping the
+    /// pending counter directly so the dispatcher never sees the
+    /// "mail" — the wait_timeout path is what we're testing, and
+    /// driving it via an actual stuck guest would leak a wasmtime
+    /// thread for the rest of the test run.
+    #[test]
+    fn drain_with_budget_returns_wedged_when_pending_does_not_drop() {
+        let entry = spawn_entry();
+        // Bump pending without going through `send` — no mpsc message
+        // is queued, so the dispatcher never wakes to decrement.
+        entry.gate.pending.fetch_add(1, Ordering::AcqRel);
+
+        let outcome = entry.drain_with_budget(Duration::from_millis(100));
+        match outcome {
+            DrainOutcome::Wedged { waited } => {
+                assert_eq!(waited, Duration::from_millis(100));
+            }
+            other => panic!("expected Wedged, got {other:?}"),
+        }
+
+        // Restore pending so close_and_join's drop doesn't leak the
+        // gate state for any other tests.
+        entry.gate.pending.fetch_sub(1, Ordering::AcqRel);
+        let _component = close_and_join(entry);
+    }
+
+    /// ADR-0063: `drain_all_with_budget` aggregates per-entry
+    /// outcomes. Quiesced entries leave `summary.deaths` empty;
+    /// died entries land there.
+    #[test]
+    fn drain_all_with_budget_collects_deaths() {
+        let registry = Arc::new(Registry::new());
+        let mailbox_ok = registry.register_component("alive");
+        let mailbox_dies = registry.register_component("dies");
+        let mailer = Arc::new(Mailer::new());
+        registry.register_sink(crate::HUB_CLAUDE_BROADCAST, Arc::new(|_, _, _, _, _, _| {}));
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
+        let entry_ok = Arc::new(ComponentEntry::spawn(
+            minimal_component(),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox_ok,
+        ));
+        let entry_dies = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox_dies,
+        ));
+        components
+            .write()
+            .unwrap()
+            .insert(mailbox_ok, Arc::clone(&entry_ok));
+        components
+            .write()
+            .unwrap()
+            .insert(mailbox_dies, Arc::clone(&entry_dies));
+
+        // Send to both: one quiesces cleanly, the other traps.
+        assert!(entry_ok.send(Mail::new(mailbox_ok, 0xBB, vec![], 1)));
+        assert!(entry_dies.send(Mail::new(mailbox_dies, 0xDD, vec![], 1)));
+
+        let summary = drain_all_with_budget(&components, Duration::from_secs(2));
+        assert!(summary.wedged.is_none(), "no entry should be wedged");
+        assert_eq!(summary.deaths.len(), 1, "exactly one entry died");
+        assert_eq!(summary.deaths[0].mailbox, mailbox_dies);
+        assert_eq!(summary.deaths[0].mailbox_name, "dies");
+    }
+
+    /// ADR-0063: a successful replace clears the prior death record
+    /// so a post-replace drain sees `Quiesced` rather than the
+    /// stale `Died` from the dispatcher we just retired.
+    #[test]
+    fn replace_clears_prior_death() {
+        let registry = Arc::new(Registry::new());
+        let mailbox = registry.register_component("rep");
+        let mailer = Arc::new(Mailer::new());
+        registry.register_sink(crate::HUB_CLAUDE_BROADCAST, Arc::new(|_, _, _, _, _, _| {}));
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
+        let entry = Arc::new(ComponentEntry::spawn(
+            component_from_wat(WAT_TRAPS_IN_RECEIVE),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox,
+        ));
+
+        // Trigger a death.
+        assert!(entry.send(Mail::new(mailbox, 0xDD, vec![], 1)));
+        match entry.drain_with_budget(Duration::from_secs(2)) {
+            DrainOutcome::Died(_) => {}
+            other => panic!("expected Died after trap, got {other:?}"),
+        }
+
+        // Splice + spawn fresh dispatcher onto the same entry.
+        let (_old_component, new_rx) = splice_inbox(&entry);
+        spawn_dispatcher_on(
+            &entry,
+            minimal_component(),
+            new_rx,
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+        );
+
+        // Death slot should be cleared, state back to LIVE, drain
+        // returns Quiesced.
+        match entry.drain_with_budget(Duration::from_secs(1)) {
+            DrainOutcome::Quiesced => {}
+            other => panic!("expected Quiesced after replace, got {other:?}"),
+        }
+
+        let _component = close_and_join(entry);
     }
 }

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -17,7 +17,7 @@ mod render;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use aether_kinds::{
     CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, InputStream,
@@ -45,6 +45,15 @@ use winit::window::{Fullscreen, Window, WindowId};
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;
+
+/// ADR-0063 fail-fast budget for the per-frame drain barrier. A
+/// dispatcher that doesn't quiesce within this window is treated as
+/// wedged: the substrate logs, broadcasts `SubstrateDying`, and
+/// exits. 5 s is patient enough that ordinary frames don't trip it
+/// even on slow first-load compiles, short enough that an operator
+/// staring at a frozen window gets a clean exit instead of a
+/// multi-minute wait.
+const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// ADR-0035 desktop chassis. Owns the winit event loop and the
 /// `App` that drives it. The `Chassis` trait's `run(self) -> Result`
@@ -828,7 +837,39 @@ impl ApplicationHandler<UserEvent> for App {
                         self.publish_window_size(size.width, size.height);
                     }
                 }
-                self.queue.drain_all();
+                // ADR-0063: budget-aware drain. Dispatcher deaths or
+                // wedges abort the substrate cleanly via `fatal_abort`
+                // — the hub respawns on the next operator action. The
+                // 5-second budget is a deliberately patient bound;
+                // anything past it indicates a wedged dispatcher
+                // (slow trap, host deadlock) we have no recovery path
+                // for in v1.
+                let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
+                if let Some((mailbox, waited)) = summary.wedged {
+                    aether_substrate_core::lifecycle::fatal_abort(
+                        &self.outbound,
+                        format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}",),
+                    );
+                }
+                if let Some(first) = summary.deaths.first() {
+                    for d in &summary.deaths {
+                        tracing::error!(
+                            target: "aether_substrate::lifecycle",
+                            mailbox = ?d.mailbox,
+                            mailbox_name = %d.mailbox_name,
+                            last_kind = %d.last_kind,
+                            reason = %d.reason,
+                            "component died; substrate aborting (ADR-0063)",
+                        );
+                    }
+                    aether_substrate_core::lifecycle::fatal_abort(
+                        &self.outbound,
+                        format!(
+                            "component died: {} (kind {}) — {}",
+                            first.mailbox_name, first.last_kind, first.reason,
+                        ),
+                    );
+                }
                 let verts = std::mem::take(&mut *self.frame_vertices.lock().unwrap());
                 let view_proj = *self.camera_state.lock().unwrap();
                 if let Some(gpu) = self.gpu.as_mut() {

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -25,6 +25,13 @@ const WORKERS: usize = 2;
 const DEFAULT_TICK_HZ: u32 = 60;
 const LOG_EVERY_FRAMES: u64 = 120;
 
+/// ADR-0063 fail-fast budget for the per-tick drain barrier. A
+/// dispatcher that doesn't quiesce within this window is treated as
+/// wedged and the substrate exits cleanly via `fatal_abort`. Same
+/// 5-second value the desktop chassis uses — both run the same
+/// dispatcher kernel.
+const DRAIN_BUDGET: Duration = Duration::from_secs(5);
+
 /// Headless chassis. Owns the tick loop + the bookkeeping every
 /// subsequent frame needs. `run(self)` takes ownership and drives
 /// the loop forever — the process exits on SIGTERM (hub-spawned
@@ -37,6 +44,9 @@ struct HeadlessChassis {
     kind_tick: u64,
     kind_frame_stats: u64,
     tick_period: Duration,
+    /// ADR-0063: passed to `lifecycle::fatal_abort` for the final
+    /// `SubstrateDying` broadcast before exit.
+    outbound: Arc<aether_substrate_core::HubOutbound>,
     // Held so the scheduler's worker threads + the hub's reader /
     // heartbeat threads stay alive for the life of the chassis.
     _scheduler: Scheduler,
@@ -73,7 +83,34 @@ impl Chassis for HeadlessChassis {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
             }
-            self.queue.drain_all();
+            // ADR-0063: budget-aware drain. Dispatcher deaths or
+            // wedges abort the substrate cleanly via `fatal_abort`.
+            let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
+            if let Some((mailbox, waited)) = summary.wedged {
+                aether_substrate_core::lifecycle::fatal_abort(
+                    &self.outbound,
+                    format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
+                );
+            }
+            if let Some(first) = summary.deaths.first() {
+                for d in &summary.deaths {
+                    tracing::error!(
+                        target: "aether_substrate::lifecycle",
+                        mailbox = ?d.mailbox,
+                        mailbox_name = %d.mailbox_name,
+                        last_kind = %d.last_kind,
+                        reason = %d.reason,
+                        "component died; substrate aborting (ADR-0063)",
+                    );
+                }
+                aether_substrate_core::lifecycle::fatal_abort(
+                    &self.outbound,
+                    format!(
+                        "component died: {} (kind {}) — {}",
+                        first.mailbox_name, first.last_kind, first.reason,
+                    ),
+                );
+            }
 
             if frame.is_multiple_of(LOG_EVERY_FRAMES) {
                 let stats = FrameStats {
@@ -258,6 +295,7 @@ fn main() -> wasmtime::Result<()> {
         kind_tick,
         kind_frame_stats,
         tick_period,
+        outbound: boot.outbound,
         _scheduler: boot.scheduler,
         _hub: hub,
     };


### PR DESCRIPTION
## Summary

Implements ADR-0063: substrate exits cleanly on any abnormal component lifecycle event instead of silently waiting for a stuck dispatcher to surface a trap. Removes the multi-second freeze on wasm32 OOM (`alloc::raw_vec::capacity_overflow`) — the operator now sees a logged abort + clean disconnect inside the drain budget instead of an unresponsive window for 3-10 seconds.

Two paths reach `lifecycle::fatal_abort`:

- **Wasm trap / host panic during `deliver`** — flips `STATE_DEAD`, records structured `DrainDeath` in the entry's gate slot, then surfaces to the chassis through `drain_with_budget` returning `Died`.
- **Drain wait exceeds budget (5 s)** — returns `Wedged`; the chassis treats it as fatal.

`fatal_abort` writes the abort reason to tracing, broadcasts a final `SubstrateDying` (new observation kind), synchronously drains the log-capture ring via `log_capture::flush_now`, and exits with code 2. Hub respawns on next operator action.

## Mechanism

- `ComponentEntry::drain_with_budget(Duration) -> DrainOutcome { Quiesced, Died(DrainDeath), Wedged { waited } }` — budget-aware variant of `drain`.
- `scheduler::drain_all_with_budget(...) -> DrainSummary { deaths, wedged }` — aggregates per-entry outcomes, stops on the first wedge.
- `kill_actor` extended to write a `DrainDeath` into `gate.death` *before* `decrement_and_notify`, so the wake on the same condvar reads a fully-formed death.
- `spawn_dispatcher_on` clears the death slot on replace (defensive — v1 abort policy means replace-after-death can't actually happen, but the data model stays coherent).
- `log_capture::flush_now` — synchronous one-shot drain on the calling thread, populated via `OnceLock<Arc<Inner>>` set by `init`.
- New module `aether-substrate-core/src/lifecycle.rs` with `fatal_abort(outbound, reason) -> !`.
- New observation kind `aether_kinds::SubstrateDying { reason }`.

Existing no-budget `drain` / `drain_all` stay for test paths that don't care about deadlines.

## Test plan

- [x] `cargo test --workspace` — 16 scheduler tests pass (5 new: `drain_with_budget_returns_quiesced_on_clean_delivery`, `drain_with_budget_returns_died_after_trap`, `drain_with_budget_returns_wedged_when_pending_does_not_drop`, `drain_all_with_budget_collects_deaths`, `replace_clears_prior_death`); 5 log_capture tests pass (1 new: `flush_into_drains_synchronously_on_calling_thread`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo check -p aether-mesh-editor-component --target wasm32-unknown-unknown` clean.
- [x] Live MCP smoke test: load a component that allocates past wasm32 `isize::MAX` and confirm the substrate aborts within ~5s with a `SubstrateDying` broadcast on the engine TCP.

## Notes

- `DRAIN_BUDGET = 5s` in both desktop and headless chassis. Patient enough that ordinary frames don't trip it, short enough that a frozen window doesn't sit unresponsive for minutes.
- `MailboxId` debug formatting in the abort reason (`mailbox=MailboxId(...)`) is operator-readable but not stable — soft contract for human eyes only.
- The wedge case as currently tested fires at the *budget* (drain returns Wedged), not at the chassis (which then calls `fatal_abort` and exits the process). The chassis-level abort isn't unit-testable cleanly because it calls `std::process::exit`; live MCP smoke is the better verification once a stuck-host-fn fixture exists.

Closes issue 383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)