### PR TITLE
refactor(core): extract handle sink as native capability (ADR-0070 phase 2)

### DIFF
--- a/crates/aether-substrate-core/src/boot.rs
+++ b/crates/aether-substrate-core/src/boot.rs
@@ -42,20 +42,11 @@ use aether_data::KindDescriptor;
 use wasmtime::{Engine, Linker};
 
 use crate::{
-    AETHER_CONTROL, AETHER_DIAGNOSTICS, ChassisControlHandler, ControlPlane, HUB_CLAUDE_BROADCAST,
-    HubClient, HubOutbound, InputSubscribers, Mailer, Registry, Scheduler, SubstrateCtx,
-    handle_sink::handle_sink_handler, handle_store::HandleStore, host_fns, input::new_subscribers,
-    log_capture, mail::MailboxId,
+    AETHER_CONTROL, AETHER_DIAGNOSTICS, BootedChassis, ChassisBuilder, ChassisControlHandler,
+    ControlPlane, HUB_CLAUDE_BROADCAST, HubClient, HubOutbound, InputSubscribers, Mailer, Registry,
+    Scheduler, SubstrateCtx, capabilities::HandleCapability, handle_store::HandleStore, host_fns,
+    input::new_subscribers, log_capture, mail::MailboxId,
 };
-
-/// Well-known mailbox name for the ADR-0045 typed-handle sink. The
-/// SDK's `Ctx::publish` mails `aether.handle.publish` to this name;
-/// the substrate's `handle_sink_handler` decodes the request,
-/// drives the `HandleStore`, and replies with the paired `*Result`
-/// kind via `Mailer::send_reply`. Lives under `aether.sink.*` per
-/// ADR-0058 — same as `"aether.sink.io"`, `"aether.sink.net"`,
-/// `"aether.sink.audio"`, etc.
-pub const HANDLE_SINK_NAME: &str = "aether.sink.handle";
 
 /// Everything a chassis needs after shared boot setup. Fields are
 /// `pub` so chassis code destructures and takes ownership of the
@@ -89,6 +80,15 @@ pub struct SubstrateBoot {
     /// set. Chassis mains pass this to `crate::io::build_registry`
     /// when wiring the `aether.sink.io` sink.
     pub namespace_roots: crate::io::NamespaceRoots,
+    /// ADR-0070 native capabilities booted during shared bring-up.
+    /// Phase 2: holds the [`HandleCapability`] dispatcher thread.
+    /// Phases 3-5 grow this as more sinks migrate. Drop runs
+    /// shutdown on every booted capability in reverse boot order, so
+    /// the chassis doesn't need to call `shutdown` explicitly unless
+    /// it wants to bound shutdown latency. Exposed publicly so
+    /// chassis binaries that want explicit control can `take()` and
+    /// call [`BootedChassis::shutdown`] themselves.
+    pub chassis: Option<BootedChassis>,
     /// Substrate identity for the hub `Hello` handshake. Owned so
     /// `connect_hub` / `connect_hub_from_env` can use them after
     /// `build()` returns.
@@ -326,16 +326,17 @@ impl<'a> SubstrateBootBuilder<'a> {
         queue.wire_outbound(Arc::clone(&outbound));
         let handle_store = Arc::new(HandleStore::from_env());
         queue.wire_handle_store(Arc::clone(&handle_store));
-        // ADR-0045 handle sink: components mail
-        // `aether.handle.{publish,release,pin,unpin}` to this
-        // well-known name, the sink drives `HandleStore` and replies
-        // via `Mailer::send_reply`. Registered before the control
-        // plane so any control-side code that wants to publish at
-        // load can reach it.
-        registry.register_sink(
-            HANDLE_SINK_NAME,
-            handle_sink_handler(Arc::clone(&handle_store), Arc::clone(&queue)),
-        );
+        // ADR-0045 handle sink. ADR-0070 Phase 2 moved this out of an
+        // inline `register_sink` call and into a native capability;
+        // booting the chassis here registers the sink + spawns the
+        // dispatcher thread before the control plane is wired so any
+        // control-side code that wants to publish at load can reach
+        // it. Future phases extend this builder with one `.with()`
+        // line per extracted sink.
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&queue))
+            .with(HandleCapability::new(Arc::clone(&handle_store)))
+            .build()
+            .map_err(|e| wasmtime::Error::msg(format!("chassis capability boot: {e}")))?;
 
         let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
         host_fns::register(&mut linker)?;
@@ -383,6 +384,7 @@ impl<'a> SubstrateBootBuilder<'a> {
             handle_store,
             boot_descriptors,
             namespace_roots,
+            chassis: Some(chassis),
             name: self.name.to_owned(),
             version: self.version.to_owned(),
         })

--- a/crates/aether-substrate-core/src/capabilities/handle.rs
+++ b/crates/aether-substrate-core/src/capabilities/handle.rs
@@ -1,0 +1,278 @@
+//! ADR-0070 Phase 2: handle sink as a native capability.
+//!
+//! First capability extraction. The handle sink (ADR-0045 typed-handle
+//! store front) was the lowest-state, lowest-coupling sink — one
+//! mailbox, one [`HandleStore`], no chassis-feature gating — so it's
+//! the right place to validate the [`Capability`] trait shape end-to-
+//! end before extracting the heavier ones (io, net, audio, render).
+//!
+//! Behavior change vs the pre-Phase-2 sink: the kernel-side dispatch
+//! used to run the per-kind handlers synchronously on the calling
+//! thread (a component dispatcher under ADR-0038). The capability
+//! shape mandated by the trait is one-actor-thread, so handle ops
+//! now serialize on the capability's own OS thread instead of
+//! running in parallel from N component dispatchers. The store's
+//! internal `RwLock` already serialized the contended path, so
+//! correctness is preserved; latency adds one mpsc hop per op (sub-
+//! microsecond on uncontended channels). See ADR-0070 §"Threading
+//! model".
+//!
+//! Shutdown is signalled via an [`AtomicBool`] the dispatcher polls
+//! on `recv_timeout`. Worst-case shutdown latency is the timeout
+//! interval (currently 100ms), which is fine for chassis teardown
+//! and avoids tying the trait API to a specific channel type.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::handle_sink;
+use crate::handle_store::HandleStore;
+
+/// Recipient name the handle capability claims. Components mail
+/// `aether.handle.{publish,release,pin,unpin}` (kind ids) to this
+/// mailbox; the SDK's `Ctx::publish` / `Handle<K>::Drop` pair both
+/// resolve through here. ADR-0058 places chassis-owned sinks under
+/// `aether.sink.*`.
+pub const HANDLE_SINK_NAME: &str = "aether.sink.handle";
+
+/// Polling interval for the dispatcher's shutdown check. See module
+/// docs for the latency tradeoff.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Native capability owning the ADR-0045 typed-handle sink. Boots a
+/// single dispatcher thread that pulls envelopes from the
+/// `aether.sink.handle` mailbox and routes them through
+/// [`handle_sink::dispatch`].
+pub struct HandleCapability {
+    store: Arc<HandleStore>,
+}
+
+impl HandleCapability {
+    /// Construct against the substrate's `HandleStore`. The store is
+    /// shared with `Mailer::wire_handle_store` so dispatch-time
+    /// `Ref<Handle>` resolution and capability-handled
+    /// publish/release/pin/unpin observe the same entries.
+    pub fn new(store: Arc<HandleStore>) -> Self {
+        Self { store }
+    }
+}
+
+/// Running handle returned by [`HandleCapability::boot`]. Holds the
+/// dispatcher thread and the shutdown flag the thread polls. Drop
+/// alone does not stop the thread — call [`HandleRunning::shutdown`]
+/// (or let the parent [`crate::BootedChassis`] do it on drop).
+pub struct HandleRunning {
+    thread: Option<JoinHandle<()>>,
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl Capability for HandleCapability {
+    type Running = HandleRunning;
+
+    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+        let claim = ctx.claim_mailbox(HANDLE_SINK_NAME)?;
+        let mailer = ctx.mail_send_handle();
+        let store = self.store;
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let thread_flag = Arc::clone(&shutdown_flag);
+        let receiver = claim.receiver;
+
+        let thread = thread::Builder::new()
+            .name("aether-handle-sink".into())
+            .spawn(move || {
+                while !thread_flag.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
+                        Ok(env) => {
+                            handle_sink::dispatch(
+                                &store,
+                                &mailer,
+                                env.kind,
+                                env.sender,
+                                &env.payload,
+                            );
+                        }
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+
+        Ok(HandleRunning {
+            thread: Some(thread),
+            shutdown_flag,
+        })
+    }
+}
+
+impl RunningCapability for HandleRunning {
+    fn shutdown(self: Box<Self>) {
+        let HandleRunning {
+            mut thread,
+            shutdown_flag,
+        } = *self;
+        shutdown_flag.store(true, Ordering::Relaxed);
+        if let Some(t) = thread.take() {
+            // Join discards the thread's result; a panic on the
+            // dispatcher already routed through the panic hook (issue
+            // 321), so there's nothing further to surface here.
+            let _ = t.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    use aether_data::{HandleId, Kind, KindId};
+    use aether_hub_protocol::{EngineToHub, SessionToken, Uuid};
+    use aether_kinds::{HandlePublish, HandlePublishResult};
+
+    use super::*;
+    use crate::capability::ChassisBuilder;
+    use crate::hub_client::HubOutbound;
+    use crate::mail::{ReplyTarget, ReplyTo};
+    use crate::mailer::Mailer;
+    use crate::registry::{MailboxEntry, Registry};
+
+    /// Build a minimally-wired kernel for capability tests: registry
+    /// with every kind descriptor (so `send_reply` resolves names),
+    /// mailer wired with a loopback hub outbound + the store. The
+    /// returned receiver carries every reply the capability emits via
+    /// `Mailer::send_reply` along the hub-outbound branch.
+    fn fresh_kernel() -> (
+        Arc<HandleStore>,
+        Arc<Mailer>,
+        Arc<Registry>,
+        mpsc::Receiver<EngineToHub>,
+    ) {
+        let store = Arc::new(HandleStore::new(64 * 1024));
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new());
+        mailer.wire(Arc::clone(&registry), Arc::new(RwLock::new(HashMap::new())));
+        mailer.wire_outbound(outbound);
+        mailer.wire_handle_store(Arc::clone(&store));
+        (store, mailer, registry, rx)
+    }
+
+    fn session_reply_to() -> ReplyTo {
+        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
+    }
+
+    /// End-to-end: boot the capability, push a `HandlePublish` mail
+    /// at the registered sink, the dispatcher thread routes it
+    /// through `handle_sink::dispatch`, the reply lands on the
+    /// hub-outbound channel.
+    #[test]
+    fn capability_routes_publish_through_dispatcher_thread() {
+        let (store, mailer, registry, rx) = fresh_kernel();
+
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(HandleCapability::new(Arc::clone(&store)))
+            .build()
+            .expect("capability boots");
+
+        // Resolve the sink the capability registered.
+        let id = registry.lookup(HANDLE_SINK_NAME).expect("sink registered");
+        let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
+            panic!("expected sink entry");
+        };
+
+        let req = HandlePublish {
+            kind_id: KindId(0xCAFE),
+            bytes: vec![1, 2, 3, 4, 5],
+        };
+        let bytes = postcard::to_allocvec(&req).unwrap();
+        handler(
+            <HandlePublish as Kind>::ID,
+            "aether.handle.publish",
+            None,
+            session_reply_to(),
+            &bytes,
+            1,
+        );
+
+        // The dispatcher runs on its own thread, so poll for the
+        // reply with a generous deadline.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let frame = loop {
+            if let Ok(f) = rx.try_recv() {
+                break f;
+            }
+            if Instant::now() >= deadline {
+                panic!("publish reply did not arrive within deadline");
+            }
+            thread::sleep(Duration::from_millis(5));
+        };
+        let payload = match frame {
+            EngineToHub::Mail(m) => m.payload,
+            other => panic!("expected Mail frame, got {other:?}"),
+        };
+        let result: HandlePublishResult = postcard::from_bytes(&payload).unwrap();
+        let HandlePublishResult::Ok {
+            kind_id,
+            id: handle_id,
+        } = result
+        else {
+            panic!("expected Ok, got {result:?}");
+        };
+        assert_eq!(kind_id, KindId(0xCAFE));
+        assert_ne!(handle_id, HandleId(0));
+        let (stored_kind, stored_bytes) = store.get(handle_id).unwrap();
+        assert_eq!(stored_kind, KindId(0xCAFE));
+        assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
+
+        chassis.shutdown();
+    }
+
+    /// Shutdown joins the dispatcher thread cleanly. The polling loop
+    /// must return within ~SHUTDOWN_POLL_INTERVAL of the flag set.
+    #[test]
+    fn shutdown_joins_dispatcher_thread() {
+        let (store, mailer, registry, _rx) = fresh_kernel();
+
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(HandleCapability::new(Arc::clone(&store)))
+            .build()
+            .expect("capability boots");
+
+        let start = Instant::now();
+        chassis.shutdown();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "shutdown should complete within a poll interval (took {elapsed:?})"
+        );
+    }
+
+    /// Builder rejects a duplicate claim if the well-known sink name
+    /// was already registered. Guards against the side-by-side window
+    /// where a phase-2 PR didn't clean up its legacy
+    /// `register_sink(HANDLE_SINK_NAME, ...)` call.
+    #[test]
+    fn duplicate_claim_rejects_with_typed_error() {
+        let (store, mailer, registry, _rx) = fresh_kernel();
+        registry.register_sink(HANDLE_SINK_NAME, Arc::new(|_, _, _, _, _, _| {}));
+
+        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(HandleCapability::new(Arc::clone(&store)))
+            .build()
+            .expect_err("collision must surface as BootError");
+        assert!(matches!(
+            err,
+            BootError::MailboxAlreadyClaimed { ref name } if name == HANDLE_SINK_NAME
+        ));
+    }
+}

--- a/crates/aether-substrate-core/src/capabilities/handle.rs
+++ b/crates/aether-substrate-core/src/capabilities/handle.rs
@@ -6,7 +6,7 @@
 //! the right place to validate the [`Capability`] trait shape end-to-
 //! end before extracting the heavier ones (io, net, audio, render).
 //!
-//! Behavior change vs the pre-Phase-2 sink: the kernel-side dispatch
+//! Behavior change vs the pre-Phase-2 sink: the substrate-side dispatch
 //! used to run the per-kind handlers synchronously on the calling
 //! thread (a component dispatcher under ADR-0038). The capability
 //! shape mandated by the trait is one-actor-thread, so handle ops
@@ -143,12 +143,12 @@ mod tests {
     use crate::mailer::Mailer;
     use crate::registry::{MailboxEntry, Registry};
 
-    /// Build a minimally-wired kernel for capability tests: registry
+    /// Build a minimally-wired substrate for capability tests: registry
     /// with every kind descriptor (so `send_reply` resolves names),
     /// mailer wired with a loopback hub outbound + the store. The
     /// returned receiver carries every reply the capability emits via
     /// `Mailer::send_reply` along the hub-outbound branch.
-    fn fresh_kernel() -> (
+    fn fresh_substrate() -> (
         Arc<HandleStore>,
         Arc<Mailer>,
         Arc<Registry>,
@@ -177,7 +177,7 @@ mod tests {
     /// hub-outbound channel.
     #[test]
     fn capability_routes_publish_through_dispatcher_thread() {
-        let (store, mailer, registry, rx) = fresh_kernel();
+        let (store, mailer, registry, rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(HandleCapability::new(Arc::clone(&store)))
@@ -241,7 +241,7 @@ mod tests {
     /// must return within ~SHUTDOWN_POLL_INTERVAL of the flag set.
     #[test]
     fn shutdown_joins_dispatcher_thread() {
-        let (store, mailer, registry, _rx) = fresh_kernel();
+        let (store, mailer, registry, _rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(HandleCapability::new(Arc::clone(&store)))
@@ -263,7 +263,7 @@ mod tests {
     /// `register_sink(HANDLE_SINK_NAME, ...)` call.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
-        let (store, mailer, registry, _rx) = fresh_kernel();
+        let (store, mailer, registry, _rx) = fresh_substrate();
         registry.register_sink(HANDLE_SINK_NAME, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))

--- a/crates/aether-substrate-core/src/capabilities/mod.rs
+++ b/crates/aether-substrate-core/src/capabilities/mod.rs
@@ -1,14 +1,19 @@
-//! Native capabilities (ADR-0070). Phase 1 lands the empty module;
-//! phases 2–5 populate it one submodule per extracted sink:
+//! Native capabilities (ADR-0070). Each submodule extracts one of
+//! the substrate's chassis-policy sinks into a [`Capability`]
+//! implementation owning its mailbox(es), state, dispatcher thread,
+//! and lifecycle.
 //!
-//! - `handle.rs` (Phase 2 — least state, validates the trait shape)
-//! - `log.rs`
-//! - `io.rs`
-//! - `net.rs`
-//! - `audio.rs` (gated by `audio` feature)
-//! - `render.rs` (gated by `render` feature; owns `aether.sink.render`
-//!   and `aether.sink.camera`)
+//! Phasing:
+//! - Phase 2 (this PR): `handle` — least-state validator of the
+//!   trait shape end-to-end.
+//! - Phase 3: `log`, `io`, `net`, `audio` (gated by `audio` feature),
+//!   `render` + `camera` (gated by `render` feature). One PR per
+//!   sink.
+//! - Phase 4–5: `HubClientCapability` and `HubServerCapability` land
+//!   in the new `aether-hub` crate, not here, so the kernel ends with
+//!   zero hub knowledge.
 //!
-//! `HubClientCapability` and `HubServerCapability` live in the
-//! `aether-hub` crate (Phase 4–5), not here, so the kernel ends with
-//! zero hub knowledge.
+//! [`Capability`]: crate::capability::Capability
+
+pub mod handle;
+pub use handle::{HANDLE_SINK_NAME, HandleCapability, HandleRunning};

--- a/crates/aether-substrate-core/src/capabilities/mod.rs
+++ b/crates/aether-substrate-core/src/capabilities/mod.rs
@@ -10,7 +10,7 @@
 //!   `render` + `camera` (gated by `render` feature). One PR per
 //!   sink.
 //! - Phase 4–5: `HubClientCapability` and `HubServerCapability` land
-//!   in the new `aether-hub` crate, not here, so the kernel ends with
+//!   in the new `aether-hub` crate, not here, so the substrate ends with
 //!   zero hub knowledge.
 //!
 //! [`Capability`]: crate::capability::Capability

--- a/crates/aether-substrate-core/src/capability.rs
+++ b/crates/aether-substrate-core/src/capability.rs
@@ -6,7 +6,7 @@
 //! (handle, log, io, net, audio, render+camera) into a submodule of
 //! `crate::capabilities` that implements [`Capability`]; Phase 4
 //! wires the dispatch path to consult [`ChassisCtx::claim_fallback_router`]
-//! and removes the kernel-side bubble-up in `Mailer`.
+//! and removes the substrate-side bubble-up in `Mailer`.
 //!
 //! The shape mirrors a wasm component (kinds + dispatcher + state +
 //! lifecycle) but compiled in: a native capability owns mailboxes,
@@ -22,7 +22,7 @@
 //!   receiver. The registered handler converts each borrowed sink
 //!   call into an owned [`Envelope`] and forwards it.
 //! - [`ChassisCtx::claim_fallback_router`] stores a single fallback
-//!   handler; kernel dispatch does not consult it yet (Phase 4).
+//!   handler; substrate dispatch does not consult it yet (Phase 4).
 //! - No sinks are migrated yet — `crate::capabilities` is an empty
 //!   submodule placeholder that future PRs populate.
 
@@ -61,13 +61,13 @@ pub struct MailboxClaim {
     pub receiver: mpsc::Receiver<Envelope>,
 }
 
-/// Generic fallback-router handler: invoked by kernel dispatch when a
+/// Generic fallback-router handler: invoked by substrate dispatch when a
 /// local mailbox lookup misses. Phase 1 stores the handler but does
 /// not call it; Phase 4 wires `Mailer::push` to consult the slot in
 /// place of today's hub-specific bubble-up.
 ///
-/// Returning `true` means "I handled this mail" (kernel does nothing
-/// further); `false` means "not mine" (kernel falls through to its
+/// Returning `true` means "I handled this mail" (substrate does nothing
+/// further); `false` means "not mine" (substrate falls through to its
 /// warn-drop path). Today only `HubClientCapability` will claim the
 /// slot; other implementations are possible (test routers, multi-hub
 /// fan-out).
@@ -212,7 +212,7 @@ impl<'a> ChassisCtx<'a> {
     /// their dispatcher state to send mail to other mailboxes
     /// (including other capabilities). Same `Arc<Mailer>` every
     /// capability sees, so an envelope sent here goes through the
-    /// kernel's routing table the same way component-originated mail
+    /// substrate's routing table the same way component-originated mail
     /// does.
     pub fn mail_send_handle(&self) -> Arc<Mailer> {
         Arc::clone(self.mailer)
@@ -222,7 +222,7 @@ impl<'a> ChassisCtx<'a> {
     /// may claim the slot; a second call returns
     /// [`BootError::FallbackRouterAlreadyClaimed`].
     ///
-    /// Phase 1 stores the handler but does not consult it from kernel
+    /// Phase 1 stores the handler but does not consult it from substrate
     /// dispatch. Phase 4 wires `Mailer::push` against this slot and
     /// removes today's hub-specific `Mailer.outbound` field, at
     /// which point `HubClientCapability` (in the new `aether-hub`
@@ -255,9 +255,9 @@ pub struct ChassisBuilder {
 }
 
 impl ChassisBuilder {
-    /// Construct a fresh builder against the given kernel handles.
+    /// Construct a fresh builder against the given substrate handles.
     /// Phase 1 leaves it to the caller to supply these — Phase 6
-    /// (TestBench rewrite) folds kernel construction into the
+    /// (TestBench rewrite) folds substrate construction into the
     /// builder; until then, the existing `SubstrateBoot::build` is
     /// the construction site.
     pub fn new(registry: Arc<Registry>, mailer: Arc<Mailer>) -> Self {
@@ -411,7 +411,7 @@ mod tests {
         }
     }
 
-    fn fresh_kernel() -> (Arc<Registry>, Arc<Mailer>) {
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn capability_claims_mailbox_and_receives_mail() {
-        let (registry, mailer) = fresh_kernel();
+        let (registry, mailer) = fresh_substrate();
         let log = Arc::new(Mutex::new(Vec::new()));
         let flag = Arc::new(Mutex::new(false));
 
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn duplicate_mailbox_claim_fails_with_loud_error() {
-        let (registry, mailer) = fresh_kernel();
+        let (registry, mailer) = fresh_substrate();
         // Pre-register the name to simulate the side-by-side period
         // where legacy `register_sink` and a new capability would
         // both target the same mailbox.
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn boot_failure_shuts_down_already_booted_capabilities() {
-        let (registry, mailer) = fresh_kernel();
+        let (registry, mailer) = fresh_substrate();
         // First capability claims a fresh name; the second is set up
         // to fail by pre-registering its target name.
         registry.register_sink("test.fail.second", Arc::new(|_, _, _, _, _, _| {}));
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn fallback_router_slot_is_single_claim() {
-        let (registry, mailer) = fresh_kernel();
+        let (registry, mailer) = fresh_substrate();
 
         struct FallbackCap {
             should_succeed: bool,
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn mail_send_handle_clones_to_same_mailer() {
-        let (registry, mailer) = fresh_kernel();
+        let (registry, mailer) = fresh_substrate();
 
         struct ProbeCap {
             captured: Arc<Mutex<Option<Arc<Mailer>>>>,

--- a/crates/aether-substrate-core/src/capability.rs
+++ b/crates/aether-substrate-core/src/capability.rs
@@ -342,12 +342,28 @@ impl BootedChassis {
         self.running.is_empty()
     }
 
-    /// Tear down every capability in reverse boot order.
-    pub fn shutdown(self) {
-        let BootedChassis { mut running, .. } = self;
-        while let Some(c) = running.pop() {
+    /// Tear down every capability in reverse boot order. Idempotent
+    /// with [`Drop`] — calling `shutdown` first leaves [`Drop`] with
+    /// nothing to do.
+    pub fn shutdown(mut self) {
+        self.shutdown_in_place();
+    }
+
+    fn shutdown_in_place(&mut self) {
+        while let Some(c) = self.running.pop() {
             c.shutdown();
         }
+    }
+}
+
+impl Drop for BootedChassis {
+    fn drop(&mut self) {
+        // Forgotten-shutdown safety net: the chassis owner can drop
+        // a `BootedChassis` without calling `shutdown` and still
+        // get its capability dispatcher threads joined. Phase 2's
+        // `HandleCapability` polls a flag every 100ms, so worst-case
+        // drop latency is one poll interval per capability.
+        self.shutdown_in_place();
     }
 }
 

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -235,7 +235,7 @@ mod tests {
     use crate::mail::{Mail, MailboxId, ReplyTarget, ReplyTo};
     use crate::registry::Registry;
 
-    /// Wires the kernel state `dispatch` reads from. Returns owned
+    /// Wires the substrate state `dispatch` reads from. Returns owned
     /// handles so each test can call [`dispatch`] directly with the
     /// store + mailer it constructs.
     fn build_harness() -> (

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -1,6 +1,11 @@
-//! ADR-0045 typed-handle sink. The `"aether.sink.handle"` sink owns
-//! `Arc<HandleStore>` and dispatches the four request kinds defined
-//! in `aether-kinds`:
+//! ADR-0045 typed-handle sink dispatch logic. ADR-0070 Phase 2
+//! moved the `aether.sink.handle` mailbox out of `SubstrateBoot`'s
+//! inline registration and into [`crate::capabilities::handle`] —
+//! this module retains the per-kind dispatch implementation, called
+//! from the capability's dispatcher thread for each envelope it
+//! receives.
+//!
+//! The four request kinds defined in `aether-kinds`:
 //!
 //! - `HandlePublish { kind_id, bytes }` → `HandlePublishResult { Ok { id } | Err }`
 //! - `HandleRelease { id }` → `HandleReleaseResult { Ok | Err }`
@@ -11,47 +16,31 @@
 //! `HandleStore` op, and replied with the paired `*Result` kind via
 //! `Mailer::send_reply` — the same dispatch path the io and net
 //! sinks use, so session / engine-mailbox / local-component replies
-//! all funnel through one router.
-//!
-//! The dispatcher runs synchronously on the sink dispatch thread —
-//! fine for handle ops, which are sub-microsecond `RwLock`
-//! acquisitions on the store. Components publish via the SDK's
+//! all funnel through one router. Components publish via the SDK's
 //! `Ctx::publish` (encode + `Sink::send` + `wait_reply`); the
 //! `Drop` impl on `Handle<K>` mails `HandleRelease` fire-and-forget
 //! to keep teardown safe.
 
-use std::sync::Arc;
-
 use crate::handle_store::{HandleStore, PutError};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
-use crate::registry::SinkHandler;
 use aether_data::{HandleId, Kind, KindId};
 use aether_kinds::{
     HandleError, HandlePin, HandlePinResult, HandlePublish, HandlePublishResult, HandleRelease,
     HandleReleaseResult, HandleUnpin, HandleUnpinResult,
 };
 
-/// Build the `"aether.sink.handle"` sink handler. Boot calls this
-/// after constructing the `HandleStore` and `Mailer`, and registers
-/// the returned closure under the `"aether.sink.handle"` mailbox name.
-/// The closure
-/// demultiplexes incoming mail by kind id and replies via
-/// `mailer.send_reply` — see module docs for the per-kind contract.
-pub fn handle_sink_handler(store: Arc<HandleStore>, mailer: Arc<Mailer>) -> SinkHandler {
-    Arc::new(
-        move |kind: KindId,
-              _kind_name: &str,
-              _origin: Option<&str>,
-              sender: ReplyTo,
-              bytes: &[u8],
-              _count: u32| {
-            dispatch(&store, &mailer, kind, sender, bytes);
-        },
-    )
-}
-
-fn dispatch(store: &HandleStore, mailer: &Mailer, kind: KindId, sender: ReplyTo, bytes: &[u8]) {
+/// Demultiplex one envelope's payload to the matching per-kind
+/// handler. Called by [`crate::capabilities::handle::HandleCapability`]'s
+/// dispatcher thread; tests call it directly to exercise the per-kind
+/// logic without spinning up a capability.
+pub(crate) fn dispatch(
+    store: &HandleStore,
+    mailer: &Mailer,
+    kind: KindId,
+    sender: ReplyTo,
+    bytes: &[u8],
+) {
     // Issue 466: `Kind::ID` is typed `KindId`, so the match arms read
     // each typed const directly.
     match kind {
@@ -231,6 +220,7 @@ fn put_error_to_handle_error(e: PutError) -> HandleError {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::sync::RwLock;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -245,12 +235,14 @@ mod tests {
     use crate::mail::{Mail, MailboxId, ReplyTarget, ReplyTo};
     use crate::registry::Registry;
 
+    /// Wires the kernel state `dispatch` reads from. Returns owned
+    /// handles so each test can call [`dispatch`] directly with the
+    /// store + mailer it constructs.
     fn build_harness() -> (
         Arc<HandleStore>,
         Arc<Mailer>,
         Arc<Registry>,
         std::sync::mpsc::Receiver<EngineToHub>,
-        SinkHandler,
     ) {
         let store = Arc::new(HandleStore::new(64 * 1024));
         let registry = Arc::new(Registry::new());
@@ -264,8 +256,7 @@ mod tests {
         mailer.wire(Arc::clone(&registry), Arc::new(RwLock::new(HashMap::new())));
         mailer.wire_outbound(outbound);
         mailer.wire_handle_store(Arc::clone(&store));
-        let handler = handle_sink_handler(Arc::clone(&store), Arc::clone(&mailer));
-        (store, mailer, registry, rx, handler)
+        (store, mailer, registry, rx)
     }
 
     /// Build a fake session-targeted ReplyTo so `send_reply` runs the
@@ -285,19 +276,18 @@ mod tests {
 
     #[test]
     fn publish_replies_with_fresh_id_and_initial_refcount() {
-        let (store, _mailer, _registry, rx, handler) = build_harness();
+        let (store, mailer, _registry, rx) = build_harness();
         let req = HandlePublish {
             kind_id: KindId(0xCAFE),
             bytes: vec![1, 2, 3, 4, 5],
         };
         let bytes = postcard::to_allocvec(&req).unwrap();
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandlePublish as Kind>::ID,
-            "aether.handle.publish",
-            None,
             session_reply_to(),
             &bytes,
-            1,
         );
 
         let frame = rx.try_recv().expect("publish_result frame");
@@ -320,18 +310,17 @@ mod tests {
 
     #[test]
     fn release_unknown_id_replies_err_unknown_handle() {
-        let (_store, _mailer, _registry, rx, handler) = build_harness();
+        let (store, mailer, _registry, rx) = build_harness();
         let req = HandleRelease {
             id: HandleId(0xBAD),
         };
         let bytes = postcard::to_allocvec(&req).unwrap();
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandleRelease as Kind>::ID,
-            "aether.handle.release",
-            None,
             session_reply_to(),
             &bytes,
-            1,
         );
         let frame = rx.try_recv().expect("release_result frame");
         let payload = extract_payload(frame);
@@ -347,19 +336,18 @@ mod tests {
 
     #[test]
     fn pin_then_unpin_round_trips_via_sink() {
-        let (store, _mailer, _registry, rx, handler) = build_harness();
+        let (store, mailer, _registry, rx) = build_harness();
         // Publish first to mint an id.
         let publish_req = HandlePublish {
             kind_id: KindId(0xCAFE),
             bytes: vec![1, 2, 3],
         };
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandlePublish as Kind>::ID,
-            "aether.handle.publish",
-            None,
             session_reply_to(),
             &postcard::to_allocvec(&publish_req).unwrap(),
-            1,
         );
         let publish_frame = rx.try_recv().unwrap();
         let HandlePublishResult::Ok { id, .. } =
@@ -369,26 +357,24 @@ mod tests {
         };
         // Pin.
         let pin_req = HandlePin { id };
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandlePin as Kind>::ID,
-            "aether.handle.pin",
-            None,
             session_reply_to(),
             &postcard::to_allocvec(&pin_req).unwrap(),
-            1,
         );
         let frame = rx.try_recv().unwrap();
         let result: HandlePinResult = postcard::from_bytes(&extract_payload(frame)).unwrap();
         assert!(matches!(result, HandlePinResult::Ok { id: r } if r == id));
         // Unpin.
         let unpin_req = HandleUnpin { id };
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandleUnpin as Kind>::ID,
-            "aether.handle.unpin",
-            None,
             session_reply_to(),
             &postcard::to_allocvec(&unpin_req).unwrap(),
-            1,
         );
         let frame = rx.try_recv().unwrap();
         let result: HandleUnpinResult = postcard::from_bytes(&extract_payload(frame)).unwrap();
@@ -402,16 +388,15 @@ mod tests {
     /// `AdapterError` carrying the diagnostic.
     #[test]
     fn publish_decode_failure_replies_adapter_error_with_zero_kind_id() {
-        let (_store, _mailer, _registry, rx, handler) = build_harness();
+        let (store, mailer, _registry, rx) = build_harness();
         // Truncated postcard bytes — a `HandlePublish` is at least
         // a u64 + a varint length, so 1 byte is malformed.
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandlePublish as Kind>::ID,
-            "aether.handle.publish",
-            None,
             session_reply_to(),
             &[0u8],
-            1,
         );
         let frame = rx.try_recv().expect("err frame");
         let result: HandlePublishResult = postcard::from_bytes(&extract_payload(frame)).unwrap();
@@ -429,14 +414,13 @@ mod tests {
     /// stays empty.
     #[test]
     fn unknown_kind_on_handle_sink_drops_without_reply() {
-        let (_store, _mailer, _registry, rx, handler) = build_harness();
-        handler(
+        let (store, mailer, _registry, rx) = build_harness();
+        dispatch(
+            &store,
+            &mailer,
             KindId(0xDEAD),
-            "test.unknown",
-            None,
             session_reply_to(),
             &[1, 2, 3],
-            1,
         );
         assert!(rx.try_recv().is_err(), "no reply for unknown kind");
     }
@@ -447,7 +431,7 @@ mod tests {
     /// captured-bytes sink masquerading as the target component.
     #[test]
     fn component_reply_path_pushes_into_component_inbox() {
-        let (_store, _mailer, registry, rx, handler) = build_harness();
+        let (store, mailer, registry, rx) = build_harness();
         let captured = Arc::new(RwLock::new(Vec::new()));
         let counter = Arc::new(AtomicUsize::new(0));
         let captured_inner = Arc::clone(&captured);
@@ -466,13 +450,12 @@ mod tests {
             kind_id: KindId(0xCAFE),
             bytes: vec![9, 9, 9],
         };
-        handler(
+        dispatch(
+            &store,
+            &mailer,
             <HandlePublish as Kind>::ID,
-            "aether.handle.publish",
-            None,
             ReplyTo::to(ReplyTarget::Component(component_mbox)),
             &postcard::to_allocvec(&publish_req).unwrap(),
-            1,
         );
         // Hub outbound stayed empty…
         assert!(rx.try_recv().is_err(), "component reply must not bubble");

--- a/docs/adr/0070-native-capabilities-and-chassis-as-builder.md
+++ b/docs/adr/0070-native-capabilities-and-chassis-as-builder.md
@@ -5,9 +5,9 @@
 
 ## Context
 
-`aether-substrate-core` is the runtime kernel that every chassis binary (`aether-substrate-desktop`, `aether-substrate-headless`, `aether-substrate-hub`) shares. Today it holds three different kinds of code in one crate:
+`aether-substrate-core` is the substrate runtime that every chassis binary (`aether-substrate-desktop`, `aether-substrate-headless`, `aether-substrate-hub`) shares. Today it holds three different kinds of code in one crate:
 
-1. **Runtime kernel** — mail scheduler (ADR-0038 actor-per-component dispatch), mailbox registry, wasmtime host, `aether.kinds` manifest walker (ADR-0028/0032/0033), control-plane dispatch (`load_component`/`replace_component`/`drop_component`/`subscribe_input`), hub client + bubble-up (ADR-0037), substrate fail-fast (ADR-0063).
+1. **Substrate runtime** — mail scheduler (ADR-0038 actor-per-component dispatch), mailbox registry, wasmtime host, `aether.kinds` manifest walker (ADR-0028/0032/0033), control-plane dispatch (`load_component`/`replace_component`/`drop_component`/`subscribe_input`), hub client + bubble-up (ADR-0037), substrate fail-fast (ADR-0063).
 2. **Sink dispatchers and their state** — render, camera, io, net, audio, log, handle. Each is a hand-rolled match-on-`kind_id` loop plus a private state struct (wgpu device, adapter registry, ureq agent, cpal voice table, tracing bridge, handle store).
 3. **Chassis-binary glue** — currently each binary picks which sinks to register at boot via inline wiring code. Desktop registers all seven; headless skips render+camera+audio; hub skips most.
 
@@ -25,13 +25,13 @@ The capability shape is also notable for its symmetry with wasm components. A wa
 
 ## Decision
 
-Introduce a `Capability` trait in `aether-substrate-core` and refactor the existing chassis sinks into in-crate submodules under `src/capabilities/`, each implementing the trait. The hub client (today inline in the kernel as bubble-up) moves out of the kernel into a new `aether-hub` lib crate alongside a new `HubServerCapability`. Chassis binaries compose capabilities declaratively via a `Chassis::builder()` API.
+Introduce a `Capability` trait in `aether-substrate-core` and refactor the existing chassis sinks into in-crate submodules under `src/capabilities/`, each implementing the trait. The hub client (today inline in the substrate as bubble-up) moves out of the substrate into a new `aether-hub` lib crate alongside a new `HubServerCapability`. Chassis binaries compose capabilities declaratively via a `Chassis::builder()` API.
 
 ### Scope
 
 In: native sinks currently inside `aether-substrate-core` (render, camera, io, net, audio, log, handle). After this ADR they live as submodules of `aether-substrate-core`, addressed through the `Capability` trait.
 
-In: hub client (currently kernel-side bubble-up). After this ADR it lives as `HubClientCapability` in the new `aether-hub` lib crate, alongside `HubServerCapability` (the TCP listener that today is inline in `aether-substrate-hub`). The kernel exposes a generic fallback-router slot the hub client claims; the kernel itself has zero hub knowledge.
+In: hub client (currently substrate-side bubble-up). After this ADR it lives as `HubClientCapability` in the new `aether-hub` lib crate, alongside `HubServerCapability` (the TCP listener that today is inline in `aether-substrate-hub`). The substrate exposes a generic fallback-router slot the hub client claims; the substrate itself has zero hub knowledge.
 
 Not in: per-capability standalone crates *for the sinks*. Submodules in `aether-substrate-core` suffice for the structural win (declarative composition, encapsulated state + lifecycle, testbench composition). The hub crate is the one exception — hub-flavored code doesn't belong in core, and the binaries that need it (desktop, headless, hub) span multiple chassis crates.
 
@@ -52,11 +52,11 @@ pub trait RunningCapability: Send {
 }
 ```
 
-`ChassisCtx<'_>` is the kernel-side handle bundle a capability needs at boot. The ctx is shared (`&mut ChassisCtx<'_>`) across every `boot()` call in the builder — there is one mailbox registry, one mail-send router, one fallback-router slot, all shared:
+`ChassisCtx<'_>` is the substrate-side handle bundle a capability needs at boot. The ctx is shared (`&mut ChassisCtx<'_>`) across every `boot()` call in the builder — there is one mailbox registry, one mail-send router, one fallback-router slot, all shared:
 
 - **Mailbox claim** — `&mut self` method that returns the `mpsc::Receiver` for a known `MailboxId` from `aether-kinds::mailboxes`. The capability owns the receiver afterward; the slot can only be claimed once.
-- **Mail-send handle** — `Clone`-able sender that injects mail into the kernel's routing table. Capabilities clone this into their dispatcher state for sending mail to other mailboxes.
-- **Fallback-router slot** — `&mut self` method that lets at most one capability register a `fn(envelope) -> Routed | Dropped` handler the kernel calls when local mailbox lookup fails. Generic — the kernel does not know what a "hub" is. `HubClientCapability` (in the `aether-hub` crate) is the standard implementation.
+- **Mail-send handle** — `Clone`-able sender that injects mail into the substrate's routing table. Capabilities clone this into their dispatcher state for sending mail to other mailboxes.
+- **Fallback-router slot** — `&mut self` method that lets at most one capability register a `fn(envelope) -> Routed | Dropped` handler the substrate calls when local mailbox lookup fails. Generic — the substrate does not know what a "hub" is. `HubClientCapability` (in the `aether-hub` crate) is the standard implementation.
 - **Config source** — env-var / file-config accessor.
 
 `BootError` is the proposed-and-shipped variant of substrate fail-fast (ADR-0063): if a capability's boot returns `Err`, the chassis aborts before any user code runs. Capabilities cannot be partially booted.
@@ -80,7 +80,7 @@ aether-substrate-core/
         └── handle.rs               — handle sink + handle store
 ```
 
-`aether-substrate-core` after this ADR has zero hub knowledge — no dep on `aether-hub-protocol`, no hub-specific code in the kernel. The fallback-router slot is generic; if no capability claims it, unresolved mail is simply dropped (with a `tracing::warn!`).
+`aether-substrate-core` after this ADR has zero hub knowledge — no dep on `aether-hub-protocol`, no hub-specific code in the substrate. The fallback-router slot is generic; if no capability claims it, unresolved mail is simply dropped (with a `tracing::warn!`).
 
 Cargo features (`render`, `audio`) replace what would have been per-crate dependency gating. Headless's binary doesn't enable them, so wgpu/cpal stay out of its compile graph the same way they do today.
 
@@ -88,7 +88,7 @@ A new `aether-hub` library crate is introduced alongside this ADR. It exports `H
 
 ### Threading model
 
-Capabilities own their threading. The kernel hands a capability the mailbox receiver (and a clonable mail-send handle); the capability decides whether to spawn a dispatcher thread, integrate into an existing event loop, or both. `RunningCapability::shutdown(self: Box<Self>)` is responsible for joining whatever the capability spawned.
+Capabilities own their threading. The substrate hands a capability the mailbox receiver (and a clonable mail-send handle); the capability decides whether to spawn a dispatcher thread, integrate into an existing event loop, or both. `RunningCapability::shutdown(self: Box<Self>)` is responsible for joining whatever the capability spawned.
 
 The three threading shapes among today's sinks (and how they map to this trait):
 
@@ -96,11 +96,11 @@ The three threading shapes among today's sinks (and how they map to this trait):
 - **Dispatcher + driver-owned thread** (audio): capability spawns one dispatcher thread that mutates voice-table state, *plus* hands cpal a callback that runs on cpal's own driver-owned thread. The capability owns lifecycle of the dispatcher; cpal's thread joins implicitly when the stream is dropped.
 - **Event-loop integrated** (render): capability spawns *no* dispatcher thread. It pumps its mailbox receiver from inside the chassis-binary's winit event loop, interleaved with frame submission. The render capability's `boot()` returns `Running` immediately; the actual mail consumption happens inside the binary's per-frame tick.
 
-A kernel that imposed "one thread per capability" would over-constrain audio and break render. Letting capabilities own their threading keeps the trait simple and the model honest.
+A substrate that imposed "one thread per capability" would over-constrain audio and break render. Letting capabilities own their threading keeps the trait simple and the model honest.
 
 ### Inter-capability communication
 
-Default: capability-to-capability via mail through the kernel's mail scheduler. Same mechanism wasm components use to reach sinks. When capability A wants to mail capability B, A clones the mail-send handle from `ChassisCtx`, addresses an envelope to B's `MailboxId`, and the kernel routes it to B's mpsc queue (the receiver B got at boot).
+Default: capability-to-capability via mail through the substrate's mail scheduler. Same mechanism wasm components use to reach sinks. When capability A wants to mail capability B, A clones the mail-send handle from `ChassisCtx`, addresses an envelope to B's `MailboxId`, and the substrate routes it to B's mpsc queue (the receiver B got at boot).
 
 Three exceptions:
 
@@ -152,7 +152,7 @@ fn run(addr: SocketAddr) -> Result<(), BootError> {
 }
 ```
 
-Each binary opts into hub bridging by adding `HubClientCapability` to its builder. The hub binary uses `HubServerCapability` instead — they are siblings in the `aether-hub` crate, not specially privileged in the kernel.
+Each binary opts into hub bridging by adding `HubClientCapability` to its builder. The hub binary uses `HubServerCapability` instead — they are siblings in the `aether-hub` crate, not specially privileged in the substrate.
 
 ### Phasing
 
@@ -171,7 +171,7 @@ Each phase is its own PR. Phase 1 is mechanical; phases 2-3 are one capability e
 These were worked through during ADR drafting; recorded here as load-bearing for review.
 
 1. **Render + camera: one capability with two mailboxes.** Camera is configuration of the render pipeline (publishes a view-proj matrix that render reads), not a peer concern. Same shape as a hypothetical "bg color" mailbox; you wouldn't extract a separate capability for that. The trait supports N mailboxes per capability — `boot()` claims as many as it owns.
-2. **Hub client lives in `aether-hub`, not in the kernel.** The kernel exposes a generic fallback-router slot; `HubClientCapability` is the standard implementation. `aether-substrate-core` ends this ADR with zero hub knowledge — no `aether-hub-protocol` dep, no hub-specific code. Symmetric: `HubServerCapability` lives alongside in `aether-hub`. Other binaries opt into either by adding the capability to their builder.
+2. **Hub client lives in `aether-hub`, not in the substrate.** The substrate exposes a generic fallback-router slot; `HubClientCapability` is the standard implementation. `aether-substrate-core` ends this ADR with zero hub knowledge — no `aether-hub-protocol` dep, no hub-specific code. Symmetric: `HubServerCapability` lives alongside in `aether-hub`. Other binaries opt into either by adding the capability to their builder.
 3. **Boot ordering: declaration order.** Builder boots capabilities in `with()` call order. Real boot-time deps between capabilities are weak (the soft preference "log first" is captured by writing it first in the binary; tracing falls through to the default subscriber if log isn't up yet). If hard deps emerge later, an explicit `Capability::depends_on()` method is non-breaking to add.
 4. **`ChassisCtx` lifetime: `&mut ChassisCtx<'_>` shared across boot calls.** One ctx live for the duration of the build. Mailbox-claim is `&mut self` (consumes the slot, fails on duplicate); mail-send and config accessors return `Clone`-able handles capabilities stash into their dispatcher state. No split BootCtx vs RunningCtx — simpler, fits how Rust ecosystem does this elsewhere.
 5. **`describe_capability` MCP tool: deferred.** Symmetric to `describe_component` (which walks loaded wasm components and surfaces handler vocabulary). Useful for Claude sessions to see "what does this chassis actually do" without grepping a binary. Tracked as a follow-up issue, not in this ADR; depends on the trait being shipped first.
@@ -182,20 +182,20 @@ These were worked through during ADR drafting; recorded here as load-bearing for
 **Positive**
 
 - Chassis composition is declarative and visible at the binary level. Reading `aether-substrate-desktop/src/main.rs` tells you exactly which capabilities are active.
-- Each capability's state and lifecycle is encapsulated in one submodule. Adding a new sink (Gemini, image-gen) becomes "add `src/capabilities/gemini.rs`, register it in chassis builders that want it." No more reaching into the kernel to wire dispatch.
+- Each capability's state and lifecycle is encapsulated in one submodule. Adding a new sink (Gemini, image-gen) becomes "add `src/capabilities/gemini.rs`, register it in chassis builders that want it." No more reaching into the substrate to wire dispatch.
 - TestBench becomes per-test composable. Tests that don't need render skip wgpu entirely; tests that exercise io+log only get exactly that.
-- `aether-substrate-core` becomes purely runtime mechanism. No hub knowledge, no chassis-policy code. The kernel can be reasoned about as scheduler + registry + wasmtime + control plane + fallback-router slot — and nothing else.
-- The `Capability` trait is reachable from external crates, so hub-flavored capabilities (`HubClientCapability`, `HubServerCapability` in the new `aether-hub` crate), binary-specific capabilities, and future third-party capabilities don't pollute the kernel.
+- `aether-substrate-core` becomes purely runtime mechanism. No hub knowledge, no chassis-policy code. The substrate can be reasoned about as scheduler + registry + wasmtime + control plane + fallback-router slot — and nothing else.
+- The `Capability` trait is reachable from external crates, so hub-flavored capabilities (`HubClientCapability`, `HubServerCapability` in the new `aether-hub` crate), binary-specific capabilities, and future third-party capabilities don't pollute the substrate.
 - Forcing function for the sink kit becomes natural: once 5+ submodules implement the trait, the shared shape is concrete and extraction is mechanical.
 - Symmetry with wasm components clarifies the architecture story. A chassis is composed of native capabilities (compiled in) plus dynamic components (wasm-loaded); both communicate by mail; both have the same lifecycle vocabulary.
 
 **Negative**
 
-- One-time refactor across `aether-substrate-core`, `aether-substrate-hub`, and (new) `aether-hub`. Every existing sink dispatcher moves; chassis boot paths rewrite; bubble-up moves out of the kernel; `aether-substrate-test-bench` rewrites. Diffs land per phase but the cumulative motion is large.
+- One-time refactor across `aether-substrate-core`, `aether-substrate-hub`, and (new) `aether-hub`. Every existing sink dispatcher moves; chassis boot paths rewrite; bubble-up moves out of the substrate; `aether-substrate-test-bench` rewrites. Diffs land per phase but the cumulative motion is large.
 - ADR-0035 (substrate-chassis split) needs an addendum: the chassis trait still holds, gains capability composition.
 - Capabilities live in submodules of one crate, so editing `io.rs` recompiles all of `aether-substrate-core`. Acceptable cost; per-crate compile isolation is deferred to a future ADR if friction emerges.
 - The trait introduces a generic associated type (`type Running: RunningCapability`) which compounds rust-analyzer / docs noise slightly. Manageable.
-- One new workspace crate (`aether-hub`). Justified by the kernel-purification it enables; the cost is one Cargo.toml.
+- One new workspace crate (`aether-hub`). Justified by the substrate purification it enables; the cost is one Cargo.toml.
 
 **Neutral**
 
@@ -224,7 +224,7 @@ These were worked through during ADR drafting; recorded here as load-bearing for
 - **Sink kit first, capability abstraction later.** Considered as the smaller-surgery path. Rejected as the leading move — kit standardizes the *inside* of a sink (dispatch loop), but doesn't give chassis-level composition. Capability is the outer shape; kit is the inner shape; outer should land first because it gives the most visible win and creates the right home (`capabilities/common.rs`) for the kit when it lands.
 - **Inline trait without a builder; `Chassis::new(vec![Box<dyn Capability>])`.** Considered for simplicity. Rejected — `vec![Box<dyn>]` loses the typed-state composition (each capability has a different `Self` config struct); a `with(impl Capability)` builder preserves typing through `T::Running` associated types and lets boot return concrete errors.
 - **One capability = one mailbox.** Rejected for the render+camera case — they share wgpu state tightly; splitting them forces shared-state-via-Arc plumbing for no real win. The trait supports N mailboxes per capability; render owns two, every other capability today owns one.
-- **Hub client in the kernel** (the original draft). Rejected after pushback during ADR drafting — hub client is a chassis-policy concern, not a kernel one. Putting it in the kernel made `aether-substrate-core` depend on `aether-hub-protocol` for a feature that not every chassis uses. Replaced by a generic fallback-router slot in the kernel + `HubClientCapability` in the new `aether-hub` crate.
+- **Hub client in the substrate** (the original draft). Rejected after pushback during ADR drafting — hub client is a chassis-policy concern, not a substrate one. Putting it in the substrate made `aether-substrate-core` depend on `aether-hub-protocol` for a feature that not every chassis uses. Replaced by a generic fallback-router slot in the substrate + `HubClientCapability` in the new `aether-hub` crate.
 - **Hub capabilities as `[lib]`+`[[bin]]` inside `aether-substrate-hub`.** Considered as the lower-crate-count form of hosting `HubClientCapability` and `HubServerCapability`. Rejected — the workspace convention (per ADR-0035) is binaries are binaries, libs are libs. Splitting into `aether-hub` (lib) + `aether-substrate-hub` (binary) keeps the convention and gives the lib a clear name; the cost of one extra crate is small.
 
 ## References


### PR DESCRIPTION
## Summary

Phase 2 of [ADR-0070](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0070-native-capabilities-and-chassis-as-builder.md): first capability extraction. The handle sink (ADR-0045 typed-handle store front) was the lowest-coupling sink — one mailbox, one `HandleStore`, no chassis-feature gating — so it's the right place to validate the `Capability` trait shape end-to-end before extracting the heavier ones (io, net, audio, render).

- `capabilities::handle::HandleCapability` claims `aether.sink.handle`, spawns one dispatcher thread that loops on the mpsc receiver and routes each envelope through the existing `handle_sink::dispatch`. Shutdown signals via `AtomicBool` + `recv_timeout(100ms)` polling, keeping the trait API channel-type-agnostic.
- `handle_sink.rs` keeps the per-kind dispatch implementation (now `pub(crate)`); the SinkHandler constructor is removed and existing tests rewrite to call `dispatch` directly.
- `SubstrateBoot::build` boots the handle capability through `ChassisBuilder` instead of `register_sink(HANDLE_SINK_NAME, ...)`. The booted chassis is retained on `SubstrateBoot.chassis: Option<BootedChassis>`; Drop on `BootedChassis` joins each capability's dispatcher thread automatically.
- `BootedChassis` gains a `Drop` impl so dropping without explicit `shutdown()` still tears capabilities down. The explicit `shutdown()` is kept for callers that want to bound shutdown latency.

**Behavior change**: handle ops now serialize on the capability's own OS thread instead of running in parallel from N component dispatchers. The store's `RwLock` already serialized the contended path, so correctness is preserved; latency adds one mpsc hop per op (sub-microsecond on uncontended channels). This is the threading model ADR-0070 mandates for "single dispatcher thread" capabilities.

**Naming cleanup**: rolled in a `kernel` → `substrate` rename across ADR-0070, Phase 1's `capability.rs`, and the new Phase 2 code. The native runtime layer is consistently called "the substrate" everywhere else (crate name, CLAUDE.md, ADR-0035); ADR-0070 imported "kernel" from generic OS vocabulary by mistake. Mechanical, no behavior change.

## Test plan

- [x] `cargo test --workspace` (all green; 232 tests in core, 68 in aether-mesh, etc.)
- [x] `cargo clippy --all-targets -- -D warnings` (workspace clean)
- [x] `cargo fmt -- --check`
- [x] New: `capability_routes_publish_through_dispatcher_thread` exercises the full round trip — boot capability, push at registered sink, dispatcher runs `dispatch`, reply lands on hub-outbound loopback
- [x] New: `shutdown_joins_dispatcher_thread` confirms shutdown completes within one poll interval
- [x] New: `duplicate_claim_rejects_with_typed_error` guards the side-by-side cleanup window
- [ ] CI green on the cross-platform matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)