### PR TITLE
feat: control-mail tick driver for test-bench (issue 400)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1341,6 +1341,39 @@ mod control_plane {
 
     // ADR-0066: `aether.mesh.load` moved to the `aether-mesh-viewer`
     // trunk crate.
+
+    /// `aether.test_bench.advance` — request the test-bench chassis
+    /// step the world forward by `ticks` Tick events. Each tick
+    /// dispatches a `Tick` mail to every subscriber, drains the
+    /// resulting mail to quiescence, and renders one frame. Replies
+    /// with `AdvanceResult` once all ticks have completed.
+    ///
+    /// The test-bench chassis is event-driven (ADR-0067): without
+    /// an `advance` request the world doesn't tick at all. Smoke
+    /// scripts pair this with `capture_frame` to drive deterministic
+    /// "send mail → step N → capture" cycles. Other chassis reply
+    /// `Err { error: "unsupported on <kind> chassis" }` so callers
+    /// fail fast.
+    ///
+    /// Reply: `AdvanceResult`.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.test_bench.advance")]
+    pub struct Advance {
+        pub ticks: u32,
+    }
+
+    /// Reply to `Advance`. `Ok` echoes the number of ticks completed
+    /// (always equal to the request's `ticks` on the happy path —
+    /// the variant is structured so a future partial-completion
+    /// outcome can extend it without widening the kind). `Err`
+    /// carries a free-form reason: chassis doesn't support advance,
+    /// dispatcher wedged mid-advance, etc.
+    #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.test_bench.advance_result")]
+    pub enum AdvanceResult {
+        Ok { ticks_completed: u32 },
+        Err { error: String },
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -17,8 +17,8 @@
 use std::sync::Arc;
 
 use aether_kinds::{
-    CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode, SetWindowModeResult,
-    SetWindowTitle, SetWindowTitleResult, WindowMode,
+    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, WindowMode,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
@@ -92,6 +92,15 @@ pub fn chassis_control_handler(
                 handle_set_window_mode(&proxy, &outbound, sender, bytes);
             } else if kind_id == SetWindowTitle::ID {
                 handle_set_window_title(&proxy, &outbound, sender, bytes);
+            } else if kind_id == Advance::ID {
+                outbound.send_reply(
+                    sender,
+                    &AdvanceResult::Err {
+                        error: "unsupported on desktop chassis — aether.test_bench.advance is \
+                                test-bench-only (ADR-0067)"
+                            .to_owned(),
+                    },
+                );
             } else {
                 tracing::warn!(
                     target: "aether_substrate::chassis",

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -13,8 +13,8 @@
 use std::sync::Arc;
 
 use aether_kinds::{
-    CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode, SetWindowModeResult,
-    SetWindowTitle, SetWindowTitleResult,
+    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{ChassisControlHandler, HubOutbound, ReplyTo};
@@ -43,6 +43,15 @@ pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHand
                     sender,
                     &SetWindowTitleResult::Err {
                         error: UNSUPPORTED.to_owned(),
+                    },
+                );
+            } else if kind_id == Advance::ID {
+                outbound.send_reply(
+                    sender,
+                    &AdvanceResult::Err {
+                        error: "unsupported on headless chassis — aether.test_bench.advance is \
+                                test-bench-only (ADR-0067)"
+                            .to_owned(),
                     },
                 );
             } else if kind_id == PlatformInfo::ID {

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -1,22 +1,25 @@
 //! Test-bench chassis-registered control-plane handler (ADR-0067).
 //!
-//! Mirrors desktop's `chassis_control_handler` for `capture_frame` —
-//! resolves the pre/post mail bundles atomically, pushes the
-//! pre-bundle, hands off a `PendingCapture` to the render thread
-//! via `CaptureQueue`. Test-bench has no winit event loop, so there
-//! is no `EventLoopProxy` hop — the std-timer tick loop polls the
-//! capture queue every iteration.
+//! Owns three custom kinds:
 //!
-//! `set_window_mode`, `set_window_title`, and `platform_info` reply
-//! `Err { error: "unsupported on test-bench chassis" }` — the
-//! chassis is GPU-capable but has no window peripherals to address.
-//! Same shape as headless's chassis handler for these kinds.
+//! - `aether.control.capture_frame` — same two-phase resolve / push
+//!   / handoff desktop uses, but the handoff target is the chassis
+//!   event channel (not a winit `EventLoopProxy`). The `PendingCapture`
+//!   itself rides in `CaptureQueue`; the event channel just signals
+//!   the loop to wake up.
+//! - `aether.test_bench.advance` — pushes an `Advance` event onto the
+//!   chassis event channel. The loop runs N ticks (Tick fanout →
+//!   drain → render or render-with-capture) and replies once they
+//!   complete.
+//! - `set_window_mode` / `set_window_title` / `platform_info` —
+//!   reply `Err` with an "unsupported on test-bench chassis" message.
+//!   Same fail-fast shape headless uses on these.
 
 use std::sync::Arc;
 
 use aether_kinds::{
-    CaptureFrame, CaptureFrameResult, PlatformInfo, PlatformInfoResult, SetWindowMode,
-    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
+    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, PlatformInfoResult,
+    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
@@ -25,12 +28,14 @@ use aether_substrate_core::{
 };
 
 use crate::capture::{CaptureQueue, PendingCapture};
+use crate::events::{ChassisEvent, EventSender};
 
 const UNSUPPORTED_WINDOW: &str = "unsupported on test-bench chassis — no window peripherals (set_window_mode, set_window_title, \
      platform_info are desktop-only)";
 
 pub fn chassis_control_handler(
     capture_queue: CaptureQueue,
+    events: EventSender,
     registry: Arc<Registry>,
     queue: Arc<Mailer>,
     outbound: Arc<HubOutbound>,
@@ -38,7 +43,17 @@ pub fn chassis_control_handler(
     Arc::new(
         move |kind_id: u64, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
-                handle_capture_frame(&capture_queue, &registry, &queue, &outbound, sender, bytes);
+                handle_capture_frame(
+                    &capture_queue,
+                    &events,
+                    &registry,
+                    &queue,
+                    &outbound,
+                    sender,
+                    bytes,
+                );
+            } else if kind_id == Advance::ID {
+                handle_advance(&events, &outbound, sender, bytes);
             } else if kind_id == SetWindowMode::ID {
                 outbound.send_reply(
                     sender,
@@ -73,11 +88,11 @@ pub fn chassis_control_handler(
 
 /// Two-phase capture request. Resolve both mail bundles atomically
 /// against the registry before touching the queue, push pre-mails,
-/// enqueue the capture, return. The tick loop polls the capture
-/// queue each iteration; if a request is pending it calls
-/// `render_and_capture`, pushes after_mails, and replies.
+/// enqueue the capture, signal the loop. The loop drains and renders-
+/// with-capture (no Tick fanout — capture observes; advance ticks).
 fn handle_capture_frame(
     capture_queue: &CaptureQueue,
+    events: &EventSender,
     registry: &Registry,
     queue: &Mailer,
     outbound: &HubOutbound,
@@ -121,6 +136,48 @@ fn handle_capture_frame(
             &CaptureFrameResult::Err {
                 error: "capture already pending; try again once the in-flight request completes"
                     .to_owned(),
+            },
+        );
+        return;
+    }
+
+    if events.send(ChassisEvent::CaptureRequested).is_err() {
+        // The tick loop has dropped its receiver — chassis is
+        // shutting down. The capture is queued but won't be drained.
+        // Reply Err so the caller doesn't hang.
+        let _ = capture_queue.take();
+        outbound.send_reply(
+            sender,
+            &CaptureFrameResult::Err {
+                error: "test-bench chassis shutting down — capture aborted".to_owned(),
+            },
+        );
+    }
+}
+
+/// Decode `Advance { ticks }`, push the request onto the event
+/// channel. The tick loop runs `ticks` cycles and replies. A
+/// shut-down loop replies `Err` inline.
+fn handle_advance(events: &EventSender, outbound: &HubOutbound, sender: ReplyTo, bytes: &[u8]) {
+    let payload: Advance = match decode_payload(bytes) {
+        Ok(p) => p,
+        Err(error) => {
+            outbound.send_reply(sender, &AdvanceResult::Err { error });
+            return;
+        }
+    };
+
+    if events
+        .send(ChassisEvent::Advance {
+            reply_to: sender,
+            ticks: payload.ticks,
+        })
+        .is_err()
+    {
+        outbound.send_reply(
+            sender,
+            &AdvanceResult::Err {
+                error: "test-bench chassis shutting down — advance aborted".to_owned(),
             },
         );
     }

--- a/crates/aether-substrate-test-bench/src/events.rs
+++ b/crates/aether-substrate-test-bench/src/events.rs
@@ -1,0 +1,109 @@
+//! Cross-thread channel from the chassis-control handler to the
+//! tick loop (ADR-0067). The handler runs on a scheduler worker;
+//! the tick loop runs on the main thread. Both `aether.test_bench.advance`
+//! and `aether.control.capture_frame` need to wake the tick loop —
+//! this channel carries the wake.
+//!
+//! `Advance` carries the reply target so the loop can reply once
+//! all ticks complete. `CaptureRequested` is a wake signal only;
+//! the actual `PendingCapture` rides separately in `CaptureQueue`
+//! (the queue stays the source of truth so multiple back-to-back
+//! advances don't lose a stale wake event).
+
+use std::sync::mpsc;
+
+use aether_substrate_core::ReplyTo;
+
+/// Events the tick loop consumes. Single-producer / single-consumer
+/// in practice — the chassis-control handler is the only producer,
+/// the tick loop is the only consumer — but the underlying channel
+/// is mpsc which would tolerate multiple producers if a future
+/// chassis variant grew them.
+pub enum ChassisEvent {
+    /// `aether.test_bench.advance { ticks }`. The tick loop runs
+    /// `ticks` full cycles (Tick fanout → drain → render or capture)
+    /// then replies with `AdvanceResult::Ok { ticks_completed }`.
+    Advance { reply_to: ReplyTo, ticks: u32 },
+    /// `aether.control.capture_frame`. The PendingCapture itself
+    /// was pushed into `CaptureQueue` by the chassis-control
+    /// handler; this event just wakes the loop so the next idle
+    /// cycle picks it up. The loop runs one drain → render-with-
+    /// capture cycle without dispatching `Tick` (capture observes,
+    /// it doesn't advance the world). If the queue is empty when
+    /// the loop wakes — possible if an in-flight `Advance` already
+    /// drained the capture — the wake is silently absorbed.
+    CaptureRequested,
+}
+
+#[derive(Clone)]
+pub struct EventSender(mpsc::Sender<ChassisEvent>);
+
+impl EventSender {
+    /// Push an event. Returns `Ok(())` on success, `Err` only if
+    /// the receiver has been dropped — at that point the chassis
+    /// is shutting down and the failure is informational.
+    pub fn send(&self, event: ChassisEvent) -> Result<(), mpsc::SendError<ChassisEvent>> {
+        self.0.send(event)
+    }
+}
+
+pub struct EventReceiver(mpsc::Receiver<ChassisEvent>);
+
+impl EventReceiver {
+    /// Block until the next event arrives or the sender is dropped.
+    pub fn recv(&self) -> Result<ChassisEvent, mpsc::RecvError> {
+        self.0.recv()
+    }
+}
+
+/// Build the sender/receiver pair the chassis wires once at boot.
+pub fn channel() -> (EventSender, EventReceiver) {
+    let (tx, rx) = mpsc::channel();
+    (EventSender(tx), EventReceiver(rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_substrate_core::ReplyTarget;
+
+    use super::*;
+
+    fn reply_to(u: u128) -> ReplyTo {
+        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))
+    }
+
+    #[test]
+    fn advance_round_trips_through_channel() {
+        let (tx, rx) = channel();
+        tx.send(ChassisEvent::Advance {
+            reply_to: reply_to(1),
+            ticks: 3,
+        })
+        .expect("send");
+        match rx.recv().expect("recv") {
+            ChassisEvent::Advance { ticks, .. } => assert_eq!(ticks, 3),
+            ChassisEvent::CaptureRequested => panic!("got CaptureRequested, expected Advance"),
+        }
+    }
+
+    #[test]
+    fn capture_requested_round_trips_through_channel() {
+        let (tx, rx) = channel();
+        tx.send(ChassisEvent::CaptureRequested).expect("send");
+        assert!(matches!(
+            rx.recv().expect("recv"),
+            ChassisEvent::CaptureRequested
+        ));
+    }
+
+    #[test]
+    fn recv_errors_after_all_senders_drop() {
+        let (tx, rx) = channel();
+        drop(tx);
+        // No clones outstanding — the receiver returns Err once the
+        // last sender goes away. The chassis loop interprets this
+        // as shutdown.
+        assert!(rx.recv().is_err());
+    }
+}

--- a/crates/aether-substrate-test-bench/src/lib.rs
+++ b/crates/aether-substrate-test-bench/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod capture;
 pub mod chassis;
+pub mod events;
 pub mod render;
 
 pub use aether_substrate_core::{

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -3,24 +3,26 @@
 // frame renders into an offscreen color target paired with a depth
 // target; capture_frame reads back from that same offscreen.
 //
-// v1 keeps headless's std-timer tick driver. ADR-0067 calls for a
-// control-mail tick driver (`aether.test_bench.advance`) so smoke
-// scripts can advance the mail clock deterministically — that
-// lands in a follow-up PR alongside the new kinds. Until then the
-// chassis ticks at AETHER_TICK_HZ (default 60), same shape as
-// headless.
+// Tick driver is control-mail (ADR-0067): the chassis loop blocks
+// waiting for `aether.test_bench.advance { ticks }` events from the
+// chassis-control handler. Each Advance runs `ticks` complete
+// frames (Tick fanout → drain → render-or-capture), then replies
+// with `AdvanceResult::Ok`. Capture-frame requests wake the loop
+// for one drain → render-with-capture cycle without dispatching
+// Tick (capture observes; advance ticks). With no Advance, the
+// world doesn't tick — the chassis is fully deterministic.
 
 mod capture;
 mod chassis;
+mod events;
 mod render;
 
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread;
 use std::time::{Duration, Instant};
 
-use aether_kinds::{CaptureFrameResult, FrameStats, InputStream, Tick};
+use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, InputStream, Tick};
 use aether_mail::{Kind, encode, encode_empty};
 use aether_substrate_core::{
     Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, ReplyTo, Scheduler,
@@ -30,10 +32,10 @@ use aether_substrate_core::{
 };
 
 use crate::capture::CaptureQueue;
+use crate::events::{ChassisEvent, EventReceiver};
 use crate::render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
 
 const WORKERS: usize = 2;
-const DEFAULT_TICK_HZ: u32 = 60;
 const LOG_EVERY_FRAMES: u64 = 120;
 
 /// Wire size of one `aether.draw_triangle` mail item: three
@@ -54,23 +56,26 @@ const DEFAULT_HEIGHT: u32 = 600;
 /// 5-second value desktop and headless use — same dispatcher kernel.
 const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
-/// Test-bench chassis. Owns the tick loop, the GPU, the shared
+/// Test-bench chassis. Owns the event loop, the GPU, the shared
 /// frame state (vertex buffer, camera matrix), and the capture
-/// queue. `run(self)` takes ownership and drives the loop forever
-/// — process exits on SIGTERM (hub-spawned) or SIGINT (manual run).
+/// queue. `run(self)` blocks on the event receiver — the loop
+/// returns only when every sender has been dropped (chassis
+/// shutdown). Process exit on SIGTERM (hub-spawned) is caught by
+/// the chassis-control handler dropping its sender; SIGINT (manual
+/// run) terminates the process directly.
 struct TestBenchChassis {
     queue: Arc<Mailer>,
     input_subscribers: InputSubscribers,
     broadcast_mbox: MailboxId,
     kind_tick: u64,
     kind_frame_stats: u64,
-    tick_period: Duration,
     gpu: Gpu,
     frame_vertices: Arc<Mutex<Vec<u8>>>,
     camera_state: Arc<Mutex<[f32; 16]>>,
     triangles_rendered: Arc<AtomicU64>,
     capture_queue: CaptureQueue,
     outbound: Arc<HubOutbound>,
+    events_rx: EventReceiver,
     _scheduler: Scheduler,
     _hub: Option<aether_substrate_core::HubClient>,
 }
@@ -86,116 +91,116 @@ impl Chassis for TestBenchChassis {
     fn run(mut self) -> wasmtime::Result<()> {
         let started = Instant::now();
         let mut frame: u64 = 0;
-        let mut next_deadline = Instant::now() + self.tick_period;
-        loop {
-            let now = Instant::now();
-            if now < next_deadline {
-                thread::sleep(next_deadline - now);
+        // `recv()` returns Err only when every sender has been
+        // dropped — that's chassis shutdown, exit the loop cleanly.
+        while let Ok(event) = self.events_rx.recv() {
+            match event {
+                ChassisEvent::Advance { reply_to, ticks } => {
+                    for _ in 0..ticks {
+                        frame += 1;
+                        self.run_frame(frame, started, /* dispatch_tick */ true);
+                    }
+                    self.outbound.send_reply(
+                        reply_to,
+                        &AdvanceResult::Ok {
+                            ticks_completed: ticks,
+                        },
+                    );
+                }
+                ChassisEvent::CaptureRequested => {
+                    frame += 1;
+                    self.run_frame(frame, started, /* dispatch_tick */ false);
+                }
             }
-            next_deadline = Instant::now() + self.tick_period;
+        }
+        Ok(())
+    }
+}
 
-            frame += 1;
+impl TestBenchChassis {
+    /// Run one frame: optionally dispatch `Tick` to subscribers,
+    /// drain the queue with the ADR-0063 budget, take any pending
+    /// capture and render-with-capture (otherwise plain render),
+    /// emit periodic frame_stats. Any death or wedge mid-drain
+    /// aborts the chassis cleanly via `lifecycle::fatal_abort`.
+    fn run_frame(&mut self, frame: u64, started: Instant, dispatch_tick: bool) {
+        if dispatch_tick {
             let subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
             }
-            // ADR-0063: budget-aware drain. Same lifecycle handling
-            // headless uses — wedges and component deaths exit the
-            // chassis cleanly via `fatal_abort`.
-            let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
-            if let Some((mailbox, waited)) = summary.wedged {
-                aether_substrate_core::lifecycle::fatal_abort(
-                    &self.outbound,
-                    format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
-                );
-            }
-            if let Some(first) = summary.deaths.first() {
-                for d in &summary.deaths {
-                    tracing::error!(
-                        target: "aether_substrate::lifecycle",
-                        mailbox = ?d.mailbox,
-                        mailbox_name = %d.mailbox_name,
-                        last_kind = %d.last_kind,
-                        reason = %d.reason,
-                        "component died; substrate aborting (ADR-0063)",
-                    );
-                }
-                aether_substrate_core::lifecycle::fatal_abort(
-                    &self.outbound,
-                    format!(
-                        "component died: {} (kind {}) — {}",
-                        first.mailbox_name, first.last_kind, first.reason,
-                    ),
-                );
-            }
-
-            // Drain accumulated vertices and the latest camera. Replace
-            // the vertex buffer with an empty same-capacity Vec so the
-            // 4 MiB allocation isn't rebuilt every frame (matches
-            // desktop's pattern).
-            let verts = std::mem::replace(
-                &mut *self.frame_vertices.lock().unwrap(),
-                Vec::with_capacity(VERTEX_BUFFER_BYTES),
+        }
+        let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
+        if let Some((mailbox, waited)) = summary.wedged {
+            aether_substrate_core::lifecycle::fatal_abort(
+                &self.outbound,
+                format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
             );
-            let view_proj = *self.camera_state.lock().unwrap();
-
-            // If a capture is pending, render with capture, push
-            // after_mails, and reply. Otherwise just render.
-            match self.capture_queue.take() {
-                Some(req) => {
-                    let result = match self.gpu.render_and_capture(&verts, &view_proj) {
-                        Ok(png) => CaptureFrameResult::Ok { png },
-                        Err(error) => CaptureFrameResult::Err { error },
-                    };
-                    for mail in req.after_mails {
-                        self.queue.push(mail);
-                    }
-                    self.outbound.send_reply(req.reply_to, &result);
-                }
-                None => {
-                    self.gpu.render(&verts, &view_proj);
-                }
-            }
-
-            if frame.is_multiple_of(LOG_EVERY_FRAMES) {
-                let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-                let stats = FrameStats { frame, triangles };
-                self.queue.push(Mail::new(
-                    self.broadcast_mbox,
-                    self.kind_frame_stats,
-                    encode(&stats),
-                    1,
-                ));
-                let elapsed = started.elapsed().as_secs_f64().max(0.001);
-                tracing::info!(
-                    target: "aether_substrate::frame_loop",
-                    frame = frame,
-                    fps = frame as f64 / elapsed,
-                    triangles,
-                    "test-bench tick",
+        }
+        if let Some(first) = summary.deaths.first() {
+            for d in &summary.deaths {
+                tracing::error!(
+                    target: "aether_substrate::lifecycle",
+                    mailbox = ?d.mailbox,
+                    mailbox_name = %d.mailbox_name,
+                    last_kind = %d.last_kind,
+                    reason = %d.reason,
+                    "component died; substrate aborting (ADR-0063)",
                 );
+            }
+            aether_substrate_core::lifecycle::fatal_abort(
+                &self.outbound,
+                format!(
+                    "component died: {} (kind {}) — {}",
+                    first.mailbox_name, first.last_kind, first.reason,
+                ),
+            );
+        }
+
+        // Drain accumulated vertices and the latest camera. Replace
+        // the vertex buffer with an empty same-capacity Vec so the
+        // 4 MiB allocation isn't rebuilt every frame.
+        let verts = std::mem::replace(
+            &mut *self.frame_vertices.lock().unwrap(),
+            Vec::with_capacity(VERTEX_BUFFER_BYTES),
+        );
+        let view_proj = *self.camera_state.lock().unwrap();
+
+        match self.capture_queue.take() {
+            Some(req) => {
+                let result = match self.gpu.render_and_capture(&verts, &view_proj) {
+                    Ok(png) => CaptureFrameResult::Ok { png },
+                    Err(error) => CaptureFrameResult::Err { error },
+                };
+                for mail in req.after_mails {
+                    self.queue.push(mail);
+                }
+                self.outbound.send_reply(req.reply_to, &result);
+            }
+            None => {
+                self.gpu.render(&verts, &view_proj);
             }
         }
-    }
-}
 
-fn parse_tick_hz_env() -> u32 {
-    match std::env::var("AETHER_TICK_HZ") {
-        Ok(s) => s
-            .trim()
-            .parse::<u32>()
-            .ok()
-            .filter(|&hz| hz > 0)
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    target: "aether_substrate::boot",
-                    value = %s,
-                    "AETHER_TICK_HZ unparseable or zero — falling back to default",
-                );
-                DEFAULT_TICK_HZ
-            }),
-        Err(_) => DEFAULT_TICK_HZ,
+        if frame.is_multiple_of(LOG_EVERY_FRAMES) {
+            let triangles = self.triangles_rendered.load(Ordering::Relaxed);
+            let stats = FrameStats { frame, triangles };
+            self.queue.push(Mail::new(
+                self.broadcast_mbox,
+                self.kind_frame_stats,
+                encode(&stats),
+                1,
+            ));
+            let elapsed = started.elapsed().as_secs_f64().max(0.001);
+            tracing::info!(
+                target: "aether_substrate::frame_loop",
+                frame = frame,
+                fps = frame as f64 / elapsed,
+                triangles,
+                "test-bench frame",
+            );
+        }
     }
 }
 
@@ -225,14 +230,17 @@ fn parse_size_env() -> (u32, u32) {
 
 fn main() -> wasmtime::Result<()> {
     let capture_queue = CaptureQueue::new();
+    let (events_tx, events_rx) = events::channel();
 
     let boot = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
         .workers(WORKERS)
         .chassis_handler({
             let cq = capture_queue.clone();
+            let tx = events_tx.clone();
             move |ctx| {
                 Some(chassis::chassis_control_handler(
                     cq,
+                    tx,
                     Arc::clone(ctx.registry),
                     Arc::clone(ctx.queue),
                     Arc::clone(ctx.outbound),
@@ -247,9 +255,9 @@ fn main() -> wasmtime::Result<()> {
         .kind_id(FrameStats::NAME)
         .expect("FrameStats registered");
 
-    // `aether.sink.render`: real renderer. The tick loop drains
-    // `frame_vertices` each tick, so every `DrawTriangle` emitted
-    // before the next tick is consolidated into one vertex buffer.
+    // `aether.sink.render`: real renderer. The frame loop drains
+    // `frame_vertices` each frame, so every `DrawTriangle` emitted
+    // before the next frame is consolidated into one vertex buffer.
     // Truncate at the sink boundary so a single oversized mesh
     // degrades gracefully.
     let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(VERTEX_BUFFER_BYTES)));
@@ -290,8 +298,8 @@ fn main() -> wasmtime::Result<()> {
     }
 
     // `aether.sink.camera`: latest-value-wins. Decode the 64-byte
-    // column-major view_proj and store; the tick loop reads it each
-    // frame and uploads to the GPU uniform.
+    // column-major view_proj and store; the frame loop reads it
+    // each frame and uploads to the GPU uniform.
     let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
     {
         let cam_for_sink = Arc::clone(&camera_state);
@@ -364,9 +372,6 @@ fn main() -> wasmtime::Result<()> {
     // egress, and including it would add a real I/O side channel.
 
     let (width, height) = parse_size_env();
-    let tick_hz = parse_tick_hz_env();
-    let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
-
     let gpu = Gpu::new(width, height);
     tracing::info!(
         target: "aether_substrate::boot",
@@ -375,12 +380,18 @@ fn main() -> wasmtime::Result<()> {
         device_type = ?gpu.adapter_info.device_type,
         width,
         height,
-        tick_hz,
         workers = WORKERS,
-        "test-bench componentless boot — load a component via aether.control.load_component",
+        "test-bench componentless boot — drive ticks via aether.test_bench.advance",
     );
 
     let hub = boot.connect_hub_from_env()?;
+
+    // The chassis owns its receiver; the chassis-control handler
+    // already holds a clone of the sender (captured into the boot
+    // closure above). Drop the local `events_tx` so the receiver
+    // hangs up cleanly when every chassis_control_handler clone is
+    // released — matches the ADR-0063 lifecycle.
+    drop(events_tx);
 
     let chassis = TestBenchChassis {
         queue: boot.queue,
@@ -388,13 +399,13 @@ fn main() -> wasmtime::Result<()> {
         broadcast_mbox: boot.broadcast_mbox,
         kind_tick,
         kind_frame_stats,
-        tick_period,
         gpu,
         frame_vertices,
         camera_state,
         triangles_rendered,
         capture_queue,
         outbound: boot.outbound,
+        events_rx,
         _scheduler: boot.scheduler,
         _hub: hub,
     };


### PR DESCRIPTION
## Summary

ADR-0067 phase 2 of 6. Replaces the test-bench std-timer with a control-mail-driven event loop so smoke scripts can advance the mail clock deterministically.

- New kinds `aether.test_bench.advance { ticks }` and `aether.test_bench.advance_result` land in `aether-kinds` (chassis primitives per ADR-0066).
- Test-bench's chassis loop blocks on a channel: an Advance event runs N full frames (Tick fanout → drain → render-or-capture) and replies with `Ok { ticks_completed }`; a CaptureRequested event drains and renders-with-capture without a Tick fanout (capture observes, advance ticks).
- With no Advance, the world doesn't tick. Smoke scripts get fully deterministic "send mail → step N → capture" cycles.
- Desktop and headless chassis grow explicit Err replies on Advance ("test-bench-only") so smoke scripts pointed at the wrong chassis fail fast.

## Test plan

- [x] `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` — clean.
- [x] `cargo test --workspace` — 149+ tests pass; new unit tests cover the event channel (Advance + CaptureRequested round-trip, sender-drop hangup).
- [x] End-to-end via MCP: spawn test-bench, send `aether.test_bench.advance { ticks: 3 }`, receive `advance_result::Ok { ticks_completed: 3 }`. Reply round-trips clean.

## Phasing

| PR | Status |
|---|---|
| 1 | scaffold test-bench chassis (PR 408, merged) |
| **2 (this)** | control-mail tick driver + advance kinds |
| 3 | aether-smoke library: Script, Runner, RunReport, YAML parser, TestBench API |
| 4 | aether-smoke-cli + smoke_dir! proc-macro |
| 5 | First per-component smokes |
| 6 | CI workflow + skill updates; closes issue 400 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)