### PR TITLE
feat(test-bench): capture_frame + replace_component scenarios (issue 430)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "aether-hub-protocol",
  "aether-kinds",
  "aether-mail",
+ "aether-scenario",
  "aether-substrate-core",
  "aether-test-fixture-probe",
  "bytemuck",
@@ -374,6 +375,7 @@ dependencies = [
  "aether-component",
  "aether-kinds",
  "aether-mail",
+ "bytemuck",
  "serde",
 ]
 

--- a/crates/aether-substrate-test-bench/Cargo.toml
+++ b/crates/aether-substrate-test-bench/Cargo.toml
@@ -41,3 +41,7 @@ wgpu = "29.0.1"
 # touches it.
 [dev-dependencies]
 aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }
+# Re-uses the visual/PNG helpers (`decode_png`, `differs_from_background`)
+# the per-component scenarios already exercise; avoids reinventing
+# pixel-diff plumbing in the test-bench's own scenarios.
+aether-scenario = { path = "../aether-scenario" }

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -322,18 +322,32 @@ impl TestBench {
         }
     }
 
-    /// Issue a `capture_frame` request. Drains the queue (so any
-    /// state-changing mail already in flight settles), runs one
-    /// render-with-capture cycle, and returns the PNG bytes.
-    /// Capture observes the current state — it does not dispatch
-    /// `Tick`. Pair with `advance` if the world needs to advance
-    /// before the capture.
+    /// Issue a `capture_frame` request with no pre/after mail bundles.
+    /// Drains the queue (so any state-changing mail already in flight
+    /// settles), runs one render-with-capture cycle, and returns the
+    /// PNG bytes. Capture observes the current state — it does not
+    /// dispatch `Tick`. Pair with `advance` if the world needs to
+    /// advance before the capture.
     pub fn capture(&mut self) -> Result<Vec<u8>, TestBenchError> {
+        self.capture_with_mails(Vec::new(), Vec::new())
+    }
+
+    /// Same as `capture` but with the two `CaptureFrame` mail bundles
+    /// (ADR-0020 §capture_frame). `pre` is dispatched *before* the
+    /// readback — its effects appear in the captured frame; `after`
+    /// is dispatched *after* the readback — typically cleanup that
+    /// restores state the caller flipped for the capture. Matches
+    /// the wire shape of the MCP `capture_frame` tool.
+    pub fn capture_with_mails(
+        &mut self,
+        pre: Vec<aether_kinds::MailEnvelope>,
+        after: Vec<aether_kinds::MailEnvelope>,
+    ) -> Result<Vec<u8>, TestBenchError> {
         let cid = self.fresh_correlation_id();
         self.push_control(
             &CaptureFrame {
-                mails: Vec::new(),
-                after_mails: Vec::new(),
+                mails: pre,
+                after_mails: after,
             },
             cid,
         );

--- a/crates/aether-substrate-test-bench/tests/scenario.rs
+++ b/crates/aether-substrate-test-bench/tests/scenario.rs
@@ -1,7 +1,9 @@
 //! Phase 3 substrate-feature scenarios (issue 430). Each test boots
 //! a `TestBench`, loads `aether-test-fixture-probe`'s wasm, and
-//! exercises one substrate primitive (input subscription, drop, etc.)
-//! by counting fixture-emitted broadcasts on the bench loopback.
+//! exercises one substrate primitive (input subscription, drop,
+//! capture_frame round-trip, replace_component) by either counting
+//! fixture-emitted broadcasts on the bench loopback or inspecting
+//! the captured frame.
 //!
 //! Skipped when:
 //! - No wgpu adapter is available (driverless Linux runners without
@@ -15,9 +17,11 @@
 
 use std::path::{Path, PathBuf};
 
-use aether_kinds::{DropComponent, LoadComponent};
-use aether_mail::{MailboxId, mailbox_id_from_name};
+use aether_kinds::{DropComponent, LoadComponent, MailEnvelope, ReplaceComponent};
+use aether_mail::{Kind, MailboxId, mailbox_id_from_name};
+use aether_scenario::{decode_png, differs_from_background};
 use aether_substrate_test_bench::TestBench;
+use aether_test_fixture_probe::SetRender;
 
 // Pin the fixture rlib so its `inventory::submit!` `KindDescriptor`
 // entries are present in this test binary. Without the reference, the
@@ -89,6 +93,18 @@ fn require_runtime() -> Option<PathBuf> {
 
 const PROBE_NAME: &str = "probe";
 const TICK_OBSERVED: &str = "aether.test_fixture.tick_observed";
+
+/// Build a `MailEnvelope` for a `CaptureFrame` mail bundle. Uses
+/// the kind's wire encoding (`encode_into_bytes`) so any K — cast
+/// or postcard — packs correctly.
+fn envelope<K: Kind>(recipient: &str, mail: &K) -> MailEnvelope {
+    MailEnvelope {
+        recipient_name: recipient.to_owned(),
+        kind_name: K::NAME.to_owned(),
+        payload: mail.encode_into_bytes(),
+        count: 1,
+    }
+}
 
 /// Loads the probe into the bench. The load mail is queued and
 /// processed during the next `advance` (the bench's queue is FIFO
@@ -170,6 +186,133 @@ fn drop_component_silences_tick_echoes() {
         bench.count_observed(TICK_OBSERVED),
         post_drop,
         "tick_observed count climbed after drop_component; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// `capture_frame` round-trip with non-empty mail bundles. The
+/// pre-mail bundle flips the fixture's render state to "visible
+/// red"; the captured PNG must contain at least one pixel that
+/// diverges from the chassis clear color. The after-mail bundle
+/// flips render back to invisible; a follow-up advance + plain
+/// capture must produce a frame back at the clear color, proving
+/// the after-mail cleanup ran.
+#[test]
+fn capture_frame_round_trip_runs_pre_and_after_mails() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    load_probe(&bench, &wasm_path);
+    // Advance once so the probe is loaded + subscribed; the capture
+    // path doesn't dispatch Tick on its own (`run_frame` runs with
+    // dispatch_tick=false during capture), so we need at least one
+    // prior tick to have wired the subscriber set.
+    bench.advance(1).expect("priming advance");
+
+    // Capture's `run_frame` runs with `dispatch_tick=false`, so the
+    // probe won't auto-tick during the captured frame. The pre-mail
+    // bundle wires it up manually: set_render flips state to "visible
+    // red", and a synthesised `aether.tick` immediately drives the
+    // probe's on_tick to emit a `DrawTriangle` into the bench's
+    // frame_vertices buffer right before the GPU readback.
+    let pre = vec![
+        envelope(
+            PROBE_NAME,
+            &SetRender {
+                r: 200,
+                g: 32,
+                b: 32,
+                visible: 1,
+            },
+        ),
+        MailEnvelope {
+            recipient_name: PROBE_NAME.to_owned(),
+            kind_name: "aether.tick".to_owned(),
+            payload: Vec::new(),
+            count: 1,
+        },
+    ];
+    // After-mail bundle dispatches *after* the readback. Flips
+    // render state to invisible so the post-cleanup capture is back
+    // at the chassis clear color.
+    let after = vec![envelope(
+        PROBE_NAME,
+        &SetRender {
+            r: 0,
+            g: 0,
+            b: 0,
+            visible: 0,
+        },
+    )];
+    let png = bench
+        .capture_with_mails(pre, after)
+        .expect("capture with mails");
+    let img = decode_png(&png).expect("decode capture png");
+    differs_from_background(&img, 5).expect("captured frame should contain a non-background pixel");
+
+    // Cleanup ran: probe.render is now { visible: 0 }. Advance once
+    // and capture again — the next tick won't emit DrawTriangle, so
+    // the frame stays at clear color. (The next advance does fire a
+    // tick against the probe, but with visible=0 the probe broadcasts
+    // tick_observed without emitting any geometry.)
+    bench.advance(1).expect("post-cleanup advance");
+    let png2 = bench.capture().expect("plain capture after cleanup");
+    let img2 = decode_png(&png2).expect("decode cleanup png");
+    assert!(
+        differs_from_background(&img2, 5).is_err(),
+        "after after-mail cleanup the captured frame should be uniform clear color, \
+         but at least one pixel still diverges (cleanup did not run)",
+    );
+}
+
+/// `replace_component` preserves the mailbox identity across the
+/// splice (ADR-0022 + ADR-0038). Loads the probe, lets it broadcast
+/// N ticks, replaces the wasm at the same mailbox id with the same
+/// fixture binary, and asserts the post-replace count climbs —
+/// proving the new component instance inherits the input
+/// subscriptions and continues receiving ticks at the original
+/// mailbox.
+#[test]
+fn replace_component_preserves_mailbox_identity() {
+    let Some(wasm_path) = require_runtime() else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    load_probe(&bench, &wasm_path);
+
+    bench.advance(3).expect("pre-replace advance");
+    let pre_replace = bench.count_observed(TICK_OBSERVED);
+    assert_eq!(
+        pre_replace,
+        3,
+        "expected 3 tick_observed before replace; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+
+    let probe_mbox = MailboxId(mailbox_id_from_name(PROBE_NAME));
+    let wasm = std::fs::read(&wasm_path).expect("re-read fixture wasm");
+    bench
+        .send_mail(
+            "aether.control",
+            &ReplaceComponent {
+                mailbox_id: probe_mbox,
+                wasm,
+                drain_timeout_ms: None,
+            },
+        )
+        .expect("dispatch replace_component");
+    bench.advance(1).expect("replace drain advance");
+
+    let post_replace_baseline = bench.count_observed(TICK_OBSERVED);
+    bench.advance(4).expect("post-replace advance");
+    let post_replace = bench.count_observed(TICK_OBSERVED);
+
+    assert!(
+        post_replace > post_replace_baseline,
+        "tick_observed count did not climb after replace; \
+         baseline={post_replace_baseline}, final={post_replace}; \
+         observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }

--- a/crates/aether-test-fixture-probe/Cargo.toml
+++ b/crates/aether-test-fixture-probe/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["cdylib", "rlib"]
 aether-component = { path = "../aether-component" }
 aether-kinds = { path = "../aether-kinds" }
 aether-mail = { path = "../aether-mail", features = ["derive"] }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -9,13 +9,15 @@
 //!   with a monotonic counter. Lets scenarios count tick deliveries
 //!   via `TestBench::count_observed` (broadcasts arrive on the
 //!   loopback and get recorded by kind name).
-//!
-//! Future surface (deferred until the relevant scenarios land):
-//! state-set + render-on-command for capture_frame round-trip,
-//! mail-echo for replace_component, IO-reply forwarding.
+//! - Receives `aether.test_fixture.set_render { r, g, b, visible }`
+//!   to update render state. When `visible` is non-zero, on_tick
+//!   emits a colored `DrawTriangle` to the chassis render sink, so
+//!   `capture_frame` scenarios can observe pre-mail effects in the
+//!   captured PNG.
 
 use aether_component::{Component, Ctx, InitCtx, Sink, handlers, resolve_sink};
-use aether_kinds::Tick;
+use aether_kinds::{DrawTriangle, Tick, Vertex};
+use bytemuck::{Pod, Zeroable};
 
 /// Broadcast payload emitted on each tick. Postcard-shaped — schema
 /// rides in the wasm's `aether.kinds` custom section, so the bench's
@@ -29,20 +31,43 @@ pub struct TickObserved {
     pub count: u64,
 }
 
+/// Driver kind: scenarios send this to flip the fixture's render
+/// state. `visible == 0` halts the per-tick draw; any other value
+/// enables it. Cast-shape so encoding is just a memcpy of four
+/// bytes — keeps the test-side `MailEnvelope.payload` construction
+/// trivial.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "aether.test_fixture.set_render")]
+pub struct SetRender {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub visible: u8,
+}
+
 const BROADCAST: Sink<TickObserved> = resolve_sink::<TickObserved>("hub.claude.broadcast");
+const RENDER: Sink<DrawTriangle> = resolve_sink::<DrawTriangle>("aether.sink.render");
 
 pub struct Probe {
     tick_count: u64,
+    render: SetRender,
 }
 
 #[handlers]
 impl Component for Probe {
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        Probe { tick_count: 0 }
+        Probe {
+            tick_count: 0,
+            render: SetRender::default(),
+        }
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running
-    /// total so scenarios can observe it on the loopback.
+    /// total so scenarios can observe it on the loopback. When the
+    /// stored render state is `visible`, also emits a colored
+    /// `DrawTriangle` covering most of the frame so `capture_frame`
+    /// scenarios can see the pre-mail effect in the PNG.
     ///
     /// # Agent
     /// Not sent manually; the substrate's tick fanout fires it once
@@ -55,6 +80,34 @@ impl Component for Probe {
         BROADCAST.send(&TickObserved {
             count: self.tick_count,
         });
+        if self.render.visible != 0 {
+            let r = self.render.r as f32 / 255.0;
+            let g = self.render.g as f32 / 255.0;
+            let b = self.render.b as f32 / 255.0;
+            let v = |x: f32, y: f32| Vertex {
+                x,
+                y,
+                z: 0.5,
+                r,
+                g,
+                b,
+            };
+            RENDER.send(&DrawTriangle {
+                verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
+            });
+        }
+    }
+
+    /// Updates the stored render state. Subsequent ticks paint the
+    /// new color (or stop painting when `visible == 0`).
+    ///
+    /// # Agent
+    /// Send via `send_mail` with `kind_name = "aether.test_fixture.set_render"`
+    /// and params `{ r, g, b, visible }`. Used by capture_frame
+    /// scenarios to flip the fixture's render output between frames.
+    #[handler]
+    fn on_set_render(&mut self, _ctx: &mut Ctx<'_>, mail: SetRender) {
+        self.render = mail;
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 second slice (issue 430). Two more substrate-feature scenarios:

- **`capture_frame_round_trip_runs_pre_and_after_mails`** — pre-mail bundle flips the fixture render state to "visible red" + dispatches a synthesised `aether.tick` inside the capture's drain pass so the new state's first render emission lands in `frame_vertices` before the GPU readback. After-mail bundle flips render back to invisible. Asserts the captured PNG differs from the chassis clear color AND a follow-up plain capture is back at clear color (proving cleanup ran).
- **`replace_component_preserves_mailbox_identity`** — load probe, advance 3 (count=3), `ReplaceComponent` at the same mailbox id with the same fixture wasm, advance more, assert the count climbs. Validates ADR-0022 splice semantics + ADR-0038 actor-per-component lifecycle: the new instance inherits input subscriptions and continues receiving ticks at the original mailbox.

## Surface additions to support the scenarios

- **`TestBench::capture_with_mails(pre, after)`** — the two-bundle shape that mirrors the MCP `capture_frame` tool. Existing `capture()` now delegates with empty bundles. No behavior change for current callers.
- **`aether-test-fixture-probe`** grew a `SetRender { r, g, b, visible }` driver kind plus an `aether.sink.render` emission path. When `visible != 0`, the per-tick handler writes a colored `DrawTriangle` covering most of the frame. Still test-only, still naming-tagged as such — `aether-test-fixture-*` and `aether.test_fixture.*` are deliberate at-a-glance "this isn't production" markers.

## Why a synthesised tick in the pre-mail bundle

`run_frame` runs with `dispatch_tick=false` during a capture (capture observes; advance dispatches ticks). Without the synthesised tick, the pre-mail's `set_render` would update fixture state but no `on_tick` would fire to actually emit `DrawTriangle` — the captured frame would still be background-only. The synthesised tick is the documented workaround the per-component scenarios already use (`tick_to(mailbox)` in mesh-viewer / sokoban / ttt-client tests); the capture-bundle path uses it inline.

## Phase 3 progress (issue 430)

- [x] Frame stats observation (PR 444)
- [x] Input subscription tick count (PR 444)
- [x] `drop_component` (PR 444)
- [x] `capture_frame` round-trip (this PR)
- [x] `replace_component` (this PR)
- [ ] IO sink read/write
- [ ] IO sink delete/list

## Test plan

- `cargo build --target wasm32-unknown-unknown -p aether-test-fixture-probe` — extended fixture wasm builds clean.
- `AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-test-bench --test scenario` — all 5 scenarios pass; CI gate fails loudly on missing pre-build.
- `AETHER_REQUIRE_RUNTIME=1 cargo test --workspace --all-targets` — full workspace clean (every prior scenario test still passes).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

Refs issue 430 (Phase 3 progress; not closing — IO sink scenarios pending in a final slice).