### PR TITLE
feat(smoke): first per-component smoke + CI wasm pre-build (issue 400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Install Linux deps (ALSA for cpal, Mesa lavapipe for wgpu)
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev mesa-vulkan-drivers
       - uses: Swatinem/rust-cache@v2
+      # Pre-build component wasm artifacts the smoke runner loads at
+      # test time. Without this, ADR-0067 per-component smokes
+      # silently skip in CI ("wasm not built"). Cheap to build —
+      # the wasm targets are tiny next to the host workspace and
+      # rust-cache picks up the wasm artifacts on subsequent runs.
+      - name: Pre-build component wasm for smoke tests
+        run: cargo build --target wasm32-unknown-unknown -p aether-camera-component
       - run: cargo test --workspace --all-targets
 
   # Desktop chassis tests run the full OS matrix because winit event

--- a/crates/aether-smoke/tests/component_smoke.rs
+++ b/crates/aether-smoke/tests/component_smoke.rs
@@ -1,0 +1,102 @@
+//! First per-component smoke (ADR-0067, PR 8). Loads a real
+//! wasm component into a `TestBench`, advances a few ticks, captures
+//! a frame, and asserts the bench survived. The visual assertion is
+//! `not_all_black` only — chassis clears to a non-black color so any
+//! capture passes — but the test still validates the load path,
+//! wasm runtime boot, mail dispatch, tick fanout, and capture
+//! end-to-end. Future smokes assert tighter visual properties once
+//! the IO sink + DSL path lets us write actual geometry.
+//!
+//! Skipped when:
+//! - No wgpu adapter is available (driverless Linux runners without
+//!   `mesa-vulkan-drivers`).
+//! - The camera-component wasm hasn't been built — the test reads
+//!   `target/wasm32-unknown-unknown/{debug,release}/aether_camera_component.wasm`
+//!   and skips with an `eprintln!` when both paths are absent. CI
+//!   builds the wasm via the workspace `build` step before invoking
+//!   `cargo test`.
+
+use std::path::{Path, PathBuf};
+
+use aether_smoke::{Runner, Script, Step, VisualAssert};
+use aether_substrate_test_bench::TestBench;
+
+/// Probe for any usable wgpu adapter.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+/// Locate the camera component's wasm artifact. Tries `release` then
+/// `debug` so either build profile satisfies the test. Returns `None`
+/// if neither exists — the caller skips the test.
+fn camera_component_wasm() -> Option<PathBuf> {
+    // CARGO_MANIFEST_DIR is the smoke crate; the workspace target dir
+    // is two levels up.
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+    for profile in ["release", "debug"] {
+        let path = workspace
+            .join("target")
+            .join("wasm32-unknown-unknown")
+            .join(profile)
+            .join("aether_camera_component.wasm");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+#[test]
+fn camera_component_lifecycle() {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let Some(wasm_path) = camera_component_wasm() else {
+        eprintln!(
+            "skipping: aether_camera_component.wasm not built; \
+             run `cargo build --target wasm32-unknown-unknown -p aether-camera-component`",
+        );
+        return;
+    };
+
+    let script = Script {
+        name: "camera component lifecycle".to_owned(),
+        steps: vec![
+            Step::LoadComponent {
+                path: wasm_path.to_string_lossy().into_owned(),
+                // Use a non-default name so `"camera"` (the chassis
+                // sink) doesn't collide — see the chassis-sink-name
+                // feedback memory.
+                name: Some("cam".to_owned()),
+            },
+            // A few ticks lets the component finish init, run on_tick,
+            // and let the renderer cycle.
+            Step::Advance { ticks: 5 },
+            Step::Capture,
+            Step::Assert {
+                check: VisualAssert::NotAllBlack,
+            },
+        ],
+    };
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(
+        report.passed,
+        "camera-component lifecycle failed:\n{:#?}",
+        report.steps,
+    );
+    // Sanity: every step ran (no premature short-circuit).
+    assert_eq!(report.steps.len(), 4);
+}


### PR DESCRIPTION
## Summary

ADR-0067 PR 8 of 9. Adds the first component-loading smoke (the canonical "does the pipeline survive a real wasm load" check) and wires CI to build the wasm before tests so the smoke actually runs in CI.

**camera_component_lifecycle:**
- LoadComponent (camera-component wasm)
- Advance 5 ticks
- Capture
- Assert `not_all_black`

The visual assert is weak by design — chassis clears to a non-black color so any capture passes — but the test still validates the load path, wasm runtime boot, mail dispatch, tick fanout, and capture end-to-end. Tighter visual smokes (mesh-viewer cube render, frame regression) wait until the IO sink + DSL path lets us stage geometry without env-var gymnastics.

Test lives in `aether-smoke/tests/` instead of `aether-camera/tests/` for v1 — the test crate already has the wgpu + test-bench dev-deps; moving it to per-component crates would bloat their dev-deps and forces the path-resolution decision before it's settled.

**CI workflow:** adds a `cargo build --target wasm32-unknown-unknown -p aether-camera-component` step before `cargo test`. Cheap to build, rust-cache picks it up on subsequent runs.

## Test plan
- [x] cargo test -p aether-smoke — all 19 tests (incl. new component smoke) pass locally
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all -- --check clean
- [ ] CI green across linux/macos/windows
- [ ] CI exercises the smoke (not skipped) — confirmed by checking the test runs in the linux job's output

## Phasing
- PR 4 (PR 412) — in-process TestBench API
- PR 5 (PR 413) — smoke library scaffold
- PR 5.5 (PR 415) — extract encode_schema + decode_schema to aether-params-codec
- PR 6 (PR 414) — component-driving steps via shared params-codec
- PR 7 (PR 416) — aether-smoke-cli + smoke_dir! proc-macro
- **PR 8 (this) — first per-component smoke + CI wasm pre-build**
- PR 9 — skill updates (delegate, sweep); closes issue 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)