### PR TITLE
feat(kinds): migrate remaining id fields to typed newtypes (ADR-0065 phase 3c)

### DIFF
--- a/crates/aether-component/src/handle.rs
+++ b/crates/aether-component/src/handle.rs
@@ -154,7 +154,9 @@ impl<K> Drop for Handle<K> {
         // Fire-and-forget: a panicking wait would poison teardown.
         // The substrate's release dispatch is idempotent — calling
         // it on an already-released id saturates harmlessly.
-        let req = HandleRelease { id: self.id };
+        let req = HandleRelease {
+            id: ::aether_mail::HandleId(self.id),
+        };
         resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send(&req);
     }
 }
@@ -169,7 +171,7 @@ impl<K> Drop for Handle<K> {
 pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleError> {
     let bytes = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
     let req = HandlePublish {
-        kind_id: K::ID,
+        kind_id: ::aether_mail::KindId(K::ID),
         bytes,
     };
     resolve_sink::<HandlePublish>(HANDLE_SINK_NAME).send(&req);
@@ -177,7 +179,7 @@ pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleEr
     let result: HandlePublishResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
     match result {
         HandlePublishResult::Ok { id, .. } => Ok(Handle {
-            id,
+            id: id.0,
             _k: PhantomData,
         }),
         HandlePublishResult::Err { error, .. } => Err(SyncHandleError::Handle(error)),
@@ -185,7 +187,9 @@ pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleEr
 }
 
 fn sync_release(id: u64) -> Result<(), SyncHandleError> {
-    let req = HandleRelease { id };
+    let req = HandleRelease {
+        id: ::aether_mail::HandleId(id),
+    };
     resolve_sink::<HandleRelease>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandleReleaseResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
@@ -196,7 +200,9 @@ fn sync_release(id: u64) -> Result<(), SyncHandleError> {
 }
 
 fn sync_pin(id: u64) -> Result<(), SyncHandleError> {
-    let req = HandlePin { id };
+    let req = HandlePin {
+        id: ::aether_mail::HandleId(id),
+    };
     resolve_sink::<HandlePin>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandlePinResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
@@ -207,7 +213,9 @@ fn sync_pin(id: u64) -> Result<(), SyncHandleError> {
 }
 
 fn sync_unpin(id: u64) -> Result<(), SyncHandleError> {
-    let req = HandleUnpin { id };
+    let req = HandleUnpin {
+        id: ::aether_mail::HandleId(id),
+    };
     resolve_sink::<HandleUnpin>(HANDLE_SINK_NAME).send(&req);
     let correlation = unsafe { raw::prev_correlation() };
     let result: HandleUnpinResult = wait(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
@@ -277,21 +285,23 @@ mod tests {
     #[test]
     fn publish_request_bytes_decode_to_handle_publish() {
         let req = HandlePublish {
-            kind_id: 0xCAFE,
+            kind_id: ::aether_mail::KindId(0xCAFE),
             bytes: vec![1, 2, 3, 4, 5],
         };
         let encoded = postcard::to_allocvec(&req).unwrap();
         let decoded: HandlePublish = postcard::from_bytes(&encoded).unwrap();
-        assert_eq!(decoded.kind_id, 0xCAFE);
+        assert_eq!(decoded.kind_id, ::aether_mail::KindId(0xCAFE));
         assert_eq!(decoded.bytes, vec![1, 2, 3, 4, 5]);
     }
 
     #[test]
     fn release_request_bytes_decode_to_handle_release() {
-        let req = HandleRelease { id: 0xDEAD };
+        let req = HandleRelease {
+            id: ::aether_mail::HandleId(0xDEAD),
+        };
         let encoded = postcard::to_allocvec(&req).unwrap();
         let decoded: HandleRelease = postcard::from_bytes(&encoded).unwrap();
-        assert_eq!(decoded.id, 0xDEAD);
+        assert_eq!(decoded.id, ::aether_mail::HandleId(0xDEAD));
     }
 
     #[test]

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -455,7 +455,7 @@ pub struct FrameStats {
 )]
 #[kind(name = "aether.observation.component_died")]
 pub struct ComponentDied {
-    pub mailbox_id: u64,
+    pub mailbox_id: aether_mail::MailboxId,
     pub mailbox_name: alloc::string::String,
     pub last_kind: alloc::string::String,
     pub reason: alloc::string::String,
@@ -507,8 +507,8 @@ pub struct SubstrateDying {
 )]
 #[kind(name = "aether.mail.unresolved")]
 pub struct UnresolvedMail {
-    pub recipient_mailbox_id: u64,
-    pub kind_id: u64,
+    pub recipient_mailbox_id: aether_mail::MailboxId,
+    pub kind_id: aether_mail::KindId,
 }
 
 // Reserved control-plane vocabulary (ADR-0010). The substrate handles
@@ -557,7 +557,7 @@ mod control_plane {
     #[kind(name = "aether.control.load_result")]
     pub enum LoadResult {
         Ok {
-            mailbox_id: u64,
+            mailbox_id: aether_mail::MailboxId,
             name: String,
             capabilities: ComponentCapabilities,
         },
@@ -588,7 +588,7 @@ mod control_plane {
     /// `# Agent` section convention when present, else the full doc.
     #[derive(aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct HandlerCapability {
-        pub id: u64,
+        pub id: aether_mail::KindId,
         pub name: String,
         pub doc: Option<String>,
     }
@@ -607,7 +607,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.drop_component")]
     pub struct DropComponent {
-        pub mailbox_id: u64,
+        pub mailbox_id: aether_mail::MailboxId,
     }
 
     /// Reply to `DropComponent`. `Ok` on success; `Err` if the
@@ -630,7 +630,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.replace_component")]
     pub struct ReplaceComponent {
-        pub mailbox_id: u64,
+        pub mailbox_id: aether_mail::MailboxId,
         pub wasm: Vec<u8>,
         pub drain_timeout_ms: Option<u32>,
     }
@@ -1312,7 +1312,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.publish")]
     pub struct HandlePublish {
-        pub kind_id: u64,
+        pub kind_id: aether_mail::KindId,
         pub bytes: Vec<u8>,
     }
 
@@ -1323,8 +1323,14 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.publish_result")]
     pub enum HandlePublishResult {
-        Ok { kind_id: u64, id: u64 },
-        Err { kind_id: u64, error: HandleError },
+        Ok {
+            kind_id: aether_mail::KindId,
+            id: aether_mail::HandleId,
+        },
+        Err {
+            kind_id: aether_mail::KindId,
+            error: HandleError,
+        },
     }
 
     /// `aether.handle.release` — drop one reference on `id`. Reply:
@@ -1334,7 +1340,7 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.release")]
     pub struct HandleRelease {
-        pub id: u64,
+        pub id: aether_mail::HandleId,
     }
 
     /// Reply to `HandleRelease`. Both arms echo the originating
@@ -1342,8 +1348,13 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.release_result")]
     pub enum HandleReleaseResult {
-        Ok { id: u64 },
-        Err { id: u64, error: HandleError },
+        Ok {
+            id: aether_mail::HandleId,
+        },
+        Err {
+            id: aether_mail::HandleId,
+            error: HandleError,
+        },
     }
 
     /// `aether.handle.pin` — protect `id` from LRU eviction even
@@ -1351,15 +1362,20 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.pin")]
     pub struct HandlePin {
-        pub id: u64,
+        pub id: aether_mail::HandleId,
     }
 
     /// Reply to `HandlePin`. Both arms echo the originating `id`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.pin_result")]
     pub enum HandlePinResult {
-        Ok { id: u64 },
-        Err { id: u64, error: HandleError },
+        Ok {
+            id: aether_mail::HandleId,
+        },
+        Err {
+            id: aether_mail::HandleId,
+            error: HandleError,
+        },
     }
 
     /// `aether.handle.unpin` — clear the pinned flag on `id`.
@@ -1368,15 +1384,20 @@ mod control_plane {
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.unpin")]
     pub struct HandleUnpin {
-        pub id: u64,
+        pub id: aether_mail::HandleId,
     }
 
     /// Reply to `HandleUnpin`. Both arms echo the originating `id`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.handle.unpin_result")]
     pub enum HandleUnpinResult {
-        Ok { id: u64 },
-        Err { id: u64, error: HandleError },
+        Ok {
+            id: aether_mail::HandleId,
+        },
+        Err {
+            id: aether_mail::HandleId,
+            error: HandleError,
+        },
     }
 
     // ADR-0060 guest-side logging via mail sink. One postcard kind on

--- a/crates/aether-mail/src/ids.rs
+++ b/crates/aether-mail/src/ids.rs
@@ -19,6 +19,7 @@ use aether_hub_protocol::{LabelNode, SchemaType};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::CastEligible;
 use crate::schema::Schema;
 use crate::tagged_id::{self, Tag};
 use crate::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name};
@@ -133,8 +134,12 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
 /// bits in the high nibble. `#[repr(transparent)]` over `u64` so
 /// cast-shape kinds keep their layouts.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct MailboxId(pub u64);
+
+impl CastEligible for MailboxId {
+    const ELIGIBLE: bool = true;
+}
 
 impl MailboxId {
     /// Stable type id — FNV-1a of `TYPE_DOMAIN ++ TYPE_NAME`. The
@@ -190,8 +195,12 @@ impl<'de> Deserialize<'de> for MailboxId {
 /// `Tag::Kind` discriminator + a 60-bit FNV-1a hash of the kind's
 /// canonical schema bytes. `#[repr(transparent)]` over `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct KindId(pub u64);
+
+impl CastEligible for KindId {
+    const ELIGIBLE: bool = true;
+}
 
 impl KindId {
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.kind_id");
@@ -227,8 +236,12 @@ impl<'de> Deserialize<'de> for KindId {
 /// counter masked into the low bits. `#[repr(transparent)]` over
 /// `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct HandleId(pub u64);
+
+impl CastEligible for HandleId {
+    const ELIGIBLE: bool = true;
+}
 
 impl HandleId {
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.handle_id");

--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -253,8 +253,8 @@ impl<'a> SubstrateBootBuilder<'a> {
                     {
                         tracing::warn!(
                             target: "aether_substrate::diagnostics",
-                            recipient_mailbox_id = format_args!("{:#x}", record.recipient_mailbox_id),
-                            kind_id = format_args!("{:#x}", record.kind_id),
+                            recipient_mailbox_id = %record.recipient_mailbox_id,
+                            kind_id = %record.kind_id,
                             "hub could not resolve bubbled-up mail recipient (ADR-0037); \
                              mail dropped. Likely a typoed mailbox name at the sender.",
                         );

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -295,7 +295,7 @@ impl ControlPlane {
         self.announce_kinds();
 
         LoadResult::Ok {
-            mailbox_id: mailbox.0,
+            mailbox_id: mailbox,
             name,
             capabilities,
         }
@@ -306,7 +306,7 @@ impl ControlPlane {
             Ok(p) => p,
             Err(error) => return DropResult::Err { error },
         };
-        let id = MailboxId(payload.mailbox_id);
+        let id = payload.mailbox_id;
         if let Err(e) = self.registry.drop_mailbox(id) {
             return DropResult::Err {
                 error: e.to_string(),
@@ -387,7 +387,7 @@ impl ControlPlane {
             Ok(p) => p,
             Err(error) => return ReplaceResult::Err { error },
         };
-        let id = MailboxId(payload.mailbox_id);
+        let id = payload.mailbox_id;
         // ADR-0038 retires the freeze-drain timeout as a load-bearing
         // knob — the splice is structural. The field is still
         // accepted for wire compatibility and ignored here; a future
@@ -595,7 +595,7 @@ mod tests {
     fn load_result_roundtrip() {
         for r in [
             LoadResult::Ok {
-                mailbox_id: 7,
+                mailbox_id: MailboxId(7),
                 name: "x".into(),
                 capabilities: aether_kinds::ComponentCapabilities::default(),
             },
@@ -745,14 +745,8 @@ mod tests {
                 capabilities: _,
             } => {
                 assert_eq!(name, "loaded");
-                assert_eq!(plane.registry.lookup("loaded"), Some(MailboxId(mailbox_id)));
-                assert!(
-                    plane
-                        .components
-                        .read()
-                        .unwrap()
-                        .contains_key(&MailboxId(mailbox_id))
-                );
+                assert_eq!(plane.registry.lookup("loaded"), Some(mailbox_id));
+                assert!(plane.components.read().unwrap().contains_key(&mailbox_id));
             }
             LoadResult::Err { error } => panic!("load should succeed: {error}"),
         }
@@ -970,17 +964,13 @@ mod tests {
         );
         assert!(
             matches!(
-                plane.registry.entry(MailboxId(mailbox_id)),
+                plane.registry.entry(mailbox_id),
                 Some(crate::registry::MailboxEntry::Dropped),
             ),
             "entry should be marked Dropped",
         );
         assert!(
-            !plane
-                .components
-                .read()
-                .unwrap()
-                .contains_key(&MailboxId(mailbox_id)),
+            !plane.components.read().unwrap().contains_key(&mailbox_id),
             "component must be removed from scheduler table",
         );
     }
@@ -1012,7 +1002,7 @@ mod tests {
             .components
             .read()
             .unwrap()
-            .get(&MailboxId(mailbox_id))
+            .get(&mailbox_id)
             .cloned()
             .expect("entry must be bound after load");
 
@@ -1030,8 +1020,12 @@ mod tests {
     #[test]
     fn drop_component_rejects_unknown_id() {
         let plane = make_plane();
-        let result =
-            plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: 99 }).unwrap());
+        let result = plane.handle_drop(
+            &postcard::to_allocvec(&DropComponent {
+                mailbox_id: MailboxId(99),
+            })
+            .unwrap(),
+        );
         assert!(matches!(result, DropResult::Err { .. }));
     }
 
@@ -1083,17 +1077,8 @@ mod tests {
         );
         assert!(matches!(result, ReplaceResult::Ok { .. }));
         // Name still resolves to the same id; new Component bound.
-        assert_eq!(
-            plane.registry.lookup("swap_target"),
-            Some(MailboxId(mailbox_id))
-        );
-        assert!(
-            plane
-                .components
-                .read()
-                .unwrap()
-                .contains_key(&MailboxId(mailbox_id))
-        );
+        assert_eq!(plane.registry.lookup("swap_target"), Some(mailbox_id));
+        assert!(plane.components.read().unwrap().contains_key(&mailbox_id));
     }
 
     #[test]
@@ -1102,7 +1087,7 @@ mod tests {
         let wasm = wat::parse_str(WAT).unwrap();
         let result = plane.handle_replace(
             &postcard::to_allocvec(&ReplaceComponent {
-                mailbox_id: 99,
+                mailbox_id: MailboxId(99),
                 wasm,
                 drain_timeout_ms: None,
             })
@@ -1201,7 +1186,7 @@ mod tests {
         assert!(matches!(dropped, DropResult::Ok));
         // Mailbox still marked Dropped; component still removed.
         assert!(matches!(
-            plane.registry.entry(MailboxId(mailbox_id)),
+            plane.registry.entry(mailbox_id),
             Some(crate::registry::MailboxEntry::Dropped),
         ));
     }
@@ -1344,12 +1329,9 @@ mod tests {
         // Ask the rehydrated component to emit its rehydrated-state
         // window to our sink. Payload: sink mailbox id as u64 LE.
         let payload = sink_mbox.0.to_le_bytes().to_vec();
-        plane.queue.push(Mail::new(
-            MailboxId(mailbox_id),
-            snapshot_kind_id,
-            payload,
-            1,
-        ));
+        plane
+            .queue
+            .push(Mail::new(mailbox_id, snapshot_kind_id, payload, 1));
         plane.queue.drain_all();
 
         let bytes = captured
@@ -1392,14 +1374,8 @@ mod tests {
         };
         assert!(error.contains("exceeds"), "got: {error}");
         // Old instance is still bound; name still resolves to its id.
-        assert_eq!(plane.registry.lookup("greedy"), Some(MailboxId(mailbox_id)));
-        assert!(
-            plane
-                .components
-                .read()
-                .unwrap()
-                .contains_key(&MailboxId(mailbox_id))
-        );
+        assert_eq!(plane.registry.lookup("greedy"), Some(mailbox_id));
+        assert!(plane.components.read().unwrap().contains_key(&mailbox_id));
     }
 
     // Retired under ADR-0038 — see the comment block above
@@ -1461,7 +1437,7 @@ mod tests {
         );
         assert!(matches!(result, ReplaceResult::Ok { .. }));
         let table = plane.components.read().unwrap();
-        let cell = table.get(&MailboxId(mailbox_id)).expect("present");
+        let cell = table.get(&mailbox_id).expect("present");
         let mut new = cell.component.lock().unwrap();
         assert_eq!(new.read_u32(396), 0);
         assert_eq!(new.read_u32(400), 0);
@@ -1496,7 +1472,7 @@ mod tests {
         let LoadResult::Ok { mailbox_id, .. } = result else {
             panic!("load should succeed: {result:?}");
         };
-        mailbox_id
+        mailbox_id.0
     }
 
     fn do_subscribe(
@@ -1623,7 +1599,12 @@ mod tests {
     fn subscribe_dropped_mailbox_is_err() {
         let plane = make_plane();
         let id = load_blank(&plane, "victim");
-        plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
+        plane.handle_drop(
+            &postcard::to_allocvec(&DropComponent {
+                mailbox_id: MailboxId(id),
+            })
+            .unwrap(),
+        );
         assert!(matches!(
             do_subscribe(&plane, id, InputStream::Tick),
             SubscribeInputResult::Err { .. }
@@ -1639,8 +1620,12 @@ mod tests {
         do_subscribe(&plane, id, InputStream::Tick);
         do_subscribe(&plane, id, InputStream::Key);
         do_subscribe(&plane, id, InputStream::MouseButton);
-        let dropped =
-            plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
+        let dropped = plane.handle_drop(
+            &postcard::to_allocvec(&DropComponent {
+                mailbox_id: MailboxId(id),
+            })
+            .unwrap(),
+        );
         assert!(matches!(dropped, DropResult::Ok));
         for s in [
             InputStream::Tick,
@@ -1665,7 +1650,7 @@ mod tests {
         do_subscribe(&plane, id, InputStream::Key);
         let result = plane.handle_replace(
             &postcard::to_allocvec(&ReplaceComponent {
-                mailbox_id: id,
+                mailbox_id: MailboxId(id),
                 wasm: wat::parse_str(WAT).unwrap(),
                 drain_timeout_ms: None,
             })
@@ -1821,13 +1806,7 @@ mod tests {
             panic!("load failed");
         };
 
-        let entry = plane
-            .components
-            .read()
-            .unwrap()
-            .get(&MailboxId(id))
-            .unwrap()
-            .clone();
+        let entry = plane.components.read().unwrap().get(&id).unwrap().clone();
         // Park three mails directly on the entry. Real workers would
         // do this when frozen=true; here we simulate the post-park
         // state without standing up a worker pool. We do NOT touch
@@ -1838,7 +1817,7 @@ mod tests {
         let _ = kind_id;
         for n in 1..=3u32 {
             entry.parked.lock().unwrap().push_back(Mail {
-                recipient: MailboxId(id),
+                recipient: id,
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,
@@ -1862,13 +1841,7 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), 1 + 2 + 3);
 
         // New entry is bound now, parked is empty, frozen cleared.
-        let entry_after = plane
-            .components
-            .read()
-            .unwrap()
-            .get(&MailboxId(id))
-            .unwrap()
-            .clone();
+        let entry_after = plane.components.read().unwrap().get(&id).unwrap().clone();
         assert!(!Arc::ptr_eq(&entry, &entry_after));
         assert!(entry_after.parked.lock().unwrap().is_empty());
         assert!(!entry_after.frozen.load(Ordering::SeqCst));
@@ -1911,7 +1884,7 @@ mod tests {
         entry.frozen.store(true, Ordering::SeqCst);
         for n in 1..=2u32 {
             entry.parked.lock().unwrap().push_back(Mail {
-                recipient: MailboxId(id),
+                recipient: id,
                 kind: 0,
                 payload: sink_id.0.to_le_bytes().to_vec(),
                 count: n,

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -86,7 +86,7 @@ fn dispatch_publish(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes
             mailer.send_reply(
                 sender,
                 &HandlePublishResult::Err {
-                    kind_id: 0,
+                    kind_id: aether_mail::KindId(0),
                     error: HandleError::AdapterError(format!("decode failed: {e}")),
                 },
             );
@@ -94,7 +94,7 @@ fn dispatch_publish(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes
         }
     };
     let id = store.next_ephemeral();
-    match store.put(id, req.kind_id, req.bytes) {
+    match store.put(id, req.kind_id.0, req.bytes) {
         Ok(()) => {
             // Hold a reference on behalf of the publishing
             // component. Drop / explicit release decrements; on
@@ -105,7 +105,7 @@ fn dispatch_publish(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes
                 sender,
                 &HandlePublishResult::Ok {
                     kind_id: req.kind_id,
-                    id,
+                    id: aether_mail::HandleId(id),
                 },
             );
         }
@@ -133,14 +133,14 @@ fn dispatch_release(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes
             mailer.send_reply(
                 sender,
                 &HandleReleaseResult::Err {
-                    id: 0,
+                    id: aether_mail::HandleId(0),
                     error: HandleError::AdapterError(format!("decode failed: {e}")),
                 },
             );
             return;
         }
     };
-    if store.dec_ref(req.id) {
+    if store.dec_ref(req.id.0) {
         mailer.send_reply(sender, &HandleReleaseResult::Ok { id: req.id });
     } else {
         mailer.send_reply(
@@ -165,14 +165,14 @@ fn dispatch_pin(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes: &[
             mailer.send_reply(
                 sender,
                 &HandlePinResult::Err {
-                    id: 0,
+                    id: aether_mail::HandleId(0),
                     error: HandleError::AdapterError(format!("decode failed: {e}")),
                 },
             );
             return;
         }
     };
-    if store.pin(req.id) {
+    if store.pin(req.id.0) {
         mailer.send_reply(sender, &HandlePinResult::Ok { id: req.id });
     } else {
         mailer.send_reply(
@@ -197,14 +197,14 @@ fn dispatch_unpin(store: &HandleStore, mailer: &Mailer, sender: ReplyTo, bytes: 
             mailer.send_reply(
                 sender,
                 &HandleUnpinResult::Err {
-                    id: 0,
+                    id: aether_mail::HandleId(0),
                     error: HandleError::AdapterError(format!("decode failed: {e}")),
                 },
             );
             return;
         }
     };
-    if store.unpin(req.id) {
+    if store.unpin(req.id.0) {
         mailer.send_reply(sender, &HandleUnpinResult::Ok { id: req.id });
     } else {
         mailer.send_reply(
@@ -288,7 +288,7 @@ mod tests {
     fn publish_replies_with_fresh_id_and_initial_refcount() {
         let (store, _mailer, _registry, rx, handler) = build_harness();
         let req = HandlePublish {
-            kind_id: 0xCAFE,
+            kind_id: aether_mail::KindId(0xCAFE),
             bytes: vec![1, 2, 3, 4, 5],
         };
         let bytes = postcard::to_allocvec(&req).unwrap();
@@ -307,11 +307,14 @@ mod tests {
         let HandlePublishResult::Ok { kind_id, id } = result else {
             panic!("expected Ok, got {result:?}");
         };
-        assert_eq!(kind_id, 0xCAFE);
-        assert!(id > 0, "id must be a real handle, not the failure sentinel");
+        assert_eq!(kind_id, aether_mail::KindId(0xCAFE));
+        assert!(
+            id.0 > 0,
+            "id must be a real handle, not the failure sentinel"
+        );
         // Bytes landed in the store with refcount=1 (so eviction
         // pressure can't drop them silently).
-        let (stored_kind, stored_bytes) = store.get(id).unwrap();
+        let (stored_kind, stored_bytes) = store.get(id.0).unwrap();
         assert_eq!(stored_kind, 0xCAFE);
         assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
     }
@@ -319,7 +322,9 @@ mod tests {
     #[test]
     fn release_unknown_id_replies_err_unknown_handle() {
         let (_store, _mailer, _registry, rx, handler) = build_harness();
-        let req = HandleRelease { id: 0xBAD };
+        let req = HandleRelease {
+            id: aether_mail::HandleId(0xBAD),
+        };
         let bytes = postcard::to_allocvec(&req).unwrap();
         handler(
             <HandleRelease as Kind>::ID,
@@ -334,7 +339,7 @@ mod tests {
         let result: HandleReleaseResult = postcard::from_bytes(&payload).unwrap();
         match result {
             HandleReleaseResult::Err { id, error } => {
-                assert_eq!(id, 0xBAD);
+                assert_eq!(id, aether_mail::HandleId(0xBAD));
                 assert_eq!(error, HandleError::UnknownHandle);
             }
             other => panic!("expected Err(UnknownHandle), got {other:?}"),
@@ -346,7 +351,7 @@ mod tests {
         let (store, _mailer, _registry, rx, handler) = build_harness();
         // Publish first to mint an id.
         let publish_req = HandlePublish {
-            kind_id: 0xCAFE,
+            kind_id: aether_mail::KindId(0xCAFE),
             bytes: vec![1, 2, 3],
         };
         handler(
@@ -390,7 +395,7 @@ mod tests {
         let result: HandleUnpinResult = postcard::from_bytes(&extract_payload(frame)).unwrap();
         assert!(matches!(result, HandleUnpinResult::Ok { id: r } if r == id));
         // Sanity-check the store actually has the entry.
-        assert!(store.contains(id));
+        assert!(store.contains(id.0));
     }
 
     /// Decode failure: send malformed bytes claiming to be a publish
@@ -413,7 +418,7 @@ mod tests {
         let result: HandlePublishResult = postcard::from_bytes(&extract_payload(frame)).unwrap();
         match result {
             HandlePublishResult::Err { kind_id, error } => {
-                assert_eq!(kind_id, 0);
+                assert_eq!(kind_id, aether_mail::KindId(0));
                 assert!(matches!(error, HandleError::AdapterError(_)));
             }
             other => panic!("expected Err, got {other:?}"),
@@ -459,7 +464,7 @@ mod tests {
         );
 
         let publish_req = HandlePublish {
-            kind_id: 0xCAFE,
+            kind_id: aether_mail::KindId(0xCAFE),
             bytes: vec![9, 9, 9],
         };
         handler(

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -151,7 +151,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
         match record {
             InputsRecord::Handler { id, name, doc } => {
                 caps.handlers.push(HandlerCapability {
-                    id,
+                    id: aether_mail::KindId(id),
                     name: name.into_owned(),
                     doc: doc.map(|d| d.into_owned()),
                 });
@@ -860,13 +860,13 @@ mod tests {
         let caps = read_inputs_from_bytes(&wasm).unwrap();
         assert_eq!(caps.doc.as_deref(), Some("Draws triangles on tick."));
         assert_eq!(caps.handlers.len(), 2);
-        assert_eq!(caps.handlers[0].id, 42);
+        assert_eq!(caps.handlers[0].id, aether_mail::KindId(42));
         assert_eq!(caps.handlers[0].name, "aether.tick");
         assert_eq!(
             caps.handlers[0].doc.as_deref(),
             Some("substrate drives this")
         );
-        assert_eq!(caps.handlers[1].id, 0xff);
+        assert_eq!(caps.handlers[1].id, aether_mail::KindId(0xff));
         assert_eq!(caps.handlers[1].name, "aether.ping");
         assert!(caps.handlers[1].doc.is_none());
         assert!(caps.fallback.is_none());

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -563,7 +563,7 @@ fn kill_actor(
     state.store(STATE_DEAD, Ordering::Release);
 
     let died = ComponentDied {
-        mailbox_id: mailbox.0,
+        mailbox_id: mailbox,
         mailbox_name,
         last_kind: last_kind.to_string(),
         reason,
@@ -1004,7 +1004,7 @@ mod tests {
         let died = captured.lock().unwrap();
         assert_eq!(died.len(), 1, "exactly one death broadcast expected");
         let d = &died[0];
-        assert_eq!(d.mailbox_id, mailbox.0);
+        assert_eq!(d.mailbox_id, mailbox);
         assert_eq!(d.mailbox_name, "crashy");
         assert!(
             d.reason.starts_with("wasmtime trap:"),

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -173,7 +173,12 @@ fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
 }
 
 fn drop_component(plane: &ControlPlane, mailbox_id: u64) {
-    dispatch(plane, &DropComponent { mailbox_id });
+    dispatch(
+        plane,
+        &DropComponent {
+            mailbox_id: aether_mail::MailboxId(mailbox_id),
+        },
+    );
 }
 
 /// Publish one Tick exactly as `App::window_event` does: snapshot the

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -197,8 +197,8 @@ fn send_unresolved_diagnostic(
         return;
     };
     let payload = bytemuck::bytes_of(&UnresolvedMail {
-        recipient_mailbox_id,
-        kind_id,
+        recipient_mailbox_id: aether_mail::MailboxId(recipient_mailbox_id),
+        kind_id: aether_mail::KindId(kind_id),
     })
     .to_vec();
     let frame = HubToEngine::MailById(MailByIdFrame {
@@ -542,8 +542,14 @@ mod tests {
             mailbox_id_from_name(AETHER_DIAGNOSTICS),
         );
         let record: &UnresolvedMail = bytemuck::from_bytes(&frame.payload);
-        assert_eq!(record.recipient_mailbox_id, 0xBAD_C0FFEE_u64);
-        assert_eq!(record.kind_id, <aether_kinds::Tick as Kind>::ID);
+        assert_eq!(
+            record.recipient_mailbox_id,
+            aether_mail::MailboxId(0xBAD_C0FFEE_u64)
+        );
+        assert_eq!(
+            record.kind_id,
+            aether_mail::KindId(<aether_kinds::Tick as Kind>::ID),
+        );
         assert_eq!(frame.count, 1);
         assert!(
             mail_rx.try_recv().is_err(),


### PR DESCRIPTION
## Summary

Sub-PR (c) of ADR-0065 phase 3. Migrates every remaining `u64` id field in `aether-kinds` to `MailboxId` / `KindId` / `HandleId`. Each kind whose schema mentions a typed id picks up a fresh `Kind::ID` (canonical schema bytes change — same migration discipline as ADR-0030 and the `SubscribeInput` shift in sub-PR a). No persisted ids exist on disk; rebaseline is mechanical.

Sub-PR (b) was skipped — only 4 import sites still reach for `aether_substrate_core::mail::MailboxId`, all internal to substrate-core. The re-export added in sub-PR (a) is fine; updating those imports would be churn for no semantic gain.

Migrated:

- `ComponentDied.mailbox_id` → `MailboxId`
- `UnresolvedMail.{recipient_mailbox_id, kind_id}` → `MailboxId`, `KindId`
- `LoadResult::Ok.mailbox_id` → `MailboxId`
- `HandlerCapability.id` → `KindId` (the handler's `<K as Kind>::ID`)
- `DropComponent.mailbox_id` → `MailboxId`
- `ReplaceComponent.mailbox_id` → `MailboxId`
- `HandlePublish.kind_id` → `KindId`
- `HandlePublishResult::{Ok, Err}.kind_id` → `KindId`, `HandlePublishResult::Ok.id` → `HandleId`
- `HandleRelease.id` / `HandlePin.id` / `HandleUnpin.id` → `HandleId`, plus their `*Result` arms

The newtypes gain `Default` + `CastEligible` so cast-eligible kinds (ComponentDied + UnresolvedMail) still ride `bytemuck::cast`. The serde `is_human_readable` branch from sub-PR (a) keeps postcard wire byte-identical; only the JSON projection switches to tagged strings.

Substrate consumers (`control.rs`, `handle_sink.rs`, `boot.rs`, `scheduler.rs`, `loopback.rs`, `kind_manifest.rs`, the desktop input-subscriptions integration test, the component-side `handle.rs` SDK) wrap or unwrap at the wire boundary as needed; internal types stay `u64` where they were `u64` before. Tracing call sites that used `{:#x}` switch to `Display` (the typed ids render as tagged strings).

Closes ADR-0065 phase 3 implementation.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] Live MCP smoke against this branch's substrate. Spawned headless, loaded camera component → `mbx-a5t5-cjw6-bsp2`. Sent `aether.control.drop_component` with `params.mailbox_id = "mbx-a5t5-cjw6-bsp2"` (tagged string into the migrated `DropComponent.mailbox_id: MailboxId` field); received `drop_result: "Ok"` end-to-end. The hub's encoder routed the JSON string through the `TypeId(MailboxId::TYPE_ID)` arm to a postcard u64 varint; the substrate decoded the typed `MailboxId`, validated, and dropped the component cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)