### PR TITLE
refactor(kinds): retire InputStream enum; key input subscribers by KindId (issue 405)

### DIFF
--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -62,7 +62,6 @@
 
 extern crate alloc;
 
-use core::any::TypeId;
 use core::marker::PhantomData;
 
 use aether_mail::{Kind, Schema, mailbox_id_from_name};
@@ -359,38 +358,15 @@ impl InitCtx<'_> {
     }
 
     /// Send `aether.control.subscribe_input` with this component's
-    /// mailbox as the subscriber for `K`'s stream. Called by
-    /// `KindList::resolve_all` for every `K::IS_INPUT` kind — ADR-0030
-    /// Phase 2 moved the subscribe side effect out of `resolve_kind`
-    /// and into the guest SDK. No-op if `K` isn't one of the four
-    /// known substrate input kind types (input kinds defined downstream
-    /// of aether-kinds get to pick their own subscribe path).
-    ///
-    /// Stream selection goes through `TypeId` rather than `K::NAME`
-    /// so a future rename on either side of the pairing surfaces as a
-    /// type error instead of silently skipping the subscribe.
+    /// mailbox as the subscriber for `K`. ADR-0068 keys subscriber
+    /// sets by `KindId` directly, so this collapses to a one-line
+    /// send: any `Kind` is sendable, the substrate's platform thread
+    /// fans out only for kinds it actually publishes, and a subscribe
+    /// for a non-stream kind is a harmless no-op.
     pub fn subscribe_input<K: Kind + 'static>(&self) {
-        use aether_kinds::{
-            InputStream, Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, Tick, WindowSize,
-        };
-        let tid = TypeId::of::<K>();
-        let stream = if tid == TypeId::of::<Tick>() {
-            InputStream::Tick
-        } else if tid == TypeId::of::<Key>() {
-            InputStream::Key
-        } else if tid == TypeId::of::<KeyRelease>() {
-            InputStream::KeyRelease
-        } else if tid == TypeId::of::<MouseMove>() {
-            InputStream::MouseMove
-        } else if tid == TypeId::of::<MouseButton>() {
-            InputStream::MouseButton
-        } else if tid == TypeId::of::<WindowSize>() {
-            InputStream::WindowSize
-        } else {
-            return;
-        };
+        use aether_kinds::SubscribeInput;
         let payload = SubscribeInput {
-            stream,
+            kind: ::aether_mail::KindId(<K as Kind>::ID),
             mailbox: ::aether_mail::MailboxId(self.mailbox),
         };
         resolve_sink::<SubscribeInput>("aether.control").send(&payload);

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -155,6 +155,7 @@ mod tests {
                 KindDescriptor {
                     name: "aether.tick".into(),
                     schema: SchemaType::Unit,
+                    is_stream: false,
                 },
                 KindDescriptor {
                     name: "aether.key".into(),
@@ -166,6 +167,7 @@ mod tests {
                         }]
                         .into(),
                     },
+                    is_stream: false,
                 },
             ],
         });
@@ -275,10 +277,12 @@ mod tests {
             KindDescriptor {
                 name: "aether.tick".into(),
                 schema: SchemaType::Unit,
+                is_stream: false,
             },
             KindDescriptor {
                 name: "physics.contact".into(),
                 schema: SchemaType::Bytes,
+                is_stream: false,
             },
         ]);
         let mut buf = Vec::new();
@@ -408,6 +412,7 @@ mod tests {
         let desc = KindDescriptor {
             name: "demo.tick".into(),
             schema: SchemaType::Unit,
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -418,6 +423,7 @@ mod tests {
         let desc = KindDescriptor {
             name: "demo.seq".into(),
             schema: SchemaType::Scalar(Primitive::U32),
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -458,6 +464,7 @@ mod tests {
         let desc = KindDescriptor {
             name: "demo.draw_triangle".into(),
             schema: triangle,
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -491,6 +498,7 @@ mod tests {
         let desc = KindDescriptor {
             name: "demo.load_component".into(),
             schema: load,
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -529,6 +537,7 @@ mod tests {
         let desc = KindDescriptor {
             name: "demo.load_result".into(),
             schema: result,
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -557,6 +566,7 @@ mod tests {
                     }]
                     .into(),
                 },
+                is_stream: false,
             }],
         });
         let mut buf = Vec::new();
@@ -644,6 +654,7 @@ mod tests {
                 }]
                 .into(),
             },
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(
@@ -662,6 +673,7 @@ mod tests {
                 key: SchemaCell::owned(SchemaType::Scalar(Primitive::U32)),
                 value: SchemaCell::owned(SchemaType::String),
             },
+            is_stream: false,
         };
         let bytes = postcard::to_allocvec(&desc).unwrap();
         assert_eq!(

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -50,10 +50,20 @@ pub struct Hello {
 /// One entry in `Hello.kinds`: a kind-name plus its schema. The hub
 /// uses the schema to encode agent-supplied params into the exact
 /// bytes the engine expects (cast-shaped or postcard, ADR-0019).
+///
+/// `is_stream` carries the guest-side `<K as Kind>::IS_STREAM` flag
+/// (ADR-0068) — `true` when the kind is a substrate-published event
+/// stream that components can subscribe to (Tick, Key, MouseMove,
+/// MouseButton, KeyRelease, WindowSize). Metadata-only: the canonical
+/// hash bytes that drive `Kind::ID` are still `(name, schema)` per
+/// ADR-0030, so toggling this flag never shifts a kind's id. The
+/// substrate uses it to decide whether a freshly-loaded handler
+/// should be auto-subscribed into the per-kind subscriber set.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindDescriptor {
     pub name: String,
     pub schema: SchemaType,
+    pub is_stream: bool,
 }
 
 /// ADR-0019 schema type vocabulary. Describes the structure of a mail

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -38,6 +38,7 @@ pub fn all() -> Vec<KindDescriptor> {
         .map(|e| KindDescriptor {
             name: e.name.to_string(),
             schema: e.schema.clone(),
+            is_stream: e.is_stream,
         })
         .collect()
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -46,7 +46,7 @@ use bytemuck::{Pod, Zeroable};
     aether_mail::Kind,
     aether_mail::Schema,
 )]
-#[kind(name = "aether.tick", input)]
+#[kind(name = "aether.tick", stream)]
 pub struct Tick;
 
 /// A single keyboard keypress, identified by the stable codes in
@@ -66,7 +66,7 @@ pub struct Tick;
     aether_mail::Kind,
     aether_mail::Schema,
 )]
-#[kind(name = "aether.key", input)]
+#[kind(name = "aether.key", stream)]
 pub struct Key {
     pub code: u32,
 }
@@ -88,7 +88,7 @@ pub struct Key {
     aether_mail::Kind,
     aether_mail::Schema,
 )]
-#[kind(name = "aether.key_release", input)]
+#[kind(name = "aether.key_release", stream)]
 pub struct KeyRelease {
     pub code: u32,
 }
@@ -109,7 +109,7 @@ pub struct KeyRelease {
     aether_mail::Kind,
     aether_mail::Schema,
 )]
-#[kind(name = "aether.mouse_button", input)]
+#[kind(name = "aether.mouse_button", stream)]
 pub struct MouseButton;
 
 /// Cursor position in window coordinates, as logical pixels cast to f32.
@@ -117,7 +117,7 @@ pub struct MouseButton;
 #[derive(
     Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_mail::Kind, aether_mail::Schema,
 )]
-#[kind(name = "aether.mouse_move", input)]
+#[kind(name = "aether.mouse_move", stream)]
 pub struct MouseMove {
     pub x: f32,
     pub y: f32,
@@ -144,7 +144,7 @@ pub struct MouseMove {
     aether_mail::Kind,
     aether_mail::Schema,
 )]
-#[kind(name = "aether.window_size", input)]
+#[kind(name = "aether.window_size", stream)]
 pub struct WindowSize {
     pub width: u32,
     pub height: u32,
@@ -558,58 +558,34 @@ mod control_plane {
         Err { error: String },
     }
 
-    // ADR-0021 publish/subscribe routing for substrate input streams.
-    // Closed enum over streams the platform layer publishes; a
-    // SubscribeInput names one and a mailbox to receive it. Reserved
-    // kind names `aether.control.subscribe_input` /
-    // `aether.control.unsubscribe_input` / `aether.control.subscribe_input_result`
-    // match the namespace used for load/drop/replace; the substrate
-    // handles them inline and replies via reply-to-sender.
-
-    /// A substrate-published input stream (ADR-0021). Closed set —
-    /// adding a platform event (e.g. `Resize`) is an additive variant
-    /// plus a publisher change on the substrate side.
-    #[derive(
-        aether_mail::Schema,
-        Serialize,
-        Deserialize,
-        Debug,
-        Clone,
-        Copy,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-    )]
-    pub enum InputStream {
-        Tick,
-        Key,
-        MouseMove,
-        MouseButton,
-        WindowSize,
-        KeyRelease,
-    }
+    // ADR-0021 publish/subscribe routing for substrate input streams,
+    // ADR-0068 keying. The substrate maintains one subscriber set per
+    // input `KindId`; a `SubscribeInput` names the kind id and the
+    // mailbox to add. Reserved kind names `aether.control.subscribe_input`
+    // / `aether.control.unsubscribe_input` /
+    // `aether.control.subscribe_input_result` match the namespace used
+    // for load/drop/replace; the substrate handles them inline and
+    // replies via reply-to-sender.
 
     /// `aether.control.subscribe_input` — add `mailbox` to the
-    /// subscriber set for `stream`. Idempotent: subscribing a mailbox
+    /// subscriber set for `kind`. Idempotent: subscribing a mailbox
     /// already in the set is still `Ok` (subscriptions are a set, not
     /// a counter). Reply: `SubscribeInputResult`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.subscribe_input")]
     pub struct SubscribeInput {
-        pub stream: InputStream,
+        pub kind: aether_mail::KindId,
         pub mailbox: aether_mail::MailboxId,
     }
 
     /// `aether.control.unsubscribe_input` — remove `mailbox` from the
-    /// subscriber set for `stream`. Idempotent: unsubscribing a mailbox
+    /// subscriber set for `kind`. Idempotent: unsubscribing a mailbox
     /// that isn't subscribed is still `Ok`. Reply:
     /// `SubscribeInputResult`.
     #[derive(aether_mail::Kind, aether_mail::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.control.unsubscribe_input")]
     pub struct UnsubscribeInput {
-        pub stream: InputStream,
+        pub kind: aether_mail::KindId,
         pub mailbox: aether_mail::MailboxId,
     }
 

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -65,7 +65,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
     let KindAttr {
         name: kind_name,
-        is_input,
+        is_stream,
     } = parse_kind_attr(&input.attrs)?;
     if let Data::Union(u) = &input.data {
         return Err(syn::Error::new_spanned(
@@ -73,11 +73,12 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
             "Kind derive does not support unions",
         ));
     }
-    let is_input_item = if is_input {
-        quote! { const IS_INPUT: bool = true; }
+    let is_stream_item = if is_stream {
+        quote! { const IS_STREAM: bool = true; }
     } else {
         quote! {}
     };
+    let is_stream_byte: u8 = if is_stream { 1 } else { 0 };
 
     // ADR-0033 wire-shape autodetect: `#[repr(C)]` on the type means
     // the substrate carried it as raw cast bytes (and the user has
@@ -140,7 +141,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     &#canonical_bytes_ident,
                 ),
             );
-            #is_input_item
+            #is_stream_item
 
             fn decode_from_bytes(bytes: &[u8]) -> ::core::option::Option<Self> {
                 #decode_body
@@ -189,17 +190,22 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 &#labels_ident,
             );
 
+        // ADR-0068 v0x03: trailing byte after the canonical bytes
+        // carries `IS_STREAM`. Canonical bytes (and therefore
+        // `Kind::ID`) unchanged from v0x02 — the stream flag is
+        // metadata that rides alongside identity, never inside it.
         #[cfg(target_arch = "wasm32")]
         #[used]
         #[unsafe(link_section = "aether.kinds")]
-        static #kind_static_ident: [u8; #canonical_len_ident + 1] = {
-            let mut out = [0u8; #canonical_len_ident + 1];
-            out[0] = 0x02;
+        static #kind_static_ident: [u8; #canonical_len_ident + 2] = {
+            let mut out = [0u8; #canonical_len_ident + 2];
+            out[0] = 0x03;
             let mut i = 0;
             while i < #canonical_len_ident {
                 out[i + 1] = #canonical_bytes_ident[i];
                 i += 1;
             }
+            out[#canonical_len_ident + 1] = #is_stream_byte;
             out
         };
 
@@ -231,6 +237,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
             ::aether_mail::__inventory::DescriptorEntry {
                 name: <#name as ::aether_mail::Kind>::NAME,
                 schema: &#schema_static_ident,
+                is_stream: <#name as ::aether_mail::Kind>::IS_STREAM,
             }
         }
     })
@@ -553,7 +560,7 @@ fn reject_hashmap(ty: &Type) -> syn::Result<()> {
 
 struct KindAttr {
     name: String,
-    is_input: bool,
+    is_stream: bool,
 }
 
 fn parse_kind_attr(attrs: &[Attribute]) -> syn::Result<KindAttr> {
@@ -562,7 +569,7 @@ fn parse_kind_attr(attrs: &[Attribute]) -> syn::Result<KindAttr> {
             continue;
         }
         let mut name: Option<String> = None;
-        let mut is_input = false;
+        let mut is_stream = false;
         attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("name") {
                 let value = meta.value()?;
@@ -575,17 +582,21 @@ fn parse_kind_attr(attrs: &[Attribute]) -> syn::Result<KindAttr> {
                 }
                 return Err(meta.error("`name` must be a string literal"));
             }
-            if meta.path.is_ident("input") {
-                // Flag-shaped — no `= value`. ADR-0021: marks this
-                // kind as a substrate-published input stream so the
-                // SDK's auto-subscribe walk catches it at init.
-                is_input = true;
+            if meta.path.is_ident("stream") {
+                // Flag-shaped — no `= value`. ADR-0021 + ADR-0068:
+                // marks this kind as a substrate-published event
+                // stream that components subscribe to via the per-kind
+                // subscriber set. Drives `<K as Kind>::IS_STREAM` and
+                // the trailing byte in the `aether.kinds` v0x03 wire
+                // format that the substrate reads to gate auto-
+                // subscribe.
+                is_stream = true;
                 return Ok(());
             }
-            Err(meta.error("expected `name = \"...\"` or `input`"))
+            Err(meta.error("expected `name = \"...\"` or `stream`"))
         })?;
         if let Some(name) = name {
-            return Ok(KindAttr { name, is_input });
+            return Ok(KindAttr { name, is_stream });
         }
     }
     Err(syn::Error::new(
@@ -1219,17 +1230,24 @@ fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn])
                     <#k as ::aether_component::__macro_internals::Kind>::NAME,
                     &#schema_ident,
                 );
+            // ADR-0068 v0x03: trailing byte after canonical bytes
+            // carries `<K as Kind>::IS_STREAM`. Same wire shape as
+            // `expand_kind`'s primary emission so retention records
+            // (when this kind lives in a dependency rlib) and the
+            // primary records pair cleanly by id without disagreeing
+            // on the trailing flag.
             #[cfg(target_arch = "wasm32")]
             #[used]
             #[unsafe(link_section = "aether.kinds")]
-            static #section_ident: [u8; #len_ident + 1] = {
-                let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x02;
+            static #section_ident: [u8; #len_ident + 2] = {
+                let mut out = [0u8; #len_ident + 2];
+                out[0] = 0x03;
                 let mut i = 0;
                 while i < #len_ident {
                     out[i + 1] = #bytes_ident[i];
                     i += 1;
                 }
+                out[#len_ident + 1] = if <#k as ::aether_component::__macro_internals::Kind>::IS_STREAM { 1 } else { 0 };
                 out
             };
 

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -44,7 +44,13 @@ pub use tagged_id::{Tag, with_tag};
 pub trait Kind {
     const NAME: &'static str;
     const ID: u64;
-    const IS_INPUT: bool = false;
+    /// `true` when the kind is a substrate-published event stream
+    /// (Tick, Key, MouseMove, etc.) that components subscribe to via
+    /// the per-kind subscriber set. Drives `auto_subscribe_inputs` on
+    /// the substrate side: handlers whose kind is a stream get wired
+    /// into the subscriber set the moment the component is loaded.
+    /// Set by `#[kind(name = "...", stream)]` on the type declaration.
+    const IS_STREAM: bool = false;
 
     /// Decode a single instance from substrate-supplied bytes. The
     /// `Kind` derive auto-implements this with the right body for the
@@ -346,12 +352,17 @@ pub mod __inventory {
     use aether_hub_protocol::SchemaType;
 
     /// Static-friendly mirror of `aether_hub_protocol::KindDescriptor`.
-    /// Owns nothing — both fields are `'static` so the value is const-
-    /// constructible from `inventory::submit!`. `descriptors::all()`
-    /// materializes the owned `KindDescriptor` form at iteration time.
+    /// Owns nothing — every field is `'static` (or a `bool`) so the
+    /// value is const-constructible from `inventory::submit!`.
+    /// `descriptors::all()` materializes the owned `KindDescriptor`
+    /// form at iteration time. `is_stream` carries `<K as Kind>::IS_STREAM`
+    /// (ADR-0068) so the native descriptor list agrees with the wasm
+    /// `aether.kinds` v0x03 trailing byte the substrate reads from
+    /// guest binaries.
     pub struct DescriptorEntry {
         pub name: &'static str,
         pub schema: &'static SchemaType,
+        pub is_stream: bool,
     }
 
     inventory::collect!(DescriptorEntry);

--- a/crates/aether-params-codec/src/decode.rs
+++ b/crates/aether-params-codec/src/decode.rs
@@ -1081,14 +1081,18 @@ mod tests {
     fn subscribe_input_kind_round_trips_with_tagged_mailbox() {
         // End-to-end through the `SubscribeInput` kind's actual
         // schema — mirrors the worked example in ADR-0065's Context
-        // section. An agent receives a tagged-string mailbox id from
-        // `load_component`, drops it directly into `subscribe_input.
-        // mailbox`, and the wire bytes match what the substrate
-        // expects.
+        // section. ADR-0068: the field is now `kind: KindId` (tagged
+        // string on the JSON side), keying subscriber sets by kind id
+        // directly. An agent receives the tagged ids from
+        // `load_component` / `describe_kinds`, drops them straight
+        // into `subscribe_input.{kind, mailbox}`, and the wire bytes
+        // match what the substrate expects.
         use aether_mail::Kind;
         let mailbox = aether_mail::MailboxId::from_name("aether.control");
-        let s = aether_mail::tagged_id::encode(mailbox.0).unwrap();
-        let json_in = json!({ "stream": "Tick", "mailbox": s });
+        let mailbox_str = aether_mail::tagged_id::encode(mailbox.0).unwrap();
+        let kind_id = aether_mail::KindId(aether_kinds::Tick::ID);
+        let kind_str = aether_mail::tagged_id::encode(kind_id.0).unwrap();
+        let json_in = json!({ "kind": kind_str, "mailbox": mailbox_str });
 
         let bytes = encode_schema(
             &json_in,
@@ -1100,7 +1104,7 @@ mod tests {
         // hand-postcard'd `SubscribeInput`.
         let decoded: aether_kinds::SubscribeInput = postcard::from_bytes(&bytes)
             .expect("postcard decode subscribe_input from hub-encoded bytes");
-        assert_eq!(decoded.stream, aether_kinds::InputStream::Tick);
+        assert_eq!(decoded.kind, kind_id);
         assert_eq!(decoded.mailbox, mailbox);
 
         // And the kind's id is sensitive to the typed identity —

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -636,6 +636,7 @@ mod tests {
             .register_kind_with_descriptor(KindDescriptor {
                 name: "test.pong".into(),
                 schema: SchemaType::Unit,
+                is_stream: false,
             })
             .expect("register kind");
         let ctx = SubstrateCtx::new(
@@ -719,6 +720,7 @@ mod tests {
             .register_kind_with_descriptor(KindDescriptor {
                 name: "test.pong".into(),
                 schema: SchemaType::Unit,
+                is_stream: false,
             })
             .expect("register kind");
         let queue = Arc::new(Mailer::new());

--- a/crates/aether-substrate-core/src/control/mod.rs
+++ b/crates/aether-substrate-core/src/control/mod.rs
@@ -28,11 +28,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use aether_hub_protocol::{EngineToHub, KindDescriptor};
 use aether_kinds::{
-    ComponentCapabilities, DropComponent, DropResult, InputStream, Key, KeyRelease, LoadComponent,
-    LoadResult, MailEnvelope, MouseButton, MouseMove, ReplaceComponent, ReplaceResult,
-    SubscribeInput, SubscribeInputResult, Tick, UnsubscribeInput, WindowSize,
+    ComponentCapabilities, DropComponent, DropResult, LoadComponent, LoadResult, MailEnvelope,
+    ReplaceComponent, ReplaceResult, SubscribeInput, SubscribeInputResult, UnsubscribeInput,
 };
-use aether_mail::{Kind, KindId};
+use aether_mail::Kind;
 use wasmtime::{Engine, Linker, Module};
 
 use crate::component::Component;
@@ -86,56 +85,33 @@ fn register_or_match_all(
     Ok(())
 }
 
-/// The substrate's six fixed input streams paired with the typed
-/// `Kind::ID` constants that drive them. `K::ID` is a compile-time
-/// const, so the table folds at const-eval; a rename or schema
-/// change on either side trips a compile error here instead of a
-/// silent name-string miss.
+/// Wire the freshly-registered mailbox into the subscriber set for
+/// every stream kind the component declares a `#[handler]` for.
+/// Called by `handle_load` (after `try_register_component`) and
+/// `handle_replace` (after the dispatcher swap commits) so the auto-
+/// subscribe is observable the moment the component is reachable,
+/// with no `subscribe_input` reply to wait on.
 ///
-/// Temporary by design — this bridge between the closed `InputStream`
-/// enum and `KindId` exists only because `InputStream` is a separate
-/// identifier. Issue #405 retires the enum and keys subscribers by
-/// `KindId` directly, at which point this table goes away entirely.
-const INPUT_STREAM_KINDS: &[(u64, InputStream)] = &[
-    (Tick::ID, InputStream::Tick),
-    (Key::ID, InputStream::Key),
-    (KeyRelease::ID, InputStream::KeyRelease),
-    (MouseMove::ID, InputStream::MouseMove),
-    (MouseButton::ID, InputStream::MouseButton),
-    (WindowSize::ID, InputStream::WindowSize),
-];
-
-/// Map an input-kind id to its `InputStream` variant. Used by the
-/// load / replace paths to derive auto-subscriptions from the
-/// component's `aether.kinds.inputs` manifest, so a component that
-/// declares an input handler is wired to the matching stream without
-/// the guest SDK needing to round-trip through `subscribe_input` at
-/// init time (which races mailbox registration — issue #403).
-///
-/// User-space input kinds (anything outside the substrate's six
-/// fixed streams) return `None`; those continue to ride the explicit
-/// `ctx.subscribe_input::<K>()` runtime API.
-fn input_stream_for_kind_id(id: KindId) -> Option<InputStream> {
-    INPUT_STREAM_KINDS
-        .iter()
-        .find_map(|(k, s)| (id.0 == *k).then_some(*s))
-}
-
-/// Wire the freshly-registered mailbox into every input-stream
-/// subscriber set its handler manifest declares. Called by `handle_
-/// load` (after `try_register_component`) and `handle_replace` (after
-/// the dispatcher swap commits) so the auto-subscribe is observable
-/// the moment the component is reachable, with no `subscribe_input`
-/// reply to wait on.
+/// ADR-0068: subscriber sets are keyed by `KindId` directly, and
+/// `KindDescriptor.is_stream` is the load-bearing flag — derived from
+/// guest-side `<K as Kind>::IS_STREAM` and ridden through the wasm
+/// `aether.kinds` v0x03 trailing byte. A handler whose kind isn't a
+/// stream (the kind's `#[kind(...)]` declaration omits `stream`) is
+/// skipped here; the runtime API `Ctx::subscribe_input::<K>()` is
+/// still the explicit path for any other use case.
 fn auto_subscribe_inputs(
     input_subscribers: &InputSubscribers,
+    registry: &Registry,
     mailbox: MailboxId,
     capabilities: &ComponentCapabilities,
 ) {
     let mut subs = input_subscribers.write().unwrap();
     for handler in &capabilities.handlers {
-        if let Some(stream) = input_stream_for_kind_id(handler.id) {
-            subs.entry(stream).or_default().insert(mailbox);
+        if registry
+            .kind_descriptor(handler.id.0)
+            .is_some_and(|d| d.is_stream)
+        {
+            subs.entry(handler.id).or_default().insert(mailbox);
         }
     }
 }
@@ -378,7 +354,12 @@ impl ControlPlane {
         // six fixed substrate input streams; the substrate wires them
         // directly so the subscribe is observable the moment the
         // component is reachable.
-        auto_subscribe_inputs(&self.input_subscribers, mailbox, &capabilities);
+        auto_subscribe_inputs(
+            &self.input_subscribers,
+            &self.registry,
+            mailbox,
+            &capabilities,
+        );
 
         self.insert_component(mailbox, component);
         self.announce_kinds();
@@ -438,7 +419,7 @@ impl ControlPlane {
         self.input_subscribers
             .write()
             .unwrap()
-            .entry(payload.stream)
+            .entry(payload.kind)
             .or_default()
             .insert(id);
         SubscribeInputResult::Ok
@@ -464,7 +445,7 @@ impl ControlPlane {
             .input_subscribers
             .write()
             .unwrap()
-            .get_mut(&payload.stream)
+            .get_mut(&payload.kind)
         {
             set.remove(&id);
         }
@@ -642,7 +623,7 @@ impl ControlPlane {
         // §4: "subscriptions are preserved across replace_component").
         // We only ensure the new manifest's input streams are wired,
         // matching the pre-#403 SDK walker behaviour.
-        auto_subscribe_inputs(&self.input_subscribers, id, &capabilities);
+        auto_subscribe_inputs(&self.input_subscribers, &self.registry, id, &capabilities);
 
         self.announce_kinds();
         ReplaceResult::Ok { capabilities }

--- a/crates/aether-substrate-core/src/control/tests.rs
+++ b/crates/aether-substrate-core/src/control/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use aether_hub_protocol::{Primitive, SchemaType};
-use aether_kinds::{DrawTriangle, HandlerCapability};
+use aether_kinds::{HandlerCapability, Key, KeyRelease, MouseButton, MouseMove, Tick, WindowSize};
+use aether_mail::KindId;
 
 #[test]
 fn load_payload_roundtrip() {
@@ -319,7 +320,7 @@ fn load_component_missing_import_does_not_reserve_name() {
 fn load_component_registers_kinds_from_embedded_manifest() {
     let plane = make_plane();
 
-    // Hand-roll the v0x02 records the derive would emit.
+    // Hand-roll the v0x03 records (ADR-0068 trailing is_stream byte) the derive would emit.
     let shape = aether_hub_protocol::KindShape {
         name: std::borrow::Cow::Borrowed("demo.embedded.kind"),
         schema: aether_hub_protocol::SchemaShape::Struct {
@@ -336,8 +337,9 @@ fn load_component_registers_kinds_from_embedded_manifest() {
             fields: std::borrow::Cow::Owned(vec![aether_hub_protocol::LabelNode::Anonymous]),
         },
     };
-    let mut canonical = vec![0x02u8];
+    let mut canonical = vec![0x03u8];
     canonical.extend(postcard::to_allocvec(&shape).unwrap());
+    canonical.push(0u8); // is_stream=false trailing byte (ADR-0068)
     let mut labels_bytes = vec![0x03u8];
     labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
     let esc = |bs: &[u8]| -> String { bs.iter().map(|b| format!("\\{b:02x}")).collect() };
@@ -401,6 +403,7 @@ fn load_component_with_same_name_different_schema_registers_distinct_kind() {
         .register_kind_with_descriptor(KindDescriptor {
             name: "demo.conflict".into(),
             schema: SchemaType::Scalar(Primitive::U32),
+            is_stream: false,
         })
         .unwrap();
 
@@ -413,8 +416,9 @@ fn load_component_with_same_name_different_schema_registers_distinct_kind() {
         kind_label: std::borrow::Cow::Borrowed("demo::Conflict"),
         root: aether_hub_protocol::LabelNode::Anonymous,
     };
-    let mut canonical = vec![0x02u8];
+    let mut canonical = vec![0x03u8];
     canonical.extend(postcard::to_allocvec(&shape).unwrap());
+    canonical.push(0u8); // is_stream=false trailing byte (ADR-0068)
     let mut labels_bytes = vec![0x03u8];
     labels_bytes.extend(postcard::to_allocvec(&labels).unwrap());
     let esc = |bs: &[u8]| -> String { bs.iter().map(|b| format!("\\{b:02x}")).collect() };
@@ -811,6 +815,7 @@ fn replace_migrates_state_observable_via_snapshot_sink() {
         .register_kind_with_descriptor(KindDescriptor {
             name: "test.snapshot".into(),
             schema: SchemaType::Bytes,
+            is_stream: false,
         })
         .expect("register snapshot kind");
 
@@ -960,21 +965,18 @@ fn replace_with_no_save_does_not_invoke_rehydrate() {
     assert_eq!(new.read_u32(400), 0);
 }
 
-// ADR-0021: per-stream subscribe / unsubscribe, drop cleanup,
-// replace-preserves-subscriptions. `make_plane` already threads an
-// empty `InputSubscribers` into the handler, so these tests only
-// need to load a component and exercise the subscribe surface.
-// (The types these tests use — `InputStream`, `SubscribeInput`,
-// `SubscribeInputResult`, `UnsubscribeInput` — come in via the
-// top-level `use aether_kinds::{...}` plus the test mod's
-// `use super::*;`; no inline import needed.)
+// ADR-0021 + ADR-0068: per-kind subscribe / unsubscribe, drop
+// cleanup, replace-preserves-subscriptions. Subscriber sets are
+// keyed by `KindId` directly — `make_plane` threads an empty
+// `InputSubscribers` into the handler, so these tests only need to
+// load a component and exercise the subscribe surface.
 
-fn subs(plane: &ControlPlane, stream: InputStream) -> std::collections::BTreeSet<MailboxId> {
+fn subs(plane: &ControlPlane, kind: KindId) -> std::collections::BTreeSet<MailboxId> {
     plane
         .input_subscribers
         .read()
         .unwrap()
-        .get(&stream)
+        .get(&kind)
         .cloned()
         .unwrap_or_default()
 }
@@ -994,20 +996,20 @@ fn load_blank(plane: &ControlPlane, name: &str) -> u64 {
     mailbox_id.0
 }
 
-fn do_subscribe(plane: &ControlPlane, mailbox: u64, stream: InputStream) -> SubscribeInputResult {
+fn do_subscribe(plane: &ControlPlane, mailbox: u64, kind: KindId) -> SubscribeInputResult {
     plane.handle_subscribe(
         &postcard::to_allocvec(&SubscribeInput {
-            stream,
+            kind,
             mailbox: MailboxId(mailbox),
         })
         .unwrap(),
     )
 }
 
-fn do_unsubscribe(plane: &ControlPlane, mailbox: u64, stream: InputStream) -> SubscribeInputResult {
+fn do_unsubscribe(plane: &ControlPlane, mailbox: u64, kind: KindId) -> SubscribeInputResult {
     plane.handle_unsubscribe(
         &postcard::to_allocvec(&UnsubscribeInput {
-            stream,
+            kind,
             mailbox: MailboxId(mailbox),
         })
         .unwrap(),
@@ -1019,10 +1021,10 @@ fn subscribe_adds_mailbox_to_stream_set() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
     assert!(matches!(
-        do_subscribe(&plane, id, InputStream::Tick),
+        do_subscribe(&plane, id, KindId(Tick::ID)),
         SubscribeInputResult::Ok
     ));
-    let set = subs(&plane, InputStream::Tick);
+    let set = subs(&plane, KindId(Tick::ID));
     assert!(set.contains(&MailboxId(id)));
     assert_eq!(set.len(), 1);
 }
@@ -1033,11 +1035,11 @@ fn subscribe_is_idempotent() {
     let id = load_blank(&plane, "listener");
     for _ in 0..3 {
         assert!(matches!(
-            do_subscribe(&plane, id, InputStream::Key),
+            do_subscribe(&plane, id, KindId(Key::ID)),
             SubscribeInputResult::Ok
         ));
     }
-    assert_eq!(subs(&plane, InputStream::Key).len(), 1);
+    assert_eq!(subs(&plane, KindId(Key::ID)).len(), 1);
 }
 
 #[test]
@@ -1046,14 +1048,14 @@ fn subscribe_two_components_fan_out_to_both() {
     let a = load_blank(&plane, "a");
     let b = load_blank(&plane, "b");
     assert!(matches!(
-        do_subscribe(&plane, a, InputStream::Tick),
+        do_subscribe(&plane, a, KindId(Tick::ID)),
         SubscribeInputResult::Ok
     ));
     assert!(matches!(
-        do_subscribe(&plane, b, InputStream::Tick),
+        do_subscribe(&plane, b, KindId(Tick::ID)),
         SubscribeInputResult::Ok
     ));
-    let set = subs(&plane, InputStream::Tick);
+    let set = subs(&plane, KindId(Tick::ID));
     assert_eq!(set.len(), 2);
     assert!(set.contains(&MailboxId(a)));
     assert!(set.contains(&MailboxId(b)));
@@ -1063,12 +1065,12 @@ fn subscribe_two_components_fan_out_to_both() {
 fn unsubscribe_removes_from_set() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, InputStream::MouseMove);
+    do_subscribe(&plane, id, KindId(MouseMove::ID));
     assert!(matches!(
-        do_unsubscribe(&plane, id, InputStream::MouseMove),
+        do_unsubscribe(&plane, id, KindId(MouseMove::ID)),
         SubscribeInputResult::Ok
     ));
-    assert!(subs(&plane, InputStream::MouseMove).is_empty());
+    assert!(subs(&plane, KindId(MouseMove::ID)).is_empty());
 }
 
 #[test]
@@ -1078,7 +1080,7 @@ fn unsubscribe_not_subscribed_is_ok() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
     assert!(matches!(
-        do_unsubscribe(&plane, id, InputStream::Tick),
+        do_unsubscribe(&plane, id, KindId(Tick::ID)),
         SubscribeInputResult::Ok
     ));
 }
@@ -1087,7 +1089,7 @@ fn unsubscribe_not_subscribed_is_ok() {
 fn subscribe_unknown_mailbox_is_err() {
     let plane = make_plane();
     assert!(matches!(
-        do_subscribe(&plane, 9999, InputStream::Tick),
+        do_subscribe(&plane, 9999, KindId(Tick::ID)),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1101,7 +1103,7 @@ fn subscribe_sink_mailbox_is_err() {
         .registry
         .register_sink("some.sink", Arc::new(|_, _, _, _, _, _| {}));
     assert!(matches!(
-        do_subscribe(&plane, sink.0, InputStream::Tick),
+        do_subscribe(&plane, sink.0, KindId(Tick::ID)),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1117,7 +1119,7 @@ fn subscribe_dropped_mailbox_is_err() {
         .unwrap(),
     );
     assert!(matches!(
-        do_subscribe(&plane, id, InputStream::Tick),
+        do_subscribe(&plane, id, KindId(Tick::ID)),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1128,9 +1130,9 @@ fn drop_component_removes_from_every_subscriber_set() {
     // stream's subscriber set, not just the ones currently held.
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, InputStream::Tick);
-    do_subscribe(&plane, id, InputStream::Key);
-    do_subscribe(&plane, id, InputStream::MouseButton);
+    do_subscribe(&plane, id, KindId(Tick::ID));
+    do_subscribe(&plane, id, KindId(Key::ID));
+    do_subscribe(&plane, id, KindId(MouseButton::ID));
     let dropped = plane.handle_drop(
         &postcard::to_allocvec(&DropComponent {
             mailbox_id: MailboxId(id),
@@ -1139,10 +1141,10 @@ fn drop_component_removes_from_every_subscriber_set() {
     );
     assert!(matches!(dropped, DropResult::Ok));
     for s in [
-        InputStream::Tick,
-        InputStream::Key,
-        InputStream::MouseMove,
-        InputStream::MouseButton,
+        KindId(Tick::ID),
+        KindId(Key::ID),
+        KindId(MouseMove::ID),
+        KindId(MouseButton::ID),
     ] {
         assert!(
             !subs(&plane, s).contains(&MailboxId(id)),
@@ -1157,8 +1159,8 @@ fn replace_component_preserves_subscriptions() {
     // are keyed by mailbox, so the new instance inherits them.
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, InputStream::Tick);
-    do_subscribe(&plane, id, InputStream::Key);
+    do_subscribe(&plane, id, KindId(Tick::ID));
+    do_subscribe(&plane, id, KindId(Key::ID));
     let result = plane.handle_replace(
         &postcard::to_allocvec(&ReplaceComponent {
             mailbox_id: MailboxId(id),
@@ -1168,8 +1170,8 @@ fn replace_component_preserves_subscriptions() {
         .unwrap(),
     );
     assert!(matches!(result, ReplaceResult::Ok { .. }));
-    assert!(subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
-    assert!(subs(&plane, InputStream::Key).contains(&MailboxId(id)));
+    assert!(subs(&plane, KindId(Tick::ID)).contains(&MailboxId(id)));
+    assert!(subs(&plane, KindId(Key::ID)).contains(&MailboxId(id)));
 }
 
 #[test]
@@ -1183,6 +1185,35 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
     // the unknown id — silently. The substrate now derives the
     // subscriptions from the manifest after registering, and this
     // test pins that wiring.
+    let plane = make_plane();
+    // Auto-subscribe consults the registry for `is_stream` per kind
+    // (ADR-0068), so prime it with descriptors matching what a guest's
+    // wasm `aether.kinds` v0x03 section would carry: Tick + WindowSize
+    // are streams; the user-space kind is not.
+    plane
+        .registry
+        .register_kind_with_descriptor(KindDescriptor {
+            name: Tick::NAME.into(),
+            schema: <Tick as aether_mail::Schema>::SCHEMA,
+            is_stream: true,
+        })
+        .unwrap();
+    plane
+        .registry
+        .register_kind_with_descriptor(KindDescriptor {
+            name: WindowSize::NAME.into(),
+            schema: <WindowSize as aether_mail::Schema>::SCHEMA,
+            is_stream: true,
+        })
+        .unwrap();
+    plane
+        .registry
+        .register_kind_with_descriptor(KindDescriptor {
+            name: "user.custom.event".into(),
+            schema: SchemaType::Unit,
+            is_stream: false,
+        })
+        .unwrap();
     let mailbox = MailboxId(0xdead_beef);
     let subscribers = input::new_subscribers();
     let capabilities = ComponentCapabilities {
@@ -1197,8 +1228,10 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
                 name: WindowSize::NAME.into(),
                 doc: None,
             },
-            // User-space kinds fall through — the runtime API
-            // (`ctx.subscribe_input::<K>()`) handles those.
+            // User-space kinds fall through — `is_stream = false` on
+            // the registry descriptor keeps `auto_subscribe_inputs`
+            // from wiring them in. The runtime API
+            // (`ctx.subscribe_input::<K>()`) is the explicit path.
             HandlerCapability {
                 id: KindId(0xdeadbeef_cafef00d),
                 name: "user.custom.event".into(),
@@ -1208,25 +1241,25 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
         fallback: None,
         doc: None,
     };
-    auto_subscribe_inputs(&subscribers, mailbox, &capabilities);
+    auto_subscribe_inputs(&subscribers, &plane.registry, mailbox, &capabilities);
     let snapshot = subscribers.read().unwrap();
     assert!(
         snapshot
-            .get(&InputStream::Tick)
+            .get(&KindId(Tick::ID))
             .is_some_and(|set| set.contains(&mailbox)),
         "Tick handler should auto-subscribe the mailbox",
     );
     assert!(
         snapshot
-            .get(&InputStream::WindowSize)
+            .get(&KindId(WindowSize::ID))
             .is_some_and(|set| set.contains(&mailbox)),
         "WindowSize handler should auto-subscribe the mailbox",
     );
     for stream in [
-        InputStream::Key,
-        InputStream::KeyRelease,
-        InputStream::MouseMove,
-        InputStream::MouseButton,
+        KindId(Key::ID),
+        KindId(KeyRelease::ID),
+        KindId(MouseMove::ID),
+        KindId(MouseButton::ID),
     ] {
         assert!(
             snapshot
@@ -1236,35 +1269,6 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
                  doesn't declare its handler",
         );
     }
-}
-
-#[test]
-fn input_stream_for_kind_id_covers_six_substrate_streams() {
-    let cases = [
-        (Tick::ID, InputStream::Tick),
-        (Key::ID, InputStream::Key),
-        (KeyRelease::ID, InputStream::KeyRelease),
-        (MouseMove::ID, InputStream::MouseMove),
-        (MouseButton::ID, InputStream::MouseButton),
-        (WindowSize::ID, InputStream::WindowSize),
-    ];
-    for (id, expected) in cases {
-        assert_eq!(input_stream_for_kind_id(KindId(id)), Some(expected));
-    }
-    // Non-input substrate kinds and user-space ids must return None
-    // so the runtime API stays the only path for non-stream
-    // subscriptions. `DrawTriangle::ID` covers the substrate-side
-    // ringer; the literal handles the user-space case.
-    assert_eq!(
-        input_stream_for_kind_id(KindId(DrawTriangle::ID)),
-        None,
-        "non-input substrate kinds must not auto-subscribe",
-    );
-    assert_eq!(
-        input_stream_for_kind_id(KindId(0xdeadbeef_cafef00d)),
-        None,
-        "user-space ids must not auto-subscribe",
-    );
 }
 
 #[test]
@@ -1287,7 +1291,7 @@ fn subscribe_dispatch_replies_with_result_kind() {
         SubscribeInput::NAME,
         crate::mail::ReplyTo::NONE,
         &postcard::to_allocvec(&SubscribeInput {
-            stream: InputStream::Tick,
+            kind: KindId(Tick::ID),
             mailbox: MailboxId(id),
         })
         .unwrap(),
@@ -1297,12 +1301,12 @@ fn subscribe_dispatch_replies_with_result_kind() {
         UnsubscribeInput::NAME,
         crate::mail::ReplyTo::NONE,
         &postcard::to_allocvec(&UnsubscribeInput {
-            stream: InputStream::Tick,
+            kind: KindId(Tick::ID),
             mailbox: MailboxId(id),
         })
         .unwrap(),
     );
-    assert!(!subs(&plane, InputStream::Tick).contains(&MailboxId(id)));
+    assert!(!subs(&plane, KindId(Tick::ID)).contains(&MailboxId(id)));
 }
 
 // ADR-0022's `drain_pending` / `pending` / `frozen` / `parked`

--- a/crates/aether-substrate-core/src/input.rs
+++ b/crates/aether-substrate-core/src/input.rs
@@ -1,4 +1,5 @@
-// ADR-0021 publish/subscribe routing for substrate input streams.
+// ADR-0021 publish/subscribe routing for substrate input streams,
+// ADR-0068 keying.
 //
 // `InputSubscribers` is the shared table between the platform thread
 // (which publishes `aether.tick`, `aether.key`, `aether.mouse_move`,
@@ -13,14 +14,15 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
 
-use aether_kinds::InputStream;
+use aether_mail::KindId;
 
 use crate::mail::MailboxId;
 
-/// Per-stream subscriber sets. One entry per `InputStream`; absent
-/// entries are treated the same as empty sets, which lets subscribe
-/// lazily initialise an entry without a boot-time prepass.
-pub type InputSubscribers = Arc<RwLock<HashMap<InputStream, BTreeSet<MailboxId>>>>;
+/// Per-kind subscriber sets, keyed on the input kind's compile-time
+/// `KindId` (ADR-0068). Absent entries are treated the same as empty
+/// sets, which lets subscribe lazily initialise an entry without a
+/// boot-time prepass.
+pub type InputSubscribers = Arc<RwLock<HashMap<KindId, BTreeSet<MailboxId>>>>;
 
 /// Build an empty subscriber table. Callers clone the returned `Arc`
 /// into both the control plane (mutator) and the platform thread
@@ -29,15 +31,15 @@ pub fn new_subscribers() -> InputSubscribers {
     Arc::new(RwLock::new(HashMap::new()))
 }
 
-/// Snapshot of the subscribers for a single stream, returned as a
+/// Snapshot of the subscribers for a single input kind, returned as a
 /// `Vec` so the caller can drop the read lock before dispatching. The
 /// platform thread calls this once per platform event; the copy is
 /// cheap (small sets, integer elements).
-pub fn subscribers_for(table: &InputSubscribers, stream: InputStream) -> Vec<MailboxId> {
+pub fn subscribers_for(table: &InputSubscribers, kind: KindId) -> Vec<MailboxId> {
     table
         .read()
         .unwrap()
-        .get(&stream)
+        .get(&kind)
         .map(|set| set.iter().copied().collect())
         .unwrap_or_default()
 }

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -4,7 +4,7 @@
 // sidecar: type paths, field names, variant names).
 //
 // Record formats:
-//   `aether.kinds`         — [0x02] [postcard(KindShape)]
+//   `aether.kinds`         — [0x03] [postcard(KindShape)] [is_stream_byte]
 //   `aether.kinds.labels`  — [0x03] [postcard(KindLabels)]
 //
 // `aether.kinds` records are identified by computing
@@ -60,8 +60,14 @@ pub const LABELS_SECTION: &str = "aether.kinds.labels";
 
 /// Wire versions accepted in `aether.kinds`. The shape record's bytes
 /// are `Kind::ID` hash input, so the format is pinned indefinitely at
-/// 0x02 — any change would shift every id.
-const KINDS_SUPPORTED_VERSIONS: &[u8] = &[0x02];
+/// 0x03's canonical-bytes layout — any change there would shift every
+/// id. v0x03 added a trailing `is_stream` byte AFTER the canonical
+/// bytes (ADR-0068); the canonical bytes themselves are unchanged
+/// from v0x02 so the hash is stable, but the v-byte signals "this
+/// record carries the stream metadata flag." v0x02 is no longer
+/// accepted — a loud rebuild-required boundary, same as the v0x02→
+/// v0x03 bump on `aether.kinds.labels`.
+const KINDS_VERSION: u8 = 0x03;
 
 /// Wire versions accepted in `aether.kinds.labels`. v0x03 added
 /// `kind_id` to `KindLabels`, making records self-identifying so the
@@ -81,7 +87,7 @@ const LABELS_SUPPORTED_VERSIONS: &[u8] = &[0x03];
 /// silently ignored so third-party emitters can add labels for kinds
 /// not present in this particular binary without breaking loads.
 pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
-    let mut shapes: Vec<KindShape> = Vec::new();
+    let mut kinds: Vec<(KindShape, bool)> = Vec::new();
     let mut labels_list: Vec<KindLabels> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm) {
@@ -90,12 +96,7 @@ pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
             continue;
         };
         match reader.name() {
-            MANIFEST_SECTION => decode_records(
-                MANIFEST_SECTION,
-                KINDS_SUPPORTED_VERSIONS,
-                reader.data(),
-                &mut shapes,
-            )?,
+            MANIFEST_SECTION => decode_kinds_records(reader.data(), &mut kinds)?,
             LABELS_SECTION => decode_records(
                 LABELS_SECTION,
                 LABELS_SUPPORTED_VERSIONS,
@@ -109,13 +110,51 @@ pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
     let labels_by_id: HashMap<u64, KindLabels> =
         labels_list.into_iter().map(|l| (l.kind_id, l)).collect();
 
-    let mut descriptors = Vec::with_capacity(shapes.len());
-    for shape in shapes {
+    let mut descriptors = Vec::with_capacity(kinds.len());
+    for (shape, is_stream) in kinds {
         let id = kind_id_from_shape(&shape);
         let label = labels_by_id.get(&id);
-        descriptors.push(merge(shape, label));
+        descriptors.push(merge(shape, label, is_stream));
     }
     Ok(descriptors)
+}
+
+/// Walk the `aether.kinds` v0x03 section: each record is
+/// `[0x03][postcard(KindShape)][is_stream_byte]`. Postcard stops
+/// decoding exactly at the shape record's end, so the next byte is
+/// the trailing `is_stream` flag, and the byte after that is the
+/// next record's version tag.
+fn decode_kinds_records(data: &[u8], out: &mut Vec<(KindShape, bool)>) -> Result<(), String> {
+    let mut cursor = data;
+    while !cursor.is_empty() {
+        let version = cursor[0];
+        if version != KINDS_VERSION {
+            return Err(format!(
+                "{MANIFEST_SECTION}: record version {version:#x} not understood by this substrate build"
+            ));
+        }
+        let body = &cursor[1..];
+        match postcard::take_from_bytes::<KindShape>(body) {
+            Ok((shape, rest)) => {
+                if rest.is_empty() {
+                    return Err(format!(
+                        "{MANIFEST_SECTION}: record {} truncated — missing trailing is_stream byte",
+                        out.len() + 1
+                    ));
+                }
+                let is_stream = rest[0] != 0;
+                out.push((shape, is_stream));
+                cursor = &rest[1..];
+            }
+            Err(e) => {
+                return Err(format!(
+                    "{MANIFEST_SECTION}: postcard decode failed at record {}: {e}",
+                    out.len() + 1
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Decode the component's `aether.kinds.inputs` section (ADR-0033)
@@ -247,10 +286,14 @@ fn decode_records<T: serde::de::DeserializeOwned>(
 /// `Struct` and the other's an `Enum`) fall back to anonymous —
 /// structural decisions follow the schema side since that's what
 /// the canonical bytes (and `K::ID`) agreed on.
-fn merge(shape: KindShape, labels: Option<&KindLabels>) -> KindDescriptor {
+fn merge(shape: KindShape, labels: Option<&KindLabels>, is_stream: bool) -> KindDescriptor {
     let name = shape.name.into_owned();
     let schema = merge_schema(&shape.schema, labels.map(|l| &l.root));
-    KindDescriptor { name, schema }
+    KindDescriptor {
+        name,
+        schema,
+        is_stream,
+    }
 }
 
 fn merge_schema(shape: &SchemaShape, label: Option<&LabelNode>) -> SchemaType {
@@ -447,11 +490,19 @@ mod tests {
         wat::parse_str(wat).unwrap()
     }
 
-    /// Append `[0x02][postcard(shape)]` to `canonical`. Matches what
-    /// the Kind derive emits into the `aether.kinds` section.
+    /// Append `[0x03][postcard(shape)][is_stream_byte]` to `canonical`.
+    /// Matches what the Kind derive emits into the `aether.kinds`
+    /// section after ADR-0068 bumped the version. Tests pass `false`
+    /// for `is_stream` since the synthetic `KindShape`s here are
+    /// non-stream demo kinds.
     fn push_shape(canonical: &mut Vec<u8>, shape: &KindShape) {
-        canonical.push(0x02);
+        push_shape_with_stream(canonical, shape, false);
+    }
+
+    fn push_shape_with_stream(canonical: &mut Vec<u8>, shape: &KindShape, is_stream: bool) {
+        canonical.push(0x03);
         canonical.extend(postcard::to_allocvec(shape).unwrap());
+        canonical.push(if is_stream { 1 } else { 0 });
     }
 
     /// Append `[0x03][postcard(labels)]` to `labels_bytes`, and stamp
@@ -559,8 +610,9 @@ mod tests {
                 repr_c: false,
             },
         };
-        let mut canonical = vec![0x02u8];
+        let mut canonical = vec![0x03u8];
         canonical.extend(postcard::to_allocvec(&shape).unwrap());
+        canonical.push(0u8); // is_stream=false trailing byte (ADR-0068)
         let wasm = wasm_with_section(MANIFEST_SECTION, &canonical);
         let descs = read_from_bytes(&wasm).unwrap();
         assert_eq!(descs.len(), 1);

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -562,6 +562,7 @@ mod tests {
             .register_kind_with_descriptor(KindDescriptor {
                 name: Note::NAME.into(),
                 schema: note_schema(),
+                is_stream: false,
             })
             .unwrap();
         let sink = CapturingSink::new();
@@ -589,12 +590,14 @@ mod tests {
             .register_kind_with_descriptor(KindDescriptor {
                 name: HeldNote::NAME.into(),
                 schema: held_note_schema(),
+                is_stream: false,
             })
             .unwrap();
         let inner_kind_id = registry
             .register_kind_with_descriptor(KindDescriptor {
                 name: Note::NAME.into(),
                 schema: note_schema(),
+                is_stream: false,
             })
             .unwrap();
 
@@ -672,6 +675,7 @@ mod tests {
             .register_kind_with_descriptor(KindDescriptor {
                 name: HeldNote::NAME.into(),
                 schema: held_note_schema(),
+                is_stream: false,
             })
             .unwrap();
 

--- a/crates/aether-substrate-core/src/registry.rs
+++ b/crates/aether-substrate-core/src/registry.rs
@@ -300,6 +300,7 @@ impl Registry {
         let descriptor = KindDescriptor {
             name: name.clone(),
             schema: SchemaType::Bytes,
+            is_stream: false,
         };
         // A fresh `Bytes` descriptor can only conflict with a prior
         // `Bytes` registration under the same name — in which case the
@@ -559,6 +560,7 @@ mod tests {
         KindDescriptor {
             name: name.to_string(),
             schema: SchemaType::Unit,
+            is_stream: false,
         }
     }
 
@@ -574,6 +576,7 @@ mod tests {
                 }]
                 .into(),
             },
+            is_stream: false,
         }
     }
 
@@ -626,6 +629,7 @@ mod tests {
                 }]
                 .into(),
             },
+            is_stream: false,
         };
         let unnamed_id = r
             .register_kind_with_descriptor(unnamed)

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -20,12 +20,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use aether_kinds::{
-    CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, InputStream,
-    Key, KeyRelease, MonitorInfo, MouseButton, MouseMove, NoteOff, NoteOn, OsInfo,
-    PlatformInfoResult, SetMasterGain, SetMasterGainResult, SetWindowModeResult,
-    SetWindowTitleResult, Tick, VideoMode, WindowInfo, WindowMode, WindowSize, keycode,
+    CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, Key,
+    KeyRelease, MonitorInfo, MouseButton, MouseMove, NoteOff, NoteOn, OsInfo, PlatformInfoResult,
+    SetMasterGain, SetMasterGainResult, SetWindowModeResult, SetWindowTitleResult, Tick, VideoMode,
+    WindowInfo, WindowMode, WindowSize, keycode,
 };
-use aether_mail::Kind;
+use aether_mail::{Kind, KindId};
 use aether_mail::{encode, encode_empty};
 use aether_substrate_core::sinks::{RenderAccumulator, build_camera_sink, build_render_sink};
 use aether_substrate_desktop::{
@@ -692,7 +692,7 @@ impl App {
     }
 
     fn publish_window_size(&self, width: u32, height: u32) {
-        let subs = subscribers_for(&self.input_subscribers, InputStream::WindowSize);
+        let subs = subscribers_for(&self.input_subscribers, KindId(WindowSize::ID));
         if subs.is_empty() {
             return;
         }
@@ -816,7 +816,7 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
-                let tick_subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+                let tick_subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
                 for mbox in tick_subs {
                     self.queue
                         .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
@@ -933,7 +933,7 @@ impl ApplicationHandler<UserEvent> for App {
                 };
                 match key_event.state {
                     ElementState::Pressed => {
-                        let subs = subscribers_for(&self.input_subscribers, InputStream::Key);
+                        let subs = subscribers_for(&self.input_subscribers, KindId(Key::ID));
                         for mbox in subs {
                             self.queue.push(Mail::new(
                                 mbox,
@@ -944,8 +944,7 @@ impl ApplicationHandler<UserEvent> for App {
                         }
                     }
                     ElementState::Released => {
-                        let subs =
-                            subscribers_for(&self.input_subscribers, InputStream::KeyRelease);
+                        let subs = subscribers_for(&self.input_subscribers, KindId(KeyRelease::ID));
                         for mbox in subs {
                             self.queue.push(Mail::new(
                                 mbox,
@@ -961,7 +960,7 @@ impl ApplicationHandler<UserEvent> for App {
                 state: ElementState::Pressed,
                 ..
             } => {
-                let subs = subscribers_for(&self.input_subscribers, InputStream::MouseButton);
+                let subs = subscribers_for(&self.input_subscribers, KindId(MouseButton::ID));
                 for mbox in subs {
                     self.queue.push(Mail::new(
                         mbox,
@@ -972,7 +971,7 @@ impl ApplicationHandler<UserEvent> for App {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let subs = subscribers_for(&self.input_subscribers, InputStream::MouseMove);
+                let subs = subscribers_for(&self.input_subscribers, KindId(MouseMove::ID));
                 if !subs.is_empty() {
                     let payload = encode(&MouseMove {
                         x: position.x as f32,

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -11,10 +11,8 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use aether_kinds::{
-    DropComponent, InputStream, LoadComponent, SubscribeInput, Tick, UnsubscribeInput,
-};
-use aether_mail::Kind;
+use aether_kinds::{DropComponent, LoadComponent, SubscribeInput, Tick, UnsubscribeInput};
+use aether_mail::{Kind, KindId};
 use aether_substrate_desktop::{
     ControlPlane, HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx,
     host_fns,
@@ -152,21 +150,21 @@ fn load_wat(plane: &ControlPlane, wat: &str, name: &str) -> u64 {
         .expect("load inserted a new component")
 }
 
-fn subscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
+fn subscribe(plane: &ControlPlane, kind: KindId, mailbox: u64) {
     dispatch(
         plane,
         &SubscribeInput {
-            stream,
+            kind,
             mailbox: aether_mail::MailboxId(mailbox),
         },
     );
 }
 
-fn unsubscribe(plane: &ControlPlane, stream: InputStream, mailbox: u64) {
+fn unsubscribe(plane: &ControlPlane, kind: KindId, mailbox: u64) {
     dispatch(
         plane,
         &UnsubscribeInput {
-            stream,
+            kind,
             mailbox: aether_mail::MailboxId(mailbox),
         },
     );
@@ -185,7 +183,7 @@ fn drop_component(plane: &ControlPlane, mailbox_id: u64) {
 /// subscriber set, push one mail per subscriber, block until the
 /// scheduler drains.
 fn publish_tick(h: &Harness) {
-    for mbox in subscribers_for(&h.input_subscribers, InputStream::Tick) {
+    for mbox in subscribers_for(&h.input_subscribers, KindId(Tick::ID)) {
         h.queue.push(Mail::new(mbox, h.kind_tick, vec![], 1));
     }
     h.queue.drain_all();
@@ -197,16 +195,16 @@ fn empty_subscribers_means_no_delivery() {
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 0);
-    assert!(subscribers_for(&h.input_subscribers, InputStream::Tick).is_empty());
+    assert!(subscribers_for(&h.input_subscribers, KindId(Tick::ID)).is_empty());
 }
 
 #[test]
 fn subscribed_component_receives_published_ticks() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "listener");
-    subscribe(&h.plane, InputStream::Tick, id);
+    subscribe(&h.plane, KindId(Tick::ID), id);
     assert_eq!(
-        subscribers_for(&h.input_subscribers, InputStream::Tick),
+        subscribers_for(&h.input_subscribers, KindId(Tick::ID)),
         vec![MailboxId(id)]
     );
     for _ in 0..3 {
@@ -220,8 +218,8 @@ fn two_subscribers_each_receive_every_tick() {
     let h = make_harness();
     let a = load_wat(&h.plane, &h.wat, "a");
     let b = load_wat(&h.plane, &h.wat, "b");
-    subscribe(&h.plane, InputStream::Tick, a);
-    subscribe(&h.plane, InputStream::Tick, b);
+    subscribe(&h.plane, KindId(Tick::ID), a);
+    subscribe(&h.plane, KindId(Tick::ID), b);
     publish_tick(&h);
     publish_tick(&h);
     // 2 subscribers × 2 ticks = 4 deliveries.
@@ -232,11 +230,11 @@ fn two_subscribers_each_receive_every_tick() {
 fn unsubscribe_stops_delivery() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "listener");
-    subscribe(&h.plane, InputStream::Tick, id);
+    subscribe(&h.plane, KindId(Tick::ID), id);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
 
-    unsubscribe(&h.plane, InputStream::Tick, id);
+    unsubscribe(&h.plane, KindId(Tick::ID), id);
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
@@ -246,12 +244,12 @@ fn unsubscribe_stops_delivery() {
 fn drop_clears_subscriptions() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "victim");
-    subscribe(&h.plane, InputStream::Tick, id);
+    subscribe(&h.plane, KindId(Tick::ID), id);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
 
     drop_component(&h.plane, id);
-    assert!(subscribers_for(&h.input_subscribers, InputStream::Tick).is_empty());
+    assert!(subscribers_for(&h.input_subscribers, KindId(Tick::ID)).is_empty());
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use aether_kinds::{FrameStats, InputStream, Tick};
-use aether_mail::{Kind, encode_empty};
+use aether_kinds::{FrameStats, Tick};
+use aether_mail::{Kind, KindId, encode_empty};
 use aether_substrate_core::{
     Chassis, ChassisCapabilities, InputSubscribers, Mailer, Scheduler, SubstrateBoot, frame_loop,
     mail::{Mail, MailboxId},
@@ -75,7 +75,7 @@ impl Chassis for HeadlessChassis {
             next_deadline = Instant::now() + self.tick_period;
 
             frame += 1;
-            let subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));

--- a/crates/aether-substrate-hub/src/mcp.rs
+++ b/crates/aether-substrate-hub/src/mcp.rs
@@ -159,6 +159,7 @@ mod tests {
         let tick = aether_hub_protocol::KindDescriptor {
             name: "aether.tick".into(),
             schema: aether_hub_protocol::SchemaType::Unit,
+            is_stream: false,
         };
         record_with_kinds(id_u128, vec![tick])
     }
@@ -275,6 +276,7 @@ mod tests {
                 ]
                 .into(),
             },
+            is_stream: false,
         }];
         let (rec, mut rx) = record_with_kinds(3, kinds);
         let id = rec.id;
@@ -309,6 +311,7 @@ mod tests {
         let kinds = vec![KindDescriptor {
             name: "aether.tick".into(),
             schema: SchemaType::Unit,
+            is_stream: false,
         }];
         let (rec, mut rx) = record_with_kinds(4, kinds);
         let id = rec.id;
@@ -382,6 +385,7 @@ mod tests {
             KindDescriptor {
                 name: "aether.tick".into(),
                 schema: SchemaType::Unit,
+                is_stream: false,
             },
             KindDescriptor {
                 name: "hello.note".into(),
@@ -393,6 +397,7 @@ mod tests {
                     }]
                     .into(),
                 },
+                is_stream: false,
             },
             KindDescriptor {
                 name: "hello.cast".into(),
@@ -404,6 +409,7 @@ mod tests {
                     }]
                     .into(),
                 },
+                is_stream: false,
             },
         ];
         let engines = EngineRegistry::new();
@@ -725,6 +731,7 @@ mod tests {
                 ]
                 .into(),
             },
+            is_stream: false,
         }];
         let (rec, _rx) = record_with_kinds(33, kinds);
         let id = rec.id;
@@ -779,6 +786,7 @@ mod tests {
                 }]
                 .into(),
             },
+            is_stream: false,
         }];
         let (rec, _rx) = record_with_kinds(34, kinds);
         let id = rec.id;
@@ -854,6 +862,7 @@ mod tests {
         let kinds = vec![KindDescriptor {
             name: "aether.observation.ping".into(),
             schema: SchemaType::Unit,
+            is_stream: false,
         }];
         let (rec, _rx) = record_with_kinds(36, kinds);
         let id = rec.id;
@@ -957,6 +966,7 @@ mod tests {
                 ]
                 .into(),
             },
+            is_stream: false,
         }
     }
 
@@ -1185,6 +1195,7 @@ mod tests {
             KindDescriptor {
                 name: "demo.tick".into(),
                 schema: SchemaType::Unit,
+                is_stream: false,
             },
         ];
         let (rec, mut rx) = record_with_kinds(781, kinds);

--- a/crates/aether-substrate-hub/src/registry.rs
+++ b/crates/aether-substrate-hub/src/registry.rs
@@ -252,6 +252,7 @@ mod tests {
         let new_kinds = vec![KindDescriptor {
             name: "physics.contact".into(),
             schema: SchemaType::Bytes,
+            is_stream: false,
         }];
         reg.update_kinds(&id, new_kinds.clone());
         assert_eq!(reg.get(&id).unwrap().kinds, new_kinds);

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -21,8 +21,8 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, InputStream, Tick};
-use aether_mail::{Kind, encode_empty};
+use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, Tick};
+use aether_mail::{Kind, KindId, encode_empty};
 use aether_substrate_core::{
     Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
     capture::CaptureQueue,
@@ -118,7 +118,7 @@ impl TestBenchChassis {
     /// aborts the chassis cleanly via `lifecycle::fatal_abort`.
     fn run_frame(&mut self, frame: u64, started: Instant, dispatch_tick: bool) {
         if dispatch_tick {
-            let subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -26,10 +26,9 @@ use std::time::Instant;
 
 use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, DRAW_TRIANGLE_BYTES, FrameStats,
-    InputStream, Tick,
+    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, DRAW_TRIANGLE_BYTES, FrameStats, Tick,
 };
-use aether_mail::{Kind, encode_empty, encode_struct, mailbox_id_from_name};
+use aether_mail::{Kind, KindId, encode_empty, encode_struct, mailbox_id_from_name};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_substrate_core::{
@@ -519,7 +518,7 @@ impl TestBench {
 
     fn run_frame(&mut self, dispatch_tick: bool) {
         if dispatch_tick {
-            let subs = subscribers_for(&self.input_subscribers, InputStream::Tick);
+            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));


### PR DESCRIPTION
## Summary

Implements ADR-0068. Subscriber sets in the substrate flip from `HashMap<InputStream, BTreeSet<MailboxId>>` to `HashMap<KindId, BTreeSet<MailboxId>>`. The hand-maintained `INPUT_STREAM_KINDS` bridge table and `input_stream_for_kind_id` helper in `control.rs` are deleted entirely; `Kind::IS_INPUT` is renamed to `Kind::IS_STREAM` and becomes structurally load-bearing — `KindDescriptor.is_stream` gates the substrate's `auto_subscribe_inputs` path.

## Wire-format changes

- `aether.kinds` custom section bumps from v0x02 to v0x03. Records carry a trailing `is_stream` byte after the canonical bytes. Canonical bytes (and therefore `Kind::ID`) unchanged so kind ids are stable across the migration.
- `KindDescriptor` gains `is_stream: bool`.
- `SubscribeInput` / `UnsubscribeInput` field rename: `stream: InputStream` becomes `kind: KindId` (+7 bytes per envelope).
- `__inventory::DescriptorEntry` carries `is_stream` so the native-side `descriptors::all()` agrees with the wasm side.
- The macro attribute `#[kind(name=..., input)]` becomes `#[kind(name=..., stream)]`.

The SDK's `Ctx::subscribe_input::<K>()` collapses to a one-line send of `K::ID` — no more TypeId match against the six fixed substrate input kinds.

## Test plan

- [x] `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`
- [x] `cargo test --workspace` — 1052 passed, 0 failed (substrate-core lib + tests, scenario tests for camera / mesh-viewer / sokoban / ttt-server / ttt-client, hub MCP tests, params-codec tests)
- [x] All wasm components rebuilt and exercised through scenario tests via TestBench: `aether-camera-component`, `aether-mesh-viewer-component`, `aether-demo-sokoban`, `aether-demo-tic-tac-toe-server`, `aether-demo-tic-tac-toe-client`, `aether-test-fixture-probe`
- [x] kinds-section v0x02 -> v0x03 round-trip verified: substrate parser reads the trailing byte, registers descriptors with `is_stream`, and `auto_subscribe_inputs` filters correctly

Closes issue 405.

<!-- pr-body-ok: b — issue 405 + ADR-0068 referenced by name; backtick-fenced field/type identifiers are intentional code spans -->