### PR TITLE
feat(tic-tac-toe-client): scenario tests + adr-0066 trunk-rlib refactor (issue 430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
             -p aether-camera-component \
             -p aether-mesh-viewer-component \
             -p aether-demo-sokoban \
-            -p aether-demo-tic-tac-toe
+            -p aether-demo-tic-tac-toe-server \
+            -p aether-demo-tic-tac-toe-client
       - run: cargo test --workspace --all-targets
         env:
           AETHER_REQUIRE_RUNTIME: "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,9 @@ dependencies = [
 name = "aether-demo-tic-tac-toe"
 version = "0.2.0-alpha"
 dependencies = [
- "aether-component",
- "aether-kinds",
  "aether-mail",
- "aether-scenario",
- "aether-substrate-test-bench",
  "bytemuck",
- "pollster",
- "serde_yml",
- "wgpu",
+ "inventory",
 ]
 
 [[package]]
@@ -110,6 +104,25 @@ dependencies = [
  "aether-component",
  "aether-demo-tic-tac-toe",
  "aether-kinds",
+ "aether-scenario",
+ "aether-substrate-test-bench",
+ "pollster",
+ "serde_yml",
+ "wgpu",
+]
+
+[[package]]
+name = "aether-demo-tic-tac-toe-server"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-component",
+ "aether-demo-tic-tac-toe",
+ "aether-mail",
+ "aether-scenario",
+ "aether-substrate-test-bench",
+ "pollster",
+ "serde_yml",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/aether-mail-derive",
     "demos/sokoban",
     "demos/tic-tac-toe",
+    "demos/tic-tac-toe-server",
     "demos/tic-tac-toe-client",
 ]
 # Reference artefacts under spikes/ are standalone Cargo workspaces

--- a/demos/tic-tac-toe-client/Cargo.toml
+++ b/demos/tic-tac-toe-client/Cargo.toml
@@ -4,9 +4,30 @@ version.workspace = true
 edition.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+# `cdylib` is the production artifact (wasm32 build → component). `rlib`
+# is added so host builds can link integration tests under `tests/` —
+# the crate's own scenario tests load the wasm at runtime, but cargo
+# still needs a host-target lib to resolve the test binary against.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-component = { path = "../../crates/aether-component" }
+# Trunk rlib for the demo (ADR-0066) — wire types + well-known names.
+# The server's runtime `Component` impl + FFI exports live in the
+# sibling `aether-demo-tic-tac-toe-server` cdylib, which this crate
+# does not depend on at all. Per issue 442.
 aether-demo-tic-tac-toe = { path = "../tic-tac-toe" }
 aether-kinds = { path = "../../crates/aether-kinds" }
+
+# Integration tests boot a `TestBench`, load the demo's own wasm
+# artifact (and the server's, for the click→PlayMove→broadcast flow),
+# and assert mail-flow + render properties via `aether-scenario`.
+# Tests run host-side; the wasm is built separately for
+# `wasm32-unknown-unknown` and discovered at runtime under
+# `target/wasm32-unknown-unknown/{debug,release}/`.
+[dev-dependencies]
+aether-scenario = { path = "../../crates/aether-scenario" }
+aether-substrate-test-bench = { path = "../../crates/aether-substrate-test-bench" }
+pollster = "0.4.0"
+serde_yml = "0.0.12"
+wgpu = "29.0.1"

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -23,11 +23,11 @@
 //!
 //! Hub-hosted deployment (ADR-0037 Phase 3):
 //! ```text
-//! cargo build -p aether-demo-tic-tac-toe --target wasm32-unknown-unknown --release
+//! cargo build -p aether-demo-tic-tac-toe-server --target wasm32-unknown-unknown --release
 //! cargo build -p aether-demo-tic-tac-toe-client --target wasm32-unknown-unknown --release
 //! cargo run -p aether-substrate-hub            # hub boots its own substrate
 //! # From a Claude session attached to the hub:
-//! #   load_component(hub_engine_id, "<path>/aether_demo_tic_tac_toe.wasm", name="tic_tac_toe")
+//! #   load_component(hub_engine_id, "<path>/aether_demo_tic_tac_toe_server.wasm", name="tic_tac_toe")
 //! #   spawn_substrate("<path>/aether-substrate-desktop")
 //! #   load_component(desktop_engine_id, "<path>/aether_demo_tic_tac_toe_client.wasm",
 //! #                  name="tic_tac_toe.client")

--- a/demos/tic-tac-toe-client/tests/scenario.rs
+++ b/demos/tic-tac-toe-client/tests/scenario.rs
@@ -1,0 +1,260 @@
+//! Tic-tac-toe client demo scenario tests. Each test boots a
+//! `TestBench`, loads this crate's own wasm artifact (and, for the
+//! click-flow scenario, the server's too), and exercises the
+//! per-tick render path plus the input → `PlayMove` → broadcast
+//! pipeline.
+//!
+//! Skipped when:
+//! - No wgpu adapter is available (driverless Linux runners without
+//!   `mesa-vulkan-drivers`).
+//! - The component's wasm hasn't been built — tests read
+//!   `target/wasm32-unknown-unknown/{debug,release}/aether_demo_tic_tac_toe_client.wasm`
+//!   (and the server's binary for the click flow) and skip with an
+//!   `eprintln!` when they're absent. CI builds both wasm artifacts
+//!   before invoking `cargo test`.
+
+use std::path::{Path, PathBuf};
+
+use aether_scenario::{Check, Runner, Script, Step};
+use aether_substrate_test_bench::TestBench;
+
+// Force linkage of this crate's own rlib so its `inventory::submit!`
+// `KindDescriptor` entries reach `aether_kinds::descriptors::all()`
+// in the test binary. Without this reference the linker strips the
+// transitive crate's descriptor symbols. The crate also re-exports
+// the server's kinds (`PlayMove`, `GameState`, `MoveResult`) via its
+// dep on `aether-demo-tic-tac-toe`, but the server's inventory items
+// only get pulled in when something in the test binary references the
+// server crate too — which `Step::SendMail` doesn't (it goes through
+// the descriptor list at runtime). The explicit `as _;` on both
+// covers both vocabularies.
+use aether_demo_tic_tac_toe as _;
+use aether_demo_tic_tac_toe_client as _;
+
+/// Probe for any usable wgpu adapter.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+/// Locate a workspace-target wasm artifact. Tries `release` then
+/// `debug` so either build profile satisfies the test.
+fn locate_wasm(name: &str) -> Option<PathBuf> {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+    for profile in ["release", "debug"] {
+        let path = workspace
+            .join("target")
+            .join("wasm32-unknown-unknown")
+            .join(profile)
+            .join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn client_wasm() -> Option<PathBuf> {
+    locate_wasm("aether_demo_tic_tac_toe_client.wasm")
+}
+
+fn server_wasm() -> Option<PathBuf> {
+    locate_wasm("aether_demo_tic_tac_toe_server.wasm")
+}
+
+/// Common setup for tests that need only the client wasm. Same
+/// shape as the camera / mesh-viewer / sokoban / ttt-server helpers.
+///
+/// `AETHER_REQUIRE_RUNTIME=1` flips both skip points into a panic so
+/// CI catches a forgotten pre-build entry instead of passing a 30ms
+/// vacuous test. CI sets this; local devs leave it unset and keep the
+/// existing skip behavior.
+fn require_runtime() -> Option<PathBuf> {
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    if !has_wgpu_adapter() {
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
+        eprintln!("skipping: no wgpu adapter available");
+        return None;
+    }
+    match client_wasm() {
+        Some(path) => Some(path),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_demo_tic_tac_toe_client.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing this crate",
+            );
+            eprintln!(
+                "skipping: aether_demo_tic_tac_toe_client.wasm not built; run \
+                 `cargo build --target wasm32-unknown-unknown -p aether-demo-tic-tac-toe-client`",
+            );
+            None
+        }
+    }
+}
+
+/// Same as `require_runtime` but also requires the server wasm —
+/// the click-flow test needs both components co-loaded so the
+/// client's `PlayMove` send has somewhere to go and the server's
+/// broadcast lands on the loopback.
+fn require_runtime_with_server() -> Option<(PathBuf, PathBuf)> {
+    let client = require_runtime()?;
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    match server_wasm() {
+        Some(server) => Some((client, server)),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_demo_tic_tac_toe_server.wasm not pre-built",
+            );
+            eprintln!(
+                "skipping: aether_demo_tic_tac_toe_server.wasm not built; run \
+                 `cargo build --target wasm32-unknown-unknown -p aether-demo-tic-tac-toe-server`",
+            );
+            None
+        }
+    }
+}
+
+/// Build a `SendMail` step that fires `aether.tick` at `mailbox` so
+/// the next `Capture` frame sees fresh render-sink emissions.
+/// Documented workaround for `TestBench::capture` running its frame
+/// with `dispatch_tick=false`.
+fn tick_to(mailbox: &str) -> Step {
+    Step::SendMail {
+        recipient: mailbox.to_owned(),
+        kind: "aether.tick".to_owned(),
+        params: serde_yml::Value::Null,
+    }
+}
+
+/// Default-render smoke test. The client renders a 3×3 grid of
+/// dark cell quads on every tick (no occupancy yet — the server
+/// hasn't sent any state). Validates `DrawTriangle` flows + the
+/// captured frame contains pixels diverging from the chassis clear
+/// color.
+#[test]
+fn default_render_paints_grid() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+
+    let script = Script {
+        name: "ttt-client default render paints grid".to_owned(),
+        steps: vec![
+            Step::LoadComponent {
+                path: wasm_path.to_string_lossy().into_owned(),
+                name: Some("tic_tac_toe.client".to_owned()),
+            },
+            // First tick: SDK auto-subscribes inputs, on_tick renders.
+            // Two more ticks settle the renderer.
+            Step::Advance { ticks: 3 },
+            tick_to("tic_tac_toe.client"),
+            Step::Capture,
+            Step::Assert {
+                check: Check::MailObserved {
+                    name: "aether.draw_triangle".to_owned(),
+                    min_count: 1,
+                },
+            },
+            Step::Assert {
+                check: Check::DiffersFromBackground { tolerance: 5 },
+            },
+        ],
+    };
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(
+        report.passed,
+        "ttt-client default-render scenario failed:\n{:#?}",
+        report.steps,
+    );
+}
+
+/// Click-driven move flow. Loads the server alongside the client so
+/// the client's `PlayMove` send (after a synthesised mouse_button
+/// over the center cell) has a real recipient. Validates the full
+/// chain: `WindowSize` cached → `MouseMove` cached → `MouseButton`
+/// hit-tests + sends `PlayMove` → server accepts + broadcasts
+/// `tic_tac_toe.game_state` → loopback records the broadcast.
+///
+/// The mouse coordinates target the center of a 64×48 window
+/// (32, 24), which maps to clip-space `(0, 0)` and lands inside cell
+/// `(1, 1)` — see `hit_test` in `demos/tic-tac-toe-client/src/lib.rs`.
+#[test]
+fn click_center_cell_drives_server_broadcast() {
+    let Some((client_path, server_path)) = require_runtime_with_server() else {
+        return;
+    };
+
+    let script = Script {
+        name: "ttt-client click drives server broadcast".to_owned(),
+        steps: vec![
+            // Server first so the SERVER mailbox name (`tic_tac_toe`)
+            // is registered before the client tries to resolve a sink
+            // pointed at it. Order isn't strictly load-bearing — the
+            // sink resolves lazily at send time — but it keeps the
+            // load order matching the agent-workflow docstring.
+            Step::LoadComponent {
+                path: server_path.to_string_lossy().into_owned(),
+                name: Some("tic_tac_toe".to_owned()),
+            },
+            Step::LoadComponent {
+                path: client_path.to_string_lossy().into_owned(),
+                name: Some("tic_tac_toe.client".to_owned()),
+            },
+            Step::Advance { ticks: 1 },
+            // Cache window size + cursor in the client. The
+            // `on_mouse_button` handler bails early if either is None.
+            Step::SendMail {
+                recipient: "tic_tac_toe.client".to_owned(),
+                kind: "aether.window_size".to_owned(),
+                params: serde_yml::from_str("width: 64\nheight: 48")
+                    .expect("window_size params parse"),
+            },
+            Step::SendMail {
+                recipient: "tic_tac_toe.client".to_owned(),
+                kind: "aether.mouse_move".to_owned(),
+                params: serde_yml::from_str("x: 32.0\ny: 24.0").expect("mouse_move params parse"),
+            },
+            // The click. Hit-test → cell (1,1) → PlayMove(1,1) sent
+            // to the server. Server accepts, broadcasts game_state.
+            Step::SendMail {
+                recipient: "tic_tac_toe.client".to_owned(),
+                kind: "aether.mouse_button".to_owned(),
+                params: serde_yml::Value::Null,
+            },
+            // One more advance so the queue drain processes the chain
+            // (window_size → mouse_move → mouse_button → PlayMove →
+            // game_state broadcast → loopback observe).
+            Step::Advance { ticks: 1 },
+            Step::Assert {
+                check: Check::MailObserved {
+                    name: "tic_tac_toe.game_state".to_owned(),
+                    min_count: 1,
+                },
+            },
+        ],
+    };
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let report = Runner::run(&mut bench, &script);
+    assert!(
+        report.passed,
+        "ttt-client click-flow scenario failed:\n{:#?}",
+        report.steps,
+    );
+}

--- a/demos/tic-tac-toe-server/Cargo.toml
+++ b/demos/tic-tac-toe-server/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "aether-demo-tic-tac-toe-server"
+version.workspace = true
+edition.workspace = true
+
+# Runtime cdylib for the tic-tac-toe demo (ADR-0066). Wire types and
+# well-known mailbox names live in the `aether-demo-tic-tac-toe` trunk
+# rlib; this crate owns the `Component` impl, the `apply_move` /
+# `reply` helpers, and the `aether_component::export!` invocation.
+# `rlib` is added so host builds can link integration tests under
+# `tests/`.
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+aether-component = { path = "../../crates/aether-component" }
+aether-demo-tic-tac-toe = { path = "../tic-tac-toe" }
+aether-mail = { path = "../../crates/aether-mail" }
+
+# Integration tests boot a `TestBench`, load the server's own wasm
+# artifact, and assert mail-flow properties via `aether-scenario`.
+# Tests run host-side; the wasm is built separately for
+# `wasm32-unknown-unknown` and discovered at runtime under
+# `target/wasm32-unknown-unknown/{debug,release}/`.
+[dev-dependencies]
+aether-scenario = { path = "../../crates/aether-scenario" }
+aether-substrate-test-bench = { path = "../../crates/aether-substrate-test-bench" }
+pollster = "0.4.0"
+serde_yml = "0.0.12"
+wgpu = "29.0.1"

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -1,0 +1,291 @@
+//! Tic-tac-toe demo runtime: a two-player game component that exists
+//! to stress the ADR-0035 headless chassis end-to-end, plus the
+//! multi-session reply / broadcast paths that the hub already
+//! supports. Two Claude sessions attach to the same hub, take turns
+//! sending `tic_tac_toe.play_move` mail, and observe
+//! `tic_tac_toe.game_state` broadcasts that fan out to every attached
+//! session after each accepted move.
+//!
+//! Scope: no identity tracking. The component doesn't care which
+//! session sent a move — it just alternates turns starting with X.
+//! Any session can play either side as long as it's that side's turn
+//! to move. Identity + join flow is a follow-up if the demo feels
+//! weak without it; this version is the smallest thing that exercises
+//! the cross-session paths.
+//!
+//! No render sink — the demo was built against the headless chassis
+//! and doesn't emit `DrawTriangle`. Desktop is welcome to load it but
+//! the window will stay blank since nothing draws.
+//!
+//! Wire types and well-known mailbox names live in the
+//! `aether-demo-tic-tac-toe` trunk rlib; the client component depends
+//! on the trunk for those without pulling in this crate's
+//! `Component` impl. Per ADR-0066.
+
+use aether_component::{Component, Ctx, InitCtx, KindId, Sink, handlers};
+use aether_demo_tic_tac_toe::{
+    CELL_EMPTY, CLIENT_OBSERVER, GAME_DRAW, GAME_PLAYING, GAME_WON_O, GAME_WON_X, GameState,
+    MOVE_CELL_OCCUPIED, MOVE_GAME_OVER, MOVE_OK, MOVE_OUT_OF_BOUNDS, MoveResult, PLAYER_NONE,
+    PLAYER_O, PLAYER_X, PlayMove, Reset,
+};
+
+/// Per-instance component state. Holds the live game board plus cached
+/// kind / sink handles — resolved once in `init` and reused across
+/// every move.
+pub struct TicTacToe {
+    state: GameState,
+    move_result_kind: KindId<MoveResult>,
+    broadcast: Sink<GameState>,
+    client_observer: Sink<GameState>,
+}
+
+/// Authoritative tic-tac-toe server. Accepts `PlayMove` and `Reset`
+/// from any attached Claude session, replies to the sender with the
+/// outcome, and broadcasts the new `GameState` to
+/// `hub.claude.broadcast` whenever the board changes.
+///
+/// # Agent
+/// Alternating turns start with X. Send `tic_tac_toe.play_move` with
+/// `{ row, col }` in `0..=2` — the component assigns whichever player
+/// is on turn. The reply is `tic_tac_toe.move_result` where
+/// `status == 0` (MOVE_OK) means accepted; non-zero means rejected
+/// (`1` out-of-bounds, `2` cell-occupied, `3` game-over) and the
+/// board is unchanged. Watch `tic_tac_toe.game_state` on your
+/// `receive_mail` stream to see every state update regardless of who
+/// sent the move — that's the broadcast path the hub fans out to
+/// every session. Send `tic_tac_toe.reset` (empty payload) to start a
+/// fresh game.
+#[handlers]
+impl Component for TicTacToe {
+    fn init(ctx: &mut InitCtx<'_>) -> Self {
+        TicTacToe {
+            state: GameState::new_game(),
+            move_result_kind: ctx.resolve::<MoveResult>(),
+            broadcast: ctx.resolve_sink::<GameState>("hub.claude.broadcast"),
+            client_observer: ctx.resolve_sink::<GameState>(CLIENT_OBSERVER),
+        }
+    }
+
+    /// Applies a move if legal, then replies to the sender with the
+    /// outcome. On acceptance the new state is also broadcast so every
+    /// attached session sees the update — not just the one that moved.
+    ///
+    /// # Agent
+    /// Send `{ row, col }` with both in `0..=2`. The reply's `status`
+    /// is the authoritative outcome; `state` is the board after the
+    /// move if accepted, or the unchanged board if rejected. Don't
+    /// infer side from the payload — the component picks based on
+    /// whose turn it is, and the resulting `state.last_move_player`
+    /// tells you which side actually got placed.
+    #[handler]
+    fn on_play_move(&mut self, ctx: &mut Ctx<'_>, mv: PlayMove) {
+        let status = self.apply_move(mv.row, mv.col);
+        self.reply(ctx, status);
+        if status == MOVE_OK {
+            ctx.send(&self.broadcast, &self.state);
+            ctx.send(&self.client_observer, &self.state);
+        }
+    }
+
+    /// Resets to a fresh game, replies to the caller, and broadcasts
+    /// the new empty state so other sessions notice.
+    ///
+    /// # Agent
+    /// Use this to start over after a win/draw or to abandon an
+    /// in-progress game. The reply always has `status == MOVE_OK`
+    /// and the broadcast is fire-and-forget.
+    #[handler]
+    fn on_reset(&mut self, ctx: &mut Ctx<'_>, _r: Reset) {
+        self.state = GameState::new_game();
+        self.reply(ctx, MOVE_OK);
+        ctx.send(&self.broadcast, &self.state);
+        ctx.send(&self.client_observer, &self.state);
+    }
+}
+
+impl TicTacToe {
+    fn apply_move(&mut self, row: u8, col: u8) -> u8 {
+        if self.state.status != GAME_PLAYING {
+            return MOVE_GAME_OVER;
+        }
+        if row >= 3 || col >= 3 {
+            return MOVE_OUT_OF_BOUNDS;
+        }
+        let (r, c) = (row as usize, col as usize);
+        if self.state.board[r][c] != CELL_EMPTY {
+            return MOVE_CELL_OCCUPIED;
+        }
+
+        let player = self.state.turn;
+        self.state.board[r][c] = player;
+        self.state.last_move_row = row;
+        self.state.last_move_col = col;
+        self.state.last_move_player = player;
+
+        if is_winner(&self.state.board, player) {
+            self.state.status = if player == PLAYER_X {
+                GAME_WON_X
+            } else {
+                GAME_WON_O
+            };
+            self.state.turn = PLAYER_NONE;
+        } else if is_board_full(&self.state.board) {
+            self.state.status = GAME_DRAW;
+            self.state.turn = PLAYER_NONE;
+        } else {
+            self.state.turn = if player == PLAYER_X {
+                PLAYER_O
+            } else {
+                PLAYER_X
+            };
+        }
+        MOVE_OK
+    }
+
+    fn reply(&self, ctx: &mut Ctx<'_>, status: u8) {
+        let Some(sender) = ctx.reply_to() else {
+            return;
+        };
+        let result = MoveResult {
+            status,
+            _pad: [0; 7],
+            state: self.state,
+        };
+        ctx.reply(sender, self.move_result_kind, &result);
+    }
+}
+
+fn is_winner(board: &[[u8; 3]; 3], player: u8) -> bool {
+    const LINES: [[(usize, usize); 3]; 8] = [
+        [(0, 0), (0, 1), (0, 2)],
+        [(1, 0), (1, 1), (1, 2)],
+        [(2, 0), (2, 1), (2, 2)],
+        [(0, 0), (1, 0), (2, 0)],
+        [(0, 1), (1, 1), (2, 1)],
+        [(0, 2), (1, 2), (2, 2)],
+        [(0, 0), (1, 1), (2, 2)],
+        [(0, 2), (1, 1), (2, 0)],
+    ];
+    LINES
+        .iter()
+        .any(|line| line.iter().all(|&(r, c)| board[r][c] == player))
+}
+
+fn is_board_full(board: &[[u8; 3]; 3]) -> bool {
+    for row in board {
+        for &cell in row {
+            if cell == CELL_EMPTY {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(target_arch = "wasm32")]
+aether_component::export!(TicTacToe);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_component() -> TicTacToe {
+        // Host-side unit tests can't route through the SDK's
+        // `InitCtx`, so fabricate a minimal instance with the same
+        // starting state the runtime would build. The kind / sink
+        // handles are dummies — `apply_move` never touches them.
+        TicTacToe {
+            state: GameState::new_game(),
+            move_result_kind: aether_component::resolve::<MoveResult>(),
+            broadcast: aether_component::resolve_sink::<GameState>("hub.claude.broadcast"),
+            client_observer: aether_component::resolve_sink::<GameState>(CLIENT_OBSERVER),
+        }
+    }
+
+    #[test]
+    fn alternating_turns() {
+        let mut c = new_component();
+        assert_eq!(c.apply_move(0, 0), MOVE_OK);
+        assert_eq!(c.state.board[0][0], PLAYER_X);
+        assert_eq!(c.state.turn, PLAYER_O);
+        assert_eq!(c.apply_move(1, 1), MOVE_OK);
+        assert_eq!(c.state.board[1][1], PLAYER_O);
+        assert_eq!(c.state.turn, PLAYER_X);
+    }
+
+    #[test]
+    fn out_of_bounds_rejected() {
+        let mut c = new_component();
+        assert_eq!(c.apply_move(3, 0), MOVE_OUT_OF_BOUNDS);
+        assert_eq!(c.apply_move(0, 3), MOVE_OUT_OF_BOUNDS);
+        assert_eq!(c.state.turn, PLAYER_X);
+    }
+
+    #[test]
+    fn occupied_cell_rejected() {
+        let mut c = new_component();
+        assert_eq!(c.apply_move(0, 0), MOVE_OK);
+        assert_eq!(c.apply_move(0, 0), MOVE_CELL_OCCUPIED);
+        assert_eq!(c.state.turn, PLAYER_O);
+    }
+
+    #[test]
+    fn row_win_detects() {
+        let mut c = new_component();
+        // X: (0,0), O: (1,0), X: (0,1), O: (1,1), X: (0,2) — X wins row 0.
+        c.apply_move(0, 0);
+        c.apply_move(1, 0);
+        c.apply_move(0, 1);
+        c.apply_move(1, 1);
+        assert_eq!(c.apply_move(0, 2), MOVE_OK);
+        assert_eq!(c.state.status, GAME_WON_X);
+        assert_eq!(c.state.turn, PLAYER_NONE);
+    }
+
+    #[test]
+    fn diagonal_win_detects() {
+        let mut c = new_component();
+        // X: (0,0), O: (0,1), X: (1,1), O: (0,2), X: (2,2) — X wins main diagonal.
+        c.apply_move(0, 0);
+        c.apply_move(0, 1);
+        c.apply_move(1, 1);
+        c.apply_move(0, 2);
+        assert_eq!(c.apply_move(2, 2), MOVE_OK);
+        assert_eq!(c.state.status, GAME_WON_X);
+    }
+
+    #[test]
+    fn draw_detects() {
+        let mut c = new_component();
+        //   X O X
+        //   X O O
+        //   O X X
+        let moves = [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 1),
+            (1, 0),
+            (1, 2),
+            (2, 1),
+            (2, 0),
+            (2, 2),
+        ];
+        for (r, col) in moves {
+            assert_eq!(c.apply_move(r, col), MOVE_OK);
+        }
+        assert_eq!(c.state.status, GAME_DRAW);
+        assert_eq!(c.state.turn, PLAYER_NONE);
+    }
+
+    #[test]
+    fn moves_after_win_rejected() {
+        let mut c = new_component();
+        c.apply_move(0, 0);
+        c.apply_move(1, 0);
+        c.apply_move(0, 1);
+        c.apply_move(1, 1);
+        c.apply_move(0, 2); // X wins row 0
+        assert_eq!(c.apply_move(2, 2), MOVE_GAME_OVER);
+    }
+}

--- a/demos/tic-tac-toe-server/tests/scenario.rs
+++ b/demos/tic-tac-toe-server/tests/scenario.rs
@@ -16,7 +16,7 @@
 //!   `mesa-vulkan-drivers`). The bench still needs the GPU even for
 //!   render-less tests because the chassis owns the offscreen target.
 //! - The component's wasm hasn't been built — tests read
-//!   `target/wasm32-unknown-unknown/{debug,release}/aether_demo_tic_tac_toe.wasm`
+//!   `target/wasm32-unknown-unknown/{debug,release}/aether_demo_tic_tac_toe_server.wasm`
 //!   and skip with an `eprintln!` when both paths are absent. CI
 //!   builds the wasm before invoking `cargo test`.
 
@@ -57,7 +57,7 @@ fn ttt_wasm() -> Option<PathBuf> {
             .join("target")
             .join("wasm32-unknown-unknown")
             .join(profile)
-            .join("aether_demo_tic_tac_toe.wasm");
+            .join("aether_demo_tic_tac_toe_server.wasm");
         if path.exists() {
             return Some(path);
         }
@@ -87,11 +87,11 @@ fn require_runtime() -> Option<PathBuf> {
         None => {
             assert!(
                 !strict,
-                "AETHER_REQUIRE_RUNTIME set but aether_demo_tic_tac_toe.wasm not pre-built; \
+                "AETHER_REQUIRE_RUNTIME set but aether_demo_tic_tac_toe_server.wasm not pre-built; \
                  CI's `Pre-build component wasm for scenario tests` step is missing this crate",
             );
             eprintln!(
-                "skipping: aether_demo_tic_tac_toe.wasm not built; \
+                "skipping: aether_demo_tic_tac_toe_server.wasm not built; \
                  run `cargo build --target wasm32-unknown-unknown -p aether-demo-tic-tac-toe`",
             );
             None

--- a/demos/tic-tac-toe/Cargo.toml
+++ b/demos/tic-tac-toe/Cargo.toml
@@ -3,25 +3,24 @@ name = "aether-demo-tic-tac-toe"
 version.workspace = true
 edition.workspace = true
 
+# Trunk rlib for the tic-tac-toe demo (ADR-0066). Hosts the kind types
+# and well-known mailbox names other components consume. The runtime
+# `Component` impl + `aether_component::export!` live in the sibling
+# `aether-demo-tic-tac-toe-server` cdylib; consumers (e.g.
+# `aether-demo-tic-tac-toe-client`) depend on this crate for the wire
+# shapes without pulling in the server's `#[handlers]` section
+# emissions, which would stack on top of their own and trip the
+# substrate's "duplicate Component record" check (issue 442).
 [lib]
-# cdylib for wasm loading (the primary product); rlib so the client
-# demo can `use` shared kinds + constants without duplicating them.
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
-aether-component = { path = "../../crates/aether-component" }
-aether-kinds = { path = "../../crates/aether-kinds" }
 aether-mail = { path = "../../crates/aether-mail", features = ["derive"] }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
 
-# Integration tests boot a `TestBench`, load the demo's own wasm
-# artifact, and assert mail-flow properties via `aether-scenario`.
-# Tests run host-side; the wasm is built separately for
-# `wasm32-unknown-unknown` and discovered at runtime under
-# `target/wasm32-unknown-unknown/{debug,release}/`.
-[dev-dependencies]
-aether-scenario = { path = "../../crates/aether-scenario" }
-aether-substrate-test-bench = { path = "../../crates/aether-substrate-test-bench" }
-pollster = "0.4.0"
-serde_yml = "0.0.12"
-wgpu = "29.0.1"
+# Issue #243: every crate that derives `Kind` needs `inventory` reachable
+# on native builds so the `aether.kinds` substrate descriptor list picks
+# up its types. Wasm guests skip the submission via the derive's
+# `cfg(not(target_arch = "wasm32"))` gate.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+inventory = "0.3"

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -1,23 +1,18 @@
-//! Tic-tac-toe demo: a two-player game component that exists to stress
-//! the ADR-0035 headless chassis end-to-end, plus the multi-session
-//! reply / broadcast paths that the hub already supports. Two Claude
-//! sessions attach to the same hub, take turns sending
-//! `tic_tac_toe.play_move` mail, and observe `tic_tac_toe.game_state`
-//! broadcasts that fan out to every attached session after each
-//! accepted move.
+//! Tic-tac-toe demo trunk rlib (ADR-0066). Hosts the kind types and
+//! well-known mailbox names every component in the demo wires
+//! against. The runtime `Component` impl + `aether_component::export!`
+//! live in the sibling `aether-demo-tic-tac-toe-server` cdylib;
+//! consumers (e.g. `aether-demo-tic-tac-toe-client`) depend on this
+//! crate for the wire shapes without pulling in the server's
+//! `#[handlers]` section emissions, which would stack on top of their
+//! own and trip the substrate's "duplicate Component record" check
+//! (issue 442).
 //!
-//! Scope: no identity tracking. The component doesn't care which
-//! session sent a move — it just alternates turns starting with X.
-//! Any session can play either side as long as it's that side's turn
-//! to move. Identity + join flow is a follow-up if the demo feels
-//! weak without it; this version is the smallest thing that exercises
-//! the cross-session paths.
-//!
-//! No render sink — the demo was built against the headless chassis
-//! and doesn't emit `DrawTriangle`. Desktop is welcome to load it but
-//! the window will stay blank since nothing draws.
+//! The demo as a whole exists to stress the ADR-0035 headless chassis
+//! end-to-end plus the multi-session reply / broadcast paths the hub
+//! supports — see the server crate's top-level docstring for the
+//! agent-driving narrative.
 
-use aether_component::{Component, Ctx, InitCtx, KindId, Sink, handlers};
 use aether_mail::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -122,16 +117,6 @@ pub struct MoveResult {
     pub state: GameState,
 }
 
-/// Per-instance component state. Holds the live game board plus cached
-/// kind / sink handles — resolved once in `init` and reused across
-/// every move.
-pub struct TicTacToe {
-    state: GameState,
-    move_result_kind: KindId<MoveResult>,
-    broadcast: Sink<GameState>,
-    client_observer: Sink<GameState>,
-}
-
 /// Well-known local mailbox name the server fans `GameState` to in
 /// addition to `hub.claude.broadcast`. Any component loaded under
 /// this name on the same substrate as the server will receive every
@@ -148,159 +133,6 @@ pub const CLIENT_OBSERVER: &str = "tic_tac_toe.client";
 /// rustdoc.
 pub const SERVER: &str = "tic_tac_toe";
 
-/// Authoritative tic-tac-toe server. Accepts `PlayMove` and `Reset`
-/// from any attached Claude session, replies to the sender with the
-/// outcome, and broadcasts the new `GameState` to
-/// `hub.claude.broadcast` whenever the board changes.
-///
-/// # Agent
-/// Alternating turns start with X. Send `tic_tac_toe.play_move` with
-/// `{ row, col }` in `0..=2` — the component assigns whichever player
-/// is on turn. The reply is `tic_tac_toe.move_result` where
-/// `status == 0` (MOVE_OK) means accepted; non-zero means rejected
-/// (`1` out-of-bounds, `2` cell-occupied, `3` game-over) and the
-/// board is unchanged. Watch `tic_tac_toe.game_state` on your
-/// `receive_mail` stream to see every state update regardless of who
-/// sent the move — that's the broadcast path the hub fans out to
-/// every session. Send `tic_tac_toe.reset` (empty payload) to start a
-/// fresh game.
-#[handlers]
-impl Component for TicTacToe {
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        TicTacToe {
-            state: GameState::new_game(),
-            move_result_kind: ctx.resolve::<MoveResult>(),
-            broadcast: ctx.resolve_sink::<GameState>("hub.claude.broadcast"),
-            client_observer: ctx.resolve_sink::<GameState>(CLIENT_OBSERVER),
-        }
-    }
-
-    /// Applies a move if legal, then replies to the sender with the
-    /// outcome. On acceptance the new state is also broadcast so every
-    /// attached session sees the update — not just the one that moved.
-    ///
-    /// # Agent
-    /// Send `{ row, col }` with both in `0..=2`. The reply's `status`
-    /// is the authoritative outcome; `state` is the board after the
-    /// move if accepted, or the unchanged board if rejected. Don't
-    /// infer side from the payload — the component picks based on
-    /// whose turn it is, and the resulting `state.last_move_player`
-    /// tells you which side actually got placed.
-    #[handler]
-    fn on_play_move(&mut self, ctx: &mut Ctx<'_>, mv: PlayMove) {
-        let status = self.apply_move(mv.row, mv.col);
-        self.reply(ctx, status);
-        if status == MOVE_OK {
-            ctx.send(&self.broadcast, &self.state);
-            ctx.send(&self.client_observer, &self.state);
-        }
-    }
-
-    /// Resets to a fresh game, replies to the caller, and broadcasts
-    /// the new empty state so other sessions notice.
-    ///
-    /// # Agent
-    /// Use this to start over after a win/draw or to abandon an
-    /// in-progress game. The reply always has `status == MOVE_OK`
-    /// and the broadcast is fire-and-forget.
-    #[handler]
-    fn on_reset(&mut self, ctx: &mut Ctx<'_>, _r: Reset) {
-        self.state = GameState::new_game();
-        self.reply(ctx, MOVE_OK);
-        ctx.send(&self.broadcast, &self.state);
-        ctx.send(&self.client_observer, &self.state);
-    }
-}
-
-impl TicTacToe {
-    fn apply_move(&mut self, row: u8, col: u8) -> u8 {
-        if self.state.status != GAME_PLAYING {
-            return MOVE_GAME_OVER;
-        }
-        if row >= 3 || col >= 3 {
-            return MOVE_OUT_OF_BOUNDS;
-        }
-        let (r, c) = (row as usize, col as usize);
-        if self.state.board[r][c] != CELL_EMPTY {
-            return MOVE_CELL_OCCUPIED;
-        }
-
-        let player = self.state.turn;
-        self.state.board[r][c] = player;
-        self.state.last_move_row = row;
-        self.state.last_move_col = col;
-        self.state.last_move_player = player;
-
-        if is_winner(&self.state.board, player) {
-            self.state.status = if player == PLAYER_X {
-                GAME_WON_X
-            } else {
-                GAME_WON_O
-            };
-            self.state.turn = PLAYER_NONE;
-        } else if is_board_full(&self.state.board) {
-            self.state.status = GAME_DRAW;
-            self.state.turn = PLAYER_NONE;
-        } else {
-            self.state.turn = if player == PLAYER_X {
-                PLAYER_O
-            } else {
-                PLAYER_X
-            };
-        }
-        MOVE_OK
-    }
-
-    fn reply(&self, ctx: &mut Ctx<'_>, status: u8) {
-        let Some(sender) = ctx.reply_to() else {
-            return;
-        };
-        let result = MoveResult {
-            status,
-            _pad: [0; 7],
-            state: self.state,
-        };
-        ctx.reply(sender, self.move_result_kind, &result);
-    }
-}
-
-fn is_winner(board: &[[u8; 3]; 3], player: u8) -> bool {
-    const LINES: [[(usize, usize); 3]; 8] = [
-        [(0, 0), (0, 1), (0, 2)],
-        [(1, 0), (1, 1), (1, 2)],
-        [(2, 0), (2, 1), (2, 2)],
-        [(0, 0), (1, 0), (2, 0)],
-        [(0, 1), (1, 1), (2, 1)],
-        [(0, 2), (1, 2), (2, 2)],
-        [(0, 0), (1, 1), (2, 2)],
-        [(0, 2), (1, 1), (2, 0)],
-    ];
-    LINES
-        .iter()
-        .any(|line| line.iter().all(|&(r, c)| board[r][c] == player))
-}
-
-fn is_board_full(board: &[[u8; 3]; 3]) -> bool {
-    for row in board {
-        for &cell in row {
-            if cell == CELL_EMPTY {
-                return false;
-            }
-        }
-    }
-    true
-}
-
-// Gated on wasm32: the `export!` macro emits `#[no_mangle]`
-// `init` / `receive_p32` / `on_drop` / `on_replace` /
-// `on_rehydrate_p32` shims the substrate calls over FFI. Those
-// symbols only mean something in a wasm guest — emitting them in
-// host builds causes duplicate-symbol link errors when a sibling
-// rlib (e.g. the tic-tac-toe-client demo) depends on this crate
-// and also has its own `export!`. Host unit tests don't need them.
-#[cfg(target_arch = "wasm32")]
-aether_component::export!(TicTacToe);
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,106 +148,5 @@ mod tests {
                 assert_eq!(cell, CELL_EMPTY);
             }
         }
-    }
-
-    fn new_component() -> TicTacToe {
-        // Host-side unit tests can't route through the SDK's
-        // `InitCtx`, so fabricate a minimal instance with the same
-        // starting state the runtime would build. The kind / sink
-        // handles are dummies — `apply_move` never touches them.
-        TicTacToe {
-            state: GameState::new_game(),
-            move_result_kind: aether_component::resolve::<MoveResult>(),
-            broadcast: aether_component::resolve_sink::<GameState>("hub.claude.broadcast"),
-            client_observer: aether_component::resolve_sink::<GameState>(CLIENT_OBSERVER),
-        }
-    }
-
-    #[test]
-    fn alternating_turns() {
-        let mut c = new_component();
-        assert_eq!(c.apply_move(0, 0), MOVE_OK);
-        assert_eq!(c.state.board[0][0], PLAYER_X);
-        assert_eq!(c.state.turn, PLAYER_O);
-        assert_eq!(c.apply_move(1, 1), MOVE_OK);
-        assert_eq!(c.state.board[1][1], PLAYER_O);
-        assert_eq!(c.state.turn, PLAYER_X);
-    }
-
-    #[test]
-    fn out_of_bounds_rejected() {
-        let mut c = new_component();
-        assert_eq!(c.apply_move(3, 0), MOVE_OUT_OF_BOUNDS);
-        assert_eq!(c.apply_move(0, 3), MOVE_OUT_OF_BOUNDS);
-        assert_eq!(c.state.turn, PLAYER_X);
-    }
-
-    #[test]
-    fn occupied_cell_rejected() {
-        let mut c = new_component();
-        assert_eq!(c.apply_move(0, 0), MOVE_OK);
-        assert_eq!(c.apply_move(0, 0), MOVE_CELL_OCCUPIED);
-        assert_eq!(c.state.turn, PLAYER_O);
-    }
-
-    #[test]
-    fn row_win_detects() {
-        let mut c = new_component();
-        // X: (0,0), O: (1,0), X: (0,1), O: (1,1), X: (0,2) — X wins row 0.
-        c.apply_move(0, 0);
-        c.apply_move(1, 0);
-        c.apply_move(0, 1);
-        c.apply_move(1, 1);
-        assert_eq!(c.apply_move(0, 2), MOVE_OK);
-        assert_eq!(c.state.status, GAME_WON_X);
-        assert_eq!(c.state.turn, PLAYER_NONE);
-    }
-
-    #[test]
-    fn diagonal_win_detects() {
-        let mut c = new_component();
-        // X: (0,0), O: (0,1), X: (1,1), O: (0,2), X: (2,2) — X wins main diagonal.
-        c.apply_move(0, 0);
-        c.apply_move(0, 1);
-        c.apply_move(1, 1);
-        c.apply_move(0, 2);
-        assert_eq!(c.apply_move(2, 2), MOVE_OK);
-        assert_eq!(c.state.status, GAME_WON_X);
-    }
-
-    #[test]
-    fn draw_detects() {
-        let mut c = new_component();
-        // A board that ends without a winner.
-        //   X O X
-        //   X O O
-        //   O X X
-        let moves = [
-            (0, 0),
-            (0, 1),
-            (0, 2),
-            (1, 1),
-            (1, 0),
-            (1, 2),
-            (2, 1),
-            (2, 0),
-            (2, 2),
-        ];
-        for (r, col) in moves {
-            assert_eq!(c.apply_move(r, col), MOVE_OK);
-        }
-        assert_eq!(c.state.status, GAME_DRAW);
-        assert_eq!(c.state.turn, PLAYER_NONE);
-    }
-
-    #[test]
-    fn moves_after_win_rejected() {
-        let mut c = new_component();
-        c.apply_move(0, 0);
-        c.apply_move(1, 0);
-        c.apply_move(0, 1);
-        c.apply_move(1, 1);
-        c.apply_move(0, 2); // X wins row 0
-        assert_eq!(c.apply_move(2, 2), MOVE_GAME_OVER);
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 ttt-client scenarios from issue 430. Two integration tests in `demos/tic-tac-toe-client/tests/scenario.rs`:

- `default_render_paints_grid` — load wasm, advance ticks, tick before capture, assert `MailObserved aether.draw_triangle` and `DiffersFromBackground`. Validates the per-tick render path.
- `click_center_cell_drives_server_broadcast` — load both server and client, send synthesised `aether.window_size` + `aether.mouse_move` + `aether.mouse_button` to the client mailbox, advance, observe `tic_tac_toe.game_state` on the loopback. Validates the full chain: cursor caching → hit-test → `PlayMove` to server → server accepts + broadcasts `game_state` → bench loopback records it.

## ADR-0066 trunk-rlib refactor

To make the click test possible (loading both server + client cdylibs co-resident), the ttt-server crate is refactored per ADR-0066. The old `aether-demo-tic-tac-toe` was a `cdylib + rlib` crate that owned both the wire types and the `Component` impl. When the client cdylib linked the server's rlib for the shared `PlayMove` / `GameState` / `MoveResult` types, the server's `#[handlers]` `aether.kinds.inputs` section emissions stacked on top of the client's own — substrate's manifest reader then rejected the wasm with "duplicate Component record." See issue 442 for the SDK-level bug; this refactor sidesteps it by adopting the camera / mesh-viewer pattern.

After the refactor:

- `aether-demo-tic-tac-toe` — trunk rlib. Wire types + well-known names. No `Component` impl, no FFI, no `aether-component` dep.
- `aether-demo-tic-tac-toe-server` (new at `demos/tic-tac-toe-server/`) — runtime cdylib with the `Component` impl, helpers, unit tests, `export!`. Inherits the existing scenario tests from PR 437 — moved verbatim, wasm artifact name updated to `aether_demo_tic_tac_toe_server.wasm`.
- `aether-demo-tic-tac-toe-client` — unchanged role; deps the trunk for wire types only. The PR 440-era `default-features = false` workaround is gone (the trunk has no `Component` impl to gate).

CI pre-build drops `aether-demo-tic-tac-toe` (no cdylib anymore) and adds `aether-demo-tic-tac-toe-server` + `aether-demo-tic-tac-toe-client`. `AETHER_REQUIRE_RUNTIME=1` (PR 440) keeps any forgotten entry loud.

## Test plan

- `cargo build --target wasm32-unknown-unknown -p aether-demo-tic-tac-toe-server -p aether-demo-tic-tac-toe-client` — single invocation, both wasm artifacts produced.
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-demo-tic-tac-toe -p aether-demo-tic-tac-toe-server -p aether-demo-tic-tac-toe-client` — 20+ tests pass: 1 trunk unit test, 7 server unit tests, 3 server scenarios, 7 client unit tests, 2 client scenarios.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo check --workspace --all-targets` — clean.

Refs issue 430 (Phase 2 ttt-client checkbox + closes the component-scenario push). Refs issue 442 (the underlying SDK section-stacking bug this refactor sidesteps).
