### PR TITLE
feat(test-bench): close phase 3 with io sink scenarios (issue 430)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "pollster",
  "postcard",
  "serde",
+ "tempfile",
  "tracing",
  "wasmtime",
  "wgpu",
@@ -1366,6 +1367,12 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -3974,6 +3981,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/crates/aether-substrate-test-bench/Cargo.toml
+++ b/crates/aether-substrate-test-bench/Cargo.toml
@@ -45,3 +45,7 @@ aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }
 # the per-component scenarios already exercise; avoids reinventing
 # pixel-diff plumbing in the test-bench's own scenarios.
 aether-scenario = { path = "../aether-scenario" }
+# IO sink scenarios sandbox `AETHER_SAVE_DIR` to a per-process
+# tempdir so `save://` writes don't pollute the developer's
+# data_dir() and parallel test threads don't collide.
+tempfile = "3"

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -309,6 +309,36 @@ impl TestBench {
         Ok(())
     }
 
+    /// Send `mail` to `recipient_name` with this bench's session as
+    /// the reply target, then pump until a matching reply arrives and
+    /// decode it as `R`. The reply must be postcard-encoded — true
+    /// for every standard reply kind (`*Result` variants in
+    /// `aether-kinds`). Use this for any sink/component whose reply
+    /// pattern is "send → await → decode" — e.g. the `aether.sink.io`
+    /// `Read`/`Write`/`Delete`/`List` round trips. `advance` and
+    /// `capture` are specialisations of this same shape against the
+    /// `aether.control` mailbox.
+    pub fn send_and_await_reply<K, R>(
+        &mut self,
+        recipient_name: &str,
+        mail: &K,
+    ) -> Result<R, TestBenchError>
+    where
+        K: Kind + serde::Serialize,
+        R: serde::de::DeserializeOwned,
+    {
+        let mailbox = self
+            .registry
+            .lookup(recipient_name)
+            .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
+        let cid = self.fresh_correlation_id();
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
+        let payload = encode_struct(mail);
+        self.queue
+            .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
+        self.pump_until_reply::<R>(cid, std::any::type_name::<R>())
+    }
+
     /// Run `ticks` complete frames synchronously. Each frame
     /// dispatches `Tick` to subscribers, drains the queue, and
     /// renders. Returns once the substrate has replied with

--- a/crates/aether-substrate-test-bench/tests/scenario.rs
+++ b/crates/aether-substrate-test-bench/tests/scenario.rs
@@ -1,23 +1,28 @@
 //! Phase 3 substrate-feature scenarios (issue 430). Each test boots
-//! a `TestBench`, loads `aether-test-fixture-probe`'s wasm, and
-//! exercises one substrate primitive (input subscription, drop,
-//! capture_frame round-trip, replace_component) by either counting
-//! fixture-emitted broadcasts on the bench loopback or inspecting
-//! the captured frame.
+//! a `TestBench` and exercises one substrate primitive — input
+//! subscription, drop, capture_frame round-trip, replace_component
+//! (all via `aether-test-fixture-probe`), or the IO sink's
+//! read/write/delete/list round trips (which talk directly to the
+//! chassis `aether.sink.io` via `TestBench::send_and_await_reply`).
 //!
 //! Skipped when:
 //! - No wgpu adapter is available (driverless Linux runners without
 //!   `mesa-vulkan-drivers`).
-//! - The fixture's wasm hasn't been built — tests read
-//!   `target/wasm32-unknown-unknown/{debug,release}/aether_test_fixture_probe.wasm`
-//!   and skip with an `eprintln!` when it's absent. CI builds the
-//!   fixture wasm before invoking `cargo test`. Setting
+//! - The fixture's wasm hasn't been built — fixture-loading tests
+//!   read `target/wasm32-unknown-unknown/{debug,release}/aether_test_fixture_probe.wasm`
+//!   and skip with an `eprintln!` when it's absent. IO scenarios
+//!   don't load the fixture, so they only need wgpu. CI builds the
+//!   fixture wasm before invoking `cargo test`; setting
 //!   `AETHER_REQUIRE_RUNTIME=1` (CI does) flips both skip points
 //!   into hard panics so a missing pre-build is loud.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
-use aether_kinds::{DropComponent, LoadComponent, MailEnvelope, ReplaceComponent};
+use aether_kinds::{
+    Delete, DeleteResult, DropComponent, IoError, List, ListResult, LoadComponent, MailEnvelope,
+    Read, ReadResult, ReplaceComponent, Write, WriteResult,
+};
 use aether_mail::{Kind, MailboxId, mailbox_id_from_name};
 use aether_scenario::{decode_png, differs_from_background};
 use aether_substrate_test_bench::TestBench;
@@ -315,6 +320,237 @@ fn replace_component_preserves_mailbox_identity() {
          observed kinds: {:?}",
         bench.observed_kinds(),
     );
+}
+
+/// Process-wide `save://` sandbox. `NamespaceRoots::from_env`
+/// reads `AETHER_SAVE_DIR` once per chassis boot, so the env var
+/// must be set before any TestBench boot. `OnceLock` linearises
+/// the set; tests gate through `init_test_save_dir()` first.
+static TEST_SAVE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Create the per-process sandbox (idempotent) and point
+/// `AETHER_SAVE_DIR` at it. Subsequent `TestBench::start()` calls
+/// see the env var and wire `save://` to this dir.
+///
+/// `set_var` is racy with concurrent `getenv` on POSIX, but
+/// `OnceLock` linearises the set, and every IO test gates through
+/// this helper before booting a TestBench — so by the time any
+/// test thread reads env, the set has completed.
+fn init_test_save_dir() -> &'static Path {
+    TEST_SAVE_DIR.get_or_init(|| {
+        let dir = std::env::temp_dir()
+            .join(format!("aether-test-bench-io-tests-{}", std::process::id(),));
+        std::fs::create_dir_all(&dir).expect("create test save dir");
+        unsafe { std::env::set_var("AETHER_SAVE_DIR", &dir) };
+        dir
+    })
+}
+
+/// IO scenarios need wgpu (the bench unconditionally builds a
+/// `Gpu` at boot) but not the fixture wasm. Skips on wgpu-less
+/// runners and panics under `AETHER_REQUIRE_RUNTIME` so a
+/// CI-side regression is loud.
+fn require_wgpu_only() -> bool {
+    if has_wgpu_adapter() {
+        return true;
+    }
+    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    assert!(
+        !strict,
+        "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+    );
+    eprintln!("skipping: no wgpu adapter available");
+    false
+}
+
+const IO_SINK: &str = "aether.sink.io";
+const IO_NAMESPACE_SAVE: &str = "save";
+
+/// `aether.io.write` followed by `aether.io.read` round-trips the
+/// bytes through the local-file adapter (ADR-0041). Both replies
+/// echo the originating namespace + path for correlation; the read
+/// reply also carries the bytes verbatim.
+#[test]
+fn io_write_then_read_round_trips_in_save_namespace() {
+    if !require_wgpu_only() {
+        return;
+    }
+    init_test_save_dir();
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+
+    let path = "io-roundtrip.bin".to_owned();
+    let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+
+    let write_reply: WriteResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Write {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+                bytes: payload.clone(),
+            },
+        )
+        .expect("write reply");
+    match write_reply {
+        WriteResult::Ok {
+            namespace,
+            path: echoed_path,
+        } => {
+            assert_eq!(namespace, IO_NAMESPACE_SAVE);
+            assert_eq!(echoed_path, path);
+        }
+        WriteResult::Err { error, .. } => panic!("write failed: {error:?}"),
+    }
+
+    let read_reply: ReadResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Read {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+            },
+        )
+        .expect("read reply");
+    match read_reply {
+        ReadResult::Ok {
+            namespace,
+            path: echoed_path,
+            bytes,
+        } => {
+            assert_eq!(namespace, IO_NAMESPACE_SAVE);
+            assert_eq!(echoed_path, path);
+            assert_eq!(bytes, payload);
+        }
+        ReadResult::Err { error, .. } => panic!("read failed: {error:?}"),
+    }
+}
+
+/// `aether.io.delete` removes a previously-written file; a
+/// follow-up `aether.io.read` of the same path returns
+/// `Err { NotFound }`.
+#[test]
+fn io_delete_removes_written_file() {
+    if !require_wgpu_only() {
+        return;
+    }
+    init_test_save_dir();
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+
+    let path = "io-delete.bin".to_owned();
+    let _: WriteResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Write {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+                bytes: vec![1, 2, 3],
+            },
+        )
+        .expect("write reply");
+
+    let delete_reply: DeleteResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Delete {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+            },
+        )
+        .expect("delete reply");
+    match delete_reply {
+        DeleteResult::Ok { .. } => {}
+        DeleteResult::Err { error, .. } => panic!("delete failed: {error:?}"),
+    }
+
+    let read_after_delete: ReadResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Read {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+            },
+        )
+        .expect("read-after-delete reply");
+    match read_after_delete {
+        ReadResult::Ok { .. } => panic!("read should not have found a deleted file"),
+        ReadResult::Err {
+            error: IoError::NotFound,
+            ..
+        } => {}
+        ReadResult::Err { error, .. } => panic!("expected NotFound, got {error:?}"),
+    }
+}
+
+/// `aether.io.list` enumerates entries under a prefix. After a
+/// write to `<sandbox>/probe-list.bin`, listing the empty prefix
+/// in `save` returns an entry list containing the bare filename.
+#[test]
+fn io_list_returns_written_path() {
+    if !require_wgpu_only() {
+        return;
+    }
+    init_test_save_dir();
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+
+    let path = "probe-list.bin".to_owned();
+    let _: WriteResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Write {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: path.clone(),
+                bytes: vec![0],
+            },
+        )
+        .expect("write reply");
+
+    let list_reply: ListResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &List {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                prefix: String::new(),
+            },
+        )
+        .expect("list reply");
+    match list_reply {
+        ListResult::Ok { entries, .. } => {
+            assert!(
+                entries.iter().any(|e| e == &path),
+                "expected entries to include {path:?}; got {entries:?}",
+            );
+        }
+        ListResult::Err { error, .. } => panic!("list failed: {error:?}"),
+    }
+}
+
+/// Reading a path that was never written returns
+/// `Err { NotFound }`. Negative companion to the round-trip test.
+#[test]
+fn io_read_unknown_path_returns_not_found() {
+    if !require_wgpu_only() {
+        return;
+    }
+    init_test_save_dir();
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+
+    let read_reply: ReadResult = bench
+        .send_and_await_reply(
+            IO_SINK,
+            &Read {
+                namespace: IO_NAMESPACE_SAVE.to_owned(),
+                path: "nonexistent-do-not-create.bin".to_owned(),
+            },
+        )
+        .expect("read reply");
+    match read_reply {
+        ReadResult::Ok { .. } => panic!("read should not have found a never-written file"),
+        ReadResult::Err {
+            error: IoError::NotFound,
+            ..
+        } => {}
+        ReadResult::Err { error, .. } => panic!("expected NotFound, got {error:?}"),
+    }
 }
 
 /// `aether.observation.frame_stats` is broadcast every 120 frames


### PR DESCRIPTION
## Summary

Final Phase 3 slice (issue 430). Four IO scenarios in `crates/aether-substrate-test-bench/tests/scenario.rs` talking directly to the chassis `aether.sink.io`:

- **`io_write_then_read_round_trips_in_save_namespace`** — write 4 bytes to `save://io-roundtrip.bin`, read back, assert payload echoes verbatim and reply carries the originating namespace + path.
- **`io_delete_removes_written_file`** — write → delete → read; expects `Err(NotFound)`.
- **`io_list_returns_written_path`** — write at `probe-list.bin`, list with empty prefix, expects entries vec to contain the bare filename.
- **`io_read_unknown_path_returns_not_found`** — read non-existent path → `Err(NotFound)`. Negative companion.

## Bench API addition

IO replies are point-to-point (addressed to the sender's session token), not broadcasts — the existing `TestBench::count_observed` path doesn't see them. New method generalises advance/capture's push-and-pump shape to arbitrary recipients:

```rust
pub fn send_and_await_reply<K, R>(
    &mut self,
    recipient_name: &str,
    mail: &K,
) -> Result<R, TestBenchError>
where
    K: Kind + serde::Serialize,
    R: serde::de::DeserializeOwned,
```

advance and capture are now special cases of this same shape against `aether.control`. Any sink with a request → reply pattern is testable inline.

## Sandbox

`AETHER_SAVE_DIR` is sandboxed to a per-process tempdir via `OnceLock` (same pattern the mesh-viewer scenarios use) so `save://` writes do not leak to the developer's `data_dir()` and parallel test threads do not collide. `tempfile` lands as a dev-dep on the test-bench crate.

## Phase 3 final tally (issue 430)

- [x] Frame stats observation (PR 444)
- [x] Input subscription tick count (PR 444)
- [x] drop_component (PR 444)
- [x] capture_frame round-trip (PR 445)
- [x] replace_component (PR 445)
- [x] IO sink read/write (this PR)
- [x] IO sink delete/list (this PR)

9 substrate-feature scenarios across 3 PRs cover every Phase 3 checkbox in the issue spec.

## Test plan

- AETHER_REQUIRE_RUNTIME=1 cargo test -p aether-substrate-test-bench --test scenario — all 9 scenarios pass.
- AETHER_REQUIRE_RUNTIME=1 cargo test --workspace --all-targets — full workspace clean.
- cargo clippy --all-targets -- -D warnings — clean.
- cargo fmt -- --check — clean.

Closes #430.