### PR TITLE
fix(substrate-core): derive component input subscriptions substrate-side (issue 403)

### DIFF
--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -852,7 +852,17 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
         ));
     }
 
-    let wrapped_init = wrap_init_with_subscribes(init_method, &handlers)?;
+    // Issue #403: the SDK no longer prepends `ctx.subscribe_input::<K>()`
+    // calls to `init` for the substrate's six fixed input streams (Tick,
+    // Key, KeyRelease, MouseMove, MouseButton, WindowSize). Pre-#403
+    // those calls fired during `Component::instantiate` — i.e. *before*
+    // `try_register_component` published the mailbox — and were rejected
+    // by `validate_subscriber_mailbox`. The substrate now derives those
+    // subscriptions from the component's `aether.kinds.inputs` manifest
+    // post-register. The `Ctx::subscribe_input` runtime API is still
+    // available for components that want to subscribe / unsubscribe at
+    // runtime (e.g. conditional input streams).
+    let wrapped_init = init_method;
     let dispatch_body = build_dispatch_body(&handlers, fallback.as_ref());
 
     let handler_methods_tokens = handlers.iter().map(|h| &h.method);
@@ -991,62 +1001,6 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
         #( #arms )*
         #tail
     }
-}
-
-/// Rewrite the user's `fn init` so its body is prepended with
-/// `ctx.subscribe_input::<K>()` for every handler kind `K` where
-/// `K::IS_INPUT` (ADR-0021, ADR-0030 Phase 2). Non-input kinds fold
-/// out at const-eval. Replaces the ADR-0027 `KindList::resolve_all`
-/// walker that phase 3 retires.
-fn wrap_init_with_subscribes(
-    mut init_method: syn::ImplItemFn,
-    handlers: &[HandlerFn],
-) -> syn::Result<syn::ImplItemFn> {
-    let ctx_ident = init_ctx_param_ident(&init_method.sig)?;
-    let subscribe_stmts: Vec<syn::Stmt> = handlers
-        .iter()
-        .map(|h| {
-            let k = &h.kind_ty;
-            syn::parse_quote! {
-                if <#k as ::aether_component::__macro_internals::Kind>::IS_INPUT {
-                    #ctx_ident.subscribe_input::<#k>();
-                }
-            }
-        })
-        .collect();
-    // Prepend: splice the subscribe block before the user's body so
-    // subscriptions are live before any user-side work (including
-    // `send`s that might race the first tick).
-    let mut new_stmts: Vec<syn::Stmt> = subscribe_stmts;
-    new_stmts.append(&mut init_method.block.stmts);
-    init_method.block.stmts = new_stmts;
-    Ok(init_method)
-}
-
-/// Pull the identifier of `init`'s `ctx` parameter so the synthesized
-/// subscribe calls reference the same binding the user's body uses.
-/// Accepts the conventional `ctx: &mut InitCtx<'_>` signature; any
-/// deviation is flagged with a clear error.
-fn init_ctx_param_ident(sig: &Signature) -> syn::Result<syn::Ident> {
-    if sig.inputs.len() != 1 {
-        return Err(syn::Error::new_spanned(
-            sig,
-            "#[handlers] requires `fn init(ctx: &mut InitCtx<'_>) -> Self`",
-        ));
-    }
-    let FnArg::Typed(pt) = &sig.inputs[0] else {
-        return Err(syn::Error::new_spanned(
-            &sig.inputs[0],
-            "#[handlers] `init` cannot take `self`",
-        ));
-    };
-    let syn::Pat::Ident(pat_ident) = pt.pat.as_ref() else {
-        return Err(syn::Error::new_spanned(
-            &pt.pat,
-            "#[handlers] `init` ctx param must be a plain binding (e.g. `ctx: &mut InitCtx<'_>`)",
-        ));
-    };
-    Ok(pat_ident.ident.clone())
 }
 
 /// Emit the `#[link_section = "aether.kinds.inputs"]` statics — one

--- a/crates/aether-mesh-viewer-component/src/lib.rs
+++ b/crates/aether-mesh-viewer-component/src/lib.rs
@@ -101,20 +101,41 @@ impl Component for MeshViewer {
     /// root and must end in `.dsl` or `.obj`.
     #[handler]
     fn on_load(&mut self, _ctx: &mut Ctx<'_>, msg: LoadMesh) {
+        tracing::info!(
+            target: "aether_mesh_viewer",
+            namespace = %msg.namespace,
+            path = %msg.path,
+            "load requested; issuing read",
+        );
         io::read(&msg.namespace, &msg.path);
     }
 
     /// Consumes the substrate's I/O reply. Dispatches on the echoed
     /// `path`'s extension and replaces the cached triangle list on
     /// success. Any failure (read error, non-utf8, parse error,
-    /// unknown extension) silently leaves the previous cache intact.
+    /// unknown extension) leaves the previous cache intact, with a
+    /// warn log explaining the failure.
     ///
     /// # Agent
     /// Substrate-driven; do not send manually.
     #[handler]
     fn on_read_result(&mut self, _ctx: &mut Ctx<'_>, r: ReadResult) {
-        let ReadResult::Ok { path, bytes, .. } = r else {
-            return;
+        let (path, bytes) = match r {
+            ReadResult::Ok { path, bytes, .. } => (path, bytes),
+            ReadResult::Err {
+                namespace,
+                path,
+                error,
+            } => {
+                tracing::warn!(
+                    target: "aether_mesh_viewer",
+                    namespace = %namespace,
+                    path = %path,
+                    error = ?error,
+                    "read failed; keeping prior mesh",
+                );
+                return;
+            }
         };
         let Ok(text) = core::str::from_utf8(&bytes) else {
             tracing::warn!(
@@ -171,12 +192,25 @@ impl MeshViewer {
                 out.push(to_draw_triangle_rgb(tri, OUTLINE_RGB));
             }
         }
+        tracing::info!(
+            target: "aether_mesh_viewer",
+            polygons = polygons.len(),
+            triangles = out.len(),
+            "DSL load complete; cache replaced",
+        );
         self.triangles = out;
     }
 
     fn try_replace_obj(&mut self, obj: &str) {
         match parse_obj(obj) {
-            Ok(tris) => self.triangles = tris,
+            Ok(tris) => {
+                tracing::info!(
+                    target: "aether_mesh_viewer",
+                    triangles = tris.len(),
+                    "OBJ load complete; cache replaced",
+                );
+                self.triangles = tris;
+            }
             Err(error) => tracing::warn!(
                 target: "aether_mesh_viewer",
                 error = ?error,

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -85,6 +85,48 @@ fn register_or_match_all(
     Ok(())
 }
 
+/// Map an input-kind name to its `InputStream` variant. Used by the
+/// load / replace paths to derive auto-subscriptions from the
+/// component's `aether.kinds.inputs` manifest, so a component that
+/// declares an input handler is wired to the matching stream without
+/// the guest SDK needing to round-trip through `subscribe_input` at
+/// init time (which races mailbox registration — issue #403).
+///
+/// User-space input kinds (anything outside the substrate's six fixed
+/// streams) return `None`; those continue to ride the explicit
+/// `ctx.subscribe_input::<K>()` runtime API.
+fn input_stream_for_kind_name(name: &str) -> Option<aether_kinds::InputStream> {
+    use aether_kinds::InputStream;
+    match name {
+        "aether.tick" => Some(InputStream::Tick),
+        "aether.key" => Some(InputStream::Key),
+        "aether.key_release" => Some(InputStream::KeyRelease),
+        "aether.mouse_move" => Some(InputStream::MouseMove),
+        "aether.mouse_button" => Some(InputStream::MouseButton),
+        "aether.window_size" => Some(InputStream::WindowSize),
+        _ => None,
+    }
+}
+
+/// Wire the freshly-registered mailbox into every input-stream
+/// subscriber set its handler manifest declares. Called by `handle_
+/// load` (after `try_register_component`) and `handle_replace` (after
+/// the dispatcher swap commits) so the auto-subscribe is observable
+/// the moment the component is reachable, with no `subscribe_input`
+/// reply to wait on.
+fn auto_subscribe_inputs(
+    input_subscribers: &InputSubscribers,
+    mailbox: MailboxId,
+    capabilities: &aether_kinds::ComponentCapabilities,
+) {
+    let mut subs = input_subscribers.write().unwrap();
+    for handler in &capabilities.handlers {
+        if let Some(stream) = input_stream_for_kind_name(&handler.name) {
+            subs.entry(stream).or_default().insert(mailbox);
+        }
+    }
+}
+
 /// Shared validation for `subscribe_input` / `unsubscribe_input`: the
 /// mailbox id must name a live component. Sinks are rejected because
 /// they handle mail inline and have no business receiving fan-out
@@ -266,10 +308,14 @@ impl ControlPlane {
         // `Component::instantiate` (which calls `init(mailbox_id)`)
         // run *before* publishing the mailbox — on instantiate
         // failure the registry is untouched and the name remains
-        // available for a retry. Subscribe-input mail emitted from
-        // `init` carries the still-unpublished id, which is fine: the
-        // subscriber set is recorded against the id and will be valid
-        // by the time the platform thread fans out events.
+        // available for a retry. Auto-subscriptions are not driven
+        // from `init` for that reason (issue #403): a `subscribe_
+        // input` mail emitted before `try_register_component` would
+        // race against `validate_subscriber_mailbox` and be rejected
+        // as an unknown id. Instead, the substrate derives the
+        // subscription set from the component's `aether.kinds.inputs`
+        // manifest after the mailbox is published — see
+        // `auto_subscribe_inputs` below.
         let mailbox = MailboxId::from_name(&name);
 
         let ctx = SubstrateCtx::new(
@@ -312,6 +358,14 @@ impl ControlPlane {
             registered, mailbox,
             "registered mailbox id must match precomputed id from name hash",
         );
+
+        // Issue #403: derive auto-subscriptions from the handler
+        // manifest now that the mailbox is registered. The guest SDK
+        // no longer fires `subscribe_input` mail during `init` for the
+        // six fixed substrate input streams; the substrate wires them
+        // directly so the subscribe is observable the moment the
+        // component is reachable.
+        auto_subscribe_inputs(&self.input_subscribers, mailbox, &capabilities);
 
         self.insert_component(mailbox, component);
         self.announce_kinds();
@@ -566,6 +620,16 @@ impl ControlPlane {
             Arc::clone(&self.registry),
             Arc::clone(&self.queue),
         );
+
+        // Issue #403: drive auto-subscriptions substrate-side here
+        // too, now that the SDK walker is retired. Replace is
+        // additive — existing subscriptions (whether they came from
+        // the prior binary's manifest or from a runtime
+        // `ctx.subscribe_input::<K>()` call) are preserved (ADR-0021
+        // §4: "subscriptions are preserved across replace_component").
+        // We only ensure the new manifest's input streams are wired,
+        // matching the pre-#403 SDK walker behaviour.
+        auto_subscribe_inputs(&self.input_subscribers, id, &capabilities);
 
         self.announce_kinds();
         ReplaceResult::Ok { capabilities }
@@ -1779,6 +1843,102 @@ mod tests {
         assert!(matches!(result, ReplaceResult::Ok { .. }));
         assert!(subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
         assert!(subs(&plane, InputStream::Key).contains(&MailboxId(id)));
+    }
+
+    #[test]
+    fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
+        // Issue #403 regression: a component declaring an input handler
+        // in its `aether.kinds.inputs` manifest must end up in the
+        // matching stream's subscriber set after `handle_load` /
+        // `handle_replace` register it. Pre-fix the SDK fired
+        // `subscribe_input` mail during `init`, before the mailbox was
+        // in the registry, and `validate_subscriber_mailbox` rejected
+        // the unknown id — silently. The substrate now derives the
+        // subscriptions from the manifest after registering, and this
+        // test pins that wiring.
+        use aether_kinds::{ComponentCapabilities, HandlerCapability, InputStream};
+        use aether_mail::KindId;
+        let mailbox = MailboxId(0xdead_beef);
+        let subscribers = input::new_subscribers();
+        let capabilities = ComponentCapabilities {
+            handlers: vec![
+                HandlerCapability {
+                    id: KindId(0),
+                    name: "aether.tick".into(),
+                    doc: None,
+                },
+                HandlerCapability {
+                    id: KindId(0),
+                    name: "aether.window_size".into(),
+                    doc: None,
+                },
+                // User-space kind names fall through — the runtime API
+                // (`ctx.subscribe_input::<K>()`) handles those.
+                HandlerCapability {
+                    id: KindId(0),
+                    name: "user.custom.event".into(),
+                    doc: None,
+                },
+            ],
+            fallback: None,
+            doc: None,
+        };
+        super::auto_subscribe_inputs(&subscribers, mailbox, &capabilities);
+        let snapshot = subscribers.read().unwrap();
+        assert!(
+            snapshot
+                .get(&InputStream::Tick)
+                .is_some_and(|set| set.contains(&mailbox)),
+            "Tick handler should auto-subscribe the mailbox",
+        );
+        assert!(
+            snapshot
+                .get(&InputStream::WindowSize)
+                .is_some_and(|set| set.contains(&mailbox)),
+            "WindowSize handler should auto-subscribe the mailbox",
+        );
+        for stream in [
+            InputStream::Key,
+            InputStream::KeyRelease,
+            InputStream::MouseMove,
+            InputStream::MouseButton,
+        ] {
+            assert!(
+                snapshot
+                    .get(&stream)
+                    .is_none_or(|set| !set.contains(&mailbox)),
+                "{stream:?} should not be subscribed when the manifest \
+                 doesn't declare its handler",
+            );
+        }
+    }
+
+    #[test]
+    fn input_stream_for_kind_name_covers_six_substrate_streams() {
+        use aether_kinds::InputStream;
+        let cases = [
+            ("aether.tick", InputStream::Tick),
+            ("aether.key", InputStream::Key),
+            ("aether.key_release", InputStream::KeyRelease),
+            ("aether.mouse_move", InputStream::MouseMove),
+            ("aether.mouse_button", InputStream::MouseButton),
+            ("aether.window_size", InputStream::WindowSize),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(super::input_stream_for_kind_name(name), Some(expected));
+        }
+        // Every other kind name (substrate sink kinds, control kinds,
+        // user-space kinds) must return None so the runtime API stays
+        // the only path for non-stream subscriptions.
+        for name in [
+            "aether.draw_triangle",
+            "aether.camera",
+            "aether.io.read",
+            "aether.control.subscribe_input",
+            "user.custom.event",
+        ] {
+            assert_eq!(super::input_stream_for_kind_name(name), None);
+        }
     }
 
     #[test]

--- a/crates/aether-substrate-core/src/control.rs
+++ b/crates/aether-substrate-core/src/control.rs
@@ -28,10 +28,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use aether_hub_protocol::{EngineToHub, KindDescriptor};
 use aether_kinds::{
-    DropComponent, DropResult, LoadComponent, LoadResult, MailEnvelope, ReplaceComponent,
-    ReplaceResult, SubscribeInput, SubscribeInputResult, UnsubscribeInput,
+    ComponentCapabilities, DropComponent, DropResult, InputStream, Key, KeyRelease, LoadComponent,
+    LoadResult, MailEnvelope, MouseButton, MouseMove, ReplaceComponent, ReplaceResult,
+    SubscribeInput, SubscribeInputResult, Tick, UnsubscribeInput, WindowSize,
 };
-use aether_mail::Kind;
+#[cfg(test)]
+use aether_kinds::{DrawTriangle, HandlerCapability};
+use aether_mail::{Kind, KindId};
 use wasmtime::{Engine, Linker, Module};
 
 use crate::component::Component;
@@ -85,27 +88,39 @@ fn register_or_match_all(
     Ok(())
 }
 
-/// Map an input-kind name to its `InputStream` variant. Used by the
+/// The substrate's six fixed input streams paired with the typed
+/// `Kind::ID` constants that drive them. `K::ID` is a compile-time
+/// const, so the table folds at const-eval; a rename or schema
+/// change on either side trips a compile error here instead of a
+/// silent name-string miss.
+///
+/// Temporary by design — this bridge between the closed `InputStream`
+/// enum and `KindId` exists only because `InputStream` is a separate
+/// identifier. Issue #405 retires the enum and keys subscribers by
+/// `KindId` directly, at which point this table goes away entirely.
+const INPUT_STREAM_KINDS: &[(u64, InputStream)] = &[
+    (Tick::ID, InputStream::Tick),
+    (Key::ID, InputStream::Key),
+    (KeyRelease::ID, InputStream::KeyRelease),
+    (MouseMove::ID, InputStream::MouseMove),
+    (MouseButton::ID, InputStream::MouseButton),
+    (WindowSize::ID, InputStream::WindowSize),
+];
+
+/// Map an input-kind id to its `InputStream` variant. Used by the
 /// load / replace paths to derive auto-subscriptions from the
 /// component's `aether.kinds.inputs` manifest, so a component that
 /// declares an input handler is wired to the matching stream without
 /// the guest SDK needing to round-trip through `subscribe_input` at
 /// init time (which races mailbox registration — issue #403).
 ///
-/// User-space input kinds (anything outside the substrate's six fixed
-/// streams) return `None`; those continue to ride the explicit
+/// User-space input kinds (anything outside the substrate's six
+/// fixed streams) return `None`; those continue to ride the explicit
 /// `ctx.subscribe_input::<K>()` runtime API.
-fn input_stream_for_kind_name(name: &str) -> Option<aether_kinds::InputStream> {
-    use aether_kinds::InputStream;
-    match name {
-        "aether.tick" => Some(InputStream::Tick),
-        "aether.key" => Some(InputStream::Key),
-        "aether.key_release" => Some(InputStream::KeyRelease),
-        "aether.mouse_move" => Some(InputStream::MouseMove),
-        "aether.mouse_button" => Some(InputStream::MouseButton),
-        "aether.window_size" => Some(InputStream::WindowSize),
-        _ => None,
-    }
+fn input_stream_for_kind_id(id: KindId) -> Option<InputStream> {
+    INPUT_STREAM_KINDS
+        .iter()
+        .find_map(|(k, s)| (id.0 == *k).then_some(*s))
 }
 
 /// Wire the freshly-registered mailbox into every input-stream
@@ -117,11 +132,11 @@ fn input_stream_for_kind_name(name: &str) -> Option<aether_kinds::InputStream> {
 fn auto_subscribe_inputs(
     input_subscribers: &InputSubscribers,
     mailbox: MailboxId,
-    capabilities: &aether_kinds::ComponentCapabilities,
+    capabilities: &ComponentCapabilities,
 ) {
     let mut subs = input_subscribers.write().unwrap();
     for handler in &capabilities.handlers {
-        if let Some(stream) = input_stream_for_kind_name(&handler.name) {
+        if let Some(stream) = input_stream_for_kind_id(handler.id) {
             subs.entry(stream).or_default().insert(mailbox);
         }
     }
@@ -683,7 +698,7 @@ mod tests {
             LoadResult::Ok {
                 mailbox_id: MailboxId(7),
                 name: "x".into(),
-                capabilities: aether_kinds::ComponentCapabilities::default(),
+                capabilities: ComponentCapabilities::default(),
             },
             LoadResult::Err {
                 error: "nope".into(),
@@ -1631,8 +1646,10 @@ mod tests {
     // replace-preserves-subscriptions. `make_plane` already threads an
     // empty `InputSubscribers` into the handler, so these tests only
     // need to load a component and exercise the subscribe surface.
-
-    use aether_kinds::{InputStream, SubscribeInput, SubscribeInputResult, UnsubscribeInput};
+    // (The types these tests use — `InputStream`, `SubscribeInput`,
+    // `SubscribeInputResult`, `UnsubscribeInput` — come in via the
+    // top-level `use aether_kinds::{...}` plus the test mod's
+    // `use super::*;`; no inline import needed.)
 
     fn subs(plane: &ControlPlane, stream: InputStream) -> std::collections::BTreeSet<MailboxId> {
         plane
@@ -1856,26 +1873,24 @@ mod tests {
         // the unknown id — silently. The substrate now derives the
         // subscriptions from the manifest after registering, and this
         // test pins that wiring.
-        use aether_kinds::{ComponentCapabilities, HandlerCapability, InputStream};
-        use aether_mail::KindId;
         let mailbox = MailboxId(0xdead_beef);
         let subscribers = input::new_subscribers();
         let capabilities = ComponentCapabilities {
             handlers: vec![
                 HandlerCapability {
-                    id: KindId(0),
-                    name: "aether.tick".into(),
+                    id: KindId(Tick::ID),
+                    name: Tick::NAME.into(),
                     doc: None,
                 },
                 HandlerCapability {
-                    id: KindId(0),
-                    name: "aether.window_size".into(),
+                    id: KindId(WindowSize::ID),
+                    name: WindowSize::NAME.into(),
                     doc: None,
                 },
-                // User-space kind names fall through — the runtime API
+                // User-space kinds fall through — the runtime API
                 // (`ctx.subscribe_input::<K>()`) handles those.
                 HandlerCapability {
-                    id: KindId(0),
+                    id: KindId(0xdeadbeef_cafef00d),
                     name: "user.custom.event".into(),
                     doc: None,
                 },
@@ -1883,7 +1898,7 @@ mod tests {
             fallback: None,
             doc: None,
         };
-        super::auto_subscribe_inputs(&subscribers, mailbox, &capabilities);
+        auto_subscribe_inputs(&subscribers, mailbox, &capabilities);
         let snapshot = subscribers.read().unwrap();
         assert!(
             snapshot
@@ -1914,31 +1929,32 @@ mod tests {
     }
 
     #[test]
-    fn input_stream_for_kind_name_covers_six_substrate_streams() {
-        use aether_kinds::InputStream;
+    fn input_stream_for_kind_id_covers_six_substrate_streams() {
         let cases = [
-            ("aether.tick", InputStream::Tick),
-            ("aether.key", InputStream::Key),
-            ("aether.key_release", InputStream::KeyRelease),
-            ("aether.mouse_move", InputStream::MouseMove),
-            ("aether.mouse_button", InputStream::MouseButton),
-            ("aether.window_size", InputStream::WindowSize),
+            (Tick::ID, InputStream::Tick),
+            (Key::ID, InputStream::Key),
+            (KeyRelease::ID, InputStream::KeyRelease),
+            (MouseMove::ID, InputStream::MouseMove),
+            (MouseButton::ID, InputStream::MouseButton),
+            (WindowSize::ID, InputStream::WindowSize),
         ];
-        for (name, expected) in cases {
-            assert_eq!(super::input_stream_for_kind_name(name), Some(expected));
+        for (id, expected) in cases {
+            assert_eq!(input_stream_for_kind_id(KindId(id)), Some(expected));
         }
-        // Every other kind name (substrate sink kinds, control kinds,
-        // user-space kinds) must return None so the runtime API stays
-        // the only path for non-stream subscriptions.
-        for name in [
-            "aether.draw_triangle",
-            "aether.camera",
-            "aether.io.read",
-            "aether.control.subscribe_input",
-            "user.custom.event",
-        ] {
-            assert_eq!(super::input_stream_for_kind_name(name), None);
-        }
+        // Non-input substrate kinds and user-space ids must return None
+        // so the runtime API stays the only path for non-stream
+        // subscriptions. `DrawTriangle::ID` covers the substrate-side
+        // ringer; the literal handles the user-space case.
+        assert_eq!(
+            input_stream_for_kind_id(KindId(DrawTriangle::ID)),
+            None,
+            "non-input substrate kinds must not auto-subscribe",
+        );
+        assert_eq!(
+            input_stream_for_kind_id(KindId(0xdeadbeef_cafef00d)),
+            None,
+            "user-space ids must not auto-subscribe",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move auto-subscription for the substrate's six fixed input streams (Tick, Key, KeyRelease, MouseMove, MouseButton, WindowSize) out of the SDK's `init` walker and into the substrate. The substrate now walks `aether.kinds.inputs` *after* `try_register_component` succeeds (in `handle_load`) and after the dispatcher swap commits (in `handle_replace`), inserting the mailbox into the matching subscriber set directly.
- Retire `wrap_init_with_subscribes` in `aether-mail-derive`. The runtime API `Ctx::subscribe_input::<K>()` stays for conditional / user-space-stream subscriptions.
- Add unit tests for `auto_subscribe_inputs` (manifest → subscriber set wiring) and `input_stream_for_kind_name` (the six fixed streams + None for everything else).
- Surface viewer load-chain failures while here: `ReadResult::Err` no longer returns silently — warn-logs namespace + path + `IoError`.

## Why

Issue 403: post-PR-399, components loaded by `handle_load` silently lost every input-stream subscription. The SDK's `#[handlers]` macro fired `aether.control.subscribe_input` from inside `init`, but `init` runs before `try_register_component` publishes the mailbox. `validate_subscriber_mailbox` rejected the unknown id and the subscriber set was never updated.

Visible effects: camera component never published `view_proj` (no Tick), mesh-viewer never re-emitted cached triangles (no Tick), every component using Tick / Key / WindowSize was silently broken.

Option A from the issue: substrate-side derivation. Keeps PR 399's no-rollback property; the manifest is the source of truth for what the component handles. Replace stays additive per ADR-0021 §4 — the new manifest's streams are re-subscribed on top of whatever was registered, runtime subscriptions survive.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] `cargo check -p aether-camera-component --target wasm32-unknown-unknown`
- [x] `cargo check -p aether-mesh-viewer-component --target wasm32-unknown-unknown`
- [x] Live MCP smoke: spawned substrate with camera + viewer, sent `aether.mesh.load box.obj` + `aether.camera.orbit.set { distance: 3, pitch: -0.6, yaw: 0.7, speed: 0 }`. Frame stats showed `triangles=12` per frame (12 × 120Hz cumulative). `capture_frame` returned the cube from the requested orbit angle. Both Tick subscriptions confirmed live.

## Follow-up

- A real prevention story for this class of bug needs E2E integration tests using the smoke binary tracked in issue 400. The unit tests added here pin the immediate logic; the smoke harness is what catches \"does the component actually receive Tick after load?\" without a hand-driven MCP session.

Closes #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)