### PR TITLE
chore: ignore /audits/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ spikes/*/target/
 !.claude/skills/adr/
 !.claude/skills/delegate/
 !.claude/skills/sweep/
+# Agent audit artifacts — runs of an audit workflow that examines
+# the repo and emits findings. Outputs are per-run and per-machine,
+# not part of the source tree; issues filed from them link back to
+# the source instead.
+/audits/


### PR DESCRIPTION
## Summary

Adds `/audits/` to `.gitignore`. The directory holds per-run agent audit artifacts; outputs are per-run and per-machine, not part of the source tree (issues filed from audits link back to the source instead).

## Test plan

- [x] `git check-ignore -v audits/anything.md` resolves cleanly to the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)