### PR TITLE
fix(hooks): suggest html-comment form for pr-body-ok override (issue 433)

### DIFF
--- a/.claude/hooks/check-pr-body.sh
+++ b/.claude/hooks/check-pr-body.sh
@@ -11,12 +11,15 @@
 #
 # To deliberately submit a body that looks like one of the patterns
 # (rare — usually the pattern means the body really is broken),
-# include `# pr-body-ok: <letters> — <reason>` in the command. The
-# letter list is one or more of a/b/c/d (comma-separated, e.g.
-# `# pr-body-ok: a,b — reason`); only listed patterns are skipped,
-# unlisted ones still fire. A bare `# pr-body-ok:` with no letter
-# list is rejected to force the author to think about which check
-# they're overriding.
+# include `<!-- pr-body-ok: <letters> — <reason> -->` in the command.
+# The letter list is one or more of a/b/c/d (comma-separated, e.g.
+# `<!-- pr-body-ok: a,b — reason -->`); only listed patterns are
+# skipped, unlisted ones still fire. A bare `pr-body-ok:` with no
+# letter list is rejected to force the author to think about which
+# check they're overriding. The legacy `# pr-body-ok: ...` form still
+# matches (the regex grabs `pr-body-ok:[^\n]*` regardless of leading
+# punctuation), but prefer the HTML-comment form because a `#` at line
+# start renders as an H1 heading on GitHub.
 
 set -u
 
@@ -40,7 +43,7 @@ if [[ -n "$override_line" ]]; then
     prefix=${rest%%[[:space:]—]*}
     allowed=$(printf '%s' "$prefix" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-d]' | tr '\n' ',' | sed 's/,$//' || true)
     if [[ -z "$allowed" ]]; then
-        printf 'pr-body-ok override needs at least one pattern letter (a/b/c/d), e.g. `# pr-body-ok: b — reason`\n' >&2
+        printf 'pr-body-ok override needs at least one pattern letter (a/b/c/d), e.g. `<!-- pr-body-ok: b — reason -->`\n' >&2
         exit 2
     fi
 fi
@@ -110,7 +113,7 @@ if (( ${#issues[@]} )); then
             printf '  - %s\n' "$i"
         done
         printf '\nSee feedback_heredoc_no_backtick_escape.md (auto-memory) for context.\n'
-        printf 'To override deliberately, include `# pr-body-ok: <letters> — <reason>` (letters: a/b/c/d, comma-separated; only listed patterns are skipped).\n'
+        printf 'To override deliberately, include `<!-- pr-body-ok: <letters> — <reason> -->` (letters: a/b/c/d, comma-separated; only listed patterns are skipped).\n'
     } >&2
     exit 2
 fi


### PR DESCRIPTION
<!-- pr-body-ok: b — quoting #NNN and the override forms for documentation -->

## Summary

- Update `.claude/hooks/check-pr-body.sh` so its three messaging surfaces (top docstring, bare-override rejection, failure help line) recommend the HTML-comment form `<!-- pr-body-ok: ... -->` instead of the `#`-prefixed form. The regex itself is unchanged (`pr-body-ok:[^\n]*` matches both), so any in-flight scripts using the legacy form keep working.
- The `#`-prefixed form renders as a giant H1 heading when pasted into a PR body on GitHub; the HTML comment renders as nothing. The recommendation move steers new uses toward the friendlier form without breaking the old one.

## Test plan

- [x] `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`, `cargo test --workspace` all green (workspace policy gate; no Rust files touched).
- [x] Hand-fed three crafted hook inputs through `bash check-pr-body.sh`: HTML-comment override on a Pattern-B body exits 0; legacy `#` override on the same body still exits 0 (no breaking change); bare `pr-body-ok:` exits 2 with the new HTML-comment example in the message.

Closes #433
