### PR TITLE
fix(tracing): log MailboxId via Display, not raw u64 or Debug (issue 435)

### DIFF
--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -317,13 +317,13 @@ fn route_mail(
                     if entry.is_dead() {
                         tracing::warn!(
                             target: "aether_substrate::queue",
-                            mailbox = ?recipient,
+                            mailbox = %recipient,
                             "mail to dead mailbox (actor panicked or trapped); discarded — see component_died broadcast",
                         );
                     } else if !entry.send(mail) {
                         tracing::warn!(
                             target: "aether_substrate::queue",
-                            mailbox = ?recipient,
+                            mailbox = %recipient,
                             "component inbox closed (shutdown); mail discarded",
                         );
                     }
@@ -331,7 +331,7 @@ fn route_mail(
                 None => {
                     tracing::warn!(
                         target: "aether_substrate::queue",
-                        mailbox = ?recipient,
+                        mailbox = %recipient,
                         "mail to registered-component mailbox but no component bound — dropped",
                     );
                 }
@@ -340,7 +340,7 @@ fn route_mail(
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
                 target: "aether_substrate::queue",
-                mailbox = ?recipient,
+                mailbox = %recipient,
                 "mail to dropped mailbox — discarded",
             );
         }
@@ -379,7 +379,7 @@ fn route_mail(
                 if !sent {
                     tracing::warn!(
                         target: "aether_substrate::queue",
-                        mailbox = ?recipient,
+                        mailbox = %recipient,
                         "bubbles-up failed (writer channel closed); mail dropped",
                     );
                 }
@@ -387,7 +387,7 @@ fn route_mail(
             }
             tracing::warn!(
                 target: "aether_substrate::queue",
-                mailbox = ?recipient,
+                mailbox = %recipient,
                 "mail to unknown mailbox — dropped",
             );
         }

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -454,7 +454,7 @@ fn dispatcher_loop(
         let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| {
             let span = tracing::info_span!(
                 "dispatch",
-                mailbox = mailbox.0,
+                mailbox = %mailbox,
                 kind = %kind_name,
             );
             let _enter = span.enter();
@@ -466,7 +466,7 @@ fn dispatcher_loop(
                 if rc == DISPATCH_UNKNOWN_KIND {
                     tracing::warn!(
                         target: "aether_substrate::scheduler",
-                        mailbox = ?mail.recipient,
+                        mailbox = %mail.recipient,
                         kind = %kind_name,
                         "component has no handler for mail kind (ADR-0033 strict receiver); dropped",
                     );
@@ -476,7 +476,7 @@ fn dispatcher_loop(
             Ok(Err(trap)) => {
                 tracing::error!(
                     target: "aether_substrate::scheduler",
-                    mailbox = ?mail.recipient,
+                    mailbox = %mail.recipient,
                     kind = %kind_name,
                     error = %trap,
                     "component deliver returned Err (wasmtime trap); marking mailbox dead",
@@ -497,7 +497,7 @@ fn dispatcher_loop(
                 let payload_msg = panic_payload_string(&payload);
                 tracing::error!(
                     target: "aether_substrate::scheduler",
-                    mailbox = ?mail.recipient,
+                    mailbox = %mail.recipient,
                     kind = %kind_name,
                     payload = %payload_msg,
                     "host-side panic during deliver; marking mailbox dead",

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -135,14 +135,14 @@ impl TestBenchChassis {
         if let Some((mailbox, waited)) = summary.wedged {
             aether_substrate_core::lifecycle::fatal_abort(
                 &self.outbound,
-                format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
+                format!("dispatcher wedged: mailbox={mailbox} waited={waited:?}"),
             );
         }
         if let Some(first) = summary.deaths.first() {
             for d in &summary.deaths {
                 tracing::error!(
                     target: "aether_substrate::lifecycle",
-                    mailbox = ?d.mailbox,
+                    mailbox = %d.mailbox,
                     mailbox_name = %d.mailbox_name,
                     last_kind = %d.last_kind,
                     reason = %d.reason,

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -529,14 +529,14 @@ impl TestBench {
         if let Some((mailbox, waited)) = summary.wedged {
             aether_substrate_core::lifecycle::fatal_abort(
                 &self.outbound,
-                format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
+                format!("dispatcher wedged: mailbox={mailbox} waited={waited:?}"),
             );
         }
         if let Some(first) = summary.deaths.first() {
             for d in &summary.deaths {
                 tracing::error!(
                     target: "aether_substrate::lifecycle",
-                    mailbox = ?d.mailbox,
+                    mailbox = %d.mailbox,
                     mailbox_name = %d.mailbox_name,
                     last_kind = %d.last_kind,
                     reason = %d.reason,


### PR DESCRIPTION
## Summary

- Swap `mailbox = mailbox.0` / `mailbox = ?...` (Debug) tracing fields and `format!(..."mailbox={...:?}")` strings to use Display so spans render the tagged-string `mbx-...` form ADR-0064 + ADR-0065 wired up, rather than a 19-digit decimal that doesn't match what Claude sees over MCP.
- Sites swept: `crates/aether-substrate-core/src/scheduler.rs` (the `dispatch` span itself plus three death/trap warn/error sites), `crates/aether-substrate-core/src/mailer.rs` (six dead/closed/dropped/unknown-mailbox warn sites), and the parallel pair in `crates/aether-substrate-test-bench/src/{main.rs,test_bench.rs}` (`fatal_abort` wedge `format!` + `component died` error log).
- Out of scope per the issue: `handle_sink.rs:71`'s deliberate `{kind_id:#x}` hex form, `boot.rs:257` and `hub_client.rs:273` (already correct), and any `format!`/`println!` outside tracing.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` — all green
- [x] Manual sanity boot: `cargo run -p aether-substrate-headless` for a few seconds and grepped stderr for `mailbox=[0-9]` — no bare-decimal hits. Caveat: componentless boot exercises only the boot path, not the dispatch / mail-routing sites that actually emit these spans; the unit-test suite is what covers those code paths and passed.

Closes #435