### PR TITLE
refactor(substrate-core): extract render and camera sink helpers (issue 428)

### DIFF
--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -45,6 +45,8 @@ pub mod registry;
 pub mod render;
 pub mod reply_table;
 pub mod scheduler;
+#[cfg(feature = "render")]
+pub mod sinks;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use chassis::{Chassis, ChassisCapabilities};

--- a/crates/aether-substrate-core/src/sinks.rs
+++ b/crates/aether-substrate-core/src/sinks.rs
@@ -1,0 +1,130 @@
+//! Shared chassis sink builders (issue 428).
+//!
+//! Desktop and test-bench register byte-for-byte identical render and
+//! camera sinks; this module is the extraction. Each builder returns
+//! the chassis-side state (vertex buffer, triangle counter, view-proj
+//! matrix) plus the [`SinkHandler`] closure that writes into it. The
+//! chassis owns the `Arc`-shared state for its frame loop to read; the
+//! handler owns the closure that updates it under mail dispatch.
+//!
+//! Gated on the `render` feature alongside [`crate::render`] — only
+//! chassis that draw pull these in. Headless keeps its 4-line nop
+//! closures inline so the warn-suppressors are self-documenting.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::registry::SinkHandler;
+use crate::render::IDENTITY_VIEW_PROJ;
+
+/// Wire size of one `aether.draw_triangle` mail item: three vertices,
+/// each `f32 x,y,z + f32 r,g,b` (24 bytes). The render sink clamps at
+/// whole-triangle multiples so a truncated frame never writes a half-
+/// triangle into the GPU vertex buffer. Lives here pending issue 427's
+/// move to `aether-kinds` alongside the kind definition itself.
+const DRAW_TRIANGLE_BYTES: usize = 72;
+
+/// State the desktop / test-bench frame loop reads from each frame.
+/// `frame_vertices` is the consolidated vertex buffer (drained at
+/// frame boundary, refilled by inbound `aether.draw_triangle` mail);
+/// `triangles_rendered` is the lifetime counter the hub's frame-stats
+/// observation reads.
+pub struct RenderAccumulator {
+    pub frame_vertices: Arc<Mutex<Vec<u8>>>,
+    pub triangles_rendered: Arc<AtomicU64>,
+}
+
+/// Build the `aether.sink.render` handler shared between desktop and
+/// test-bench. `cap` is the maximum bytes the accumulator will hold
+/// before truncating with a warn — both chassis pass
+/// [`crate::render::VERTEX_BUFFER_BYTES`].
+///
+/// The returned handler is ready to hand to
+/// `Registry::register_sink("aether.sink.render", handler)`. Hold the
+/// returned [`RenderAccumulator`] for the frame loop to drain.
+pub fn build_render_sink(cap: usize) -> (RenderAccumulator, SinkHandler) {
+    let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(cap)));
+    let triangles_rendered = Arc::new(AtomicU64::new(0));
+    let verts_for_sink = Arc::clone(&frame_vertices);
+    let tris_for_sink = Arc::clone(&triangles_rendered);
+    let handler: SinkHandler = Arc::new(
+        move |_kind_id: u64,
+              _kind_name: &str,
+              _origin: Option<&str>,
+              _sender,
+              bytes: &[u8],
+              _count: u32| {
+            // Truncate at the sink boundary so a single oversized
+            // mesh degrades gracefully instead of collapsing the
+            // whole frame downstream. Round to whole triangles so
+            // the GPU vertex buffer never sees a half-triangle.
+            let mut verts = verts_for_sink.lock().unwrap();
+            let available = cap.saturating_sub(verts.len());
+            let write_len = bytes.len().min(available);
+            let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+            if write_len > 0 {
+                verts.extend_from_slice(&bytes[..write_len]);
+                tris_for_sink
+                    .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+            }
+            if write_len < bytes.len() {
+                tracing::warn!(
+                    target: "aether_substrate::render",
+                    accepted_bytes = write_len,
+                    dropped_bytes = bytes.len() - write_len,
+                    cap = cap,
+                    "render sink dropped triangles beyond fixed vertex buffer",
+                );
+            }
+        },
+    );
+    (
+        RenderAccumulator {
+            frame_vertices,
+            triangles_rendered,
+        },
+        handler,
+    )
+}
+
+/// Build the `aether.sink.camera` handler shared between desktop and
+/// test-bench. Returns the `Arc<Mutex<[f32; 16]>>` the frame loop
+/// reads each tick to upload the latest view-proj to the GPU uniform,
+/// plus the handler that decodes inbound `aether.camera` mail into it.
+///
+/// Latest-value-wins semantics: each successful mail overwrites; on
+/// length mismatch or cast failure the prior value stays. Initialises
+/// to [`IDENTITY_VIEW_PROJ`] so the first frame draws unchanged until
+/// a camera component starts publishing.
+pub fn build_camera_sink() -> (Arc<Mutex<[f32; 16]>>, SinkHandler) {
+    let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
+    let cam_for_sink = Arc::clone(&camera_state);
+    let handler: SinkHandler = Arc::new(
+        move |_kind_id: u64,
+              _kind_name: &str,
+              _origin: Option<&str>,
+              _sender,
+              bytes: &[u8],
+              _count: u32| {
+            if bytes.len() != 64 {
+                tracing::warn!(
+                    target: "aether_substrate::camera",
+                    got = bytes.len(),
+                    expected = 64,
+                    "camera sink: payload length mismatch, dropping",
+                );
+                return;
+            }
+            match bytemuck::try_pod_read_unaligned::<[f32; 16]>(bytes) {
+                Ok(mat) => *cam_for_sink.lock().unwrap() = mat,
+                Err(e) => tracing::warn!(
+                    target: "aether_substrate::camera",
+                    error = %e,
+                    "camera sink: cast failed, dropping",
+                ),
+            }
+        },
+    );
+    (camera_state, handler)
+}

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -27,6 +27,7 @@ use aether_kinds::{
 };
 use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
+use aether_substrate_core::sinks::{RenderAccumulator, build_camera_sink, build_render_sink};
 use aether_substrate_desktop::{
     CaptureQueue, Chassis, ChassisCapabilities, HubClient, HubOutbound, InputSubscribers, Mailer,
     Scheduler, SubstrateBoot, UserEvent,
@@ -35,7 +36,7 @@ use aether_substrate_desktop::{
     mail::{Mail, MailboxId, ReplyTarget, ReplyTo},
     subscribers_for,
 };
-use render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+use render::{Gpu, VERTEX_BUFFER_BYTES};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -45,12 +46,6 @@ use winit::window::{Fullscreen, Window, WindowId};
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;
-
-/// Wire size of one `aether.draw_triangle` mail item: three vertices,
-/// each `f32 x,y,z + f32 r,g,b` (24 bytes). The render sink clamps at
-/// whole-triangle multiples so we never write a half-triangle into the
-/// GPU vertex buffer when the cap forces a truncate.
-const DRAW_TRIANGLE_BYTES: usize = 72;
 
 /// ADR-0063 fail-fast budget for the per-frame drain barrier. A
 /// dispatcher that doesn't quiesce within this window is treated as
@@ -1082,46 +1077,15 @@ fn main() -> wasmtime::Result<()> {
     // Desktop-only render sink: the winit render thread drains
     // `frame_vertices` each redraw, so every `DrawTriangle` emitted
     // before the next frame is consolidated into one vertex buffer.
-    let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(4096)));
-    let triangles_rendered = Arc::new(AtomicU64::new(0));
-    {
-        let verts_for_sink = Arc::clone(&frame_vertices);
-        let tris_for_sink = Arc::clone(&triangles_rendered);
-        boot.registry.register_sink(
-            "aether.sink.render",
-            Arc::new(
-                move |_kind_id: u64,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      _sender,
-                      bytes: &[u8],
-                      _count: u32| {
-                    // Truncate at the sink boundary so a single oversized
-                    // mesh degrades gracefully instead of collapsing the
-                    // whole frame downstream. Round to whole triangles so
-                    // the GPU vertex buffer never sees a half-triangle.
-                    let mut verts = verts_for_sink.lock().unwrap();
-                    let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
-                    let write_len = bytes.len().min(available);
-                    let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-                    if write_len > 0 {
-                        verts.extend_from_slice(&bytes[..write_len]);
-                        tris_for_sink
-                            .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-                    }
-                    if write_len < bytes.len() {
-                        tracing::warn!(
-                            target: "aether_substrate::render",
-                            accepted_bytes = write_len,
-                            dropped_bytes = bytes.len() - write_len,
-                            cap = VERTEX_BUFFER_BYTES,
-                            "render sink dropped triangles beyond fixed vertex buffer",
-                        );
-                    }
-                },
-            ),
-        );
-    }
+    // Helper lives in `aether-substrate-core::sinks` (issue 428) so
+    // desktop and test-bench share one definition.
+    let (render_acc, render_handler) = build_render_sink(VERTEX_BUFFER_BYTES);
+    let RenderAccumulator {
+        frame_vertices,
+        triangles_rendered,
+    } = render_acc;
+    boot.registry
+        .register_sink("aether.sink.render", render_handler);
 
     // `aether.audio.*`: ADR-0039 Phase 2. Try to build a cpal stream;
     // if it succeeds, register a sink that decodes inbound NoteOn /
@@ -1174,40 +1138,11 @@ fn main() -> wasmtime::Result<()> {
     // bytes (4x4 f32 column-major view_proj). The render loop reads
     // the stored value each frame and uploads to the GPU uniform.
     // Malformed payloads are dropped with a warn so a buggy component
-    // can't spook the camera.
-    let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
-    {
-        let cam_for_sink = Arc::clone(&camera_state);
-        boot.registry.register_sink(
-            "aether.sink.camera",
-            Arc::new(
-                move |_kind_id: u64,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      _sender,
-                      bytes: &[u8],
-                      _count: u32| {
-                    if bytes.len() != 64 {
-                        tracing::warn!(
-                            target: "aether_substrate::camera",
-                            got = bytes.len(),
-                            expected = 64,
-                            "camera sink: payload length mismatch, dropping",
-                        );
-                        return;
-                    }
-                    match bytemuck::try_pod_read_unaligned::<[f32; 16]>(bytes) {
-                        Ok(mat) => *cam_for_sink.lock().unwrap() = mat,
-                        Err(e) => tracing::warn!(
-                            target: "aether_substrate::camera",
-                            error = %e,
-                            "camera sink: cast failed, dropping",
-                        ),
-                    }
-                },
-            ),
-        );
-    }
+    // can't spook the camera. Helper shared with test-bench via
+    // `aether-substrate-core::sinks` (issue 428).
+    let (camera_state, camera_handler) = build_camera_sink();
+    boot.registry
+        .register_sink("aether.sink.camera", camera_handler);
 
     // `aether.io.*`: ADR-0041 substrate file I/O. Build the default
     // adapter registry (save/assets/config roots from env vars or

--- a/crates/aether-substrate-desktop/src/render.rs
+++ b/crates/aether-substrate-desktop/src/render.rs
@@ -26,7 +26,7 @@ use aether_substrate_core::render::{
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
-pub use render::{IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+pub use render::VERTEX_BUFFER_BYTES;
 
 /// Wireframe-overlay shader: same vertex layout as the main shader so
 /// the pipeline shares the existing vertex buffer. The fragment stage

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -24,25 +24,18 @@ use std::time::{Duration, Instant};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, InputStream, Tick};
 use aether_mail::{Kind, encode, encode_empty};
 use aether_substrate_core::{
-    Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, ReplyTo, Scheduler,
-    SubstrateBoot,
+    Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
     capture::CaptureQueue,
     mail::{Mail, MailboxId},
+    sinks::{RenderAccumulator, build_camera_sink, build_render_sink},
     subscribers_for,
 };
 
 use crate::events::{ChassisEvent, EventReceiver};
-use crate::render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;
-
-/// Wire size of one `aether.draw_triangle` mail item: three
-/// vertices, each `f32 x,y,z + f32 r,g,b` (24 bytes). The render
-/// sink clamps at whole-triangle multiples so we never write a
-/// half-triangle into the GPU vertex buffer when the cap forces a
-/// truncate.
-const DRAW_TRIANGLE_BYTES: usize = 72;
 
 /// Default offscreen target size when `AETHER_TEST_BENCH_SIZE` is
 /// unset. 800x600 matches the scenario harness convention — large
@@ -258,80 +251,23 @@ fn main() -> wasmtime::Result<()> {
     // `frame_vertices` each frame, so every `DrawTriangle` emitted
     // before the next frame is consolidated into one vertex buffer.
     // Truncate at the sink boundary so a single oversized mesh
-    // degrades gracefully.
-    let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(VERTEX_BUFFER_BYTES)));
-    let triangles_rendered = Arc::new(AtomicU64::new(0));
-    {
-        let verts_for_sink = Arc::clone(&frame_vertices);
-        let tris_for_sink = Arc::clone(&triangles_rendered);
-        boot.registry.register_sink(
-            "aether.sink.render",
-            Arc::new(
-                move |_kind_id: u64,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      _sender: ReplyTo,
-                      bytes: &[u8],
-                      _count: u32| {
-                    let mut verts = verts_for_sink.lock().unwrap();
-                    let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
-                    let write_len = bytes.len().min(available);
-                    let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-                    if write_len > 0 {
-                        verts.extend_from_slice(&bytes[..write_len]);
-                        tris_for_sink
-                            .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-                    }
-                    if write_len < bytes.len() {
-                        tracing::warn!(
-                            target: "aether_substrate::render",
-                            accepted_bytes = write_len,
-                            dropped_bytes = bytes.len() - write_len,
-                            cap = VERTEX_BUFFER_BYTES,
-                            "render sink dropped triangles beyond fixed vertex buffer",
-                        );
-                    }
-                },
-            ),
-        );
-    }
+    // degrades gracefully. Helper shared with desktop via
+    // `aether-substrate-core::sinks` (issue 428).
+    let (render_acc, render_handler) = build_render_sink(VERTEX_BUFFER_BYTES);
+    let RenderAccumulator {
+        frame_vertices,
+        triangles_rendered,
+    } = render_acc;
+    boot.registry
+        .register_sink("aether.sink.render", render_handler);
 
     // `aether.sink.camera`: latest-value-wins. Decode the 64-byte
     // column-major view_proj and store; the frame loop reads it
-    // each frame and uploads to the GPU uniform.
-    let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
-    {
-        let cam_for_sink = Arc::clone(&camera_state);
-        boot.registry.register_sink(
-            "aether.sink.camera",
-            Arc::new(
-                move |_kind_id: u64,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      _sender: ReplyTo,
-                      bytes: &[u8],
-                      _count: u32| {
-                    if bytes.len() != 64 {
-                        tracing::warn!(
-                            target: "aether_substrate::camera",
-                            got = bytes.len(),
-                            expected = 64,
-                            "camera sink: payload length mismatch, dropping",
-                        );
-                        return;
-                    }
-                    match bytemuck::try_pod_read_unaligned::<[f32; 16]>(bytes) {
-                        Ok(mat) => *cam_for_sink.lock().unwrap() = mat,
-                        Err(e) => tracing::warn!(
-                            target: "aether_substrate::camera",
-                            error = %e,
-                            "camera sink: cast failed, dropping",
-                        ),
-                    }
-                },
-            ),
-        );
-    }
+    // each frame and uploads to the GPU uniform. Helper shared with
+    // desktop via `aether-substrate-core::sinks` (issue 428).
+    let (camera_state, camera_handler) = build_camera_sink();
+    boot.registry
+        .register_sink("aether.sink.camera", camera_handler);
 
     // `aether.sink.io` per ADR-0041. Test-bench gets the same sink
     // as desktop / headless — the io path is purely I/O. Boot-time

--- a/crates/aether-substrate-test-bench/src/render.rs
+++ b/crates/aether-substrate-test-bench/src/render.rs
@@ -10,7 +10,7 @@ use aether_substrate_core::render::{
     prepare_capture_copy, record_main_pass,
 };
 
-pub use render::{IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+pub use render::VERTEX_BUFFER_BYTES;
 
 /// Render target format. Test-bench commits to RGBA at init since
 /// there's no surface to query, which keeps the readback path swizzle-

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -40,7 +40,8 @@ use aether_substrate_core::{
 
 use crate::chassis;
 use crate::events::{ChassisEvent, EventReceiver, channel as event_channel};
-use crate::render::{Gpu, IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
+use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
+use aether_substrate_core::render::IDENTITY_VIEW_PROJ;
 
 const WORKERS: usize = 2;
 const LOG_EVERY_FRAMES: u64 = 120;


### PR DESCRIPTION
## Summary

- New `aether-substrate-core::sinks` module with `build_render_sink(cap)` and `build_camera_sink()`. Each helper returns chassis-side state (vertex buffer + triangle counter, or view-proj matrix) plus a ready-to-register `SinkHandler`.
- Desktop and test-bench main.rs render+camera registration blocks shrink from ~95 lines of duplicated closures to a destructure + register call. Behaviour unchanged.
- Headless's nop render and camera sinks stay inline as designed — the 4-line empty closures are self-documenting.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo test -p aether-substrate-test-bench` — scenario + io integration tests pass (render + camera sinks exercised)
- [x] `cargo check --target wasm32-unknown-unknown -p aether-camera-component -p aether-mesh-viewer-component` — wasm components build

Closes #428

<!-- pr-body-ok: b — Closes #NNN closing keyword required for github auto-close -->

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>