### PR TITLE
feat(mail): add TypeId schema variant + typed id newtypes (ADR-0065 phase 3a)

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -391,7 +391,7 @@ impl InitCtx<'_> {
         };
         let payload = SubscribeInput {
             stream,
-            mailbox: self.mailbox,
+            mailbox: ::aether_mail::MailboxId(self.mailbox),
         };
         resolve_sink::<SubscribeInput>("aether.control").send(&payload);
     }

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -12,8 +12,8 @@
 use crate::types::{EnumVariant, Primitive, SchemaCell, SchemaType};
 
 use super::primitives::{
-    cow_enum_variants, cow_named_fields, cow_schema_types, str_len, varint_u32_len,
-    varint_usize_len, write_str, write_varint_u32, write_varint_usize,
+    cow_enum_variants, cow_named_fields, cow_schema_types, str_len, varint_u32_len, varint_u64_len,
+    varint_usize_len, write_str, write_varint_u32, write_varint_u64, write_varint_usize,
 };
 
 const SCHEMA_UNIT: u8 = 0;
@@ -28,6 +28,7 @@ const SCHEMA_STRUCT: u8 = 8;
 const SCHEMA_ENUM: u8 = 9;
 const SCHEMA_REF: u8 = 10;
 const SCHEMA_MAP: u8 = 11;
+const SCHEMA_TYPE_ID: u8 = 12;
 
 const VARIANT_UNIT: u8 = 0;
 const VARIANT_TUPLE: u8 = 1;
@@ -79,6 +80,7 @@ pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
         }
         SchemaType::Ref(cell) => 1 + canonical_len_cell(cell),
         SchemaType::Map { key, value } => 1 + canonical_len_cell(key) + canonical_len_cell(value),
+        SchemaType::TypeId(id) => 1 + varint_u64_len(*id),
     }
 }
 
@@ -204,6 +206,7 @@ fn schema_to_shape(s: &SchemaType) -> crate::types::SchemaShape {
             key: alloc::boxed::Box::new(schema_to_shape(key)),
             value: alloc::boxed::Box::new(schema_to_shape(value)),
         },
+        SchemaType::TypeId(id) => SchemaShape::TypeId(*id),
     }
 }
 
@@ -363,6 +366,11 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
             pos += 1;
             pos = write_cell(key, out, pos);
             pos = write_cell(value, out, pos);
+        }
+        SchemaType::TypeId(id) => {
+            out[pos] = SCHEMA_TYPE_ID;
+            pos += 1;
+            pos = write_varint_u64(*id, out, pos);
         }
     }
     pos

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -116,6 +116,16 @@ pub enum SchemaType {
         key: SchemaCell,
         value: SchemaCell,
     },
+    /// ADR-0065: a first-class typed reference, identified by a
+    /// 64-bit type id (FNV-1a of the type's canonical name with a
+    /// disjoint `TYPE_DOMAIN` prefix). The codec's `TypeId` arm
+    /// hard-codes the per-id encode/decode logic — for v1, the three
+    /// known type ids are `MailboxId`, `KindId`, `HandleId`, all of
+    /// which are u64 varint on postcard and tagged-string on JSON.
+    /// Cast-shape size/align is 8 bytes, 8-byte align — same as a
+    /// `u64`, so a typed-id field embedded in a `repr_c: true`
+    /// struct keeps the parent's cast-eligibility.
+    TypeId(u64),
 }
 
 /// Recursion-breaking indirection for nested `SchemaType` fields
@@ -300,6 +310,9 @@ pub enum SchemaShape {
         key: Box<SchemaShape>,
         value: Box<SchemaShape>,
     },
+    /// ADR-0065 first-class typed reference. Wire-identical to
+    /// `SchemaType::TypeId(u64)`.
+    TypeId(u64),
 }
 
 /// Positional enum variant — `VariantShape::Tuple { discriminant, fields }`

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -686,7 +686,7 @@ mod control_plane {
     #[kind(name = "aether.control.subscribe_input")]
     pub struct SubscribeInput {
         pub stream: InputStream,
-        pub mailbox: u64,
+        pub mailbox: aether_mail::MailboxId,
     }
 
     /// `aether.control.unsubscribe_input` — remove `mailbox` from the
@@ -697,7 +697,7 @@ mod control_plane {
     #[kind(name = "aether.control.unsubscribe_input")]
     pub struct UnsubscribeInput {
         pub stream: InputStream,
-        pub mailbox: u64,
+        pub mailbox: aether_mail::MailboxId,
     }
 
     /// Reply to both subscribe and unsubscribe (ADR-0021 §2). Only

--- a/crates/aether-mail/src/ids.rs
+++ b/crates/aether-mail/src/ids.rs
@@ -1,0 +1,260 @@
+//! ADR-0065 typed id newtypes — `MailboxId`, `KindId`, `HandleId`.
+//!
+//! Each type is `#[repr(transparent)]` over a `u64` (postcard
+//! wire-identical to a raw u64; cast-shape kinds keep their
+//! `#[repr(C)]` layout) and exposes a `pub const TYPE_ID: u64`
+//! that the `Schema` impl emits as `SchemaType::TypeId(Self::TYPE_ID)`.
+//! The hub's encoder/decoder dispatch on the `TYPE_ID` value to
+//! translate JSON (tagged-string form per ADR-0064) ↔ postcard
+//! (u64 varint) at the wire boundary.
+//!
+//! The underlying `u64` carries the ADR-0064 tag bits (4-bit type
+//! discriminator in the high nibble + 60-bit FNV-1a hash in the low
+//! 60 bits). `Display` renders the tagged string form, falling back
+//! to hex for the reserved-tag sentinels (e.g. `MailboxId::NONE`).
+
+use core::fmt;
+
+use aether_hub_protocol::{LabelNode, SchemaType};
+use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::schema::Schema;
+use crate::tagged_id::{self, Tag};
+use crate::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name};
+
+/// Shared `Display` body — render tagged-string form when the tag
+/// bits are valid, fall back to hex for reserved sentinels.
+fn fmt_tagged(id: u64, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match tagged_id::encode(id) {
+        Some(s) => f.write_str(&s),
+        None => write!(f, "{id:#018x}"),
+    }
+}
+
+/// Shared serde body for typed-id types. Branches on the
+/// serializer's `is_human_readable` flag so binary backends
+/// (postcard, the substrate's wire format) get a raw `u64` varint
+/// while text backends (JSON, the MCP wire) get the ADR-0064
+/// tagged-string form. Falls back to a raw `u64` for reserved-tag
+/// sentinels (e.g. `MailboxId::NONE = 0`) so the encoder doesn't
+/// error on a sentinel payload.
+fn serialize_id<S: Serializer>(id: u64, s: S) -> Result<S::Ok, S::Error> {
+    if s.is_human_readable() {
+        match tagged_id::encode(id) {
+            Some(encoded) => s.serialize_str(&encoded),
+            None => s.serialize_u64(id),
+        }
+    } else {
+        s.serialize_u64(id)
+    }
+}
+
+/// Shared serde body for typed-id types. For human-readable
+/// formats (JSON), accepts either a tagged string or a raw u64
+/// number (back-compat for callers that haven't migrated). For
+/// binary formats (postcard), reads a raw u64 varint — the
+/// substrate wire is byte-identical to a `u64` field.
+fn deserialize_id<'de, D: Deserializer<'de>>(d: D, expected: Tag) -> Result<u64, D::Error> {
+    use serde::de::{self, Visitor};
+
+    struct IdVisitor {
+        expected: Tag,
+    }
+
+    impl Visitor<'_> for IdVisitor {
+        type Value = u64;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "tagged id string ({}-XXXX-XXXX-XXXX) or u64 number",
+                self.expected.prefix()
+            )
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<u64, E> {
+            tagged_id::decode_with_tag(v, self.expected).map_err(de::Error::custom)
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<u64, E> {
+            Ok(v)
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<u64, E> {
+            v.try_into().map_err(|_| de::Error::custom("negative id"))
+        }
+    }
+
+    if d.is_human_readable() {
+        d.deserialize_any(IdVisitor { expected })
+    } else {
+        u64::deserialize(d)
+    }
+}
+
+/// Resolve a `SchemaType::TypeId(id)` payload to the `Tag` the
+/// hub's codec should expect on the JSON side. Returns `None` for
+/// any id that doesn't correspond to a known typed-id newtype —
+/// callers should treat that as an error (the schema declares a
+/// `TypeId` the codec doesn't know how to translate).
+///
+/// Adding a new typed-id wrapper is one entry here plus its
+/// `TYPE_ID`/`TYPE_NAME` consts on the newtype itself.
+pub const fn tag_for_type_id(type_id: u64) -> Option<Tag> {
+    if type_id == MailboxId::TYPE_ID {
+        Some(Tag::Mailbox)
+    } else if type_id == KindId::TYPE_ID {
+        Some(Tag::Kind)
+    } else if type_id == HandleId::TYPE_ID {
+        Some(Tag::Handle)
+    } else {
+        None
+    }
+}
+
+/// Resolve a `SchemaType::TypeId(id)` to its canonical type name —
+/// the `TYPE_NAME` const on the matching newtype. Surface for
+/// `describe_component` and for diagnostic rendering.
+pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
+    if type_id == MailboxId::TYPE_ID {
+        Some(MailboxId::TYPE_NAME)
+    } else if type_id == KindId::TYPE_ID {
+        Some(KindId::TYPE_NAME)
+    } else if type_id == HandleId::TYPE_ID {
+        Some(HandleId::TYPE_NAME)
+    } else {
+        None
+    }
+}
+
+/// Routing token for any mailbox — component or substrate-owned sink.
+/// Carries the ADR-0029 deterministic name hash with ADR-0064 tag
+/// bits in the high nibble. `#[repr(transparent)]` over `u64` so
+/// cast-shape kinds keep their layouts.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct MailboxId(pub u64);
+
+impl MailboxId {
+    /// Stable type id — FNV-1a of `TYPE_DOMAIN ++ TYPE_NAME`. The
+    /// `Schema` impl emits this as `SchemaType::TypeId(...)`; the
+    /// hub's codec arms key on it to pick the JSON/postcard
+    /// translation.
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.mailbox_id");
+
+    /// Canonical name used to compute `TYPE_ID`. Surfaced by
+    /// `describe_component` / tracing as the human-friendly type
+    /// label.
+    pub const TYPE_NAME: &'static str = "aether.mailbox_id";
+
+    /// Reserved sentinel for "no origin". Registration rejects any
+    /// name whose hash collides with 0 (practical probability
+    /// ~2⁻⁶⁴, but the guard is cheap) so this id never belongs to a
+    /// real mailbox.
+    pub const NONE: MailboxId = MailboxId(0);
+
+    /// Compute the deterministic id for a mailbox name. Same algorithm
+    /// the guest SDK uses on the component side — ids round-trip
+    /// verbatim across the FFI.
+    pub fn from_name(name: &str) -> MailboxId {
+        MailboxId(mailbox_id_from_name(name))
+    }
+}
+
+impl fmt::Display for MailboxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Schema for MailboxId {
+    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+}
+
+impl Serialize for MailboxId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for MailboxId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Mailbox).map(MailboxId)
+    }
+}
+
+/// Schema-hashed identity for a mail kind (ADR-0030). Carries the
+/// `Tag::Kind` discriminator + a 60-bit FNV-1a hash of the kind's
+/// canonical schema bytes. `#[repr(transparent)]` over `u64`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct KindId(pub u64);
+
+impl KindId {
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.kind_id");
+    pub const TYPE_NAME: &'static str = "aether.kind_id";
+}
+
+impl fmt::Display for KindId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Schema for KindId {
+    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+}
+
+impl Serialize for KindId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for KindId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Kind).map(KindId)
+    }
+}
+
+/// Substrate-minted reference to a parked value in the handle store
+/// (ADR-0045). Carries the `Tag::Handle` discriminator + a 60-bit
+/// counter masked into the low bits. `#[repr(transparent)]` over
+/// `u64`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct HandleId(pub u64);
+
+impl HandleId {
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.handle_id");
+    pub const TYPE_NAME: &'static str = "aether.handle_id";
+}
+
+impl fmt::Display for HandleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Schema for HandleId {
+    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+}
+
+impl Serialize for HandleId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for HandleId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Handle).map(HandleId)
+    }
+}

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -21,7 +21,9 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::fmt;
 
+pub mod ids;
 pub mod tagged_id;
+pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
 pub use tagged_id::{Tag, with_tag};
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
@@ -183,6 +185,12 @@ pub const MAILBOX_DOMAIN: &[u8] = b"mailbox:";
 /// the rationale; the derive macro and `kind_id_from_parts` both
 /// prepend this before the canonical schema bytes.
 pub const KIND_DOMAIN: &[u8] = b"kind:";
+
+/// ADR-0065: domain prefix for type-id hashes. Hashed input is
+/// `TYPE_DOMAIN ++ canonical_type_name.as_bytes()` (e.g.
+/// `"type:aether.mailbox_id"`). Disjoint from mailbox / kind domains
+/// so a typed-id `TYPE_ID` cannot alias either space.
+pub const TYPE_DOMAIN: &[u8] = b"type:";
 
 /// FNV-1a 64 over a byte slice (ADR-0032). Retained for the few
 /// call sites that hash neither a mailbox name nor a kind schema.

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -342,7 +342,7 @@ impl ControlPlane {
             Ok(p) => p,
             Err(error) => return SubscribeInputResult::Err { error },
         };
-        let id = MailboxId(payload.mailbox);
+        let id = payload.mailbox;
         if let Err(e) = validate_subscriber_mailbox(&self.registry, id) {
             return SubscribeInputResult::Err { error: e };
         }
@@ -360,7 +360,7 @@ impl ControlPlane {
             Ok(p) => p,
             Err(error) => return SubscribeInputResult::Err { error },
         };
-        let id = MailboxId(payload.mailbox);
+        let id = payload.mailbox;
         // Unsubscribe is idempotent on "not currently subscribed" but
         // still validates the mailbox: an unknown or sink id is a
         // clear programming error, not something to swallow. A dropped
@@ -1504,7 +1504,13 @@ mod tests {
         mailbox: u64,
         stream: InputStream,
     ) -> SubscribeInputResult {
-        plane.handle_subscribe(&postcard::to_allocvec(&SubscribeInput { stream, mailbox }).unwrap())
+        plane.handle_subscribe(
+            &postcard::to_allocvec(&SubscribeInput {
+                stream,
+                mailbox: MailboxId(mailbox),
+            })
+            .unwrap(),
+        )
     }
 
     fn do_unsubscribe(
@@ -1513,7 +1519,11 @@ mod tests {
         stream: InputStream,
     ) -> SubscribeInputResult {
         plane.handle_unsubscribe(
-            &postcard::to_allocvec(&UnsubscribeInput { stream, mailbox }).unwrap(),
+            &postcard::to_allocvec(&UnsubscribeInput {
+                stream,
+                mailbox: MailboxId(mailbox),
+            })
+            .unwrap(),
         )
     }
 
@@ -1687,7 +1697,7 @@ mod tests {
             crate::mail::ReplyTo::NONE,
             &postcard::to_allocvec(&SubscribeInput {
                 stream: InputStream::Tick,
-                mailbox: id,
+                mailbox: MailboxId(id),
             })
             .unwrap(),
         );
@@ -1697,7 +1707,7 @@ mod tests {
             crate::mail::ReplyTo::NONE,
             &postcard::to_allocvec(&UnsubscribeInput {
                 stream: InputStream::Tick,
-                mailbox: id,
+                mailbox: MailboxId(id),
             })
             .unwrap(),
         );

--- a/crates/aether-substrate-core/src/handle_store.rs
+++ b/crates/aether-substrate-core/src/handle_store.rs
@@ -409,6 +409,9 @@ pub fn schema_contains_ref(schema: &SchemaType) -> bool {
         // those defensively rather than the type system, so be
         // conservative and walk both sides.
         SchemaType::Map { key, value } => schema_contains_ref(key) || schema_contains_ref(value),
+        // ADR-0065: typed-id leaves carry no nested fields and so
+        // can never embed a `Ref`.
+        SchemaType::TypeId(_) => false,
     }
 }
 
@@ -666,6 +669,13 @@ fn walk(
                 }
                 _ => Err(WalkError::UnknownRefDiscriminant),
             }
+        }
+        // ADR-0065: typed-id wire is a u64 varint regardless of
+        // which `TYPE_ID` is set. Skip the varint; nothing to
+        // resolve since typed-ids don't embed `Ref`s.
+        SchemaType::TypeId(_) => {
+            state.skip_varint()?;
+            Ok(None)
         }
     }
 }

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -349,6 +349,7 @@ fn merge_schema(shape: &SchemaShape, label: Option<&LabelNode>) -> SchemaType {
                 value: SchemaCell::owned(merge_schema(value, value_label)),
             }
         }
+        SchemaShape::TypeId(id) => SchemaType::TypeId(*id),
     }
 }
 

--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -1,48 +1,13 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
-use std::fmt;
-
 use aether_hub_protocol::{EngineId, SessionToken};
-use aether_mail::mailbox_id_from_name;
-use aether_mail::tagged_id;
 
 /// Addressing token for any mailbox — component or substrate-owned sink.
-/// Opaque `u64` newtype so it can't be accidentally mixed with wasmtime
-/// indices or raw integers. The id is `aether_mail::mailbox_id_from_name`
-/// of the mailbox's registered name (ADR-0029) — deterministic across
-/// processes and sessions.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct MailboxId(pub u64);
-
-impl MailboxId {
-    /// Reserved sentinel for "no origin". Registration rejects any
-    /// name whose hash collides with 0 (practical probability
-    /// ~2⁻⁶⁴, but the guard is cheap) so this id never belongs to a
-    /// real mailbox.
-    pub const NONE: MailboxId = MailboxId(0);
-
-    /// Compute the deterministic id for a mailbox name. Same algorithm
-    /// the guest SDK uses on the component side — ids round-trip
-    /// verbatim across the FFI.
-    pub fn from_name(name: &str) -> MailboxId {
-        MailboxId(mailbox_id_from_name(name))
-    }
-}
-
-/// ADR-0064: render as the tagged string form (`mbx-XXXX-XXXX-XXXX`)
-/// when a tracing call site uses `%`. Falls back to a hex dump for
-/// reserved / invalid tag bits (`MailboxId::NONE` in particular) so a
-/// stray sentinel doesn't silently render as a malformed prefixed
-/// string.
-impl fmt::Display for MailboxId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match tagged_id::encode(self.0) {
-            Some(s) => f.write_str(&s),
-            None => write!(f, "{:#018x}", self.0),
-        }
-    }
-}
+/// ADR-0065 hoisted the canonical home into `aether_mail`; this remains
+/// re-exported under the `aether_substrate_core::mail::MailboxId` path
+/// so existing call sites compile unchanged.
+pub use aether_mail::MailboxId;
 
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -153,11 +153,23 @@ fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {
 }
 
 fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
-    dispatch(plane, &SubscribeInput { stream, mailbox });
+    dispatch(
+        plane,
+        &SubscribeInput {
+            stream,
+            mailbox: aether_mail::MailboxId(mailbox),
+        },
+    );
 }
 
 fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
-    dispatch(plane, &UnsubscribeInput { stream, mailbox });
+    dispatch(
+        plane,
+        &UnsubscribeInput {
+            stream,
+            mailbox: aether_mail::MailboxId(mailbox),
+        },
+    );
 }
 
 fn drop_component(plane: &ControlPlane, mailbox_id: u64) {

--- a/crates/aether-substrate-hub/src/decoder.rs
+++ b/crates/aether-substrate-hub/src/decoder.rs
@@ -177,6 +177,13 @@ fn decode_cast_field(
         SchemaType::Struct { repr_c: false, .. } => Err(DecodeError::UnsupportedSchema(
             "Struct { repr_c: false } in cast-shaped parent",
         )),
+        SchemaType::TypeId(type_id) => {
+            // ADR-0065: typed-id inside cast-shape parent. 8 bytes
+            // LE, 8-byte align — same as a `u64`.
+            cur.skip_pad_to(8);
+            let id = u64::from_le_bytes(cur.take::<8>(path)?);
+            Ok(render_type_id_value(id, *type_id, path)?)
+        }
         SchemaType::Bool
         | SchemaType::String
         | SchemaType::Bytes
@@ -188,6 +195,22 @@ fn decode_cast_field(
         | SchemaType::Map { .. } => Err(DecodeError::UnsupportedSchema(
             "non-cast field inside cast-shaped struct",
         )),
+    }
+}
+
+/// u64 → JSON helper for `SchemaType::TypeId(type_id)`. Emits the
+/// ADR-0064 tagged string form when the id's tag bits are valid;
+/// falls back to a JSON number for the reserved-tag sentinels (e.g.
+/// `MailboxId::NONE = 0`) so the codec doesn't error on a sentinel
+/// payload. Errors with `UnsupportedSchema` if the schema's
+/// `type_id` doesn't correspond to a typed-id newtype the codec
+/// knows how to translate.
+fn render_type_id_value(id: u64, type_id: u64, _path: &str) -> Result<Value, DecodeError> {
+    let _expected = aether_mail::tag_for_type_id(type_id)
+        .ok_or(DecodeError::UnsupportedSchema("unknown TypeId in schema"))?;
+    match aether_mail::tagged_id::encode(id) {
+        Some(s) => Ok(Value::String(s)),
+        None => Ok(Value::from(id)),
     }
 }
 
@@ -221,6 +244,8 @@ fn struct_alignment(fields: &[NamedField]) -> Result<usize, DecodeError> {
 fn alignment_of_schema(ty: &SchemaType) -> Result<usize, DecodeError> {
     match ty {
         SchemaType::Scalar(p) => Ok(align_of_primitive(*p)),
+        // ADR-0065: typed ids are u64-shaped — 8 bytes, 8-byte align.
+        SchemaType::TypeId(_) => Ok(8),
         SchemaType::Array { element, .. } => alignment_of_schema(element),
         SchemaType::Struct {
             fields,
@@ -375,6 +400,13 @@ fn decode_postcard(
                     discriminant: disc,
                 }),
             }
+        }
+        SchemaType::TypeId(type_id) => {
+            // ADR-0065 typed id. Wire is a u64 varint; emit the
+            // tagged string form (or back-compat number for
+            // reserved-tag sentinels).
+            let id = read_varint_u64(cur, path)?;
+            render_type_id_value(id, *type_id, path)
         }
     }
 }
@@ -1008,5 +1040,89 @@ mod tests {
         // 1-byte payload is enough to fail at the field-walk step.
         let err = decode_schema(&[0], &schema).unwrap_err();
         assert!(matches!(err, DecodeError::UnsupportedSchema(_)));
+    }
+
+    // ADR-0065: typed-id round-trips through both wire shapes.
+
+    #[test]
+    fn type_id_postcard_round_trips_as_tagged_string() {
+        // JSON in: tagged string. Wire: u64 varint. JSON out: same
+        // tagged string. The post-migration shape an agent sees end
+        // to end.
+        let schema = pc_struct(vec![NamedField {
+            name: "mailbox".into(),
+            ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+        }]);
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        roundtrip(json!({ "mailbox": s }), &schema);
+    }
+
+    #[test]
+    fn type_id_cast_round_trips_as_tagged_string() {
+        // Same as above but with a `repr_c: true` parent so the
+        // cast-shape path runs (8 bytes LE at 8-byte align).
+        let schema = cast_struct(vec![
+            NamedField {
+                name: "stream".into(),
+                ty: SchemaType::Scalar(Primitive::U8),
+            },
+            NamedField {
+                name: "mailbox".into(),
+                ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+            },
+        ]);
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        roundtrip(json!({ "stream": 1, "mailbox": s }), &schema);
+    }
+
+    #[test]
+    fn subscribe_input_kind_round_trips_with_tagged_mailbox() {
+        // End-to-end through the `SubscribeInput` kind's actual
+        // schema — mirrors the worked example in ADR-0065's Context
+        // section. An agent receives a tagged-string mailbox id from
+        // `load_component`, drops it directly into `subscribe_input.
+        // mailbox`, and the wire bytes match what the substrate
+        // expects.
+        use aether_mail::Kind;
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        let json_in = json!({ "stream": "Tick", "mailbox": s });
+
+        let bytes = encode_schema(
+            &json_in,
+            &<aether_kinds::SubscribeInput as aether_mail::Schema>::SCHEMA,
+        )
+        .expect("encode subscribe_input via TypeId schema");
+
+        // Substrate decode path — wire is byte-identical to a
+        // hand-postcard'd `SubscribeInput`.
+        let decoded: aether_kinds::SubscribeInput = postcard::from_bytes(&bytes)
+            .expect("postcard decode subscribe_input from hub-encoded bytes");
+        assert_eq!(decoded.stream, aether_kinds::InputStream::Tick);
+        assert_eq!(decoded.mailbox, mailbox);
+
+        // And the kind's id is sensitive to the typed identity —
+        // ADR-0065 phase 3 shifts it from the previous `u64`-shape
+        // hash. Cross-check it lands on a `Tag::Kind` value (the
+        // `with_tag` discipline holds through the schema-bytes
+        // change).
+        assert_eq!(
+            aether_mail::tagged_id::tag_of(aether_kinds::SubscribeInput::ID),
+            Some(aether_mail::Tag::Kind),
+        );
+    }
+
+    #[test]
+    fn type_id_round_trip_of_sentinel_uses_back_compat_number() {
+        // `MailboxId::NONE` (= 0) has reserved tag bits, so it
+        // serialises as a JSON number. Round-trip preserves the
+        // sentinel value end to end.
+        let schema = pc_struct(vec![NamedField {
+            name: "mailbox".into(),
+            ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+        }]);
+        roundtrip(json!({ "mailbox": 0u64 }), &schema);
     }
 }

--- a/crates/aether-substrate-hub/src/encoder.rs
+++ b/crates/aether-substrate-hub/src/encoder.rs
@@ -32,6 +32,7 @@
 use std::fmt;
 
 use aether_hub_protocol::{EnumVariant, NamedField, Primitive, SchemaType};
+use aether_mail::tagged_id;
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -338,6 +339,40 @@ fn encode_postcard(
                 }),
             }
         }
+        // ADR-0065 typed id. Wire is a u64 varint; JSON is the
+        // ADR-0064 tagged-string form (`mbx-XXXX-XXXX-XXXX` etc.)
+        // for the post-migration shape, with a back-compat path that
+        // accepts a JSON number for callers (test fixtures, older
+        // examples) that haven't migrated yet.
+        SchemaType::TypeId(type_id) => {
+            let id = decode_type_id_value(value, *type_id, path)?;
+            write_varint_u64(out, id);
+            Ok(())
+        }
+    }
+}
+
+/// JSON → u64 helper for `SchemaType::TypeId(type_id)`. Accepts a
+/// tagged string (decoded via `tagged_id::decode_with_tag` against
+/// the expected `Tag` for `type_id`) or a JSON number (back-compat).
+/// Errors with `TypeMismatch` on any other shape, or
+/// `UnsupportedSchema` if the schema's `type_id` doesn't correspond
+/// to a typed-id newtype the codec knows how to translate.
+fn decode_type_id_value(value: &Value, type_id: u64, path: &str) -> Result<u64, EncodeError> {
+    let expected = aether_mail::tag_for_type_id(type_id)
+        .ok_or(EncodeError::UnsupportedSchema("unknown TypeId in schema"))?;
+    match value {
+        Value::String(s) => {
+            tagged_id::decode_with_tag(s, expected).map_err(|e| EncodeError::OutOfRange {
+                field: path.to_owned(),
+                reason: format!("invalid tagged id: {e}"),
+            })
+        }
+        Value::Number(_) => Ok(as_unsigned(value, path, "u64 (typed-id back-compat)")?),
+        _ => Err(EncodeError::TypeMismatch {
+            field: path.to_owned(),
+            expected: "tagged-id string or u64 number",
+        }),
     }
 }
 
@@ -660,6 +695,16 @@ fn encode_field_value(
         SchemaType::Struct { repr_c: false, .. } => Err(EncodeError::UnsupportedSchema(
             "Struct { repr_c: false } in cast-shaped parent",
         )),
+        SchemaType::TypeId(type_id) => {
+            // ADR-0065 typed id inside a `repr_c: true` parent. Wire
+            // is a u64 (8 bytes, 8-byte align — same as a `u64`
+            // scalar) so the typed wrapper doesn't disturb the
+            // parent's cast-eligibility.
+            pad_to(out, 8);
+            let id = decode_type_id_value(value, *type_id, name)?;
+            out.extend_from_slice(&id.to_le_bytes());
+            Ok(8)
+        }
         SchemaType::Bool
         | SchemaType::String
         | SchemaType::Bytes
@@ -679,6 +724,8 @@ fn encode_field_value(
 fn alignment_of_schema(ty: &SchemaType) -> Result<usize, EncodeError> {
     match ty {
         SchemaType::Scalar(p) => Ok(align_of_primitive(*p)),
+        // ADR-0065: typed ids are u64-shaped — 8 bytes, 8-byte align.
+        SchemaType::TypeId(_) => Ok(8),
         SchemaType::Array { element, .. } => alignment_of_schema(element),
         SchemaType::Struct {
             fields,
@@ -1381,6 +1428,92 @@ mod tests {
             .into(),
         };
         let err = encode_schema(&json!({"headers": {"k": "v"}}), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::UnsupportedSchema(_)));
+    }
+
+    // ADR-0065: typed-id JSON ↔ postcard.
+
+    #[test]
+    fn type_id_postcard_accepts_tagged_string() {
+        // `mailbox` field carrying a tagged `mbx-...` string lands as
+        // a postcard u64 varint — wire-identical to a raw `u64` field.
+        let schema = postcard_struct(vec![NamedField {
+            name: "mailbox".into(),
+            ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+        }]);
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        let bytes = encode_schema(&json!({ "mailbox": s }), &schema).unwrap();
+        let mut expected = Vec::new();
+        write_varint_u64(&mut expected, mailbox.0);
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn type_id_postcard_accepts_raw_number_for_back_compat() {
+        // Pre-ADR-0065 callers passing a JSON number still work — the
+        // codec falls through to the back-compat `as_unsigned` path.
+        let schema = postcard_struct(vec![NamedField {
+            name: "mailbox".into(),
+            ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+        }]);
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let bytes = encode_schema(&json!({ "mailbox": mailbox.0 }), &schema).unwrap();
+        let mut expected = Vec::new();
+        write_varint_u64(&mut expected, mailbox.0);
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn type_id_postcard_rejects_wrong_tag() {
+        // A `KindId`-tagged string passed to a `MailboxId` field
+        // surfaces a typed `OutOfRange` so the agent learns the field
+        // expected `mbx-...` rather than corrupting the wire.
+        let schema = postcard_struct(vec![NamedField {
+            name: "mailbox".into(),
+            ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+        }]);
+        let knd_string = aether_mail::tagged_id::encode(aether_mail::with_tag(
+            aether_mail::Tag::Kind,
+            0xdeadbeef,
+        ))
+        .unwrap();
+        let err = encode_schema(&json!({ "mailbox": knd_string }), &schema).unwrap_err();
+        assert!(matches!(err, EncodeError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn type_id_cast_struct_lays_out_as_u64() {
+        // Inside a `repr_c: true` parent, a typed-id field is 8 bytes
+        // LE at 8-byte alignment — same layout as a `u64`. Two-field
+        // `{ stream: u8, mailbox: MailboxId }` lays out as 1 + 7 pad +
+        // 8 = 16 bytes.
+        let schema = cast_struct(vec![
+            scalar("stream", Primitive::U8),
+            NamedField {
+                name: "mailbox".into(),
+                ty: SchemaType::TypeId(aether_mail::MailboxId::TYPE_ID),
+            },
+        ]);
+        let mailbox = aether_mail::MailboxId::from_name("aether.control");
+        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        let bytes = encode_schema(&json!({ "stream": 1, "mailbox": s }), &schema).unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(bytes[0], 1);
+        assert_eq!(&bytes[1..8], &[0u8; 7]);
+        assert_eq!(&bytes[8..16], &mailbox.0.to_le_bytes());
+    }
+
+    #[test]
+    fn type_id_postcard_rejects_unknown_type_id() {
+        // A schema declaring a `TypeId(...)` value the codec doesn't
+        // recognise must surface `UnsupportedSchema` rather than
+        // corrupt the wire or silently fall through.
+        let schema = postcard_struct(vec![NamedField {
+            name: "mystery".into(),
+            ty: SchemaType::TypeId(0xdead_beef_cafe_f00d),
+        }]);
+        let err = encode_schema(&json!({ "mystery": 0u64 }), &schema).unwrap_err();
         assert!(matches!(err, EncodeError::UnsupportedSchema(_)));
     }
 }


### PR DESCRIPTION
## Summary

ADR-0065 sub-PR (a). Lifts typed ids into the schema vocabulary as a first-class peer to `Struct` / `Enum`, defines `MailboxId` / `KindId` / `HandleId` in `aether-mail`, and migrates `SubscribeInput` / `UnsubscribeInput` to the new types so an agent can drop a tagged-string mailbox id from `load_component` directly into `subscribe_input.mailbox` without manual tag-decoding or hitting the JSON 2^53 hole.

- `aether-hub-protocol`: `SchemaType::TypeId(u64)` + `SchemaShape::TypeId(u64)` + `SCHEMA_TYPE_ID = 12` in the canonical writer/decoder.
- `aether-mail`: typed-id newtypes (`#[repr(transparent)]` over `u64`, `Pod + Zeroable`, `pub const TYPE_ID` + `TYPE_NAME`, `Schema → SchemaType::TypeId(_)`). Custom serde branches on `is_human_readable` so JSON gets tagged strings while postcard stays as raw u64 varints — wire-identical to the previous `u64` fields. Hoists substrate-core's `MailboxId` here; substrate-core re-exports for back-compat.
- `aether-substrate-hub`: hard-coded match arms in `encoder.rs` / `decoder.rs` (no trait, no runtime registry — same shape as every other `SchemaType` arm). Tagged-string ↔ u64 varint on postcard; raw-number back-compat on JSON-in for migration. Cast-shape path treats `TypeId` as 8 bytes / 8-byte align.
- `aether-kinds`: `SubscribeInput.mailbox` and `UnsubscribeInput.mailbox` migrate `u64 → MailboxId`. Both kind ids shift because canonical schema bytes change (ADR-0030 pattern).
- Tests: postcard + cast paths, tagged-string + back-compat number, wrong-tag rejection, unknown-`TypeId` rejection, and an end-to-end `SubscribeInput` round-trip through the kind's `Schema::SCHEMA` into postcard bytes the substrate decodes.

Sub-PRs (b) and (c) follow: (b) cleanup pass that updates internal call sites to import `MailboxId` from `aether-mail` directly rather than through the substrate-core re-export; (c) migrates the remaining ~19 id fields in `aether-kinds`.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] Live MCP smoke against this branch's substrate + hub. Loaded camera component → `mbx-a5t5-cjw6-bsp2`. Sent `subscribe_input { stream: "Key", mailbox: "mbx-a5t5-cjw6-bsp2" }` via `send_mail`; received `subscribe_input_result: Ok` back. Sent the same kind with `mailbox: "knd-aaaa-aaaa-aaaa"` (wrong tag); rejected at the codec with `tag mismatch: expected mbx, found knd`, never hit the wire. Second mailbox-tagged subscribe on a different stream also returned Ok — codec path is repeatable, not a single-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)