### PR TITLE
docs(kinds): correct OrbitParams pitch sign convention (issue 331)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1351,8 +1351,9 @@ mod control_plane {
     pub struct OrbitParams {
         /// Eye radius from `target`. `0.0` collapses to the target.
         pub distance: Option<f32>,
-        /// Vertical tilt (radians). Positive tilts the eye up so the
-        /// camera looks down. `±π/2` are degenerate.
+        /// Vertical tilt (radians). Positive places the eye below the
+        /// target (camera looks up); negative places it above (camera
+        /// looks down). `±π/2` are degenerate.
         pub pitch: Option<f32>,
         /// Absolute yaw (radians). Auto-advance keeps ticking from
         /// this value next frame; pair with `speed: Some(0.0)` to pin.


### PR DESCRIPTION
## Summary

- The `OrbitParams::pitch` doc claimed positive pitch tilts the eye up so the camera looks down, but the actual right-handed YXZ math puts the eye below the target (camera looks up) for positive pitch.
- Updated the doc wording in `aether-kinds` to match the empirical behavior; math is unchanged.

Closes #331

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check -p aether-camera-component --target wasm32-unknown-unknown`