### PR TITLE
refactor(core): extract io sink as native capability (ADR-0070 phase 3, part 2)

### DIFF
--- a/crates/aether-substrate-core/src/capabilities/io.rs
+++ b/crates/aether-substrate-core/src/capabilities/io.rs
@@ -1,0 +1,240 @@
+//! ADR-0070 Phase 3 (part 2): file I/O sink as a native capability.
+//!
+//! Wraps the ADR-0041 `aether.sink.io` mailbox: components mail
+//! `aether.io.{read,write,delete,list}` here, the capability decodes
+//! through `io::dispatch_io_mail`, drives the matching adapter, and
+//! replies via `Mailer::send_reply`.
+//!
+//! State held by the capability: an `AdapterRegistry` mapping logical
+//! namespace prefixes (`save`, `assets`, `config`) to backing adapters.
+//! `boot()` builds the registry from a [`NamespaceRoots`] passed in by
+//! the chassis main — either resolved from env via
+//! [`NamespaceRoots::from_env`] or supplied explicitly (test-bench
+//! tempdirs, embedder overrides).
+//!
+//! Boot error policy: per ADR-0063 fail-fast, adapter init failure
+//! aborts the chassis. Pre-Phase-3-part-2 behavior was log-and-skip;
+//! the capability tightens this to a typed `BootError`. Operators with
+//! filesystem misconfiguration will see the error loudly at startup
+//! rather than silently lose the io sink.
+//!
+//! Threading: single dispatcher thread, `AtomicBool` +
+//! `recv_timeout(100ms)` shutdown — same shape as `HandleCapability`
+//! and `LogCapability`. Adapter calls run synchronously on the
+//! dispatcher thread; ADR-0041 flagged a future host-fn fast path
+//! for asset-sized streaming.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::io::{self, NamespaceRoots};
+
+/// Recipient name the io capability claims. ADR-0058 places
+/// chassis-owned sinks under `aether.sink.*`.
+pub const IO_SINK_NAME: &str = "aether.sink.io";
+
+/// Polling interval for the dispatcher's shutdown check.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Native capability owning the ADR-0041 file-I/O sink. Constructor
+/// takes the resolved [`NamespaceRoots`] explicitly — the chassis
+/// main reads env (per issue 464) and passes the roots through.
+pub struct IoCapability {
+    roots: NamespaceRoots,
+}
+
+impl IoCapability {
+    pub fn new(roots: NamespaceRoots) -> Self {
+        Self { roots }
+    }
+}
+
+/// Running handle returned by [`IoCapability::boot`]. Same shape as
+/// the other dispatcher-thread capabilities.
+pub struct IoRunning {
+    thread: Option<JoinHandle<()>>,
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl Capability for IoCapability {
+    type Running = IoRunning;
+
+    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+        let claim = ctx.claim_mailbox(IO_SINK_NAME)?;
+        let mailer = ctx.mail_send_handle();
+        let (registry, roots) = io::build_registry(self.roots).map_err(|e| {
+            BootError::Other(Box::new(std::io::Error::new(
+                e.kind(),
+                format!("io adapter init failed: {e}"),
+            )))
+        })?;
+        tracing::info!(
+            target: "aether_substrate::io",
+            save = %roots.save.display(),
+            assets = %roots.assets.display(),
+            config = %roots.config.display(),
+            "io adapters registered",
+        );
+
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let thread_flag = Arc::clone(&shutdown_flag);
+        let receiver = claim.receiver;
+
+        let thread = thread::Builder::new()
+            .name("aether-io-sink".into())
+            .spawn(move || {
+                while !thread_flag.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
+                        Ok(env) => {
+                            io::dispatch_io_mail(
+                                &registry,
+                                &mailer,
+                                env.kind,
+                                env.sender,
+                                &env.payload,
+                            );
+                        }
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+
+        Ok(IoRunning {
+            thread: Some(thread),
+            shutdown_flag,
+        })
+    }
+}
+
+impl RunningCapability for IoRunning {
+    fn shutdown(self: Box<Self>) {
+        let IoRunning {
+            mut thread,
+            shutdown_flag,
+        } = *self;
+        shutdown_flag.store(true, Ordering::Relaxed);
+        if let Some(t) = thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::capability::ChassisBuilder;
+    use crate::mailer::Mailer;
+    use crate::registry::Registry;
+
+    /// Same shape as `io::tests::scratch_root` — manual tempdir to
+    /// avoid pulling in the `tempfile` crate. Caller cleans up via
+    /// [`cleanup`] after the test asserts.
+    fn scratch_root(tag: &str) -> PathBuf {
+        let pid = std::process::id();
+        let nonce: u64 = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        (registry, Arc::new(Mailer::new()))
+    }
+
+    fn roots_under(root: &Path) -> NamespaceRoots {
+        let r = NamespaceRoots {
+            save: root.join("save"),
+            assets: root.join("assets"),
+            config: root.join("config"),
+        };
+        std::fs::create_dir_all(&r.save).unwrap();
+        std::fs::create_dir_all(&r.assets).unwrap();
+        std::fs::create_dir_all(&r.config).unwrap();
+        r
+    }
+
+    /// Boot the capability against a fresh tempdir; assert the sink
+    /// is registered. The dispatch path itself is exercised by
+    /// `io::tests` against the same `dispatch_io_mail` function the
+    /// capability calls; this test validates the wiring layer.
+    #[test]
+    fn capability_boots_and_registers_sink() {
+        let root = scratch_root("boots");
+        let (registry, mailer) = fresh_substrate();
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(IoCapability::new(roots_under(&root)))
+            .build()
+            .expect("io capability boots");
+        assert!(
+            registry.lookup(IO_SINK_NAME).is_some(),
+            "sink mailbox registered"
+        );
+        chassis.shutdown();
+        cleanup(&root);
+    }
+
+    /// Boot fails with a typed [`BootError::Other`] when the adapter
+    /// registry can't be built. Provoke `LocalFileAdapter::new`
+    /// failure by pointing the save root at a regular file rather
+    /// than a directory.
+    #[test]
+    fn boot_fails_with_typed_error_when_adapter_init_fails() {
+        let root = scratch_root("init-fails");
+        let save_path = root.join("save_is_actually_a_file");
+        std::fs::write(&save_path, b"not a dir").unwrap();
+        let roots = NamespaceRoots {
+            save: save_path,
+            assets: root.join("assets"),
+            config: root.join("config"),
+        };
+        std::fs::create_dir_all(&roots.assets).unwrap();
+        std::fs::create_dir_all(&roots.config).unwrap();
+
+        let (registry, mailer) = fresh_substrate();
+        let err = ChassisBuilder::new(registry, mailer)
+            .with(IoCapability::new(roots))
+            .build()
+            .expect_err("save root being a file must fail");
+        assert!(matches!(err, BootError::Other(_)));
+        cleanup(&root);
+    }
+
+    /// Builder rejects a duplicate claim. Same protection as the
+    /// other capabilities.
+    #[test]
+    fn duplicate_claim_rejects_with_typed_error() {
+        let root = scratch_root("collide");
+        let (registry, mailer) = fresh_substrate();
+        registry.register_sink(IO_SINK_NAME, Arc::new(|_, _, _, _, _, _| {}));
+
+        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(IoCapability::new(roots_under(&root)))
+            .build()
+            .expect_err("collision must surface as BootError");
+        assert!(matches!(
+            err,
+            BootError::MailboxAlreadyClaimed { ref name } if name == IO_SINK_NAME
+        ));
+        cleanup(&root);
+    }
+}

--- a/crates/aether-substrate-core/src/capabilities/mod.rs
+++ b/crates/aether-substrate-core/src/capabilities/mod.rs
@@ -18,6 +18,8 @@
 //! [`Capability`]: crate::capability::Capability
 
 pub mod handle;
+pub mod io;
 pub mod log;
 pub use handle::{HANDLE_SINK_NAME, HandleCapability, HandleRunning};
+pub use io::{IO_SINK_NAME, IoCapability, IoRunning};
 pub use log::{LOG_SINK_NAME, LogCapability, LogRunning};

--- a/crates/aether-substrate-core/src/io.rs
+++ b/crates/aether-substrate-core/src/io.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
-use crate::registry::SinkHandler;
 use aether_data::{Kind, KindId};
 use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
@@ -320,13 +319,12 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
     build_registry(NamespaceRoots::from_env())
 }
 
-/// Build the `"aether.sink.io"` sink handler. The chassis calls this
-/// at boot after populating `registry` with adapters and passes the
-/// result to `registry.register_sink("aether.sink.io", handler)`. The
-/// returned closure
-/// demultiplexes by `kind_id` (Read / Write / Delete / List, all
-/// postcard-decoded), drives the adapter, and replies with the
-/// paired `*Result` kind via `mailer.send_reply`.
+/// Demultiplex one envelope's payload to the matching per-kind
+/// adapter call. ADR-0070 Phase 3 (part 2) moved the wrapping
+/// `aether.sink.io` mailbox dispatch out of an inline
+/// `register_sink` call and into [`crate::capabilities::io`] —
+/// this function is what the capability's dispatcher thread invokes
+/// for each envelope it receives.
 ///
 /// The reply router is `Mailer::send_reply`, not
 /// `HubOutbound::send_reply`, so session / engine-mailbox /
@@ -335,24 +333,11 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
 /// into the requesting component's inbox; session / engine mail
 /// hands off to the hub outbound as before.
 ///
-/// Adapter calls run synchronously on the sink dispatch thread —
+/// Adapter calls run synchronously on the dispatcher thread —
 /// fine for save/config (KB-MB files). Asset-sized workloads
 /// should not ride this path; ADR-0041 flags a future host-fn fast
 /// path for zero-copy streaming reads.
-pub fn io_sink_handler(registry: Arc<AdapterRegistry>, mailer: Arc<Mailer>) -> SinkHandler {
-    Arc::new(
-        move |kind: KindId,
-              _kind_name: &str,
-              _origin: Option<&str>,
-              sender: ReplyTo,
-              bytes: &[u8],
-              _count: u32| {
-            dispatch_io_mail(&registry, &mailer, kind, sender, bytes);
-        },
-    )
-}
-
-fn dispatch_io_mail(
+pub(crate) fn dispatch_io_mail(
     registry: &AdapterRegistry,
     mailer: &Mailer,
     kind: KindId,
@@ -823,20 +808,12 @@ mod tests {
             .unwrap()
             .write("slot.bin", &[9, 9, 9])
             .unwrap();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
             namespace: "save".to_string(),
             path: "slot.bin".to_string(),
         })
         .unwrap();
-        handler(
-            <Read as Kind>::ID,
-            Read::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
         match decode_reply::<ReadResult>(&rx) {
             ReadResult::Ok {
                 namespace,
@@ -857,20 +834,12 @@ mod tests {
         let root = scratch_root("dispatch-ns");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
             namespace: "nope".to_string(),
             path: "x.bin".to_string(),
         })
         .unwrap();
-        handler(
-            <Read as Kind>::ID,
-            Read::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
         match decode_reply::<ReadResult>(&rx) {
             ReadResult::Err {
                 namespace,
@@ -893,20 +862,12 @@ mod tests {
         let root = scratch_root("dispatch-nf");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
             namespace: "save".to_string(),
             path: "ghost.bin".to_string(),
         })
         .unwrap();
-        handler(
-            <Read as Kind>::ID,
-            Read::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
         assert!(matches!(
             decode_reply::<ReadResult>(&rx),
             ReadResult::Err {
@@ -922,21 +883,13 @@ mod tests {
         let root = scratch_root("dispatch-write");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Write {
             namespace: "save".to_string(),
             path: "slot.bin".to_string(),
             bytes: vec![1, 2, 3],
         })
         .unwrap();
-        handler(
-            <Write as Kind>::ID,
-            Write::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Write as Kind>::ID, session_sender(), &req);
         match decode_reply::<WriteResult>(&rx) {
             WriteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
@@ -956,21 +909,13 @@ mod tests {
         let root = scratch_root("dispatch-ro");
         let reg = build_save_only_registry(&root, false);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Write {
             namespace: "save".to_string(),
             path: "slot.bin".to_string(),
             bytes: vec![],
         })
         .unwrap();
-        handler(
-            <Write as Kind>::ID,
-            Write::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Write as Kind>::ID, session_sender(), &req);
         assert!(matches!(
             decode_reply::<WriteResult>(&rx),
             WriteResult::Err {
@@ -987,20 +932,12 @@ mod tests {
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("x.bin", b"x").unwrap();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Delete {
             namespace: "save".to_string(),
             path: "x.bin".to_string(),
         })
         .unwrap();
-        handler(
-            <Delete as Kind>::ID,
-            Delete::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <Delete as Kind>::ID, session_sender(), &req);
         match decode_reply::<DeleteResult>(&rx) {
             DeleteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
@@ -1022,20 +959,12 @@ mod tests {
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("b.bin", b"").unwrap();
         reg.get("save").unwrap().write("a.bin", b"").unwrap();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&List {
             namespace: "save".to_string(),
             prefix: "".to_string(),
         })
         .unwrap();
-        handler(
-            <List as Kind>::ID,
-            List::NAME,
-            None,
-            session_sender(),
-            &req,
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, <List as Kind>::ID, session_sender(), &req);
         match decode_reply::<ListResult>(&rx) {
             ListResult::Ok {
                 namespace,
@@ -1059,15 +988,7 @@ mod tests {
         let root = scratch_root("dispatch-unknown");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
-        handler(
-            KindId(0xdead_beef),
-            "some.other",
-            None,
-            session_sender(),
-            &[],
-            1,
-        );
+        dispatch_io_mail(&reg, &mailer, KindId(0xdead_beef), session_sender(), &[]);
         assert!(rx.try_recv().is_err(), "unexpected reply on unknown kind");
         cleanup(&root);
     }
@@ -1156,19 +1077,17 @@ mod tests {
             .insert(caller_mailbox, Arc::clone(&entry));
 
         // Dispatch a Read with sender = Component(caller_mailbox).
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
         let req = postcard::to_allocvec(&Read {
             namespace: "save".to_string(),
             path: "slot.bin".to_string(),
         })
         .unwrap();
-        handler(
+        dispatch_io_mail(
+            &reg,
+            &mailer,
             <Read as Kind>::ID,
-            Read::NAME,
-            Some("test_caller"),
             ReplyTo::to(crate::mail::ReplyTarget::Component(caller_mailbox)),
             &req,
-            1,
         );
 
         // Wait for the reply to reach receive.
@@ -1199,14 +1118,12 @@ mod tests {
         let root = scratch_root("dispatch-mal");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = io_sink_handler(Arc::clone(&reg), Arc::clone(&mailer));
-        handler(
+        dispatch_io_mail(
+            &reg,
+            &mailer,
             <Read as Kind>::ID,
-            Read::NAME,
-            None,
             session_sender(),
             &[0xffu8; 4],
-            1,
         );
         match decode_reply::<ReadResult>(&rx) {
             ReadResult::Err {

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -1123,36 +1123,14 @@ fn main() -> wasmtime::Result<()> {
     boot.registry
         .register_sink("aether.sink.camera", camera_handler);
 
-    // `aether.io.*`: ADR-0041 substrate file I/O. Wire the
-    // `"aether.sink.io"` sink against the namespace roots resolved at
-    // boot (`boot.namespace_roots` — supplied via the builder
-    // override or `NamespaceRoots::from_env`, per issue 464). If the
-    // boot-time filesystem setup fails (usually a perms issue on one
-    // of the root directories), log loud and skip the sink — components
-    // mailing `aether.sink.io` then warn-drop as "unknown mailbox" so
-    // failure is visible rather than silent.
-    match aether_substrate_desktop::io::build_registry(boot.namespace_roots.clone()) {
-        Ok((registry, roots)) => {
-            tracing::info!(
-                target: "aether_substrate::io",
-                save = %roots.save.display(),
-                assets = %roots.assets.display(),
-                config = %roots.config.display(),
-                "io adapters registered",
-            );
-            boot.registry.register_sink(
-                "aether.sink.io",
-                aether_substrate_desktop::io::io_sink_handler(registry, Arc::clone(&boot.queue)),
-            );
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::io",
-                error = %e,
-                "io adapter init failed — `io` sink not registered",
-            );
-        }
-    }
+    // `aether.io.*`: ADR-0041 substrate file I/O. ADR-0070 phase 3
+    // wraps the sink as a native capability with its own dispatcher
+    // thread. Adapter init failure (usually a perms or path issue on
+    // one of the roots) now aborts the chassis via `BootError` per
+    // ADR-0063 fail-fast, instead of the prior log-and-skip.
+    boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
+        boot.namespace_roots.clone(),
+    ))?;
 
     // `aether.net.fetch`: ADR-0043 substrate HTTP egress. Deny-by-
     // default: if `AETHER_NET_ALLOWLIST` is unset or empty, every

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -208,35 +208,15 @@ fn main() -> wasmtime::Result<()> {
         ),
     );
 
-    // `aether.io.*` per ADR-0041. Headless gets the same sink as
-    // desktop — the io path is purely I/O, no GPU or window surface,
-    // so there's nothing chassis-specific to diverge on. The
-    // namespace roots come from `boot.namespace_roots` (built from
-    // env at the top of `main`, per issue 464). Boot-time filesystem
-    // failure logs loud and skips the sink (same policy as desktop)
-    // rather than failing the whole chassis.
-    match aether_substrate_core::io::build_registry(boot.namespace_roots.clone()) {
-        Ok((registry, roots)) => {
-            tracing::info!(
-                target: "aether_substrate::io",
-                save = %roots.save.display(),
-                assets = %roots.assets.display(),
-                config = %roots.config.display(),
-                "io adapters registered",
-            );
-            boot.registry.register_sink(
-                "aether.sink.io",
-                aether_substrate_core::io::io_sink_handler(registry, Arc::clone(&boot.queue)),
-            );
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::io",
-                error = %e,
-                "io adapter init failed — `io` sink not registered",
-            );
-        }
-    }
+    // `aether.io.*` per ADR-0041. Same capability as desktop —
+    // the io path is purely I/O, no GPU or window surface, so
+    // there's nothing chassis-specific to diverge on. ADR-0070
+    // phase 3 wraps it as a native capability with fail-fast boot
+    // semantics (ADR-0063); pre-phase-3 behavior was log-and-skip
+    // on adapter init failure.
+    boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
+        boot.namespace_roots.clone(),
+    ))?;
 
     // `aether.net.fetch`: ADR-0043 substrate HTTP egress. Headless
     // runs the asset pipeline, so net is first-class here — same

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -253,34 +253,13 @@ fn main() -> wasmtime::Result<()> {
     boot.registry
         .register_sink("aether.sink.camera", camera_handler);
 
-    // `aether.sink.io` per ADR-0041. Test-bench gets the same sink
-    // as desktop / headless — the io path is purely I/O. The
-    // namespace roots come from `boot.namespace_roots` (built from
-    // env at the top of `main`, per issue 464). Boot-time filesystem
-    // failure logs loud and skips the sink (same policy as the other
-    // chassis) rather than failing the whole chassis.
-    match aether_substrate_core::io::build_registry(boot.namespace_roots.clone()) {
-        Ok((registry, roots)) => {
-            tracing::info!(
-                target: "aether_substrate::io",
-                save = %roots.save.display(),
-                assets = %roots.assets.display(),
-                config = %roots.config.display(),
-                "io adapters registered",
-            );
-            boot.registry.register_sink(
-                "aether.sink.io",
-                aether_substrate_core::io::io_sink_handler(registry, Arc::clone(&boot.queue)),
-            );
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::io",
-                error = %e,
-                "io adapter init failed — `io` sink not registered",
-            );
-        }
-    }
+    // `aether.sink.io` per ADR-0041. Same capability as desktop and
+    // headless — io is purely I/O, no GPU or window surface to
+    // diverge on. ADR-0070 phase 3 wraps it as a native capability
+    // with fail-fast boot semantics (ADR-0063).
+    boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
+        boot.namespace_roots.clone(),
+    ))?;
 
     // `aether.sink.log` per ADR-0060. Same capability as desktop and
     // headless — guest log mail is independent of GPU / windowing.

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, encode_empty, encode_struct};
 use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
@@ -279,17 +279,21 @@ impl TestBench {
         let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
         register_camera_sink(&boot, &camera_state, &observed_kinds);
 
-        // Build the IO adapter registry against the boot's namespace
+        // Build the IO capability against the boot's namespace
         // roots — either the override the caller supplied via
         // `TestBench::builder().namespace_roots(...)` or the env-
         // derived defaults. Per issue 464, this path no longer reads
-        // env directly.
-        if let Ok((reg, _roots)) =
-            aether_substrate_core::io::build_registry(boot.namespace_roots.clone())
-        {
-            boot.registry.register_sink(
-                "aether.sink.io",
-                aether_substrate_core::io::io_sink_handler(reg, Arc::clone(&boot.queue)),
+        // env directly. Silent-skip on adapter init failure preserves
+        // pre-Phase-3 behavior so tests on systems without writable
+        // default roots don't fail at the harness layer; tests that
+        // care about io supply tempdir roots via the builder.
+        if let Err(e) = boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
+            boot.namespace_roots.clone(),
+        )) {
+            tracing::warn!(
+                target: "aether_substrate::io",
+                error = %e,
+                "io capability boot failed in TestBench (expected on systems without writable default roots)",
             );
         }
         boot.add_capability(aether_substrate_core::capabilities::LogCapability::new())
@@ -494,20 +498,33 @@ impl TestBench {
 
     /// Pump the event channel and the loopback receiver until a
     /// reply with `cid` arrives, decoded as `R`. Each iteration
-    /// fully drains the queue and processes any pending events,
-    /// so even multi-tick advances finish in one or two iterations.
+    /// fully drains the queue and processes any pending events.
+    /// Quiet iterations (no events surfaced, no reply on loopback)
+    /// sleep briefly to give ADR-0070 capability dispatcher threads
+    /// time to wake up — `IoCapability` and friends poll their mpsc
+    /// receivers on a 100ms `recv_timeout`, so without this sleep a
+    /// capability-mediated reply (e.g. `aether.io.write` →
+    /// `WriteResult`) can't beat the bail-out check.
     fn pump_until_reply<R>(&mut self, cid: u64, expected: &'static str) -> Result<R, TestBenchError>
     where
         R: serde::de::DeserializeOwned,
     {
         const MAX_ITERATIONS: u32 = 256;
+        // Sleep per quiet iteration. 10 ms × QUIET_BUDGET caps total
+        // wait around 1 s, well under any realistic test timeout but
+        // long enough that the slowest-polling capability (100 ms
+        // recv_timeout) gets ~10 wakeups.
+        const QUIET_SLEEP: Duration = Duration::from_millis(10);
+        // How many consecutive quiet iterations to tolerate before
+        // giving up.
+        const QUIET_BUDGET: u32 = 100;
 
         // Check the stash first.
         if let Some(frame) = self.stashed_replies.remove(&cid) {
             return Self::decode_reply::<R>(frame, expected);
         }
 
-        let mut events_processed = 0u32;
+        let mut quiet_iterations = 0u32;
         for iteration in 0..MAX_ITERATIONS {
             // Settle the queue. The control mail we pushed flows
             // through the dispatcher → control plane → chassis
@@ -517,13 +534,16 @@ impl TestBench {
 
             // Drain any pending chassis events. Each invocation
             // potentially produces a reply on `outbound`.
+            let mut found_event = false;
             while let Ok(event) = self.events_rx.try_recv() {
                 self.dispatch_event(event);
-                events_processed += 1;
+                found_event = true;
             }
 
             // Look for our reply on the loopback.
+            let mut found_reply = false;
             while let Ok(frame) = self.loopback_rx.try_recv() {
+                found_reply = true;
                 if let Some(frame_cid) = correlation_of(&frame) {
                     if frame_cid == cid {
                         return Self::decode_reply::<R>(frame, expected);
@@ -543,16 +563,19 @@ impl TestBench {
                 }
             }
 
-            if iteration > 0 && events_processed == 0 {
-                // No events surfaced this iteration AND no events
-                // last iteration; the chassis is idle. The reply
-                // isn't coming.
-                return Err(TestBenchError::Timeout {
-                    expected,
-                    pumped_iterations: iteration + 1,
-                });
+            if found_event || found_reply {
+                quiet_iterations = 0;
+            } else {
+                quiet_iterations += 1;
+                if quiet_iterations >= QUIET_BUDGET {
+                    return Err(TestBenchError::Timeout {
+                        expected,
+                        pumped_iterations: iteration + 1,
+                    });
+                }
+                // Yield to capability dispatcher threads (ADR-0070).
+                std::thread::sleep(QUIET_SLEEP);
             }
-            events_processed = 0;
         }
         Err(TestBenchError::Timeout {
             expected,


### PR DESCRIPTION
## Summary

Second chassis-conditional capability extraction. Same shape as phase 3 part 1 (log) but with real per-instance state — `NamespaceRoots` and an `AdapterRegistry` mapping logical namespace prefixes to backing adapters.

**IoCapability:**
- Constructor takes resolved `NamespaceRoots`; chassis main reads env once and passes through (issue 464 pattern).
- `boot()` runs `io::build_registry`, logs the resolved paths via `tracing::info`, spawns one dispatcher thread that loops on the mpsc receiver and routes each envelope through `io::dispatch_io_mail`.
- **Behavior change**: adapter init failure now aborts the chassis via `BootError` per ADR-0063 fail-fast. Pre-phase-3 behavior was log-and-skip, which left a silent gap if `aether.sink.io` mail arrived later.
- `io.rs` keeps the per-kind dispatcher (`dispatch_io_mail`, now `pub(crate)`); the `io_sink_handler` SinkHandler constructor is removed and the 10 `io.rs` unit tests rewrite to call `dispatch_io_mail` directly.

**Chassis main updates:**
- desktop, headless, test-bench `main.rs`: `?`-propagating fail-fast via `boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?`.
- test-bench `test_bench.rs` (test fixture): silent-skip preserved via `if let Err(e) = ...` so tests on systems without writable default roots don't break.

**TestBench pump fix (load-bearing):**
- `pump_until_reply` previously bailed after one quiet iteration. The actor-model dispatcher (mpsc + 100ms `recv_timeout`) needs ~10ms to wake up and dispatch, so quiet iterations now sleep 10ms and the bail-out budget is 100 iterations (≈1s total). Without this, every io scenario test (write→reply, read→reply, …) timed out.

## Test plan

- [x] `cargo test --workspace` (237 core lib tests + 9 io scenario tests + everything else green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] New: `capability_boots_and_registers_sink`, `boot_fails_with_typed_error_when_adapter_init_fails`, `duplicate_claim_rejects_with_typed_error`
- [x] CI green on the cross-platform matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)