### PR TITLE
feat(test-bench): substrate-feature scenarios via test-fixture-probe (issue 430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
             -p aether-mesh-viewer-component \
             -p aether-demo-sokoban \
             -p aether-demo-tic-tac-toe-server \
-            -p aether-demo-tic-tac-toe-client
+            -p aether-demo-tic-tac-toe-client \
+            -p aether-test-fixture-probe
       - run: cargo test --workspace --all-targets
         env:
           AETHER_REQUIRE_RUNTIME: "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "aether-kinds",
  "aether-mail",
  "aether-substrate-core",
+ "aether-test-fixture-probe",
  "bytemuck",
  "png",
  "pollster",
@@ -364,6 +365,16 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wgpu",
+]
+
+[[package]]
+name = "aether-test-fixture-probe"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-component",
+ "aether-kinds",
+ "aether-mail",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/aether-mesh-viewer",
     "crates/aether-camera-component",
     "crates/aether-mesh-viewer-component",
+    "crates/aether-test-fixture-probe",
     "crates/aether-hub-protocol",
     "crates/aether-mail",
     "crates/aether-mail-derive",

--- a/crates/aether-substrate-test-bench/Cargo.toml
+++ b/crates/aether-substrate-test-bench/Cargo.toml
@@ -33,3 +33,11 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 wasmtime = "30"
 wgpu = "29.0.1"
+
+# Phase 3 substrate-feature scenarios (issue 430). Tests boot a
+# `TestBench` and load `aether-test-fixture-probe`'s wasm to exercise
+# input subscription, drop_component, etc. The fixture is the only
+# component crate that's a dev-dep here — production code never
+# touches it.
+[dev-dependencies]
+aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }

--- a/crates/aether-substrate-test-bench/tests/scenario.rs
+++ b/crates/aether-substrate-test-bench/tests/scenario.rs
@@ -1,0 +1,201 @@
+//! Phase 3 substrate-feature scenarios (issue 430). Each test boots
+//! a `TestBench`, loads `aether-test-fixture-probe`'s wasm, and
+//! exercises one substrate primitive (input subscription, drop, etc.)
+//! by counting fixture-emitted broadcasts on the bench loopback.
+//!
+//! Skipped when:
+//! - No wgpu adapter is available (driverless Linux runners without
+//!   `mesa-vulkan-drivers`).
+//! - The fixture's wasm hasn't been built — tests read
+//!   `target/wasm32-unknown-unknown/{debug,release}/aether_test_fixture_probe.wasm`
+//!   and skip with an `eprintln!` when it's absent. CI builds the
+//!   fixture wasm before invoking `cargo test`. Setting
+//!   `AETHER_REQUIRE_RUNTIME=1` (CI does) flips both skip points
+//!   into hard panics so a missing pre-build is loud.
+
+use std::path::{Path, PathBuf};
+
+use aether_kinds::{DropComponent, LoadComponent};
+use aether_mail::{MailboxId, mailbox_id_from_name};
+use aether_substrate_test_bench::TestBench;
+
+// Pin the fixture rlib so its `inventory::submit!` `KindDescriptor`
+// entries are present in this test binary. Without the reference, the
+// host-target rlib's descriptor symbols can be stripped by the linker
+// and `aether_kinds::descriptors::all()` won't see fixture kinds.
+use aether_test_fixture_probe as _;
+
+/// Probe for any usable wgpu adapter.
+fn has_wgpu_adapter() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .is_ok()
+}
+
+/// Locate the fixture's wasm artifact under the workspace target dir.
+/// Tries `release` first, then `debug` so either build profile works.
+fn locate_fixture_wasm() -> Option<PathBuf> {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+    for profile in ["release", "debug"] {
+        let path = workspace
+            .join("target")
+            .join("wasm32-unknown-unknown")
+            .join(profile)
+            .join("aether_test_fixture_probe.wasm");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Common boot path: probe wgpu, locate the fixture wasm, return
+/// both. `AETHER_REQUIRE_RUNTIME=1` turns either missing requirement
+/// into a panic so CI failures are loud.
+fn require_runtime() -> Option<PathBuf> {
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    if !has_wgpu_adapter() {
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
+        eprintln!("skipping: no wgpu adapter available");
+        return None;
+    }
+    match locate_fixture_wasm() {
+        Some(path) => Some(path),
+        None => {
+            assert!(
+                !strict,
+                "AETHER_REQUIRE_RUNTIME set but aether_test_fixture_probe.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing this crate",
+            );
+            eprintln!(
+                "skipping: aether_test_fixture_probe.wasm not built; run \
+                 `cargo build --target wasm32-unknown-unknown -p aether-test-fixture-probe`",
+            );
+            None
+        }
+    }
+}
+
+const PROBE_NAME: &str = "probe";
+const TICK_OBSERVED: &str = "aether.test_fixture.tick_observed";
+
+/// Loads the probe into the bench. The load mail is queued and
+/// processed during the next `advance` (the bench's queue is FIFO
+/// and drains ahead of the chassis Advance event, so the freshly
+/// instantiated probe is fully subscribed before any tick fans out).
+fn load_probe(bench: &TestBench, wasm_path: &Path) {
+    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    bench
+        .send_mail(
+            "aether.control",
+            &LoadComponent {
+                wasm,
+                name: Some(PROBE_NAME.to_owned()),
+            },
+        )
+        .expect("dispatch load_component");
+}
+
+/// Subscribing the fixture to Tick yields exactly one
+/// `tick_observed` broadcast per advance tick. Validates the
+/// subscribe_input → tick fanout path end-to-end.
+#[test]
+fn input_subscription_yields_one_tick_observed_per_advance() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    load_probe(&bench, &wasm_path);
+
+    bench.advance(5).expect("advance 5");
+    assert_eq!(
+        bench.count_observed(TICK_OBSERVED),
+        5,
+        "expected exactly 5 tick_observed broadcasts after advance(5); \
+         observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// Dropping the probe stops further tick_observed broadcasts.
+/// Validates that `aether.control.drop_component` removes the
+/// mailbox from the input subscriber set so subsequent ticks don't
+/// reach it (ADR-0021 + ADR-0038 actor lifecycle).
+#[test]
+fn drop_component_silences_tick_echoes() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    load_probe(&bench, &wasm_path);
+
+    bench.advance(3).expect("pre-drop advance");
+    assert_eq!(
+        bench.count_observed(TICK_OBSERVED),
+        3,
+        "expected 3 tick_observed before drop; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+
+    // Queue the drop. The same FIFO ordering that lets the load mail
+    // beat the first tick fanout means the drop mail beats the next
+    // tick fanout — by the time `Advance{1}`'s `run_frame` queries
+    // subscribers, the probe's mailbox is already gone.
+    let probe_mbox = MailboxId(mailbox_id_from_name(PROBE_NAME));
+    bench
+        .send_mail(
+            "aether.control",
+            &DropComponent {
+                mailbox_id: probe_mbox,
+            },
+        )
+        .expect("dispatch drop_component");
+    bench.advance(1).expect("drop drain advance");
+
+    let post_drop = bench.count_observed(TICK_OBSERVED);
+
+    bench.advance(10).expect("post-drop advance");
+    assert_eq!(
+        bench.count_observed(TICK_OBSERVED),
+        post_drop,
+        "tick_observed count climbed after drop_component; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// `aether.observation.frame_stats` is broadcast every 120 frames
+/// (ADR-0023). Advancing exactly 120 ticks should yield one such
+/// broadcast on the loopback. The bench emits this from its own
+/// frame loop — no fixture component needed.
+#[test]
+fn frame_stats_broadcast_at_120_tick_cadence() {
+    if !has_wgpu_adapter() {
+        let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+        assert!(
+            !strict,
+            "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+        );
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    bench.advance(120).expect("advance 120");
+    let stats_count = bench.count_observed("aether.observation.frame_stats");
+    assert_eq!(
+        stats_count,
+        1,
+        "expected exactly one frame_stats broadcast at 120 ticks; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}

--- a/crates/aether-test-fixture-probe/Cargo.toml
+++ b/crates/aether-test-fixture-probe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "aether-test-fixture-probe"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+aether-component = { path = "../aether-component" }
+aether-kinds = { path = "../aether-kinds" }
+aether-mail = { path = "../aether-mail", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -1,0 +1,61 @@
+//! Test-fixture component for substrate-feature scenarios. Not a
+//! demo, not exemplary — its only job is to expose substrate /
+//! test-bench primitives (input subscription, drop, replace, capture)
+//! to scenario assertions in a way that's easy to observe.
+//!
+//! Behaviour:
+//!
+//! - On every tick, broadcasts `aether.test_fixture.tick_observed`
+//!   with a monotonic counter. Lets scenarios count tick deliveries
+//!   via `TestBench::count_observed` (broadcasts arrive on the
+//!   loopback and get recorded by kind name).
+//!
+//! Future surface (deferred until the relevant scenarios land):
+//! state-set + render-on-command for capture_frame round-trip,
+//! mail-echo for replace_component, IO-reply forwarding.
+
+use aether_component::{Component, Ctx, InitCtx, Sink, handlers, resolve_sink};
+use aether_kinds::Tick;
+
+/// Broadcast payload emitted on each tick. Postcard-shaped — schema
+/// rides in the wasm's `aether.kinds` custom section, so the bench's
+/// loopback decoder can record the kind name without the test
+/// pre-registering anything.
+#[derive(
+    aether_mail::Kind, aether_mail::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixture.tick_observed")]
+pub struct TickObserved {
+    pub count: u64,
+}
+
+const BROADCAST: Sink<TickObserved> = resolve_sink::<TickObserved>("hub.claude.broadcast");
+
+pub struct Probe {
+    tick_count: u64,
+}
+
+#[handlers]
+impl Component for Probe {
+    fn init(_ctx: &mut InitCtx<'_>) -> Self {
+        Probe { tick_count: 0 }
+    }
+
+    /// Counts ticks delivered to this mailbox; broadcasts the running
+    /// total so scenarios can observe it on the loopback.
+    ///
+    /// # Agent
+    /// Not sent manually; the substrate's tick fanout fires it once
+    /// per advance for every input-subscribed mailbox. Watch
+    /// `receive_mail` for `aether.test_fixture.tick_observed` to see
+    /// the count climbing.
+    #[handler]
+    fn on_tick(&mut self, _ctx: &mut Ctx<'_>, _: Tick) {
+        self.tick_count += 1;
+        BROADCAST.send(&TickObserved {
+            count: self.tick_count,
+        });
+    }
+}
+
+aether_component::export!(Probe);


### PR DESCRIPTION
## Summary

Phase 3 of issue 430 first slice. Three substrate-feature scenarios landing in `crates/aether-substrate-test-bench/tests/scenario.rs` as Rust integration tests:

- **`input_subscription_yields_one_tick_observed_per_advance`** — load fixture, advance(5), assert exactly 5 `aether.test_fixture.tick_observed` broadcasts. Validates SDK auto-subscribe + tick fanout end-to-end.
- **`drop_component_silences_tick_echoes`** — load + advance(3) (count=3), drop, advance(11) more, assert count unchanged. Validates ADR-0021 input subscriber removal on drop + ADR-0038 actor lifecycle.
- **`frame_stats_broadcast_at_120_tick_cadence`** — advance(120), assert exactly one `aether.observation.frame_stats` (ADR-0023). No fixture required; the bench emits this from its own frame loop.

## New crate: aether-test-fixture-probe

A minimal cdylib whose only job is to broadcast a counter on each tick. Naming is deliberately test-only (`test-fixture-probe`, kind name `aether.test_fixture.tick_observed`) so a future reader can tell at a glance it isnt a demo or production component. Surface grows as Phase 3 remaining scenarios (capture_frame round-trip, replace_component, IO sink) land in follow-up PRs.

## Why Rust integration tests, not YAML scenarios

The issue spec said "in `aether-substrate-test-bench/tests/scenarios/` (or wherever the chassis-level YAMLs land)." YAML would have required encoding `MailboxId` into params (`DropComponent` takes a `MailboxId` field) — solvable but adds friction. Rust integration tests give direct bench API access (`bench.send_mail::<DropComponent>`, `bench.count_observed`) and follow the same shape as the per-component scenarios in PRs 432/434/436/437/443.

## Why FIFO drain ordering matters

A first cut had a priming `advance(1)` between load and counting — turned out to be off-by-one. The bench queue is FIFO and drains the load mail (and the SDK `subscribe_input`) before processing the chassis Advance event in the same drain pass, so a fresh `advance(N)` post-load gives exactly N tick echoes (not N-1). Comment on `load_probe` documents this so future scenarios dont repeat the wrong mental model.

## Phase 3 progress (issue 430)

- [x] Frame stats observation
- [x] Input subscription tick count
- [x] drop_component
- [ ] capture_frame round-trip
- [ ] replace_component
- [ ] IO sink read/write
- [ ] IO sink delete/list

## Test plan

- `cargo build --target wasm32-unknown-unknown -p aether-test-fixture-probe` — fixture wasm builds clean.
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-test-bench --test scenario` — all 3 new scenarios pass; CI gate fails loudly on missing pre-build.
- `AETHER_REQUIRE_RUNTIME=1 cargo test --workspace --all-targets` — full workspace clean (every prior scenario test still passes).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

Refs issue 430 (Phase 3 progress; not closing — capture_frame / replace_component / IO scenarios pending in follow-ups).