### PR TITLE
refactor(mail): type Kind::ID as KindId; introduce typed mailbox constants (issue 466)

### DIFF
--- a/crates/aether-component/src/handle.rs
+++ b/crates/aether-component/src/handle.rs
@@ -144,7 +144,9 @@ impl<K: Kind> Handle<K> {
     pub fn as_ref(&self) -> Ref<K> {
         Ref::Handle {
             id: self.id,
-            kind_id: K::ID,
+            // `Ref::Handle.kind_id` is wire-format `u64`; `Kind::ID`
+            // is typed `KindId` post-issue 466, so drop into `.0`.
+            kind_id: K::ID.0,
         }
     }
 }
@@ -171,7 +173,7 @@ impl<K> Drop for Handle<K> {
 pub fn publish<K: Kind + Serialize>(value: &K) -> Result<Handle<K>, SyncHandleError> {
     let bytes = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
     let req = HandlePublish {
-        kind_id: ::aether_mail::KindId(K::ID),
+        kind_id: K::ID,
         bytes,
     };
     resolve_sink::<HandlePublish>(HANDLE_SINK_NAME).send(&req);
@@ -243,7 +245,7 @@ where
     let mut buf: Vec<u8> = vec![0u8; capacity];
     let rc = unsafe {
         raw::wait_reply(
-            K::ID,
+            K::ID.0,
             buf.as_mut_ptr().addr() as u32,
             buf.len() as u32,
             timeout_ms,
@@ -317,7 +319,7 @@ mod tests {
         match handle.as_ref() {
             Ref::Handle { id, kind_id } => {
                 assert_eq!(id, 42);
-                assert_eq!(kind_id, Payload::ID);
+                assert_eq!(kind_id, Payload::ID.0);
             }
             Ref::Inline(_) => panic!("as_ref should produce Handle, not Inline"),
         }

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -231,7 +231,7 @@ where
     let mut buf: Vec<u8> = alloc::vec![0u8; capacity];
     let rc = unsafe {
         raw::wait_reply(
-            K::ID,
+            K::ID.0,
             buf.as_mut_ptr().addr() as u32,
             buf.len() as u32,
             timeout_ms,

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -245,7 +245,7 @@ pub const fn resolve<K: Kind>() -> KindId<K> {
 /// exist on the substrate side at init time.
 pub const fn resolve_sink<K: Kind>(mailbox_name: &str) -> Sink<K> {
     Sink {
-        mailbox: mailbox_id_from_name(mailbox_name),
+        mailbox: mailbox_id_from_name(mailbox_name).0,
         kind: K::ID.0,
         _k: PhantomData,
     }
@@ -1084,8 +1084,8 @@ mod tests {
     struct FakeKind;
     impl Kind for FakeKind {
         const NAME: &'static str = "test.fake";
-        const ID: ::aether_mail::KindId =
-            ::aether_mail::KindId(aether_mail::mailbox_id_from_name(Self::NAME));
+        // Stable test sentinel — distinct from real schema-hashed kind ids.
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(0xDEAD_BEEF_0001_0001);
     }
 
     #[test]
@@ -1145,8 +1145,8 @@ mod tests {
     }
     impl Kind for FakePod {
         const NAME: &'static str = "test.fake_pod";
-        const ID: ::aether_mail::KindId =
-            ::aether_mail::KindId(aether_mail::mailbox_id_from_name(Self::NAME));
+        // Stable test sentinel — distinct from real schema-hashed kind ids.
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(0xDEAD_BEEF_0001_0002);
     }
 
     #[test]

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -233,7 +233,7 @@ impl<K: Kind + bytemuck::NoUninit> Sink<K> {
 /// revision, and that surfaces as "kind not found" on the first mail.
 pub const fn resolve<K: Kind>() -> KindId<K> {
     KindId {
-        raw: K::ID,
+        raw: K::ID.0,
         _k: PhantomData,
     }
 }
@@ -246,7 +246,7 @@ pub const fn resolve<K: Kind>() -> KindId<K> {
 pub const fn resolve_sink<K: Kind>(mailbox_name: &str) -> Sink<K> {
     Sink {
         mailbox: mailbox_id_from_name(mailbox_name),
-        kind: K::ID,
+        kind: K::ID.0,
         _k: PhantomData,
     }
 }
@@ -366,7 +366,7 @@ impl InitCtx<'_> {
     pub fn subscribe_input<K: Kind + 'static>(&self) {
         use aether_kinds::SubscribeInput;
         let payload = SubscribeInput {
-            kind: ::aether_mail::KindId(<K as Kind>::ID),
+            kind: <K as Kind>::ID,
             mailbox: ::aether_mail::MailboxId(self.mailbox),
         };
         resolve_sink::<SubscribeInput>("aether.control").send(&payload);
@@ -596,7 +596,7 @@ impl DropCtx<'_> {
     where
         K: Kind + Schema + serde::Serialize,
     {
-        let mut out = alloc::vec::Vec::from(K::ID.to_le_bytes());
+        let mut out = alloc::vec::Vec::from(K::ID.0.to_le_bytes());
         let payload = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
         out.extend_from_slice(&payload);
         self.save_state(version, &out);
@@ -671,7 +671,7 @@ impl<'a> PriorState<'a> {
         let mut id_arr = [0u8; 8];
         id_arr.copy_from_slice(id_bytes);
         let id = u64::from_le_bytes(id_arr);
-        if id != K::ID {
+        if id != K::ID.0 {
             return None;
         }
         postcard::from_bytes(payload).ok()
@@ -810,7 +810,7 @@ impl<'a> Mail<'a> {
     /// how to handle a kind, or as a signal check when `K` is a
     /// zero-sized input marker like `Tick` / `MouseButton`.
     pub fn is<K: Kind>(&self) -> bool {
-        self.kind == K::ID
+        self.kind == K::ID.0
     }
 
     /// Type-driven sibling of `decode`: takes `K` as a type parameter
@@ -822,7 +822,7 @@ impl<'a> Mail<'a> {
     /// Copies rather than borrows so alignment of the underlying bytes
     /// doesn't matter — same semantics as `decode`.
     pub fn decode_typed<K: Kind + bytemuck::AnyBitPattern>(&self) -> Option<K> {
-        if self.kind != K::ID || self.count != 1 {
+        if self.kind != K::ID.0 || self.count != 1 {
             return None;
         }
         let byte_len = core::mem::size_of::<K>();
@@ -836,7 +836,7 @@ impl<'a> Mail<'a> {
     /// Type-driven sibling of `decode_slice`. Borrowed, alignment
     /// required (returns `None` if misaligned).
     pub fn decode_slice_typed<K: Kind + bytemuck::AnyBitPattern>(&self) -> Option<&'a [K]> {
-        if self.kind != K::ID {
+        if self.kind != K::ID.0 {
             return None;
         }
         let byte_len = core::mem::size_of::<K>() * self.count as usize;
@@ -866,7 +866,7 @@ impl<'a> Mail<'a> {
     /// didn't override, a cast-size mismatch, or a postcard decode
     /// error.
     pub fn decode_kind<K: Kind>(&self) -> Option<K> {
-        if self.kind != K::ID || self.count != 1 {
+        if self.kind != K::ID.0 || self.count != 1 {
             return None;
         }
         let bytes =
@@ -1084,7 +1084,8 @@ mod tests {
     struct FakeKind;
     impl Kind for FakeKind {
         const NAME: &'static str = "test.fake";
-        const ID: u64 = aether_mail::mailbox_id_from_name(Self::NAME);
+        const ID: ::aether_mail::KindId =
+            ::aether_mail::KindId(aether_mail::mailbox_id_from_name(Self::NAME));
     }
 
     #[test]
@@ -1144,7 +1145,8 @@ mod tests {
     }
     impl Kind for FakePod {
         const NAME: &'static str = "test.fake_pod";
-        const ID: u64 = aether_mail::mailbox_id_from_name(Self::NAME);
+        const ID: ::aether_mail::KindId =
+            ::aether_mail::KindId(aether_mail::mailbox_id_from_name(Self::NAME));
     }
 
     #[test]
@@ -1266,7 +1268,7 @@ mod tests {
 
     #[test]
     fn mail_is_typed_matches_kind_id() {
-        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID, 0, 0, 0, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr_test(FakeKind::ID.0, 0, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.is::<FakeKind>());
         assert!(!mail.is::<FakePod>());
     }
@@ -1277,7 +1279,7 @@ mod tests {
         let ptr_raw = (&value as *const FakePod).addr();
         let byte_len = core::mem::size_of::<FakePod>() as u32;
         let mail =
-            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr_test(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let out = mail.decode_typed::<FakePod>().unwrap();
         assert_eq!(out, value);
     }
@@ -1289,7 +1291,7 @@ mod tests {
         let byte_len = core::mem::size_of::<FakePod>() as u32;
         // Kind id deliberately mismatched (FakeKind instead of FakePod).
         let mail =
-            unsafe { Mail::__from_ptr_test(FakeKind::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr_test(FakeKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1299,7 +1301,7 @@ mod tests {
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
         let mail =
-            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr_test(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -1309,7 +1311,7 @@ mod tests {
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
         let mail =
-            unsafe { Mail::__from_ptr_test(FakePod::ID, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr_test(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let out = mail.decode_slice_typed::<FakePod>().unwrap();
         assert_eq!(out, &values);
     }
@@ -1342,7 +1344,7 @@ mod tests {
         let bytes = postcard::to_allocvec(&value).unwrap();
         let mail = unsafe {
             Mail::__from_ptr_test(
-                FakePostcard::ID,
+                FakePostcard::ID.0,
                 bytes.as_ptr().addr(),
                 bytes.len() as u32,
                 1,
@@ -1379,7 +1381,7 @@ mod tests {
         let ptr_raw = (&value as *const FakeCastKind).addr();
         let byte_len = core::mem::size_of::<FakeCastKind>() as u32;
         let mail = unsafe {
-            Mail::__from_ptr_test(FakeCastKind::ID, ptr_raw, byte_len, 1, NO_REPLY_HANDLE)
+            Mail::__from_ptr_test(FakeCastKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE)
         };
         let out = mail.decode_kind::<FakeCastKind>().expect("decode");
         assert_eq!(out, value);
@@ -1442,7 +1444,7 @@ mod tests {
         let bytes = postcard::to_allocvec(&value).unwrap();
         let mail = unsafe {
             Mail::__from_ptr_test(
-                FakeKind::ID,
+                FakeKind::ID.0,
                 bytes.as_ptr().addr(),
                 bytes.len() as u32,
                 1,
@@ -1461,7 +1463,7 @@ mod tests {
         let bytes = postcard::to_allocvec(&value).unwrap();
         let mail = unsafe {
             Mail::__from_ptr_test(
-                FakePostcard::ID,
+                FakePostcard::ID.0,
                 bytes.as_ptr().addr(),
                 bytes.len() as u32,
                 2,
@@ -1483,7 +1485,7 @@ mod tests {
         // and surfaces the parse error as `None`.
         let mail = unsafe {
             Mail::__from_ptr_test(
-                FakePostcard::ID,
+                FakePostcard::ID.0,
                 bytes.as_ptr().addr(),
                 2,
                 1,
@@ -1502,7 +1504,7 @@ mod tests {
         // is UB even when the length is zero.
         let buf: [u8; 1] = [0];
         let mail = unsafe {
-            Mail::__from_ptr_test(FakeKind::ID, buf.as_ptr().addr(), 0, 1, NO_REPLY_HANDLE)
+            Mail::__from_ptr_test(FakeKind::ID.0, buf.as_ptr().addr(), 0, 1, NO_REPLY_HANDLE)
         };
         assert!(mail.decode_kind::<FakeKind>().is_none());
     }
@@ -1517,7 +1519,7 @@ mod tests {
         let ptr_raw = (&value as *const FakePod).addr();
         let bogus_byte_len = (core::mem::size_of::<FakePod>() + 4) as u32;
         let mail = unsafe {
-            Mail::__from_ptr_test(FakePod::ID, ptr_raw, bogus_byte_len, 1, NO_REPLY_HANDLE)
+            Mail::__from_ptr_test(FakePod::ID.0, ptr_raw, bogus_byte_len, 1, NO_REPLY_HANDLE)
         };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
@@ -1552,7 +1554,7 @@ mod tests {
     }
 
     fn frame_bundle<K: Kind + Schema + Serialize>(value: &K) -> Vec<u8> {
-        let mut out = Vec::from(K::ID.to_le_bytes());
+        let mut out = Vec::from(K::ID.0.to_le_bytes());
         let payload = postcard::to_allocvec(value).unwrap();
         out.extend_from_slice(&payload);
         out
@@ -1612,7 +1614,7 @@ mod tests {
     fn as_kind_correct_id_garbage_payload_returns_none() {
         // Leading id matches but the postcard tail is truncated.
         // Decode error must surface as None, not a panic.
-        let mut buf = Vec::from(StateStruct::ID.to_le_bytes());
+        let mut buf = Vec::from(StateStruct::ID.0.to_le_bytes());
         buf.push(0xff);
         let prior = prior_from(&buf, 0);
         assert!(prior.as_kind::<StateStruct>().is_none());

--- a/crates/aether-component/src/net.rs
+++ b/crates/aether-component/src/net.rs
@@ -131,7 +131,7 @@ pub fn fetch_blocking(fetch: &Fetch, timeout_ms: u32) -> Result<FetchResponse, S
     let mut buf: Vec<u8> = alloc::vec![0u8; FETCH_REPLY_CAP];
     let rc = unsafe {
         raw::wait_reply(
-            <FetchResult as Kind>::ID,
+            <FetchResult as Kind>::ID.0,
             buf.as_mut_ptr().addr() as u32,
             buf.len() as u32,
             timeout_ms,

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -101,11 +101,11 @@ fn manifest_const_round_trips_to_expected_records() {
                 handler_count += 1;
                 match name.as_ref() {
                     "test.tick" => {
-                        assert_eq!(*id, <Tick as Kind>::ID);
+                        assert_eq!(*id, <Tick as Kind>::ID.0);
                         tick_doc = doc.as_ref().map(|c| c.to_string());
                     }
                     "test.ping" => {
-                        assert_eq!(*id, <Ping as Kind>::ID);
+                        assert_eq!(*id, <Ping as Kind>::ID.0);
                     }
                     other => panic!("unexpected handler name: {other}"),
                 }

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -134,11 +134,17 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
             // bit pattern alone. The `KIND_DOMAIN` byte prefix still
             // rides the FNV input (ADR-0030) — type info ends up
             // encoded in two independent places that cross-check.
-            const ID: u64 = ::aether_mail::with_tag(
-                ::aether_mail::Tag::Kind,
-                ::aether_mail::fnv1a_64_prefixed(
-                    ::aether_mail::KIND_DOMAIN,
-                    &#canonical_bytes_ident,
+            // Issue 466: `Kind::ID` is typed `KindId`; the wrapper
+            // wraps the raw `u64` hash. Wire-format sites that need
+            // raw bytes call `.0`; dispatch sites compare `KindId` to
+            // `KindId` directly.
+            const ID: ::aether_mail::KindId = ::aether_mail::KindId(
+                ::aether_mail::with_tag(
+                    ::aether_mail::Tag::Kind,
+                    ::aether_mail::fnv1a_64_prefixed(
+                        ::aether_mail::KIND_DOMAIN,
+                        &#canonical_bytes_ident,
+                    ),
                 ),
             );
             #is_stream_item
@@ -177,7 +183,10 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         // `&#labels_ident` see a stable `'static` reference.
         static #labels_ident: ::aether_mail::__derive_runtime::KindLabels =
             ::aether_mail::__derive_runtime::KindLabels {
-                kind_id: <#name as ::aether_mail::Kind>::ID,
+                // KindLabels.kind_id is wire-format `u64`; `Kind::ID` is
+                // typed `KindId` (issue 466) so we drop into the raw
+                // hash for the wire bytes.
+                kind_id: <#name as ::aether_mail::Kind>::ID.0,
                 kind_label: ::aether_mail::__derive_runtime::Cow::Borrowed(
                     ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#name)),
                 ),
@@ -994,8 +1003,11 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
     let arms = handlers.iter().map(|h| {
         let k = &h.kind_ty;
         let method = &h.method.sig.ident;
+        // `Mail::kind()` returns the raw `u64` the FFI carried; `Kind::ID`
+        // is typed `KindId` post-issue 466, so we drop into `.0` for the
+        // comparison.
         quote! {
-            if __aether_kind == <#k as ::aether_component::__macro_internals::Kind>::ID {
+            if __aether_kind == <#k as ::aether_component::__macro_internals::Kind>::ID.0 {
                 if let ::core::option::Option::Some(__aether_decoded) =
                     __aether_mail.decode_kind::<#k>()
                 {
@@ -1048,9 +1060,12 @@ fn build_inputs_manifest_consts(
     for h in handlers {
         let k = &h.kind_ty;
         let doc_expr = option_str_token(&h.agent_doc);
+        // `inputs_handler_len` / `write_inputs_handler` take a raw `u64`
+        // for the wire bytes; `Kind::ID` is `KindId` post-issue 466 so
+        // we drop into `.0` here.
         len_terms.push(quote! {
             (1 + ::aether_component::__macro_internals::canonical::inputs_handler_len(
-                <#k as ::aether_component::__macro_internals::Kind>::ID,
+                <#k as ::aether_component::__macro_internals::Kind>::ID.0,
                 <#k as ::aether_component::__macro_internals::Kind>::NAME,
                 #doc_expr,
             ))
@@ -1059,13 +1074,13 @@ fn build_inputs_manifest_consts(
             {
                 const REC_LEN: usize =
                     ::aether_component::__macro_internals::canonical::inputs_handler_len(
-                        <#k as ::aether_component::__macro_internals::Kind>::ID,
+                        <#k as ::aether_component::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_component::__macro_internals::Kind>::NAME,
                         #doc_expr,
                     );
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_component::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
-                        <#k as ::aether_component::__macro_internals::Kind>::ID,
+                        <#k as ::aether_component::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_component::__macro_internals::Kind>::NAME,
                         #doc_expr,
                     );
@@ -1276,7 +1291,9 @@ fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn])
             // Schema impls).
             static #labels_static_ident: ::aether_component::__macro_internals::KindLabels =
                 ::aether_component::__macro_internals::KindLabels {
-                    kind_id: <#k as ::aether_component::__macro_internals::Kind>::ID,
+                    // KindLabels.kind_id is wire-format `u64`; drop into
+                    // `.0` from the typed `Kind::ID` (issue 466).
+                    kind_id: <#k as ::aether_component::__macro_internals::Kind>::ID.0,
                     kind_label: ::aether_component::__macro_internals::Cow::Borrowed(
                         match <#k as ::aether_component::__macro_internals::Schema>::LABEL {
                             ::core::option::Option::Some(s) => s,

--- a/crates/aether-mail-derive/tests/derive.rs
+++ b/crates/aether-mail-derive/tests/derive.rs
@@ -259,7 +259,7 @@ fn ref_inner_kind_id_is_carried_in_handle_arm() {
         panic!("expected Handle variant");
     };
     assert_eq!(id, 0xfeed_0000);
-    assert_eq!(kind_id, <Note as Kind>::ID);
+    assert_eq!(kind_id, <Note as Kind>::ID.0);
 }
 
 #[test]

--- a/crates/aether-mail/src/ids.rs
+++ b/crates/aether-mail/src/ids.rs
@@ -163,7 +163,7 @@ impl MailboxId {
     /// the guest SDK uses on the component side — ids round-trip
     /// verbatim across the FFI.
     pub fn from_name(name: &str) -> MailboxId {
-        MailboxId(mailbox_id_from_name(name))
+        mailbox_id_from_name(name)
     }
 }
 

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -22,6 +22,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 pub mod ids;
+pub mod mailboxes;
 pub mod tagged_id;
 pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
 pub use tagged_id::{Tag, with_tag};
@@ -43,7 +44,7 @@ pub use tagged_id::{Tag, with_tag};
 /// leave the default alone.
 pub trait Kind {
     const NAME: &'static str;
-    const ID: u64;
+    const ID: KindId;
     /// `true` when the kind is a substrate-published event stream
     /// (Tick, Key, MouseMove, etc.) that components subscribe to via
     /// the per-kind subscriber set. Drives `auto_subscribe_inputs` on
@@ -270,7 +271,10 @@ impl<K: Kind> Ref<K> {
     /// callers can't pass a kind id that disagrees with the type
     /// parameter.
     pub const fn handle(id: u64) -> Self {
-        Ref::Handle { id, kind_id: K::ID }
+        Ref::Handle {
+            id,
+            kind_id: K::ID.0,
+        }
     }
 }
 
@@ -670,7 +674,7 @@ mod tests {
         // doesn't matter. `mailbox_id_from_name` gives us a stable
         // derivation without pulling Schema into tests that don't
         // use it.
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
     }
 
     #[repr(C)]
@@ -681,7 +685,7 @@ mod tests {
     }
     impl Kind for Vertex {
         const NAME: &'static str = "test.vertex";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
     }
 
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -691,13 +695,13 @@ mod tests {
     }
     impl Kind for TestStruct {
         const NAME: &'static str = "test.struct";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
     }
 
     struct Signal;
     impl Kind for Signal {
         const NAME: &'static str = "test.signal";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
     }
 
     #[test]
@@ -781,7 +785,7 @@ mod tests {
         match r {
             Ref::Handle { id, kind_id } => {
                 assert_eq!(id, 42);
-                assert_eq!(kind_id, TestStruct::ID);
+                assert_eq!(kind_id, TestStruct::ID.0);
             }
             _ => panic!("expected Handle variant"),
         }

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -779,7 +779,7 @@ mod tests {
             )),
         );
         assert_eq!(tagged_id::tag_of(a.0), Some(Tag::Mailbox));
-        assert_ne!(mailbox_id_from_name("").0, 0xcbf29ce484222325);
+        assert_ne!(mailbox_id_from_name(""), MailboxId(0xcbf29ce484222325));
     }
 
     #[test]

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -160,11 +160,11 @@ impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
 /// At 64 bits the birthday bound is far past realistic mailbox
 /// counts — see ADR-0029 "Consequences" for the table.
 ///
-/// The returned `u64` is the raw id wrapped into
-/// `aether_substrate::mail::MailboxId` on the substrate side; guests
-/// use it directly as the `recipient` on `send_mail`. `0` is reserved
-/// as the no-sender sentinel — callers should reject on the astronomical
-/// chance of a collision with it.
+/// The returned `MailboxId` is a `#[repr(transparent)]` newtype
+/// over `u64`; guests that need the raw scalar for FFI (`send_mail`'s
+/// `recipient`) call `.0`. `0` is reserved as the no-sender sentinel —
+/// callers should reject on the astronomical chance of a collision
+/// with it.
 ///
 /// ADR-0064: the high 4 bits carry the `Tag::Mailbox` discriminator;
 /// the low 60 bits are the FNV-1a output masked by `HASH_MASK`. The
@@ -172,11 +172,11 @@ impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
 /// type ends up encoded twice (in the tag bits and avalanched into
 /// the hash via the domain prefix), and the two layers cross-check
 /// each other.
-pub const fn mailbox_id_from_name(name: &str) -> u64 {
-    with_tag(
+pub const fn mailbox_id_from_name(name: &str) -> MailboxId {
+    MailboxId(with_tag(
         Tag::Mailbox,
         fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes()),
-    )
+    ))
 }
 
 /// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
@@ -668,13 +668,13 @@ mod tests {
         a: u32,
         b: f32,
     }
+    // Tests exercise encode/decode, not routing, so the exact ID
+    // values don't matter — they only need to be stable and distinct
+    // across the four test kinds. Hand-picked sentinels are clearer
+    // than hashing a name through a domain-mismatched helper.
     impl Kind for TestPod {
         const NAME: &'static str = "test.pod";
-        // Tests exercise encode/decode, not routing, so the exact ID
-        // doesn't matter. `mailbox_id_from_name` gives us a stable
-        // derivation without pulling Schema into tests that don't
-        // use it.
-        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
+        const ID: KindId = KindId(0xDEAD_BEEF_0000_0001);
     }
 
     #[repr(C)]
@@ -685,7 +685,7 @@ mod tests {
     }
     impl Kind for Vertex {
         const NAME: &'static str = "test.vertex";
-        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
+        const ID: KindId = KindId(0xDEAD_BEEF_0000_0002);
     }
 
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -695,13 +695,13 @@ mod tests {
     }
     impl Kind for TestStruct {
         const NAME: &'static str = "test.struct";
-        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
+        const ID: KindId = KindId(0xDEAD_BEEF_0000_0003);
     }
 
     struct Signal;
     impl Kind for Signal {
         const NAME: &'static str = "test.signal";
-        const ID: KindId = KindId(mailbox_id_from_name(Self::NAME));
+        const ID: KindId = KindId(0xDEAD_BEEF_0000_0004);
     }
 
     #[test]
@@ -773,10 +773,13 @@ mod tests {
         // ADR-0064 (the high 4 bits carry the `Tag::Mailbox` tag).
         assert_eq!(
             mailbox_id_from_name(""),
-            with_tag(Tag::Mailbox, fnv1a_64_prefixed(MAILBOX_DOMAIN, &[]),),
+            MailboxId(with_tag(
+                Tag::Mailbox,
+                fnv1a_64_prefixed(MAILBOX_DOMAIN, &[]),
+            )),
         );
-        assert_eq!(tagged_id::tag_of(a), Some(Tag::Mailbox));
-        assert_ne!(mailbox_id_from_name(""), 0xcbf29ce484222325);
+        assert_eq!(tagged_id::tag_of(a.0), Some(Tag::Mailbox));
+        assert_ne!(mailbox_id_from_name("").0, 0xcbf29ce484222325);
     }
 
     #[test]

--- a/crates/aether-mail/src/mailboxes.rs
+++ b/crates/aether-mail/src/mailboxes.rs
@@ -1,0 +1,51 @@
+//! Typed `MailboxId` constants for the well-known mailbox names in the
+//! substrate vocabulary. The names themselves are scattered across the
+//! codebase as `&'static str` constants (`AETHER_CONTROL`,
+//! `HANDLE_SINK_NAME`, `AETHER_DIAGNOSTICS`, etc.) — those keep their
+//! string form for log-message interpolation. This module is the typed
+//! companion: anywhere a `MailboxId` is being compared or constructed
+//! against a well-known mailbox, prefer one of these constants over
+//! `MailboxId(mailbox_id_from_name("..."))` so the resolution happens
+//! at compile time and the call site is one symbol instead of a name +
+//! hash invocation.
+//!
+//! Adding a new chassis-owned sink: pick the `aether.sink.*` name,
+//! mirror it as a `pub const` here, and the substrate side stays in
+//! lockstep.
+
+use crate::{MailboxId, mailbox_id_from_name};
+
+/// ADR-0010 control plane mailbox. Every load / drop / replace /
+/// subscribe-input / unsubscribe-input lands here.
+pub const CONTROL: MailboxId = MailboxId(mailbox_id_from_name("aether.control"));
+
+/// ADR-0023 diagnostics mailbox. Hub-side observation traffic
+/// (engine_logs, frame_stats, etc.) is addressed here.
+pub const DIAGNOSTICS: MailboxId = MailboxId(mailbox_id_from_name("aether.diagnostics"));
+
+/// Render sink (chassis-owned). DrawTriangle, etc. flow here per
+/// ADR-0058 namespace conventions.
+pub const SINK_RENDER: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.render"));
+
+/// Camera sink (chassis-owned). `aether.camera { view_proj }` lands
+/// here; latest value wins per tick.
+pub const SINK_CAMERA: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.camera"));
+
+/// Audio sink (desktop chassis). NoteOn / NoteOff / SetMasterGain
+/// (ADR-0039) route here.
+pub const SINK_AUDIO: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.audio"));
+
+/// File I/O sink (ADR-0041). Read / Write / Delete / List addressed
+/// against logical namespaces flow through this mailbox.
+pub const SINK_IO: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.io"));
+
+/// Network sink (ADR-0043). Fetch / Cancel route here.
+pub const SINK_NET: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.net"));
+
+/// Log sink — components emit `LogEvent` here for structured logging
+/// that surfaces through `engine_logs`.
+pub const SINK_LOG: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.log"));
+
+/// Handle store sink (ADR-0045). Publish / Drop / Resolve route
+/// against the substrate-owned refcounted byte cache.
+pub const SINK_HANDLE: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.handle"));

--- a/crates/aether-mail/src/mailboxes.rs
+++ b/crates/aether-mail/src/mailboxes.rs
@@ -5,9 +5,9 @@
 //! string form for log-message interpolation. This module is the typed
 //! companion: anywhere a `MailboxId` is being compared or constructed
 //! against a well-known mailbox, prefer one of these constants over
-//! `MailboxId(mailbox_id_from_name("..."))` so the resolution happens
-//! at compile time and the call site is one symbol instead of a name +
-//! hash invocation.
+//! `mailbox_id_from_name("...")` so the resolution happens at compile
+//! time and the call site is one symbol instead of a name + hash
+//! invocation.
 //!
 //! Adding a new chassis-owned sink: pick the `aether.sink.*` name,
 //! mirror it as a `pub const` here, and the substrate side stays in
@@ -17,35 +17,35 @@ use crate::{MailboxId, mailbox_id_from_name};
 
 /// ADR-0010 control plane mailbox. Every load / drop / replace /
 /// subscribe-input / unsubscribe-input lands here.
-pub const CONTROL: MailboxId = MailboxId(mailbox_id_from_name("aether.control"));
+pub const CONTROL: MailboxId = mailbox_id_from_name("aether.control");
 
 /// ADR-0023 diagnostics mailbox. Hub-side observation traffic
 /// (engine_logs, frame_stats, etc.) is addressed here.
-pub const DIAGNOSTICS: MailboxId = MailboxId(mailbox_id_from_name("aether.diagnostics"));
+pub const DIAGNOSTICS: MailboxId = mailbox_id_from_name("aether.diagnostics");
 
 /// Render sink (chassis-owned). DrawTriangle, etc. flow here per
 /// ADR-0058 namespace conventions.
-pub const SINK_RENDER: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.render"));
+pub const SINK_RENDER: MailboxId = mailbox_id_from_name("aether.sink.render");
 
 /// Camera sink (chassis-owned). `aether.camera { view_proj }` lands
 /// here; latest value wins per tick.
-pub const SINK_CAMERA: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.camera"));
+pub const SINK_CAMERA: MailboxId = mailbox_id_from_name("aether.sink.camera");
 
 /// Audio sink (desktop chassis). NoteOn / NoteOff / SetMasterGain
 /// (ADR-0039) route here.
-pub const SINK_AUDIO: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.audio"));
+pub const SINK_AUDIO: MailboxId = mailbox_id_from_name("aether.sink.audio");
 
 /// File I/O sink (ADR-0041). Read / Write / Delete / List addressed
 /// against logical namespaces flow through this mailbox.
-pub const SINK_IO: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.io"));
+pub const SINK_IO: MailboxId = mailbox_id_from_name("aether.sink.io");
 
 /// Network sink (ADR-0043). Fetch / Cancel route here.
-pub const SINK_NET: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.net"));
+pub const SINK_NET: MailboxId = mailbox_id_from_name("aether.sink.net");
 
 /// Log sink — components emit `LogEvent` here for structured logging
 /// that surfaces through `engine_logs`.
-pub const SINK_LOG: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.log"));
+pub const SINK_LOG: MailboxId = mailbox_id_from_name("aether.sink.log");
 
 /// Handle store sink (ADR-0045). Publish / Drop / Resolve route
 /// against the substrate-owned refcounted byte cache.
-pub const SINK_HANDLE: MailboxId = MailboxId(mailbox_id_from_name("aether.sink.handle"));
+pub const SINK_HANDLE: MailboxId = mailbox_id_from_name("aether.sink.handle");

--- a/crates/aether-params-codec/src/decode.rs
+++ b/crates/aether-params-codec/src/decode.rs
@@ -1090,7 +1090,7 @@ mod tests {
         use aether_mail::Kind;
         let mailbox = aether_mail::MailboxId::from_name("aether.control");
         let mailbox_str = aether_mail::tagged_id::encode(mailbox.0).unwrap();
-        let kind_id = aether_mail::KindId(aether_kinds::Tick::ID);
+        let kind_id = aether_kinds::Tick::ID;
         let kind_str = aether_mail::tagged_id::encode(kind_id.0).unwrap();
         let json_in = json!({ "kind": kind_str, "mailbox": mailbox_str });
 
@@ -1113,7 +1113,7 @@ mod tests {
         // `with_tag` discipline holds through the schema-bytes
         // change).
         assert_eq!(
-            aether_mail::tagged_id::tag_of(aether_kinds::SubscribeInput::ID),
+            aether_mail::tagged_id::tag_of(aether_kinds::SubscribeInput::ID.0),
             Some(aether_mail::Tag::Kind),
         );
     }

--- a/crates/aether-substrate-core/src/control/mod.rs
+++ b/crates/aether-substrate-core/src/control/mod.rs
@@ -223,29 +223,41 @@ impl ControlPlane {
     }
 
     fn dispatch(&self, kind: KindId, kind_name: &str, sender: crate::mail::ReplyTo, bytes: &[u8]) {
-        if kind == KindId(LoadComponent::ID) {
-            let result = self.handle_load(bytes);
-            self.outbound.send_reply(sender, &result);
-        } else if kind == KindId(DropComponent::ID) {
-            let result = self.handle_drop(bytes);
-            self.outbound.send_reply(sender, &result);
-        } else if kind == KindId(ReplaceComponent::ID) {
-            let result = self.handle_replace(bytes);
-            self.outbound.send_reply(sender, &result);
-        } else if kind == KindId(SubscribeInput::ID) {
-            let result = self.handle_subscribe(bytes);
-            self.outbound.send_reply(sender, &result);
-        } else if kind == KindId(UnsubscribeInput::ID) {
-            let result = self.handle_unsubscribe(bytes);
-            self.outbound.send_reply(sender, &result);
-        } else if let Some(handler) = &self.chassis_handler {
-            handler(kind, kind_name, sender, bytes);
-        } else {
-            tracing::warn!(
-                target: "aether_substrate::control",
-                kind = %kind_name,
-                "{AETHER_CONTROL} received unrecognised kind (no chassis handler registered) — dropping",
-            );
+        // Issue 466: `Kind::ID` is typed `KindId`, so each arm pattern
+        // is the typed const directly — no `KindId(X::ID)` wrapping
+        // required. Subsumes issue 465's match-on-`.0` workaround.
+        match kind {
+            LoadComponent::ID => {
+                let result = self.handle_load(bytes);
+                self.outbound.send_reply(sender, &result);
+            }
+            DropComponent::ID => {
+                let result = self.handle_drop(bytes);
+                self.outbound.send_reply(sender, &result);
+            }
+            ReplaceComponent::ID => {
+                let result = self.handle_replace(bytes);
+                self.outbound.send_reply(sender, &result);
+            }
+            SubscribeInput::ID => {
+                let result = self.handle_subscribe(bytes);
+                self.outbound.send_reply(sender, &result);
+            }
+            UnsubscribeInput::ID => {
+                let result = self.handle_unsubscribe(bytes);
+                self.outbound.send_reply(sender, &result);
+            }
+            _ => {
+                if let Some(handler) = &self.chassis_handler {
+                    handler(kind, kind_name, sender, bytes);
+                } else {
+                    tracing::warn!(
+                        target: "aether_substrate::control",
+                        kind = %kind_name,
+                        "{AETHER_CONTROL} received unrecognised kind (no chassis handler registered) — dropping",
+                    );
+                }
+            }
         }
     }
 

--- a/crates/aether-substrate-core/src/control/tests.rs
+++ b/crates/aether-substrate-core/src/control/tests.rs
@@ -1009,10 +1009,10 @@ fn subscribe_adds_mailbox_to_stream_set() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
     assert!(matches!(
-        do_subscribe(&plane, id, KindId(Tick::ID)),
+        do_subscribe(&plane, id, Tick::ID),
         SubscribeInputResult::Ok
     ));
-    let set = subs(&plane, KindId(Tick::ID));
+    let set = subs(&plane, Tick::ID);
     assert!(set.contains(&id));
     assert_eq!(set.len(), 1);
 }
@@ -1023,11 +1023,11 @@ fn subscribe_is_idempotent() {
     let id = load_blank(&plane, "listener");
     for _ in 0..3 {
         assert!(matches!(
-            do_subscribe(&plane, id, KindId(Key::ID)),
+            do_subscribe(&plane, id, Key::ID),
             SubscribeInputResult::Ok
         ));
     }
-    assert_eq!(subs(&plane, KindId(Key::ID)).len(), 1);
+    assert_eq!(subs(&plane, Key::ID).len(), 1);
 }
 
 #[test]
@@ -1036,14 +1036,14 @@ fn subscribe_two_components_fan_out_to_both() {
     let a = load_blank(&plane, "a");
     let b = load_blank(&plane, "b");
     assert!(matches!(
-        do_subscribe(&plane, a, KindId(Tick::ID)),
+        do_subscribe(&plane, a, Tick::ID),
         SubscribeInputResult::Ok
     ));
     assert!(matches!(
-        do_subscribe(&plane, b, KindId(Tick::ID)),
+        do_subscribe(&plane, b, Tick::ID),
         SubscribeInputResult::Ok
     ));
-    let set = subs(&plane, KindId(Tick::ID));
+    let set = subs(&plane, Tick::ID);
     assert_eq!(set.len(), 2);
     assert!(set.contains(&a));
     assert!(set.contains(&b));
@@ -1053,12 +1053,12 @@ fn subscribe_two_components_fan_out_to_both() {
 fn unsubscribe_removes_from_set() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, KindId(MouseMove::ID));
+    do_subscribe(&plane, id, MouseMove::ID);
     assert!(matches!(
-        do_unsubscribe(&plane, id, KindId(MouseMove::ID)),
+        do_unsubscribe(&plane, id, MouseMove::ID),
         SubscribeInputResult::Ok
     ));
-    assert!(subs(&plane, KindId(MouseMove::ID)).is_empty());
+    assert!(subs(&plane, MouseMove::ID).is_empty());
 }
 
 #[test]
@@ -1068,7 +1068,7 @@ fn unsubscribe_not_subscribed_is_ok() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
     assert!(matches!(
-        do_unsubscribe(&plane, id, KindId(Tick::ID)),
+        do_unsubscribe(&plane, id, Tick::ID),
         SubscribeInputResult::Ok
     ));
 }
@@ -1077,7 +1077,7 @@ fn unsubscribe_not_subscribed_is_ok() {
 fn subscribe_unknown_mailbox_is_err() {
     let plane = make_plane();
     assert!(matches!(
-        do_subscribe(&plane, MailboxId(9999), KindId(Tick::ID)),
+        do_subscribe(&plane, MailboxId(9999), Tick::ID),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1091,7 +1091,7 @@ fn subscribe_sink_mailbox_is_err() {
         .registry
         .register_sink("some.sink", Arc::new(|_, _, _, _, _, _| {}));
     assert!(matches!(
-        do_subscribe(&plane, sink, KindId(Tick::ID)),
+        do_subscribe(&plane, sink, Tick::ID),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1102,7 +1102,7 @@ fn subscribe_dropped_mailbox_is_err() {
     let id = load_blank(&plane, "victim");
     plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
     assert!(matches!(
-        do_subscribe(&plane, id, KindId(Tick::ID)),
+        do_subscribe(&plane, id, Tick::ID),
         SubscribeInputResult::Err { .. }
     ));
 }
@@ -1113,18 +1113,13 @@ fn drop_component_removes_from_every_subscriber_set() {
     // stream's subscriber set, not just the ones currently held.
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, KindId(Tick::ID));
-    do_subscribe(&plane, id, KindId(Key::ID));
-    do_subscribe(&plane, id, KindId(MouseButton::ID));
+    do_subscribe(&plane, id, Tick::ID);
+    do_subscribe(&plane, id, Key::ID);
+    do_subscribe(&plane, id, MouseButton::ID);
     let dropped =
         plane.handle_drop(&postcard::to_allocvec(&DropComponent { mailbox_id: id }).unwrap());
     assert!(matches!(dropped, DropResult::Ok));
-    for s in [
-        KindId(Tick::ID),
-        KindId(Key::ID),
-        KindId(MouseMove::ID),
-        KindId(MouseButton::ID),
-    ] {
+    for s in [Tick::ID, Key::ID, MouseMove::ID, MouseButton::ID] {
         assert!(
             !subs(&plane, s).contains(&id),
             "stream {s:?} still contains dropped id"
@@ -1138,8 +1133,8 @@ fn replace_component_preserves_subscriptions() {
     // are keyed by mailbox, so the new instance inherits them.
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
-    do_subscribe(&plane, id, KindId(Tick::ID));
-    do_subscribe(&plane, id, KindId(Key::ID));
+    do_subscribe(&plane, id, Tick::ID);
+    do_subscribe(&plane, id, Key::ID);
     let result = plane.handle_replace(
         &postcard::to_allocvec(&ReplaceComponent {
             mailbox_id: id,
@@ -1149,8 +1144,8 @@ fn replace_component_preserves_subscriptions() {
         .unwrap(),
     );
     assert!(matches!(result, ReplaceResult::Ok { .. }));
-    assert!(subs(&plane, KindId(Tick::ID)).contains(&id));
-    assert!(subs(&plane, KindId(Key::ID)).contains(&id));
+    assert!(subs(&plane, Tick::ID).contains(&id));
+    assert!(subs(&plane, Key::ID).contains(&id));
 }
 
 #[test]
@@ -1198,12 +1193,12 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
     let capabilities = ComponentCapabilities {
         handlers: vec![
             HandlerCapability {
-                id: KindId(Tick::ID),
+                id: Tick::ID,
                 name: Tick::NAME.into(),
                 doc: None,
             },
             HandlerCapability {
-                id: KindId(WindowSize::ID),
+                id: WindowSize::ID,
                 name: WindowSize::NAME.into(),
                 doc: None,
             },
@@ -1224,22 +1219,17 @@ fn auto_subscribe_inputs_wires_known_streams_from_capabilities() {
     let snapshot = subscribers.read().unwrap();
     assert!(
         snapshot
-            .get(&KindId(Tick::ID))
+            .get(&Tick::ID)
             .is_some_and(|set| set.contains(&mailbox)),
         "Tick handler should auto-subscribe the mailbox",
     );
     assert!(
         snapshot
-            .get(&KindId(WindowSize::ID))
+            .get(&WindowSize::ID)
             .is_some_and(|set| set.contains(&mailbox)),
         "WindowSize handler should auto-subscribe the mailbox",
     );
-    for stream in [
-        KindId(Key::ID),
-        KindId(KeyRelease::ID),
-        KindId(MouseMove::ID),
-        KindId(MouseButton::ID),
-    ] {
+    for stream in [Key::ID, KeyRelease::ID, MouseMove::ID, MouseButton::ID] {
         assert!(
             snapshot
                 .get(&stream)
@@ -1266,26 +1256,26 @@ fn subscribe_dispatch_replies_with_result_kind() {
     let plane = make_plane();
     let id = load_blank(&plane, "listener");
     plane.dispatch(
-        KindId(SubscribeInput::ID),
+        SubscribeInput::ID,
         SubscribeInput::NAME,
         crate::mail::ReplyTo::NONE,
         &postcard::to_allocvec(&SubscribeInput {
-            kind: KindId(Tick::ID),
+            kind: Tick::ID,
             mailbox: id,
         })
         .unwrap(),
     );
     plane.dispatch(
-        KindId(UnsubscribeInput::ID),
+        UnsubscribeInput::ID,
         UnsubscribeInput::NAME,
         crate::mail::ReplyTo::NONE,
         &postcard::to_allocvec(&UnsubscribeInput {
-            kind: KindId(Tick::ID),
+            kind: Tick::ID,
             mailbox: id,
         })
         .unwrap(),
     );
-    assert!(!subs(&plane, KindId(Tick::ID)).contains(&id));
+    assert!(!subs(&plane, Tick::ID).contains(&id));
 }
 
 // ADR-0022's `drain_pending` / `pending` / `frozen` / `parked`

--- a/crates/aether-substrate-core/src/frame_loop.rs
+++ b/crates/aether-substrate-core/src/frame_loop.rs
@@ -357,7 +357,7 @@ mod tests {
         let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
         mailer.wire(Arc::clone(&registry), components);
 
-        let kind_id = aether_mail::KindId(FrameStats::ID);
+        let kind_id = FrameStats::ID;
         emit_frame_stats(&mailer, broadcast, MailboxId(0), kind_id, 1, 0);
         emit_frame_stats(&mailer, broadcast, MailboxId(0), kind_id, 119, 0);
         assert!(captured.read().unwrap().is_empty());
@@ -387,7 +387,7 @@ mod tests {
             &mailer,
             broadcast,
             MailboxId(0),
-            aether_mail::KindId(FrameStats::ID),
+            FrameStats::ID,
             LOG_EVERY_FRAMES,
             42,
         );

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -53,24 +53,24 @@ pub fn handle_sink_handler(store: Arc<HandleStore>, mailer: Arc<Mailer>) -> Sink
 }
 
 fn dispatch(store: &HandleStore, mailer: &Mailer, kind: KindId, sender: ReplyTo, bytes: &[u8]) {
-    if kind == KindId(<HandlePublish as Kind>::ID) {
-        dispatch_publish(store, mailer, sender, bytes);
-    } else if kind == KindId(<HandleRelease as Kind>::ID) {
-        dispatch_release(store, mailer, sender, bytes);
-    } else if kind == KindId(<HandlePin as Kind>::ID) {
-        dispatch_pin(store, mailer, sender, bytes);
-    } else if kind == KindId(<HandleUnpin as Kind>::ID) {
-        dispatch_unpin(store, mailer, sender, bytes);
-    } else {
-        // Unknown kind on this sink — warn and drop. The sender's
-        // wait_reply on a paired *Result kind will time out, which
-        // is the right surface for "you mailed something the
-        // handle sink doesn't know about."
-        tracing::warn!(
-            target: "aether_substrate::handle_sink",
-            kind = %kind,
-            "handle sink received unknown kind",
-        );
+    // Issue 466: `Kind::ID` is typed `KindId`, so the match arms read
+    // each typed const directly.
+    match kind {
+        <HandlePublish as Kind>::ID => dispatch_publish(store, mailer, sender, bytes),
+        <HandleRelease as Kind>::ID => dispatch_release(store, mailer, sender, bytes),
+        <HandlePin as Kind>::ID => dispatch_pin(store, mailer, sender, bytes),
+        <HandleUnpin as Kind>::ID => dispatch_unpin(store, mailer, sender, bytes),
+        _ => {
+            // Unknown kind on this sink — warn and drop. The sender's
+            // wait_reply on a paired *Result kind will time out, which
+            // is the right surface for "you mailed something the
+            // handle sink doesn't know about."
+            tracing::warn!(
+                target: "aether_substrate::handle_sink",
+                kind = %kind,
+                "handle sink received unknown kind",
+            );
+        }
     }
 }
 
@@ -293,7 +293,7 @@ mod tests {
         };
         let bytes = postcard::to_allocvec(&req).unwrap();
         handler(
-            KindId(<HandlePublish as Kind>::ID),
+            <HandlePublish as Kind>::ID,
             "aether.handle.publish",
             None,
             session_reply_to(),
@@ -327,7 +327,7 @@ mod tests {
         };
         let bytes = postcard::to_allocvec(&req).unwrap();
         handler(
-            KindId(<HandleRelease as Kind>::ID),
+            <HandleRelease as Kind>::ID,
             "aether.handle.release",
             None,
             session_reply_to(),
@@ -355,7 +355,7 @@ mod tests {
             bytes: vec![1, 2, 3],
         };
         handler(
-            KindId(<HandlePublish as Kind>::ID),
+            <HandlePublish as Kind>::ID,
             "aether.handle.publish",
             None,
             session_reply_to(),
@@ -371,7 +371,7 @@ mod tests {
         // Pin.
         let pin_req = HandlePin { id };
         handler(
-            KindId(<HandlePin as Kind>::ID),
+            <HandlePin as Kind>::ID,
             "aether.handle.pin",
             None,
             session_reply_to(),
@@ -384,7 +384,7 @@ mod tests {
         // Unpin.
         let unpin_req = HandleUnpin { id };
         handler(
-            KindId(<HandleUnpin as Kind>::ID),
+            <HandleUnpin as Kind>::ID,
             "aether.handle.unpin",
             None,
             session_reply_to(),
@@ -407,7 +407,7 @@ mod tests {
         // Truncated postcard bytes — a `HandlePublish` is at least
         // a u64 + a varint length, so 1 byte is malformed.
         handler(
-            KindId(<HandlePublish as Kind>::ID),
+            <HandlePublish as Kind>::ID,
             "aether.handle.publish",
             None,
             session_reply_to(),
@@ -468,7 +468,7 @@ mod tests {
             bytes: vec![9, 9, 9],
         };
         handler(
-            KindId(<HandlePublish as Kind>::ID),
+            <HandlePublish as Kind>::ID,
             "aether.handle.publish",
             None,
             ReplyTo::to(ReplyTarget::Component(component_mbox)),

--- a/crates/aether-substrate-core/src/handle_store.rs
+++ b/crates/aether-substrate-core/src/handle_store.rs
@@ -889,7 +889,7 @@ mod tests {
 
     impl Kind for Note {
         const NAME: &'static str = "test.note";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
     }
 
     fn note_schema() -> SchemaType {
@@ -1007,7 +1007,7 @@ mod tests {
         match outcome {
             WalkOutcome::Parked { handle, kind } => {
                 assert_eq!(handle, HandleId(0xCAFE));
-                assert_eq!(kind, KindId(Note::ID));
+                assert_eq!(kind, Note::ID);
             }
             WalkOutcome::Resolved { .. } => panic!("expected park on missing handle"),
         }
@@ -1021,9 +1021,7 @@ mod tests {
             seq: 99,
         };
         let inner_bytes = postcard::to_allocvec(&inner).unwrap();
-        store
-            .put(HandleId(0xCAFE), KindId(Note::ID), inner_bytes)
-            .unwrap();
+        store.put(HandleId(0xCAFE), Note::ID, inner_bytes).unwrap();
 
         let outer = HeldNote {
             held: Ref::handle(0xCAFE),
@@ -1069,14 +1067,14 @@ mod tests {
         store
             .put(
                 HandleId(1),
-                KindId(Note::ID),
+                Note::ID,
                 postcard::to_allocvec(&stored_a).unwrap(),
             )
             .unwrap();
         store
             .put(
                 HandleId(2),
-                KindId(Note::ID),
+                Note::ID,
                 postcard::to_allocvec(&stored_b).unwrap(),
             )
             .unwrap();
@@ -1117,7 +1115,7 @@ mod tests {
         store
             .put(
                 HandleId(1),
-                KindId(Note::ID),
+                Note::ID,
                 postcard::to_allocvec(&stored).unwrap(),
             )
             .unwrap();
@@ -1190,9 +1188,7 @@ mod tests {
             seq: 7,
         };
         let inner_bytes = postcard::to_allocvec(&inner_note).unwrap();
-        store
-            .put(HandleId(20), KindId(Note::ID), inner_bytes)
-            .unwrap();
+        store.put(HandleId(20), Note::ID, inner_bytes).unwrap();
 
         // Mid-level HeldNote, with held = Handle(Y), goes under X.
         let mid = HeldNote {

--- a/crates/aether-substrate-core/src/handle_store.rs
+++ b/crates/aether-substrate-core/src/handle_store.rs
@@ -697,7 +697,7 @@ mod tests {
     use std::sync::Arc;
 
     use aether_hub_protocol::{NamedField, SchemaCell};
-    use aether_mail::{Kind, Ref, mailbox_id_from_name};
+    use aether_mail::{Kind, Ref};
 
     use crate::mail::{Mail, MailboxId};
 
@@ -889,7 +889,8 @@ mod tests {
 
     impl Kind for Note {
         const NAME: &'static str = "test.note";
-        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
+        // Stable test sentinel — distinct from real schema-hashed kind ids.
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(0xDEAD_BEEF_0002_0001);
     }
 
     fn note_schema() -> SchemaType {

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -122,7 +122,9 @@ impl HubOutbound {
             } => self.send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
                 target_engine_id: engine_id,
                 target_mailbox_id: mailbox_id.0,
-                kind_id: K::ID,
+                // wire frame is `u64`; drop into `.0` from the typed
+                // `Kind::ID` (issue 466).
+                kind_id: K::ID.0,
                 payload,
                 count: 1,
                 correlation_id: sender.correlation_id,

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -365,7 +365,7 @@ fn dispatch_io_mail(
     // strings in the echo fields — the `AdapterError` text carries
     // the decode diagnostic, and empty-string echo is a loud signal
     // that the request itself was malformed.
-    if kind == KindId(<Read as Kind>::ID) {
+    if kind == <Read as Kind>::ID {
         let req: Read = match postcard::from_bytes(bytes) {
             Ok(r) => r,
             Err(e) => {
@@ -414,7 +414,7 @@ fn dispatch_io_mail(
                 },
             ),
         };
-    } else if kind == KindId(<Write as Kind>::ID) {
+    } else if kind == <Write as Kind>::ID {
         let req: Write = match postcard::from_bytes(bytes) {
             Ok(r) => r,
             Err(e) => {
@@ -462,7 +462,7 @@ fn dispatch_io_mail(
                 },
             ),
         };
-    } else if kind == KindId(<Delete as Kind>::ID) {
+    } else if kind == <Delete as Kind>::ID {
         let req: Delete = match postcard::from_bytes(bytes) {
             Ok(r) => r,
             Err(e) => {
@@ -510,7 +510,7 @@ fn dispatch_io_mail(
                 },
             ),
         };
-    } else if kind == KindId(<List as Kind>::ID) {
+    } else if kind == <List as Kind>::ID {
         let req: List = match postcard::from_bytes(bytes) {
             Ok(r) => r,
             Err(e) => {
@@ -826,7 +826,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Read as Kind>::ID),
+            <Read as Kind>::ID,
             Read::NAME,
             None,
             session_sender(),
@@ -860,7 +860,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Read as Kind>::ID),
+            <Read as Kind>::ID,
             Read::NAME,
             None,
             session_sender(),
@@ -896,7 +896,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Read as Kind>::ID),
+            <Read as Kind>::ID,
             Read::NAME,
             None,
             session_sender(),
@@ -926,7 +926,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Write as Kind>::ID),
+            <Write as Kind>::ID,
             Write::NAME,
             None,
             session_sender(),
@@ -960,7 +960,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Write as Kind>::ID),
+            <Write as Kind>::ID,
             Write::NAME,
             None,
             session_sender(),
@@ -990,7 +990,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Delete as Kind>::ID),
+            <Delete as Kind>::ID,
             Delete::NAME,
             None,
             session_sender(),
@@ -1025,7 +1025,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<List as Kind>::ID),
+            <List as Kind>::ID,
             List::NAME,
             None,
             session_sender(),
@@ -1159,7 +1159,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Read as Kind>::ID),
+            <Read as Kind>::ID,
             Read::NAME,
             Some("test_caller"),
             ReplyTo::to(crate::mail::ReplyTarget::Component(caller_mailbox)),
@@ -1177,7 +1177,7 @@ mod tests {
         let observed_kind = lo | (hi << 32);
         assert_eq!(
             observed_kind,
-            <ReadResult as Kind>::ID,
+            <ReadResult as Kind>::ID.0,
             "component received a kind id different from ReadResult",
         );
 
@@ -1197,7 +1197,7 @@ mod tests {
         let (mailer, rx) = test_mailer_and_rx();
         let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         handler(
-            KindId(<Read as Kind>::ID),
+            <Read as Kind>::ID,
             Read::NAME,
             None,
             session_sender(),

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -365,206 +365,212 @@ fn dispatch_io_mail(
     // strings in the echo fields — the `AdapterError` text carries
     // the decode diagnostic, and empty-string echo is a loud signal
     // that the request itself was malformed.
-    if kind == <Read as Kind>::ID {
-        let req: Read = match postcard::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::io",
-                    error = %e,
-                    "read: decode failed, replying Err",
-                );
+    match kind {
+        <Read as Kind>::ID => {
+            let req: Read = match postcard::from_bytes(bytes) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::io",
+                        error = %e,
+                        "read: decode failed, replying Err",
+                    );
+                    mailer.send_reply(
+                        sender,
+                        &ReadResult::Err {
+                            namespace: String::new(),
+                            path: String::new(),
+                            error: IoError::AdapterError(format!("decode failed: {e}")),
+                        },
+                    );
+                    return;
+                }
+            };
+            let Some(adapter) = registry.get(&req.namespace) else {
                 mailer.send_reply(
                     sender,
                     &ReadResult::Err {
-                        namespace: String::new(),
-                        path: String::new(),
-                        error: IoError::AdapterError(format!("decode failed: {e}")),
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                        error: IoError::UnknownNamespace,
                     },
                 );
                 return;
-            }
-        };
-        let Some(adapter) = registry.get(&req.namespace) else {
-            mailer.send_reply(
-                sender,
-                &ReadResult::Err {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                    error: IoError::UnknownNamespace,
-                },
-            );
-            return;
-        };
-        let _ = match adapter.read(&req.path) {
-            Ok(bytes) => mailer.send_reply(
-                sender,
-                &ReadResult::Ok {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                    bytes,
-                },
-            ),
-            Err(error) => mailer.send_reply(
-                sender,
-                &ReadResult::Err {
-                    namespace: req.namespace,
-                    path: req.path,
-                    error,
-                },
-            ),
-        };
-    } else if kind == <Write as Kind>::ID {
-        let req: Write = match postcard::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::io",
-                    error = %e,
-                    "write: decode failed, replying Err",
-                );
+            };
+            let _ = match adapter.read(&req.path) {
+                Ok(bytes) => mailer.send_reply(
+                    sender,
+                    &ReadResult::Ok {
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                        bytes,
+                    },
+                ),
+                Err(error) => mailer.send_reply(
+                    sender,
+                    &ReadResult::Err {
+                        namespace: req.namespace,
+                        path: req.path,
+                        error,
+                    },
+                ),
+            };
+        }
+        <Write as Kind>::ID => {
+            let req: Write = match postcard::from_bytes(bytes) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::io",
+                        error = %e,
+                        "write: decode failed, replying Err",
+                    );
+                    mailer.send_reply(
+                        sender,
+                        &WriteResult::Err {
+                            namespace: String::new(),
+                            path: String::new(),
+                            error: IoError::AdapterError(format!("decode failed: {e}")),
+                        },
+                    );
+                    return;
+                }
+            };
+            let Some(adapter) = registry.get(&req.namespace) else {
                 mailer.send_reply(
                     sender,
                     &WriteResult::Err {
-                        namespace: String::new(),
-                        path: String::new(),
-                        error: IoError::AdapterError(format!("decode failed: {e}")),
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                        error: IoError::UnknownNamespace,
                     },
                 );
                 return;
-            }
-        };
-        let Some(adapter) = registry.get(&req.namespace) else {
-            mailer.send_reply(
-                sender,
-                &WriteResult::Err {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                    error: IoError::UnknownNamespace,
-                },
-            );
-            return;
-        };
-        let _ = match adapter.write(&req.path, &req.bytes) {
-            Ok(()) => mailer.send_reply(
-                sender,
-                &WriteResult::Ok {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                },
-            ),
-            Err(error) => mailer.send_reply(
-                sender,
-                &WriteResult::Err {
-                    namespace: req.namespace,
-                    path: req.path,
-                    error,
-                },
-            ),
-        };
-    } else if kind == <Delete as Kind>::ID {
-        let req: Delete = match postcard::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::io",
-                    error = %e,
-                    "delete: decode failed, replying Err",
-                );
+            };
+            let _ = match adapter.write(&req.path, &req.bytes) {
+                Ok(()) => mailer.send_reply(
+                    sender,
+                    &WriteResult::Ok {
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                    },
+                ),
+                Err(error) => mailer.send_reply(
+                    sender,
+                    &WriteResult::Err {
+                        namespace: req.namespace,
+                        path: req.path,
+                        error,
+                    },
+                ),
+            };
+        }
+        <Delete as Kind>::ID => {
+            let req: Delete = match postcard::from_bytes(bytes) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::io",
+                        error = %e,
+                        "delete: decode failed, replying Err",
+                    );
+                    mailer.send_reply(
+                        sender,
+                        &DeleteResult::Err {
+                            namespace: String::new(),
+                            path: String::new(),
+                            error: IoError::AdapterError(format!("decode failed: {e}")),
+                        },
+                    );
+                    return;
+                }
+            };
+            let Some(adapter) = registry.get(&req.namespace) else {
                 mailer.send_reply(
                     sender,
                     &DeleteResult::Err {
-                        namespace: String::new(),
-                        path: String::new(),
-                        error: IoError::AdapterError(format!("decode failed: {e}")),
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                        error: IoError::UnknownNamespace,
                     },
                 );
                 return;
-            }
-        };
-        let Some(adapter) = registry.get(&req.namespace) else {
-            mailer.send_reply(
-                sender,
-                &DeleteResult::Err {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                    error: IoError::UnknownNamespace,
-                },
-            );
-            return;
-        };
-        let _ = match adapter.delete(&req.path) {
-            Ok(()) => mailer.send_reply(
-                sender,
-                &DeleteResult::Ok {
-                    namespace: req.namespace.clone(),
-                    path: req.path.clone(),
-                },
-            ),
-            Err(error) => mailer.send_reply(
-                sender,
-                &DeleteResult::Err {
-                    namespace: req.namespace,
-                    path: req.path,
-                    error,
-                },
-            ),
-        };
-    } else if kind == <List as Kind>::ID {
-        let req: List = match postcard::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::io",
-                    error = %e,
-                    "list: decode failed, replying Err",
-                );
+            };
+            let _ = match adapter.delete(&req.path) {
+                Ok(()) => mailer.send_reply(
+                    sender,
+                    &DeleteResult::Ok {
+                        namespace: req.namespace.clone(),
+                        path: req.path.clone(),
+                    },
+                ),
+                Err(error) => mailer.send_reply(
+                    sender,
+                    &DeleteResult::Err {
+                        namespace: req.namespace,
+                        path: req.path,
+                        error,
+                    },
+                ),
+            };
+        }
+        <List as Kind>::ID => {
+            let req: List = match postcard::from_bytes(bytes) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::io",
+                        error = %e,
+                        "list: decode failed, replying Err",
+                    );
+                    mailer.send_reply(
+                        sender,
+                        &ListResult::Err {
+                            namespace: String::new(),
+                            prefix: String::new(),
+                            error: IoError::AdapterError(format!("decode failed: {e}")),
+                        },
+                    );
+                    return;
+                }
+            };
+            let Some(adapter) = registry.get(&req.namespace) else {
                 mailer.send_reply(
                     sender,
                     &ListResult::Err {
-                        namespace: String::new(),
-                        prefix: String::new(),
-                        error: IoError::AdapterError(format!("decode failed: {e}")),
+                        namespace: req.namespace.clone(),
+                        prefix: req.prefix.clone(),
+                        error: IoError::UnknownNamespace,
                     },
                 );
                 return;
-            }
-        };
-        let Some(adapter) = registry.get(&req.namespace) else {
-            mailer.send_reply(
-                sender,
-                &ListResult::Err {
-                    namespace: req.namespace.clone(),
-                    prefix: req.prefix.clone(),
-                    error: IoError::UnknownNamespace,
-                },
+            };
+            let _ = match adapter.list(&req.prefix) {
+                Ok(entries) => mailer.send_reply(
+                    sender,
+                    &ListResult::Ok {
+                        namespace: req.namespace.clone(),
+                        prefix: req.prefix.clone(),
+                        entries,
+                    },
+                ),
+                Err(error) => mailer.send_reply(
+                    sender,
+                    &ListResult::Err {
+                        namespace: req.namespace,
+                        prefix: req.prefix,
+                        error,
+                    },
+                ),
+            };
+        }
+        _ => {
+            tracing::warn!(
+                target: "aether_substrate::io",
+                kind = %kind,
+                "io sink received unknown kind — dropping",
             );
-            return;
-        };
-        let _ = match adapter.list(&req.prefix) {
-            Ok(entries) => mailer.send_reply(
-                sender,
-                &ListResult::Ok {
-                    namespace: req.namespace.clone(),
-                    prefix: req.prefix.clone(),
-                    entries,
-                },
-            ),
-            Err(error) => mailer.send_reply(
-                sender,
-                &ListResult::Err {
-                    namespace: req.namespace,
-                    prefix: req.prefix,
-                    error,
-                },
-            ),
-        };
-    } else {
-        tracing::warn!(
-            target: "aether_substrate::io",
-            kind = %kind,
-            "io sink received unknown kind — dropping",
-        );
+        }
     }
 }
 

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -403,7 +403,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use aether_hub_protocol::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
-    use aether_mail::{Kind, Ref, mailbox_id_from_name};
+    use aether_mail::{Kind, Ref};
 
     use super::*;
     use crate::handle_store::HandleStore;
@@ -470,7 +470,8 @@ mod tests {
     }
     impl Kind for Note {
         const NAME: &'static str = "test.mailer_note";
-        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
+        // Stable test sentinel — distinct from real schema-hashed kind ids.
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(0xDEAD_BEEF_0003_0001);
     }
 
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -480,7 +481,8 @@ mod tests {
     }
     impl Kind for HeldNote {
         const NAME: &'static str = "test.mailer_held_note";
-        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
+        // Stable test sentinel — distinct from real schema-hashed kind ids.
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(0xDEAD_BEEF_0003_0002);
     }
 
     fn note_schema() -> SchemaType {

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -196,7 +196,7 @@ impl Mailer {
                 // correlation picks the right reply out of the mpsc.
                 // Reply target is None — nobody replies to a reply.
                 let reply_to = ReplyTo::with_correlation(ReplyTarget::None, sender.correlation_id);
-                self.push(Mail::new(mailbox, KindId(K::ID), payload, 1).with_reply_to(reply_to));
+                self.push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
                 true
             }
         }
@@ -470,7 +470,7 @@ mod tests {
     }
     impl Kind for Note {
         const NAME: &'static str = "test.mailer_note";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
     }
 
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -480,7 +480,7 @@ mod tests {
     }
     impl Kind for HeldNote {
         const NAME: &'static str = "test.mailer_held_note";
-        const ID: u64 = mailbox_id_from_name(Self::NAME);
+        const ID: ::aether_mail::KindId = ::aether_mail::KindId(mailbox_id_from_name(Self::NAME));
     }
 
     fn note_schema() -> SchemaType {

--- a/crates/aether-substrate-core/src/net.rs
+++ b/crates/aether-substrate-core/src/net.rs
@@ -426,7 +426,7 @@ fn dispatch_net_mail(
     bytes: &[u8],
     default_timeout: Duration,
 ) {
-    if kind != KindId(<Fetch as Kind>::ID) {
+    if kind != <Fetch as Kind>::ID {
         tracing::warn!(
             target: "aether_substrate::net",
             kind = %kind,
@@ -566,7 +566,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Fetch as Kind>::ID),
+            <Fetch as Kind>::ID,
             Fetch::NAME,
             None,
             session_sender(),
@@ -680,7 +680,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Fetch as Kind>::ID),
+            <Fetch as Kind>::ID,
             Fetch::NAME,
             None,
             session_sender(),
@@ -721,7 +721,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Fetch as Kind>::ID),
+            <Fetch as Kind>::ID,
             Fetch::NAME,
             None,
             session_sender(),
@@ -751,7 +751,7 @@ mod tests {
             Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
         );
         handler(
-            KindId(<Fetch as Kind>::ID),
+            <Fetch as Kind>::ID,
             Fetch::NAME,
             None,
             session_sender(),
@@ -814,7 +814,7 @@ mod tests {
         })
         .unwrap();
         handler(
-            KindId(<Fetch as Kind>::ID),
+            <Fetch as Kind>::ID,
             Fetch::NAME,
             None,
             session_sender(),

--- a/crates/aether-substrate-core/src/scheduler.rs
+++ b/crates/aether-substrate-core/src/scheduler.rs
@@ -601,7 +601,7 @@ fn kill_actor(
     let broadcast_mbox = MailboxId::from_name(crate::HUB_CLAUDE_BROADCAST);
     let mail = Mail {
         recipient: broadcast_mbox,
-        kind: aether_mail::KindId(ComponentDied::ID),
+        kind: ComponentDied::ID,
         payload,
         count: 1,
         from_component: Some(mailbox),
@@ -1019,7 +1019,7 @@ mod tests {
         registry.register_sink(
             crate::HUB_CLAUDE_BROADCAST,
             Arc::new(move |kind, _, _, _, bytes, _| {
-                if kind == aether_mail::KindId(ComponentDied::ID)
+                if kind == ComponentDied::ID
                     && let Ok(d) = postcard::from_bytes::<ComponentDied>(bytes)
                 {
                     cap.lock().unwrap().push(d);

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -71,8 +71,9 @@ pub fn chassis_control_handler(
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
-        move |kind: aether_mail::KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
-            if kind == aether_mail::KindId(CaptureFrame::ID) {
+        move |kind: aether_mail::KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| match kind
+        {
+            CaptureFrame::ID => {
                 let proxy = proxy.clone();
                 begin_capture_request(
                     &queue,
@@ -90,23 +91,28 @@ pub fn chassis_control_handler(
                         Ok(())
                     },
                 );
-            } else if kind == aether_mail::KindId(PlatformInfo::ID) {
+            }
+            PlatformInfo::ID => {
                 // Empty payload; forward the sender straight to the
                 // event loop and let it snapshot + reply on its own
                 // thread (winit monitor / scale-factor APIs require it).
                 let _ = proxy.send_event(UserEvent::PlatformInfo { reply_to: sender });
-            } else if kind == aether_mail::KindId(SetWindowMode::ID) {
+            }
+            SetWindowMode::ID => {
                 handle_set_window_mode(&proxy, &outbound, sender, bytes);
-            } else if kind == aether_mail::KindId(SetWindowTitle::ID) {
+            }
+            SetWindowTitle::ID => {
                 handle_set_window_title(&proxy, &outbound, sender, bytes);
-            } else if kind == aether_mail::KindId(Advance::ID) {
+            }
+            Advance::ID => {
                 reply_unsupported_advance(
                     &outbound,
                     sender,
                     "unsupported on desktop chassis — aether.test_bench.advance is \
                      test-bench-only (ADR-0067)",
                 );
-            } else {
+            }
+            _ => {
                 tracing::warn!(
                     target: "aether_substrate::chassis",
                     kind = %kind_name,

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -25,7 +25,7 @@ use aether_kinds::{
     SetMasterGain, SetMasterGainResult, SetWindowModeResult, SetWindowTitleResult, Tick, VideoMode,
     WindowInfo, WindowMode, WindowSize, keycode,
 };
-use aether_mail::{Kind, KindId};
+use aether_mail::Kind;
 use aether_mail::{encode, encode_empty};
 use aether_substrate_core::sinks::{RenderAccumulator, build_camera_sink, build_render_sink};
 use aether_substrate_desktop::{
@@ -692,7 +692,7 @@ impl App {
     }
 
     fn publish_window_size(&self, width: u32, height: u32) {
-        let subs = subscribers_for(&self.input_subscribers, KindId(WindowSize::ID));
+        let subs = subscribers_for(&self.input_subscribers, WindowSize::ID);
         if subs.is_empty() {
             return;
         }
@@ -816,7 +816,7 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
-                let tick_subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
+                let tick_subs = subscribers_for(&self.input_subscribers, Tick::ID);
                 for mbox in tick_subs {
                     self.queue
                         .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
@@ -933,7 +933,7 @@ impl ApplicationHandler<UserEvent> for App {
                 };
                 match key_event.state {
                     ElementState::Pressed => {
-                        let subs = subscribers_for(&self.input_subscribers, KindId(Key::ID));
+                        let subs = subscribers_for(&self.input_subscribers, Key::ID);
                         for mbox in subs {
                             self.queue.push(Mail::new(
                                 mbox,
@@ -944,7 +944,7 @@ impl ApplicationHandler<UserEvent> for App {
                         }
                     }
                     ElementState::Released => {
-                        let subs = subscribers_for(&self.input_subscribers, KindId(KeyRelease::ID));
+                        let subs = subscribers_for(&self.input_subscribers, KeyRelease::ID);
                         for mbox in subs {
                             self.queue.push(Mail::new(
                                 mbox,
@@ -960,7 +960,7 @@ impl ApplicationHandler<UserEvent> for App {
                 state: ElementState::Pressed,
                 ..
             } => {
-                let subs = subscribers_for(&self.input_subscribers, KindId(MouseButton::ID));
+                let subs = subscribers_for(&self.input_subscribers, MouseButton::ID);
                 for mbox in subs {
                     self.queue.push(Mail::new(
                         mbox,
@@ -971,7 +971,7 @@ impl ApplicationHandler<UserEvent> for App {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let subs = subscribers_for(&self.input_subscribers, KindId(MouseMove::ID));
+                let subs = subscribers_for(&self.input_subscribers, MouseMove::ID);
                 if !subs.is_empty() {
                     let payload = encode(&MouseMove {
                         x: position.x as f32,

--- a/crates/aether-substrate-desktop/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-desktop/tests/input_subscriptions.rs
@@ -111,7 +111,7 @@ fn dispatch<K: aether_mail::Kind + serde::Serialize>(plane: &ControlPlane, paylo
     let bytes = postcard::to_allocvec(payload).unwrap();
     let handler = plane.clone().into_sink_handler();
     handler(
-        aether_mail::KindId(K::ID),
+        K::ID,
         K::NAME,
         None,
         aether_substrate_desktop::ReplyTo::NONE,
@@ -154,7 +154,7 @@ fn drop_component(plane: &ControlPlane, mailbox_id: aether_mail::MailboxId) {
 /// subscriber set, push one mail per subscriber, block until the
 /// scheduler drains.
 fn publish_tick(h: &Harness) {
-    for mbox in subscribers_for(&h.input_subscribers, KindId(Tick::ID)) {
+    for mbox in subscribers_for(&h.input_subscribers, Tick::ID) {
         h.queue.push(Mail::new(mbox, h.kind_tick, vec![], 1));
     }
     h.queue.drain_all();
@@ -166,18 +166,15 @@ fn empty_subscribers_means_no_delivery() {
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 0);
-    assert!(subscribers_for(&h.input_subscribers, KindId(Tick::ID)).is_empty());
+    assert!(subscribers_for(&h.input_subscribers, Tick::ID).is_empty());
 }
 
 #[test]
 fn subscribed_component_receives_published_ticks() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "listener");
-    subscribe(&h.plane, KindId(Tick::ID), id);
-    assert_eq!(
-        subscribers_for(&h.input_subscribers, KindId(Tick::ID)),
-        vec![id]
-    );
+    subscribe(&h.plane, Tick::ID, id);
+    assert_eq!(subscribers_for(&h.input_subscribers, Tick::ID), vec![id]);
     for _ in 0..3 {
         publish_tick(&h);
     }
@@ -189,8 +186,8 @@ fn two_subscribers_each_receive_every_tick() {
     let h = make_harness();
     let a = load_wat(&h.plane, &h.wat, "a");
     let b = load_wat(&h.plane, &h.wat, "b");
-    subscribe(&h.plane, KindId(Tick::ID), a);
-    subscribe(&h.plane, KindId(Tick::ID), b);
+    subscribe(&h.plane, Tick::ID, a);
+    subscribe(&h.plane, Tick::ID, b);
     publish_tick(&h);
     publish_tick(&h);
     // 2 subscribers × 2 ticks = 4 deliveries.
@@ -201,11 +198,11 @@ fn two_subscribers_each_receive_every_tick() {
 fn unsubscribe_stops_delivery() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "listener");
-    subscribe(&h.plane, KindId(Tick::ID), id);
+    subscribe(&h.plane, Tick::ID, id);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
 
-    unsubscribe(&h.plane, KindId(Tick::ID), id);
+    unsubscribe(&h.plane, Tick::ID, id);
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
@@ -215,12 +212,12 @@ fn unsubscribe_stops_delivery() {
 fn drop_clears_subscriptions() {
     let h = make_harness();
     let id = load_wat(&h.plane, &h.wat, "victim");
-    subscribe(&h.plane, KindId(Tick::ID), id);
+    subscribe(&h.plane, Tick::ID, id);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);
 
     drop_component(&h.plane, id);
-    assert!(subscribers_for(&h.input_subscribers, KindId(Tick::ID)).is_empty());
+    assert!(subscribers_for(&h.input_subscribers, Tick::ID).is_empty());
     publish_tick(&h);
     publish_tick(&h);
     assert_eq!(h.counter.load(Ordering::SeqCst), 1);

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -29,21 +29,26 @@ const UNSUPPORTED_ADVANCE: &str =
 
 pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHandler {
     Arc::new(
-        move |kind: KindId, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| {
-            if kind == KindId(CaptureFrame::ID) {
+        move |kind: KindId, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| match kind {
+            CaptureFrame::ID => {
                 reply_unsupported_capture_frame(&outbound, sender, UNSUPPORTED);
-            } else if kind == KindId(SetWindowMode::ID) {
+            }
+            SetWindowMode::ID => {
                 reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED);
-            } else if kind == KindId(SetWindowTitle::ID) {
+            }
+            SetWindowTitle::ID => {
                 reply_unsupported_window_title(&outbound, sender, UNSUPPORTED);
-            } else if kind == KindId(Advance::ID) {
+            }
+            Advance::ID => {
                 reply_unsupported_advance(&outbound, sender, UNSUPPORTED_ADVANCE);
-            } else if kind == KindId(PlatformInfo::ID) {
+            }
+            PlatformInfo::ID => {
                 // PlatformInfoResult::Err also exists — future work
                 // could return a partial Ok (OS + engine info, empty
                 // GPU/monitors) once headless needs that detail.
                 reply_unsupported_platform_info(&outbound, sender, UNSUPPORTED);
-            } else {
+            }
+            _ => {
                 tracing::warn!(
                     target: "aether_substrate::chassis",
                     kind = %kind_name,

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -75,7 +75,7 @@ impl Chassis for HeadlessChassis {
             next_deadline = Instant::now() + self.tick_period;
 
             frame += 1;
-            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
+            let subs = subscribers_for(&self.input_subscribers, Tick::ID);
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -41,9 +41,9 @@ use aether_hub_protocol::{
     EngineId, EngineMailToHubSubstrateFrame, EngineToHub, HubToEngine, MailByIdFrame, Uuid,
 };
 use aether_kinds::UnresolvedMail;
-use aether_mail::{Kind, mailbox_id_from_name};
+use aether_mail::Kind;
 use aether_substrate_core::{
-    AETHER_DIAGNOSTICS, Mail, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
+    Mail, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
     dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
@@ -207,8 +207,8 @@ fn send_unresolved_diagnostic(
     })
     .to_vec();
     let frame = HubToEngine::MailById(MailByIdFrame {
-        recipient_mailbox_id: mailbox_id_from_name(AETHER_DIAGNOSTICS),
-        kind_id: UnresolvedMail::ID,
+        recipient_mailbox_id: aether_mail::mailboxes::DIAGNOSTICS.0,
+        kind_id: UnresolvedMail::ID.0,
         payload,
         count: 1,
         correlation_id: 0,
@@ -526,7 +526,7 @@ mod tests {
             originator_id,
             EngineMailToHubSubstrateFrame {
                 recipient_mailbox_id: 0xBAD_C0FFEE_u64,
-                kind_id: <aether_kinds::Tick as Kind>::ID,
+                kind_id: <aether_kinds::Tick as Kind>::ID.0,
                 payload: vec![],
                 count: 1,
                 source_mailbox_id: Some(0x5151),
@@ -541,20 +541,17 @@ mod tests {
         let HubToEngine::MailById(frame) = got else {
             panic!("expected MailById, got {got:?}");
         };
-        assert_eq!(frame.kind_id, UnresolvedMail::ID);
+        assert_eq!(frame.kind_id, UnresolvedMail::ID.0);
         assert_eq!(
             frame.recipient_mailbox_id,
-            mailbox_id_from_name(AETHER_DIAGNOSTICS),
+            aether_mail::mailboxes::DIAGNOSTICS.0,
         );
         let record: &UnresolvedMail = bytemuck::from_bytes(&frame.payload);
         assert_eq!(
             record.recipient_mailbox_id,
             aether_mail::MailboxId(0xBAD_C0FFEE_u64)
         );
-        assert_eq!(
-            record.kind_id,
-            aether_mail::KindId(<aether_kinds::Tick as Kind>::ID),
-        );
+        assert_eq!(record.kind_id, <aether_kinds::Tick as Kind>::ID);
         assert_eq!(frame.count, 1);
         assert!(
             mail_rx.try_recv().is_err(),

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -43,8 +43,8 @@ pub fn chassis_control_handler(
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
-        move |kind: KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| {
-            if kind == KindId(CaptureFrame::ID) {
+        move |kind: KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| match kind {
+            CaptureFrame::ID => {
                 let events = events.clone();
                 begin_capture_request(
                     &queue,
@@ -59,15 +59,20 @@ pub fn chassis_control_handler(
                             .map_err(|_| "test-bench chassis shutting down — capture aborted")
                     },
                 );
-            } else if kind == KindId(Advance::ID) {
+            }
+            Advance::ID => {
                 handle_advance(&events, &outbound, sender, bytes);
-            } else if kind == KindId(SetWindowMode::ID) {
+            }
+            SetWindowMode::ID => {
                 reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED_WINDOW);
-            } else if kind == KindId(SetWindowTitle::ID) {
+            }
+            SetWindowTitle::ID => {
                 reply_unsupported_window_title(&outbound, sender, UNSUPPORTED_WINDOW);
-            } else if kind == KindId(PlatformInfo::ID) {
+            }
+            PlatformInfo::ID => {
                 reply_unsupported_platform_info(&outbound, sender, UNSUPPORTED_WINDOW);
-            } else {
+            }
+            _ => {
                 tracing::warn!(
                     target: "aether_substrate::chassis",
                     kind = %kind_name,

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, Tick};
-use aether_mail::{Kind, KindId, encode_empty};
+use aether_mail::{Kind, encode_empty};
 use aether_substrate_core::{
     Chassis, ChassisCapabilities, HubOutbound, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
     capture::CaptureQueue,
@@ -118,7 +118,7 @@ impl TestBenchChassis {
     /// aborts the chassis cleanly via `lifecycle::fatal_abort`.
     fn run_frame(&mut self, frame: u64, started: Instant, dispatch_tick: bool) {
         if dispatch_tick {
-            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
+            let subs = subscribers_for(&self.input_subscribers, Tick::ID);
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -28,7 +28,7 @@ use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
 use aether_kinds::{
     Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, DRAW_TRIANGLE_BYTES, FrameStats, Tick,
 };
-use aether_mail::{Kind, KindId, encode_empty, encode_struct, mailbox_id_from_name};
+use aether_mail::{Kind, KindId, encode_empty, encode_struct};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_substrate_core::{
@@ -365,8 +365,7 @@ impl TestBench {
             .lookup(recipient_name)
             .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
         let payload = encode_struct(mail);
-        self.queue
-            .push(Mail::new(mailbox, KindId(K::ID), payload, 1));
+        self.queue.push(Mail::new(mailbox, K::ID, payload, 1));
         Ok(())
     }
 
@@ -415,7 +414,7 @@ impl TestBench {
         let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
         let payload = encode_struct(mail);
         self.queue
-            .push(Mail::new(mailbox, KindId(K::ID), payload, 1).with_reply_to(reply_to));
+            .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
         self.pump_until_reply::<R>(cid, std::any::type_name::<R>())
     }
 
@@ -475,11 +474,11 @@ impl TestBench {
     where
         K: Kind + serde::Serialize,
     {
-        let mailbox = MailboxId(mailbox_id_from_name(aether_substrate_core::AETHER_CONTROL));
+        let mailbox = aether_mail::mailboxes::CONTROL;
         let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
         let payload = encode_struct(mail);
         self.queue
-            .push(Mail::new(mailbox, KindId(K::ID), payload, 1).with_reply_to(reply_to));
+            .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
     }
 
     fn fresh_correlation_id(&self) -> u64 {
@@ -599,7 +598,7 @@ impl TestBench {
 
     fn run_frame(&mut self, dispatch_tick: bool) {
         if dispatch_tick {
-            let subs = subscribers_for(&self.input_subscribers, KindId(Tick::ID));
+            let subs = subscribers_for(&self.input_subscribers, Tick::ID);
             for mbox in subs {
                 self.queue
                     .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));

--- a/crates/aether-substrate-test-bench/tests/scenario.rs
+++ b/crates/aether-substrate-test-bench/tests/scenario.rs
@@ -28,7 +28,7 @@ use aether_kinds::{
     Delete, DeleteResult, DropComponent, IoError, List, ListResult, LoadComponent, MailEnvelope,
     Read, ReadResult, ReplaceComponent, Write, WriteResult,
 };
-use aether_mail::{Kind, MailboxId, mailbox_id_from_name};
+use aether_mail::{Kind, mailbox_id_from_name};
 use aether_scenario::test_helpers::{
     has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots,
 };
@@ -119,7 +119,7 @@ fn drop_component_silences_tick_echoes() {
     // beat the first tick fanout means the drop mail beats the next
     // tick fanout — by the time `Advance{1}`'s `run_frame` queries
     // subscribers, the probe's mailbox is already gone.
-    let probe_mbox = MailboxId(mailbox_id_from_name(PROBE_NAME));
+    let probe_mbox = mailbox_id_from_name(PROBE_NAME);
     bench
         .send_mail(
             "aether.control",
@@ -241,7 +241,7 @@ fn replace_component_preserves_mailbox_identity() {
         bench.observed_kinds(),
     );
 
-    let probe_mbox = MailboxId(mailbox_id_from_name(PROBE_NAME));
+    let probe_mbox = mailbox_id_from_name(PROBE_NAME);
     let wasm = std::fs::read(&wasm_path).expect("re-read fixture wasm");
     bench
         .send_mail(


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #466 is the GitHub Closes-keyword link; #465 is a cross-reference to the superseded sibling issue -->

## Summary

- `Kind::ID` is now `KindId`, not `u64`. Wire-format sites that need raw u64 bytes call `.0`; dispatch sites compare typed `KindId` values directly.
- New `aether_mail::mailboxes` module ships compile-time `MailboxId` constants (`CONTROL`, `DIAGNOSTICS`, `SINK_RENDER`, `SINK_CAMERA`, `SINK_AUDIO`, `SINK_IO`, `SINK_NET`, `SINK_LOG`, `SINK_HANDLE`) for the chassis-owned mailboxes. Existing `&'static str` constants (`AETHER_CONTROL`, `HANDLE_SINK_NAME`, `AETHER_DIAGNOSTICS`) keep their string form for log-message interpolation.
- `ControlPlane::dispatch` and the parallel chassis dispatchers (desktop / headless / test-bench / handle sink / io sink) collapse to clean `match kind { LoadComponent::ID => ..., ... }` expressions. This subsumes issue 465's match-on-`.0` workaround (issue 465 was already closed as superseded).

Wire format is unchanged — `aether.kinds` custom section still emits raw u64 bytes; postcard wire still encodes u64; this is a Rust-side typing change with no observable wire behaviour.

Closes #466

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo check -p aether-camera-component --target wasm32-unknown-unknown` — wasm components build
- [x] `cargo check -p aether-mesh-viewer-component --target wasm32-unknown-unknown` — wasm components build
- [x] `cargo check -p aether-test-fixture-probe --target wasm32-unknown-unknown` — wasm components build

🤖 Generated with [Claude Code](https://claude.com/claude-code)