### PR TITLE
feat: scaffold aether-substrate-test-bench chassis (issue 400)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-substrate-test-bench"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-hub-protocol",
+ "aether-kinds",
+ "aether-mail",
+ "aether-substrate-core",
+ "bytemuck",
+ "png",
+ "pollster",
+ "tracing",
+ "wasmtime",
+ "wgpu",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/aether-substrate-desktop",
     "crates/aether-substrate-headless",
     "crates/aether-substrate-hub",
+    "crates/aether-substrate-test-bench",
     "crates/aether-kinds",
     "crates/aether-math",
     "crates/aether-component",

--- a/crates/aether-substrate-test-bench/Cargo.toml
+++ b/crates/aether-substrate-test-bench/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "aether-substrate-test-bench"
+version.workspace = true
+edition.workspace = true
+
+# ADR-0067 test-bench chassis binary: GPU-capable, no window, no
+# winit. Mirrors the desktop chassis's offscreen render path
+# (offscreen color target + depth target + capture readback) but
+# omits surface acquisition and presentation. The shared runtime
+# (scheduler, mail, wasmtime host, control plane, hub client) lives
+# in aether-substrate-core; this crate binds that core to a wgpu
+# device with no presentation surface — suitable for CI smoke
+# verification and Rust integration tests where opening a window
+# isn't an option.
+#
+# v1 keeps the std-timer tick driver from headless. ADR-0067 calls
+# for a control-mail tick driver (`aether.test_bench.advance`) so
+# smoke scripts can advance the mail clock deterministically; that
+# lands in a follow-up PR alongside the new kinds.
+
+[[bin]]
+name = "aether-substrate-test-bench"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+aether-substrate-core = { path = "../aether-substrate-core" }
+aether-hub-protocol = { path = "../aether-hub-protocol" }
+aether-mail = { path = "../aether-mail" }
+aether-kinds = { path = "../aether-kinds" }
+bytemuck = "1.19"
+png = "0.17"
+pollster = "0.4.0"
+tracing = "0.1"
+wasmtime = "30"
+wgpu = "29.0.1"

--- a/crates/aether-substrate-test-bench/src/capture.rs
+++ b/crates/aether-substrate-test-bench/src/capture.rs
@@ -1,0 +1,109 @@
+// Cross-thread handoff for `aether.control.capture_frame` requests.
+//
+// The chassis-side capture_frame handler runs on a scheduler worker;
+// the actual capture (offscreen texture → staging buffer → PNG)
+// happens on the render thread where the wgpu `Device` lives.
+// `CaptureQueue` is the single-slot mailbox between them.
+//
+// One in-flight capture at a time is plenty for v1. If a second
+// request arrives while one is pending, the chassis handler rejects
+// it immediately with `CaptureFrameResult::Err` rather than queuing —
+// keeps the slot a scalar and avoids unbounded buildup if the render
+// thread stalls.
+//
+// Waking the event loop on enqueue is the caller's job now — after a
+// successful `request()`, the desktop chassis handler pokes its
+// `EventLoopProxy<UserEvent>` directly. Keeping the wake out of
+// `CaptureQueue` means this type has zero chassis-awareness and could
+// live in any chassis crate that ever supports captures.
+
+use std::sync::{Arc, Mutex};
+
+use aether_substrate_core::{Mail, ReplyTo};
+
+/// One pending capture request. Carries the reply handle so the
+/// render thread can reply once it has bytes, plus a resolved list
+/// of `after_mails` the control plane already validated; the
+/// render thread pushes them onto the queue after readback, before
+/// replying.
+pub struct PendingCapture {
+    pub reply_to: ReplyTo,
+    pub after_mails: Vec<Mail>,
+}
+
+/// Single-slot queue. Cheaply cloneable (wraps an `Arc`), shared
+/// between the chassis-side control handler and the render thread.
+#[derive(Clone, Default)]
+pub struct CaptureQueue {
+    slot: Arc<Mutex<Option<PendingCapture>>>,
+}
+
+impl CaptureQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Try to install `pending` as the pending capture. Returns `true`
+    /// if the slot was empty and the request is now pending; `false`
+    /// if a capture is already in flight. The caller wakes the event
+    /// loop on success — `CaptureQueue` itself stays chassis-agnostic.
+    pub fn request(&self, pending: PendingCapture) -> bool {
+        let mut slot = self.slot.lock().unwrap();
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(pending);
+        true
+    }
+
+    /// Take the pending capture if one is set. Called by the render
+    /// thread at the start of a frame; leaves the slot empty so the
+    /// next capture request can land before this one completes.
+    pub fn take(&self) -> Option<PendingCapture> {
+        self.slot.lock().unwrap().take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_substrate_core::ReplyTarget;
+
+    use super::*;
+
+    fn reply_to(u: u128) -> ReplyTo {
+        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))
+    }
+
+    fn pending(u: u128) -> PendingCapture {
+        PendingCapture {
+            reply_to: reply_to(u),
+            after_mails: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn request_into_empty_slot_succeeds() {
+        let q = CaptureQueue::new();
+        assert!(q.request(pending(1)));
+    }
+
+    #[test]
+    fn second_request_rejected_while_pending() {
+        let q = CaptureQueue::new();
+        assert!(q.request(pending(1)));
+        assert!(!q.request(pending(2)));
+    }
+
+    #[test]
+    fn take_clears_slot_for_next_request() {
+        let q = CaptureQueue::new();
+        assert!(q.request(pending(1)));
+        let got = q.take().expect("pending");
+        assert_eq!(got.reply_to, reply_to(1));
+        // Slot is empty again.
+        assert!(q.take().is_none());
+        // Next request lands.
+        assert!(q.request(pending(2)));
+    }
+}

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -1,0 +1,127 @@
+//! Test-bench chassis-registered control-plane handler (ADR-0067).
+//!
+//! Mirrors desktop's `chassis_control_handler` for `capture_frame` —
+//! resolves the pre/post mail bundles atomically, pushes the
+//! pre-bundle, hands off a `PendingCapture` to the render thread
+//! via `CaptureQueue`. Test-bench has no winit event loop, so there
+//! is no `EventLoopProxy` hop — the std-timer tick loop polls the
+//! capture queue every iteration.
+//!
+//! `set_window_mode`, `set_window_title`, and `platform_info` reply
+//! `Err { error: "unsupported on test-bench chassis" }` — the
+//! chassis is GPU-capable but has no window peripherals to address.
+//! Same shape as headless's chassis handler for these kinds.
+
+use std::sync::Arc;
+
+use aether_kinds::{
+    CaptureFrame, CaptureFrameResult, PlatformInfo, PlatformInfoResult, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
+};
+use aether_mail::Kind;
+use aether_substrate_core::{
+    ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo,
+    control::{decode_payload, resolve_bundle},
+};
+
+use crate::capture::{CaptureQueue, PendingCapture};
+
+const UNSUPPORTED_WINDOW: &str = "unsupported on test-bench chassis — no window peripherals (set_window_mode, set_window_title, \
+     platform_info are desktop-only)";
+
+pub fn chassis_control_handler(
+    capture_queue: CaptureQueue,
+    registry: Arc<Registry>,
+    queue: Arc<Mailer>,
+    outbound: Arc<HubOutbound>,
+) -> ChassisControlHandler {
+    Arc::new(
+        move |kind_id: u64, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
+            if kind_id == CaptureFrame::ID {
+                handle_capture_frame(&capture_queue, &registry, &queue, &outbound, sender, bytes);
+            } else if kind_id == SetWindowMode::ID {
+                outbound.send_reply(
+                    sender,
+                    &SetWindowModeResult::Err {
+                        error: UNSUPPORTED_WINDOW.to_owned(),
+                    },
+                );
+            } else if kind_id == SetWindowTitle::ID {
+                outbound.send_reply(
+                    sender,
+                    &SetWindowTitleResult::Err {
+                        error: UNSUPPORTED_WINDOW.to_owned(),
+                    },
+                );
+            } else if kind_id == PlatformInfo::ID {
+                outbound.send_reply(
+                    sender,
+                    &PlatformInfoResult::Err {
+                        error: UNSUPPORTED_WINDOW.to_owned(),
+                    },
+                );
+            } else {
+                tracing::warn!(
+                    target: "aether_substrate::chassis",
+                    kind = %kind_name,
+                    "test-bench chassis has no handler for control kind — dropping",
+                );
+            }
+        },
+    )
+}
+
+/// Two-phase capture request. Resolve both mail bundles atomically
+/// against the registry before touching the queue, push pre-mails,
+/// enqueue the capture, return. The tick loop polls the capture
+/// queue each iteration; if a request is pending it calls
+/// `render_and_capture`, pushes after_mails, and replies.
+fn handle_capture_frame(
+    capture_queue: &CaptureQueue,
+    registry: &Registry,
+    queue: &Mailer,
+    outbound: &HubOutbound,
+    sender: ReplyTo,
+    bytes: &[u8],
+) {
+    let payload: CaptureFrame = match decode_payload(bytes) {
+        Ok(p) => p,
+        Err(error) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error });
+            return;
+        }
+    };
+
+    let pre = match resolve_bundle(registry, &payload.mails, "capture bundle") {
+        Ok(v) => v,
+        Err(e) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
+            return;
+        }
+    };
+    let after = match resolve_bundle(registry, &payload.after_mails, "capture after bundle") {
+        Ok(v) => v,
+        Err(e) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
+            return;
+        }
+    };
+
+    for mail in pre {
+        queue.push(mail);
+    }
+
+    let pending = PendingCapture {
+        reply_to: sender,
+        after_mails: after,
+    };
+    if !capture_queue.request(pending) {
+        outbound.send_reply(
+            sender,
+            &CaptureFrameResult::Err {
+                error: "capture already pending; try again once the in-flight request completes"
+                    .to_owned(),
+            },
+        );
+    }
+}

--- a/crates/aether-substrate-test-bench/src/lib.rs
+++ b/crates/aether-substrate-test-bench/src/lib.rs
@@ -1,0 +1,29 @@
+//! aether-substrate-test-bench: the test-bench chassis binary crate (ADR-0067).
+//!
+//! Holds the wgpu renderer (no presentation surface), the
+//! `CaptureQueue` handoff slot for synchronous capture, and the
+//! chassis-side control-plane handler that owns capture_frame and
+//! replies `Err` on the window-only kinds (set_window_mode,
+//! set_window_title, platform_info). The shared runtime lives in
+//! `aether-substrate-core`; this lib re-exports the subset the
+//! binary and its dependents (the smoke runner per ADR-0067) lean
+//! on.
+//!
+//! The lib + bin split means Rust integration tests can link the
+//! chassis driver directly without going through process spawning.
+
+pub mod capture;
+pub mod chassis;
+pub mod render;
+
+pub use aether_substrate_core::{
+    AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,
+    HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mail, MailKind, MailboxEntry,
+    MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, Scheduler, SinkHandler, SubstrateBoot,
+    SubstrateCtx, component, control, ctx, host_fns, hub_client, input, io, kind_manifest,
+    log_capture, mail, mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler,
+    subscribers_for,
+};
+
+pub use capture::{CaptureQueue, PendingCapture};
+pub use chassis::chassis_control_handler;

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -1,0 +1,410 @@
+// Test-bench chassis binary (ADR-0067). GPU-capable, no window, no
+// winit. wgpu initialises without a presentation surface; every
+// frame renders into an offscreen color target paired with a depth
+// target; capture_frame reads back from that same offscreen.
+//
+// v1 keeps headless's std-timer tick driver. ADR-0067 calls for a
+// control-mail tick driver (`aether.test_bench.advance`) so smoke
+// scripts can advance the mail clock deterministically — that
+// lands in a follow-up PR alongside the new kinds. Until then the
+// chassis ticks at AETHER_TICK_HZ (default 60), same shape as
+// headless.
+
+mod capture;
+mod chassis;
+mod render;
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use aether_kinds::{CaptureFrameResult, FrameStats, InputStream, Tick};
+use aether_mail::{Kind, encode, encode_empty};
+use aether_substrate_core::{
+    Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, ReplyTo, Scheduler,
+    SubstrateBoot,
+    mail::{Mail, MailboxId},
+    subscribers_for,
+};
+
+use crate::capture::CaptureQueue;
+use crate::render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+
+const WORKERS: usize = 2;
+const DEFAULT_TICK_HZ: u32 = 60;
+const LOG_EVERY_FRAMES: u64 = 120;
+
+/// Wire size of one `aether.draw_triangle` mail item: three
+/// vertices, each `f32 x,y,z + f32 r,g,b` (24 bytes). The render
+/// sink clamps at whole-triangle multiples so we never write a
+/// half-triangle into the GPU vertex buffer when the cap forces a
+/// truncate.
+const DRAW_TRIANGLE_BYTES: usize = 72;
+
+/// Default offscreen target size when `AETHER_TEST_BENCH_SIZE` is
+/// unset. 800x600 matches the smoke harness convention — large
+/// enough that `min_non_bg_pixels` thresholds discriminate, small
+/// enough that capture readback is cheap.
+const DEFAULT_WIDTH: u32 = 800;
+const DEFAULT_HEIGHT: u32 = 600;
+
+/// ADR-0063 fail-fast budget for the per-tick drain barrier. Same
+/// 5-second value desktop and headless use — same dispatcher kernel.
+const DRAIN_BUDGET: Duration = Duration::from_secs(5);
+
+/// Test-bench chassis. Owns the tick loop, the GPU, the shared
+/// frame state (vertex buffer, camera matrix), and the capture
+/// queue. `run(self)` takes ownership and drives the loop forever
+/// — process exits on SIGTERM (hub-spawned) or SIGINT (manual run).
+struct TestBenchChassis {
+    queue: Arc<Mailer>,
+    input_subscribers: InputSubscribers,
+    broadcast_mbox: MailboxId,
+    kind_tick: u64,
+    kind_frame_stats: u64,
+    tick_period: Duration,
+    gpu: Gpu,
+    frame_vertices: Arc<Mutex<Vec<u8>>>,
+    camera_state: Arc<Mutex<[f32; 16]>>,
+    triangles_rendered: Arc<AtomicU64>,
+    capture_queue: CaptureQueue,
+    outbound: Arc<HubOutbound>,
+    _scheduler: Scheduler,
+    _hub: Option<aether_substrate_core::HubClient>,
+}
+
+impl Chassis for TestBenchChassis {
+    const KIND: &'static str = "test-bench";
+    const CAPABILITIES: ChassisCapabilities = ChassisCapabilities {
+        has_gpu: true,
+        has_window: false,
+        has_tcp_listener: false,
+    };
+
+    fn run(mut self) -> wasmtime::Result<()> {
+        let started = Instant::now();
+        let mut frame: u64 = 0;
+        let mut next_deadline = Instant::now() + self.tick_period;
+        loop {
+            let now = Instant::now();
+            if now < next_deadline {
+                thread::sleep(next_deadline - now);
+            }
+            next_deadline = Instant::now() + self.tick_period;
+
+            frame += 1;
+            let subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+            for mbox in subs {
+                self.queue
+                    .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
+            }
+            // ADR-0063: budget-aware drain. Same lifecycle handling
+            // headless uses — wedges and component deaths exit the
+            // chassis cleanly via `fatal_abort`.
+            let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
+            if let Some((mailbox, waited)) = summary.wedged {
+                aether_substrate_core::lifecycle::fatal_abort(
+                    &self.outbound,
+                    format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
+                );
+            }
+            if let Some(first) = summary.deaths.first() {
+                for d in &summary.deaths {
+                    tracing::error!(
+                        target: "aether_substrate::lifecycle",
+                        mailbox = ?d.mailbox,
+                        mailbox_name = %d.mailbox_name,
+                        last_kind = %d.last_kind,
+                        reason = %d.reason,
+                        "component died; substrate aborting (ADR-0063)",
+                    );
+                }
+                aether_substrate_core::lifecycle::fatal_abort(
+                    &self.outbound,
+                    format!(
+                        "component died: {} (kind {}) — {}",
+                        first.mailbox_name, first.last_kind, first.reason,
+                    ),
+                );
+            }
+
+            // Drain accumulated vertices and the latest camera. Replace
+            // the vertex buffer with an empty same-capacity Vec so the
+            // 4 MiB allocation isn't rebuilt every frame (matches
+            // desktop's pattern).
+            let verts = std::mem::replace(
+                &mut *self.frame_vertices.lock().unwrap(),
+                Vec::with_capacity(VERTEX_BUFFER_BYTES),
+            );
+            let view_proj = *self.camera_state.lock().unwrap();
+
+            // If a capture is pending, render with capture, push
+            // after_mails, and reply. Otherwise just render.
+            match self.capture_queue.take() {
+                Some(req) => {
+                    let result = match self.gpu.render_and_capture(&verts, &view_proj) {
+                        Ok(png) => CaptureFrameResult::Ok { png },
+                        Err(error) => CaptureFrameResult::Err { error },
+                    };
+                    for mail in req.after_mails {
+                        self.queue.push(mail);
+                    }
+                    self.outbound.send_reply(req.reply_to, &result);
+                }
+                None => {
+                    self.gpu.render(&verts, &view_proj);
+                }
+            }
+
+            if frame.is_multiple_of(LOG_EVERY_FRAMES) {
+                let triangles = self.triangles_rendered.load(Ordering::Relaxed);
+                let stats = FrameStats { frame, triangles };
+                self.queue.push(Mail::new(
+                    self.broadcast_mbox,
+                    self.kind_frame_stats,
+                    encode(&stats),
+                    1,
+                ));
+                let elapsed = started.elapsed().as_secs_f64().max(0.001);
+                tracing::info!(
+                    target: "aether_substrate::frame_loop",
+                    frame = frame,
+                    fps = frame as f64 / elapsed,
+                    triangles,
+                    "test-bench tick",
+                );
+            }
+        }
+    }
+}
+
+fn parse_tick_hz_env() -> u32 {
+    match std::env::var("AETHER_TICK_HZ") {
+        Ok(s) => s
+            .trim()
+            .parse::<u32>()
+            .ok()
+            .filter(|&hz| hz > 0)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    target: "aether_substrate::boot",
+                    value = %s,
+                    "AETHER_TICK_HZ unparseable or zero — falling back to default",
+                );
+                DEFAULT_TICK_HZ
+            }),
+        Err(_) => DEFAULT_TICK_HZ,
+    }
+}
+
+/// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
+/// missing/unparseable input with a warn log so smoke scripts can
+/// see what dimensions they actually got.
+fn parse_size_env() -> (u32, u32) {
+    let raw = match std::env::var("AETHER_TEST_BENCH_SIZE") {
+        Ok(s) => s,
+        Err(_) => return (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+    };
+    let trimmed = raw.trim();
+    if let Some((w, h)) = trimmed.split_once('x')
+        && let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>())
+        && w > 0
+        && h > 0
+    {
+        return (w, h);
+    }
+    tracing::warn!(
+        target: "aether_substrate::boot",
+        value = %raw,
+        "AETHER_TEST_BENCH_SIZE unparseable — falling back to default 800x600",
+    );
+    (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+}
+
+fn main() -> wasmtime::Result<()> {
+    let capture_queue = CaptureQueue::new();
+
+    let boot = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
+        .workers(WORKERS)
+        .chassis_handler({
+            let cq = capture_queue.clone();
+            move |ctx| {
+                Some(chassis::chassis_control_handler(
+                    cq,
+                    Arc::clone(ctx.registry),
+                    Arc::clone(ctx.queue),
+                    Arc::clone(ctx.outbound),
+                ))
+            }
+        })
+        .build()?;
+
+    let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
+    let kind_frame_stats = boot
+        .registry
+        .kind_id(FrameStats::NAME)
+        .expect("FrameStats registered");
+
+    // `aether.sink.render`: real renderer. The tick loop drains
+    // `frame_vertices` each tick, so every `DrawTriangle` emitted
+    // before the next tick is consolidated into one vertex buffer.
+    // Truncate at the sink boundary so a single oversized mesh
+    // degrades gracefully.
+    let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(VERTEX_BUFFER_BYTES)));
+    let triangles_rendered = Arc::new(AtomicU64::new(0));
+    {
+        let verts_for_sink = Arc::clone(&frame_vertices);
+        let tris_for_sink = Arc::clone(&triangles_rendered);
+        boot.registry.register_sink(
+            "aether.sink.render",
+            Arc::new(
+                move |_kind_id: u64,
+                      _kind_name: &str,
+                      _origin: Option<&str>,
+                      _sender: ReplyTo,
+                      bytes: &[u8],
+                      _count: u32| {
+                    let mut verts = verts_for_sink.lock().unwrap();
+                    let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
+                    let write_len = bytes.len().min(available);
+                    let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+                    if write_len > 0 {
+                        verts.extend_from_slice(&bytes[..write_len]);
+                        tris_for_sink
+                            .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+                    }
+                    if write_len < bytes.len() {
+                        tracing::warn!(
+                            target: "aether_substrate::render",
+                            accepted_bytes = write_len,
+                            dropped_bytes = bytes.len() - write_len,
+                            cap = VERTEX_BUFFER_BYTES,
+                            "render sink dropped triangles beyond fixed vertex buffer",
+                        );
+                    }
+                },
+            ),
+        );
+    }
+
+    // `aether.sink.camera`: latest-value-wins. Decode the 64-byte
+    // column-major view_proj and store; the tick loop reads it each
+    // frame and uploads to the GPU uniform.
+    let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
+    {
+        let cam_for_sink = Arc::clone(&camera_state);
+        boot.registry.register_sink(
+            "aether.sink.camera",
+            Arc::new(
+                move |_kind_id: u64,
+                      _kind_name: &str,
+                      _origin: Option<&str>,
+                      _sender: ReplyTo,
+                      bytes: &[u8],
+                      _count: u32| {
+                    if bytes.len() != 64 {
+                        tracing::warn!(
+                            target: "aether_substrate::camera",
+                            got = bytes.len(),
+                            expected = 64,
+                            "camera sink: payload length mismatch, dropping",
+                        );
+                        return;
+                    }
+                    match bytemuck::try_pod_read_unaligned::<[f32; 16]>(bytes) {
+                        Ok(mat) => *cam_for_sink.lock().unwrap() = mat,
+                        Err(e) => tracing::warn!(
+                            target: "aether_substrate::camera",
+                            error = %e,
+                            "camera sink: cast failed, dropping",
+                        ),
+                    }
+                },
+            ),
+        );
+    }
+
+    // `aether.sink.io` per ADR-0041. Test-bench gets the same sink
+    // as desktop / headless — the io path is purely I/O. Boot-time
+    // filesystem failure logs loud and skips the sink (same policy
+    // as the other chassis) rather than failing the whole chassis.
+    match aether_substrate_core::io::build_default_registry() {
+        Ok((registry, roots)) => {
+            tracing::info!(
+                target: "aether_substrate::io",
+                save = %roots.save.display(),
+                assets = %roots.assets.display(),
+                config = %roots.config.display(),
+                "io adapters registered",
+            );
+            boot.registry.register_sink(
+                "aether.sink.io",
+                aether_substrate_core::io::io_sink_handler(registry, Arc::clone(&boot.queue)),
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "aether_substrate::io",
+                error = %e,
+                "io adapter init failed — `io` sink not registered",
+            );
+        }
+    }
+
+    // `aether.sink.log` per ADR-0060. Same handler as desktop and
+    // headless — guest log mail is independent of GPU / windowing.
+    aether_substrate_core::log_sink::register_log_sink(&boot.registry);
+
+    // ADR-0067 sink set is render + camera + io + log. Audio is
+    // skipped (no cpal — smoke tests don't need audio output and
+    // skipping it removes a flaky-driver surface on CI runners).
+    // Net is also out for v1 — smoke tests don't need network
+    // egress, and including it would add a real I/O side channel.
+
+    let (width, height) = parse_size_env();
+    let tick_hz = parse_tick_hz_env();
+    let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
+
+    let gpu = Gpu::new(width, height);
+    tracing::info!(
+        target: "aether_substrate::boot",
+        adapter = %gpu.adapter_info.name,
+        backend = ?gpu.adapter_info.backend,
+        device_type = ?gpu.adapter_info.device_type,
+        width,
+        height,
+        tick_hz,
+        workers = WORKERS,
+        "test-bench componentless boot — load a component via aether.control.load_component",
+    );
+
+    let hub = boot.connect_hub_from_env()?;
+
+    let chassis = TestBenchChassis {
+        queue: boot.queue,
+        input_subscribers: boot.input_subscribers,
+        broadcast_mbox: boot.broadcast_mbox,
+        kind_tick,
+        kind_frame_stats,
+        tick_period,
+        gpu,
+        frame_vertices,
+        camera_state,
+        triangles_rendered,
+        capture_queue,
+        outbound: boot.outbound,
+        _scheduler: boot.scheduler,
+        _hub: hub,
+    };
+    tracing::info!(
+        target: "aether_substrate::boot",
+        kind = TestBenchChassis::KIND,
+        has_gpu = TestBenchChassis::CAPABILITIES.has_gpu,
+        has_window = TestBenchChassis::CAPABILITIES.has_window,
+        has_tcp_listener = TestBenchChassis::CAPABILITIES.has_tcp_listener,
+        "chassis initialised",
+    );
+    chassis.run()
+}

--- a/crates/aether-substrate-test-bench/src/render.rs
+++ b/crates/aether-substrate-test-bench/src/render.rs
@@ -1,0 +1,537 @@
+// wgpu plumbing for the test-bench chassis. Owns the device/queue
+// plus a fixed vertex buffer, a camera uniform buffer + bind group,
+// a shader module, and a render pipeline matching the (pos vec3,
+// color vec3) vertex layout. Each frame the main thread hands in a
+// byte blob drained from the render sink plus the latest camera
+// view_proj; render() uploads both and issues one draw call.
+// World-space vertices flow through the vertex shader's
+// `camera.view_proj * vec4(position, 1.0)` to produce clip space.
+//
+// This is the desktop chassis's render path with the presentation
+// surface and swapchain blit removed (ADR-0067). There is no winit
+// window, so we initialise wgpu without a `Surface`, render into an
+// offscreen texture every frame, and the capture path reads from
+// the same offscreen — exactly the same source desktop's capture
+// uses, just without the parallel swapchain copy.
+//
+// Format is fixed to `Rgba8UnormSrgb` rather than queried from a
+// surface — there's no surface to ask, and committing to RGBA at
+// init time means the readback path doesn't need a BGRA swizzle.
+//
+// Depth: a `Depth32Float` texture paired with the offscreen target
+// is cleared to 1.0 each frame and paired with `LessEqual` depth
+// testing. Same convention as desktop — floors / backdrop geometry
+// at z=0, movers / foreground at z=0.1+.
+
+const VERTEX_STRIDE: u64 = 24; // 3 * f32 position + 3 * f32 color
+pub(crate) const VERTEX_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+const CAMERA_UNIFORM_BYTES: u64 = 64; // 4x4 f32 column-major
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+/// Render target format. Fixed to RGBA so the capture-path readback
+/// can extend straight into its output buffer with no swizzle.
+const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+
+/// Identity matrix in column-major order — what the camera uniform
+/// holds before the first `aether.camera` mail arrives.
+pub const IDENTITY_VIEW_PROJ: [f32; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0, //
+];
+
+/// 256-byte row-alignment required by wgpu's `copy_texture_to_buffer`.
+const COPY_ROW_ALIGN: u32 = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+
+pub struct Gpu {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+    /// Snapshot of the adapter chosen at `new()`. Kept for
+    /// diagnostics — desktop also exposes this for `platform_info`,
+    /// which test-bench replies `Err` to (window-only operation), but
+    /// the field is cheap and lets the boot log report adapter info.
+    pub adapter_info: wgpu::AdapterInfo,
+    /// Resolved adapter limits. Kept for diagnostics; desktop uses
+    /// the equivalent for `platform_info` which test-bench replies
+    /// `Err` to.
+    #[allow(dead_code)]
+    pub limits: wgpu::Limits,
+    width: u32,
+    height: u32,
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    camera_buffer: wgpu::Buffer,
+    camera_bind_group: wgpu::BindGroup,
+    offscreen: OffscreenTarget,
+    depth: DepthTarget,
+    /// Lazily-allocated readback buffer for the capture path.
+    /// Reallocated on resize or first capture after a size change.
+    readback: Option<Readback>,
+}
+
+struct OffscreenTarget {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    width: u32,
+    height: u32,
+}
+
+struct DepthTarget {
+    #[allow(dead_code)] // keep the texture alive; only the view is bound
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+}
+
+struct Readback {
+    buffer: wgpu::Buffer,
+    width: u32,
+    height: u32,
+}
+
+impl Gpu {
+    /// Initialise wgpu with no presentation surface. `width` and
+    /// `height` size the offscreen color + depth targets — they're
+    /// the dimensions every captured frame will report. wgpu picks
+    /// an adapter via `request_adapter` with `compatible_surface:
+    /// None`; on CI runners this resolves to whatever Vulkan/Metal/
+    /// DX12 driver is available (ADR-0067 driver fallback policy).
+    pub fn new(width: u32, height: u32) -> Self {
+        let instance =
+            wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::default(),
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("no compatible wgpu adapter");
+        let adapter_info = adapter.get_info();
+        let limits = wgpu::Limits::default();
+
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("aether-test-bench device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: limits.clone(),
+            experimental_features: wgpu::ExperimentalFeatures::default(),
+            memory_hints: wgpu::MemoryHints::default(),
+            trace: wgpu::Trace::default(),
+        }))
+        .expect("request_device");
+
+        let width = width.max(1);
+        let height = height.max(1);
+
+        let offscreen = create_offscreen(&device, COLOR_FORMAT, width, height);
+        let depth = create_depth(&device, width, height);
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("test-bench shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+        });
+
+        let camera_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("camera bind group layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(CAMERA_UNIFORM_BYTES),
+                    },
+                    count: None,
+                }],
+            });
+
+        let camera_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("camera uniform"),
+            size: CAMERA_UNIFORM_BYTES,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&camera_buffer, 0, bytemuck::cast_slice(&IDENTITY_VIEW_PROJ));
+
+        let camera_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("camera bind group"),
+            layout: &camera_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: camera_buffer.as_entire_binding(),
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("test-bench pipeline layout"),
+            bind_group_layouts: &[Some(&camera_bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let vertex_layout = wgpu::VertexBufferLayout {
+            array_stride: VERTEX_STRIDE,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+                wgpu::VertexAttribute {
+                    offset: 12,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+            ],
+        };
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("test-bench pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: std::slice::from_ref(&vertex_layout),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: COLOR_FORMAT,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: Some(true),
+                depth_compare: Some(wgpu::CompareFunction::LessEqual),
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("test-bench vertex buffer"),
+            size: VERTEX_BUFFER_BYTES as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            device,
+            queue,
+            adapter_info,
+            limits,
+            width,
+            height,
+            pipeline,
+            vertex_buffer,
+            camera_buffer,
+            camera_bind_group,
+            offscreen,
+            depth,
+            readback: None,
+        }
+    }
+
+    /// Resize the offscreen target. Test-bench has no surface, so a
+    /// resize just reallocates the offscreen color + depth textures
+    /// and invalidates the readback buffer. Smoke scripts that need
+    /// a different aspect ratio can mail an advance-style control to
+    /// trigger this — for v1 the size is fixed at boot.
+    #[allow(dead_code)] // wired in PR2 alongside test_bench.advance kinds
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.width = width;
+        self.height = height;
+        self.offscreen = create_offscreen(&self.device, COLOR_FORMAT, width, height);
+        self.depth = create_depth(&self.device, width, height);
+        self.readback = None;
+    }
+
+    pub fn render(&mut self, vertices: &[u8], view_proj: &[f32; 16]) {
+        let _ = self.render_impl(vertices, view_proj, false);
+    }
+
+    /// Variant of `render` that also copies the offscreen texture
+    /// into a readback buffer, maps it, and returns an encoded PNG.
+    /// On any capture-path failure, returns `Err(reason)`; the frame
+    /// still rendered to the offscreen — capture is a side channel.
+    pub fn render_and_capture(
+        &mut self,
+        vertices: &[u8],
+        view_proj: &[f32; 16],
+    ) -> Result<Vec<u8>, String> {
+        self.render_impl(vertices, view_proj, true)
+            .ok_or_else(|| "capture did not produce a result".to_owned())?
+    }
+
+    /// Draw `vertices` into the offscreen target with `view_proj` as
+    /// the camera uniform, optionally encode a capture copy. Returns
+    /// `Some(Ok(png))` / `Some(Err(reason))` when `capture` is set;
+    /// `None` when `capture` is false or the capture path couldn't
+    /// allocate. There is no presentation step — desktop's swapchain
+    /// blit is omitted because there's no surface.
+    fn render_impl(
+        &mut self,
+        vertices: &[u8],
+        view_proj: &[f32; 16],
+        capture: bool,
+    ) -> Option<Result<Vec<u8>, String>> {
+        let vertex_bytes = vertices.len();
+        if vertex_bytes > VERTEX_BUFFER_BYTES {
+            tracing::warn!(
+                target: "aether_substrate::render",
+                vertex_bytes,
+                cap = VERTEX_BUFFER_BYTES,
+                "dropping frame: vertex bytes exceed fixed buffer",
+            );
+            return None;
+        }
+        if !vertices.is_empty() {
+            self.queue.write_buffer(&self.vertex_buffer, 0, vertices);
+        }
+        self.queue
+            .write_buffer(&self.camera_buffer, 0, bytemuck::cast_slice(view_proj));
+        let vertex_count = (vertex_bytes as u64 / VERTEX_STRIDE) as u32;
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("frame encoder"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("triangle pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.offscreen.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.05,
+                            g: 0.07,
+                            b: 0.12,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &self.depth.view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Discard,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            if vertex_count > 0 {
+                pass.set_pipeline(&self.pipeline);
+                pass.set_bind_group(0, &self.camera_bind_group, &[]);
+                pass.set_vertex_buffer(0, self.vertex_buffer.slice(..vertex_bytes as u64));
+                pass.draw(0..vertex_count, 0..1);
+            }
+        }
+
+        let capture_meta = if capture {
+            Some(self.prepare_capture_copy(&mut encoder))
+        } else {
+            None
+        };
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        capture_meta.map(|meta| self.finish_capture(meta))
+    }
+
+    /// Ensure a readback buffer exists sized to the offscreen
+    /// texture, then encode a copy from the offscreen into it.
+    /// Returns the padded row stride + dims so `finish_capture` can
+    /// map the buffer and strip padding.
+    fn prepare_capture_copy(&mut self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
+        let width = self.offscreen.width;
+        let height = self.offscreen.height;
+        let bytes_per_pixel = 4u32;
+        let unpadded_row_bytes = width * bytes_per_pixel;
+        let padded_row_bytes = align_up(unpadded_row_bytes, COPY_ROW_ALIGN);
+        let buffer_size = u64::from(padded_row_bytes) * u64::from(height);
+
+        let needs_realloc = match &self.readback {
+            Some(rb) => rb.width != width || rb.height != height,
+            None => true,
+        };
+        if needs_realloc {
+            let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("capture readback"),
+                size: buffer_size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+            self.readback = Some(Readback {
+                buffer,
+                width,
+                height,
+            });
+        }
+
+        let readback = self.readback.as_ref().expect("readback just set");
+
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.offscreen.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback.buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row_bytes),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        CaptureMeta {
+            width,
+            height,
+            padded_row_bytes,
+            unpadded_row_bytes,
+        }
+    }
+
+    fn finish_capture(&self, meta: CaptureMeta) -> Result<Vec<u8>, String> {
+        let readback = self
+            .readback
+            .as_ref()
+            .ok_or_else(|| "readback buffer missing".to_owned())?;
+
+        let slice = readback.buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |res| {
+            let _ = tx.send(res);
+        });
+        self.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|e| format!("device poll: {e:?}"))?;
+        rx.recv()
+            .map_err(|e| format!("map channel dropped: {e}"))?
+            .map_err(|e| format!("buffer map failed: {e:?}"))?;
+
+        let mapped = slice.get_mapped_range();
+        // Strip row padding. Format is fixed RGBA so no swizzle is
+        // needed (desktop's path BGRA-swizzles when the surface
+        // picked Bgra8Unorm; test-bench commits to RGBA at init).
+        let mut rgba =
+            Vec::with_capacity((meta.unpadded_row_bytes as usize) * (meta.height as usize));
+        for row in 0..meta.height {
+            let start = (row * meta.padded_row_bytes) as usize;
+            let end = start + meta.unpadded_row_bytes as usize;
+            rgba.extend_from_slice(&mapped[start..end]);
+        }
+        drop(mapped);
+        readback.buffer.unmap();
+
+        encode_png(&rgba, meta.width, meta.height)
+    }
+}
+
+fn create_offscreen(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+) -> OffscreenTarget {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("offscreen color target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    OffscreenTarget {
+        texture,
+        view,
+        width,
+        height,
+    }
+}
+
+fn create_depth(device: &wgpu::Device, width: u32, height: u32) -> DepthTarget {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("depth target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: DEPTH_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    DepthTarget { texture, view }
+}
+
+struct CaptureMeta {
+    width: u32,
+    height: u32,
+    padded_row_bytes: u32,
+    unpadded_row_bytes: u32,
+}
+
+fn align_up(value: u32, alignment: u32) -> u32 {
+    value.div_ceil(alignment) * alignment
+}
+
+fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut out, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| format!("png header: {e}"))?;
+        writer
+            .write_image_data(rgba)
+            .map_err(|e| format!("png write: {e}"))?;
+    }
+    Ok(out)
+}

--- a/crates/aether-substrate-test-bench/src/shader.wgsl
+++ b/crates/aether-substrate-test-bench/src/shader.wgsl
@@ -1,0 +1,36 @@
+// Vertex positions are world-space (x, y, z). The camera uniform
+// `view_proj` (column-major, uploaded verbatim from the
+// `aether.camera` sink) multiplies every vertex to produce clip
+// space. Before the first `Camera` mail arrives the uniform holds
+// identity, so components still emitting clip-space-ish world coords
+// render unchanged.
+
+struct Camera {
+    view_proj: mat4x4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> camera: Camera;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec3<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec3<f32>,
+}
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_pos = camera.view_proj * vec4<f32>(in.position, 1.0);
+    out.color = in.color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(in.color, 1.0);
+}


### PR DESCRIPTION
## Summary

ADR-0067 phase 1 of 6. New chassis sibling to ADR-0035's desktop / headless / hub split: GPU-capable, no window, no winit. Offscreen wgpu init with `compatible_surface: None`, color + depth targets, capture readback from the same offscreen the render pass writes to.

- Lifts desktop's render + capture path with the presentation surface and swapchain blit removed.
- Format pinned to `Rgba8UnormSrgb` so capture extends straight to output bytes (no BGRA swizzle).
- Sink set per ADR-0067: render + camera + io + log. Audio + net are out of v1.
- chassis_control_handler replies Err on set_window_mode / set_window_title / platform_info (mirrors headless); capture_frame runs the same two-phase resolve/push/handoff desktop uses, dispatching via CaptureQueue to the tick loop.
- Tick driver is std-timer (60 Hz default, `AETHER_TICK_HZ` override). Control-mail tick driver `aether.test_bench.advance` lands in PR 2.
- Lib + bin split per ADR-0067 — Rust integration tests (PR 3 onwards) link the lib directly without process spawning.

This PR does not close issue 400; the test-bench + smoke runner ship across 6 PRs and 400 closes on the last one.

## Test plan

- [x] `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` — all clean.
- [x] `cargo test --workspace` — 149+ tests pass; 3 new unit tests covering CaptureQueue.
- [x] Local SIGTERM-bounded run confirms wgpu initialises on Metal (Apple M4 Pro) without a window; chassis logs adapter info, advertises `has_gpu: true, has_window: false`, ticks at 60 Hz.
- [ ] Smoke verification deferred to PR 5 once the smoke harness exists.

## Phasing

| PR | Scope |
|---|---|
| **1 (this)** | Scaffold `aether-substrate-test-bench` |
| 2 | Control-mail tick driver + `aether.test_bench.{advance, advance_result}` kinds |
| 3 | `aether-smoke` library: `Script`, `Runner`, `RunReport`, YAML parser, `TestBench` API |
| 4 | `aether-smoke-cli` + `smoke_dir!` proc-macro |
| 5 | First per-component smokes (mesh-viewer cube, camera stability) |
| 6 | CI workflow + `/delegate` and `/sweep` skill updates; closes issue 400 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)