### PR TITLE
feat(sokoban): scenario tests for default render + key-press path (issue 430)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,12 @@ dependencies = [
  "aether-component",
  "aether-kinds",
  "aether-mail",
+ "aether-scenario",
+ "aether-substrate-test-bench",
  "bytemuck",
+ "pollster",
+ "serde_yml",
+ "wgpu",
 ]
 
 [[package]]

--- a/demos/sokoban/Cargo.toml
+++ b/demos/sokoban/Cargo.toml
@@ -4,7 +4,11 @@ version.workspace = true
 edition.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+# `cdylib` is the production artifact (wasm32 build → component). `rlib`
+# is added so host builds can link integration tests under `tests/` —
+# the crate's own scenario tests load the wasm at runtime, but cargo
+# still needs a host-target lib to resolve the test binary against.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-component = { path = "../../crates/aether-component" }
@@ -12,3 +16,15 @@ aether-camera = { path = "../../crates/aether-camera" }
 aether-kinds = { path = "../../crates/aether-kinds" }
 aether-mail = { path = "../../crates/aether-mail", features = ["derive"] }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
+
+# Integration tests boot a `TestBench`, load the demo's own wasm
+# artifact, and assert mail-flow + render properties via `aether-scenario`.
+# Tests run host-side; the wasm is built separately for
+# `wasm32-unknown-unknown` and discovered at runtime under
+# `target/wasm32-unknown-unknown/{debug,release}/`.
+[dev-dependencies]
+aether-scenario = { path = "../../crates/aether-scenario" }
+aether-substrate-test-bench = { path = "../../crates/aether-substrate-test-bench" }
+pollster = "0.4.0"
+serde_yml = "0.0.12"
+wgpu = "29.0.1"

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -1,0 +1,185 @@
+//! Sokoban demo scenario tests. Each test boots a `TestBench`, loads
+//! this crate's own wasm artifact (built separately for
+//! `wasm32-unknown-unknown`), and asserts the grid-and-player render
+//! path.
+//!
+//! Skipped when:
+//! - No wgpu adapter is available (driverless Linux runners without
+//!   `mesa-vulkan-drivers`).
+//! - The component's wasm hasn't been built — tests read
+//!   `target/wasm32-unknown-unknown/{debug,release}/aether_demo_sokoban.wasm`
+//!   and skip with an `eprintln!` when both paths are absent. CI
+//!   builds the wasm before invoking `cargo test`.
+
+use std::path::{Path, PathBuf};
+
+use aether_kinds::keycode;
+use aether_scenario::{Check, Runner, Script, Step};
+use aether_substrate_test_bench::TestBench;
+
+// Force linkage of this crate's own rlib so its `inventory::submit!`
+// `KindDescriptor` entries reach `aether_kinds::descriptors::all()`
+// in the test binary. The integration test compiles as a separate
+// crate that depends on the parent's rlib; without an explicit
+// reference the linker strips the descriptor symbols, and
+// `Step::SendMail` for `demo.sokoban.*` kinds fails with "unknown
+// kind". Same fix as PR 432 / PR 434 used for the trunk-rlib
+// pattern.
+use aether_demo_sokoban as _;
+
+/// Probe for any usable wgpu adapter.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+/// Locate this crate's wasm artifact. Tries `release` then `debug`
+/// so either build profile satisfies the test. `CARGO_MANIFEST_DIR`
+/// is `demos/sokoban`; the workspace target dir is two levels up.
+fn sokoban_wasm() -> Option<PathBuf> {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+    for profile in ["release", "debug"] {
+        let path = workspace
+            .join("target")
+            .join("wasm32-unknown-unknown")
+            .join(profile)
+            .join("aether_demo_sokoban.wasm");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Common setup: skip-if-no-adapter / skip-if-no-wasm. Returns the
+/// wasm path on success.
+fn require_runtime() -> Option<PathBuf> {
+    if !has_wgpu_adapter() {
+        eprintln!("skipping: no wgpu adapter available");
+        return None;
+    }
+    let path = sokoban_wasm()?;
+    Some(path)
+}
+
+/// Build a `SendMail` step that fires a direct `aether.tick` to
+/// `mailbox` so the next `Capture` frame sees fresh render-sink
+/// emissions.
+///
+/// Background: `TestBench::capture` runs its frame with
+/// `dispatch_tick=false` (capture is a state snapshot, not a tick
+/// advance). The render sink's vert buffer is consumed-and-replaced
+/// every frame, so a component that emits geometry only on
+/// `on_tick` paints nothing during the capture frame even though
+/// the previous `Advance` ticked it. Pushing `aether.tick` to the
+/// component's mailbox right before `Capture` queues a tick that
+/// drains alongside the capture request, populating the buffer
+/// before the offscreen render reads it.
+fn tick_to(mailbox: &str) -> Step {
+    Step::SendMail {
+        recipient: mailbox.to_owned(),
+        kind: "aether.tick".to_owned(),
+        params: serde_yml::Value::Null,
+    }
+}
+
+/// Default-level rendering smoke test. Loads the wasm, advances a
+/// few ticks so init + tick can flush, fires one more tick before
+/// capture (so render-sink verts populate), and asserts both that
+/// `DrawTriangle` mail flows and that the captured frame contains
+/// pixels diverging from the chassis clear color.
+#[test]
+fn default_level_renders_grid_and_player() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+
+    let script = Script {
+        name: "sokoban default level renders".to_owned(),
+        steps: vec![
+            Step::LoadComponent {
+                path: wasm_path.to_string_lossy().into_owned(),
+                name: Some("world".to_owned()),
+            },
+            Step::Advance { ticks: 3 },
+            tick_to("world"),
+            Step::Capture,
+            Step::Assert {
+                check: Check::MailObserved {
+                    name: "aether.draw_triangle".to_owned(),
+                    min_count: 1,
+                },
+            },
+            Step::Assert {
+                check: Check::DiffersFromBackground { tolerance: 5 },
+            },
+        ],
+    };
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(
+        report.passed,
+        "sokoban default level scenario failed:\n{:#?}",
+        report.steps,
+    );
+}
+
+/// Key-press path doesn't break rendering. Sokoban's `on_key`
+/// handler steps the player one cell on `KEY_D`; the next tick must
+/// still produce a renderable frame. Validates that the input
+/// dispatch doesn't trap or wedge the component's render loop.
+#[test]
+fn key_press_keeps_render_path_alive() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+
+    let key_d_yaml = format!("code: {}", keycode::KEY_D);
+    let script = Script {
+        name: "sokoban key press keeps rendering".to_owned(),
+        steps: vec![
+            Step::LoadComponent {
+                path: wasm_path.to_string_lossy().into_owned(),
+                name: Some("world".to_owned()),
+            },
+            Step::Advance { ticks: 2 },
+            // Press D — sokoban steps the player east; the WASD/arrow
+            // mapping lives in `step_delta` inside the demo's lib.rs.
+            Step::SendMail {
+                recipient: "world".to_owned(),
+                kind: "aether.key".to_owned(),
+                params: serde_yml::from_str(&key_d_yaml).expect("key params parse"),
+            },
+            Step::Advance { ticks: 2 },
+            tick_to("world"),
+            Step::Capture,
+            Step::Assert {
+                check: Check::MailObserved {
+                    name: "aether.draw_triangle".to_owned(),
+                    min_count: 1,
+                },
+            },
+            Step::Assert {
+                check: Check::DiffersFromBackground { tolerance: 5 },
+            },
+        ],
+    };
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(
+        report.passed,
+        "sokoban key-press scenario failed:\n{:#?}",
+        report.steps,
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 sokoban scenarios from issue 430. Two integration tests in `demos/sokoban/tests/scenario.rs`:

- `default_level_renders_grid_and_player` — load wasm, advance ticks (init + on_tick draws the grid and player), tick before capture so render-sink verts populate, assert `MailObserved aether.draw_triangle` and `DiffersFromBackground`.
- `key_press_keeps_render_path_alive` — same shape but with an `aether.key { code: KEY_D }` between advances. Validates that the input dispatch (sokoban's `on_key` handler steps the player) doesn't trap or wedge the render loop on the next tick.

## Setup

Crate setup mirrors PR 432 / PR 434: `cdylib + rlib` for host-side test linkage, plus `use aether_demo_sokoban as _;` in the test file to keep the crate's own inventory descriptors out of the linker's strip pile. Sokoban hosts `demo.sokoban.*` kinds inline in its lib.rs (no separate trunk rlib), so the `as _;` reference points at the parent crate itself.

The `tick_to(mailbox)` workaround stays — `TestBench::capture` runs its frame with `dispatch_tick=false`, so a component that emits geometry only on `on_tick` paints nothing during the capture frame unless a fresh tick is queued just before the capture request drains. This is the third call site for the helper (camera, mesh-viewer, sokoban); extraction into `aether-scenario::helpers` is now warranted and worth doing as a follow-up cleanup PR once tic-tac-toe + tic-tac-toe-client land for symmetry.

## Test plan

- `cargo test -p aether-demo-sokoban --test scenario` — both tests pass locally on macOS Metal in 1.3 s.
- `cargo clippy -p aether-demo-sokoban --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo check -p aether-demo-sokoban --target wasm32-unknown-unknown` — wasm build still good after the rlib + dev-dep additions.

Refs issue 430 (Phase 2 sokoban checkbox only — issue stays open for tic-tac-toe variants and Phase 3 substrate features).
