### PR TITLE
feat(hub): tagged-string mailbox ids on the MCP wire (ADR-0064 phase 2)

### DIFF
--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -1,8 +1,11 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
+use std::fmt;
+
 use aether_hub_protocol::{EngineId, SessionToken};
 use aether_mail::mailbox_id_from_name;
+use aether_mail::tagged_id;
 
 /// Addressing token for any mailbox — component or substrate-owned sink.
 /// Opaque `u64` newtype so it can't be accidentally mixed with wasmtime
@@ -24,6 +27,20 @@ impl MailboxId {
     /// verbatim across the FFI.
     pub fn from_name(name: &str) -> MailboxId {
         MailboxId(mailbox_id_from_name(name))
+    }
+}
+
+/// ADR-0064: render as the tagged string form (`mbx-XXXX-XXXX-XXXX`)
+/// when a tracing call site uses `%`. Falls back to a hex dump for
+/// reserved / invalid tag bits (`MailboxId::NONE` in particular) so a
+/// stray sentinel doesn't silently render as a malformed prefixed
+/// string.
+impl fmt::Display for MailboxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match tagged_id::encode(self.0) {
+            Some(s) => f.write_str(&s),
+            None => write!(f, "{:#018x}", self.0),
+        }
     }
 }
 

--- a/crates/aether-substrate-hub/src/mcp.rs
+++ b/crates/aether-substrate-hub/src/mcp.rs
@@ -459,15 +459,20 @@ mod tests {
     #[tokio::test]
     async fn describe_component_returns_stored_capabilities() {
         use crate::registry::ComponentRecord;
+        use aether_mail::tagged_id::{self, Tag};
+        use aether_mail::with_tag;
 
         let engines = EngineRegistry::new();
         let (rec, _rx) = record(50);
         let id = rec.id;
         engines.insert(rec);
         let capabilities = stub_capabilities();
+        // ADR-0064: registry stores raw u64 with tag bits set; the
+        // wire form is the tagged-string encoding of that u64.
+        let mailbox_id = with_tag(Tag::Mailbox, 7);
         engines.upsert_component(
             &id,
-            7,
+            mailbox_id,
             ComponentRecord {
                 name: "hello".into(),
                 capabilities: capabilities.clone(),
@@ -478,7 +483,7 @@ mod tests {
         let json = hub
             .describe_component(Parameters(args::DescribeComponentArgs {
                 engine_id: id.0.to_string(),
-                mailbox_id: "7".into(),
+                mailbox_id: tagged_id::encode(mailbox_id).unwrap(),
             }))
             .await
             .unwrap();
@@ -496,8 +501,58 @@ mod tests {
 
     #[tokio::test]
     async fn describe_component_unknown_mailbox_errors() {
+        use aether_mail::tagged_id::{self, Tag};
+        use aether_mail::with_tag;
+
         let engines = EngineRegistry::new();
         let (rec, _rx) = record(51);
+        let id = rec.id;
+        engines.insert(rec);
+        let hub = Hub::new(test_state(engines, SessionRegistry::new()));
+
+        let bogus = tagged_id::encode(with_tag(Tag::Mailbox, 999)).unwrap();
+        let err = hub
+            .describe_component(Parameters(args::DescribeComponentArgs {
+                engine_id: id.0.to_string(),
+                mailbox_id: bogus.clone(),
+            }))
+            .await
+            .unwrap_err();
+        // The error message echoes the original tagged-string form so
+        // the agent sees back what they passed in (not a re-encoded
+        // u64). Asserting on the prefix keeps the test robust to the
+        // base32 body's exact bytes.
+        let msg = format!("{err:?}");
+        assert!(msg.contains("no component at mailbox_id"));
+        assert!(msg.contains(&bogus));
+    }
+
+    #[tokio::test]
+    async fn describe_component_unknown_engine_errors() {
+        use aether_mail::tagged_id::{self, Tag};
+        use aether_mail::with_tag;
+
+        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(state);
+
+        let err = hub
+            .describe_component(Parameters(args::DescribeComponentArgs {
+                engine_id: Uuid::from_u128(0xdead).to_string(),
+                mailbox_id: tagged_id::encode(with_tag(Tag::Mailbox, 0)).unwrap(),
+            }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("unknown engine_id"));
+    }
+
+    #[tokio::test]
+    async fn describe_component_rejects_malformed_mailbox_id() {
+        // ADR-0064: a bare-number mailbox id is no longer valid wire
+        // form. Reject at the boundary with a typed error so the
+        // agent sees a clear "looks malformed" signal rather than a
+        // mysterious lookup miss.
+        let engines = EngineRegistry::new();
+        let (rec, _rx) = record(52);
         let id = rec.id;
         engines.insert(rec);
         let hub = Hub::new(test_state(engines, SessionRegistry::new()));
@@ -509,22 +564,34 @@ mod tests {
             }))
             .await
             .unwrap_err();
-        assert!(format!("{err:?}").contains("no component at mailbox_id 999"));
+        assert!(format!("{err:?}").to_lowercase().contains("mailbox_id"));
     }
 
     #[tokio::test]
-    async fn describe_component_unknown_engine_errors() {
-        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
-        let hub = Hub::new(state);
+    async fn describe_component_rejects_wrong_tag() {
+        // Passing a kind id (`knd-...`) where a mailbox id is expected
+        // is exactly what the tag bits exist to catch. Verify the
+        // boundary surfaces it as a tag-mismatch error rather than
+        // silently treating the kind id as a mailbox id and missing
+        // the lookup.
+        use aether_mail::tagged_id::{self, Tag};
+        use aether_mail::with_tag;
 
+        let engines = EngineRegistry::new();
+        let (rec, _rx) = record(53);
+        let id = rec.id;
+        engines.insert(rec);
+        let hub = Hub::new(test_state(engines, SessionRegistry::new()));
+
+        let kind_form = tagged_id::encode(with_tag(Tag::Kind, 42)).unwrap();
         let err = hub
             .describe_component(Parameters(args::DescribeComponentArgs {
-                engine_id: Uuid::from_u128(0xdead).to_string(),
-                mailbox_id: "0".into(),
+                engine_id: id.0.to_string(),
+                mailbox_id: kind_form,
             }))
             .await
             .unwrap_err();
-        assert!(format!("{err:?}").contains("unknown engine_id"));
+        assert!(format!("{err:?}").contains("tag mismatch"));
     }
 
     async fn push_queued(sessions: &SessionRegistry, token: SessionToken, mail: QueuedMail) {

--- a/crates/aether-substrate-hub/src/mcp/args.rs
+++ b/crates/aether-substrate-hub/src/mcp/args.rs
@@ -22,10 +22,12 @@ pub struct DescribeComponentArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,
     /// Mailbox id of the loaded component (from `load_component`'s
-    /// response). Passed as a string because MCP clients serialize
-    /// JSON numbers through IEEE-754 double, which loses precision
-    /// beyond 2^53 — and mailbox ids are full 64-bit name hashes
-    /// (ADR-0029).
+    /// response). ADR-0064 tagged-string form: `mbx-XXXX-XXXX-XXXX`,
+    /// 12 lowercase base32 chars (RFC 4648 alphabet) grouped 4-4-4
+    /// after the `mbx-` prefix. Strings, not numbers, because
+    /// JSON's IEEE-754 double rounds 64-bit ids past 2^53; the
+    /// prefix also makes copy-paste mistakes between mailbox / kind /
+    /// handle ids reject at the boundary instead of failing later.
     pub mailbox_id: String,
 }
 
@@ -351,10 +353,10 @@ pub struct FallbackCapabilityWire {
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct LoadComponentResponse {
-    /// Substrate-assigned mailbox id for the loaded component. Hand
-    /// this to `replace_component` or use as the `mailbox` in
-    /// `subscribe_input`.
-    pub mailbox_id: u64,
+    /// Substrate-assigned mailbox id for the loaded component, in the
+    /// ADR-0064 tagged-string form `mbx-XXXX-XXXX-XXXX`. Hand this to
+    /// `replace_component` or `describe_component` verbatim.
+    pub mailbox_id: String,
     /// Substrate-resolved name. Matches the `name` in the request if
     /// provided; otherwise the substrate-defaulted value.
     pub name: String,
@@ -370,9 +372,10 @@ pub struct LoadComponentResponse {
 pub struct ReplaceComponentArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,
-    /// Mailbox id of the live component to replace (from a prior
+    /// Mailbox id of the live component to replace, in the ADR-0064
+    /// tagged-string form `mbx-XXXX-XXXX-XXXX` (from a prior
     /// `load_component` or `list_engines`-derived lookup).
-    pub mailbox_id: u64,
+    pub mailbox_id: String,
     /// Absolute path to the replacement WASM binary on the hub's
     /// filesystem. Same filesystem rule as `load_component`. Kind
     /// vocabulary is embedded in the wasm's `aether.kinds` custom

--- a/crates/aether-substrate-hub/src/mcp/tools.rs
+++ b/crates/aether-substrate-hub/src/mcp/tools.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_hub_protocol::{EngineId, LogLevel, Uuid};
+use aether_mail::tagged_id::{self, Tag};
 use base64::Engine as _;
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -560,6 +561,15 @@ impl Hub {
                         capabilities: capabilities.clone(),
                     },
                 );
+                // ADR-0064: encode the raw u64 the substrate returned
+                // into the tagged-string form so the agent never sees
+                // the precision-losing JSON number on the wire.
+                let mailbox_id = tagged_id::encode(mailbox_id).ok_or_else(|| {
+                    McpError::internal_error(
+                        format!("substrate returned untagged mailbox id {mailbox_id:#x}"),
+                        None,
+                    )
+                })?;
                 Ok(LoadComponentResponse {
                     mailbox_id,
                     name,
@@ -586,6 +596,11 @@ impl Hub {
                 None,
             ));
         }
+        // ADR-0064: decode the tagged-string mailbox id back to u64
+        // for the substrate-side wire (the substrate keeps internal
+        // ids raw; the prefix-string form is purely the MCP boundary).
+        let mailbox_id = tagged_id::decode_with_tag(&args.mailbox_id, Tag::Mailbox)
+            .map_err(|e| McpError::invalid_params(format!("mailbox_id: {e}"), None))?;
 
         let wasm = tokio::fs::read(&args.binary_path).await.map_err(|e| {
             McpError::invalid_params(
@@ -595,7 +610,7 @@ impl Hub {
         })?;
 
         let params = serde_json::json!({
-            "mailbox_id": args.mailbox_id,
+            "mailbox_id": mailbox_id,
             "wasm": wasm,
             "drain_timeout_ms": args.drain_timeout_ms,
         });
@@ -659,13 +674,13 @@ impl Hub {
                 // so `describe_component` reflects what's actually
                 // bound now. Name is preserved — `replace_component`
                 // keeps the existing mailbox + name by design.
-                let existing = self.state.engines.get_component(&id, args.mailbox_id);
+                let existing = self.state.engines.get_component(&id, mailbox_id);
                 let name = existing
                     .map(|r| r.name)
                     .unwrap_or_else(|| format!("mailbox_{}", args.mailbox_id));
                 self.state.engines.upsert_component(
                     &id,
-                    args.mailbox_id,
+                    mailbox_id,
                     ComponentRecord {
                         name,
                         capabilities: capabilities.clone(),
@@ -694,14 +709,15 @@ impl Hub {
                 None,
             ));
         }
-        let mailbox_id: u64 = args.mailbox_id.parse().map_err(|e| {
-            McpError::invalid_params(format!("mailbox_id must be a u64-shaped string: {e}"), None)
-        })?;
+        // ADR-0064: agents pass the tagged-string form (`mbx-XXXX-...`).
+        // Decode here so the registry lookup uses the raw u64.
+        let mailbox_id = tagged_id::decode_with_tag(&args.mailbox_id, Tag::Mailbox)
+            .map_err(|e| McpError::invalid_params(format!("mailbox_id: {e}"), None))?;
         let Some(component) = self.state.engines.get_component(&id, mailbox_id) else {
             return Err(McpError::invalid_params(
                 format!(
                     "no component at mailbox_id {} on engine {}",
-                    mailbox_id, args.engine_id
+                    args.mailbox_id, args.engine_id
                 ),
                 None,
             ));


### PR DESCRIPTION
## Summary

Phase 2 of ADR-0064. Wire the tagged-string form (`mbx-XXXX-XXXX-XXXX`) at the hub MCP boundary. Closes the JSON 2^53 precision loss for `mailbox_id` arguments + responses end-to-end:

- **`LoadComponentResponse.mailbox_id`**: `u64` → `String`. The shared `do_load_component` helper encodes the substrate's u64 reply once, so both the public `load_component` tool and the `spawn_substrate` preload path return the tagged form.
- **`ReplaceComponentArgs.mailbox_id`**: `u64` → `String`. Decoded via `tagged_id::decode_with_tag(_, Tag::Mailbox)` at the handler entry. Agents can now copy-paste the value from `load_component` directly.
- **`DescribeComponentArgs.mailbox_id`**: was already `String` carrying decimal-stringified u64 (an early precision-loss workaround). Handler now decodes the tagged form via the same path.

Plus a `Display` impl for `MailboxId` so `tracing::info!(mailbox = %id, …)` renders as `mbx-q3lr-bv2x-mtdr` in `engine_logs`. Falls back to hex for reserved/invalid tag bits so `MailboxId::NONE` or stray sentinels don't render as malformed prefixed strings.

Two new tests pin the boundary:
- `describe_component_rejects_malformed_mailbox_id` — bare-number ids reject with a typed error.
- `describe_component_rejects_wrong_tag` — passing a `knd-...` where a `mbx-...` is expected surfaces as a `tag mismatch` error rather than a silent lookup miss.

## Out of scope (Phase 3)

Structured `params` JSON inside `send_mail` / `capture_frame.mails` can still carry inline u64 ids (e.g. `SubscribeInput.mailbox: u64`). The codecs that JSON↔postcard those payloads are schema-driven and don't yet recognize "this u64 is a tagged id; accept the string form." A schema-level annotation lands in a follow-up.

The user noted during review that a `u64`-backed newtype with custom `Serialize`/`Deserialize` would be cleaner than handler-level encode/decode + raw `String`. Acknowledged; deferred to keep this PR tight.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Live MCP smoke: load a component, copy `mailbox_id` from the response into `replace_component`, verify the round-trip succeeds (the workflow `feedback_mcp_mailbox_id_json_precision` flagged as broken)