### PR TITLE
refactor(substrate-core): extract capture control handler helper (issue 429)

### DIFF
--- a/crates/aether-substrate-core/src/capture.rs
+++ b/crates/aether-substrate-core/src/capture.rs
@@ -16,10 +16,25 @@
 // `EventLoopProxy<UserEvent>` directly. Keeping the wake out of
 // `CaptureQueue` means this type has zero chassis-awareness and could
 // live in any chassis crate that ever supports captures.
+//
+// `begin_capture_request` and the `reply_unsupported_*` helpers shave
+// ~50 lines off each chassis's control handler by collapsing the
+// resolve-bundle / push / enqueue / wake workflow (and the repeated
+// `XxxResult::Err { error: reason.to_owned() }` branches) into single
+// calls. See issue 429.
 
 use std::sync::{Arc, Mutex};
 
-use crate::{Mail, ReplyTo};
+use aether_kinds::{
+    AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfoResult, SetWindowModeResult,
+    SetWindowTitleResult,
+};
+
+use crate::control::{decode_payload, resolve_bundle};
+use crate::hub_client::HubOutbound;
+use crate::mail::{Mail, ReplyTo};
+use crate::mailer::Mailer;
+use crate::registry::Registry;
 
 /// One pending capture request. Carries the reply handle so the
 /// render thread can reply once it has bytes, plus a resolved list
@@ -62,6 +77,153 @@ impl CaptureQueue {
     pub fn take(&self) -> Option<PendingCapture> {
         self.slot.lock().unwrap().take()
     }
+}
+
+/// Run the full chassis-side capture-request workflow: decode the
+/// `CaptureFrame` payload, resolve both mail bundles atomically against
+/// the registry, push the pre-capture mails, install a `PendingCapture`
+/// on `capture_queue`, and invoke `wake` to nudge the chassis loop.
+///
+/// On any failure (decode, resolve, queue full, wake-channel down) the
+/// helper replies inline via `outbound` with `CaptureFrameResult::Err`
+/// and rolls back the queue install if the wake step is what failed.
+/// The caller doesn't see a `Result` — every error path is reported
+/// through the same reply channel the happy path uses, matching the
+/// rest of the control-plane shape.
+///
+/// The `wake` closure carries the chassis-specific bit. Desktop pokes
+/// its `EventLoopProxy<UserEvent>` (which only fails if the loop has
+/// shut down, and that case is a no-op anyway, so desktop returns
+/// `Ok`). Test-bench sends on its `EventSender`; if the receiver has
+/// been dropped (chassis shutting down), it returns the static reason
+/// string this helper attaches to the rollback reply.
+pub fn begin_capture_request(
+    queue: &Mailer,
+    capture_queue: &CaptureQueue,
+    registry: &Registry,
+    outbound: &HubOutbound,
+    sender: ReplyTo,
+    bytes: &[u8],
+    wake: impl FnOnce() -> Result<(), &'static str>,
+) {
+    let payload: CaptureFrame = match decode_payload(bytes) {
+        Ok(p) => p,
+        Err(error) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error });
+            return;
+        }
+    };
+
+    // Phase 1: resolve every envelope in both bundles before pushing
+    // anything or requesting a capture. Any failure aborts the whole
+    // request so a partial dispatch can't leak into the next frame.
+    let pre = match resolve_bundle(registry, &payload.mails, "capture bundle") {
+        Ok(v) => v,
+        Err(e) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
+            return;
+        }
+    };
+    let after = match resolve_bundle(registry, &payload.after_mails, "capture after bundle") {
+        Ok(v) => v,
+        Err(e) => {
+            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
+            return;
+        }
+    };
+
+    // Phase 2: push resolved pre-mails, enqueue capture, wake loop.
+    // The chassis loop's per-mailbox drain (ADR-0038 Phase 3) is what
+    // enforces "capture after all mail processed".
+    for mail in pre {
+        queue.push(mail);
+    }
+
+    let pending = PendingCapture {
+        reply_to: sender,
+        after_mails: after,
+    };
+    if !capture_queue.request(pending) {
+        outbound.send_reply(
+            sender,
+            &CaptureFrameResult::Err {
+                error: "capture already pending; try again once the in-flight \
+                    request completes"
+                    .to_owned(),
+            },
+        );
+        return;
+    }
+
+    if let Err(reason) = wake() {
+        // Wake target is gone (chassis shutting down). Roll back the
+        // queue install so a stray capture doesn't leak into the next
+        // boot, and reply Err inline so the caller doesn't hang.
+        let _ = capture_queue.take();
+        outbound.send_reply(
+            sender,
+            &CaptureFrameResult::Err {
+                error: reason.to_owned(),
+            },
+        );
+    }
+}
+
+/// Reply `SetWindowModeResult::Err` with the given reason. Used by
+/// chassis variants that don't own a window (headless, test-bench).
+pub fn reply_unsupported_window_mode(outbound: &HubOutbound, sender: ReplyTo, reason: &str) {
+    outbound.send_reply(
+        sender,
+        &SetWindowModeResult::Err {
+            error: reason.to_owned(),
+        },
+    );
+}
+
+/// Reply `SetWindowTitleResult::Err` with the given reason. Used by
+/// chassis variants that don't own a window (headless, test-bench).
+pub fn reply_unsupported_window_title(outbound: &HubOutbound, sender: ReplyTo, reason: &str) {
+    outbound.send_reply(
+        sender,
+        &SetWindowTitleResult::Err {
+            error: reason.to_owned(),
+        },
+    );
+}
+
+/// Reply `PlatformInfoResult::Err` with the given reason. Used by
+/// chassis variants that don't expose platform peripherals (headless,
+/// test-bench).
+pub fn reply_unsupported_platform_info(outbound: &HubOutbound, sender: ReplyTo, reason: &str) {
+    outbound.send_reply(
+        sender,
+        &PlatformInfoResult::Err {
+            error: reason.to_owned(),
+        },
+    );
+}
+
+/// Reply `AdvanceResult::Err` with the given reason. Used by chassis
+/// variants that don't drive ticks via `aether.test_bench.advance`
+/// (desktop, headless — only test-bench supports advance).
+pub fn reply_unsupported_advance(outbound: &HubOutbound, sender: ReplyTo, reason: &str) {
+    outbound.send_reply(
+        sender,
+        &AdvanceResult::Err {
+            error: reason.to_owned(),
+        },
+    );
+}
+
+/// Reply `CaptureFrameResult::Err` with the given reason. Used by
+/// chassis variants that have no GPU (headless).
+pub fn reply_unsupported_capture_frame(outbound: &HubOutbound, sender: ReplyTo, reason: &str) {
+    outbound.send_reply(
+        sender,
+        &CaptureFrameResult::Err {
+            error: reason.to_owned(),
+        },
+    );
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -17,14 +17,14 @@
 use std::sync::Arc;
 
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode,
-    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, WindowMode,
+    Advance, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowModeResult, SetWindowTitle,
+    SetWindowTitleResult, WindowMode,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
     ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo,
-    capture::{CaptureQueue, PendingCapture},
-    control::{decode_payload, resolve_bundle},
+    capture::{CaptureQueue, begin_capture_request, reply_unsupported_advance},
+    control::decode_payload,
 };
 use winit::event_loop::EventLoopProxy;
 
@@ -73,14 +73,22 @@ pub fn chassis_control_handler(
     Arc::new(
         move |kind_id: u64, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
-                handle_capture_frame(
-                    &proxy,
+                let proxy = proxy.clone();
+                begin_capture_request(
+                    &queue,
                     &capture_queue,
                     &registry,
-                    &queue,
                     &outbound,
                     sender,
                     bytes,
+                    move || {
+                        // `send_event` only fails if the event loop
+                        // has shut down; in that case nothing listens
+                        // for captures anyway, so swallow the error
+                        // and let the queued capture sit until exit.
+                        let _ = proxy.send_event(UserEvent::Capture);
+                        Ok(())
+                    },
                 );
             } else if kind_id == PlatformInfo::ID {
                 // Empty payload; forward the sender straight to the
@@ -92,13 +100,11 @@ pub fn chassis_control_handler(
             } else if kind_id == SetWindowTitle::ID {
                 handle_set_window_title(&proxy, &outbound, sender, bytes);
             } else if kind_id == Advance::ID {
-                outbound.send_reply(
+                reply_unsupported_advance(
+                    &outbound,
                     sender,
-                    &AdvanceResult::Err {
-                        error: "unsupported on desktop chassis — aether.test_bench.advance is \
-                                test-bench-only (ADR-0067)"
-                            .to_owned(),
-                    },
+                    "unsupported on desktop chassis — aether.test_bench.advance is \
+                     test-bench-only (ADR-0067)",
                 );
             } else {
                 tracing::warn!(
@@ -109,75 +115,6 @@ pub fn chassis_control_handler(
             }
         },
     )
-}
-
-/// Two-phase capture request (pre-capture mail push + render handoff).
-/// Ports the old `ControlPlane::handle_capture_frame` verbatim: resolve
-/// both mail bundles atomically against the registry before touching
-/// the queue, push pre-mails, enqueue the capture, poke the event loop.
-/// Decode / resolve / queue-full errors reply inline; the render thread
-/// fulfils the happy path on its next redraw.
-fn handle_capture_frame(
-    proxy: &EventLoopProxy<UserEvent>,
-    capture_queue: &CaptureQueue,
-    registry: &Registry,
-    queue: &Mailer,
-    outbound: &HubOutbound,
-    sender: ReplyTo,
-    bytes: &[u8],
-) {
-    let payload: CaptureFrame = match decode_payload(bytes) {
-        Ok(p) => p,
-        Err(error) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error });
-            return;
-        }
-    };
-
-    // Phase 1: resolve every envelope in both bundles before pushing
-    // anything or requesting a capture. Any failure aborts the whole
-    // request so a partial dispatch can't leak into the next frame.
-    let pre = match resolve_bundle(registry, &payload.mails, "capture bundle") {
-        Ok(v) => v,
-        Err(e) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
-            return;
-        }
-    };
-    let after = match resolve_bundle(registry, &payload.after_mails, "capture after bundle") {
-        Ok(v) => v,
-        Err(e) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
-            return;
-        }
-    };
-
-    // Phase 2: push resolved pre-mails, enqueue capture, wake loop.
-    // `queue.drain_all()` on the render thread is what enforces
-    // "capture after all mail processed" (per-mailbox drain under
-    // ADR-0038 Phase 3).
-    for mail in pre {
-        queue.push(mail);
-    }
-
-    let pending = PendingCapture {
-        reply_to: sender,
-        after_mails: after,
-    };
-    if !capture_queue.request(pending) {
-        outbound.send_reply(
-            sender,
-            &CaptureFrameResult::Err {
-                error: "capture already pending; try again once the in-flight \
-                    request completes"
-                    .to_owned(),
-            },
-        );
-        return;
-    }
-    // `send_event` only fails if the event loop has shut down; in
-    // that case nothing listens for captures anyway.
-    let _ = proxy.send_event(UserEvent::Capture);
 }
 
 /// Decode + forward to the event loop. Applying the mode requires

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -12,58 +12,37 @@
 
 use std::sync::Arc;
 
-use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, SetWindowMode,
-    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
-};
+use aether_kinds::{Advance, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowTitle};
 use aether_mail::Kind;
-use aether_substrate_core::{ChassisControlHandler, HubOutbound, ReplyTo};
+use aether_substrate_core::{
+    ChassisControlHandler, HubOutbound, ReplyTo,
+    capture::{
+        reply_unsupported_advance, reply_unsupported_capture_frame,
+        reply_unsupported_platform_info, reply_unsupported_window_mode,
+        reply_unsupported_window_title,
+    },
+};
 
 const UNSUPPORTED: &str = "unsupported on headless chassis — no GPU or window peripherals";
+const UNSUPPORTED_ADVANCE: &str =
+    "unsupported on headless chassis — aether.test_bench.advance is test-bench-only (ADR-0067)";
 
 pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHandler {
     Arc::new(
         move |kind_id: u64, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
-                outbound.send_reply(
-                    sender,
-                    &CaptureFrameResult::Err {
-                        error: UNSUPPORTED.to_owned(),
-                    },
-                );
+                reply_unsupported_capture_frame(&outbound, sender, UNSUPPORTED);
             } else if kind_id == SetWindowMode::ID {
-                outbound.send_reply(
-                    sender,
-                    &SetWindowModeResult::Err {
-                        error: UNSUPPORTED.to_owned(),
-                    },
-                );
+                reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED);
             } else if kind_id == SetWindowTitle::ID {
-                outbound.send_reply(
-                    sender,
-                    &SetWindowTitleResult::Err {
-                        error: UNSUPPORTED.to_owned(),
-                    },
-                );
+                reply_unsupported_window_title(&outbound, sender, UNSUPPORTED);
             } else if kind_id == Advance::ID {
-                outbound.send_reply(
-                    sender,
-                    &AdvanceResult::Err {
-                        error: "unsupported on headless chassis — aether.test_bench.advance is \
-                                test-bench-only (ADR-0067)"
-                            .to_owned(),
-                    },
-                );
+                reply_unsupported_advance(&outbound, sender, UNSUPPORTED_ADVANCE);
             } else if kind_id == PlatformInfo::ID {
                 // PlatformInfoResult::Err also exists — future work
                 // could return a partial Ok (OS + engine info, empty
                 // GPU/monitors) once headless needs that detail.
-                outbound.send_reply(
-                    sender,
-                    &aether_kinds::PlatformInfoResult::Err {
-                        error: UNSUPPORTED.to_owned(),
-                    },
-                );
+                reply_unsupported_platform_info(&outbound, sender, UNSUPPORTED);
             } else {
                 tracing::warn!(
                     target: "aether_substrate::chassis",

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -18,14 +18,16 @@
 use std::sync::Arc;
 
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, PlatformInfo, PlatformInfoResult,
-    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult,
+    Advance, AdvanceResult, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowTitle,
 };
 use aether_mail::Kind;
 use aether_substrate_core::{
     ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo,
-    capture::{CaptureQueue, PendingCapture},
-    control::{decode_payload, resolve_bundle},
+    capture::{
+        CaptureQueue, begin_capture_request, reply_unsupported_platform_info,
+        reply_unsupported_window_mode, reply_unsupported_window_title,
+    },
+    control::decode_payload,
 };
 
 use crate::events::{ChassisEvent, EventSender};
@@ -43,38 +45,28 @@ pub fn chassis_control_handler(
     Arc::new(
         move |kind_id: u64, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
             if kind_id == CaptureFrame::ID {
-                handle_capture_frame(
-                    &capture_queue,
-                    &events,
-                    &registry,
+                let events = events.clone();
+                begin_capture_request(
                     &queue,
+                    &capture_queue,
+                    &registry,
                     &outbound,
                     sender,
                     bytes,
+                    move || {
+                        events
+                            .send(ChassisEvent::CaptureRequested)
+                            .map_err(|_| "test-bench chassis shutting down — capture aborted")
+                    },
                 );
             } else if kind_id == Advance::ID {
                 handle_advance(&events, &outbound, sender, bytes);
             } else if kind_id == SetWindowMode::ID {
-                outbound.send_reply(
-                    sender,
-                    &SetWindowModeResult::Err {
-                        error: UNSUPPORTED_WINDOW.to_owned(),
-                    },
-                );
+                reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED_WINDOW);
             } else if kind_id == SetWindowTitle::ID {
-                outbound.send_reply(
-                    sender,
-                    &SetWindowTitleResult::Err {
-                        error: UNSUPPORTED_WINDOW.to_owned(),
-                    },
-                );
+                reply_unsupported_window_title(&outbound, sender, UNSUPPORTED_WINDOW);
             } else if kind_id == PlatformInfo::ID {
-                outbound.send_reply(
-                    sender,
-                    &PlatformInfoResult::Err {
-                        error: UNSUPPORTED_WINDOW.to_owned(),
-                    },
-                );
+                reply_unsupported_platform_info(&outbound, sender, UNSUPPORTED_WINDOW);
             } else {
                 tracing::warn!(
                     target: "aether_substrate::chassis",
@@ -84,75 +76,6 @@ pub fn chassis_control_handler(
             }
         },
     )
-}
-
-/// Two-phase capture request. Resolve both mail bundles atomically
-/// against the registry before touching the queue, push pre-mails,
-/// enqueue the capture, signal the loop. The loop drains and renders-
-/// with-capture (no Tick fanout — capture observes; advance ticks).
-fn handle_capture_frame(
-    capture_queue: &CaptureQueue,
-    events: &EventSender,
-    registry: &Registry,
-    queue: &Mailer,
-    outbound: &HubOutbound,
-    sender: ReplyTo,
-    bytes: &[u8],
-) {
-    let payload: CaptureFrame = match decode_payload(bytes) {
-        Ok(p) => p,
-        Err(error) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error });
-            return;
-        }
-    };
-
-    let pre = match resolve_bundle(registry, &payload.mails, "capture bundle") {
-        Ok(v) => v,
-        Err(e) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
-            return;
-        }
-    };
-    let after = match resolve_bundle(registry, &payload.after_mails, "capture after bundle") {
-        Ok(v) => v,
-        Err(e) => {
-            outbound.send_reply(sender, &CaptureFrameResult::Err { error: e });
-            return;
-        }
-    };
-
-    for mail in pre {
-        queue.push(mail);
-    }
-
-    let pending = PendingCapture {
-        reply_to: sender,
-        after_mails: after,
-    };
-    if !capture_queue.request(pending) {
-        outbound.send_reply(
-            sender,
-            &CaptureFrameResult::Err {
-                error: "capture already pending; try again once the in-flight request completes"
-                    .to_owned(),
-            },
-        );
-        return;
-    }
-
-    if events.send(ChassisEvent::CaptureRequested).is_err() {
-        // The tick loop has dropped its receiver — chassis is
-        // shutting down. The capture is queued but won't be drained.
-        // Reply Err so the caller doesn't hang.
-        let _ = capture_queue.take();
-        outbound.send_reply(
-            sender,
-            &CaptureFrameResult::Err {
-                error: "test-bench chassis shutting down — capture aborted".to_owned(),
-            },
-        );
-    }
 }
 
 /// Decode `Advance { ticks }`, push the request onto the event


### PR DESCRIPTION
## Summary

- Hoist the desktop + test-bench capture-frame workflow (decode CaptureFrame, resolve pre/after bundles, push pre-mails, install PendingCapture, wake the loop) into begin_capture_request in aether_substrate_core::capture. Wake mechanism is the only chassis-specific bit and rides in via a Result-returning closure so test-bench's shutdown rollback (channel-receiver-dropped) lives in the helper instead of being duplicated.
- Add five reply_unsupported_* helpers (window_mode, window_title, platform_info, advance, capture_frame) next to it. Each chassis's unsupported-control-kind ladder collapses to one-liner branches: headless drops from 76 to 54 lines, test-bench loses ~50 lines, desktop's Advance branch becomes a single call.
- No behaviour change. The helper bodies are verbatim ports of the prior chassis code; the wake closures preserve each chassis's existing wake mechanism.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (all green; capture round-trip exercised by aether-substrate-test-bench's capture_frame_round_trip_runs_pre_and_after_mails scenario test plus the existing aether-substrate-core capture unit tests)

Closes #429

<!-- pr-body-ok: b — Closes #NNN closing keyword required for github auto-close -->

Generated with Claude Code