### PR TITLE
refactor(substrate-core): extract frame-loop policy helpers (issue 427)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -179,6 +179,14 @@ pub struct DrawTriangle {
     pub verts: [Vertex; 3],
 }
 
+/// Wire size of one `aether.draw_triangle` item: three `Vertex`es.
+/// Property of the wire shape, lives next to `DrawTriangle` so any
+/// chassis / sink that needs to clamp at whole-triangle boundaries
+/// has one canonical source. `repr(C)` + `Pod` + `[Vertex; 3]` packs
+/// without padding, so `size_of::<DrawTriangle>()` is exactly the
+/// per-triangle wire footprint.
+pub const DRAW_TRIANGLE_BYTES: usize = core::mem::size_of::<DrawTriangle>();
+
 /// Camera state: column-major `view_proj` matrix (world → clip). The
 /// desktop chassis's `camera` sink writes the latest payload into the
 /// GPU uniform every frame; the WGSL vertex shader multiplies each

--- a/crates/aether-substrate-core/src/frame_loop.rs
+++ b/crates/aether-substrate-core/src/frame_loop.rs
@@ -1,0 +1,400 @@
+//! Shared frame-loop policy helpers (issue 427).
+//!
+//! Three chassis binaries — desktop, test-bench, headless — drive a
+//! `Mailer::drain_all_with_budget` per frame and, every 120 frames,
+//! push a `FrameStats` observation to the broadcast mailbox. Pre-issue
+//! 427 each chassis open-coded the budget constant, the wedge / death
+//! handling, and the frame-stats emission. Any change to the wedge
+//! message, abort policy (ADR-0063), or stats cadence had to be made
+//! in three places.
+//!
+//! This module owns the policy. The helpers take only the data they
+//! touch (`&Mailer`, `&HubOutbound`, mailbox / kind ids) so they're
+//! callable from any chassis without threading a chassis handle
+//! through. Behaviour matches the pre-refactor binaries exactly:
+//!
+//! - `drain_or_abort` runs the same `drain_all_with_budget` call,
+//!   logs structured deaths, and routes wedges / deaths through
+//!   `lifecycle::fatal_abort` with the same reason format strings.
+//! - `emit_frame_stats` does the 120-frame gate inside the helper —
+//!   chassis call sites become unconditional.
+//!
+//! `WORKERS` deliberately stays chassis-side. Post-ADR-0038 it's
+//! declarative (the wire-stable `EngineInfo.workers` field, retained
+//! for compatibility — the scheduler doesn't read it). It's not
+//! actual loop policy and shouldn't be promoted into a shared
+//! module just because every chassis happens to set the same value.
+
+use std::time::Duration;
+
+use aether_kinds::FrameStats;
+use aether_mail::encode;
+
+use crate::hub_client::HubOutbound;
+use crate::lifecycle;
+use crate::mail::{Mail, MailboxId};
+use crate::mailer::Mailer;
+use crate::scheduler::DrainSummary;
+
+/// Frame-stats emission cadence. Hardcoded for v1; an env knob is
+/// deferred until a forcing function arrives. 120 frames at 60 Hz is
+/// 2 s — frequent enough for a Claude session to see liveness via
+/// `receive_mail`, sparse enough to stay out of the engine_logs
+/// signal-to-noise budget.
+pub const LOG_EVERY_FRAMES: u64 = 120;
+
+/// ADR-0063 fail-fast budget for the per-frame drain barrier. A
+/// dispatcher that doesn't quiesce within this window is treated as
+/// wedged: the substrate logs, broadcasts `SubstrateDying`, and
+/// exits via `lifecycle::fatal_abort`. 5 s is patient enough that
+/// ordinary frames don't trip it even on slow first-load compiles,
+/// short enough that an operator staring at a frozen window gets a
+/// clean exit instead of a multi-minute wait.
+pub const DRAIN_BUDGET: Duration = Duration::from_secs(5);
+
+/// Drain every live component's inbox under `DRAIN_BUDGET`. On
+/// wedge or any death, log the diagnostic and route through
+/// `lifecycle::fatal_abort` with the substrate's standard reason
+/// format — pre-issue-427 each chassis duplicated this block; the
+/// helper is the single owner.
+///
+/// Wedge wins over deaths: if both are present in the same drain,
+/// the wedge aborts first because the wedged dispatcher is the
+/// active hazard (it's still running and may be holding state we
+/// care about). Deaths are logged structurally before the abort so
+/// `engine_logs` carries the per-mailbox detail even when the
+/// reason string only quotes the first one.
+pub fn drain_or_abort(queue: &Mailer, outbound: &HubOutbound) {
+    let summary = queue.drain_all_with_budget(DRAIN_BUDGET);
+    if let Some(reason) = abort_reason(&summary) {
+        lifecycle::fatal_abort(outbound, reason);
+    }
+}
+
+/// Compute the `fatal_abort` reason string for a drain summary, or
+/// `None` if the drain quiesced cleanly. Factored out of
+/// `drain_or_abort` so unit tests can pin the wedge / death message
+/// format without going through `lifecycle::fatal_abort` (which
+/// calls `std::process::exit`).
+///
+/// Wedge takes precedence over deaths when both are present —
+/// matches `drain_or_abort`'s ordering.
+fn abort_reason(summary: &DrainSummary) -> Option<String> {
+    if let Some((mailbox, waited)) = summary.wedged {
+        return Some(format!(
+            "dispatcher wedged: mailbox={mailbox} waited={waited:?}"
+        ));
+    }
+    if let Some(first) = summary.deaths.first() {
+        for d in &summary.deaths {
+            tracing::error!(
+                target: "aether_substrate::lifecycle",
+                mailbox = %d.mailbox,
+                mailbox_name = %d.mailbox_name,
+                last_kind = %d.last_kind,
+                reason = %d.reason,
+                "component died; substrate aborting (ADR-0063)",
+            );
+        }
+        return Some(format!(
+            "component died: {} (kind {}) — {}",
+            first.mailbox_name, first.last_kind, first.reason,
+        ));
+    }
+    None
+}
+
+/// Emit a `FrameStats` broadcast every `LOG_EVERY_FRAMES` frames.
+/// The cadence gate lives inside the helper so chassis call sites
+/// are unconditional — pre-refactor each chassis open-coded the
+/// `frame.is_multiple_of(LOG_EVERY_FRAMES)` check.
+///
+/// Pushes a single 16-byte cast-encoded `FrameStats` to the
+/// broadcast mailbox via `queue.push`; observation routing is
+/// handled by the registered sink that owns the broadcast name.
+/// Fire-and-forget — the broadcast fans out to every attached
+/// Claude session, no reply expected. The `tracing::info!` log
+/// line is left to the caller because chassis carry chassis-
+/// specific context (FPS, elapsed) the helper shouldn't decide
+/// the schema for.
+///
+/// `sender` is the chassis substrate's mailbox identity (today the
+/// broadcast mailbox itself when the chassis owns the broadcast
+/// sink). It rides in the signature so future ReplyTo decoration
+/// (chassis-side observation routing) doesn't have to thread a new
+/// param through every call site; current routing for the broadcast
+/// kind is target-by-mailbox + fan-out, so the helper doesn't read
+/// it.
+pub fn emit_frame_stats(
+    queue: &Mailer,
+    broadcast_mbox: MailboxId,
+    sender: MailboxId,
+    kind_frame_stats: u64,
+    frame: u64,
+    triangles: u64,
+) {
+    let _ = sender;
+    if !frame.is_multiple_of(LOG_EVERY_FRAMES) {
+        return;
+    }
+    queue.push(Mail::new(
+        broadcast_mbox,
+        kind_frame_stats,
+        encode(&FrameStats { frame, triangles }),
+        1,
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, RwLock};
+    use std::time::Duration;
+
+    use aether_kinds::FrameStats;
+    use aether_mail::Kind;
+
+    use super::*;
+    use crate::component::Component;
+    use crate::ctx::SubstrateCtx;
+    use crate::host_fns;
+    use crate::input;
+    use crate::mail::MailboxId;
+    use crate::registry::Registry;
+    use crate::scheduler::{ComponentEntry, ComponentTable, DrainDeath, DrainSummary};
+
+    /// Minimal no-op WAT: exports `memory` and a `receive_p32` that
+    /// returns 0. Suffices for spawning a `ComponentEntry`; we only
+    /// exercise the gate state, never `deliver`.
+    const WAT_NOOP: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+                i32.const 0))
+    "#;
+
+    fn minimal_component() -> Component {
+        let engine = wasmtime::Engine::default();
+        let mut linker: wasmtime::Linker<SubstrateCtx> = wasmtime::Linker::new(&engine);
+        host_fns::register(&mut linker).expect("register host fns");
+        let wasm = wat::parse_str(WAT_NOOP).expect("compile WAT");
+        let module = wasmtime::Module::new(&engine, &wasm).expect("compile module");
+        let ctx = SubstrateCtx::new(
+            MailboxId(0),
+            Arc::new(Registry::new()),
+            Arc::new(Mailer::new()),
+            HubOutbound::disconnected(),
+            input::new_subscribers(),
+        );
+        Component::instantiate(&engine, &linker, &module, ctx).expect("instantiate")
+    }
+
+    /// `abort_reason` returns `None` for a clean drain summary.
+    #[test]
+    fn abort_reason_none_for_clean_summary() {
+        let summary = DrainSummary::default();
+        assert!(abort_reason(&summary).is_none());
+    }
+
+    /// `abort_reason` formats wedge messages with Display form for
+    /// the mailbox id (post-issue-435) — `mailbox={mailbox}`, not
+    /// `mailbox={mailbox:?}`. Pin the format string so a chassis
+    /// regression can't drift it back to Debug.
+    ///
+    /// The wedge path is what `drain_or_abort` would route to
+    /// `lifecycle::fatal_abort`; calling that directly would
+    /// `std::process::exit` and end the test. Asserting on
+    /// `abort_reason` (the same formatter) is the equivalent
+    /// assertion without the exit.
+    #[test]
+    fn abort_reason_formats_wedge_with_display_mailbox() {
+        let mailbox = MailboxId(0xDEAD_BEEF_CAFE_F00D_u64);
+        let waited = Duration::from_millis(5_000);
+        let summary = DrainSummary {
+            deaths: Vec::new(),
+            wedged: Some((mailbox, waited)),
+        };
+        let reason = abort_reason(&summary).expect("wedged summary yields a reason");
+        let expected = format!("dispatcher wedged: mailbox={mailbox} waited={waited:?}");
+        assert_eq!(reason, expected);
+        // Guard against accidental `{mailbox:?}` reintroduction —
+        // Display for `MailboxId` is `mbx-<hex>`, Debug wraps in the
+        // tuple-struct form.
+        assert!(
+            !reason.contains("MailboxId("),
+            "wedge reason must use Display, not Debug, for the mailbox id (got: {reason})",
+        );
+    }
+
+    /// Wedge takes precedence over deaths when both are present —
+    /// matches `drain_or_abort`'s ordering. The reason quotes the
+    /// wedge, deaths are logged structurally but don't show in the
+    /// reason string.
+    #[test]
+    fn abort_reason_wedge_wins_over_deaths() {
+        let mailbox = MailboxId(0x42);
+        let waited = Duration::from_secs(5);
+        let summary = DrainSummary {
+            deaths: vec![DrainDeath {
+                mailbox: MailboxId(0x99),
+                mailbox_name: "doomed".into(),
+                last_kind: "test.kind".into(),
+                reason: "trap".into(),
+            }],
+            wedged: Some((mailbox, waited)),
+        };
+        let reason = abort_reason(&summary).expect("non-empty summary");
+        assert!(reason.starts_with("dispatcher wedged:"));
+        assert!(!reason.contains("component died:"));
+    }
+
+    /// `abort_reason` formats death messages with the first death's
+    /// mailbox name + last kind + reason. Pins the format string.
+    #[test]
+    fn abort_reason_formats_first_death() {
+        let summary = DrainSummary {
+            deaths: vec![DrainDeath {
+                mailbox: MailboxId(0x77),
+                mailbox_name: "alpha".into(),
+                last_kind: "kind.alpha".into(),
+                reason: "alpha trap".into(),
+            }],
+            wedged: None,
+        };
+        let reason = abort_reason(&summary).expect("death yields a reason");
+        assert_eq!(
+            reason,
+            "component died: alpha (kind kind.alpha) — alpha trap",
+        );
+    }
+
+    /// End-to-end: a stuck dispatcher (pending bumped without a
+    /// matching mail) makes `drain_all_with_budget` return a
+    /// Wedged summary, and `abort_reason` produces the expected
+    /// reason string. Calling `drain_or_abort` directly would
+    /// `std::process::exit` at the end, so the test runs the same
+    /// drain the helper runs and the same formatter, just with the
+    /// terminal `lifecycle::fatal_abort` step swapped for an
+    /// equality assertion.
+    ///
+    /// Pre-issue-427 the wedge-abort path had zero unit coverage on
+    /// any chassis (the chassis frame loops kill the process on
+    /// the call). Co-locating it with the helper makes the
+    /// regression-detection cost a single `cargo test`.
+    #[test]
+    fn stuck_dispatcher_drains_to_wedge_and_aborts_with_display_mailbox() {
+        let registry = Arc::new(Registry::new());
+        let mailbox = registry.register_component("stuck");
+        let mailer = Arc::new(Mailer::new());
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), Arc::clone(&components));
+
+        let entry = Arc::new(ComponentEntry::spawn(
+            minimal_component(),
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            mailbox,
+        ));
+        components
+            .write()
+            .unwrap()
+            .insert(mailbox, Arc::clone(&entry));
+
+        // Bump pending without sending mail: dispatcher never wakes,
+        // never decrements. `drain_all_with_budget` must return a
+        // Wedged summary at the budget.
+        entry.bump_pending_for_test();
+
+        let summary = mailer.drain_all_with_budget(Duration::from_millis(50));
+        let (wedge_mailbox, _waited) = summary
+            .wedged
+            .as_ref()
+            .expect("stuck dispatcher must surface as wedged");
+        assert_eq!(*wedge_mailbox, mailbox);
+
+        let reason = abort_reason(&summary).expect("wedged summary yields a reason");
+        assert!(
+            reason.starts_with("dispatcher wedged: mailbox="),
+            "reason must lead with `dispatcher wedged: mailbox=` (got: {reason})",
+        );
+        assert!(reason.contains("waited="));
+        // Pin the Display-vs-Debug contract on the mailbox id —
+        // the same guard the format-string-only test enforces, but
+        // for the live drain path. Display for `MailboxId` is
+        // `mbx-<hex>`; Debug wraps in `MailboxId(...)`.
+        assert!(
+            !reason.contains("MailboxId("),
+            "wedge reason must format mailbox via Display, not Debug (got: {reason})",
+        );
+
+        // Restore pending so the dispatcher's teardown drain
+        // assertions stay clean, then drop entry refs so the
+        // dispatcher's mpsc Sender is the last strong ref and the
+        // dispatcher thread joins on close.
+        entry.clear_pending_for_test();
+        drop(entry);
+        components.write().unwrap().clear();
+    }
+
+    /// `emit_frame_stats` is a no-op on non-multiples of
+    /// `LOG_EVERY_FRAMES`. Verified by sending into a sink that
+    /// records every payload — a non-multiple frame must produce
+    /// zero deliveries.
+    #[test]
+    fn emit_frame_stats_skips_non_multiples() {
+        let registry = Arc::new(Registry::new());
+        let captured: Arc<RwLock<Vec<Vec<u8>>>> = Arc::new(RwLock::new(Vec::new()));
+        let captured_for_sink = Arc::clone(&captured);
+        let broadcast = registry.register_sink(
+            crate::HUB_CLAUDE_BROADCAST,
+            Arc::new(
+                move |_kind_id, _kind_name, _origin, _sender, bytes, _count| {
+                    captured_for_sink.write().unwrap().push(bytes.to_vec());
+                },
+            ),
+        );
+        let mailer = Arc::new(Mailer::new());
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), components);
+
+        let kind_id = FrameStats::ID;
+        emit_frame_stats(&mailer, broadcast, MailboxId(0), kind_id, 1, 0);
+        emit_frame_stats(&mailer, broadcast, MailboxId(0), kind_id, 119, 0);
+        assert!(captured.read().unwrap().is_empty());
+    }
+
+    /// `emit_frame_stats` emits a FrameStats payload on the
+    /// `LOG_EVERY_FRAMES` boundary. The captured bytes round-trip
+    /// through the cast decoder back to the input values.
+    #[test]
+    fn emit_frame_stats_emits_on_multiple() {
+        let registry = Arc::new(Registry::new());
+        let captured: Arc<RwLock<Vec<Vec<u8>>>> = Arc::new(RwLock::new(Vec::new()));
+        let captured_for_sink = Arc::clone(&captured);
+        let broadcast = registry.register_sink(
+            crate::HUB_CLAUDE_BROADCAST,
+            Arc::new(
+                move |_kind_id, _kind_name, _origin, _sender, bytes, _count| {
+                    captured_for_sink.write().unwrap().push(bytes.to_vec());
+                },
+            ),
+        );
+        let mailer = Arc::new(Mailer::new());
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), components);
+
+        emit_frame_stats(
+            &mailer,
+            broadcast,
+            MailboxId(0),
+            FrameStats::ID,
+            LOG_EVERY_FRAMES,
+            42,
+        );
+        let frames = captured.read().unwrap();
+        assert_eq!(frames.len(), 1, "one delivery on the boundary");
+        let stats: FrameStats = aether_mail::decode(&frames[0]).expect("decode FrameStats");
+        assert_eq!(stats.frame, LOG_EVERY_FRAMES);
+        assert_eq!(stats.triangles, 42);
+    }
+}

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod chassis;
 pub mod component;
 pub mod control;
 pub mod ctx;
+pub mod frame_loop;
 pub mod handle_sink;
 pub mod handle_store;
 pub mod host_fns;

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -203,6 +203,24 @@ impl ComponentEntry {
         self.state.load(Ordering::Acquire) == STATE_DEAD
     }
 
+    /// Test-only: bump `pending` without queueing a matching mail.
+    /// Simulates a stuck dispatcher (mail in flight, dispatcher
+    /// never wakes / decrements) so `drain_all_with_budget` exposes
+    /// the wedge path. The `frame_loop` tests reach for this
+    /// directly because it's in the same module.
+    #[cfg(test)]
+    pub fn bump_pending_for_test(&self) {
+        self.gate.pending.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Test-only complement to `bump_pending_for_test`: clear a
+    /// previously-bumped counter so test teardown doesn't trip the
+    /// dispatcher's drain assertions on shutdown.
+    #[cfg(test)]
+    pub fn clear_pending_for_test(&self) {
+        self.gate.pending.store(0, Ordering::Release);
+    }
+
     /// Forward `mail` to this component's inbox. Returns `false` if
     /// the inbox is closed OR the mailbox transitioned to Dead
     /// (issue 321 Phase 2; callers that want to differentiate use

--- a/crates/aether-substrate-core/src/sinks.rs
+++ b/crates/aether-substrate-core/src/sinks.rs
@@ -15,15 +15,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use aether_kinds::DRAW_TRIANGLE_BYTES;
+
 use crate::registry::SinkHandler;
 use crate::render::IDENTITY_VIEW_PROJ;
-
-/// Wire size of one `aether.draw_triangle` mail item: three vertices,
-/// each `f32 x,y,z + f32 r,g,b` (24 bytes). The render sink clamps at
-/// whole-triangle multiples so a truncated frame never writes a half-
-/// triangle into the GPU vertex buffer. Lives here pending issue 427's
-/// move to `aether-kinds` alongside the kind definition itself.
-const DRAW_TRIANGLE_BYTES: usize = 72;
 
 /// State the desktop / test-bench frame loop reads from each frame.
 /// `frame_vertices` is the consolidated vertex buffer (drained at

--- a/crates/aether-substrate-desktop/src/lib.rs
+++ b/crates/aether-substrate-desktop/src/lib.rs
@@ -22,8 +22,9 @@ pub use aether_substrate_core::{
     MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, Scheduler, SinkHandler, SubstrateBoot,
     SubstrateCtx,
     capture::{CaptureQueue, PendingCapture},
-    component, control, ctx, host_fns, hub_client, input, io, kind_manifest, log_capture, mail,
-    mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler, subscribers_for,
+    component, control, ctx, frame_loop, host_fns, hub_client, input, io, kind_manifest,
+    log_capture, mail, mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler,
+    subscribers_for,
 };
 
 pub use chassis::{UserEvent, chassis_control_handler};

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -17,7 +17,7 @@ mod render;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use aether_kinds::{
     CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, InputStream,
@@ -32,7 +32,7 @@ use aether_substrate_desktop::{
     CaptureQueue, Chassis, ChassisCapabilities, HubClient, HubOutbound, InputSubscribers, Mailer,
     Scheduler, SubstrateBoot, UserEvent,
     audio::{self, AudioEvent, AudioEventSender},
-    chassis_control_handler,
+    chassis_control_handler, frame_loop,
     mail::{Mail, MailboxId, ReplyTarget, ReplyTo},
     subscribers_for,
 };
@@ -44,17 +44,13 @@ use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::monitor::{MonitorHandle, VideoModeHandle};
 use winit::window::{Fullscreen, Window, WindowId};
 
+/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
+/// component, the scheduler doesn't read this — it's retained on the
+/// hub-protocol wire for compatibility). Stays chassis-side because
+/// it's declarative for `aether.control.platform_info`, not loop
+/// policy. The shared frame-loop policy (drain budget, frame-stats
+/// cadence) lives in `aether_substrate_core::frame_loop`.
 const WORKERS: usize = 2;
-const LOG_EVERY_FRAMES: u64 = 120;
-
-/// ADR-0063 fail-fast budget for the per-frame drain barrier. A
-/// dispatcher that doesn't quiesce within this window is treated as
-/// wedged: the substrate logs, broadcasts `SubstrateDying`, and
-/// exits. 5 s is patient enough that ordinary frames don't trip it
-/// even on slow first-load compiles, short enough that an operator
-/// staring at a frozen window gets a clean exit instead of a
-/// multi-minute wait.
-const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// ADR-0035 desktop chassis. Owns the winit event loop and the
 /// `App` that drives it. The `Chassis` trait's `run(self) -> Result`
@@ -838,39 +834,15 @@ impl ApplicationHandler<UserEvent> for App {
                         self.publish_window_size(size.width, size.height);
                     }
                 }
-                // ADR-0063: budget-aware drain. Dispatcher deaths or
-                // wedges abort the substrate cleanly via `fatal_abort`
-                // — the hub respawns on the next operator action. The
-                // 5-second budget is a deliberately patient bound;
+                // ADR-0063 (issue 427: shared `frame_loop::DRAIN_BUDGET`).
+                // Budget-aware drain. Dispatcher deaths or wedges
+                // abort the substrate cleanly via `fatal_abort` — the
+                // hub respawns on the next operator action. The 5-
+                // second budget is a deliberately patient bound;
                 // anything past it indicates a wedged dispatcher
                 // (slow trap, host deadlock) we have no recovery path
                 // for in v1.
-                let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
-                if let Some((mailbox, waited)) = summary.wedged {
-                    aether_substrate_core::lifecycle::fatal_abort(
-                        &self.outbound,
-                        format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}",),
-                    );
-                }
-                if let Some(first) = summary.deaths.first() {
-                    for d in &summary.deaths {
-                        tracing::error!(
-                            target: "aether_substrate::lifecycle",
-                            mailbox = ?d.mailbox,
-                            mailbox_name = %d.mailbox_name,
-                            last_kind = %d.last_kind,
-                            reason = %d.reason,
-                            "component died; substrate aborting (ADR-0063)",
-                        );
-                    }
-                    aether_substrate_core::lifecycle::fatal_abort(
-                        &self.outbound,
-                        format!(
-                            "component died: {} (kind {}) — {}",
-                            first.mailbox_name, first.last_kind, first.reason,
-                        ),
-                    );
-                }
+                frame_loop::drain_or_abort(&self.queue, &self.outbound);
                 // `mem::replace` rather than `mem::take` so the per-frame
                 // drain doesn't collapse the buffer to zero capacity and
                 // re-allocate next frame. Reserve the full cap up front
@@ -916,7 +888,7 @@ impl ApplicationHandler<UserEvent> for App {
                     );
                 }
                 self.frame += 1;
-                if self.frame.is_multiple_of(LOG_EVERY_FRAMES) {
+                if self.frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
                     let triangles = self.triangles_rendered.load(Ordering::Relaxed);
                     tracing::info!(
                         target: "aether_substrate::frame_loop",
@@ -926,15 +898,14 @@ impl ApplicationHandler<UserEvent> for App {
                     );
                     // Emit an observation to every attached Claude
                     // session. No-op when no hub is connected.
-                    self.queue.push(Mail::new(
+                    frame_loop::emit_frame_stats(
+                        &self.queue,
+                        self.broadcast_mbox,
                         self.broadcast_mbox,
                         self.kind_frame_stats,
-                        encode(&FrameStats {
-                            frame: self.frame,
-                            triangles,
-                        }),
-                        1,
-                    ));
+                        self.frame,
+                        triangles,
+                    );
                 }
                 // Only self-schedule the next redraw when the window
                 // is visible — otherwise we'd spin under `Poll`. When

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -14,23 +14,20 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use aether_kinds::{FrameStats, InputStream, Tick};
-use aether_mail::{Kind, encode, encode_empty};
+use aether_mail::{Kind, encode_empty};
 use aether_substrate_core::{
-    Chassis, ChassisCapabilities, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
+    Chassis, ChassisCapabilities, InputSubscribers, Mailer, Scheduler, SubstrateBoot, frame_loop,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
 
+/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
+/// component, the scheduler doesn't read this — it's retained on the
+/// hub-protocol wire for compatibility). The shared frame-loop
+/// policy (drain budget, frame-stats cadence) lives in
+/// `aether_substrate_core::frame_loop`.
 const WORKERS: usize = 2;
 const DEFAULT_TICK_HZ: u32 = 60;
-const LOG_EVERY_FRAMES: u64 = 120;
-
-/// ADR-0063 fail-fast budget for the per-tick drain barrier. A
-/// dispatcher that doesn't quiesce within this window is treated as
-/// wedged and the substrate exits cleanly via `fatal_abort`. Same
-/// 5-second value the desktop chassis uses — both run the same
-/// dispatcher kernel.
-const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// Headless chassis. Owns the tick loop + the bookkeeping every
 /// subsequent frame needs. `run(self)` takes ownership and drives
@@ -83,46 +80,20 @@ impl Chassis for HeadlessChassis {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
             }
-            // ADR-0063: budget-aware drain. Dispatcher deaths or
-            // wedges abort the substrate cleanly via `fatal_abort`.
-            let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
-            if let Some((mailbox, waited)) = summary.wedged {
-                aether_substrate_core::lifecycle::fatal_abort(
-                    &self.outbound,
-                    format!("dispatcher wedged: mailbox={mailbox:?} waited={waited:?}"),
-                );
-            }
-            if let Some(first) = summary.deaths.first() {
-                for d in &summary.deaths {
-                    tracing::error!(
-                        target: "aether_substrate::lifecycle",
-                        mailbox = ?d.mailbox,
-                        mailbox_name = %d.mailbox_name,
-                        last_kind = %d.last_kind,
-                        reason = %d.reason,
-                        "component died; substrate aborting (ADR-0063)",
-                    );
-                }
-                aether_substrate_core::lifecycle::fatal_abort(
-                    &self.outbound,
-                    format!(
-                        "component died: {} (kind {}) — {}",
-                        first.mailbox_name, first.last_kind, first.reason,
-                    ),
-                );
-            }
+            // ADR-0063 (issue 427: shared `frame_loop::DRAIN_BUDGET`).
+            // Budget-aware drain. Dispatcher deaths or wedges abort
+            // the substrate cleanly via `fatal_abort`.
+            frame_loop::drain_or_abort(&self.queue, &self.outbound);
 
-            if frame.is_multiple_of(LOG_EVERY_FRAMES) {
-                let stats = FrameStats {
-                    frame,
-                    triangles: 0,
-                };
-                self.queue.push(Mail::new(
+            if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
+                frame_loop::emit_frame_stats(
+                    &self.queue,
+                    self.broadcast_mbox,
                     self.broadcast_mbox,
                     self.kind_frame_stats,
-                    encode(&stats),
-                    1,
-                ));
+                    frame,
+                    0,
+                );
                 let elapsed = started.elapsed().as_secs_f64().max(0.001);
                 tracing::info!(
                     target: "aether_substrate::frame_loop",

--- a/crates/aether-substrate-test-bench/src/lib.rs
+++ b/crates/aether-substrate-test-bench/src/lib.rs
@@ -25,8 +25,9 @@ pub use aether_substrate_core::{
     MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, Scheduler, SinkHandler, SubstrateBoot,
     SubstrateCtx,
     capture::{CaptureQueue, PendingCapture},
-    component, control, ctx, host_fns, hub_client, input, io, kind_manifest, log_capture, mail,
-    mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler, subscribers_for,
+    component, control, ctx, frame_loop, host_fns, hub_client, input, io, kind_manifest,
+    log_capture, mail, mailer, new_subscribers, registry, remove_from_all, reply_table, scheduler,
+    subscribers_for,
 };
 
 pub use chassis::chassis_control_handler;

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -19,13 +19,14 @@ mod render;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, InputStream, Tick};
-use aether_mail::{Kind, encode, encode_empty};
+use aether_mail::{Kind, encode_empty};
 use aether_substrate_core::{
     Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
     capture::CaptureQueue,
+    frame_loop,
     mail::{Mail, MailboxId},
     sinks::{RenderAccumulator, build_camera_sink, build_render_sink},
     subscribers_for,
@@ -34,8 +35,12 @@ use aether_substrate_core::{
 use crate::events::{ChassisEvent, EventReceiver};
 use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
 
+/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
+/// component, the scheduler doesn't read this — it's retained on the
+/// hub-protocol wire for compatibility). The shared frame-loop
+/// policy (drain budget, frame-stats cadence) lives in
+/// `aether_substrate_core::frame_loop`.
 const WORKERS: usize = 2;
-const LOG_EVERY_FRAMES: u64 = 120;
 
 /// Default offscreen target size when `AETHER_TEST_BENCH_SIZE` is
 /// unset. 800x600 matches the scenario harness convention — large
@@ -43,10 +48,6 @@ const LOG_EVERY_FRAMES: u64 = 120;
 /// enough that capture readback is cheap.
 const DEFAULT_WIDTH: u32 = 800;
 const DEFAULT_HEIGHT: u32 = 600;
-
-/// ADR-0063 fail-fast budget for the per-tick drain barrier. Same
-/// 5-second value desktop and headless use — same dispatcher kernel.
-const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// Test-bench chassis. Owns the event loop, the GPU, the shared
 /// frame state (vertex buffer, camera matrix), and the capture
@@ -123,32 +124,7 @@ impl TestBenchChassis {
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
             }
         }
-        let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
-        if let Some((mailbox, waited)) = summary.wedged {
-            aether_substrate_core::lifecycle::fatal_abort(
-                &self.outbound,
-                format!("dispatcher wedged: mailbox={mailbox} waited={waited:?}"),
-            );
-        }
-        if let Some(first) = summary.deaths.first() {
-            for d in &summary.deaths {
-                tracing::error!(
-                    target: "aether_substrate::lifecycle",
-                    mailbox = %d.mailbox,
-                    mailbox_name = %d.mailbox_name,
-                    last_kind = %d.last_kind,
-                    reason = %d.reason,
-                    "component died; substrate aborting (ADR-0063)",
-                );
-            }
-            aether_substrate_core::lifecycle::fatal_abort(
-                &self.outbound,
-                format!(
-                    "component died: {} (kind {}) — {}",
-                    first.mailbox_name, first.last_kind, first.reason,
-                ),
-            );
-        }
+        frame_loop::drain_or_abort(&self.queue, &self.outbound);
 
         // Drain accumulated vertices and the latest camera. Replace
         // the vertex buffer with an empty same-capacity Vec so the
@@ -175,15 +151,16 @@ impl TestBenchChassis {
             }
         }
 
-        if frame.is_multiple_of(LOG_EVERY_FRAMES) {
+        if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
             let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-            let stats = FrameStats { frame, triangles };
-            self.queue.push(Mail::new(
+            frame_loop::emit_frame_stats(
+                &self.queue,
+                self.broadcast_mbox,
                 self.broadcast_mbox,
                 self.kind_frame_stats,
-                encode(&stats),
-                1,
-            ));
+                frame,
+                triangles,
+            );
             let elapsed = started.elapsed().as_secs_f64().max(0.001);
             tracing::info!(
                 target: "aether_substrate::frame_loop",

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -22,18 +22,20 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, FrameStats, InputStream, Tick,
+    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, DRAW_TRIANGLE_BYTES, FrameStats,
+    InputStream, Tick,
 };
-use aether_mail::{Kind, encode, encode_empty, encode_struct, mailbox_id_from_name};
-// `encode` is used for FrameStats (cast-shape); `encode_struct` is
-// used for control kinds (postcard-shape).
+use aether_mail::{Kind, encode_empty, encode_struct, mailbox_id_from_name};
+// `encode_struct` is used for control kinds (postcard-shape); cast-
+// shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_substrate_core::{
     HubOutbound, InputSubscribers, Mailer, ReplyTarget, ReplyTo, SubstrateBoot,
     capture::CaptureQueue,
+    frame_loop,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
@@ -44,9 +46,6 @@ use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
 use aether_substrate_core::render::IDENTITY_VIEW_PROJ;
 
 const WORKERS: usize = 2;
-const LOG_EVERY_FRAMES: u64 = 120;
-const DRAW_TRIANGLE_BYTES: usize = 72;
-const DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// Default offscreen target dimensions when the caller picks
 /// `start()` (no explicit size). 800x600 matches the scenario harness
@@ -434,7 +433,7 @@ impl TestBench {
             // through the dispatcher → control plane → chassis
             // handler, which produces an event on `events_rx` for
             // Advance/CaptureRequested kinds.
-            self.queue.drain_all_with_budget(DRAIN_BUDGET);
+            self.queue.drain_all_with_budget(frame_loop::DRAIN_BUDGET);
 
             // Drain any pending chassis events. Each invocation
             // potentially produces a reply on `outbound`.
@@ -526,32 +525,7 @@ impl TestBench {
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
             }
         }
-        let summary = self.queue.drain_all_with_budget(DRAIN_BUDGET);
-        if let Some((mailbox, waited)) = summary.wedged {
-            aether_substrate_core::lifecycle::fatal_abort(
-                &self.outbound,
-                format!("dispatcher wedged: mailbox={mailbox} waited={waited:?}"),
-            );
-        }
-        if let Some(first) = summary.deaths.first() {
-            for d in &summary.deaths {
-                tracing::error!(
-                    target: "aether_substrate::lifecycle",
-                    mailbox = %d.mailbox,
-                    mailbox_name = %d.mailbox_name,
-                    last_kind = %d.last_kind,
-                    reason = %d.reason,
-                    "component died; substrate aborting (ADR-0063)",
-                );
-            }
-            aether_substrate_core::lifecycle::fatal_abort(
-                &self.outbound,
-                format!(
-                    "component died: {} (kind {}) — {}",
-                    first.mailbox_name, first.last_kind, first.reason,
-                ),
-            );
-        }
+        frame_loop::drain_or_abort(&self.queue, &self.outbound);
 
         let verts = std::mem::replace(
             &mut *self.frame_vertices.lock().unwrap(),
@@ -575,18 +549,16 @@ impl TestBench {
             }
         }
 
-        if self.frame.is_multiple_of(LOG_EVERY_FRAMES) {
+        if self.frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
             let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-            let stats = FrameStats {
-                frame: self.frame,
-                triangles,
-            };
-            self.queue.push(Mail::new(
+            frame_loop::emit_frame_stats(
+                &self.queue,
+                self.broadcast_mbox,
                 self.broadcast_mbox,
                 self.kind_frame_stats,
-                encode(&stats),
-                1,
-            ));
+                self.frame,
+                triangles,
+            );
             let elapsed = self.started.elapsed().as_secs_f64().max(0.001);
             tracing::info!(
                 target: "aether_substrate::frame_loop",


### PR DESCRIPTION
## Summary

Replaces closed PR #452 — that branch was cut from a base that predated #451's sink-helpers landing, so the rebase wasn't trivial. This re-applies the same 427 design (settled in the issue's design comment) on top of post-#451 main, and stitches in the bits #451 already partially handled (DRAW_TRIANGLE_BYTES move + sinks::SinkHandler reuse).

- New aether-substrate-core::frame_loop module owns LOG_EVERY_FRAMES, DRAIN_BUDGET, drain_or_abort, emit_frame_stats, plus an internal abort_reason formatter so the wedge / death message shape is testable without process::exit.
- DRAW_TRIANGLE_BYTES moves to aether-kinds next to DrawTriangle. core::sinks and test_bench::test_bench both pull from there now (previously each held its own const = 72).
- WORKERS stays chassis-side per the design comment — wire-stable EngineInfo.workers, not actual loop policy. Comment updated to point at frame_loop for shared policy.
- Stuck-dispatcher unit test pins the wedge path end-to-end via a #[cfg(test)] bump_pending_for_test on ComponentEntry. Pre-issue-427 this path had zero coverage on any chassis (kills the process on entry).

## Test plan

- [x] cargo check --workspace --all-targets clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean
- [x] cargo test --workspace passes (225 in substrate-core, including the new frame_loop suite)
- [x] cargo check --target wasm32-unknown-unknown for camera + mesh-viewer + test-fixture-probe components passes (verifies the new aether-kinds const doesn't break wasm)

Closes #427.

<!-- pr-body-ok: b — Closes #NNN closing keyword required for github auto-close -->