### PR TITLE
refactor: extract typed-id newtypes to aether-id crate (issue 469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,18 @@ dependencies = [
 name = "aether-hub-protocol"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-id",
  "postcard",
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "aether-id"
+version = "0.2.0-alpha"
+dependencies = [
+ "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -150,6 +159,7 @@ name = "aether-mail"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-hub-protocol",
+ "aether-id",
  "aether-mail-derive",
  "bytemuck",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/aether-mesh-viewer-component",
     "crates/aether-test-fixture-probe",
     "crates/aether-hub-protocol",
+    "crates/aether-id",
     "crates/aether-mail",
     "crates/aether-mail-derive",
     "demos/sokoban",

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -101,11 +101,11 @@ fn manifest_const_round_trips_to_expected_records() {
                 handler_count += 1;
                 match name.as_ref() {
                     "test.tick" => {
-                        assert_eq!(*id, <Tick as Kind>::ID.0);
+                        assert_eq!(*id, <Tick as Kind>::ID);
                         tick_doc = doc.as_ref().map(|c| c.to_string());
                     }
                     "test.ping" => {
-                        assert_eq!(*id, <Ping as Kind>::ID.0);
+                        assert_eq!(*id, <Ping as Kind>::ID);
                     }
                     other => panic!("unexpected handler name: {other}"),
                 }

--- a/crates/aether-hub-protocol/Cargo.toml
+++ b/crates/aether-hub-protocol/Cargo.toml
@@ -14,6 +14,12 @@ default = ["std"]
 std = []
 
 [dependencies]
+# `aether-id` is a leaf crate (ADR-0064 / ADR-0065 typed-id newtypes
+# + tag-bit constants + FNV helpers). Living below `aether-mail`
+# lets the wire structs in this crate type their mailbox / kind /
+# handle fields without the `aether-mail → aether-hub-protocol`
+# dep cycle.
+aether-id = { path = "../aether-id" }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 uuid = { version = "1", default-features = false, features = ["serde"] }

--- a/crates/aether-hub-protocol/src/canonical/labels.rs
+++ b/crates/aether-hub-protocol/src/canonical/labels.rs
@@ -26,7 +26,7 @@ const VARIANT_LABEL_STRUCT: u8 = 2;
 
 /// Byte length for `KindLabels` postcard encoding.
 pub const fn canonical_len_labels(labels: &KindLabels) -> usize {
-    varint_u64_len(labels.kind_id)
+    varint_u64_len(labels.kind_id.0)
         + str_len(cow_str_as_str(&labels.kind_label))
         + label_node_len(&labels.root)
 }
@@ -128,7 +128,7 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
 /// Serialize `labels` into `N` bytes of canonical postcard form.
 pub const fn canonical_serialize_labels<const N: usize>(labels: &KindLabels) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = write_varint_u64(labels.kind_id, &mut out, 0);
+    let mut pos = write_varint_u64(labels.kind_id.0, &mut out, 0);
     pos = write_str(cow_str_as_str(&labels.kind_label), &mut out, pos);
     pos = write_label_node(&labels.root, &mut out, pos);
     if pos != N {

--- a/crates/aether-hub-protocol/src/canonical/mod.rs
+++ b/crates/aether-hub-protocol/src/canonical/mod.rs
@@ -69,11 +69,11 @@ mod tests {
         primitives::write_varint_u64,
         schema::{KIND_DOMAIN, fnv1a_64_prefixed},
     };
-    use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
     use crate::types::{
         EnumVariant, KindLabels, KindShape, LabelCell, LabelNode, NamedField, Primitive,
         SchemaCell, SchemaShape, SchemaType, VariantLabel, VariantShape,
     };
+    use aether_id::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
     use alloc::borrow::Cow;
 
     static F32: SchemaType = SchemaType::Scalar(Primitive::F32);
@@ -313,7 +313,7 @@ mod tests {
     };
 
     static TRIANGLE_LABELS: KindLabels = KindLabels {
-        kind_id: 0,
+        kind_id: aether_id::KindId(0),
         kind_label: Cow::Borrowed("my_crate::Triangle"),
         root: LabelNode::Struct {
             type_label: Some(Cow::Borrowed("my_crate::Triangle")),
@@ -331,7 +331,7 @@ mod tests {
     }
 
     static RESULT_LABELS: KindLabels = KindLabels {
-        kind_id: 0,
+        kind_id: aether_id::KindId(0),
         kind_label: Cow::Borrowed("my_crate::Result"),
         root: LabelNode::Enum {
             type_label: Some(Cow::Borrowed("my_crate::Result")),
@@ -367,7 +367,7 @@ mod tests {
     // on either side breaks `describe_kinds`.
 
     static REF_VERTEX_LABELS: KindLabels = KindLabels {
-        kind_id: 0,
+        kind_id: aether_id::KindId(0),
         kind_label: Cow::Borrowed("my_crate::HeldVertex"),
         root: LabelNode::Ref(LabelCell::Static(&VERTEX_LABELS)),
     };
@@ -395,7 +395,7 @@ mod tests {
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         match decoded {
             InputsRecord::Handler { id, name, doc } => {
-                assert_eq!(id, ID);
+                assert_eq!(id, aether_id::KindId(ID));
                 assert_eq!(name, NAME);
                 assert_eq!(doc.as_deref(), DOC);
             }
@@ -414,7 +414,7 @@ mod tests {
         assert_eq!(
             decoded,
             InputsRecord::Handler {
-                id: ID,
+                id: aether_id::KindId(ID),
                 name: NAME.into(),
                 doc: None,
             }

--- a/crates/aether-hub-protocol/src/canonical/schema.rs
+++ b/crates/aether-hub-protocol/src/canonical/schema.rs
@@ -242,7 +242,7 @@ fn variant_to_shape(v: &EnumVariant) -> crate::types::VariantShape {
 /// other way around).
 pub(crate) const KIND_DOMAIN: &[u8] = b"kind:";
 
-use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
+use aether_id::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
 
 /// Derive a `Kind::ID` from a `(name, schema)` pair at runtime. Matches
 /// the `#[derive(Kind)]` compile-time emission byte-for-byte:

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -22,7 +22,11 @@ mod types;
 pub use types::*;
 
 pub mod canonical;
-pub mod tag_bits;
+// ADR-0064 tag-bit constants migrated to the `aether-id` leaf crate
+// (see `aether-id::tag_bits`). The re-export keeps the historical
+// `aether_hub_protocol::tag_bits::TAG_KIND` call paths working for
+// downstream crates without forcing them to take a fresh dep edge.
+pub use aether_id::tag_bits;
 
 /// Maximum accepted frame body size. Bounded so a malformed length
 /// prefix cannot drive a reader into an OOM. 16 MiB is comfortably
@@ -594,7 +598,7 @@ mod tests {
     #[test]
     fn inputs_record_handler_roundtrip() {
         let rec = InputsRecord::Handler {
-            id: 0xdead_beef_cafe_f00d,
+            id: aether_id::KindId(0xdead_beef_cafe_f00d),
             name: "aether.tick".into(),
             doc: Some("Not useful to send manually — the substrate drives this.".into()),
         };
@@ -605,7 +609,7 @@ mod tests {
     #[test]
     fn inputs_record_handler_without_doc_roundtrip() {
         let rec = InputsRecord::Handler {
-            id: 1,
+            id: aether_id::KindId(1),
             name: "aether.key".into(),
             doc: None,
         };
@@ -712,12 +716,12 @@ mod tests {
                 doc: "A canary component.".into(),
             },
             InputsRecord::Handler {
-                id: 42,
+                id: aether_id::KindId(42),
                 name: "aether.tick".into(),
                 doc: Some("heartbeat".into()),
             },
             InputsRecord::Handler {
-                id: 0xff,
+                id: aether_id::KindId(0xff),
                 name: "test.ping".into(),
                 doc: None,
             },

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -7,6 +7,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use aether_id::{KindId, MailboxId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
@@ -787,7 +788,7 @@ impl<'de> Deserialize<'de> for VariantLabel {
 /// in any order and the reader will rejoin them correctly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindLabels {
-    pub kind_id: u64,
+    pub kind_id: KindId,
     pub kind_label: Cow<'static, str>,
     pub root: LabelNode,
 }
@@ -804,7 +805,7 @@ pub struct KindLabels {
 pub enum InputsRecord {
     /// A `#[handler]` method's advertised capability.
     Handler {
-        id: u64,
+        id: KindId,
         name: Cow<'static, str>,
         doc: Option<Cow<'static, str>>,
     },
@@ -941,11 +942,11 @@ pub enum LogLevel {
 /// component.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineMailToHubSubstrateFrame {
-    pub recipient_mailbox_id: u64,
-    pub kind_id: u64,
+    pub recipient_mailbox_id: MailboxId,
+    pub kind_id: KindId,
     pub payload: Vec<u8>,
     pub count: u32,
-    pub source_mailbox_id: Option<u64>,
+    pub source_mailbox_id: Option<MailboxId>,
     /// ADR-0042 correlation id the originating component's
     /// `SubstrateCtx::send` minted. Carried across the hub so a
     /// bubbled-up mail's reply (ADR-0037 Phase 2) can echo back
@@ -964,8 +965,8 @@ pub struct EngineMailToHubSubstrateFrame {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MailToEngineMailboxFrame {
     pub target_engine_id: EngineId,
-    pub target_mailbox_id: u64,
-    pub kind_id: u64,
+    pub target_mailbox_id: MailboxId,
+    pub kind_id: KindId,
     pub payload: Vec<u8>,
     pub count: u32,
     /// ADR-0042 correlation echo. Set by the reply-emitting engine
@@ -984,8 +985,8 @@ pub struct MailToEngineMailboxFrame {
 /// `Mailer`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MailByIdFrame {
-    pub recipient_mailbox_id: u64,
-    pub kind_id: u64,
+    pub recipient_mailbox_id: MailboxId,
+    pub kind_id: KindId,
     pub payload: Vec<u8>,
     pub count: u32,
     /// ADR-0042 correlation echo. Carries through from

--- a/crates/aether-id/Cargo.toml
+++ b/crates/aether-id/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "aether-id"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+bytemuck = { version = "1.19", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }

--- a/crates/aether-id/src/hash.rs
+++ b/crates/aether-id/src/hash.rs
@@ -1,0 +1,71 @@
+//! FNV-1a 64-bit hashing + namespace prefixes used to construct
+//! deterministic ids from names / canonical schema bytes.
+//!
+//! The byte-domain prefixes (`MAILBOX_DOMAIN`, `KIND_DOMAIN`,
+//! `TYPE_DOMAIN`) keep id spaces statistically disjoint so a misrouted
+//! `MailboxId`-into-`KindId` slot (or vice versa) hashes to a
+//! different value rather than colliding silently.
+
+use crate::ids::MailboxId;
+use crate::tagged_id::{Tag, with_tag};
+
+/// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
+/// space is disjoint from `Kind::ID`. Both ids are 64-bit FNV-1a
+/// outputs; without a prefix the spaces overlap and a future bug that
+/// feeds a mailbox id into a kind-id slot (or vice versa) would
+/// misattribute silently. Prefixing makes the mis-attribution
+/// statistically impossible rather than relying on positional
+/// discipline at every call site.
+pub const MAILBOX_DOMAIN: &[u8] = b"mailbox:";
+
+/// Domain tag prefixed to every kind-id hash. See `MAILBOX_DOMAIN` for
+/// the rationale; the derive macro and `kind_id_from_parts` both
+/// prepend this before the canonical schema bytes.
+pub const KIND_DOMAIN: &[u8] = b"kind:";
+
+/// ADR-0065: domain prefix for type-id hashes. Hashed input is
+/// `TYPE_DOMAIN ++ canonical_type_name.as_bytes()` (e.g.
+/// `"type:aether.mailbox_id"`). Disjoint from mailbox / kind domains
+/// so a typed-id `TYPE_ID` cannot alias either space.
+pub const TYPE_DOMAIN: &[u8] = b"type:";
+
+/// FNV-1a 64 over a byte slice. Retained for the few call sites that
+/// hash neither a mailbox name nor a kind schema. New callers should
+/// prefer `fnv1a_64_prefixed` with an explicit domain so the output
+/// id space doesn't collide with an existing domain by accident.
+pub const fn fnv1a_64_bytes(bytes: &[u8]) -> u64 {
+    fnv1a_64_prefixed(&[], bytes)
+}
+
+/// FNV-1a 64 over `prefix ++ payload` without allocating. Equivalent
+/// to `fnv1a_64_bytes(&[prefix, payload].concat())` but `const`-safe.
+/// Used by `mailbox_id_from_name` (prefix `MAILBOX_DOMAIN`) and by
+/// `#[derive(Kind)]` through the macro (prefix `KIND_DOMAIN`).
+pub const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    let mut i = 0;
+    while i < prefix.len() {
+        hash ^= prefix[i] as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+        i += 1;
+    }
+    let mut i = 0;
+    while i < payload.len() {
+        hash ^= payload[i] as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+        i += 1;
+    }
+    hash
+}
+
+/// Compute the deterministic `MailboxId` for a mailbox name. ADR-0029
+/// FNV-1a with the `MAILBOX_DOMAIN` prefix, ADR-0064 tag bits stamped
+/// into the high nibble. Substrate and guest SDK compute this
+/// identically so ids round-trip verbatim across the FFI without a
+/// host-fn resolve.
+pub const fn mailbox_id_from_name(name: &str) -> MailboxId {
+    MailboxId(with_tag(
+        Tag::Mailbox,
+        fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes()),
+    ))
+}

--- a/crates/aether-id/src/ids.rs
+++ b/crates/aether-id/src/ids.rs
@@ -3,10 +3,10 @@
 //! Each type is `#[repr(transparent)]` over a `u64` (postcard
 //! wire-identical to a raw u64; cast-shape kinds keep their
 //! `#[repr(C)]` layout) and exposes a `pub const TYPE_ID: u64`
-//! that the `Schema` impl emits as `SchemaType::TypeId(Self::TYPE_ID)`.
-//! The hub's encoder/decoder dispatch on the `TYPE_ID` value to
-//! translate JSON (tagged-string form per ADR-0064) ↔ postcard
-//! (u64 varint) at the wire boundary.
+//! that downstream `Schema` impls (in `aether-mail`) emit as
+//! `SchemaType::TypeId(Self::TYPE_ID)`. The hub's encoder/decoder
+//! dispatch on the `TYPE_ID` value to translate JSON (tagged-string
+//! form per ADR-0064) ↔ postcard (u64 varint) at the wire boundary.
 //!
 //! The underlying `u64` carries the ADR-0064 tag bits (4-bit type
 //! discriminator in the high nibble + 60-bit FNV-1a hash in the low
@@ -15,14 +15,11 @@
 
 use core::fmt;
 
-use aether_hub_protocol::{LabelNode, SchemaType};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::CastEligible;
-use crate::schema::Schema;
+use crate::hash::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name};
 use crate::tagged_id::{self, Tag};
-use crate::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name};
 
 /// Shared `Display` body — render tagged-string form when the tag
 /// bits are valid, fall back to hex for reserved sentinels.
@@ -137,15 +134,11 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct MailboxId(pub u64);
 
-impl CastEligible for MailboxId {
-    const ELIGIBLE: bool = true;
-}
-
 impl MailboxId {
     /// Stable type id — FNV-1a of `TYPE_DOMAIN ++ TYPE_NAME`. The
-    /// `Schema` impl emits this as `SchemaType::TypeId(...)`; the
-    /// hub's codec arms key on it to pick the JSON/postcard
-    /// translation.
+    /// `Schema` impl (in `aether-mail`) emits this as
+    /// `SchemaType::TypeId(...)`; the hub's codec arms key on it to
+    /// pick the JSON/postcard translation.
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.mailbox_id");
 
     /// Canonical name used to compute `TYPE_ID`. Surfaced by
@@ -173,12 +166,6 @@ impl fmt::Display for MailboxId {
     }
 }
 
-impl Schema for MailboxId {
-    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
-    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
-    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
-}
-
 impl Serialize for MailboxId {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         serialize_id(self.0, s)
@@ -198,10 +185,6 @@ impl<'de> Deserialize<'de> for MailboxId {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct KindId(pub u64);
 
-impl CastEligible for KindId {
-    const ELIGIBLE: bool = true;
-}
-
 impl KindId {
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.kind_id");
     pub const TYPE_NAME: &'static str = "aether.kind_id";
@@ -211,12 +194,6 @@ impl fmt::Display for KindId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
-}
-
-impl Schema for KindId {
-    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
-    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
-    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
 }
 
 impl Serialize for KindId {
@@ -239,10 +216,6 @@ impl<'de> Deserialize<'de> for KindId {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct HandleId(pub u64);
 
-impl CastEligible for HandleId {
-    const ELIGIBLE: bool = true;
-}
-
 impl HandleId {
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.handle_id");
     pub const TYPE_NAME: &'static str = "aether.handle_id";
@@ -252,12 +225,6 @@ impl fmt::Display for HandleId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
-}
-
-impl Schema for HandleId {
-    const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
-    const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
-    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
 }
 
 impl Serialize for HandleId {

--- a/crates/aether-id/src/lib.rs
+++ b/crates/aether-id/src/lib.rs
@@ -1,0 +1,29 @@
+//! Typed-id leaf crate: ADR-0064 / ADR-0065 newtypes + ADR-0029
+//! mailbox-name hashing + tag-bit layout. Sits below both
+//! `aether-mail` and `aether-hub-protocol` so the wire-protocol
+//! crate can type its mailbox/kind/handle fields without the
+//! `aether-mail → aether-hub-protocol` dep cycle. `aether-mail`
+//! still owns the `Schema` and `CastEligible` trait impls for these
+//! types (orphan rules — those traits live in `aether-mail`).
+//!
+//! The newtypes are `#[repr(transparent)]` over `u64`, so the
+//! postcard binary wire is byte-identical to a raw `u64` field.
+//! `Serialize` / `Deserialize` branch on `is_human_readable`: JSON
+//! gets the ADR-0064 tagged-string form (`mbx-XXXX-XXXX-XXXX`),
+//! binary gets the raw varint.
+
+#![no_std]
+
+extern crate alloc;
+
+pub mod hash;
+pub mod ids;
+pub mod tag_bits;
+pub mod tagged_id;
+
+pub use hash::{
+    KIND_DOMAIN, MAILBOX_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
+    mailbox_id_from_name,
+};
+pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
+pub use tagged_id::{Tag, with_tag};

--- a/crates/aether-id/src/tag_bits.rs
+++ b/crates/aether-id/src/tag_bits.rs
@@ -1,12 +1,5 @@
 //! ADR-0064 bit-layout constants for tagged opaque ids.
 //!
-//! Lives here rather than in `aether-mail` because
-//! `aether-hub-protocol::canonical::schema::kind_id_from_parts`
-//! needs to OR the kind tag in at runtime, and the dep direction is
-//! `aether-mail → aether-hub-protocol`. `aether-mail::tagged_id`
-//! re-exports these and layers the `Tag` enum + base32 string
-//! encoding on top.
-//!
 //! `[tag: 4 bits | hash: 60 bits]`. The tag identifies the id space
 //! (mailbox / kind / handle); the hash is the low 60 bits of an
 //! FNV-1a output (mailbox, kind) or a counter (handle). `0x0` is

--- a/crates/aether-id/src/tagged_id.rs
+++ b/crates/aether-id/src/tagged_id.rs
@@ -18,7 +18,7 @@
 use alloc::string::String;
 use core::fmt;
 
-pub use aether_hub_protocol::tag_bits::{HASH_MASK, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT};
+pub use crate::tag_bits::{HASH_MASK, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT};
 
 /// Type tag identifying an id space. Encoded in the high 4 bits of
 /// every tagged id. `0x0` is reserved as an invalid sentinel — a
@@ -129,11 +129,6 @@ pub fn encode(id: u64) -> Option<String> {
     let body = body_of(id);
     let mut out = String::with_capacity(3 + 1 + 12 + 2);
     out.push_str(tag.prefix());
-    // Emit 12 base32 chars (60 bits / 5 bits per char), grouped
-    // into three 4-char chunks separated by `-`. The shift starts
-    // at bit 55 (the most significant of the 60 hash bits) and
-    // counts down by 5 each char so the leftmost chars carry the
-    // most significant bits — same convention as hex.
     for i in 0..12 {
         if i % 4 == 0 {
             out.push('-');
@@ -148,7 +143,6 @@ pub fn encode(id: u64) -> Option<String> {
 /// Decode a tagged-id string back to its `u64` form, or fail with a
 /// typed error. Case-insensitive.
 pub fn decode(s: &str) -> Result<u64, DecodeError> {
-    // Total length: 3 (prefix) + 1 (dash) + 4 + 1 + 4 + 1 + 4 = 18.
     if s.len() != 18 {
         return Err(DecodeError::Malformed);
     }
@@ -225,8 +219,6 @@ mod tests {
 
     #[test]
     fn alphabet_excludes_digit_lookalikes() {
-        // Body of all-1s should produce all `7`s (the highest base32
-        // char), exercising the high end of the alphabet.
         let id = with_tag(Tag::Kind, HASH_MASK);
         let s = encode(id).unwrap();
         assert_eq!(s, "knd-7777-7777-7777");
@@ -238,11 +230,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_zero_tag() {
-        // 0x0 in the high nibble is reserved invalid. `encode(0u64)`
-        // should refuse rather than emit a string that decodes to a
-        // bogus id.
         assert!(encode(0u64).is_none());
-        // Hand-crafted "rsv-" prefix isn't in the table → Malformed.
         assert_eq!(decode("rsv-aaaa-aaaa-aaaa"), Err(DecodeError::Malformed));
     }
 
@@ -254,8 +242,6 @@ mod tests {
 
     #[test]
     fn decode_rejects_invalid_chars() {
-        // `0` and `1` are not in the base32 alphabet (they're the
-        // ones we deliberately skipped).
         assert_eq!(
             decode("mbx-0aaa-aaaa-aaaa"),
             Err(DecodeError::InvalidChar('0'))
@@ -290,10 +276,6 @@ mod tests {
 
     #[test]
     fn body_drops_high_bits() {
-        // Caller passes a "raw" hash with high bits set; with_tag
-        // masks them off before OR-ing the tag in. Critical that
-        // the natural FNV-1a high bits don't leak past the boundary
-        // and corrupt the tag.
         let id = with_tag(Tag::Mailbox, 0xFFFF_FFFF_FFFF_FFFF);
         assert_eq!(tag_of(id), Some(Tag::Mailbox));
         assert_eq!(body_of(id), HASH_MASK);

--- a/crates/aether-mail-derive/src/lib.rs
+++ b/crates/aether-mail-derive/src/lib.rs
@@ -183,10 +183,9 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         // `&#labels_ident` see a stable `'static` reference.
         static #labels_ident: ::aether_mail::__derive_runtime::KindLabels =
             ::aether_mail::__derive_runtime::KindLabels {
-                // KindLabels.kind_id is wire-format `u64`; `Kind::ID` is
-                // typed `KindId` (issue 466) so we drop into the raw
-                // hash for the wire bytes.
-                kind_id: <#name as ::aether_mail::Kind>::ID.0,
+                // Issue 469: `KindLabels.kind_id` is now typed
+                // `KindId` (matches `Kind::ID`); pass through directly.
+                kind_id: <#name as ::aether_mail::Kind>::ID,
                 kind_label: ::aether_mail::__derive_runtime::Cow::Borrowed(
                     ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#name)),
                 ),
@@ -1291,9 +1290,9 @@ fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn])
             // Schema impls).
             static #labels_static_ident: ::aether_component::__macro_internals::KindLabels =
                 ::aether_component::__macro_internals::KindLabels {
-                    // KindLabels.kind_id is wire-format `u64`; drop into
-                    // `.0` from the typed `Kind::ID` (issue 466).
-                    kind_id: <#k as ::aether_component::__macro_internals::Kind>::ID.0,
+                    // Issue 469: `KindLabels.kind_id` is typed
+                    // `KindId` end-to-end; pass through directly.
+                    kind_id: <#k as ::aether_component::__macro_internals::Kind>::ID,
                     kind_label: ::aether_component::__macro_internals::Cow::Borrowed(
                         match <#k as ::aether_component::__macro_internals::Schema>::LABEL {
                             ::core::option::Option::Some(s) => s,

--- a/crates/aether-mail/Cargo.toml
+++ b/crates/aether-mail/Cargo.toml
@@ -16,6 +16,7 @@ derive = ["dep:aether-mail-derive"]
 # `Schema` trait and the derive's `const ID` emission work uniformly
 # on host and wasm.
 aether-hub-protocol = { path = "../aether-hub-protocol", default-features = false }
+aether-id = { path = "../aether-id" }
 aether-mail-derive = { path = "../aether-mail-derive", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }

--- a/crates/aether-mail/src/lib.rs
+++ b/crates/aether-mail/src/lib.rs
@@ -21,11 +21,20 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::fmt;
 
-pub mod ids;
 pub mod mailboxes;
-pub mod tagged_id;
-pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
-pub use tagged_id::{Tag, with_tag};
+
+// Typed-id newtypes (ADR-0064 / ADR-0065) live in the `aether-id`
+// leaf crate so `aether-hub-protocol` can type its wire fields
+// without the `aether-mail → aether-hub-protocol` dep cycle. The
+// `Schema` and `CastEligible` impls for these types stay here
+// (orphan rules — those traits are owned by `aether-mail`). Module
+// re-exports preserve the historical `aether_mail::tagged_id::encode`
+// and `aether_mail::ids::MailboxId` call paths.
+pub use aether_id::{
+    HandleId, KIND_DOMAIN, KindId, MAILBOX_DOMAIN, MailboxId, TYPE_DOMAIN, Tag, fnv1a_64_bytes,
+    fnv1a_64_prefixed, hash, ids, mailbox_id_from_name, tag_bits, tag_for_type_id, tagged_id,
+    type_name_for_type_id, with_tag,
+};
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`) and a `u64` id derived from
@@ -118,6 +127,21 @@ macro_rules! cast_eligible_primitive {
 
 cast_eligible_primitive!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, bool);
 
+// Typed-id newtypes are `#[repr(transparent)]` over `u64`, so a
+// cast-shape struct field typed `MailboxId` / `KindId` / `HandleId`
+// is wire-identical to a `u64` field. The trait lives here, the
+// types live in `aether-id` — orphan rules let us write the impl
+// in `aether-mail`.
+impl CastEligible for MailboxId {
+    const ELIGIBLE: bool = true;
+}
+impl CastEligible for KindId {
+    const ELIGIBLE: bool = true;
+}
+impl CastEligible for HandleId {
+    const ELIGIBLE: bool = true;
+}
+
 impl<T: CastEligible, const N: usize> CastEligible for [T; N] {
     const ELIGIBLE: bool = T::ELIGIBLE;
 }
@@ -146,87 +170,6 @@ impl<K> CastEligible for Ref<K> {
 // parent struct from `repr_c`, same as `Vec`/`String`/`Option`.
 impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
     const ELIGIBLE: bool = false;
-}
-
-/// Deterministic 64-bit hash of a mailbox name (ADR-0029). Both the
-/// substrate registry and the guest SDK compute mailbox ids from names
-/// this way, which is how ids end up meaningful across processes and
-/// sessions without needing a host-fn resolve.
-///
-/// FNV-1a 64 is chosen for: (a) no dependencies — the algorithm is
-/// ~8 lines; (b) determinism across builds, platforms, and rust
-/// versions, without having to pin a third-party hasher; (c) the
-/// distribution is more than good enough at mailbox cardinality.
-/// At 64 bits the birthday bound is far past realistic mailbox
-/// counts — see ADR-0029 "Consequences" for the table.
-///
-/// The returned `MailboxId` is a `#[repr(transparent)]` newtype
-/// over `u64`; guests that need the raw scalar for FFI (`send_mail`'s
-/// `recipient`) call `.0`. `0` is reserved as the no-sender sentinel —
-/// callers should reject on the astronomical chance of a collision
-/// with it.
-///
-/// ADR-0064: the high 4 bits carry the `Tag::Mailbox` discriminator;
-/// the low 60 bits are the FNV-1a output masked by `HASH_MASK`. The
-/// `MAILBOX_DOMAIN` byte prefix still rides on the FNV input — the
-/// type ends up encoded twice (in the tag bits and avalanched into
-/// the hash via the domain prefix), and the two layers cross-check
-/// each other.
-pub const fn mailbox_id_from_name(name: &str) -> MailboxId {
-    MailboxId(with_tag(
-        Tag::Mailbox,
-        fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes()),
-    ))
-}
-
-/// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
-/// space is disjoint from `Kind::ID`. Both ids are 64-bit FNV-1a
-/// outputs; without a prefix the spaces overlap and a future bug that
-/// feeds a mailbox id into a kind-id slot (or vice versa) would
-/// misattribute silently. Prefixing makes the mis-attribution
-/// statistically impossible rather than relying on positional
-/// discipline at every call site.
-pub const MAILBOX_DOMAIN: &[u8] = b"mailbox:";
-
-/// Domain tag prefixed to every kind-id hash. See `MAILBOX_DOMAIN` for
-/// the rationale; the derive macro and `kind_id_from_parts` both
-/// prepend this before the canonical schema bytes.
-pub const KIND_DOMAIN: &[u8] = b"kind:";
-
-/// ADR-0065: domain prefix for type-id hashes. Hashed input is
-/// `TYPE_DOMAIN ++ canonical_type_name.as_bytes()` (e.g.
-/// `"type:aether.mailbox_id"`). Disjoint from mailbox / kind domains
-/// so a typed-id `TYPE_ID` cannot alias either space.
-pub const TYPE_DOMAIN: &[u8] = b"type:";
-
-/// FNV-1a 64 over a byte slice (ADR-0032). Retained for the few
-/// call sites that hash neither a mailbox name nor a kind schema.
-/// New callers should prefer `fnv1a_64_prefixed` with an explicit
-/// domain so the output id space doesn't collide with an existing
-/// domain by accident.
-pub const fn fnv1a_64_bytes(bytes: &[u8]) -> u64 {
-    fnv1a_64_prefixed(&[], bytes)
-}
-
-/// FNV-1a 64 over `prefix ++ payload` without allocating. Equivalent
-/// to `fnv1a_64_bytes(&[prefix, payload].concat())` but `const`-safe.
-/// Used by `mailbox_id_from_name` (prefix `MAILBOX_DOMAIN`) and by
-/// `#[derive(Kind)]` through the macro (prefix `KIND_DOMAIN`).
-pub const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
-    let mut hash: u64 = 0xcbf29ce484222325;
-    let mut i = 0;
-    while i < prefix.len() {
-        hash ^= prefix[i] as u64;
-        hash = hash.wrapping_mul(0x100000001b3);
-        i += 1;
-    }
-    let mut i = 0;
-    while i < payload.len() {
-        hash ^= payload[i] as u64;
-        hash = hash.wrapping_mul(0x100000001b3);
-        i += 1;
-    }
-    hash
 }
 
 /// ADR-0045 typed handle reference — wire form for fields that
@@ -520,6 +463,28 @@ mod schema {
         };
         const LABEL: Option<&'static str> = None;
         const LABEL_NODE: LabelNode = LabelNode::Array(LabelCell::Static(&T::LABEL_NODE));
+    }
+
+    // ADR-0064 / ADR-0065 typed-id newtypes. Bodies live in the
+    // `aether-id` leaf crate (so `aether-hub-protocol` can type its
+    // wire fields without a dep cycle); the `Schema` trait is owned
+    // here, so the impls also live here.
+    impl Schema for aether_id::MailboxId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(aether_id::MailboxId::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(aether_id::MailboxId::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+    }
+
+    impl Schema for aether_id::KindId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(aether_id::KindId::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(aether_id::KindId::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+    }
+
+    impl Schema for aether_id::HandleId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(aether_id::HandleId::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(aether_id::HandleId::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
     }
 
     // ADR-0045 typed handle reference. `Ref<K>` exposes both the

--- a/crates/aether-substrate-core/src/control/tests.rs
+++ b/crates/aether-substrate-core/src/control/tests.rs
@@ -329,7 +329,7 @@ fn load_component_registers_kinds_from_embedded_manifest() {
         },
     };
     let labels = aether_hub_protocol::KindLabels {
-        kind_id: aether_hub_protocol::canonical::kind_id_from_shape(&shape),
+        kind_id: aether_mail::KindId(aether_hub_protocol::canonical::kind_id_from_shape(&shape)),
         kind_label: std::borrow::Cow::Borrowed("demo::EmbeddedKind"),
         root: aether_hub_protocol::LabelNode::Struct {
             type_label: Some(std::borrow::Cow::Borrowed("demo::EmbeddedKind")),
@@ -412,7 +412,7 @@ fn load_component_with_same_name_different_schema_registers_distinct_kind() {
         schema: aether_hub_protocol::SchemaShape::Scalar(Primitive::U64),
     };
     let labels = aether_hub_protocol::KindLabels {
-        kind_id: aether_hub_protocol::canonical::kind_id_from_shape(&shape),
+        kind_id: aether_mail::KindId(aether_hub_protocol::canonical::kind_id_from_shape(&shape)),
         kind_label: std::borrow::Cow::Borrowed("demo::Conflict"),
         root: aether_hub_protocol::LabelNode::Anonymous,
     };

--- a/crates/aether-substrate-core/src/ctx.rs
+++ b/crates/aether-substrate-core/src/ctx.rs
@@ -255,11 +255,11 @@ mod tests {
         let frame = outbound_rx.try_recv().expect("bubble-up frame emitted");
         match frame {
             EngineToHub::MailToHubSubstrate(f) => {
-                assert_eq!(f.recipient_mailbox_id, unknown.0);
-                assert_eq!(f.kind_id, kind.0);
+                assert_eq!(f.recipient_mailbox_id, unknown);
+                assert_eq!(f.kind_id, kind);
                 assert_eq!(f.payload, vec![1, 2, 3]);
                 assert_eq!(f.count, 1);
-                assert_eq!(f.source_mailbox_id, Some(sender.0));
+                assert_eq!(f.source_mailbox_id, Some(sender));
             }
             other => panic!("expected MailToHubSubstrate, got {other:?}"),
         }

--- a/crates/aether-substrate-core/src/host_fns.rs
+++ b/crates/aether-substrate-core/src/host_fns.rs
@@ -222,8 +222,8 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
                     ctx.outbound.send(EngineToHub::MailToEngineMailbox(
                         aether_hub_protocol::MailToEngineMailboxFrame {
                             target_engine_id: engine_id,
-                            target_mailbox_id: mailbox_id.0,
-                            kind_id: kind.0,
+                            target_mailbox_id: mailbox_id,
+                            kind_id: kind,
                             payload,
                             count,
                             correlation_id: correlation,

--- a/crates/aether-substrate-core/src/hub_client.rs
+++ b/crates/aether-substrate-core/src/hub_client.rs
@@ -121,10 +121,9 @@ impl HubOutbound {
                 mailbox_id,
             } => self.send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
                 target_engine_id: engine_id,
-                target_mailbox_id: mailbox_id.0,
-                // wire frame is `u64`; drop into `.0` from the typed
-                // `Kind::ID` (issue 466).
-                kind_id: K::ID.0,
+                target_mailbox_id: mailbox_id,
+                // Issue 469: wire frame fields are typed end-to-end.
+                kind_id: K::ID,
                 payload,
                 count: 1,
                 correlation_id: sender.correlation_id,
@@ -299,18 +298,18 @@ pub fn dispatch_hub_to_engine_mail(frame: MailFrame, registry: &Registry, queue:
 /// up. Public so the hub-chassis's engine read loop can call the
 /// same helper from its own side of the wire.
 pub fn dispatch_hub_mail_by_id(frame: MailByIdFrame, registry: &Registry, queue: &Mailer) {
-    let kind = aether_mail::KindId(frame.kind_id);
+    let kind = frame.kind_id;
     if registry.kind_name(kind).is_none() {
         tracing::warn!(
             target: "aether_substrate::hub_client",
-            kind_id = frame.kind_id,
-            mailbox_id = frame.recipient_mailbox_id,
+            kind_id = %frame.kind_id,
+            mailbox_id = %frame.recipient_mailbox_id,
             "MailById with unknown kind — dropped",
         );
         return;
     }
     queue.push(Mail::new(
-        crate::mail::MailboxId(frame.recipient_mailbox_id),
+        frame.recipient_mailbox_id,
         kind,
         frame.payload,
         frame.count,

--- a/crates/aether-substrate-core/src/kind_manifest.rs
+++ b/crates/aether-substrate-core/src/kind_manifest.rs
@@ -107,12 +107,12 @@ pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
         }
     }
 
-    let labels_by_id: HashMap<u64, KindLabels> =
+    let labels_by_id: HashMap<aether_mail::KindId, KindLabels> =
         labels_list.into_iter().map(|l| (l.kind_id, l)).collect();
 
     let mut descriptors = Vec::with_capacity(kinds.len());
     for (shape, is_stream) in kinds {
-        let id = kind_id_from_shape(&shape);
+        let id = aether_mail::KindId(kind_id_from_shape(&shape));
         let label = labels_by_id.get(&id);
         descriptors.push(merge(shape, label, is_stream));
     }
@@ -190,7 +190,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
         match record {
             InputsRecord::Handler { id, name, doc } => {
                 caps.handlers.push(HandlerCapability {
-                    id: aether_mail::KindId(id),
+                    id,
                     name: name.into_owned(),
                     doc: doc.map(|d| d.into_owned()),
                 });
@@ -510,7 +510,7 @@ mod tests {
     /// merge finds it. Matches what the Kind derive emits into
     /// `aether.kinds.labels` (v0x03 adds `kind_id`).
     fn push_labels(labels_bytes: &mut Vec<u8>, shape: &KindShape, labels: &mut KindLabels) {
-        labels.kind_id = kind_id_from_shape(shape);
+        labels.kind_id = aether_mail::KindId(kind_id_from_shape(shape));
         labels_bytes.push(0x03);
         labels_bytes.extend(postcard::to_allocvec(labels).unwrap());
     }
@@ -525,7 +525,7 @@ mod tests {
             },
         };
         let mut labels = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my_crate::TestKind"),
             root: LabelNode::Struct {
                 type_label: Some(Cow::Borrowed("my_crate::TestKind")),
@@ -565,12 +565,12 @@ mod tests {
             },
         ];
         let mut labels_a = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my::A"),
             root: LabelNode::Anonymous,
         };
         let mut labels_b = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my::B"),
             root: LabelNode::Anonymous,
         };
@@ -661,7 +661,7 @@ mod tests {
             },
         };
         let mut labels = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my::Dup"),
             root: LabelNode::Struct {
                 type_label: Some(Cow::Borrowed("my::Dup")),
@@ -702,7 +702,7 @@ mod tests {
         };
         let mut orphan = KindLabels {
             // Deliberately a id that won't match `shape`.
-            kind_id: 0xDEADBEEF_DEADBEEF,
+            kind_id: aether_mail::KindId(0xDEADBEEF_DEADBEEF),
             kind_label: Cow::Borrowed("my::Missing"),
             root: LabelNode::Anonymous,
         };
@@ -768,7 +768,7 @@ mod tests {
             },
         };
         let mut labels = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my::Outcome"),
             root: LabelNode::Enum {
                 type_label: Some(Cow::Borrowed("my::Outcome")),
@@ -844,7 +844,7 @@ mod tests {
         // Array's child goes through a LabelCell::Owned because we
         // build it at runtime here. Derive-time would use Static.
         let mut labels = KindLabels {
-            kind_id: 0,
+            kind_id: aether_mail::KindId(0),
             kind_label: Cow::Borrowed("my::Triangle"),
             root: LabelNode::Struct {
                 type_label: Some(Cow::Borrowed("my::Triangle")),
@@ -898,12 +898,12 @@ mod tests {
                 doc: "Draws triangles on tick.".into(),
             },
             InputsRecord::Handler {
-                id: 42,
+                id: aether_mail::KindId(42),
                 name: "aether.tick".into(),
                 doc: Some("substrate drives this".into()),
             },
             InputsRecord::Handler {
-                id: 0xff,
+                id: aether_mail::KindId(0xff),
                 name: "aether.ping".into(),
                 doc: None,
             },

--- a/crates/aether-substrate-core/src/mailer.rs
+++ b/crates/aether-substrate-core/src/mailer.rs
@@ -363,15 +363,15 @@ fn route_mail(
                 // for the receiving component. `None` for mail
                 // with no local component origin (broadcast-
                 // originated, substrate-generated).
-                let source_mailbox_id = mail.from_component.map(|mbox| mbox.0);
+                let source_mailbox_id = mail.from_component;
                 // ADR-0042: carry the correlation through the bubble-
                 // up frame so a reply coming back via Phase-2 reply
                 // routing lands at the originator's `wait_reply_p32`.
                 let correlation_id = mail.reply_to.correlation_id;
                 let sent = outbound.send(EngineToHub::MailToHubSubstrate(
                     EngineMailToHubSubstrateFrame {
-                        recipient_mailbox_id: recipient.0,
-                        kind_id: mail.kind.0,
+                        recipient_mailbox_id: recipient,
+                        kind_id: mail.kind,
                         payload: mail.payload,
                         count: mail.count,
                         source_mailbox_id,
@@ -432,8 +432,8 @@ mod tests {
         let frame = outbound_rx.try_recv().expect("bubble-up frame emitted");
         match frame {
             EngineToHub::MailToHubSubstrate(f) => {
-                assert_eq!(f.recipient_mailbox_id, unknown.0);
-                assert_eq!(f.kind_id, kind.0);
+                assert_eq!(f.recipient_mailbox_id, unknown);
+                assert_eq!(f.kind_id, kind);
                 assert_eq!(f.payload, payload);
                 assert_eq!(f.count, 1);
             }

--- a/crates/aether-substrate-hub/src/loopback.rs
+++ b/crates/aether-substrate-hub/src/loopback.rs
@@ -43,8 +43,7 @@ use aether_hub_protocol::{
 use aether_kinds::UnresolvedMail;
 use aether_mail::Kind;
 use aether_substrate_core::{
-    Mail, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
-    dispatch_hub_to_engine_mail,
+    Mail, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot, dispatch_hub_to_engine_mail,
 };
 use tokio::sync::mpsc;
 
@@ -128,19 +127,18 @@ impl LoopbackHandle {
     ) {
         let EngineMailToHubSubstrateFrame {
             recipient_mailbox_id,
-            kind_id,
+            kind_id: kind,
             payload,
             count,
             source_mailbox_id,
             correlation_id,
         } = frame;
-        let kind = aether_mail::KindId(kind_id);
         // Kind lookup guards against an engine bubbling up a kind
         // the hub substrate doesn't know — without it the mail
         // would reach a component expecting a different layout.
         if self.registry.kind_name(kind).is_none() {
             eprintln!(
-                "aether-substrate-hub: bubbled-up mail of unknown kind_id={kind_id} \
+                "aether-substrate-hub: bubbled-up mail of unknown kind_id={kind} \
                  mailbox_id={recipient_mailbox_id} — dropped"
             );
             return;
@@ -151,37 +149,27 @@ impl LoopbackHandle {
         // `aether.mail.unresolved` observation back to the
         // originating engine so the typo surfaces in that engine's
         // own `engine_logs`. ADR-0037 follow-up / issue #185.
-        if self
-            .registry
-            .entry(MailboxId(recipient_mailbox_id))
-            .is_none()
-        {
+        if self.registry.entry(recipient_mailbox_id).is_none() {
             eprintln!(
                 "aether-substrate-hub: bubbled-up mail from engine {source_engine_id:?} to \
-                 unknown mailbox_id={recipient_mailbox_id:#x} kind_id={kind_id:#x} — returning \
+                 unknown mailbox_id={recipient_mailbox_id} kind_id={kind} — returning \
                  `aether.mail.unresolved` diagnostic to originator"
             );
-            send_unresolved_diagnostic(
-                engines,
-                source_engine_id,
-                MailboxId(recipient_mailbox_id),
-                kind,
-            );
+            send_unresolved_diagnostic(engines, source_engine_id, recipient_mailbox_id, kind);
             return;
         }
         let sender = match source_mailbox_id {
             Some(mailbox_id) => ReplyTo::with_correlation(
                 ReplyTarget::EngineMailbox {
                     engine_id: source_engine_id,
-                    mailbox_id: MailboxId(mailbox_id),
+                    mailbox_id,
                 },
                 correlation_id,
             ),
             None => ReplyTo::with_correlation(ReplyTarget::None, correlation_id),
         };
-        self.queue.push(
-            Mail::new(MailboxId(recipient_mailbox_id), kind, payload, count).with_reply_to(sender),
-        );
+        self.queue
+            .push(Mail::new(recipient_mailbox_id, kind, payload, count).with_reply_to(sender));
     }
 }
 
@@ -207,8 +195,8 @@ fn send_unresolved_diagnostic(
     })
     .to_vec();
     let frame = HubToEngine::MailById(MailByIdFrame {
-        recipient_mailbox_id: aether_mail::mailboxes::DIAGNOSTICS.0,
-        kind_id: UnresolvedMail::ID.0,
+        recipient_mailbox_id: aether_mail::mailboxes::DIAGNOSTICS,
+        kind_id: UnresolvedMail::ID,
         payload,
         count: 1,
         correlation_id: 0,
@@ -435,8 +423,8 @@ mod tests {
         outbound_tx
             .send(EngineToHub::MailToEngineMailbox(MailToEngineMailboxFrame {
                 target_engine_id,
-                target_mailbox_id: 99,
-                kind_id: 42,
+                target_mailbox_id: aether_mail::MailboxId(99),
+                kind_id: aether_mail::KindId(42),
                 payload: vec![1, 2, 3],
                 count: 1,
                 correlation_id: 0,
@@ -449,8 +437,8 @@ mod tests {
             .expect("mail_rx closed");
         match got {
             HubToEngine::MailById(frame) => {
-                assert_eq!(frame.recipient_mailbox_id, 99);
-                assert_eq!(frame.kind_id, 42);
+                assert_eq!(frame.recipient_mailbox_id, aether_mail::MailboxId(99));
+                assert_eq!(frame.kind_id, aether_mail::KindId(42));
                 assert_eq!(frame.payload, vec![1, 2, 3]);
                 assert_eq!(frame.count, 1);
             }
@@ -477,8 +465,8 @@ mod tests {
         handle.deliver_bubbled_mail(
             EngineId(Uuid::from_u128(0x1234)),
             EngineMailToHubSubstrateFrame {
-                recipient_mailbox_id: 42,
-                kind_id: 0xDEAD_BEEF_DEAD_BEEF,
+                recipient_mailbox_id: aether_mail::MailboxId(42),
+                kind_id: aether_mail::KindId(0xDEAD_BEEF_DEAD_BEEF),
                 payload: vec![1, 2, 3],
                 count: 1,
                 source_mailbox_id: None,
@@ -525,11 +513,11 @@ mod tests {
         handle.deliver_bubbled_mail(
             originator_id,
             EngineMailToHubSubstrateFrame {
-                recipient_mailbox_id: 0xBAD_C0FFEE_u64,
-                kind_id: <aether_kinds::Tick as Kind>::ID.0,
+                recipient_mailbox_id: aether_mail::MailboxId(0xBAD_C0FFEE_u64),
+                kind_id: <aether_kinds::Tick as Kind>::ID,
                 payload: vec![],
                 count: 1,
-                source_mailbox_id: Some(0x5151),
+                source_mailbox_id: Some(aether_mail::MailboxId(0x5151)),
                 correlation_id: 0,
             },
             &engines,
@@ -541,10 +529,10 @@ mod tests {
         let HubToEngine::MailById(frame) = got else {
             panic!("expected MailById, got {got:?}");
         };
-        assert_eq!(frame.kind_id, UnresolvedMail::ID.0);
+        assert_eq!(frame.kind_id, UnresolvedMail::ID);
         assert_eq!(
             frame.recipient_mailbox_id,
-            aether_mail::mailboxes::DIAGNOSTICS.0,
+            aether_mail::mailboxes::DIAGNOSTICS,
         );
         let record: &UnresolvedMail = bytemuck::from_bytes(&frame.payload);
         assert_eq!(


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #469 must use # for GitHub auto-close -->

## Summary

- New leaf crate aether-id houses MailboxId, KindId, HandleId, the ADR-0064 tag-bit machinery, and FNV mailbox-name hashing. Sits below both aether-mail and aether-hub-protocol so the wire structs in hub-protocol can finally type their nine u64 mailbox/kind fields without the dep cycle that blocked issue 469.
- Wire bytes unchanged: typed-id newtypes are repr(transparent) over u64 and their serde impls branch on is_human_readable, so postcard fall-throughs are bit-identical to a raw u64. Substrate ↔ hub TCP frames and the aether.kinds.labels / aether.kinds.inputs wasm custom sections match byte-for-byte across versions.
- aether-mail re-exports the moved surface (HandleId, KindId, MailboxId, Tag, with_tag, mailbox_id_from_name, fnv1a_64_prefixed, the *_DOMAIN consts, the tagged_id / tag_bits / ids / hash modules) so every existing call site keeps working. Schema and CastEligible impls for the typed-ids stay in aether-mail (orphan rules). The Kind derive's KindLabels.kind_id and #[handlers]' InputsRecord::Handler.id drop their .0 extractions now that both wire fields are typed.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace
- [x] cargo check -p aether-camera-component --target wasm32-unknown-unknown (sanity for component-side macro emission)

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)