### PR TITLE
refactor(substrate-core): push env-var reading to chassis mains (issue 464)

### DIFF
--- a/crates/aether-mesh-viewer-component/tests/scenario.rs
+++ b/crates/aether-mesh-viewer-component/tests/scenario.rs
@@ -14,11 +14,14 @@
 //!   builds the wasm before invoking `cargo test`.
 //!
 //! All boot-time mechanics (wgpu probe, wasm locator, skip-or-panic
-//! gate, `AETHER_SAVE_DIR` sandbox, `tick_to`, `Runner::run` + assert
+//! gate, `save://` sandbox, `tick_to`, `Runner::run` + assert
 //! postscript) live in `aether_scenario::test_helpers` (issue 460).
+//! Per issue 464, the sandbox is plumbed via
+//! `TestBench::builder().namespace_roots(...)` rather than env-var
+//! mutation.
 
 use aether_scenario::test_helpers::{
-    init_save_sandbox, require_runtime, run_or_panic, tick_to, write_fixture,
+    init_save_sandbox, require_runtime, run_or_panic, test_namespace_roots, tick_to, write_fixture,
 };
 use aether_scenario::{Check, Script, Step};
 use aether_substrate_test_bench::TestBench;
@@ -52,7 +55,7 @@ fn dsl_box_loads_and_renders() {
     let Some(wasm_path) = require_runtime("aether_mesh_viewer_component") else {
         return;
     };
-    init_save_sandbox("mesh-viewer");
+    let sandbox = init_save_sandbox("mesh-viewer");
     let path = write_fixture("dsl_box.dsl", BOX_DSL);
 
     let script = Script {
@@ -87,7 +90,11 @@ fn dsl_box_loads_and_renders() {
         ],
     };
 
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
     run_or_panic(&mut bench, &script);
 }
 
@@ -100,7 +107,7 @@ fn obj_quad_loads_and_renders() {
     let Some(wasm_path) = require_runtime("aether_mesh_viewer_component") else {
         return;
     };
-    init_save_sandbox("mesh-viewer");
+    let sandbox = init_save_sandbox("mesh-viewer");
     let path = write_fixture("obj_quad.obj", QUAD_OBJ);
 
     let script = Script {
@@ -132,7 +139,11 @@ fn obj_quad_loads_and_renders() {
         ],
     };
 
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
     run_or_panic(&mut bench, &script);
 }
 
@@ -147,7 +158,7 @@ fn parse_failure_keeps_prior_mesh() {
     let Some(wasm_path) = require_runtime("aether_mesh_viewer_component") else {
         return;
     };
-    init_save_sandbox("mesh-viewer");
+    let sandbox = init_save_sandbox("mesh-viewer");
     let good = write_fixture("good.dsl", BOX_DSL);
     let bad = write_fixture("bad.dsl", BAD_DSL);
 
@@ -191,6 +202,10 @@ fn parse_failure_keeps_prior_mesh() {
         ],
     };
 
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
     run_or_panic(&mut bench, &script);
 }

--- a/crates/aether-scenario/src/test_helpers.rs
+++ b/crates/aether-scenario/src/test_helpers.rs
@@ -4,7 +4,9 @@
 //! - probe for a wgpu adapter (skip otherwise),
 //! - locate their own pre-built wasm artifact under
 //!   `target/wasm32-unknown-unknown/{release,debug}/`,
-//! - sandbox `AETHER_SAVE_DIR` to a per-process tempdir,
+//! - sandbox `save://` to a per-process tempdir (per issue 464,
+//!   passed to `TestBench::builder().namespace_roots(...)` instead
+//!   of via env mutation),
 //! - and close every `Script` invocation with a `Runner::run` +
 //!   `assert!(report.passed, …)` postscript.
 //!
@@ -34,11 +36,15 @@
 //!     let Some(wasm_path) = require_runtime("aether_my_component") else {
 //!         return;
 //!     };
+//!     let sandbox = init_save_sandbox("my-component");
 //!     let script = Script {
 //!         name: "smoke".to_owned(),
 //!         steps: vec![/* … */],
 //!     };
-//!     let mut bench = aether_substrate_test_bench::TestBench::start_with_size(64, 48)
+//!     let mut bench = aether_substrate_test_bench::TestBench::builder()
+//!         .size(64, 48)
+//!         .namespace_roots(test_namespace_roots(sandbox))
+//!         .build()
 //!         .expect("boot");
 //!     run_or_panic(&mut bench, &script);
 //! }
@@ -48,17 +54,18 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use aether_substrate_test_bench::TestBench;
+use aether_substrate_test_bench::io::NamespaceRoots;
 
 use crate::{Runner, Script, Step};
 
-/// Process-wide test sandbox. Single `OnceLock` linearises the
-/// `AETHER_SAVE_DIR` env-var write so concurrent `getenv` from a
-/// freshly-booting `TestBench` sees a stable value.
+/// Process-wide test sandbox. Single `OnceLock` so repeat calls
+/// across a binary's tests resolve to the same dir — handy for
+/// `write_fixture` consumers that look up the sandbox by label.
 ///
-/// First call wins; the label baked into the dirname makes the
-/// tempdir self-describing for debugging. Each integration test
-/// binary is its own process and only ever calls `init_save_sandbox`
-/// with one label, so "first wins" collapses to "the binary's label".
+/// Per issue 464, the sandbox is just a directory; `TestBench`
+/// receives it via `TestBench::builder().namespace_roots(...)`, not
+/// via env-var mutation. The `OnceLock` no longer linearises a
+/// `set_var` call — it just memoises the path.
 static TEST_SAVE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 /// Probe for any usable wgpu adapter. Used by `require_runtime` and
@@ -139,20 +146,17 @@ pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
     }
 }
 
-/// Process-wide `save://` sandbox under `AETHER_SAVE_DIR`. Idempotent;
-/// the dir is created on the first call and `AETHER_SAVE_DIR` points
-/// at it for the remainder of the process. Returns the resolved path.
+/// Process-wide `save://` sandbox dir. Idempotent; the dir is created
+/// on the first call and the same path is returned on every
+/// subsequent call. Per issue 464, this helper no longer mutates
+/// process env — callers pass the returned path to
+/// `TestBench::builder().namespace_roots(test_namespace_roots(path))`.
 ///
 /// `label` is baked into the dirname so the tempdir is self-describing
 /// (`/tmp/aether-<label>-tests-<pid>`); pass a stable per-crate label
 /// like `"mesh-viewer"` or `"test-bench-io"`. Each integration test
 /// binary is its own process, so the label is only ever set once per
 /// process and collisions across binaries don't arise.
-///
-/// Concurrency: `set_var` is racy with concurrent `getenv` on POSIX,
-/// but `OnceLock` linearises the set, and every test that boots a
-/// `TestBench` is expected to gate through this helper first — so by
-/// the time any test thread reads env, the set has completed.
 pub fn init_save_sandbox(label: &str) -> &'static Path {
     TEST_SAVE_DIR.get_or_init(|| {
         let dir = std::env::temp_dir().join(format!(
@@ -160,13 +164,25 @@ pub fn init_save_sandbox(label: &str) -> &'static Path {
             pid = std::process::id(),
         ));
         std::fs::create_dir_all(&dir).expect("create test save dir");
-        // SAFETY: `set_var` is racy with concurrent `getenv` on POSIX;
-        // see the rustdoc above — `OnceLock` linearises the set and
-        // every test gates through this helper before booting a
-        // `TestBench`, so no concurrent `getenv` runs during the set.
-        unsafe { std::env::set_var("AETHER_SAVE_DIR", &dir) };
         dir
     })
+}
+
+/// Build a [`NamespaceRoots`] suitable for a per-process test
+/// sandbox. The supplied `save_dir` (typically the path returned by
+/// [`init_save_sandbox`]) backs the `save://` namespace; `assets://`
+/// and `config://` reuse the same dir so writes that target either
+/// don't escape the sandbox. Pass the result to
+/// `TestBench::builder().namespace_roots(...)`.
+///
+/// Per issue 464, this is the no-env replacement for the old
+/// `init_save_sandbox`-sets-`AETHER_SAVE_DIR` pattern.
+pub fn test_namespace_roots(save_dir: &Path) -> NamespaceRoots {
+    NamespaceRoots {
+        save: save_dir.to_path_buf(),
+        assets: save_dir.to_path_buf(),
+        config: save_dir.to_path_buf(),
+    }
 }
 
 /// Write `bytes` into the sandbox at filename `name`, returning the

--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -20,11 +20,18 @@
 //! **Hub connect is explicit.** `build()` does NOT dial
 //! `AETHER_HUB_URL`. The chassis registers its own sinks and any
 //! other state that should exist before the hub knows the engine is
-//! alive, then calls `boot.connect_hub_from_env()` to dial. Without
-//! this separation, a hub-driven `load_component` could race ahead
-//! of the chassis's main thread and bind a chassis sink name to a
-//! freshly-loaded component before the chassis's later
-//! `register_sink` call, panicking the substrate (issue #262).
+//! alive, then calls `boot.connect_hub(url)` (or its `_from_env`
+//! wrapper) to dial. Without this separation, a hub-driven
+//! `load_component` could race ahead of the chassis's main thread
+//! and bind a chassis sink name to a freshly-loaded component before
+//! the chassis's later `register_sink` call, panicking the substrate
+//! (issue #262).
+//!
+//! **Env-var reading is the chassis's job.** Per issue 464,
+//! substrate-core takes config explicitly (`connect_hub` accepts an
+//! optional URL; `SubstrateBootBuilder::namespace_roots` accepts
+//! resolved roots) and chassis `main()` is the single edge that
+//! reads env vars. Tests pass config in directly, never touch env.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -69,12 +76,20 @@ pub struct SubstrateBoot {
     /// way through; chassis-level handlers (PR 3 host-fn shims)
     /// will publish into it via `Mailer::handle_store()`.
     pub handle_store: Arc<HandleStore>,
-    /// Retained so `connect_hub_from_env` can hand the descriptor
-    /// list to `HubClient::connect`, the chassis can log the count,
-    /// etc. Same `Vec` that was registered with the `Registry`.
+    /// Retained so `connect_hub` / `connect_hub_from_env` can hand
+    /// the descriptor list to `HubClient::connect`, the chassis can
+    /// log the count, etc. Same `Vec` that was registered with the
+    /// `Registry`.
     pub boot_descriptors: Vec<KindDescriptor>,
+    /// Resolved ADR-0041 filesystem roots. Either the override
+    /// supplied to `SubstrateBootBuilder::namespace_roots` or
+    /// [`crate::io::NamespaceRoots::from_env`] when no override was
+    /// set. Chassis mains pass this to `crate::io::build_registry`
+    /// when wiring the `aether.sink.io` sink.
+    pub namespace_roots: crate::io::NamespaceRoots,
     /// Substrate identity for the hub `Hello` handshake. Owned so
-    /// `connect_hub_from_env` can use them after `build()` returns.
+    /// `connect_hub` / `connect_hub_from_env` can use them after
+    /// `build()` returns.
     name: String,
     version: String,
 }
@@ -97,6 +112,7 @@ pub struct SubstrateBootBuilder<'a> {
     name: &'a str,
     version: &'a str,
     workers: usize,
+    namespace_roots: Option<crate::io::NamespaceRoots>,
     build_handler: ChassisHandlerFactory,
 }
 
@@ -110,30 +126,36 @@ impl SubstrateBoot {
             name,
             version,
             workers: 2,
+            namespace_roots: None,
             build_handler: Box::new(|_| None),
         }
     }
 
-    /// Dial `AETHER_HUB_URL` and start the hub reader + heartbeat
-    /// threads. Returns `Ok(Some(client))` on success — the chassis
-    /// MUST keep the client alive (typically by stashing it in its
-    /// own struct) for those threads to stay running. `Ok(None)` if
-    /// `AETHER_HUB_URL` is unset (substrate runs locally, no hub).
-    /// `Err` propagates a hub-connect failure (TCP refused, handshake
-    /// timeout, etc.) so the chassis can decide whether to fail the
-    /// boot or run hub-disconnected.
+    /// Dial `url` and start the hub reader + heartbeat threads.
+    /// Returns `Ok(Some(client))` on success — the chassis MUST keep
+    /// the client alive (typically by stashing it in its own struct)
+    /// for those threads to stay running. `Ok(None)` if `url` is
+    /// `None` (substrate runs locally, no hub). `Err` propagates a
+    /// hub-connect failure (TCP refused, handshake timeout, etc.) so
+    /// the chassis can decide whether to fail the boot or run
+    /// hub-disconnected.
     ///
     /// Call this **after** every chassis sink is registered (and any
     /// other state that should exist before the hub knows about the
     /// engine). Before this returns, no hub-driven `load_component`
     /// can race the chassis's setup. See issue #262.
-    pub fn connect_hub_from_env(&self) -> wasmtime::Result<Option<HubClient>> {
-        let url = match std::env::var("AETHER_HUB_URL") {
-            Ok(u) => u,
-            Err(_) => return Ok(None),
+    ///
+    /// Per issue 464, this is the substrate-core entry point — the
+    /// chassis main reads `AETHER_HUB_URL` from env and passes it
+    /// through. `connect_hub_from_env` is a thin wrapper for callers
+    /// that still want the env-driven behaviour inline.
+    pub fn connect_hub(&self, url: Option<&str>) -> wasmtime::Result<Option<HubClient>> {
+        let url = match url {
+            Some(u) if !u.is_empty() => u,
+            _ => return Ok(None),
         };
         let client = HubClient::connect(
-            url.as_str(),
+            url,
             &self.name,
             &self.version,
             self.boot_descriptors.clone(),
@@ -144,12 +166,41 @@ impl SubstrateBoot {
         .map_err(|e| wasmtime::Error::msg(format!("hub connect to {url:?} failed: {e}")))?;
         Ok(Some(client))
     }
+
+    /// Env-driven wrapper around [`SubstrateBoot::connect_hub`].
+    /// Reads `AETHER_HUB_URL` from the process env and forwards it
+    /// to `connect_hub`. Returns `Ok(None)` if the var is unset or
+    /// empty.
+    ///
+    /// Chassis mains should prefer reading the env once and calling
+    /// `connect_hub` directly — see issue 464. This wrapper is kept
+    /// for callers that don't need to thread env through their own
+    /// config struct.
+    pub fn connect_hub_from_env(&self) -> wasmtime::Result<Option<HubClient>> {
+        self.connect_hub(std::env::var("AETHER_HUB_URL").ok().as_deref())
+    }
 }
 
 impl<'a> SubstrateBootBuilder<'a> {
     /// Scheduler worker count. Default 2.
     pub fn workers(mut self, workers: usize) -> Self {
         self.workers = workers;
+        self
+    }
+
+    /// Override the ADR-0041 namespace roots used at boot. When not
+    /// set, the builder defaults to [`crate::io::NamespaceRoots::from_env`]
+    /// — same behaviour as before issue 464. Tests and chassis-as-
+    /// library embedders pass an explicit `NamespaceRoots` here so
+    /// no env mutation is required to redirect `save://` / `config://`
+    /// / `assets://` at a tempdir.
+    ///
+    /// The override doesn't itself wire the `aether.sink.io` sink —
+    /// the chassis still drives that via `crate::io::build_registry`,
+    /// reading [`SubstrateBoot::namespace_roots`] for the resolved
+    /// paths.
+    pub fn namespace_roots(mut self, roots: crate::io::NamespaceRoots) -> Self {
+        self.namespace_roots = Some(roots);
         self
     }
 
@@ -314,6 +365,10 @@ impl<'a> SubstrateBootBuilder<'a> {
         };
         registry.register_sink(AETHER_CONTROL, control_plane.into_sink_handler());
 
+        let namespace_roots = self
+            .namespace_roots
+            .unwrap_or_else(crate::io::NamespaceRoots::from_env);
+
         Ok(SubstrateBoot {
             engine,
             registry,
@@ -325,6 +380,7 @@ impl<'a> SubstrateBootBuilder<'a> {
             scheduler,
             handle_store,
             boot_descriptors,
+            namespace_roots,
             name: self.name.to_owned(),
             version: self.version.to_owned(),
         })
@@ -340,34 +396,23 @@ mod tests {
     /// sinks can race ahead and bind a chassis sink name to a
     /// component, panicking the substrate when the chassis later
     /// tries to install the real sink handler. The fix moved hub
-    /// connect out of `build()` into the explicit
-    /// `connect_hub_from_env` so the chassis controls the timing.
-    /// Set `AETHER_HUB_URL` to a bogus address — if `build()` still
-    /// tried to dial, this test would either hang or surface a
-    /// connect error. Neither happens because the dial doesn't
-    /// occur.
+    /// connect out of `build()` into the explicit `connect_hub` (and
+    /// `connect_hub_from_env` wrapper) so the chassis controls the
+    /// timing. Per issue 464, the env-driven helper is the chassis's
+    /// edge — this test passes a bogus URL through `connect_hub`
+    /// directly to confirm `build()` itself never dials, without
+    /// touching process env.
     #[test]
     fn build_does_not_dial_hub() {
-        // Use a setter+resetter to keep the env mutation scoped; if
-        // a sibling test reads `AETHER_HUB_URL`, it sees the
-        // restored state.
-        let prior = std::env::var("AETHER_HUB_URL").ok();
-        // SAFETY: tests run with --test-threads in CI but this var is
-        // only consulted by `connect_hub_from_env`, which we don't call.
-        unsafe {
-            std::env::set_var("AETHER_HUB_URL", "127.0.0.1:1");
-        }
-        let result = SubstrateBoot::builder("test", env!("CARGO_PKG_VERSION")).build();
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var("AETHER_HUB_URL", v),
-                None => std::env::remove_var("AETHER_HUB_URL"),
-            }
-        }
-        let boot = result.expect("build must succeed without dialling the hub");
+        let boot = SubstrateBoot::builder("test", env!("CARGO_PKG_VERSION"))
+            .build()
+            .expect("build must succeed without dialling the hub");
         // The boot is alive; chassis sinks can be registered without
         // racing a hub-driven load.
         boot.registry
             .register_sink("test_chassis_sink", Arc::new(|_, _, _, _, _, _| {}));
+        // And `connect_hub(None)` short-circuits to `Ok(None)` —
+        // proving the env-free path.
+        assert!(boot.connect_hub(None).expect("connect_hub None").is_none());
     }
 }

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -224,6 +224,7 @@ fn io_error_from_std(err: std::io::Error) -> IoError {
 /// chassis reads this at boot, hands each path to a `LocalFileAdapter`,
 /// and registers the result in an `AdapterRegistry` keyed on the
 /// namespace short name (`"save"`, `"assets"`, `"config"`).
+#[derive(Clone, Debug)]
 pub struct NamespaceRoots {
     pub save: PathBuf,
     pub assets: PathBuf,
@@ -245,6 +246,13 @@ impl NamespaceRoots {
     /// If a platform directory lookup fails (e.g. no HOME) or
     /// `current_exe()` can't resolve, the fallback is `temp_dir()/aether/...`
     /// so a boot always finishes even on headless CI.
+    ///
+    /// Per issue 464, this is the chassis-main edge — substrate-core
+    /// itself never reads env. The builder
+    /// (`SubstrateBootBuilder::namespace_roots`) accepts a resolved
+    /// `NamespaceRoots` directly so tests and chassis-as-library
+    /// embedders can supply their own roots without process-env
+    /// mutation.
     pub fn from_env() -> Self {
         let save = env_or_default("AETHER_SAVE_DIR", || {
             dirs::data_dir()
@@ -280,13 +288,19 @@ fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
 }
 
 /// Populate a fresh `AdapterRegistry` with `LocalFileAdapter`s for
-/// each of the three ADR-0041 namespaces. `save` and `config` are
-/// writable; `assets` is read-only. Returns the populated registry
-/// along with the resolved roots so the chassis can log what it
-/// actually wired. Propagates any `create_dir_all` / `canonicalize`
-/// failure verbatim so the chassis can decide whether to fail boot.
-pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
-    let roots = NamespaceRoots::from_env();
+/// each of the three ADR-0041 namespaces using the supplied
+/// [`NamespaceRoots`]. `save` and `config` are writable; `assets` is
+/// read-only. Returns the populated registry along with the roots
+/// echoed back (cloned) so the chassis can log what it actually
+/// wired. Propagates any `create_dir_all` / `canonicalize` failure
+/// verbatim so the chassis can decide whether to fail boot.
+///
+/// Per issue 464, this is the explicit-config entry point — chassis
+/// mains read env into a `NamespaceRoots` and pass it here. Tests
+/// pass their own tempdir-backed roots directly.
+pub fn build_registry(
+    roots: NamespaceRoots,
+) -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
     let mut registry = AdapterRegistry::new();
     let save = Arc::new(LocalFileAdapter::new(roots.save.clone(), true)?);
     let assets = Arc::new(LocalFileAdapter::new(roots.assets.clone(), false)?);
@@ -295,6 +309,16 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
     registry.register("assets", assets as Arc<dyn FileAdapter>);
     registry.register("config", config as Arc<dyn FileAdapter>);
     Ok((Arc::new(registry), roots))
+}
+
+/// Env-driven wrapper around [`build_registry`]. Resolves
+/// [`NamespaceRoots::from_env`] then delegates. Kept for callers
+/// that don't need to thread roots through their own config.
+///
+/// Chassis mains should prefer reading env once into `NamespaceRoots`
+/// and calling `build_registry` directly (issue 464).
+pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
+    build_registry(NamespaceRoots::from_env())
 }
 
 /// Build the `"aether.sink.io"` sink handler. The chassis calls this
@@ -742,7 +766,7 @@ mod tests {
     use crate::hub_client::HubOutbound;
     use aether_hub_protocol::{EngineToHub, SessionToken, Uuid};
 
-    fn build_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
+    fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
         let adapter: Arc<dyn FileAdapter> =
             Arc::new(LocalFileAdapter::new(root.to_path_buf(), writable).unwrap());
         let mut r = AdapterRegistry::new();
@@ -789,7 +813,7 @@ mod tests {
     #[test]
     fn dispatch_read_ok_replies_with_bytes() {
         let root = scratch_root("dispatch-read");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save")
             .unwrap()
@@ -827,7 +851,7 @@ mod tests {
     #[test]
     fn dispatch_read_unknown_namespace_replies_err() {
         let root = scratch_root("dispatch-ns");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
@@ -863,7 +887,7 @@ mod tests {
     #[test]
     fn dispatch_read_not_found_replies_err() {
         let root = scratch_root("dispatch-nf");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
@@ -892,7 +916,7 @@ mod tests {
     #[test]
     fn dispatch_write_ok_persists_bytes() {
         let root = scratch_root("dispatch-write");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Write {
@@ -926,7 +950,7 @@ mod tests {
     #[test]
     fn dispatch_write_read_only_namespace_replies_forbidden() {
         let root = scratch_root("dispatch-ro");
-        let reg = build_registry(&root, false);
+        let reg = build_save_only_registry(&root, false);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Write {
@@ -956,7 +980,7 @@ mod tests {
     #[test]
     fn dispatch_delete_then_read_surfaces_not_found() {
         let root = scratch_root("dispatch-del");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("x.bin", b"x").unwrap();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
@@ -990,7 +1014,7 @@ mod tests {
     #[test]
     fn dispatch_list_returns_sorted_entries() {
         let root = scratch_root("dispatch-list");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("b.bin", b"").unwrap();
         reg.get("save").unwrap().write("a.bin", b"").unwrap();
@@ -1029,7 +1053,7 @@ mod tests {
         // not panic, and must not produce a reply (nothing for the
         // sender to be waiting on).
         let root = scratch_root("dispatch-unknown");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         handler(
@@ -1084,7 +1108,7 @@ mod tests {
         "#;
 
         let root = scratch_root("dispatch-component-reply");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         reg.get("save")
             .unwrap()
             .write("slot.bin", &[1, 2, 3])
@@ -1169,7 +1193,7 @@ mod tests {
         // parsed request to pull them from — loud signal that the
         // request itself was malformed.
         let root = scratch_root("dispatch-mal");
-        let reg = build_registry(&root, true);
+        let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         handler(

--- a/crates/aether-substrate-core/src/net.rs
+++ b/crates/aether-substrate-core/src/net.rs
@@ -238,56 +238,117 @@ fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
     }
 }
 
-/// Build the default adapter from environment variables per
-/// ADR-0043 §5/§8. `AETHER_NET_DISABLE=1` short-circuits to a
-/// `DisabledNetAdapter`; otherwise reads the allowlist, body cap,
-/// and https flag and returns a `UreqNetAdapter`.
+/// Resolved configuration for the substrate's net adapter. Chassis
+/// mains read env vars (`AETHER_NET_DISABLE`, `AETHER_NET_ALLOWLIST`,
+/// `AETHER_NET_REQUIRE_HTTPS`, `AETHER_NET_MAX_BODY_BYTES`,
+/// `AETHER_NET_TIMEOUT_MS`) into a `NetConfig` and pass it to
+/// [`build_net_adapter`] / [`net_sink_handler`]. Tests build a
+/// `NetConfig` directly, never touching process env (issue 464).
+#[derive(Clone, Debug)]
+pub struct NetConfig {
+    /// `AETHER_NET_DISABLE=1` swaps the `UreqNetAdapter` for a
+    /// `DisabledNetAdapter` that replies `NetError::Disabled` to
+    /// every fetch.
+    pub disabled: bool,
+    /// Hostnames the adapter will dial. Empty = deny all
+    /// (deny-by-default per ADR-0043).
+    pub allowlist: HashSet<String>,
+    /// `AETHER_NET_REQUIRE_HTTPS=1` rejects `http://` URLs with
+    /// `NetError::InvalidUrl`.
+    pub require_https: bool,
+    /// Cap on inbound and outbound body bytes. Defaults to
+    /// [`DEFAULT_MAX_BODY_BYTES`] (16 MB).
+    pub max_body_bytes: usize,
+    /// Default per-request timeout when `Fetch.timeout_ms` is
+    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MS`] (30 s).
+    pub default_timeout: Duration,
+}
+
+impl Default for NetConfig {
+    /// Conservative default: enabled, empty allowlist (deny all),
+    /// no require-https, default body cap and timeout. Tests that
+    /// want a closed adapter typically construct
+    /// `NetConfig { disabled: true, ..Default::default() }`.
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            allowlist: HashSet::new(),
+            require_https: false,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            default_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        }
+    }
+}
+
+impl NetConfig {
+    /// Resolve every field from the corresponding `AETHER_NET_*`
+    /// environment variable. Used by `build_default_adapter` and by
+    /// chassis mains; tests build `NetConfig` directly so they
+    /// never read process env.
+    pub fn from_env() -> Self {
+        Self {
+            disabled: disable_flag_env(),
+            allowlist: parse_allowlist_env(),
+            require_https: https_flag_env(),
+            max_body_bytes: parse_max_body_bytes_env(),
+            default_timeout: parse_default_timeout_env(),
+        }
+    }
+}
+
+/// Build a net adapter from explicit configuration. `disabled`
+/// short-circuits to a `DisabledNetAdapter`; otherwise constructs a
+/// `UreqNetAdapter` with the supplied allowlist / https-flag /
+/// body-cap. Per issue 464, this is the explicit-config entry point.
+pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
+    if config.disabled {
+        tracing::info!(
+            target: "aether_substrate::net",
+            "net adapter disabled — every fetch replies Disabled",
+        );
+        return Arc::new(DisabledNetAdapter);
+    }
+
+    tracing::info!(
+        target: "aether_substrate::net",
+        allowlist_size = config.allowlist.len(),
+        require_https = config.require_https,
+        max_body_bytes = config.max_body_bytes,
+        "net adapter configured",
+    );
+
+    Arc::new(UreqNetAdapter::new(
+        config.allowlist,
+        config.require_https,
+        config.max_body_bytes,
+    ))
+}
+
+/// Env-driven wrapper around [`build_net_adapter`]. Resolves
+/// [`NetConfig::from_env`] then delegates. Kept for callers that
+/// don't need to thread config through their own struct.
 ///
 /// Deny-by-default: unset or empty `AETHER_NET_ALLOWLIST` means the
 /// allowlist is empty, and every fetch replies `AllowlistDenied`.
 /// Set the var to a comma-separated list of hostnames to allow
 /// those hosts.
 pub fn build_default_adapter() -> Arc<dyn NetAdapter> {
-    if disable_flag() {
-        tracing::info!(
-            target: "aether_substrate::net",
-            "AETHER_NET_DISABLE=1 — net sink replies Disabled for every fetch",
-        );
-        return Arc::new(DisabledNetAdapter);
-    }
-
-    let allowlist = parse_allowlist();
-    let require_https = https_flag();
-    let max_body_bytes = parse_max_body_bytes();
-
-    tracing::info!(
-        target: "aether_substrate::net",
-        allowlist_size = allowlist.len(),
-        require_https,
-        max_body_bytes,
-        "net adapter configured",
-    );
-
-    Arc::new(UreqNetAdapter::new(
-        allowlist,
-        require_https,
-        max_body_bytes,
-    ))
+    build_net_adapter(NetConfig::from_env())
 }
 
-fn disable_flag() -> bool {
+fn disable_flag_env() -> bool {
     std::env::var("AETHER_NET_DISABLE")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
 }
 
-fn https_flag() -> bool {
+fn https_flag_env() -> bool {
     std::env::var("AETHER_NET_REQUIRE_HTTPS")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
 }
 
-fn parse_allowlist() -> HashSet<String> {
+fn parse_allowlist_env() -> HashSet<String> {
     std::env::var("AETHER_NET_ALLOWLIST")
         .ok()
         .map(|s| {
@@ -300,14 +361,14 @@ fn parse_allowlist() -> HashSet<String> {
         .unwrap_or_default()
 }
 
-fn parse_max_body_bytes() -> usize {
+fn parse_max_body_bytes_env() -> usize {
     std::env::var("AETHER_NET_MAX_BODY_BYTES")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(DEFAULT_MAX_BODY_BYTES)
 }
 
-fn parse_default_timeout() -> Duration {
+fn parse_default_timeout_env() -> Duration {
     let ms = std::env::var("AETHER_NET_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
@@ -316,7 +377,7 @@ fn parse_default_timeout() -> Duration {
 }
 
 /// Build the `"aether.sink.net"` sink handler. The chassis calls this
-/// at boot after `build_default_adapter` and passes the result to
+/// at boot after `build_net_adapter` and passes the result to
 /// `registry.register_sink("aether.sink.net", handler)`. The returned closure
 /// decodes incoming `Fetch` mail, hands it to the adapter, and
 /// replies with the paired `FetchResult` via `mailer.send_reply`.
@@ -325,11 +386,19 @@ fn parse_default_timeout() -> Duration {
 /// mailbox / local-component replies all funnel through one path —
 /// identical to the io sink.
 ///
+/// `default_timeout` is the fallback applied when an incoming
+/// `Fetch` has `timeout_ms: None`. Chassis mains source it from
+/// [`NetConfig::default_timeout`]; in practice the same `NetConfig`
+/// fed to `build_net_adapter` flows here.
+///
 /// Fetches run synchronously on the sink dispatch thread — ADR-0043
 /// §2 flags this as the head-of-line blocking source to fix via a
 /// multi-threaded dispatcher ADR.
-pub fn net_sink_handler(adapter: Arc<dyn NetAdapter>, mailer: Arc<Mailer>) -> SinkHandler {
-    let default_timeout = parse_default_timeout();
+pub fn net_sink_handler(
+    adapter: Arc<dyn NetAdapter>,
+    mailer: Arc<Mailer>,
+    default_timeout: Duration,
+) -> SinkHandler {
     Arc::new(
         move |kind: KindId,
               _kind_name: &str,
@@ -483,7 +552,11 @@ mod tests {
     fn disabled_adapter_replies_disabled() {
         let adapter: Arc<dyn NetAdapter> = Arc::new(DisabledNetAdapter);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(Arc::clone(&adapter), Arc::clone(&mailer));
+        let handler = net_sink_handler(
+            Arc::clone(&adapter),
+            Arc::clone(&mailer),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -593,7 +666,11 @@ mod tests {
             body: b"{}".to_vec(),
         })) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(Arc::clone(&adapter), Arc::clone(&mailer));
+        let handler = net_sink_handler(
+            Arc::clone(&adapter),
+            Arc::clone(&mailer),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/v1".to_string(),
             method: HttpMethod::Get,
@@ -630,7 +707,11 @@ mod tests {
     fn dispatch_fetch_err_echoes_url_and_error() {
         let adapter = StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(Arc::clone(&adapter), Arc::clone(&mailer));
+        let handler = net_sink_handler(
+            Arc::clone(&adapter),
+            Arc::clone(&mailer),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://slow.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -664,7 +745,11 @@ mod tests {
             body: vec![],
         })) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(Arc::clone(&adapter), Arc::clone(&mailer));
+        let handler = net_sink_handler(
+            Arc::clone(&adapter),
+            Arc::clone(&mailer),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        );
         handler(
             KindId(<Fetch as Kind>::ID),
             Fetch::NAME,
@@ -688,7 +773,11 @@ mod tests {
     fn dispatch_unknown_kind_does_not_reply() {
         let adapter = StubAdapter::with(Err(NetError::Disabled)) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(Arc::clone(&adapter), Arc::clone(&mailer));
+        let handler = net_sink_handler(
+            Arc::clone(&adapter),
+            Arc::clone(&mailer),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
+        );
         handler(
             KindId(0xdead_beef),
             "some.other",
@@ -702,11 +791,12 @@ mod tests {
 
     #[test]
     fn dispatch_fetch_uses_default_timeout_when_none_provided() {
-        // StubAdapter captures the request; we just need to confirm
-        // the dispatcher picks a reasonable default when
-        // `timeout_ms: None` arrives on the wire. Default path
-        // resolves to `parse_default_timeout()` which honours
-        // `AETHER_NET_TIMEOUT_MS` at closure construction time.
+        // The dispatcher should fall back to the default timeout
+        // baked into the handler closure when an incoming `Fetch`
+        // arrives with `timeout_ms: None`. Per issue 464, that
+        // default is now an explicit handler argument; this test
+        // builds it from `NetConfig::default` so no env read is
+        // involved.
         let adapter_stub = StubAdapter::with(Ok(FetchResponse {
             status: 200,
             headers: vec![],
@@ -714,7 +804,7 @@ mod tests {
         }));
         let adapter: Arc<dyn NetAdapter> = Arc::clone(&adapter_stub) as Arc<dyn NetAdapter>;
         let (mailer, _rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(adapter, mailer);
+        let handler = net_sink_handler(adapter, mailer, NetConfig::default().default_timeout);
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -737,22 +827,22 @@ mod tests {
             .unwrap()
             .take()
             .expect("adapter was not called");
-        // Default is 30s unless AETHER_NET_TIMEOUT_MS was set; a
-        // nonzero timeout is enough to prove the closure handed a
-        // default through, without coupling the test to the exact
-        // env state.
+        // Default is 30s; a nonzero timeout is enough to prove the
+        // closure handed the default through, without pinning to
+        // the exact value.
         assert!(observed.timeout > Duration::ZERO);
     }
 
     #[test]
-    fn build_default_adapter_with_disable_returns_disabled() {
-        // Set the env var only for this test; clear after. Running
-        // single-threaded is the safe path (cargo test --test-threads=1)
-        // but we scope the mutation tightly regardless.
-        // SAFETY: std::env::set_var in Rust 2024 is `unsafe` because
-        // of POSIX getenv thread-safety.
-        unsafe { std::env::set_var("AETHER_NET_DISABLE", "1") };
-        let a = build_default_adapter();
+    fn build_net_adapter_with_disable_returns_disabled() {
+        // Per issue 464, env mutation is the chassis main's concern.
+        // Tests build a `NetConfig` directly so this path stays env-
+        // free and thread-safe under cargo's default parallel runner.
+        let cfg = NetConfig {
+            disabled: true,
+            ..NetConfig::default()
+        };
+        let a = build_net_adapter(cfg);
         let resp = a.fetch(FetchRequest {
             url: "https://example.com/".to_string(),
             method: HttpMethod::Get,
@@ -760,7 +850,6 @@ mod tests {
             body: vec![],
             timeout: Duration::from_secs(30),
         });
-        unsafe { std::env::remove_var("AETHER_NET_DISABLE") };
         assert!(matches!(resp, Err(NetError::Disabled)));
     }
 }

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -999,6 +999,14 @@ fn main() -> wasmtime::Result<()> {
     event_loop.set_control_flow(ControlFlow::Poll);
     let capture_queue = CaptureQueue::new();
 
+    // Per issue 464, this `main()` is the env-reading edge. Read every
+    // chassis-relevant env var into a config struct and thread it
+    // through the substrate-core APIs explicitly. Substrate-core
+    // itself never reads env from now on.
+    let hub_url = std::env::var("AETHER_HUB_URL").ok();
+    let net_config = aether_substrate_core::net::NetConfig::from_env();
+    let namespace_roots = aether_substrate_core::io::NamespaceRoots::from_env();
+
     // Shared runtime bring-up: log capture, registry + kind descriptors,
     // broadcast sink, scheduler, control plane, optional hub connect.
     // The chassis handler closure is invoked during build() once
@@ -1006,6 +1014,7 @@ fn main() -> wasmtime::Result<()> {
     // plane is wired, so it can `Arc::clone` what it needs to own.
     let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION"))
         .workers(WORKERS)
+        .namespace_roots(namespace_roots)
         .chassis_handler({
             let proxy = event_loop.create_proxy();
             let capture_queue = capture_queue.clone();
@@ -1114,14 +1123,15 @@ fn main() -> wasmtime::Result<()> {
     boot.registry
         .register_sink("aether.sink.camera", camera_handler);
 
-    // `aether.io.*`: ADR-0041 substrate file I/O. Build the default
-    // adapter registry (save/assets/config roots from env vars or
-    // dirs-crate defaults) and wire the `"aether.sink.io"` sink. If the
-    // boot-time filesystem setup fails (usually a perms issue on one of
-    // the root directories), log loud and skip the sink — components
+    // `aether.io.*`: ADR-0041 substrate file I/O. Wire the
+    // `"aether.sink.io"` sink against the namespace roots resolved at
+    // boot (`boot.namespace_roots` — supplied via the builder
+    // override or `NamespaceRoots::from_env`, per issue 464). If the
+    // boot-time filesystem setup fails (usually a perms issue on one
+    // of the root directories), log loud and skip the sink — components
     // mailing `aether.sink.io` then warn-drop as "unknown mailbox" so
     // failure is visible rather than silent.
-    match aether_substrate_desktop::io::build_default_registry() {
+    match aether_substrate_desktop::io::build_registry(boot.namespace_roots.clone()) {
         Ok((registry, roots)) => {
             tracing::info!(
                 target: "aether_substrate::io",
@@ -1150,10 +1160,15 @@ fn main() -> wasmtime::Result<()> {
     // circuits to a nop adapter that replies `Disabled`. The sink
     // always registers so mail isn't silently bubble-dropped — the
     // adapter carries the gating.
-    let net_adapter = aether_substrate_core::net::build_default_adapter();
+    let net_default_timeout = net_config.default_timeout;
+    let net_adapter = aether_substrate_core::net::build_net_adapter(net_config);
     boot.registry.register_sink(
         "aether.sink.net",
-        aether_substrate_core::net::net_sink_handler(net_adapter, Arc::clone(&boot.queue)),
+        aether_substrate_core::net::net_sink_handler(
+            net_adapter,
+            Arc::clone(&boot.queue),
+            net_default_timeout,
+        ),
     );
 
     // `aether.sink.log`: ADR-0060 guest-side logging. Decode `LogEvent`
@@ -1198,8 +1213,9 @@ fn main() -> wasmtime::Result<()> {
     // Before this returns no hub-driven `load_component` can race
     // ahead of the chassis's setup and bind a chassis sink name to a
     // component (issue #262). Must happen before moving fields out of
-    // `boot` into `App` below — connect_hub_from_env borrows `&boot`.
-    let hub = boot.connect_hub_from_env()?;
+    // `boot` into `App` below — connect_hub borrows `&boot`. Per
+    // issue 464, `hub_url` was read from env at the top of `main`.
+    let hub = boot.connect_hub(hub_url.as_deref())?;
 
     let app = App {
         queue: boot.queue,

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -126,8 +126,17 @@ fn parse_tick_hz_env() -> u32 {
 }
 
 fn main() -> wasmtime::Result<()> {
+    // Per issue 464, this `main()` is the env-reading edge. Read every
+    // chassis-relevant env var into a config struct and thread it
+    // through the substrate-core APIs explicitly. Substrate-core
+    // itself never reads env from now on.
+    let hub_url = std::env::var("AETHER_HUB_URL").ok();
+    let net_config = aether_substrate_core::net::NetConfig::from_env();
+    let namespace_roots = aether_substrate_core::io::NamespaceRoots::from_env();
+
     let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
         .workers(WORKERS)
+        .namespace_roots(namespace_roots)
         .chassis_handler(|ctx| Some(chassis::chassis_control_handler(Arc::clone(ctx.outbound))))
         .build()?;
 
@@ -201,10 +210,12 @@ fn main() -> wasmtime::Result<()> {
 
     // `aether.io.*` per ADR-0041. Headless gets the same sink as
     // desktop — the io path is purely I/O, no GPU or window surface,
-    // so there's nothing chassis-specific to diverge on. Boot-time
-    // filesystem failure logs loud and skips the sink (same policy
-    // as desktop) rather than failing the whole chassis.
-    match aether_substrate_core::io::build_default_registry() {
+    // so there's nothing chassis-specific to diverge on. The
+    // namespace roots come from `boot.namespace_roots` (built from
+    // env at the top of `main`, per issue 464). Boot-time filesystem
+    // failure logs loud and skips the sink (same policy as desktop)
+    // rather than failing the whole chassis.
+    match aether_substrate_core::io::build_registry(boot.namespace_roots.clone()) {
         Ok((registry, roots)) => {
             tracing::info!(
                 target: "aether_substrate::io",
@@ -231,11 +242,17 @@ fn main() -> wasmtime::Result<()> {
     // runs the asset pipeline, so net is first-class here — same
     // shape as desktop. Deny-by-default via `AETHER_NET_ALLOWLIST`;
     // `AETHER_NET_DISABLE=1` swaps to a nop adapter that replies
-    // `Disabled`.
-    let net_adapter = aether_substrate_core::net::build_default_adapter();
+    // `Disabled`. The `NetConfig` was built from env at the top of
+    // `main` (issue 464).
+    let net_default_timeout = net_config.default_timeout;
+    let net_adapter = aether_substrate_core::net::build_net_adapter(net_config);
     boot.registry.register_sink(
         "aether.sink.net",
-        aether_substrate_core::net::net_sink_handler(net_adapter, Arc::clone(&boot.queue)),
+        aether_substrate_core::net::net_sink_handler(
+            net_adapter,
+            Arc::clone(&boot.queue),
+            net_default_timeout,
+        ),
     );
 
     // `aether.sink.log`: ADR-0060. Same handler as desktop — guest
@@ -256,8 +273,9 @@ fn main() -> wasmtime::Result<()> {
     // Before this returns no hub-driven `load_component` can race
     // ahead of the chassis setup and bind a chassis sink name to a
     // component (issue #262). Must happen before moving fields out of
-    // `boot` below — connect_hub_from_env borrows `&boot`.
-    let hub = boot.connect_hub_from_env()?;
+    // `boot` below — connect_hub borrows `&boot`. Per issue 464,
+    // `hub_url` was read from env at the top of `main`.
+    let hub = boot.connect_hub(hub_url.as_deref())?;
 
     let chassis = HeadlessChassis {
         queue: boot.queue,

--- a/crates/aether-substrate-test-bench/src/lib.rs
+++ b/crates/aether-substrate-test-bench/src/lib.rs
@@ -17,7 +17,7 @@ pub mod events;
 pub mod render;
 mod test_bench;
 
-pub use test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH, TestBench, TestBenchError};
+pub use test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH, TestBench, TestBenchBuilder, TestBenchError};
 
 pub use aether_substrate_core::{
     AETHER_CONTROL, Chassis, ChassisCapabilities, ChassisControlHandler, Component, ControlPlane,

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -201,8 +201,15 @@ fn main() -> wasmtime::Result<()> {
     let capture_queue = CaptureQueue::new();
     let (events_tx, events_rx) = events::channel();
 
+    // Per issue 464, this `main()` is the env-reading edge. Read
+    // `AETHER_HUB_URL` and the namespace roots once and thread them
+    // through substrate-core's APIs explicitly.
+    let hub_url = std::env::var("AETHER_HUB_URL").ok();
+    let namespace_roots = aether_substrate_core::io::NamespaceRoots::from_env();
+
     let boot = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
         .workers(WORKERS)
+        .namespace_roots(namespace_roots)
         .chassis_handler({
             let cq = capture_queue.clone();
             let tx = events_tx.clone();
@@ -247,10 +254,12 @@ fn main() -> wasmtime::Result<()> {
         .register_sink("aether.sink.camera", camera_handler);
 
     // `aether.sink.io` per ADR-0041. Test-bench gets the same sink
-    // as desktop / headless — the io path is purely I/O. Boot-time
-    // filesystem failure logs loud and skips the sink (same policy
-    // as the other chassis) rather than failing the whole chassis.
-    match aether_substrate_core::io::build_default_registry() {
+    // as desktop / headless — the io path is purely I/O. The
+    // namespace roots come from `boot.namespace_roots` (built from
+    // env at the top of `main`, per issue 464). Boot-time filesystem
+    // failure logs loud and skips the sink (same policy as the other
+    // chassis) rather than failing the whole chassis.
+    match aether_substrate_core::io::build_registry(boot.namespace_roots.clone()) {
         Ok((registry, roots)) => {
             tracing::info!(
                 target: "aether_substrate::io",
@@ -296,7 +305,7 @@ fn main() -> wasmtime::Result<()> {
         "test-bench componentless boot — drive ticks via aether.test_bench.advance",
     );
 
-    let hub = boot.connect_hub_from_env()?;
+    let hub = boot.connect_hub(hub_url.as_deref())?;
 
     // The chassis owns its receiver; the chassis-control handler
     // already holds a clone of the sender (captured into the boot

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -35,6 +35,7 @@ use aether_substrate_core::{
     HubOutbound, InputSubscribers, Mailer, ReplyTarget, ReplyTo, SubstrateBoot,
     capture::CaptureQueue,
     frame_loop,
+    io::NamespaceRoots,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
@@ -156,7 +157,67 @@ pub struct TestBench {
 /// so the boot path is reproducible and the value shows up in logs.
 const TESTBENCH_SESSION_UUID: u128 = 0x7E57_BE7C_C0FF_EE15_AE7E_7BE7_5E55_1077;
 
+/// Builder for [`TestBench`]. Holds the optional config a test wants
+/// to override (offscreen target size, ADR-0041 namespace roots).
+/// Tests that want full default behaviour skip the builder and call
+/// [`TestBench::start`] / [`TestBench::start_with_size`] directly.
+///
+/// Per issue 464, the `namespace_roots` override lets a test redirect
+/// `save://` / `assets://` / `config://` at a tempdir without touching
+/// process env. Pair with `tempfile::TempDir` to scope the redirect to
+/// a single test.
+pub struct TestBenchBuilder {
+    width: u32,
+    height: u32,
+    namespace_roots: Option<NamespaceRoots>,
+}
+
+impl Default for TestBenchBuilder {
+    fn default() -> Self {
+        Self {
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            namespace_roots: None,
+        }
+    }
+}
+
+impl TestBenchBuilder {
+    /// Set the offscreen target size. Width / height are clamped to a
+    /// minimum of 1 inside `Gpu::new`.
+    pub fn size(mut self, width: u32, height: u32) -> Self {
+        self.width = width;
+        self.height = height;
+        self
+    }
+
+    /// Override the ADR-0041 namespace roots. Forwarded to
+    /// `SubstrateBootBuilder::namespace_roots` at boot, so the
+    /// `aether.sink.io` adapter wired by the bench resolves
+    /// `save://` / `assets://` / `config://` against these paths
+    /// instead of [`NamespaceRoots::from_env`].
+    pub fn namespace_roots(mut self, roots: NamespaceRoots) -> Self {
+        self.namespace_roots = Some(roots);
+        self
+    }
+
+    /// Boot the bench. Equivalent to `TestBench::start_with_size` for
+    /// the default builder; overrides applied via the builder methods
+    /// flow through to `SubstrateBoot::builder` and the chassis-side
+    /// IO sink wiring.
+    pub fn build(self) -> Result<TestBench, TestBenchError> {
+        TestBench::start_inner(self.width, self.height, self.namespace_roots)
+    }
+}
+
 impl TestBench {
+    /// Begin a `TestBench` boot. Default size 800x600, no
+    /// `NamespaceRoots` override — chained methods on the returned
+    /// builder set those.
+    pub fn builder() -> TestBenchBuilder {
+        TestBenchBuilder::default()
+    }
+
     /// Boot a TestBench at the default 800x600 offscreen size.
     pub fn start() -> Result<Self, TestBenchError> {
         Self::start_with_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
@@ -165,10 +226,18 @@ impl TestBench {
     /// Boot a TestBench with a specific offscreen target size.
     /// Width / height are clamped to a minimum of 1 inside `Gpu::new`.
     pub fn start_with_size(width: u32, height: u32) -> Result<Self, TestBenchError> {
+        Self::start_inner(width, height, None)
+    }
+
+    fn start_inner(
+        width: u32,
+        height: u32,
+        namespace_roots: Option<NamespaceRoots>,
+    ) -> Result<Self, TestBenchError> {
         let capture_queue = CaptureQueue::new();
         let (events_tx, events_rx) = event_channel();
 
-        let boot = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
+        let mut builder = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
             .workers(WORKERS)
             .chassis_handler({
                 let cq = capture_queue.clone();
@@ -182,7 +251,11 @@ impl TestBench {
                         Arc::clone(ctx.outbound),
                     ))
                 }
-            })
+            });
+        if let Some(roots) = namespace_roots {
+            builder = builder.namespace_roots(roots);
+        }
+        let boot = builder
             .build()
             .map_err(|e| TestBenchError::Boot(e.to_string()))?;
 
@@ -206,7 +279,14 @@ impl TestBench {
         let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
         register_camera_sink(&boot, &camera_state, &observed_kinds);
 
-        if let Ok((reg, _roots)) = aether_substrate_core::io::build_default_registry() {
+        // Build the IO adapter registry against the boot's namespace
+        // roots — either the override the caller supplied via
+        // `TestBench::builder().namespace_roots(...)` or the env-
+        // derived defaults. Per issue 464, this path no longer reads
+        // env directly.
+        if let Ok((reg, _roots)) =
+            aether_substrate_core::io::build_registry(boot.namespace_roots.clone())
+        {
             boot.registry.register_sink(
                 "aether.sink.io",
                 aether_substrate_core::io::io_sink_handler(reg, Arc::clone(&boot.queue)),

--- a/crates/aether-substrate-test-bench/tests/scenario.rs
+++ b/crates/aether-substrate-test-bench/tests/scenario.rs
@@ -17,8 +17,10 @@
 //!   into hard panics so a missing pre-build is loud.
 //!
 //! All boot-time mechanics (wgpu probe, wasm locator, skip-or-panic
-//! gate, `AETHER_SAVE_DIR` sandbox) live in
-//! `aether_scenario::test_helpers` (issue 460).
+//! gate, `save://` sandbox) live in `aether_scenario::test_helpers`
+//! (issue 460). Per issue 464, the sandbox flows in via
+//! `TestBench::builder().namespace_roots(...)` rather than env-var
+//! mutation.
 
 use std::path::Path;
 
@@ -27,7 +29,9 @@ use aether_kinds::{
     Read, ReadResult, ReplaceComponent, Write, WriteResult,
 };
 use aether_mail::{Kind, MailboxId, mailbox_id_from_name};
-use aether_scenario::test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime};
+use aether_scenario::test_helpers::{
+    has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots,
+};
 use aether_scenario::{decode_png, differs_from_background};
 use aether_substrate_test_bench::TestBench;
 use aether_test_fixture_probe::SetRender;
@@ -293,8 +297,12 @@ fn io_write_then_read_round_trips_in_save_namespace() {
     if !require_wgpu_only() {
         return;
     }
-    init_save_sandbox("test-bench-io");
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let sandbox = init_save_sandbox("test-bench-io");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
 
     let path = "io-roundtrip.bin".to_owned();
     let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
@@ -351,8 +359,12 @@ fn io_delete_removes_written_file() {
     if !require_wgpu_only() {
         return;
     }
-    init_save_sandbox("test-bench-io");
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let sandbox = init_save_sandbox("test-bench-io");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
 
     let path = "io-delete.bin".to_owned();
     let _: WriteResult = bench
@@ -407,8 +419,12 @@ fn io_list_returns_written_path() {
     if !require_wgpu_only() {
         return;
     }
-    init_save_sandbox("test-bench-io");
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let sandbox = init_save_sandbox("test-bench-io");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
 
     let path = "probe-list.bin".to_owned();
     let _: WriteResult = bench
@@ -449,8 +465,12 @@ fn io_read_unknown_path_returns_not_found() {
     if !require_wgpu_only() {
         return;
     }
-    init_save_sandbox("test-bench-io");
-    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let sandbox = init_save_sandbox("test-bench-io");
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
 
     let read_reply: ReadResult = bench
         .send_and_await_reply(


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #NNN is the required GitHub auto-close keyword per the issue prompt -->

## Summary

- Substrate-core no longer reads `AETHER_HUB_URL`, `AETHER_NET_*`, or `AETHER_SAVE_DIR` / `AETHER_ASSETS_DIR` / `AETHER_CONFIG_DIR` itself; chassis `main()` is the single env-reading edge.
- New explicit-config entry points: `SubstrateBoot::connect_hub(Option<&str>)`, `SubstrateBootBuilder::namespace_roots(roots)`, `io::build_registry(roots)`, `NetConfig` + `build_net_adapter(config)`. The env-driven helpers (`connect_hub_from_env`, `build_default_registry`, `build_default_adapter`, `NetConfig::from_env`) are kept as thin wrappers.
- All four `unsafe { std::env::set_var(...) }` sites removed (boot test, net test, two scenario test files via the new `TestBench::builder().namespace_roots(...)` form + `test_helpers::test_namespace_roots(path)` helper).

## Judgment calls

- `NamespaceRoots` stays in `aether-substrate-core::io`; the builder stores an optional override and exposes the resolved roots on `SubstrateBoot.namespace_roots`. Chassis mains call `io::build_registry(boot.namespace_roots.clone())`. The override doesn't itself wire the IO sink, matching the existing chassis-side wiring shape.
- `TestBench::builder()` is the new path-explicit form. `start()` / `start_with_size()` keep their existing default-from-env behaviour for callers that don't need an override.
- `init_save_sandbox` now just creates the dir and returns its path; the new `test_namespace_roots(path)` helper builds a `NamespaceRoots` from it. The `OnceLock` stays so `write_fixture` can still resolve the sandbox by label.
- Hub chassis (`aether-substrate-hub`) reads no chassis env vars and was left untouched per "out of scope" in the issue body.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] `grep -rn 'std::env::set_var\|std::env::remove_var\|unsafe { std::env::' crates/` returns zero hits
- [x] `cargo test -p aether-substrate-test-bench` (scenario tests now drive `TestBench::builder().namespace_roots(...)`)
- [x] `cargo test -p aether-mesh-viewer-component` (scenario tests run on the same builder path)

Closes #464