### PR TITLE
refactor(sdk): emit aether.kinds.inputs section in export!(), not handlers (issue 442)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
 name = "aether-component"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-hub-protocol",
  "aether-kinds",
  "aether-mail",
  "bytemuck",

--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -43,6 +43,14 @@ serde = { version = "1", default-features = false, features = ["derive", "alloc"
 # native targets. The macro path needs `::inventory` reachable. Tests
 # always run native, so a plain dev-dep with no target gating is right.
 inventory = "0.3"
+# Issue 442 regression test (`tests/handlers_manifest.rs`) decodes the
+# `aether.kinds.inputs` payload `#[handlers]` emits as a const on the
+# component type. The wire shape is `postcard(InputsRecord)` per
+# ADR-0033; pulling hub-protocol in as a dev-dep gives the test direct
+# access to that type without forcing it into the SDK's runtime
+# dependency surface.
+aether-hub-protocol = { path = "../aether-hub-protocol" }
+postcard = { version = "1.1", features = ["alloc"] }
 
 # ADR-0017 (component-to-component reply) smoke pair: caller sends
 # `demo.request` to "echoer" and observes the reply.

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -962,6 +962,20 @@ unsafe impl<T> Sync for Slot<T> {}
 ///   `T::init`, stashes the result in the slot.
 /// - `extern "C" fn receive(kind, ptr, count) -> u32` — builds
 ///   `Ctx` and `Mail`, calls `T::receive` on the stashed instance.
+/// - The `#[link_section = "aether.kinds.inputs"]` static that pins
+///   the component's handler manifest into the wasm custom section
+///   the substrate reads at `load_component`. The manifest *bytes*
+///   are emitted as associated consts on `T`'s inherent impl by
+///   `#[handlers]`; this macro is the only place they get a
+///   `link_section` attribute, which means the section can only
+///   land in the cdylib root that calls `export!()` — never in
+///   transitive rlib pulls of a `#[handlers]`-using crate (issue
+///   442). That structural property is what keeps duplicate
+///   Component records from stacking when a cdylib deps on a
+///   sibling `cdylib + rlib` crate's rlib output. ADR-0066's
+///   trunk-rlib pattern (kinds + names in an rlib, runtime impl in
+///   a separate cdylib) is the recommended layout for shared
+///   component types regardless.
 ///
 /// Only one component per guest crate. A second `export!` call in
 /// the same crate is a duplicate-symbol compile error on the shared
@@ -977,6 +991,21 @@ unsafe impl<T> Sync for Slot<T> {}
 macro_rules! export {
     ($component:ty) => {
         static __AETHER_COMPONENT: $crate::Slot<$component> = $crate::Slot::new();
+
+        // ADR-0033 / issue 442: pin the component's `aether.kinds.inputs`
+        // bytes into the cdylib's wasm custom section. The const data
+        // (`__AETHER_INPUTS_MANIFEST_LEN` / `__AETHER_INPUTS_MANIFEST`)
+        // is emitted by `#[handlers]` on the type's inherent impl;
+        // section emission lives here so it only fires in the cdylib
+        // root crate (where `export!()` is invoked) and never in
+        // transitive rlib pulls of a `#[handlers]`-using crate, which
+        // would otherwise stack duplicate Component records and fail
+        // the substrate's manifest reader.
+        #[cfg(target_arch = "wasm32")]
+        #[used]
+        #[unsafe(link_section = "aether.kinds.inputs")]
+        static __AETHER_INPUTS_SECTION: [u8; <$component>::__AETHER_INPUTS_MANIFEST_LEN] =
+            <$component>::__AETHER_INPUTS_MANIFEST;
 
         /// # Safety
         /// Called exactly once by the substrate before any `receive`.

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -1,0 +1,118 @@
+//! Issue 442 regression: `#[handlers]` emits the
+//! `aether.kinds.inputs` payload as associated consts on the
+//! component type's inherent impl, NOT as `#[link_section]` statics.
+//! `aether_component::export!()` is the only place that pins those
+//! bytes into the wasm custom section, so the section can only land
+//! in the cdylib root that calls `export!()` — never in transitive
+//! rlib pulls of a `#[handlers]`-using crate.
+//!
+//! Pre-issue-442 the macro emitted N separate `#[link_section]`
+//! statics, one per handler/fallback/component-doc record, gated on
+//! `target_arch = "wasm32"`. That gate fired for both the cdylib
+//! root and any transitive wasm32 rlib pull, so a cdylib that
+//! depended on a sibling `cdylib + rlib` crate's rlib output would
+//! see both crates' Component records stack in its
+//! `aether.kinds.inputs` section and fail the substrate's "duplicate
+//! Component record" check.
+
+#![allow(dead_code)]
+
+use aether_component::{Component, Ctx, DropCtx, InitCtx, handlers};
+use aether_hub_protocol::{INPUTS_SECTION_VERSION, InputsRecord};
+use aether_mail::Kind;
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.tick")]
+struct Tick;
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct ManifestProbe;
+
+#[handlers]
+impl Component for ManifestProbe {
+    fn init(_ctx: &mut InitCtx<'_>) -> Self {
+        Self
+    }
+
+    /// # Agent
+    /// Increments the tick counter.
+    #[handler]
+    fn on_tick(&mut self, _ctx: &mut Ctx<'_>, _tick: Tick) {}
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut Ctx<'_>, _ping: Ping) {}
+
+    /// # Agent
+    /// Catch-all for anything else.
+    #[fallback]
+    fn on_other(&mut self, _ctx: &mut Ctx<'_>, _mail: aether_component::Mail<'_>) {}
+
+    fn on_drop(&mut self, _ctx: &mut DropCtx<'_>) {}
+}
+
+fn parse_section(bytes: &[u8]) -> Vec<InputsRecord> {
+    let mut out: Vec<InputsRecord> = Vec::new();
+    let mut cursor = bytes;
+    while !cursor.is_empty() {
+        assert_eq!(
+            cursor[0], INPUTS_SECTION_VERSION,
+            "every record must start with the section version byte"
+        );
+        cursor = &cursor[1..];
+        let (rec, rest) = postcard::take_from_bytes::<InputsRecord>(cursor)
+            .expect("postcard decode of InputsRecord failed");
+        out.push(rec);
+        cursor = rest;
+    }
+    out
+}
+
+#[test]
+fn manifest_const_round_trips_to_expected_records() {
+    const LEN: usize = ManifestProbe::__AETHER_INPUTS_MANIFEST_LEN;
+    const { assert!(LEN > 0, "ManifestProbe declares two handlers + fallback") };
+    let bytes: &[u8] = &ManifestProbe::__AETHER_INPUTS_MANIFEST;
+    assert_eq!(bytes.len(), LEN);
+
+    let records = parse_section(bytes);
+
+    let mut handler_count = 0usize;
+    let mut fallback_count = 0usize;
+    let mut tick_doc: Option<String> = None;
+
+    for rec in &records {
+        match rec {
+            InputsRecord::Handler { id, name, doc } => {
+                handler_count += 1;
+                match name.as_ref() {
+                    "test.tick" => {
+                        assert_eq!(*id, <Tick as Kind>::ID);
+                        tick_doc = doc.as_ref().map(|c| c.to_string());
+                    }
+                    "test.ping" => {
+                        assert_eq!(*id, <Ping as Kind>::ID);
+                    }
+                    other => panic!("unexpected handler name: {other}"),
+                }
+            }
+            InputsRecord::Fallback { .. } => fallback_count += 1,
+            InputsRecord::Component { .. } => {}
+        }
+    }
+
+    assert_eq!(handler_count, 2, "expected two #[handler] records");
+    assert_eq!(fallback_count, 1, "expected one #[fallback] record");
+    assert_eq!(
+        tick_doc.as_deref(),
+        Some("Increments the tick counter."),
+        "rustdoc # Agent body should land on the Tick handler"
+    );
+}

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -34,6 +34,13 @@ struct Ping {
     seq: u32,
 }
 
+// Minimal fixture, mirrored from `examples/hello.rs`. Lives here as a
+// duplicate (rather than reused) because `examples/*.rs` declare
+// `crate-type = ["cdylib"]` and only build for `wasm32-unknown-unknown`
+// — the test exercises the const path host-side. Maintenance is the
+// usual SDK-surface cadence: when `Component` / `Ctx` / `Mail` /
+// `#[handlers]` change shape, this fixture moves with every other
+// component in the workspace.
 struct ManifestProbe;
 
 #[handlers]

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -678,10 +678,20 @@ fn to_screaming_snake_case(s: &str) -> String {
 //       Guarded by `if <K as Kind>::IS_INPUT` so non-input kinds
 //       compile down to no-ops.
 //
-//   (c) Per-method `aether.kinds.inputs` custom-section statics — one
-//       per `#[handler]`, one per `#[fallback]` (when present), one
-//       for the component-level doc (when present) — read by the hub
-//       at load_component for MCP capability surfacing.
+//   (c) Two associated consts on `C`'s inherent impl —
+//       `__AETHER_INPUTS_MANIFEST_LEN: usize` and
+//       `__AETHER_INPUTS_MANIFEST: [u8; …LEN]` — carrying the
+//       concatenated `aether.kinds.inputs` record bytes (one record per
+//       `#[handler]`, one per `#[fallback]` if present, one for the
+//       component-level doc if present, each prefixed with the section
+//       version byte). The `#[link_section]` static that pins these
+//       bytes into the wasm custom section is emitted by
+//       `aether_component::export!()` in the cdylib root crate, NOT
+//       here. Sections only land where `export!()` runs (the cdylib
+//       root); transitive rlib pulls of a `#[handlers]`-using crate
+//       carry only the const data and contribute no section bytes —
+//       which is what keeps duplicate Component records from stacking
+//       when a cdylib deps on a sibling cdylib's rlib output.
 //
 // The user's handler methods ride as inherent methods on `C` (since
 // `impl Trait for C` can't host non-trait items); helpers go the same
@@ -869,8 +879,8 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     let fallback_method_tokens = fallback.as_ref().map(|f| &f.method);
     let helper_methods_tokens = helpers.iter();
 
-    let statics =
-        build_inputs_section_statics(self_ty, &handlers, fallback.as_ref(), &component_doc);
+    let inputs_manifest_consts =
+        build_inputs_manifest_consts(&handlers, fallback.as_ref(), &component_doc);
     let kind_retention_statics = build_kinds_section_retention_statics(self_ty, &handlers);
 
     Ok(quote! {
@@ -890,12 +900,13 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
                 #dispatch_body
             }
 
+            #inputs_manifest_consts
+
             #(#handler_methods_tokens)*
             #fallback_method_tokens
             #(#helper_methods_tokens)*
         }
 
-        #statics
         #kind_retention_statics
     })
 }
@@ -1003,127 +1014,129 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
     }
 }
 
-/// Emit the `#[link_section = "aether.kinds.inputs"]` statics — one
-/// per `#[handler]`, one for `#[fallback]` (when present), and one
-/// for the component-level doc (when present). Each static's bytes
-/// are `[INPUTS_SECTION_VERSION, ..postcard(InputsRecord)..]`
+/// Emit two associated consts inside the component's inherent impl —
+/// `__AETHER_INPUTS_MANIFEST_LEN: usize` and
+/// `__AETHER_INPUTS_MANIFEST: [u8; …LEN]` — carrying the
+/// concatenated `aether.kinds.inputs` record bytes. Each record is
+/// `[INPUTS_SECTION_VERSION (0x01), ..postcard(InputsRecord)..]`,
 /// assembled at const-eval via the hub-protocol const-fn encoders.
-/// Statics are gated to `target_arch = "wasm32"` to keep the bytes
-/// out of native test executables (same pattern as the existing
-/// `aether.kinds` emission in the `Kind` derive).
-fn build_inputs_section_statics(
-    self_ty: &Type,
+/// `aether_component::export!()` reads these consts and emits the
+/// `#[unsafe(link_section = "aether.kinds.inputs")]` static in the
+/// cdylib root crate. Keeping the section emission out of this macro
+/// is what prevents the section from stacking when a `#[handlers]`-
+/// using crate is pulled in as a wasm32 rlib by another cdylib (a
+/// rlib that doesn't call `export!()` contributes no section bytes).
+fn build_inputs_manifest_consts(
     handlers: &[HandlerFn],
     fallback: Option<&FallbackFn>,
     component_doc: &Option<String>,
 ) -> TokenStream2 {
-    let self_ty_hint = type_hint(self_ty);
+    let mut len_terms: Vec<TokenStream2> = Vec::new();
+    let mut copy_blocks: Vec<TokenStream2> = Vec::new();
 
-    let handler_statics = handlers.iter().enumerate().map(|(idx, h)| {
-        let len_ident = quote::format_ident!(
-            "__AETHER_INPUT_HANDLER_{}_{}_LEN",
-            self_ty_hint,
-            idx
-        );
-        let bytes_ident = quote::format_ident!(
-            "__AETHER_INPUT_HANDLER_{}_{}_BYTES",
-            self_ty_hint,
-            idx
-        );
-        let section_ident = quote::format_ident!(
-            "__AETHER_INPUT_HANDLER_{}_{}_SECTION",
-            self_ty_hint,
-            idx
-        );
+    for h in handlers {
         let k = &h.kind_ty;
         let doc_expr = option_str_token(&h.agent_doc);
-        quote! {
-            const #len_ident: usize =
-                ::aether_component::__macro_internals::canonical::inputs_handler_len(
-                    <#k as ::aether_component::__macro_internals::Kind>::ID,
-                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
-                    #doc_expr,
-                );
-            const #bytes_ident: [u8; #len_ident] =
-                ::aether_component::__macro_internals::canonical::write_inputs_handler::<#len_ident>(
-                    <#k as ::aether_component::__macro_internals::Kind>::ID,
-                    <#k as ::aether_component::__macro_internals::Kind>::NAME,
-                    #doc_expr,
-                );
-            #[cfg(target_arch = "wasm32")]
-            #[used]
-            #[unsafe(link_section = "aether.kinds.inputs")]
-            static #section_ident: [u8; #len_ident + 1] = {
-                let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x01;
+        len_terms.push(quote! {
+            (1 + ::aether_component::__macro_internals::canonical::inputs_handler_len(
+                <#k as ::aether_component::__macro_internals::Kind>::ID,
+                <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                #doc_expr,
+            ))
+        });
+        copy_blocks.push(quote! {
+            {
+                const REC_LEN: usize =
+                    ::aether_component::__macro_internals::canonical::inputs_handler_len(
+                        <#k as ::aether_component::__macro_internals::Kind>::ID,
+                        <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                        #doc_expr,
+                    );
+                const REC_BYTES: [u8; REC_LEN] =
+                    ::aether_component::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
+                        <#k as ::aether_component::__macro_internals::Kind>::ID,
+                        <#k as ::aether_component::__macro_internals::Kind>::NAME,
+                        #doc_expr,
+                    );
+                out[pos] = 0x01;
+                pos += 1;
                 let mut i = 0;
-                while i < #len_ident {
-                    out[i + 1] = #bytes_ident[i];
+                while i < REC_LEN {
+                    out[pos] = REC_BYTES[i];
+                    pos += 1;
                     i += 1;
                 }
-                out
-            };
-        }
-    });
+            }
+        });
+    }
 
-    let fallback_static = fallback.map(|f| {
-        let len_ident = quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_LEN", self_ty_hint);
-        let bytes_ident = quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_BYTES", self_ty_hint);
-        let section_ident =
-            quote::format_ident!("__AETHER_INPUT_FALLBACK_{}_SECTION", self_ty_hint);
+    if let Some(f) = fallback {
         let doc_expr = option_str_token(&f.agent_doc);
-        quote! {
-            const #len_ident: usize =
-                ::aether_component::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
-            const #bytes_ident: [u8; #len_ident] =
-                ::aether_component::__macro_internals::canonical::write_inputs_fallback::<#len_ident>(#doc_expr);
-            #[cfg(target_arch = "wasm32")]
-            #[used]
-            #[unsafe(link_section = "aether.kinds.inputs")]
-            static #section_ident: [u8; #len_ident + 1] = {
-                let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x01;
+        len_terms.push(quote! {
+            (1 + ::aether_component::__macro_internals::canonical::inputs_fallback_len(#doc_expr))
+        });
+        copy_blocks.push(quote! {
+            {
+                const REC_LEN: usize =
+                    ::aether_component::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
+                const REC_BYTES: [u8; REC_LEN] =
+                    ::aether_component::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
+                out[pos] = 0x01;
+                pos += 1;
                 let mut i = 0;
-                while i < #len_ident {
-                    out[i + 1] = #bytes_ident[i];
+                while i < REC_LEN {
+                    out[pos] = REC_BYTES[i];
+                    pos += 1;
                     i += 1;
                 }
-                out
-            };
-        }
-    });
+            }
+        });
+    }
 
-    let component_static = component_doc.as_ref().map(|doc| {
-        let len_ident = quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_LEN", self_ty_hint);
-        let bytes_ident = quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_BYTES", self_ty_hint);
-        let section_ident =
-            quote::format_ident!("__AETHER_INPUT_COMPONENT_{}_SECTION", self_ty_hint);
+    if let Some(doc) = component_doc.as_ref() {
         let doc_lit = doc.as_str();
-        quote! {
-            const #len_ident: usize =
-                ::aether_component::__macro_internals::canonical::inputs_component_len(#doc_lit);
-            const #bytes_ident: [u8; #len_ident] =
-                ::aether_component::__macro_internals::canonical::write_inputs_component::<#len_ident>(#doc_lit);
-            #[cfg(target_arch = "wasm32")]
-            #[used]
-            #[unsafe(link_section = "aether.kinds.inputs")]
-            static #section_ident: [u8; #len_ident + 1] = {
-                let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x01;
+        len_terms.push(quote! {
+            (1 + ::aether_component::__macro_internals::canonical::inputs_component_len(#doc_lit))
+        });
+        copy_blocks.push(quote! {
+            {
+                const REC_LEN: usize =
+                    ::aether_component::__macro_internals::canonical::inputs_component_len(#doc_lit);
+                const REC_BYTES: [u8; REC_LEN] =
+                    ::aether_component::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
+                out[pos] = 0x01;
+                pos += 1;
                 let mut i = 0;
-                while i < #len_ident {
-                    out[i + 1] = #bytes_ident[i];
+                while i < REC_LEN {
+                    out[pos] = REC_BYTES[i];
+                    pos += 1;
                     i += 1;
                 }
-                out
-            };
-        }
-    });
+            }
+        });
+    }
+
+    let len_expr = if len_terms.is_empty() {
+        // Unreachable in practice — `handlers_impl` rejects the empty
+        // case earlier — but keep the const arithmetic well-typed so
+        // a stripped-down macro test with no records still compiles.
+        quote! { 0usize }
+    } else {
+        quote! { #(#len_terms)+* }
+    };
 
     quote! {
-        #(#handler_statics)*
-        #fallback_static
-        #component_static
+        #[doc(hidden)]
+        pub const __AETHER_INPUTS_MANIFEST_LEN: usize = #len_expr;
+
+        #[doc(hidden)]
+        pub const __AETHER_INPUTS_MANIFEST: [u8; Self::__AETHER_INPUTS_MANIFEST_LEN] = {
+            let mut out = [0u8; Self::__AETHER_INPUTS_MANIFEST_LEN];
+            let mut pos: usize = 0usize;
+            #(#copy_blocks)*
+            let _ = pos;
+            out
+        };
     }
 }
 


### PR DESCRIPTION
## Summary

- Moves `#[link_section = "aether.kinds.inputs"]` emission out of the `#[handlers]` macro into `aether_component::export!()`. Section now only lands in cdylib roots, never in transitive rlib pulls — the duplicate-Component-record stacking bug is structurally impossible.
- `#[handlers]` instead emits the manifest bytes as two associated consts on the component type's inherent impl (`__AETHER_INPUTS_MANIFEST_LEN: usize` + `__AETHER_INPUTS_MANIFEST: [u8; LEN]`); `export!()` reads those consts and pins them into the wasm custom section.
- Wire shape unchanged — substrate manifest reader sees the same `[VERSION_BYTE][postcard(InputsRecord)]` records back-to-back.
- Adds a host-side regression test (`crates/aether-component/tests/handlers_manifest.rs`) decoding the manifest via `postcard::take_from_bytes::<InputsRecord>` and asserting handler / fallback / Agent-doc records and `K::ID` round-trips.

## Why this works

The pre-fix bug: `target_arch = "wasm32"` is true for both the cdylib root and transitive wasm32 rlib pulls. Every `#[handlers]` impl in the dep graph emitted its own `#[link_section]` static, the wasm linker stacked them, and the substrate rejected the result.

After: `#[handlers]` emits no `link_section` attributes at all — only const data. `export!()` is the single emission point for the section static, and it only runs in the crate that invokes it (= the cdylib root). Transitive rlib pulls of a `#[handlers]`-using crate carry only the const data, dead-stripped if unused. ADR-0066's trunk-rlib pattern is still the recommended layout for shared component types but is no longer load-bearing for avoiding this specific failure.

## Test plan

- [x] `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`
- [x] `cargo test --workspace` — 1053 passed, 0 failed (incl. new regression test)
- [x] Wasm builds clean for all components: camera, mesh-viewer, sokoban, ttt-server, ttt-client
- [x] `wasm-tools dump` confirms each cdylib has exactly one `aether.kinds.inputs` section
- [x] Substrate `kind_manifest` decoder tests still pass (same wire shape)

Closes #442

<!-- pr-body-ok: b — backtick-fenced macro names render as code, not links -->