### PR TITLE
feat(scenario): mail-observation and background-pixel asserts (issue 430)

### DIFF
--- a/crates/aether-scenario/src/lib.rs
+++ b/crates/aether-scenario/src/lib.rs
@@ -21,5 +21,5 @@ mod visual;
 pub use aether_scenario_macros::scenario_dir;
 pub use report::{RunReport, StepReport, StepStatus};
 pub use runner::{Runner, RunnerError, run_yaml_str};
-pub use script::{Script, Step, VisualAssert, parse_script};
-pub use visual::{Image, ImageError, decode_png, not_all_black};
+pub use script::{Check, Script, Step, parse_script};
+pub use visual::{Image, ImageError, decode_png, differs_from_background, not_all_black};

--- a/crates/aether-scenario/src/runner.rs
+++ b/crates/aether-scenario/src/runner.rs
@@ -19,8 +19,8 @@ use aether_substrate_test_bench::TestBench;
 use thiserror::Error;
 
 use crate::report::{RunReport, StepReport, StepStatus};
-use crate::script::{Script, Step, VisualAssert};
-use crate::visual::{Image, decode_png, not_all_black};
+use crate::script::{Check, Script, Step};
+use crate::visual::{Image, decode_png, differs_from_background, not_all_black};
 
 #[derive(Debug, Error)]
 pub enum RunnerError {
@@ -117,17 +117,7 @@ fn run_step(
             },
             Err(e) => StepStatus::Fail(format!("capture failed: {e}")),
         },
-        Step::Assert { check } => match last_capture.as_ref() {
-            None => StepStatus::Fail(
-                "assert with no prior capture: add a `capture` step first".to_owned(),
-            ),
-            Some(img) => match check {
-                VisualAssert::NotAllBlack => match not_all_black(img) {
-                    Ok(()) => StepStatus::Pass,
-                    Err(reason) => StepStatus::Fail(reason),
-                },
-            },
-        },
+        Step::Assert { check } => run_assert(bench, check, last_capture.as_ref()),
         Step::LoadComponent { path, name } => {
             let wasm = match fs::read(path) {
                 Ok(bytes) => bytes,
@@ -153,6 +143,53 @@ fn run_step(
                 Err(e) => StepStatus::Fail(format!("send_bytes to {recipient}: {e}")),
             },
         },
+    }
+}
+
+/// Dispatch one `Assert` check against the current bench state.
+/// Visual checks require a prior capture; mail checks always read
+/// `TestBench::count_observed` and never touch `last_capture`.
+fn run_assert(bench: &TestBench, check: &Check, last_capture: Option<&Image>) -> StepStatus {
+    match check {
+        Check::NotAllBlack => match last_capture {
+            None => StepStatus::Fail(
+                "assert with no prior capture: add a `capture` step first".to_owned(),
+            ),
+            Some(img) => match not_all_black(img) {
+                Ok(()) => StepStatus::Pass,
+                Err(reason) => StepStatus::Fail(reason),
+            },
+        },
+        Check::DiffersFromBackground { tolerance } => match last_capture {
+            None => StepStatus::Fail(
+                "assert with no prior capture: add a `capture` step first".to_owned(),
+            ),
+            Some(img) => match differs_from_background(img, *tolerance) {
+                Ok(()) => StepStatus::Pass,
+                Err(reason) => StepStatus::Fail(reason),
+            },
+        },
+        Check::MailObserved { name, min_count } => {
+            let actual = bench.count_observed(name);
+            if actual >= *min_count {
+                StepStatus::Pass
+            } else {
+                StepStatus::Fail(format!(
+                    "expected `{name}` observed at least {min_count} time(s), got {actual}; observed kinds so far: {:?}",
+                    bench.observed_kinds()
+                ))
+            }
+        }
+        Check::MailNotObserved { name } => {
+            let actual = bench.count_observed(name);
+            if actual == 0 {
+                StepStatus::Pass
+            } else {
+                StepStatus::Fail(format!(
+                    "expected `{name}` not observed, but saw {actual} occurrence(s)"
+                ))
+            }
+        }
     }
 }
 
@@ -191,13 +228,13 @@ fn op_label(step: &Step) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use crate::script::{Script, Step, VisualAssert};
+    use crate::script::{Check, Script, Step};
 
     fn assert_before_capture_script() -> Script {
         Script {
             name: "early assert".to_owned(),
             steps: vec![Step::Assert {
-                check: VisualAssert::NotAllBlack,
+                check: Check::NotAllBlack,
             }],
         }
     }
@@ -220,7 +257,7 @@ mod tests {
             (Step::Capture, "capture"),
             (
                 Step::Assert {
-                    check: VisualAssert::NotAllBlack,
+                    check: Check::NotAllBlack,
                 },
                 "assert",
             ),

--- a/crates/aether-scenario/src/script.rs
+++ b/crates/aether-scenario/src/script.rs
@@ -28,10 +28,11 @@ pub enum Step {
     /// Capture the current offscreen frame as a PNG and stash it on
     /// the runner so subsequent `Assert` steps can inspect it.
     Capture,
-    /// Run a visual assertion against the most recent capture. Fails
-    /// the step if no capture has been taken yet, with a clear error
-    /// pointing at script ordering.
-    Assert { check: VisualAssert },
+    /// Run an assertion against the bench state — visual checks
+    /// inspect the most-recent capture; mail checks inspect the
+    /// observation log accumulated since boot. Visual checks fail
+    /// with a clear error if no capture has been taken yet.
+    Assert { check: Check },
     /// Load a WASM component from `path` (filesystem, read by the
     /// runner before sending). `name` is optional; when omitted the
     /// substrate auto-derives one from the component's manifest.
@@ -56,15 +57,53 @@ pub enum Step {
     },
 }
 
-/// Visual assertions over a captured frame's decoded pixels. Names
-/// describe the property being asserted, not the failure mode.
+/// Assertions runnable inside an `Assert` step. Visual variants
+/// inspect the most-recent capture; mail variants inspect the bench's
+/// observation log. Names describe the property being asserted, not
+/// the failure mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-pub enum VisualAssert {
-    /// Asserts at least one pixel in the frame is non-black. Cheapest
-    /// "the chassis rendered something" check — useful when a script
-    /// loaded a mesh and expects geometry to land on the framebuffer.
+pub enum Check {
+    /// Visual: asserts at least one pixel in the frame has a non-zero
+    /// RGB component. Weak — the chassis clear color is non-black, so
+    /// this only catches "the GPU produced no output at all." Prefer
+    /// `DiffersFromBackground` for "geometry rendered on top of the
+    /// clear pass" checks.
     NotAllBlack,
+    /// Visual: asserts at least one pixel differs from the top-left
+    /// pixel by more than `tolerance` per channel. The top-left is
+    /// (almost) always the chassis clear color in our scenes since
+    /// geometry is centered, so this catches "the frame is a uniform
+    /// clear color" — i.e. nothing rendered on top. `tolerance`
+    /// absorbs sRGB-encoding noise across GPUs.
+    DiffersFromBackground {
+        #[serde(default = "default_tolerance")]
+        tolerance: u8,
+    },
+    /// Mail: asserts at least `min_count` mail frames with kind name
+    /// `name` were observed. Observations come from the bench's
+    /// chassis-owned `aether.sink.render` and `aether.sink.camera`
+    /// sinks plus broadcast / session-zero frames on the loopback —
+    /// see `TestBench::count_observed` for the full surface.
+    MailObserved {
+        name: String,
+        #[serde(default = "default_min_count")]
+        min_count: usize,
+    },
+    /// Mail: asserts no mail frame with kind name `name` has been
+    /// observed since bench boot. Negative companion to
+    /// `MailObserved`. Bench observations are cumulative — if a kind
+    /// arrived earlier in the script, this assert will fail even
+    /// after the producing component has been dropped.
+    MailNotObserved { name: String },
+}
+
+fn default_tolerance() -> u8 {
+    5
+}
+
+fn default_min_count() -> usize {
+    1
 }
 
 /// Parse a script from YAML source. Returns the underlying serde_yml
@@ -102,8 +141,72 @@ steps:
         }
         match &script.steps[2] {
             Step::Assert { check } => {
-                assert!(matches!(check, VisualAssert::NotAllBlack));
+                assert!(matches!(check, Check::NotAllBlack));
             }
+            other => panic!("expected Assert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_differs_from_background_with_default_tolerance() {
+        let yaml = r#"
+name: bg
+steps:
+  - op: assert
+    check:
+      kind: differs_from_background
+"#;
+        let script = parse_script(yaml).expect("parse");
+        match &script.steps[0] {
+            Step::Assert { check } => match check {
+                Check::DiffersFromBackground { tolerance } => assert_eq!(*tolerance, 5),
+                other => panic!("expected DiffersFromBackground, got {other:?}"),
+            },
+            other => panic!("expected Assert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_mail_observed_with_default_min_count() {
+        let yaml = r#"
+name: mail
+steps:
+  - op: assert
+    check:
+      kind: mail_observed
+      name: aether.draw_triangle
+"#;
+        let script = parse_script(yaml).expect("parse");
+        match &script.steps[0] {
+            Step::Assert { check } => match check {
+                Check::MailObserved { name, min_count } => {
+                    assert_eq!(name, "aether.draw_triangle");
+                    assert_eq!(*min_count, 1);
+                }
+                other => panic!("expected MailObserved, got {other:?}"),
+            },
+            other => panic!("expected Assert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_mail_not_observed() {
+        let yaml = r#"
+name: no-mail
+steps:
+  - op: assert
+    check:
+      kind: mail_not_observed
+      name: aether.audio.note_on
+"#;
+        let script = parse_script(yaml).expect("parse");
+        match &script.steps[0] {
+            Step::Assert { check } => match check {
+                Check::MailNotObserved { name } => {
+                    assert_eq!(name, "aether.audio.note_on");
+                }
+                other => panic!("expected MailNotObserved, got {other:?}"),
+            },
             other => panic!("expected Assert, got {other:?}"),
         }
     }

--- a/crates/aether-scenario/src/visual.rs
+++ b/crates/aether-scenario/src/visual.rs
@@ -67,6 +67,37 @@ pub fn not_all_black(image: &Image) -> Result<(), String> {
     ))
 }
 
+/// Asserts at least one pixel differs from the top-left pixel by
+/// more than `tolerance` per RGB channel. The top-left pixel is the
+/// "background reference" — for chassis-rendered scenes it's almost
+/// always the clear color (geometry sits in the middle), so a passing
+/// check means "something was drawn on top of the clear pass." Alpha
+/// is ignored. Returns a one-line failure string identifying the
+/// reference color, suitable for `StepReport::Fail`.
+pub fn differs_from_background(image: &Image, tolerance: u8) -> Result<(), String> {
+    if image.rgba.len() < 4 {
+        return Err(format!(
+            "image too small to sample background: {}x{}",
+            image.width, image.height
+        ));
+    }
+    let bg_r = image.rgba[0];
+    let bg_g = image.rgba[1];
+    let bg_b = image.rgba[2];
+    for chunk in image.rgba.chunks_exact(4) {
+        let dr = chunk[0].abs_diff(bg_r);
+        let dg = chunk[1].abs_diff(bg_g);
+        let db = chunk[2].abs_diff(bg_b);
+        if dr > tolerance || dg > tolerance || db > tolerance {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "all {}x{} pixels within tolerance ±{} of top-left ({},{},{})",
+        image.width, image.height, tolerance, bg_r, bg_g, bg_b
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,5 +143,42 @@ mod tests {
         let mut img = solid(2, 2, [0, 0, 0, 255]);
         img.rgba[8] = 1; // R channel of pixel index 2
         assert!(not_all_black(&img).is_ok());
+    }
+
+    #[test]
+    fn differs_from_background_fails_on_uniform_color() {
+        let img = solid(8, 8, [69, 79, 105, 255]);
+        let err = differs_from_background(&img, 5).unwrap_err();
+        assert!(err.contains("69,79,105"));
+        assert!(err.contains("8x8"));
+    }
+
+    #[test]
+    fn differs_from_background_passes_when_one_pixel_diverges() {
+        let mut img = solid(4, 4, [69, 79, 105, 255]);
+        img.rgba[20] = 200; // R channel of pixel index 5
+        assert!(differs_from_background(&img, 5).is_ok());
+    }
+
+    #[test]
+    fn differs_from_background_respects_tolerance() {
+        // Pixel at idx 5 has R that differs from bg by 4 — within
+        // tolerance 5.
+        let mut img = solid(4, 4, [69, 79, 105, 255]);
+        img.rgba[20] = 73;
+        assert!(differs_from_background(&img, 5).is_err());
+        // Tolerance 3 — same diff now exceeds.
+        assert!(differs_from_background(&img, 3).is_ok());
+    }
+
+    #[test]
+    fn differs_from_background_handles_tiny_image() {
+        let img = Image {
+            width: 0,
+            height: 0,
+            rgba: Vec::new(),
+        };
+        let err = differs_from_background(&img, 5).unwrap_err();
+        assert!(err.contains("too small"));
     }
 }

--- a/crates/aether-scenario/tests/component_scenario.rs
+++ b/crates/aether-scenario/tests/component_scenario.rs
@@ -18,7 +18,7 @@
 
 use std::path::{Path, PathBuf};
 
-use aether_scenario::{Runner, Script, Step, VisualAssert};
+use aether_scenario::{Check, Runner, Script, Step};
 use aether_substrate_test_bench::TestBench;
 
 /// Probe for any usable wgpu adapter.
@@ -85,7 +85,7 @@ fn camera_component_lifecycle() {
             Step::Advance { ticks: 5 },
             Step::Capture,
             Step::Assert {
-                check: VisualAssert::NotAllBlack,
+                check: Check::NotAllBlack,
             },
         ],
     };

--- a/crates/aether-scenario/tests/fixtures/scenarios/empty_boot_observes_no_geometry.yml
+++ b/crates/aether-scenario/tests/fixtures/scenarios/empty_boot_observes_no_geometry.yml
@@ -1,0 +1,23 @@
+name: empty boot observes no geometry
+# An empty bench should clear to the chassis background, never produce
+# DrawTriangle, and emit no FrameStats within fewer than 120 ticks.
+# Validates the new mail-observation and visual asserts on the
+# baseline state. NotAllBlack should pass (background is non-black);
+# DiffersFromBackground should fail (uniform clear); MailNotObserved
+# for DrawTriangle should pass; MailNotObserved for FrameStats should
+# pass at <120 ticks.
+steps:
+  - op: advance
+    ticks: 5
+  - op: capture
+  - op: assert
+    check:
+      kind: not_all_black
+  - op: assert
+    check:
+      kind: mail_not_observed
+      name: aether.draw_triangle
+  - op: assert
+    check:
+      kind: mail_not_observed
+      name: aether.observation.frame_stats

--- a/crates/aether-scenario/tests/fixtures/scenarios/frame_stats_emitted_after_120_ticks.yml
+++ b/crates/aether-scenario/tests/fixtures/scenarios/frame_stats_emitted_after_120_ticks.yml
@@ -1,0 +1,12 @@
+name: frame_stats emitted after 120 ticks
+# The substrate emits aether.observation.frame_stats every 120 frames
+# (ADR-0023). Advancing exactly 120 ticks should produce one such
+# broadcast on the loopback, observable via mail_observed.
+steps:
+  - op: advance
+    ticks: 120
+  - op: assert
+    check:
+      kind: mail_observed
+      name: aether.observation.frame_stats
+      min_count: 1

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -136,6 +136,16 @@ pub struct TestBench {
     /// late-arriving frame) doesn't get silently dropped.
     stashed_replies: HashMap<u64, EngineToHub>,
 
+    /// Kind names of mail observed via the chassis-owned sinks
+    /// (`aether.sink.render`, `aether.sink.camera`) plus broadcast /
+    /// session-zero frames that arrived on the loopback. Used by
+    /// scenario assertions like `Check::MailObserved`. Limitation
+    /// (v1): mail addressed to other sinks (`aether.sink.io`,
+    /// `aether.sink.log`) and direct component-to-component mail does
+    /// not show up here — those flows don't pass through outbound and
+    /// are not observed by the chassis-owned sinks the bench wraps.
+    observed_kinds: Arc<Mutex<Vec<String>>>,
+
     /// Lifetime guard. Boot owns the scheduler; dropping the
     /// TestBench drops the boot which joins the worker threads.
     _boot: SubstrateBoot,
@@ -188,12 +198,14 @@ impl TestBench {
             .kind_id(FrameStats::NAME)
             .expect("FrameStats registered");
 
+        let observed_kinds = Arc::new(Mutex::new(Vec::<String>::new()));
+
         let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(VERTEX_BUFFER_BYTES)));
         let triangles_rendered = Arc::new(AtomicU64::new(0));
-        register_render_sink(&boot, &frame_vertices, &triangles_rendered);
+        register_render_sink(&boot, &frame_vertices, &triangles_rendered, &observed_kinds);
 
         let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
-        register_camera_sink(&boot, &camera_state);
+        register_camera_sink(&boot, &camera_state, &observed_kinds);
 
         if let Ok((reg, _roots)) = aether_substrate_core::io::build_default_registry() {
             boot.registry.register_sink(
@@ -235,8 +247,30 @@ impl TestBench {
             next_correlation_id: AtomicU64::new(1),
             session: SessionToken(Uuid::from_u128(TESTBENCH_SESSION_UUID)),
             stashed_replies: HashMap::new(),
+            observed_kinds,
             _boot: boot,
         })
+    }
+
+    /// Count how many mail observations match `kind_name`. Includes
+    /// mail observed at the chassis-owned `aether.sink.render` /
+    /// `aether.sink.camera` sinks plus any broadcast / session-zero
+    /// frames that arrived on the loopback. Mail to other sinks and
+    /// direct component-to-component flows are not observed (v1).
+    pub fn count_observed(&self, kind_name: &str) -> usize {
+        self.observed_kinds
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|n| n.as_str() == kind_name)
+            .count()
+    }
+
+    /// Snapshot every kind name currently observed, oldest first.
+    /// Cheap clone — used for scenario diagnostics when an assert
+    /// trips, so the failure message can list "what we did see."
+    pub fn observed_kinds(&self) -> Vec<String> {
+        self.observed_kinds.lock().unwrap().clone()
     }
 
     /// Push a fire-and-forget mail into the queue. Recipient is
@@ -375,7 +409,14 @@ impl TestBench {
                     continue;
                 }
                 // Broadcast or session-zero — frame_stats and the
-                // like. Drop.
+                // like. Record the kind so scenario assertions can
+                // observe substrate-emitted broadcasts.
+                if let EngineToHub::Mail(m) = &frame {
+                    self.observed_kinds
+                        .lock()
+                        .unwrap()
+                        .push(m.kind_name.clone());
+                }
             }
 
             if iteration > 0 && events_processed == 0 {
@@ -529,18 +570,21 @@ fn register_render_sink(
     boot: &SubstrateBoot,
     frame_vertices: &Arc<Mutex<Vec<u8>>>,
     triangles_rendered: &Arc<AtomicU64>,
+    observed_kinds: &Arc<Mutex<Vec<String>>>,
 ) {
     let verts_for_sink = Arc::clone(frame_vertices);
     let tris_for_sink = Arc::clone(triangles_rendered);
+    let observed_for_sink = Arc::clone(observed_kinds);
     boot.registry.register_sink(
         "aether.sink.render",
         Arc::new(
             move |_kind_id: u64,
-                  _kind_name: &str,
+                  kind_name: &str,
                   _origin: Option<&str>,
                   _sender: ReplyTo,
                   bytes: &[u8],
                   _count: u32| {
+                observed_for_sink.lock().unwrap().push(kind_name.to_owned());
                 let mut verts = verts_for_sink.lock().unwrap();
                 let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
                 let write_len = bytes.len().min(available);
@@ -564,17 +608,23 @@ fn register_render_sink(
     );
 }
 
-fn register_camera_sink(boot: &SubstrateBoot, camera_state: &Arc<Mutex<[f32; 16]>>) {
+fn register_camera_sink(
+    boot: &SubstrateBoot,
+    camera_state: &Arc<Mutex<[f32; 16]>>,
+    observed_kinds: &Arc<Mutex<Vec<String>>>,
+) {
     let cam_for_sink = Arc::clone(camera_state);
+    let observed_for_sink = Arc::clone(observed_kinds);
     boot.registry.register_sink(
         "aether.sink.camera",
         Arc::new(
             move |_kind_id: u64,
-                  _kind_name: &str,
+                  kind_name: &str,
                   _origin: Option<&str>,
                   _sender: ReplyTo,
                   bytes: &[u8],
                   _count: u32| {
+                observed_for_sink.lock().unwrap().push(kind_name.to_owned());
                 if bytes.len() != 64 {
                     tracing::warn!(
                         target: "aether_substrate::camera",


### PR DESCRIPTION
## Summary

Phase 1 of issue 430 — extends the `aether-scenario` assertion vocabulary so per-component / per-substrate scenarios can catch the regressions Phase 2 and 3 will write tests against.

- Renames `VisualAssert` → `Check` (broader scope; existing `kind: not_all_black` YAML still parses).
- Adds `Check::DiffersFromBackground { tolerance }` — samples top-left pixel as the chassis-clear reference and asserts at least one other pixel diverges. Catches "rendered nothing on top of clear" which `NotAllBlack` misses (chassis clears to dark blue, not black, so empty frames pass `NotAllBlack`).
- Adds `Check::MailObserved { name, min_count }` and `Check::MailNotObserved { name }` — read `TestBench::count_observed`, which tracks mail through the chassis-owned `aether.sink.render` / `aether.sink.camera` sinks plus broadcast / session-zero frames on the loopback. Mail to other sinks (`aether.sink.io`, `aether.sink.log`) and direct component-to-component flows are not observed in v1; that limitation is documented inline.
- Two new fixture scenarios exercise the new variants: `empty_boot_observes_no_geometry.yml` (negative mail asserts on a clean bench) and `frame_stats_emitted_after_120_ticks.yml` (positive observation of the 120-frame `aether.observation.frame_stats` broadcast cadence).

## Test plan

- [x] `cargo test --workspace` — every test group green; 4 scenario YAMLs now run via `scenario_dir!` (was 2).
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.
- [x] New unit tests in `script.rs` round-trip the new YAML variants with default field values.
- [x] New unit tests in `visual.rs` exercise `differs_from_background` on uniform / divergent / tolerance-edge / tiny images.
- [x] `frame_stats_emitted_after_120_ticks` validates broadcast observation via the loopback drain path.

Refs issue 430 (Phase 1). Phases 2 (per-component scenarios) and 3 (substrate-feature scenarios) remain.

# pr-body-ok: b — issue auto-link references in summary