### PR TITLE
fix(ci): pre-build wasm for every scenario crate; fail loud on missing (issue 438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,20 @@ jobs:
       # silently skip in CI ("wasm not built"). Cheap to build —
       # the wasm targets are tiny next to the host workspace and
       # rust-cache picks up the wasm artifacts on subsequent runs.
+      # Every component crate that ships a `tests/scenario.rs` belongs
+      # in this list; `AETHER_REQUIRE_RUNTIME=1` on the test step turns
+      # any missing wasm into a hard failure so a forgotten pre-build
+      # entry is loud, not silent.
       - name: Pre-build component wasm for scenario tests
-        run: cargo build --target wasm32-unknown-unknown -p aether-camera-component
+        run: |
+          cargo build --target wasm32-unknown-unknown \
+            -p aether-camera-component \
+            -p aether-mesh-viewer-component \
+            -p aether-demo-sokoban \
+            -p aether-demo-tic-tac-toe
       - run: cargo test --workspace --all-targets
+        env:
+          AETHER_REQUIRE_RUNTIME: "1"
 
   # Desktop chassis tests run the full OS matrix because winit event
   # loops, wgpu driver init, and platform-specific frame capture are

--- a/crates/aether-camera-component/tests/scenario.rs
+++ b/crates/aether-camera-component/tests/scenario.rs
@@ -38,6 +38,40 @@ fn has_wgpu_adapter() -> bool {
     .is_ok()
 }
 
+/// Common setup: skip-if-no-adapter / skip-if-no-wasm. Returns the
+/// wasm path on success.
+///
+/// `AETHER_REQUIRE_RUNTIME=1` flips both skip points into a panic so
+/// CI catches a forgotten pre-build entry instead of passing a 30ms
+/// vacuous test. CI sets this; local devs leave it unset and keep the
+/// existing skip behavior.
+fn require_runtime() -> Option<PathBuf> {
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    if !has_wgpu_adapter() {
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
+        eprintln!("skipping: no wgpu adapter available");
+        return None;
+    }
+    match camera_component_wasm() {
+        Some(path) => Some(path),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_camera_component.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing this crate",
+            );
+            eprintln!(
+                "skipping: aether_camera_component.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown -p aether-camera-component`",
+            );
+            None
+        }
+    }
+}
+
 /// Locate this crate's wasm artifact. Tries `release` then `debug`
 /// so either build profile satisfies the test. Returns `None` if
 /// neither exists — the caller skips the test. `CARGO_MANIFEST_DIR`
@@ -63,15 +97,7 @@ fn camera_component_wasm() -> Option<PathBuf> {
 
 #[test]
 fn camera_component_lifecycle() {
-    if !has_wgpu_adapter() {
-        eprintln!("skipping: no wgpu adapter available");
-        return;
-    }
-    let Some(wasm_path) = camera_component_wasm() else {
-        eprintln!(
-            "skipping: aether_camera_component.wasm not built; \
-             run `cargo build --target wasm32-unknown-unknown -p aether-camera-component`",
-        );
+    let Some(wasm_path) = require_runtime() else {
         return;
     };
 
@@ -115,15 +141,7 @@ fn camera_component_lifecycle() {
 /// `TestBench::count_observed`.
 #[test]
 fn camera_default_orbit_publishes_view_proj() {
-    if !has_wgpu_adapter() {
-        eprintln!("skipping: no wgpu adapter available");
-        return;
-    }
-    let Some(wasm_path) = camera_component_wasm() else {
-        eprintln!(
-            "skipping: aether_camera_component.wasm not built; \
-             run `cargo build --target wasm32-unknown-unknown -p aether-camera-component`",
-        );
+    let Some(wasm_path) = require_runtime() else {
         return;
     };
 
@@ -167,15 +185,7 @@ fn camera_default_orbit_publishes_view_proj() {
 /// shouldn't take down the chassis.
 #[test]
 fn camera_destroy_main_keeps_substrate_alive() {
-    if !has_wgpu_adapter() {
-        eprintln!("skipping: no wgpu adapter available");
-        return;
-    }
-    let Some(wasm_path) = camera_component_wasm() else {
-        eprintln!(
-            "skipping: aether_camera_component.wasm not built; \
-             run `cargo build --target wasm32-unknown-unknown -p aether-camera-component`",
-        );
+    let Some(wasm_path) = require_runtime() else {
         return;
     };
 

--- a/crates/aether-mesh-viewer-component/tests/scenario.rs
+++ b/crates/aether-mesh-viewer-component/tests/scenario.rs
@@ -98,13 +98,36 @@ fn mesh_viewer_wasm() -> Option<PathBuf> {
 
 /// Common setup: skip-if-no-adapter / skip-if-no-wasm. Returns the
 /// wasm path on success.
+///
+/// `AETHER_REQUIRE_RUNTIME=1` flips both skip points into a panic so
+/// CI catches a forgotten pre-build entry instead of passing a 30ms
+/// vacuous test. CI sets this; local devs leave it unset and keep the
+/// existing skip behavior.
 fn require_runtime() -> Option<PathBuf> {
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     if !has_wgpu_adapter() {
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
         eprintln!("skipping: no wgpu adapter available");
         return None;
     }
-    let path = mesh_viewer_wasm()?;
-    Some(path)
+    match mesh_viewer_wasm() {
+        Some(path) => Some(path),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_mesh_viewer_component.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing this crate",
+            );
+            eprintln!(
+                "skipping: aether_mesh_viewer_component.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown -p aether-mesh-viewer-component`",
+            );
+            None
+        }
+    }
 }
 
 const BOX_DSL: &[u8] = b"(box 1 1 1 :color 0)\n";

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -62,13 +62,36 @@ fn sokoban_wasm() -> Option<PathBuf> {
 
 /// Common setup: skip-if-no-adapter / skip-if-no-wasm. Returns the
 /// wasm path on success.
+///
+/// `AETHER_REQUIRE_RUNTIME=1` flips both skip points into a panic so
+/// CI catches a forgotten pre-build entry instead of passing a 30ms
+/// vacuous test. CI sets this; local devs leave it unset and keep the
+/// existing skip behavior.
 fn require_runtime() -> Option<PathBuf> {
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     if !has_wgpu_adapter() {
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
         eprintln!("skipping: no wgpu adapter available");
         return None;
     }
-    let path = sokoban_wasm()?;
-    Some(path)
+    match sokoban_wasm() {
+        Some(path) => Some(path),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_demo_sokoban.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing this crate",
+            );
+            eprintln!(
+                "skipping: aether_demo_sokoban.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown -p aether-demo-sokoban`",
+            );
+            None
+        }
+    }
 }
 
 /// Build a `SendMail` step that fires a direct `aether.tick` to


### PR DESCRIPTION
## Summary

Phase 2 PRs (432 / 434 / 436) merged green but CI was only pre-building the camera component's wasm. Mesh-viewer + sokoban scenario tests on the Linux runner finished in 30ms — the `eprintln!` skip path — instead of the ~1.5s a real `TestBench` boot + load takes. Confirmed in PR 436's CI log: both sokoban tests "passed in 0.03s."

Two layered fixes:

- **Pre-build line covers every scenario crate.** `.github/workflows/ci.yml` now passes every component-with-scenarios to one `cargo build --target wasm32-unknown-unknown` invocation. Issue 439 tracks the follow-up to discover scenario crates from `cargo metadata` so this list stops growing by hand.
- **`AETHER_REQUIRE_RUNTIME=1` env-gates the skip path.** With the env var set, missing wgpu adapter or missing wasm panics with a message naming the workflow step that needs updating, instead of silently returning Ok. CI sets the env var on the test step. Local dev leaves it unset and keeps the existing skip behavior.

Camera-component test file got a `require_runtime` helper extracted from three identical inline skip blocks; mesh-viewer + sokoban already had the helper and just needed the env-gating spliced in.

The fourth crate (`aether-demo-tic-tac-toe`, PR 437 still open) will pick up the same pattern when that PR rebases — a follow-up commit on that branch adds the env check and extends the pre-build line.

## Test plan

Local:
- `cargo test -p aether-camera-component -p aether-mesh-viewer-component -p aether-demo-sokoban` passes with and without `AETHER_REQUIRE_RUNTIME=1` when wasm is pre-built (1.97s real run vs 0s skip).
- Deleting `aether_demo_sokoban.wasm` and re-running with `AETHER_REQUIRE_RUNTIME=1` panics with the exact message the CI failure mode is supposed to surface (verified in commit's test plan section).

CI:
- This PR is the first run that should show all three Phase 2 component scenario test files actually running their tests on Linux. Look for `Running tests/scenario.rs` lines with timings ~1–3s each, not 30ms. If any returns 0s, the env-gating wasn't picked up correctly.

Closes #438.
