### PR TITLE
feat(mail): tag mailbox / kind / handle ids with type bits (ADR-0064 phase 1)

### DIFF
--- a/crates/aether-hub-protocol/src/canonical/mod.rs
+++ b/crates/aether-hub-protocol/src/canonical/mod.rs
@@ -69,6 +69,7 @@ mod tests {
         primitives::write_varint_u64,
         schema::{KIND_DOMAIN, fnv1a_64_prefixed},
     };
+    use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
     use crate::types::{
         EnumVariant, KindLabels, KindShape, LabelCell, LabelNode, NamedField, Primitive,
         SchemaCell, SchemaShape, SchemaType, VariantLabel, VariantShape,
@@ -222,11 +223,9 @@ mod tests {
         const N: usize = canonical_len_kind(NAME, &TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_kind::<N>(NAME, &TRIANGLE);
         // Domain-prefixed (issue #186) + ADR-0064 tag-stamped — agrees
-        // with the derive macro's compile-time emission. The tag bits
-        // and the body mask are private constants on `schema`; the
-        // expected value here mirrors them by construction.
+        // with the derive macro's compile-time emission.
         let expected =
-            (0x2_u64 << 60) | (fnv1a_64_prefixed(KIND_DOMAIN, &BYTES) & 0x0FFF_FFFF_FFFF_FFFF);
+            ((TAG_KIND as u64) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &BYTES) & HASH_MASK);
         assert_eq!(kind_id_from_parts(NAME, &TRIANGLE), expected);
     }
 

--- a/crates/aether-hub-protocol/src/canonical/mod.rs
+++ b/crates/aether-hub-protocol/src/canonical/mod.rs
@@ -221,9 +221,12 @@ mod tests {
         const NAME: &str = "test.triangle";
         const N: usize = canonical_len_kind(NAME, &TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_kind::<N>(NAME, &TRIANGLE);
-        // Domain-prefixed (issue #186) — agrees with the derive macro's
-        // compile-time emission.
-        let expected = fnv1a_64_prefixed(KIND_DOMAIN, &BYTES);
+        // Domain-prefixed (issue #186) + ADR-0064 tag-stamped — agrees
+        // with the derive macro's compile-time emission. The tag bits
+        // and the body mask are private constants on `schema`; the
+        // expected value here mirrors them by construction.
+        let expected =
+            (0x2_u64 << 60) | (fnv1a_64_prefixed(KIND_DOMAIN, &BYTES) & 0x0FFF_FFFF_FFFF_FFFF);
         assert_eq!(kind_id_from_parts(NAME, &TRIANGLE), expected);
     }
 

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -239,18 +239,7 @@ fn variant_to_shape(v: &EnumVariant) -> crate::types::VariantShape {
 /// other way around).
 pub(crate) const KIND_DOMAIN: &[u8] = b"kind:";
 
-/// ADR-0064 type tag for kind ids. Kept in sync with
-/// `aether_mail::tagged_id::Tag::Kind` (which can't be imported here —
-/// `aether-mail` depends on `aether-hub-protocol`, not the other way
-/// around). Same shape as `KIND_DOMAIN` and `fnv1a_64_prefixed`:
-/// duplicated for the dep direction, identical to the upstream
-/// constant.
-pub(crate) const KIND_TAG: u64 = 0x2 << 60;
-
-/// ADR-0064 mask isolating the 60-bit hash body inside a tagged id.
-/// Drops the natural high 4 bits of FNV-1a output so the tag bits
-/// can OR in without collision.
-pub(crate) const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
+use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
 
 /// Derive a `Kind::ID` from a `(name, schema)` pair at runtime. Matches
 /// the `#[derive(Kind)]` compile-time emission byte-for-byte:
@@ -261,7 +250,8 @@ pub(crate) const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
 /// the component published as `<K as Kind>::ID` (ADR-0030 Phase 2 +
 /// ADR-0064).
 pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
-    KIND_TAG | (fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema)) & HASH_MASK)
+    ((TAG_KIND as u64) << TAG_SHIFT)
+        | (fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema)) & HASH_MASK)
 }
 
 /// Derive a `Kind::ID` from a decoded `KindShape`. Same hash as
@@ -272,7 +262,7 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 pub fn kind_id_from_shape(shape: &crate::types::KindShape) -> u64 {
     let bytes =
         postcard::to_allocvec(shape).expect("canonical KindShape serialization is infallible");
-    KIND_TAG | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
+    ((TAG_KIND as u64) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
 }
 
 /// FNV-1a 64 over `prefix ++ payload`, mirrored from

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -239,14 +239,29 @@ fn variant_to_shape(v: &EnumVariant) -> crate::types::VariantShape {
 /// other way around).
 pub(crate) const KIND_DOMAIN: &[u8] = b"kind:";
 
+/// ADR-0064 type tag for kind ids. Kept in sync with
+/// `aether_mail::tagged_id::Tag::Kind` (which can't be imported here —
+/// `aether-mail` depends on `aether-hub-protocol`, not the other way
+/// around). Same shape as `KIND_DOMAIN` and `fnv1a_64_prefixed`:
+/// duplicated for the dep direction, identical to the upstream
+/// constant.
+pub(crate) const KIND_TAG: u64 = 0x2 << 60;
+
+/// ADR-0064 mask isolating the 60-bit hash body inside a tagged id.
+/// Drops the natural high 4 bits of FNV-1a output so the tag bits
+/// can OR in without collision.
+pub(crate) const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
+
 /// Derive a `Kind::ID` from a `(name, schema)` pair at runtime. Matches
-/// `fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema))`
-/// byte-for-byte with the derive's compile-time emission, so a
-/// substrate computing `kind_id_from_parts(&desc.name, &desc.schema)`
+/// the `#[derive(Kind)]` compile-time emission byte-for-byte:
+/// `Tag::Kind` ORed into the high 4 bits + the low 60 bits of
+/// `fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema))`.
+/// A substrate computing `kind_id_from_parts(&desc.name, &desc.schema)`
 /// after a runtime `register_kind_with_descriptor` agrees with the id
-/// the component published as `<K as Kind>::ID` (ADR-0030 Phase 2).
+/// the component published as `<K as Kind>::ID` (ADR-0030 Phase 2 +
+/// ADR-0064).
 pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
-    fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema))
+    KIND_TAG | (fnv1a_64_prefixed(KIND_DOMAIN, &canonical_kind_bytes(name, schema)) & HASH_MASK)
 }
 
 /// Derive a `Kind::ID` from a decoded `KindShape`. Same hash as
@@ -257,7 +272,7 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 pub fn kind_id_from_shape(shape: &crate::types::KindShape) -> u64 {
     let bytes =
         postcard::to_allocvec(shape).expect("canonical KindShape serialization is infallible");
-    fnv1a_64_prefixed(KIND_DOMAIN, &bytes)
+    KIND_TAG | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
 }
 
 /// FNV-1a 64 over `prefix ++ payload`, mirrored from

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -22,6 +22,7 @@ mod types;
 pub use types::*;
 
 pub mod canonical;
+pub mod tag_bits;
 
 /// Maximum accepted frame body size. Bounded so a malformed length
 /// prefix cannot drive a reader into an OOM. 16 MiB is comfortably

--- a/crates/aether-hub-protocol/src/tag_bits.rs
+++ b/crates/aether-hub-protocol/src/tag_bits.rs
@@ -1,0 +1,32 @@
+//! ADR-0064 bit-layout constants for tagged opaque ids.
+//!
+//! Lives here rather than in `aether-mail` because
+//! `aether-hub-protocol::canonical::schema::kind_id_from_parts`
+//! needs to OR the kind tag in at runtime, and the dep direction is
+//! `aether-mail → aether-hub-protocol`. `aether-mail::tagged_id`
+//! re-exports these and layers the `Tag` enum + base32 string
+//! encoding on top.
+//!
+//! `[tag: 4 bits | hash: 60 bits]`. The tag identifies the id space
+//! (mailbox / kind / handle); the hash is the low 60 bits of an
+//! FNV-1a output (mailbox, kind) or a counter (handle). `0x0` is
+//! reserved as an invalid sentinel — a zero-initialised `u64` is
+//! never a valid tagged id.
+
+/// Bit-shift placing the 4-bit tag in the high nibble of a `u64`.
+/// `id = (tag as u64 << TAG_SHIFT) | (hash & HASH_MASK)`.
+pub const TAG_SHIFT: u32 = 60;
+
+/// Mask isolating the 60-bit hash body inside a tagged id. Drops
+/// the natural high 4 bits of the hash output before the tag bits
+/// OR in.
+pub const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
+
+/// Tag value for mailbox ids (ADR-0029).
+pub const TAG_MAILBOX: u8 = 0x1;
+
+/// Tag value for kind ids (ADR-0030).
+pub const TAG_KIND: u8 = 0x2;
+
+/// Tag value for reply-handle ids (ADR-0045).
+pub const TAG_HANDLE: u8 = 0x3;

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -128,9 +128,17 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     Ok(quote! {
         impl ::aether_mail::Kind for #name {
             const NAME: &'static str = #kind_name;
-            const ID: u64 = ::aether_mail::fnv1a_64_prefixed(
-                ::aether_mail::KIND_DOMAIN,
-                &#canonical_bytes_ident,
+            // ADR-0064: tag the high 4 bits with `Tag::Kind` so kind
+            // ids are distinguishable from mailbox / handle ids by
+            // bit pattern alone. The `KIND_DOMAIN` byte prefix still
+            // rides the FNV input (ADR-0030) — type info ends up
+            // encoded in two independent places that cross-check.
+            const ID: u64 = ::aether_mail::with_tag(
+                ::aether_mail::Tag::Kind,
+                ::aether_mail::fnv1a_64_prefixed(
+                    ::aether_mail::KIND_DOMAIN,
+                    &#canonical_bytes_ident,
+                ),
             );
             #is_input_item
 

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -21,6 +21,9 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::fmt;
 
+pub mod tagged_id;
+pub use tagged_id::{Tag, with_tag};
+
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`) and a `u64` id derived from
 /// that name plus the kind's canonical schema bytes (ADR-0030 Phase 2,
@@ -153,8 +156,18 @@ impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
 /// use it directly as the `recipient` on `send_mail`. `0` is reserved
 /// as the no-sender sentinel — callers should reject on the astronomical
 /// chance of a collision with it.
+///
+/// ADR-0064: the high 4 bits carry the `Tag::Mailbox` discriminator;
+/// the low 60 bits are the FNV-1a output masked by `HASH_MASK`. The
+/// `MAILBOX_DOMAIN` byte prefix still rides on the FNV input — the
+/// type ends up encoded twice (in the tag bits and avalanched into
+/// the hash via the domain prefix), and the two layers cross-check
+/// each other.
 pub const fn mailbox_id_from_name(name: &str) -> u64 {
-    fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes())
+    with_tag(
+        Tag::Mailbox,
+        fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes()),
+    )
 }
 
 /// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
@@ -732,14 +745,14 @@ mod tests {
         let c = mailbox_id_from_name("render");
         assert_eq!(a, b);
         assert_ne!(a, c);
-        // Empty name hashes the domain prefix alone. Pins the
-        // prefixing convention — a regression that drops the prefix
-        // would collapse to `0xcbf29ce484222325` (the raw FNV offset
-        // basis) here.
+        // Empty name hashes the domain prefix alone. Pins both
+        // ADR-0029 (the domain prefix rides the FNV input) and
+        // ADR-0064 (the high 4 bits carry the `Tag::Mailbox` tag).
         assert_eq!(
             mailbox_id_from_name(""),
-            fnv1a_64_prefixed(MAILBOX_DOMAIN, &[]),
+            with_tag(Tag::Mailbox, fnv1a_64_prefixed(MAILBOX_DOMAIN, &[]),),
         );
+        assert_eq!(tagged_id::tag_of(a), Some(Tag::Mailbox));
         assert_ne!(mailbox_id_from_name(""), 0xcbf29ce484222325);
     }
 

--- a/crates/aether-mail/src/tagged_id.rs
+++ b/crates/aether-mail/src/tagged_id.rs
@@ -18,13 +18,7 @@
 use alloc::string::String;
 use core::fmt;
 
-/// Mask isolating the 60-bit hash body inside a tagged `u64`. Used
-/// by `with_tag` to drop the hash's natural high bits before OR-ing
-/// in the tag, and by `body_of` for tag-stripping.
-pub const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
-
-/// Bit-shift placing the 4-bit tag in the high nibble of a `u64`.
-pub const TAG_SHIFT: u32 = 60;
+pub use aether_hub_protocol::tag_bits::{HASH_MASK, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT};
 
 /// Type tag identifying an id space. Encoded in the high 4 bits of
 /// every tagged id. `0x0` is reserved as an invalid sentinel — a
@@ -35,11 +29,11 @@ pub const TAG_SHIFT: u32 = 60;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Tag {
     /// Mailbox id (ADR-0029) — recipient of mail.
-    Mailbox = 0x1,
+    Mailbox = TAG_MAILBOX,
     /// Kind id (ADR-0030) — schema-hashed payload identity.
-    Kind = 0x2,
+    Kind = TAG_KIND,
     /// Handle id (ADR-0045) — entry in the substrate's handle store.
-    Handle = 0x3,
+    Handle = TAG_HANDLE,
 }
 
 impl Tag {
@@ -59,9 +53,9 @@ impl Tag {
     /// for any reserved-future value (`0x4..=0xF`).
     pub const fn from_bits(bits: u8) -> Option<Tag> {
         match bits {
-            0x1 => Some(Tag::Mailbox),
-            0x2 => Some(Tag::Kind),
-            0x3 => Some(Tag::Handle),
+            TAG_MAILBOX => Some(Tag::Mailbox),
+            TAG_KIND => Some(Tag::Kind),
+            TAG_HANDLE => Some(Tag::Handle),
             _ => None,
         }
     }

--- a/crates/aether-mail/src/tagged_id.rs
+++ b/crates/aether-mail/src/tagged_id.rs
@@ -1,0 +1,307 @@
+//! Tagged opaque ids (ADR-0064). Every `u64` id (mailbox, kind,
+//! reply-handle) carries a 4-bit type tag in its high bits + a 60-bit
+//! hash in its low bits. The string form (`mbx-q3lr-bv2x-mtdr` etc.)
+//! is the wire encoding for the MCP boundary and human-facing
+//! diagnostics; internal types stay raw `u64`.
+//!
+//! Bit layout: `[tag: 4][hash: 60]`. The tag identifies the id space
+//! (mailbox / kind / handle); the hash is the low 60 bits of an
+//! FNV-1a output (mailbox, kind) or a counter (handle). The byte-
+//! domain prefixes from ADR-0029/0030 (`MAILBOX_DOMAIN`, `KIND_DOMAIN`)
+//! still ride on the FNV input — the type ends up encoded twice (in
+//! the tag bits *and* avalanched into the hash via the domain
+//! prefix), and the two layers cross-check each other.
+//!
+//! `0x0` is intentionally invalid so a zero-initialised `u64` can
+//! never be mistaken for a real id.
+
+use alloc::string::String;
+use core::fmt;
+
+/// Mask isolating the 60-bit hash body inside a tagged `u64`. Used
+/// by `with_tag` to drop the hash's natural high bits before OR-ing
+/// in the tag, and by `body_of` for tag-stripping.
+pub const HASH_MASK: u64 = 0x0FFF_FFFF_FFFF_FFFF;
+
+/// Bit-shift placing the 4-bit tag in the high nibble of a `u64`.
+pub const TAG_SHIFT: u32 = 60;
+
+/// Type tag identifying an id space. Encoded in the high 4 bits of
+/// every tagged id. `0x0` is reserved as an invalid sentinel — a
+/// zero-initialised `u64` is never a valid tagged id, which catches
+/// uninitialised state at the boundary instead of silently routing
+/// to a hash collision.
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Tag {
+    /// Mailbox id (ADR-0029) — recipient of mail.
+    Mailbox = 0x1,
+    /// Kind id (ADR-0030) — schema-hashed payload identity.
+    Kind = 0x2,
+    /// Handle id (ADR-0045) — entry in the substrate's handle store.
+    Handle = 0x3,
+}
+
+impl Tag {
+    /// Three-letter wire prefix for the string form (`mbx`, `knd`,
+    /// `hdl`). Concatenated with `-` and the base32 body to produce
+    /// the full encoded id.
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            Tag::Mailbox => "mbx",
+            Tag::Kind => "knd",
+            Tag::Handle => "hdl",
+        }
+    }
+
+    /// Decode a 4-bit tag value from the high nibble of a `u64`.
+    /// Returns `None` for `0x0` (the reserved invalid sentinel) and
+    /// for any reserved-future value (`0x4..=0xF`).
+    pub const fn from_bits(bits: u8) -> Option<Tag> {
+        match bits {
+            0x1 => Some(Tag::Mailbox),
+            0x2 => Some(Tag::Kind),
+            0x3 => Some(Tag::Handle),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.prefix())
+    }
+}
+
+/// Stamp `tag` into the high 4 bits of `hash`'s low 60 bits, dropping
+/// the hash's natural high 4 bits. Const-fold-friendly so the `Kind`
+/// derive and `mailbox_id_from_name` can bake the tag at compile time.
+pub const fn with_tag(tag: Tag, hash: u64) -> u64 {
+    ((tag as u64) << TAG_SHIFT) | (hash & HASH_MASK)
+}
+
+/// Read the tag bits out of a tagged id. `None` on the `0x0`
+/// sentinel or a reserved-future tag value.
+pub const fn tag_of(id: u64) -> Option<Tag> {
+    Tag::from_bits((id >> TAG_SHIFT) as u8 & 0x0F)
+}
+
+/// Return the 60-bit hash body with tag bits stripped.
+pub const fn body_of(id: u64) -> u64 {
+    id & HASH_MASK
+}
+
+/// Errors decoding a tagged-id string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// String didn't match the `<prefix>-XXXX-XXXX-XXXX` shape (wrong
+    /// length, missing dashes, or unknown 3-letter prefix).
+    Malformed,
+    /// Body contained a character outside the lowercase base32
+    /// alphabet (`a-z` + `2-7`).
+    InvalidChar(char),
+    /// Tag value the caller expected (e.g. they called
+    /// `decode_mailbox`) didn't match the tag implied by the prefix.
+    TagMismatch { expected: Tag, found: Tag },
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::Malformed => f.write_str("malformed tagged id"),
+            DecodeError::InvalidChar(c) => write!(f, "invalid base32 char: {c:?}"),
+            DecodeError::TagMismatch { expected, found } => {
+                write!(f, "tag mismatch: expected {expected}, found {found}")
+            }
+        }
+    }
+}
+
+/// RFC 4648 base32 alphabet, lowercase. 32 chars covering 5 bits each
+/// — `a..z` + `2..7`. Skipping `0`/`1`/`8`/`9` keeps digit/letter
+/// look-alikes (`0`/`O`, `1`/`l`) out of the encoded body.
+const ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+/// Encode a tagged id to its string form. Renders as
+/// `<prefix>-XXXX-XXXX-XXXX` where `<prefix>` is the 3-letter tag and
+/// the body is the 60-bit hash in lowercase base32, grouped 4-4-4.
+///
+/// Returns `None` if the id's tag bits are reserved or invalid (the
+/// `0x0` sentinel or `0x4..=0xF`). Callers that need a printable form
+/// for a possibly-malformed id should fall back to hex via
+/// `format!("{:#x}", id)`.
+pub fn encode(id: u64) -> Option<String> {
+    let tag = tag_of(id)?;
+    let body = body_of(id);
+    let mut out = String::with_capacity(3 + 1 + 12 + 2);
+    out.push_str(tag.prefix());
+    // Emit 12 base32 chars (60 bits / 5 bits per char), grouped
+    // into three 4-char chunks separated by `-`. The shift starts
+    // at bit 55 (the most significant of the 60 hash bits) and
+    // counts down by 5 each char so the leftmost chars carry the
+    // most significant bits — same convention as hex.
+    for i in 0..12 {
+        if i % 4 == 0 {
+            out.push('-');
+        }
+        let shift = 55 - i * 5;
+        let nibble = ((body >> shift) & 0x1F) as usize;
+        out.push(ALPHABET[nibble] as char);
+    }
+    Some(out)
+}
+
+/// Decode a tagged-id string back to its `u64` form, or fail with a
+/// typed error. Case-insensitive.
+pub fn decode(s: &str) -> Result<u64, DecodeError> {
+    // Total length: 3 (prefix) + 1 (dash) + 4 + 1 + 4 + 1 + 4 = 18.
+    if s.len() != 18 {
+        return Err(DecodeError::Malformed);
+    }
+    let bytes = s.as_bytes();
+    let prefix = &bytes[0..3];
+    let tag = match prefix {
+        b"mbx" | b"MBX" => Tag::Mailbox,
+        b"knd" | b"KND" => Tag::Kind,
+        b"hdl" | b"HDL" => Tag::Handle,
+        _ => return Err(DecodeError::Malformed),
+    };
+    if bytes[3] != b'-' || bytes[8] != b'-' || bytes[13] != b'-' {
+        return Err(DecodeError::Malformed);
+    }
+    let mut body: u64 = 0;
+    let group_starts = [4usize, 9, 14];
+    for &start in &group_starts {
+        for i in 0..4 {
+            let c = bytes[start + i];
+            let v = decode_char(c)?;
+            body = (body << 5) | v as u64;
+        }
+    }
+    Ok(with_tag(tag, body))
+}
+
+/// Decode a tagged-id string and assert its tag matches `expected`.
+/// Convenience for callers that know which space they're decoding
+/// into — e.g. `decode_with_tag(s, Tag::Mailbox)?` for the
+/// `mailbox_id` argument of an MCP tool.
+pub fn decode_with_tag(s: &str, expected: Tag) -> Result<u64, DecodeError> {
+    let id = decode(s)?;
+    let found = tag_of(id).ok_or(DecodeError::Malformed)?;
+    if found != expected {
+        return Err(DecodeError::TagMismatch { expected, found });
+    }
+    Ok(id)
+}
+
+const fn decode_char(c: u8) -> Result<u8, DecodeError> {
+    match c {
+        b'a'..=b'z' => Ok(c - b'a'),
+        b'A'..=b'Z' => Ok(c - b'A'),
+        b'2'..=b'7' => Ok(c - b'2' + 26),
+        _ => Err(DecodeError::InvalidChar(c as char)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_all_tags() {
+        for &tag in &[Tag::Mailbox, Tag::Kind, Tag::Handle] {
+            for hash in [0u64, 0x1, 0x0FFF_FFFF_FFFF_FFFF, 0xDEAD_BEEF_CAFE_BABE] {
+                let id = with_tag(tag, hash);
+                assert_eq!(tag_of(id), Some(tag));
+                assert_eq!(body_of(id), hash & HASH_MASK);
+                let s = encode(id).unwrap();
+                assert_eq!(decode(&s).unwrap(), id);
+            }
+        }
+    }
+
+    #[test]
+    fn encoding_shape() {
+        let id = with_tag(Tag::Mailbox, 0);
+        let s = encode(id).unwrap();
+        assert_eq!(s.len(), 18);
+        assert!(s.starts_with("mbx-"));
+        assert_eq!(s, "mbx-aaaa-aaaa-aaaa");
+    }
+
+    #[test]
+    fn alphabet_excludes_digit_lookalikes() {
+        // Body of all-1s should produce all `7`s (the highest base32
+        // char), exercising the high end of the alphabet.
+        let id = with_tag(Tag::Kind, HASH_MASK);
+        let s = encode(id).unwrap();
+        assert_eq!(s, "knd-7777-7777-7777");
+        assert!(!s.contains('0'));
+        assert!(!s.contains('1'));
+        assert!(!s.contains('8'));
+        assert!(!s.contains('9'));
+    }
+
+    #[test]
+    fn decode_rejects_zero_tag() {
+        // 0x0 in the high nibble is reserved invalid. `encode(0u64)`
+        // should refuse rather than emit a string that decodes to a
+        // bogus id.
+        assert!(encode(0u64).is_none());
+        // Hand-crafted "rsv-" prefix isn't in the table → Malformed.
+        assert_eq!(decode("rsv-aaaa-aaaa-aaaa"), Err(DecodeError::Malformed));
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert_eq!(decode("mbx-aaaa-aaaa"), Err(DecodeError::Malformed));
+        assert_eq!(decode("mbx-aaaa-aaaa-aaaaa"), Err(DecodeError::Malformed));
+    }
+
+    #[test]
+    fn decode_rejects_invalid_chars() {
+        // `0` and `1` are not in the base32 alphabet (they're the
+        // ones we deliberately skipped).
+        assert_eq!(
+            decode("mbx-0aaa-aaaa-aaaa"),
+            Err(DecodeError::InvalidChar('0'))
+        );
+        assert_eq!(
+            decode("mbx-aaaa-1aaa-aaaa"),
+            Err(DecodeError::InvalidChar('1'))
+        );
+    }
+
+    #[test]
+    fn decode_is_case_insensitive() {
+        let id = with_tag(Tag::Handle, 0x1234_5678_9abc_def0 & HASH_MASK);
+        let lower = encode(id).unwrap();
+        let upper = lower.to_uppercase();
+        assert_eq!(decode(&lower).unwrap(), id);
+        assert_eq!(decode(&upper).unwrap(), id);
+    }
+
+    #[test]
+    fn decode_with_tag_catches_mismatch() {
+        let mailbox = encode(with_tag(Tag::Mailbox, 0x42)).unwrap();
+        let err = decode_with_tag(&mailbox, Tag::Kind).unwrap_err();
+        assert_eq!(
+            err,
+            DecodeError::TagMismatch {
+                expected: Tag::Kind,
+                found: Tag::Mailbox,
+            }
+        );
+    }
+
+    #[test]
+    fn body_drops_high_bits() {
+        // Caller passes a "raw" hash with high bits set; with_tag
+        // masks them off before OR-ing the tag in. Critical that
+        // the natural FNV-1a high bits don't leak past the boundary
+        // and corrupt the tag.
+        let id = with_tag(Tag::Mailbox, 0xFFFF_FFFF_FFFF_FFFF);
+        assert_eq!(tag_of(id), Some(Tag::Mailbox));
+        assert_eq!(body_of(id), HASH_MASK);
+    }
+}

--- a/crates/aether-substrate-core/src/handle_store.rs
+++ b/crates/aether-substrate-core/src/handle_store.rs
@@ -171,14 +171,19 @@ impl HandleStore {
     /// addressed ids land in Phase 3. `0` is reserved as the
     /// "no-handle" sentinel — the counter starts at 1 and never
     /// returns 0.
+    ///
+    /// ADR-0064: the high 4 bits carry `Tag::Handle` so handle ids
+    /// are bit-distinguishable from mailbox / kind ids. The counter
+    /// occupies the low 60 bits — at one mint per nanosecond it
+    /// wraps in ~37 years, well past any single substrate lifetime.
     pub fn next_ephemeral(&self) -> HandleId {
         let mut inner = self.inner.write().unwrap();
-        let id = inner.next_ephemeral;
+        let counter = inner.next_ephemeral;
         inner.next_ephemeral = inner.next_ephemeral.wrapping_add(1);
         if inner.next_ephemeral == 0 {
             inner.next_ephemeral = 1;
         }
-        id
+        aether_mail::with_tag(aether_mail::Tag::Handle, counter)
     }
 
     /// Insert (or update) a handle. The same `(id, kind_id)` pair can
@@ -751,8 +756,15 @@ mod tests {
         let store = HandleStore::new(1024);
         let a = store.next_ephemeral();
         let b = store.next_ephemeral();
-        assert_eq!(a, 1);
-        assert_eq!(b, 2);
+        // ADR-0064: counter occupies the low 60 bits; the high 4
+        // bits carry `Tag::Handle`. Strip the tag to assert on the
+        // raw counter value.
+        assert_eq!(aether_mail::tagged_id::body_of(a), 1);
+        assert_eq!(aether_mail::tagged_id::body_of(b), 2);
+        assert_eq!(
+            aether_mail::tagged_id::tag_of(a),
+            Some(aether_mail::Tag::Handle)
+        );
         assert_ne!(a, 0);
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0064. Reshapes every u64 id (mailbox, kind, reply-handle) so the high 4 bits carry a type tag and the low 60 bits carry the hash. Internal change only — the MCP wire still ships raw u64; the string encoding (`mbx-XXXX-XXXX-XXXX` etc.) rides on the new `tagged_id` module and lands in phase 2 when the hub MCP serialiser is wired.

- New `aether_mail::tagged_id` module: `Tag` enum (Mailbox / Kind / Handle), `with_tag` / `tag_of` / `body_of` helpers, RFC-4648 base32-lowercase encode/decode for the wire form, round-trip + alphabet + tag-mismatch tests (8 unit tests).
- `mailbox_id_from_name` ORs in `Tag::Mailbox`.
- `#[derive(Kind)]` ORs in `Tag::Kind` on the emitted `const ID`.
- `aether-hub-protocol`'s duplicate `kind_id_from_parts` / `kind_id_from_shape` (used by `register_kind_with_descriptor` in the substrate registry) match the derive's tag stamp — keeps the substrate registry's id agreeing with `<K as Kind>::ID` byte-for-byte.
- `HandleStore::next_ephemeral` ORs in `Tag::Handle`. Counter still starts at 1 in the low 60 bits.

The byte-domain prefixes from ADR-0029/0030 stay on the FNV input as ADR-0064 specified: type now appears in two independent places (tag bits and avalanched into the hash via the domain prefix), and the two layers cross-check.

Phase 2 (separate PR): wire string encoding at the hub MCP boundary, add `Display` for tracing, update `engine_logs` to render the prefixed form.

## Test plan

- [x] `cargo test --workspace` — all green (1244 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo check -p aether-camera-component --target wasm32-unknown-unknown` — wasm path clean
- [ ] Live MCP smoke (deferred to phase 2 — phase 1 is wire-equivalent on JSON, so behaviour is unchanged from an MCP caller's perspective; the precision-loss workaround stays in place until phase 2)