### PR TITLE
feat(smoke): scaffold aether-smoke library (issue 400)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-smoke"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-substrate-test-bench",
+ "png",
+ "pollster",
+ "serde",
+ "serde_yml",
+ "thiserror 1.0.69",
+ "wgpu",
+]
+
+[[package]]
 name = "aether-substrate-core"
 version = "0.2.0-alpha"
 dependencies = [
@@ -2140,6 +2153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3647,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/aether-substrate-headless",
     "crates/aether-substrate-hub",
     "crates/aether-substrate-test-bench",
+    "crates/aether-smoke",
     "crates/aether-kinds",
     "crates/aether-math",
     "crates/aether-component",

--- a/crates/aether-smoke/Cargo.toml
+++ b/crates/aether-smoke/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aether-smoke"
+version.workspace = true
+edition.workspace = true
+
+# ADR-0067 smoke library: declarative Script → Runner → RunReport
+# pipeline that drives an in-process `TestBench` chassis through a
+# sequence of steps and asserts visual properties of captured frames.
+# This crate ships the core types + a YAML parser; per-component
+# smokes live in their owning crates' tests/ directories and the CLI
+# wrapper (PR 6) gives agents a one-shot "run smoke at path" entry.
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+aether-substrate-test-bench = { path = "../aether-substrate-test-bench" }
+png = "0.17"
+serde = { version = "1", features = ["derive"] }
+serde_yml = "0.0.12"
+thiserror = "1"
+
+[dev-dependencies]
+pollster = "0.4.0"
+wgpu = "29.0.1"

--- a/crates/aether-smoke/src/lib.rs
+++ b/crates/aether-smoke/src/lib.rs
@@ -1,0 +1,22 @@
+//! `aether-smoke` — declarative smoke-test runner for the test-bench
+//! chassis (ADR-0067).
+//!
+//! A `Script` enumerates the steps to execute against a freshly-booted
+//! `TestBench`: advance ticks, capture a frame, assert visual
+//! properties. The `Runner` walks the steps and produces a `RunReport`
+//! whose `passed` flag is the gate CI consumes.
+//!
+//! v1 vocabulary covers chassis-level smokes (does the bench boot?
+//! does an empty capture round-trip?). Component-driving steps
+//! (`load_component`, `send_mail`) land in a follow-up PR alongside
+//! descriptor-based JSON encoding.
+
+mod report;
+mod runner;
+mod script;
+mod visual;
+
+pub use report::{RunReport, StepReport, StepStatus};
+pub use runner::{Runner, RunnerError};
+pub use script::{Script, Step, VisualAssert, parse_script};
+pub use visual::{Image, ImageError, decode_png, not_all_black};

--- a/crates/aether-smoke/src/report.rs
+++ b/crates/aether-smoke/src/report.rs
@@ -1,0 +1,63 @@
+//! `RunReport` — what the runner returns after walking a script.
+//! Each step gets a `StepReport`; the top-level `passed` flag is the
+//! AND of every step's success. The CLI surfaces this as exit code,
+//! Rust tests assert on `passed`, and human-readers eyeball the
+//! per-step status to find the first failure.
+
+/// Outcome of a single step. `Pass` carries no detail; `Fail` carries
+/// a one-line reason fit for log output.
+#[derive(Debug, Clone)]
+pub enum StepStatus {
+    Pass,
+    Fail(String),
+}
+
+impl StepStatus {
+    pub fn is_pass(&self) -> bool {
+        matches!(self, StepStatus::Pass)
+    }
+}
+
+/// Per-step summary. `index` is the 0-based position in the original
+/// script — duplicating it here means a serialized report still
+/// pinpoints the failed step without re-zipping with the source.
+#[derive(Debug, Clone)]
+pub struct StepReport {
+    pub index: usize,
+    pub op: &'static str,
+    pub status: StepStatus,
+}
+
+/// Top-level run output. `passed` is the AND of every `StepReport`'s
+/// status. A short-circuit failure (e.g. assert before capture) still
+/// produces a fully-populated `steps` list — later steps are reported
+/// as `Fail("skipped: prior step failed")` so the CLI's output stays
+/// regular regardless of where the script broke.
+#[derive(Debug, Clone)]
+pub struct RunReport {
+    pub script_name: String,
+    pub steps: Vec<StepReport>,
+    pub passed: bool,
+}
+
+impl RunReport {
+    /// Build an empty report for a script that hasn't started running
+    /// (used when boot fails before any step executes).
+    pub fn boot_failed(script_name: String, error: String) -> Self {
+        Self {
+            script_name,
+            steps: vec![StepReport {
+                index: 0,
+                op: "boot",
+                status: StepStatus::Fail(error),
+            }],
+            passed: false,
+        }
+    }
+
+    /// First failing step's status, if any. Useful for terse CLI
+    /// output: "script X failed at step N: <reason>".
+    pub fn first_failure(&self) -> Option<&StepReport> {
+        self.steps.iter().find(|s| !s.status.is_pass())
+    }
+}

--- a/crates/aether-smoke/src/runner.rs
+++ b/crates/aether-smoke/src/runner.rs
@@ -1,0 +1,121 @@
+//! `Runner` — walks a `Script` against a borrowed `TestBench`,
+//! producing a `RunReport`. The bench is `&mut` because `advance`
+//! and `capture` mutate state; the runner doesn't own the bench so
+//! tests can interleave smokes with their own bench operations.
+
+use aether_substrate_test_bench::TestBench;
+use thiserror::Error;
+
+use crate::report::{RunReport, StepReport, StepStatus};
+use crate::script::{Script, Step, VisualAssert};
+use crate::visual::{Image, decode_png, not_all_black};
+
+#[derive(Debug, Error)]
+pub enum RunnerError {
+    #[error("test-bench operation failed: {0}")]
+    TestBench(String),
+}
+
+/// Stateless walker. The runner threads its own `last_capture`
+/// through the step loop so consecutive `Assert` steps reuse the
+/// most-recent capture without re-rendering.
+pub struct Runner;
+
+impl Runner {
+    /// Run the script. Returns the populated report; panics or
+    /// internal errors from the bench surface as `StepStatus::Fail`
+    /// strings rather than propagating, so the caller always gets
+    /// a regular report shape to display.
+    pub fn run(bench: &mut TestBench, script: &Script) -> RunReport {
+        let mut steps = Vec::with_capacity(script.steps.len());
+        let mut last_capture: Option<Image> = None;
+        let mut short_circuited = false;
+
+        for (index, step) in script.steps.iter().enumerate() {
+            let op = op_label(step);
+            if short_circuited {
+                steps.push(StepReport {
+                    index,
+                    op,
+                    status: StepStatus::Fail("skipped: prior step failed".to_owned()),
+                });
+                continue;
+            }
+
+            let status = match step {
+                Step::Advance { ticks } => match bench.advance(*ticks) {
+                    Ok(_) => StepStatus::Pass,
+                    Err(e) => StepStatus::Fail(format!("advance({ticks}) failed: {e}")),
+                },
+                Step::Capture => match bench.capture() {
+                    Ok(bytes) => match decode_png(&bytes) {
+                        Ok(img) => {
+                            last_capture = Some(img);
+                            StepStatus::Pass
+                        }
+                        Err(e) => StepStatus::Fail(format!("capture decode failed: {e}")),
+                    },
+                    Err(e) => StepStatus::Fail(format!("capture failed: {e}")),
+                },
+                Step::Assert { check } => match last_capture.as_ref() {
+                    None => StepStatus::Fail(
+                        "assert with no prior capture: add a `capture` step first".to_owned(),
+                    ),
+                    Some(img) => match check {
+                        VisualAssert::NotAllBlack => match not_all_black(img) {
+                            Ok(()) => StepStatus::Pass,
+                            Err(reason) => StepStatus::Fail(reason),
+                        },
+                    },
+                },
+            };
+
+            if !status.is_pass() {
+                short_circuited = true;
+            }
+            steps.push(StepReport { index, op, status });
+        }
+
+        let passed = steps.iter().all(|s| s.status.is_pass());
+        RunReport {
+            script_name: script.name.clone(),
+            steps,
+            passed,
+        }
+    }
+}
+
+fn op_label(step: &Step) -> &'static str {
+    match step {
+        Step::Advance { .. } => "advance",
+        Step::Capture => "capture",
+        Step::Assert { .. } => "assert",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::script::{Script, Step, VisualAssert};
+
+    fn assert_before_capture_script() -> Script {
+        Script {
+            name: "early assert".to_owned(),
+            steps: vec![Step::Assert {
+                check: VisualAssert::NotAllBlack,
+            }],
+        }
+    }
+
+    /// The runner doesn't need a live bench to flag ordering errors —
+    /// a script that asserts before capturing fails on the assert
+    /// step's "no prior capture" check. We can't actually invoke
+    /// `Runner::run` without a `&mut TestBench`, so this test
+    /// verifies the report shape via direct Script construction.
+    #[test]
+    fn assert_before_capture_step_label() {
+        let script = assert_before_capture_script();
+        // op_label is the public-facing identifier in StepReport; if
+        // the variant naming drifts the runner output drifts too.
+        assert_eq!(super::op_label(&script.steps[0]), "assert");
+    }
+}

--- a/crates/aether-smoke/src/script.rs
+++ b/crates/aether-smoke/src/script.rs
@@ -1,0 +1,99 @@
+//! Declarative `Script` — name + ordered list of steps the runner
+//! executes against a `TestBench`. Parses from YAML so smoke tests
+//! live alongside the component they cover as plain text the
+//! component author edits without touching Rust.
+
+use serde::{Deserialize, Serialize};
+
+/// A complete smoke script. The `name` is surfaced in `RunReport`
+/// so failure logs identify which script tripped without re-reading
+/// the file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Script {
+    pub name: String,
+    pub steps: Vec<Step>,
+}
+
+/// One operation the runner executes. The variants are intentionally
+/// minimal in v1 — chassis-level smokes only. Component-driving
+/// steps (`LoadComponent`, `SendMail`) join in a follow-up PR.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Step {
+    /// Run `ticks` advance cycles. The chassis fans `Tick` to every
+    /// subscribed component and drains the mail queue between each.
+    Advance { ticks: u32 },
+    /// Capture the current offscreen frame as a PNG and stash it on
+    /// the runner so subsequent `Assert` steps can inspect it.
+    Capture,
+    /// Run a visual assertion against the most recent capture. Fails
+    /// the step if no capture has been taken yet, with a clear error
+    /// pointing at script ordering.
+    Assert { check: VisualAssert },
+}
+
+/// Visual assertions over a captured frame's decoded pixels. Names
+/// describe the property being asserted, not the failure mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VisualAssert {
+    /// Asserts at least one pixel in the frame is non-black. Cheapest
+    /// "the chassis rendered something" check — useful when a script
+    /// loaded a mesh and expects geometry to land on the framebuffer.
+    NotAllBlack,
+}
+
+/// Parse a script from YAML source. Returns the underlying serde_yml
+/// error wrapped with file context handled at call sites.
+pub fn parse_script(yaml: &str) -> Result<Script, serde_yml::Error> {
+    serde_yml::from_str(yaml)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_basic_script() {
+        let yaml = r#"
+name: empty boot
+steps:
+  - op: advance
+    ticks: 1
+  - op: capture
+  - op: assert
+    check:
+      kind: not_all_black
+"#;
+        let script = parse_script(yaml).expect("parse");
+        assert_eq!(script.name, "empty boot");
+        assert_eq!(script.steps.len(), 3);
+        match &script.steps[0] {
+            Step::Advance { ticks } => assert_eq!(*ticks, 1),
+            other => panic!("expected Advance, got {other:?}"),
+        }
+        match &script.steps[1] {
+            Step::Capture => (),
+            other => panic!("expected Capture, got {other:?}"),
+        }
+        match &script.steps[2] {
+            Step::Assert { check } => {
+                assert!(matches!(check, VisualAssert::NotAllBlack));
+            }
+            other => panic!("expected Assert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_steps_is_valid() {
+        let script = parse_script("name: nothing\nsteps: []\n").expect("parse");
+        assert_eq!(script.name, "nothing");
+        assert!(script.steps.is_empty());
+    }
+
+    #[test]
+    fn missing_op_field_errors() {
+        let yaml = "name: bad\nsteps:\n  - ticks: 1\n";
+        assert!(parse_script(yaml).is_err());
+    }
+}

--- a/crates/aether-smoke/src/visual.rs
+++ b/crates/aether-smoke/src/visual.rs
@@ -1,0 +1,116 @@
+//! Visual assertions over decoded frame pixels. PNGs come back from
+//! `TestBench::capture` as bytes; this module decodes once and runs
+//! O(n) checks against the pixel buffer. Assertion functions take a
+//! `&Image` so a single capture can drive many asserts without
+//! re-decoding.
+
+use thiserror::Error;
+
+/// Decoded frame: RGBA8 pixels in row-major top-down order, width
+/// and height in pixels. The chassis renders at the size requested
+/// at boot (`TestBench::start_with_size`); decoded `width`/`height`
+/// always match.
+pub struct Image {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
+#[derive(Debug, Error)]
+pub enum ImageError {
+    #[error("PNG decode failed: {0}")]
+    Decode(String),
+    #[error("unsupported PNG color type: {0:?}")]
+    UnsupportedColor(png::ColorType),
+}
+
+/// Decode a captured PNG byte stream into an `Image`. The chassis
+/// always emits 8-bit RGBA, so non-RGBA decodes are flagged as
+/// `UnsupportedColor` rather than silently coerced.
+pub fn decode_png(bytes: &[u8]) -> Result<Image, ImageError> {
+    let decoder = png::Decoder::new(bytes);
+    let mut reader = decoder
+        .read_info()
+        .map_err(|e| ImageError::Decode(e.to_string()))?;
+    let info = reader.info();
+    let width = info.width;
+    let height = info.height;
+    let color = info.color_type;
+    if color != png::ColorType::Rgba {
+        return Err(ImageError::UnsupportedColor(color));
+    }
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    reader
+        .next_frame(&mut buf)
+        .map_err(|e| ImageError::Decode(e.to_string()))?;
+    Ok(Image {
+        width,
+        height,
+        rgba: buf,
+    })
+}
+
+/// Asserts at least one pixel has a non-zero RGB component. Alpha
+/// is ignored — a fully-cleared depth-test frame can have alpha 1.0
+/// everywhere yet still be visually black, and a transparent overlay
+/// shouldn't count as "drew something". Returns a one-line failure
+/// string suitable for `StepReport::Fail`.
+pub fn not_all_black(image: &Image) -> Result<(), String> {
+    for chunk in image.rgba.chunks_exact(4) {
+        if chunk[0] != 0 || chunk[1] != 0 || chunk[2] != 0 {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "all {}x{} pixels are black (RGB=0,0,0)",
+        image.width, image.height
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthesize an Image from a fill color so asserts can run
+    /// without going through the chassis. RGBA bytes laid out
+    /// row-major, top-down.
+    fn solid(width: u32, height: u32, rgba: [u8; 4]) -> Image {
+        let mut buf = Vec::with_capacity((width * height * 4) as usize);
+        for _ in 0..(width * height) {
+            buf.extend_from_slice(&rgba);
+        }
+        Image {
+            width,
+            height,
+            rgba: buf,
+        }
+    }
+
+    #[test]
+    fn not_all_black_passes_on_any_color() {
+        let img = solid(4, 4, [0, 0, 1, 255]);
+        assert!(not_all_black(&img).is_ok());
+    }
+
+    #[test]
+    fn not_all_black_fails_on_pure_black() {
+        let img = solid(4, 4, [0, 0, 0, 255]);
+        let err = not_all_black(&img).unwrap_err();
+        assert!(err.contains("4x4"));
+    }
+
+    #[test]
+    fn not_all_black_ignores_alpha() {
+        // Fully-transparent black is still "all black" — alpha doesn't
+        // count as drawn pixels.
+        let img = solid(2, 2, [0, 0, 0, 0]);
+        assert!(not_all_black(&img).is_err());
+    }
+
+    #[test]
+    fn not_all_black_passes_when_one_pixel_lit() {
+        let mut img = solid(2, 2, [0, 0, 0, 255]);
+        img.rgba[8] = 1; // R channel of pixel index 2
+        assert!(not_all_black(&img).is_ok());
+    }
+}

--- a/crates/aether-smoke/tests/runner_round_trip.rs
+++ b/crates/aether-smoke/tests/runner_round_trip.rs
@@ -1,0 +1,96 @@
+//! End-to-end smoke runner test: parse YAML, boot a TestBench,
+//! run the script, assert the report. Skipped on driverless runners
+//! by probing for a wgpu adapter — same gating pattern as the
+//! TestBench unit test (ADR-0067).
+
+use aether_smoke::{Runner, parse_script};
+use aether_substrate_test_bench::TestBench;
+
+/// Probe for any usable wgpu adapter. Headless Linux runners without
+/// `mesa-vulkan-drivers` skip the test rather than panic.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+#[test]
+fn empty_script_passes_with_no_steps() {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let script = parse_script("name: empty\nsteps: []\n").expect("parse");
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(report.passed, "empty script should pass: {report:?}");
+    assert_eq!(report.script_name, "empty");
+    assert!(report.steps.is_empty());
+}
+
+/// The chassis clears to a non-black color, so advance, capture, and
+/// `not_all_black` all pass against a freshly-booted bench with no
+/// scene loaded. End-to-end happy path: parse YAML, run, observe pass.
+#[test]
+fn advance_capture_assert_round_trip() {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let script = parse_script(
+        r#"
+name: clear-color round trip
+steps:
+  - op: advance
+    ticks: 1
+  - op: capture
+  - op: assert
+    check:
+      kind: not_all_black
+"#,
+    )
+    .expect("parse");
+    let mut bench = TestBench::start_with_size(32, 32).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(report.passed, "round trip should pass: {report:?}");
+    assert_eq!(report.steps.len(), 3);
+    assert!(report.steps.iter().all(|s| s.status.is_pass()));
+}
+
+#[test]
+fn assert_before_capture_short_circuits() {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let script = parse_script(
+        r#"
+name: ordering
+steps:
+  - op: assert
+    check:
+      kind: not_all_black
+  - op: advance
+    ticks: 1
+"#,
+    )
+    .expect("parse");
+    let mut bench = TestBench::start_with_size(32, 32).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(!report.passed);
+    // First step (assert) fails; subsequent steps are reported as
+    // skipped rather than executed.
+    assert!(matches!(
+        report.steps[0].status,
+        aether_smoke::StepStatus::Fail(_)
+    ));
+    let aether_smoke::StepStatus::Fail(reason) = &report.steps[1].status else {
+        panic!("expected step 1 to be skipped");
+    };
+    assert!(reason.contains("skipped"), "step 1 reason: {reason}");
+}


### PR DESCRIPTION
## Summary

ADR-0067 PR 5 of 8. Scaffolds the declarative smoke runner:

- `Script` — name + ordered `Vec<Step>`, parses from YAML via `serde_yml`
- `Step` — v1 vocabulary: `Advance { ticks }`, `Capture`, `Assert { check }` (chassis-level smokes only; component driving steps land in the next PR alongside descriptor-based JSON encoding)
- `VisualAssert::NotAllBlack` — first visual check; more land as components ship smokes
- `Runner::run(&mut TestBench, &Script) -> RunReport` — walks steps, threads `last_capture` through, short-circuits on first failure (later steps reported as `skipped: prior step failed` so output stays regular)
- `RunReport` — script name + per-step `StepReport` + `passed` rollup; `first_failure()` for terse CLI output

End-to-end integration test boots a real wgpu chassis, parses YAML, runs the script, asserts the report shape. Adapter probe gates the test on driverless runners (Linux without Mesa skips, macOS/Windows runs).

## Test plan
- [x] cargo test -p aether-smoke — 8 unit + 3 integration tests pass locally
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all -- --check clean
- [x] CI green across linux/macos/windows

## Phasing
- PR 4 (PR 412, merged) — in-process TestBench API
- **PR 5 (this) — smoke library scaffold**
- PR 6 — aether-smoke-cli + smoke_dir! proc-macro + descriptor-based send_mail step
- PR 7 — first per-component smokes (mesh-viewer, camera)
- PR 8 — CI workflow + skill updates; closes issue 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)