### PR TITLE
refactor(substrate-core): promote test_channel to attached_loopback

### DIFF
--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -630,7 +630,7 @@ mod tests {
         use crate::hub_client::HubOutbound;
         use crate::mail::MailboxId as M;
 
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let pong_id = registry
             .register_kind_with_descriptor(KindDescriptor {
@@ -712,7 +712,7 @@ mod tests {
         use crate::hub_client::HubOutbound;
         use crate::mail::MailboxId as M;
 
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let caller = registry.register_component("caller");
         let pong_id = registry

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -232,7 +232,7 @@ mod tests {
     /// `ReplyTo::EngineMailbox` for the receiving component.
     #[test]
     fn unknown_recipient_bubbles_up_with_sender_mailbox() {
-        let (outbound, outbound_rx) = HubOutbound::test_channel();
+        let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry.register_component("client");
 
@@ -270,7 +270,7 @@ mod tests {
     /// upstream frame.
     #[test]
     fn unknown_recipient_without_outbound_warn_drops() {
-        let (outbound, outbound_rx) = HubOutbound::test_channel();
+        let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry.register_component("client");
 

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -260,7 +260,7 @@ mod tests {
         for d in aether_kinds::descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         let mailer = Arc::new(Mailer::new());
         mailer.wire(Arc::clone(&registry), Arc::new(RwLock::new(HashMap::new())));
         mailer.wire_outbound(outbound);

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -140,12 +140,12 @@ impl HubOutbound {
         self.tx.get().is_some()
     }
 
-    /// Test helper: build an attached outbound paired with the
-    /// receiver end so tests can assert on the frames components
-    /// emit. Mirrors the channel `HubClient::connect` would attach
-    /// but skips the TCP machinery.
-    #[cfg(test)]
-    pub fn test_channel() -> (Arc<Self>, std::sync::mpsc::Receiver<EngineToHub>) {
+    /// Build an attached outbound paired with the receiver end so
+    /// in-process drivers (tests, the test-bench's `TestBench` API
+    /// per ADR-0067) can intercept frames the substrate would
+    /// otherwise serialise to a hub. Mirrors the channel
+    /// `HubClient::connect` attaches, minus the TCP machinery.
+    pub fn attached_loopback() -> (Arc<Self>, mpsc::Receiver<EngineToHub>) {
         let (tx, rx) = mpsc::channel::<EngineToHub>();
         let outbound = Arc::new(Self {
             tx: OnceLock::new(),

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -736,7 +736,7 @@ mod tests {
     // against a tempdir, pushes encoded mail bytes through the
     // handler closure, and reads the outbound reply channel to
     // confirm the correct `*Result` variant was sent back. The
-    // outbound is built via `HubOutbound::test_channel` which skips
+    // outbound is built via `HubOutbound::attached_loopback` which skips
     // the TCP plumbing but keeps `send_reply`'s encode path live.
 
     use crate::hub_client::HubOutbound;
@@ -763,7 +763,7 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::RwLock;
 
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         let mailer = Arc::new(Mailer::new());
         mailer.wire(
             Arc::new(crate::registry::Registry::new()),
@@ -1088,7 +1088,7 @@ mod tests {
         let registry = Arc::new(Registry::new());
         let caller_mailbox = registry.register_component("test_caller");
         let components: crate::scheduler::ComponentTable = Arc::new(RwLock::new(HashMap::new()));
-        let (outbound, _outbound_rx) = HubOutbound::test_channel();
+        let (outbound, _outbound_rx) = HubOutbound::attached_loopback();
         let mailer = Arc::new(Mailer::new());
         mailer.wire(Arc::clone(&registry), Arc::clone(&components));
         mailer.wire_outbound(Arc::clone(&outbound));

--- a/crates/aether-substrate-core/src/log_capture.rs
+++ b/crates/aether-substrate-core/src/log_capture.rs
@@ -338,7 +338,7 @@ mod tests {
     use super::*;
 
     fn make_inner() -> (Arc<Inner>, std::sync::mpsc::Receiver<EngineToHub>) {
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         (Arc::new(Inner::new(outbound)), rx)
     }
 

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -414,7 +414,7 @@ mod tests {
     /// mailbox id / kind / payload / count the caller pushed.
     #[test]
     fn unknown_mailbox_with_connected_outbound_bubbles_up() {
-        let (outbound, outbound_rx) = HubOutbound::test_channel();
+        let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let components = Arc::new(RwLock::new(HashMap::new()));
 

--- a/crates/aether-substrate-core/src/net.rs
+++ b/crates/aether-substrate-core/src/net.rs
@@ -458,7 +458,7 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::RwLock;
 
-        let (outbound, rx) = HubOutbound::test_channel();
+        let (outbound, rx) = HubOutbound::attached_loopback();
         let mailer = Arc::new(Mailer::new());
         mailer.wire(
             Arc::new(crate::registry::Registry::new()),


### PR DESCRIPTION
## Summary

ADR-0067 PR 3 prep. Promotes `HubOutbound::test_channel` to a public stable API renamed `attached_loopback` so the test-bench's in-process `TestBench` API (the actual PR 3 work, follow-up) can intercept substrate-emitted frames without standing up a hub.

- Drops the `#[cfg(test)]` gate.
- Renames to reflect the broader purpose — it's the in-process loopback channel pair, not just a unit-test convenience.
- Updates every in-tree caller; behaviour unchanged.

## Test plan

- [x] `cargo check --workspace --all-targets` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace` passes (this rename touched 12 test sites that exercise the function).

## Phasing

| PR | Status |
|---|---|
| 1 | scaffold test-bench chassis (PR 408, merged) |
| 2 | control-mail tick driver + advance kinds (PR 409, merged) |
| **3 (this)** | promote `attached_loopback` so PR 4 can use it |
| 4 | `aether-smoke` library + in-process `TestBench` API |
| 5 | smoke YAML grammar + `smoke_dir!` proc-macro + `aether-smoke-cli` |
| 6 | First per-component smokes |
| 7 | CI workflow + `/delegate` and `/sweep` skill updates; closes issue 400 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)