### PR TITLE
refactor(core): extract net sink as native capability (ADR-0070 phase 3, part 3)

### DIFF
--- a/crates/aether-substrate-core/src/capabilities/mod.rs
+++ b/crates/aether-substrate-core/src/capabilities/mod.rs
@@ -20,6 +20,8 @@
 pub mod handle;
 pub mod io;
 pub mod log;
+pub mod net;
 pub use handle::{HANDLE_SINK_NAME, HandleCapability, HandleRunning};
 pub use io::{IO_SINK_NAME, IoCapability, IoRunning};
 pub use log::{LOG_SINK_NAME, LogCapability, LogRunning};
+pub use net::{NET_SINK_NAME, NetCapability, NetRunning};

--- a/crates/aether-substrate-core/src/capabilities/net.rs
+++ b/crates/aether-substrate-core/src/capabilities/net.rs
@@ -1,0 +1,170 @@
+//! ADR-0070 Phase 3 (part 3): network egress sink as a native
+//! capability.
+//!
+//! Wraps the ADR-0043 `aether.sink.net` mailbox: components mail
+//! `aether.net.fetch` here, the capability decodes through
+//! `net::dispatch_net_mail`, drives the `NetAdapter` (typically
+//! `UreqNetAdapter`), and replies via `Mailer::send_reply`.
+//!
+//! State held by the capability: an `Arc<dyn NetAdapter>` configured
+//! at boot from the [`NetConfig`] passed in by the chassis main, plus
+//! the default-timeout the dispatcher applies when a `Fetch` request
+//! omits `timeout_ms`. Adapter construction is infallible
+//! (`build_net_adapter` returns `Arc<dyn NetAdapter>` directly), so
+//! there's no fail-fast ergonomics question — boot can't return an
+//! error today.
+//!
+//! Threading: single dispatcher thread, `AtomicBool` +
+//! `recv_timeout(100ms)` shutdown — same shape as the other
+//! capabilities. The dispatcher's `fetch` call blocks on the network
+//! synchronously; ADR-0043 §2 flags this as the head-of-line blocking
+//! source to fix in a future multi-threaded dispatcher ADR.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::net::{self, NetConfig};
+
+/// Recipient name the net capability claims. ADR-0058 places
+/// chassis-owned sinks under `aether.sink.*`.
+pub const NET_SINK_NAME: &str = "aether.sink.net";
+
+/// Polling interval for the dispatcher's shutdown check.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Native capability owning the ADR-0043 net-egress sink. Constructor
+/// takes a [`NetConfig`] (resolved from env or built explicitly by
+/// the chassis main per issue 464).
+pub struct NetCapability {
+    config: NetConfig,
+}
+
+impl NetCapability {
+    pub fn new(config: NetConfig) -> Self {
+        Self { config }
+    }
+}
+
+/// Running handle returned by [`NetCapability::boot`]. Same shape as
+/// the other dispatcher-thread capabilities.
+pub struct NetRunning {
+    thread: Option<JoinHandle<()>>,
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl Capability for NetCapability {
+    type Running = NetRunning;
+
+    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+        let claim = ctx.claim_mailbox(NET_SINK_NAME)?;
+        let mailer = ctx.mail_send_handle();
+        let default_timeout = self.config.default_timeout;
+        let adapter = net::build_net_adapter(self.config);
+
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let thread_flag = Arc::clone(&shutdown_flag);
+        let receiver = claim.receiver;
+
+        let thread = thread::Builder::new()
+            .name("aether-net-sink".into())
+            .spawn(move || {
+                while !thread_flag.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
+                        Ok(env) => {
+                            net::dispatch_net_mail(
+                                adapter.as_ref(),
+                                &mailer,
+                                env.kind,
+                                env.sender,
+                                &env.payload,
+                                default_timeout,
+                            );
+                        }
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+
+        Ok(NetRunning {
+            thread: Some(thread),
+            shutdown_flag,
+        })
+    }
+}
+
+impl RunningCapability for NetRunning {
+    fn shutdown(self: Box<Self>) {
+        let NetRunning {
+            mut thread,
+            shutdown_flag,
+        } = *self;
+        shutdown_flag.store(true, Ordering::Relaxed);
+        if let Some(t) = thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::ChassisBuilder;
+    use crate::mailer::Mailer;
+    use crate::registry::Registry;
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        (registry, Arc::new(Mailer::new()))
+    }
+
+    /// Boot the capability against a default disabled NetConfig and
+    /// confirm the sink is registered. The dispatch path itself is
+    /// exercised by `net::tests` against the same `dispatch_net_mail`.
+    #[test]
+    fn capability_boots_and_registers_sink() {
+        let (registry, mailer) = fresh_substrate();
+        let config = NetConfig {
+            disabled: true,
+            ..NetConfig::default()
+        };
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(NetCapability::new(config))
+            .build()
+            .expect("net capability boots");
+        assert!(
+            registry.lookup(NET_SINK_NAME).is_some(),
+            "sink mailbox registered"
+        );
+        chassis.shutdown();
+    }
+
+    /// Builder rejects a duplicate claim. Same protection as the
+    /// other capabilities.
+    #[test]
+    fn duplicate_claim_rejects_with_typed_error() {
+        let (registry, mailer) = fresh_substrate();
+        registry.register_sink(NET_SINK_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        let config = NetConfig {
+            disabled: true,
+            ..NetConfig::default()
+        };
+
+        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(NetCapability::new(config))
+            .build()
+            .expect_err("collision must surface as BootError");
+        assert!(matches!(
+            err,
+            BootError::MailboxAlreadyClaimed { ref name } if name == NET_SINK_NAME
+        ));
+    }
+}

--- a/crates/aether-substrate-core/src/net.rs
+++ b/crates/aether-substrate-core/src/net.rs
@@ -1,8 +1,10 @@
 //! Substrate HTTP egress (ADR-0043). The `NetAdapter` trait is the
 //! extension point for HTTP backends — `ureq` today, anything else
-//! that implements the trait later. The chassis that wires the
-//! `"aether.sink.net"` sink builds an adapter from env config, hands it to
-//! `net_sink_handler`, and registers the result.
+//! that implements the trait later. ADR-0070 Phase 3 wraps the
+//! `"aether.sink.net"` mailbox as a native capability — see
+//! [`crate::capabilities::net`] for the dispatcher; this module
+//! retains the `Fetch`-decode-and-call-adapter implementation
+//! [`dispatch_net_mail`].
 //!
 //! v1 semantics:
 //! - Blocking on the sink dispatch thread (one request at a time).
@@ -23,7 +25,6 @@ use std::time::Duration;
 
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
-use crate::registry::SinkHandler;
 use aether_data::{Kind, KindId};
 use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
@@ -241,7 +242,7 @@ fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
 /// mains read env vars (`AETHER_NET_DISABLE`, `AETHER_NET_ALLOWLIST`,
 /// `AETHER_NET_REQUIRE_HTTPS`, `AETHER_NET_MAX_BODY_BYTES`,
 /// `AETHER_NET_TIMEOUT_MS`) into a `NetConfig` and pass it to
-/// [`build_net_adapter`] / [`net_sink_handler`]. Tests build a
+/// [`build_net_adapter`] / [`crate::capabilities::net::NetCapability`]. Tests build a
 /// `NetConfig` directly, never touching process env (issue 464).
 #[derive(Clone, Debug)]
 pub struct NetConfig {
@@ -375,49 +376,24 @@ fn parse_default_timeout_env() -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-/// Build the `"aether.sink.net"` sink handler. The chassis calls this
-/// at boot after `build_net_adapter` and passes the result to
-/// `registry.register_sink("aether.sink.net", handler)`. The returned closure
-/// decodes incoming `Fetch` mail, hands it to the adapter, and
-/// replies with the paired `FetchResult` via `mailer.send_reply`.
+/// Demultiplex one envelope's payload to `Fetch` dispatch. ADR-0070
+/// Phase 3 (part 3) moved the wrapping `aether.sink.net` mailbox
+/// dispatch out of an inline `register_sink` call and into
+/// [`crate::capabilities::net`] — this function is what the
+/// capability's dispatcher thread invokes for each envelope it
+/// receives.
 ///
 /// The reply router is `Mailer::send_reply`, so session / engine-
 /// mailbox / local-component replies all funnel through one path —
 /// identical to the io sink.
 ///
 /// `default_timeout` is the fallback applied when an incoming
-/// `Fetch` has `timeout_ms: None`. Chassis mains source it from
-/// [`NetConfig::default_timeout`]; in practice the same `NetConfig`
-/// fed to `build_net_adapter` flows here.
+/// `Fetch` has `timeout_ms: None`.
 ///
-/// Fetches run synchronously on the sink dispatch thread — ADR-0043
+/// Fetches run synchronously on the dispatcher thread — ADR-0043
 /// §2 flags this as the head-of-line blocking source to fix via a
 /// multi-threaded dispatcher ADR.
-pub fn net_sink_handler(
-    adapter: Arc<dyn NetAdapter>,
-    mailer: Arc<Mailer>,
-    default_timeout: Duration,
-) -> SinkHandler {
-    Arc::new(
-        move |kind: KindId,
-              _kind_name: &str,
-              _origin: Option<&str>,
-              sender: ReplyTo,
-              bytes: &[u8],
-              _count: u32| {
-            dispatch_net_mail(
-                adapter.as_ref(),
-                &mailer,
-                kind,
-                sender,
-                bytes,
-                default_timeout,
-            );
-        },
-    )
-}
-
-fn dispatch_net_mail(
+pub(crate) fn dispatch_net_mail(
     adapter: &dyn NetAdapter,
     mailer: &Mailer,
     kind: KindId,
@@ -550,11 +526,6 @@ mod tests {
     fn disabled_adapter_replies_disabled() {
         let adapter: Arc<dyn NetAdapter> = Arc::new(DisabledNetAdapter);
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(
-            Arc::clone(&adapter),
-            Arc::clone(&mailer),
-            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
-        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -563,13 +534,13 @@ mod tests {
             timeout_ms: None,
         })
         .unwrap();
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             <Fetch as Kind>::ID,
-            Fetch::NAME,
-            None,
             session_sender(),
             &req,
-            1,
+            NetConfig::default().default_timeout,
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Err {
@@ -664,11 +635,6 @@ mod tests {
             body: b"{}".to_vec(),
         })) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(
-            Arc::clone(&adapter),
-            Arc::clone(&mailer),
-            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
-        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/v1".to_string(),
             method: HttpMethod::Get,
@@ -677,13 +643,13 @@ mod tests {
             timeout_ms: Some(5000),
         })
         .unwrap();
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             <Fetch as Kind>::ID,
-            Fetch::NAME,
-            None,
             session_sender(),
             &req,
-            1,
+            NetConfig::default().default_timeout,
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Ok {
@@ -705,11 +671,6 @@ mod tests {
     fn dispatch_fetch_err_echoes_url_and_error() {
         let adapter = StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(
-            Arc::clone(&adapter),
-            Arc::clone(&mailer),
-            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
-        );
         let req = postcard::to_allocvec(&Fetch {
             url: "https://slow.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -718,13 +679,13 @@ mod tests {
             timeout_ms: None,
         })
         .unwrap();
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             <Fetch as Kind>::ID,
-            Fetch::NAME,
-            None,
             session_sender(),
             &req,
-            1,
+            NetConfig::default().default_timeout,
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Err { url, error } => {
@@ -743,18 +704,13 @@ mod tests {
             body: vec![],
         })) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(
-            Arc::clone(&adapter),
-            Arc::clone(&mailer),
-            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
-        );
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             <Fetch as Kind>::ID,
-            Fetch::NAME,
-            None,
             session_sender(),
             &[0xffu8; 8],
-            1,
+            NetConfig::default().default_timeout,
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Err {
@@ -771,18 +727,13 @@ mod tests {
     fn dispatch_unknown_kind_does_not_reply() {
         let adapter = StubAdapter::with(Err(NetError::Disabled)) as Arc<dyn NetAdapter>;
         let (mailer, rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(
-            Arc::clone(&adapter),
-            Arc::clone(&mailer),
-            Duration::from_millis(DEFAULT_TIMEOUT_MS as u64),
-        );
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             KindId(0xdead_beef),
-            "some.other",
-            None,
             session_sender(),
             &[],
-            1,
+            NetConfig::default().default_timeout,
         );
         assert!(rx.try_recv().is_err(), "unexpected reply on unknown kind");
     }
@@ -802,7 +753,6 @@ mod tests {
         }));
         let adapter: Arc<dyn NetAdapter> = Arc::clone(&adapter_stub) as Arc<dyn NetAdapter>;
         let (mailer, _rx) = test_mailer_and_rx();
-        let handler = net_sink_handler(adapter, mailer, NetConfig::default().default_timeout);
         let req = postcard::to_allocvec(&Fetch {
             url: "https://api.example.com/".to_string(),
             method: HttpMethod::Get,
@@ -811,13 +761,13 @@ mod tests {
             timeout_ms: None,
         })
         .unwrap();
-        handler(
+        dispatch_net_mail(
+            adapter.as_ref(),
+            &mailer,
             <Fetch as Kind>::ID,
-            Fetch::NAME,
-            None,
             session_sender(),
             &req,
-            1,
+            NetConfig::default().default_timeout,
         );
         let observed = adapter_stub
             .last_request

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -1137,17 +1137,11 @@ fn main() -> wasmtime::Result<()> {
     // fetch replies `AllowlistDenied`. `AETHER_NET_DISABLE=1` short-
     // circuits to a nop adapter that replies `Disabled`. The sink
     // always registers so mail isn't silently bubble-dropped — the
-    // adapter carries the gating.
-    let net_default_timeout = net_config.default_timeout;
-    let net_adapter = aether_substrate_core::net::build_net_adapter(net_config);
-    boot.registry.register_sink(
-        "aether.sink.net",
-        aether_substrate_core::net::net_sink_handler(
-            net_adapter,
-            Arc::clone(&boot.queue),
-            net_default_timeout,
-        ),
-    );
+    // adapter carries the gating. ADR-0070 phase 3 wraps it as a
+    // native capability with its own dispatcher thread.
+    boot.add_capability(aether_substrate_core::capabilities::NetCapability::new(
+        net_config,
+    ))?;
 
     // `aether.sink.log`: ADR-0060 guest-side logging. Decode `LogEvent`
     // mail and re-emit through the host `log` facade; the existing

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -223,17 +223,11 @@ fn main() -> wasmtime::Result<()> {
     // shape as desktop. Deny-by-default via `AETHER_NET_ALLOWLIST`;
     // `AETHER_NET_DISABLE=1` swaps to a nop adapter that replies
     // `Disabled`. The `NetConfig` was built from env at the top of
-    // `main` (issue 464).
-    let net_default_timeout = net_config.default_timeout;
-    let net_adapter = aether_substrate_core::net::build_net_adapter(net_config);
-    boot.registry.register_sink(
-        "aether.sink.net",
-        aether_substrate_core::net::net_sink_handler(
-            net_adapter,
-            Arc::clone(&boot.queue),
-            net_default_timeout,
-        ),
-    );
+    // `main` (issue 464). ADR-0070 phase 3 wraps it as a native
+    // capability with its own dispatcher thread.
+    boot.add_capability(aether_substrate_core::capabilities::NetCapability::new(
+        net_config,
+    ))?;
 
     // `aether.sink.log`: ADR-0060. Same capability as desktop — guest
     // log mail is independent of GPU / windowing, so headless wires


### PR DESCRIPTION
## Summary

Third chassis-conditional capability extraction. Same shape as the io capability — `NetCapability::new(NetConfig)` builds the `NetAdapter` at boot and spawns one dispatcher thread that loops on the mpsc receiver.

**NetCapability:**
- Constructor takes resolved `NetConfig`; chassis main reads env once (issue 464) and passes through.
- `boot()` calls `net::build_net_adapter` (infallible — `DisabledNetAdapter` on `disabled = true`, otherwise `UreqNetAdapter`). Spawns the dispatcher thread that routes each envelope through `dispatch_net_mail`.
- `net.rs` keeps the per-kind dispatcher (`dispatch_net_mail`, now `pub(crate)`); the `net_sink_handler` SinkHandler constructor is removed and the 5 `net.rs` unit tests rewrite to call `dispatch_net_mail` directly.

**Chassis main updates:**
- desktop and headless: `boot.add_capability(NetCapability::new(net_config))?` replaces the inline `build_net_adapter` + `register_sink` + `net_sink_handler` block.
- test-bench skips net per its existing policy comment (no scenarios need network egress).
- hub still skips net (no use case).

## Test plan

- [x] `cargo test --workspace` (239 core lib tests + everything else green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] New: `capability_boots_and_registers_sink`, `duplicate_claim_rejects_with_typed_error`
- [x] CI green on the cross-platform matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)