### PR TITLE
feat(smoke): aether-smoke-cli + smoke_dir! proc-macro (issue 400)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "aether-hub-protocol",
  "aether-kinds",
  "aether-params-codec",
+ "aether-smoke-macros",
  "aether-substrate-test-bench",
  "png",
  "pollster",
@@ -213,6 +214,23 @@ dependencies = [
  "serde_yml",
  "thiserror 1.0.69",
  "wgpu",
+]
+
+[[package]]
+name = "aether-smoke-cli"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-smoke",
+ "pollster",
+ "wgpu",
+]
+
+[[package]]
+name = "aether-smoke-macros"
+version = "0.2.0-alpha"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "crates/aether-substrate-hub",
     "crates/aether-substrate-test-bench",
     "crates/aether-smoke",
+    "crates/aether-smoke-cli",
+    "crates/aether-smoke-macros",
     "crates/aether-params-codec",
     "crates/aether-kinds",
     "crates/aether-math",

--- a/crates/aether-smoke-cli/Cargo.toml
+++ b/crates/aether-smoke-cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aether-smoke-cli"
+version.workspace = true
+edition.workspace = true
+
+# Thin CLI wrapper around `aether-smoke`. Takes a path to a YAML
+# smoke script, boots a TestBench, runs the script, prints a report,
+# exits 0 on pass / 1 on fail. The agent-facing entry point —
+# component developers running smokes from the IDE use the
+# `smoke_dir!` proc-macro instead (`aether-smoke-macros`).
+
+[[bin]]
+name = "aether-smoke"
+path = "src/main.rs"
+
+[dependencies]
+aether-smoke = { path = "../aether-smoke" }
+
+[dev-dependencies]
+pollster = "0.4.0"
+wgpu = "29.0.1"

--- a/crates/aether-smoke-cli/src/main.rs
+++ b/crates/aether-smoke-cli/src/main.rs
@@ -1,0 +1,74 @@
+//! `aether-smoke` CLI — runs a YAML smoke script through the
+//! in-process `TestBench` chassis. Designed for agents and CI: takes
+//! one path argument, boots a fresh bench, walks the script, prints
+//! a report, exits 0 on pass / 1 on fail. Component developers
+//! typically reach for the `smoke_dir!` proc-macro instead so they
+//! get IDE-friendly per-script `#[test]` integration.
+
+use std::fs;
+use std::process::ExitCode;
+
+use aether_smoke::{RunReport, RunnerError, StepStatus, run_yaml_str};
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: aether-smoke <path-to-yaml>");
+        return ExitCode::from(2);
+    };
+    if args.next().is_some() {
+        eprintln!("usage: aether-smoke <path-to-yaml> (extra args not supported)");
+        return ExitCode::from(2);
+    }
+
+    let yaml = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("read {path}: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match run_yaml_str(&yaml) {
+        Ok(report) => {
+            print_report(&report);
+            if report.passed {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            }
+        }
+        Err(RunnerError::Parse(msg)) => {
+            eprintln!("yaml parse failed in {path}: {msg}");
+            ExitCode::from(2)
+        }
+        Err(RunnerError::Boot(msg)) => {
+            eprintln!("test-bench boot failed: {msg}");
+            ExitCode::from(2)
+        }
+        Err(other) => {
+            eprintln!("runner error: {other}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Pretty-print a `RunReport`. One line per step plus a final
+/// pass/fail line so `grep` against CI logs identifies the script
+/// and step that broke without re-parsing structured output.
+fn print_report(report: &RunReport) {
+    println!("smoke: {}", report.script_name);
+    for step in &report.steps {
+        match &step.status {
+            StepStatus::Pass => println!("  [{:>3}] {} ok", step.index, step.op),
+            StepStatus::Fail(reason) => {
+                println!("  [{:>3}] {} FAIL: {}", step.index, step.op, reason)
+            }
+        }
+    }
+    if report.passed {
+        println!("result: pass ({} steps)", report.steps.len());
+    } else {
+        println!("result: FAIL");
+    }
+}

--- a/crates/aether-smoke-cli/tests/cli_round_trip.rs
+++ b/crates/aether-smoke-cli/tests/cli_round_trip.rs
@@ -1,0 +1,66 @@
+//! End-to-end CLI test: invoke the `aether-smoke` binary against a
+//! fixture YAML, assert exit code + stdout. The binary boots a real
+//! TestBench, so this needs a wgpu adapter — same gating as the
+//! library's integration tests.
+
+use std::process::Command;
+
+/// Probe for any usable wgpu adapter. Headless Linux runners without
+/// `mesa-vulkan-drivers` skip the test rather than fail the binary.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+#[test]
+fn cli_runs_passing_smoke() {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_aether-smoke");
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/clear_color.yml"
+    );
+    let output = Command::new(bin).arg(fixture).output().expect("run cli");
+    assert!(
+        output.status.success(),
+        "cli exited with {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("result: pass"),
+        "missing pass marker in stdout:\n{stdout}",
+    );
+}
+
+#[test]
+fn cli_missing_path_arg_exits_nonzero() {
+    let bin = env!("CARGO_BIN_EXE_aether-smoke");
+    let output = Command::new(bin).output().expect("run cli");
+    assert!(
+        !output.status.success(),
+        "cli should fail without args, got {:?}",
+        output.status
+    );
+}
+
+#[test]
+fn cli_missing_file_exits_nonzero() {
+    let bin = env!("CARGO_BIN_EXE_aether-smoke");
+    let output = Command::new(bin)
+        .arg("/this/path/does/not/exist.yml")
+        .output()
+        .expect("run cli");
+    assert!(!output.status.success());
+}

--- a/crates/aether-smoke-cli/tests/fixtures/clear_color.yml
+++ b/crates/aether-smoke-cli/tests/fixtures/clear_color.yml
@@ -1,0 +1,8 @@
+name: clear color cli round trip
+steps:
+  - op: advance
+    ticks: 1
+  - op: capture
+  - op: assert
+    check:
+      kind: not_all_black

--- a/crates/aether-smoke-macros/Cargo.toml
+++ b/crates/aether-smoke-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aether-smoke-macros"
+version.workspace = true
+edition.workspace = true
+
+# Proc-macros that expand a directory of YAML smoke scripts into one
+# `#[test]` per file at the call site. Component crates `use
+# aether_smoke_macros::smoke_dir;` and invoke `smoke_dir!("smokes")`
+# so each `.yml` under that directory becomes an IDE-runnable Rust
+# test that boots a TestBench, runs the script, and asserts it passed.
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"

--- a/crates/aether-smoke-macros/src/lib.rs
+++ b/crates/aether-smoke-macros/src/lib.rs
@@ -1,0 +1,119 @@
+//! `smoke_dir!` — proc-macro that scans a directory at expansion
+//! time and emits one `#[test] fn ...` per `.yml` file. Each
+//! generated test embeds the script via `include_str!` (so cargo
+//! tracks file content changes), boots a fresh `TestBench`, runs
+//! the script, and asserts the report passed.
+//!
+//! The `include_str!` per-file path tracks individual file content,
+//! but cargo doesn't track *new* files added to the directory —
+//! adding a YAML file requires touching the source that calls
+//! `smoke_dir!` to retrigger expansion. That's the v1 trade-off;
+//! `proc_macro::tracked_path::path` (unstable) would close the gap
+//! once it stabilizes.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// `smoke_dir!("relative/dir")` — expand to one `#[test]` per
+/// `.yml` file under `relative/dir` (relative to `CARGO_MANIFEST_DIR`).
+/// Sub-directories are ignored — keep the layout flat in v1.
+///
+/// Generated test names are `smoke_<file_stem>` with non-identifier
+/// characters replaced by underscores. Two files whose stems collapse
+/// to the same identifier produce a duplicate-symbol compile error
+/// the author resolves by renaming.
+#[proc_macro]
+pub fn smoke_dir(input: TokenStream) -> TokenStream {
+    let dir_arg = match parse_string_literal(input) {
+        Ok(s) => s,
+        Err(msg) => return compile_error(&msg),
+    };
+    let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(s) => PathBuf::from(s),
+        Err(e) => return compile_error(&format!("CARGO_MANIFEST_DIR unavailable: {e}")),
+    };
+    let dir = manifest_dir.join(&dir_arg);
+    let yaml_files = match collect_yaml_files(&dir) {
+        Ok(v) => v,
+        Err(msg) => return compile_error(&msg),
+    };
+
+    let tests = yaml_files.iter().map(|path| emit_test(path, &manifest_dir));
+    quote!(#(#tests)*).into()
+}
+
+fn parse_string_literal(input: TokenStream) -> Result<String, String> {
+    let s = input.to_string();
+    let trimmed = s.trim();
+    if trimmed.len() < 2 || !trimmed.starts_with('"') || !trimmed.ends_with('"') {
+        return Err(format!(
+            "smoke_dir!(...) expects a single string literal, got `{s}`"
+        ));
+    }
+    Ok(trimmed[1..trimmed.len() - 1].to_owned())
+}
+
+fn collect_yaml_files(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    if !dir.exists() {
+        return Err(format!(
+            "smoke_dir!: directory does not exist: {}",
+            dir.display()
+        ));
+    }
+    let entries = fs::read_dir(dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))?;
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .extension()
+                .is_some_and(|ext| ext == "yml" || ext == "yaml")
+        {
+            out.push(path);
+        }
+    }
+    out.sort(); // Stable test order across platforms.
+    Ok(out)
+}
+
+fn emit_test(path: &Path, manifest_dir: &Path) -> proc_macro2::TokenStream {
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("smoke");
+    let test_name = format_ident!("smoke_{}", sanitize_ident(stem));
+    // Path emitted to `include_str!` is relative to `CARGO_MANIFEST_DIR`
+    // (the crate's source tree) so the macro works regardless of where
+    // cargo invokes it.
+    let rel = path
+        .strip_prefix(manifest_dir)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned());
+    quote! {
+        #[test]
+        fn #test_name() {
+            let yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", #rel));
+            let report = aether_smoke::run_yaml_str(yaml).expect("run smoke");
+            assert!(
+                report.passed,
+                "smoke {:?} failed:\n{:#?}",
+                report.script_name, report.steps,
+            );
+        }
+    }
+}
+
+/// Replace characters that aren't valid in Rust identifiers with '_'.
+/// Doesn't try to be clever about leading digits — the generated name
+/// is always prefixed with `smoke_` so it can't start with a digit.
+fn sanitize_ident(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+fn compile_error(msg: &str) -> TokenStream {
+    quote! {
+        compile_error!(#msg);
+    }
+    .into()
+}

--- a/crates/aether-smoke/Cargo.toml
+++ b/crates/aether-smoke/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 aether-hub-protocol = { path = "../aether-hub-protocol" }
 aether-kinds = { path = "../aether-kinds" }
 aether-params-codec = { path = "../aether-params-codec" }
+aether-smoke-macros = { path = "../aether-smoke-macros" }
 aether-substrate-test-bench = { path = "../aether-substrate-test-bench" }
 png = "0.17"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aether-smoke/src/lib.rs
+++ b/crates/aether-smoke/src/lib.rs
@@ -18,7 +18,8 @@ mod runner;
 mod script;
 mod visual;
 
+pub use aether_smoke_macros::smoke_dir;
 pub use report::{RunReport, StepReport, StepStatus};
-pub use runner::{Runner, RunnerError};
+pub use runner::{Runner, RunnerError, run_yaml_str};
 pub use script::{Script, Step, VisualAssert, parse_script};
 pub use visual::{Image, ImageError, decode_png, not_all_black};

--- a/crates/aether-smoke/src/runner.rs
+++ b/crates/aether-smoke/src/runner.rs
@@ -24,8 +24,25 @@ use crate::visual::{Image, decode_png, not_all_black};
 
 #[derive(Debug, Error)]
 pub enum RunnerError {
+    #[error("yaml parse failed: {0}")]
+    Parse(String),
+    #[error("test-bench boot failed: {0}")]
+    Boot(String),
     #[error("test-bench operation failed: {0}")]
     TestBench(String),
+}
+
+/// One-shot helper: parse a YAML script, boot a fresh `TestBench`,
+/// run the script, return the report. The bench is dropped before
+/// the function returns. Use this for the common "spin up, execute,
+/// observe" path the CLI and proc-macro consume; for finer control
+/// (existing bench, custom size, multiple scripts in one bench)
+/// drive `Runner::run` directly.
+pub fn run_yaml_str(yaml: &str) -> Result<RunReport, RunnerError> {
+    let script =
+        crate::script::parse_script(yaml).map_err(|e| RunnerError::Parse(e.to_string()))?;
+    let mut bench = TestBench::start().map_err(|e| RunnerError::Boot(e.to_string()))?;
+    Ok(Runner::run(&mut bench, &script))
 }
 
 /// Stateless walker. The runner threads its own `last_capture`

--- a/crates/aether-smoke/src/script.rs
+++ b/crates/aether-smoke/src/script.rs
@@ -45,8 +45,9 @@ pub enum Step {
     },
     /// Generic mail send. `recipient` is a mailbox name (e.g.
     /// `"aether.sink.io"`); `kind` names the payload kind in the
-    /// catalog (e.g. `"aether.io.write"`); `params` is the YAML body
-    /// the catalog's encoder maps onto the kind's wire shape.
+    /// substrate's descriptor inventory (e.g. `"aether.io.write"`);
+    /// `params` is the YAML body the schema encoder maps onto the
+    /// kind's wire shape.
     SendMail {
         recipient: String,
         kind: String,

--- a/crates/aether-smoke/tests/fixtures/smokes/clear_color_round_trip.yml
+++ b/crates/aether-smoke/tests/fixtures/smokes/clear_color_round_trip.yml
@@ -1,0 +1,8 @@
+name: clear color round trip
+steps:
+  - op: advance
+    ticks: 1
+  - op: capture
+  - op: assert
+    check:
+      kind: not_all_black

--- a/crates/aether-smoke/tests/fixtures/smokes/empty_boot.yml
+++ b/crates/aether-smoke/tests/fixtures/smokes/empty_boot.yml
@@ -1,0 +1,2 @@
+name: empty boot
+steps: []

--- a/crates/aether-smoke/tests/macro_smoke_dir.rs
+++ b/crates/aether-smoke/tests/macro_smoke_dir.rs
@@ -1,0 +1,15 @@
+//! Exercises the `smoke_dir!` proc-macro: scans `tests/fixtures/smokes`
+//! and emits one `#[test]` per `.yml` file. Each generated test boots
+//! a fresh `TestBench`, runs the script, and asserts the report
+//! passed. Because `run_yaml_str` boots its own bench, every test
+//! gets fresh GPU state — no cross-contamination.
+//!
+//! These tests also exercise the wgpu adapter on driverless runners.
+//! `run_yaml_str` will return `Boot` errors there, which the
+//! generated `expect("run smoke")` propagates as a test panic. To
+//! keep CI green on Linux we rely on `mesa-vulkan-drivers` being
+//! installed (CI workflow); on a developer box without Mesa, these
+//! tests fail loudly rather than silently skip — that's the
+//! agent-facing semantic the smoke runner wants.
+
+aether_smoke::smoke_dir!("tests/fixtures/smokes");


### PR DESCRIPTION
## Summary

ADR-0067 PR 7 of 9. Adds the two surfaces component authors and agents use to run smoke scripts:

- **aether-smoke-cli** — bin crate. `aether-smoke <path.yml>` boots a TestBench, runs the script, prints a per-step report, exits 0 on pass / 1 on fail / 2 on usage errors. The agent-facing entry point invoked from CI or by hand.
- **aether-smoke-macros** — proc-macro crate exposing `smoke_dir!`. Component crates write `aether_smoke::smoke_dir!("smokes")` and every `.yml` under that directory becomes an IDE-runnable Rust test that boots a fresh bench, runs the script, asserts pass. Each generated test embeds the YAML via `include_str!` so cargo tracks file content. Adding new files requires a source touch (`proc_macro::tracked_path::path` is unstable — v1 trade-off).

aether-smoke gains `run_yaml_str()` — the one-shot helper both CLI and proc-macro consume — and re-exports `smoke_dir!` so users only take one dep.

Fixtures + integration tests:
- `aether-smoke/tests/fixtures/smokes/` proves the proc-macro generates working tests (2 generated `#[test]`s pass against a real bench).
- `aether-smoke-cli/tests/cli_round_trip.rs` invokes the bin against a fixture and asserts exit code + stdout shape (3 tests).

## Test plan
- [x] cargo test --workspace — full suite passes locally including the new generated/CLI tests
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all -- --check clean
- [x] CI green across linux/macos/windows

## Phasing
- PR 4 (PR 412, merged) — in-process TestBench API
- PR 5 (PR 413, merged) — smoke library scaffold
- PR 5.5 (PR 415, merged) — extract encode_schema + decode_schema to aether-params-codec
- PR 6 (PR 414, merged) — component-driving steps via shared params-codec
- **PR 7 (this) — aether-smoke-cli + smoke_dir! proc-macro**
- PR 8 — first per-component smokes (mesh-viewer, camera)
- PR 9 — CI workflow + skill updates; closes issue 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)