### PR TITLE
fix(render): truncate render sink at vertex buffer cap (issue 389)

### DIFF
--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -35,7 +35,7 @@ use aether_substrate_desktop::{
     mail::{Mail, MailboxId, ReplyTarget, ReplyTo},
     subscribers_for,
 };
-use render::{Gpu, IDENTITY_VIEW_PROJ};
+use render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -45,6 +45,12 @@ use winit::window::{Fullscreen, Window, WindowId};
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;
+
+/// Wire size of one `aether.draw_triangle` mail item: three vertices,
+/// each `f32 x,y,z + f32 r,g,b` (24 bytes). The render sink clamps at
+/// whole-triangle multiples so we never write a half-triangle into the
+/// GPU vertex buffer when the cap forces a truncate.
+const DRAW_TRIANGLE_BYTES: usize = 72;
 
 /// ADR-0063 fail-fast budget for the per-frame drain barrier. A
 /// dispatcher that doesn't quiesce within this window is treated as
@@ -870,7 +876,15 @@ impl ApplicationHandler<UserEvent> for App {
                         ),
                     );
                 }
-                let verts = std::mem::take(&mut *self.frame_vertices.lock().unwrap());
+                // `mem::replace` rather than `mem::take` so the per-frame
+                // drain doesn't collapse the buffer to zero capacity and
+                // re-allocate next frame. Reserve the full cap up front
+                // (4 MiB) — the buffer is bounded by the sink-side clamp
+                // so this is the worst-case allocation either way.
+                let verts = std::mem::replace(
+                    &mut *self.frame_vertices.lock().unwrap(),
+                    Vec::with_capacity(VERTEX_BUFFER_BYTES),
+                );
                 let view_proj = *self.camera_state.lock().unwrap();
                 if let Some(gpu) = self.gpu.as_mut() {
                     match pending_capture {
@@ -1081,9 +1095,29 @@ fn main() -> wasmtime::Result<()> {
                       _origin: Option<&str>,
                       _sender,
                       bytes: &[u8],
-                      count: u32| {
-                    verts_for_sink.lock().unwrap().extend_from_slice(bytes);
-                    tris_for_sink.fetch_add(u64::from(count), Ordering::Relaxed);
+                      _count: u32| {
+                    // Truncate at the sink boundary so a single oversized
+                    // mesh degrades gracefully instead of collapsing the
+                    // whole frame downstream. Round to whole triangles so
+                    // the GPU vertex buffer never sees a half-triangle.
+                    let mut verts = verts_for_sink.lock().unwrap();
+                    let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
+                    let write_len = bytes.len().min(available);
+                    let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+                    if write_len > 0 {
+                        verts.extend_from_slice(&bytes[..write_len]);
+                        tris_for_sink
+                            .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+                    }
+                    if write_len < bytes.len() {
+                        tracing::warn!(
+                            target: "aether_substrate::render",
+                            accepted_bytes = write_len,
+                            dropped_bytes = bytes.len() - write_len,
+                            cap = VERTEX_BUFFER_BYTES,
+                            "render sink dropped triangles beyond fixed vertex buffer",
+                        );
+                    }
                 },
             ),
         );

--- a/crates/aether-substrate-desktop/src/render.rs
+++ b/crates/aether-substrate-desktop/src/render.rs
@@ -38,7 +38,7 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 const VERTEX_STRIDE: u64 = 24; // 3 * f32 position + 3 * f32 color
-const VERTEX_BUFFER_BYTES: u64 = 4 * 1024 * 1024;
+pub(crate) const VERTEX_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 const CAMERA_UNIFORM_BYTES: u64 = 64; // 4x4 f32 column-major
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
@@ -353,7 +353,7 @@ impl Gpu {
 
         let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("hello-triangle vertex buffer"),
-            size: VERTEX_BUFFER_BYTES,
+            size: VERTEX_BUFFER_BYTES as u64,
             usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -485,8 +485,12 @@ impl Gpu {
         view_proj: &[f32; 16],
         capture: bool,
     ) -> Option<Result<Vec<u8>, String>> {
-        let vertex_bytes = vertices.len() as u64;
+        let vertex_bytes = vertices.len();
         if vertex_bytes > VERTEX_BUFFER_BYTES {
+            // Belt-and-suspenders: the render sink truncates at the cap
+            // already, so we should never get here. Drop the frame
+            // rather than overflow the buffer if a future caller
+            // bypasses the sink-side clamp.
             tracing::warn!(
                 target: "aether_substrate::render",
                 vertex_bytes,
@@ -502,7 +506,7 @@ impl Gpu {
         // 64 bytes is cheap enough that a dirty flag isn't worth it.
         self.queue
             .write_buffer(&self.camera_buffer, 0, bytemuck::cast_slice(view_proj));
-        let vertex_count = (vertex_bytes / VERTEX_STRIDE) as u32;
+        let vertex_count = (vertex_bytes as u64 / VERTEX_STRIDE) as u32;
 
         let mut encoder = self
             .device
@@ -541,7 +545,7 @@ impl Gpu {
             if vertex_count > 0 {
                 pass.set_pipeline(&self.pipeline);
                 pass.set_bind_group(0, &self.camera_bind_group, &[]);
-                pass.set_vertex_buffer(0, self.vertex_buffer.slice(..vertex_bytes));
+                pass.set_vertex_buffer(0, self.vertex_buffer.slice(..vertex_bytes as u64));
                 pass.draw(0..vertex_count, 0..1);
                 if let Some(wire) = &self.wire_pipeline {
                     pass.set_pipeline(wire);


### PR DESCRIPTION
## Summary

- Truncate `aether.draw_triangle` mail at the desktop chassis render sink boundary, rounded down to whole `DrawTriangle` (72 bytes) units, instead of dropping the entire frame downstream when accumulated vertex bytes exceed `VERTEX_BUFFER_BYTES`. Surfaces a single warn log per oversized batch with `accepted_bytes` / `dropped_bytes`; the `render_impl` overflow guard stays as a defensive backstop.
- Replace `mem::take` on the per-frame drain with `mem::replace(.., Vec::with_capacity(VERTEX_BUFFER_BYTES))` so the sink buffer doesn't collapse to zero capacity and re-allocate every frame.
- Widen `VERTEX_BUFFER_BYTES` from `u64` to `pub(crate) usize` so `main.rs` can use it for the sink-side clamp; the wgpu `size:` upload casts `as u64` at the boundary.

Closes #389

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [ ] MCP smoke: load mesh viewer, drive it through a sphere with subdivisions large enough to overflow 4 MiB; verify the window keeps drawing the truncated frame and `engine_logs --level warn` shows the new "render sink dropped triangles" message instead of the prior "dropping frame: vertex bytes exceed fixed buffer".