### PR TITLE
feat(headless): extract HeadlessTimerCapability (ADR-0071 phase 5)

### DIFF
--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -11,17 +11,28 @@
 //! unsupported error".
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use aether_data::{Kind, KindId};
-use aether_kinds::{Advance, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowTitle};
+use aether_kinds::{
+    Advance, CaptureFrame, FrameStats, PlatformInfo, SetMasterGain, SetMasterGainResult,
+    SetWindowMode, SetWindowTitle, Tick,
+};
+use aether_substrate_core::capability::BootError;
+use aether_substrate_core::chassis_builder::{Builder, BuiltChassis, NoDriver};
 use aether_substrate_core::{
-    ChassisControlHandler, HubOutbound, ReplyTo,
+    Chassis, ChassisControlHandler, HubOutbound, ReplyTo, SubstrateBoot,
+    capabilities::{
+        IoCapability, LogCapability, NetCapability, io::NamespaceRoots, net::NetConfig as NetConf,
+    },
     capture::{
         reply_unsupported_advance, reply_unsupported_capture_frame,
         reply_unsupported_platform_info, reply_unsupported_window_mode,
         reply_unsupported_window_title,
     },
 };
+
+use crate::driver::{HeadlessTimerCapability, WORKERS, parse_tick_hz_env};
 
 const UNSUPPORTED: &str = "unsupported on headless chassis — no GPU or window peripherals";
 const UNSUPPORTED_ADVANCE: &str =
@@ -57,4 +68,170 @@ pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHand
             }
         },
     )
+}
+
+/// Marker type for the headless chassis. Carries no fields — the
+/// chassis instance is the [`BuiltChassis<HeadlessChassis>`] returned
+/// by [`Self::build`]. Same shape as [`crate::DesktopChassis`] post
+/// ADR-0071 phase 3.
+pub struct HeadlessChassis;
+
+impl Chassis for HeadlessChassis {
+    const PROFILE: &'static str = "headless";
+
+    fn run(self) -> wasmtime::Result<()> {
+        Err(wasmtime::Error::msg(
+            "HeadlessChassis is built via build(env) — call run() on the BuiltChassis<HeadlessChassis> instead",
+        ))
+    }
+}
+
+/// Bag of resolved configs the headless chassis takes at build time.
+/// `main()` populates it from env vars (per ADR-0070's "substrate-core
+/// never reads env" invariant); tests construct one directly.
+pub struct HeadlessEnv {
+    pub hub_url: Option<String>,
+    pub namespace_roots: NamespaceRoots,
+    pub net: NetConf,
+    pub tick_period: Duration,
+}
+
+impl HeadlessEnv {
+    /// Read every chassis-relevant env var into a fresh `HeadlessEnv`.
+    /// The single env-reading edge for the headless chassis (per
+    /// issue 464). Tests bypass this by constructing `HeadlessEnv`
+    /// directly.
+    pub fn from_env() -> Self {
+        let hub_url = std::env::var("AETHER_HUB_URL").ok();
+        let net = NetConf::from_env();
+        let namespace_roots = NamespaceRoots::from_env();
+        let tick_hz = parse_tick_hz_env();
+        let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
+        HeadlessEnv {
+            hub_url,
+            namespace_roots,
+            net,
+            tick_period,
+        }
+    }
+}
+
+impl HeadlessChassis {
+    /// Build the headless chassis: stand up substrate-core internals,
+    /// register the nop chassis sinks (render / camera / audio — they
+    /// keep mailbox names resolvable so desktop-designed components
+    /// loaded on headless don't warn-storm), add the legacy
+    /// ADR-0070 capabilities (io, net, log) on the existing
+    /// `boot.add_capability` path, connect the hub, then wrap the
+    /// timer in a [`HeadlessTimerCapability`] and hand it to the
+    /// chassis_builder [`Builder`]. Returns a [`BuiltChassis`] whose
+    /// [`BuiltChassis::run`] blocks on the tick loop.
+    pub fn build(env: HeadlessEnv) -> wasmtime::Result<BuiltChassis<HeadlessChassis>> {
+        let HeadlessEnv {
+            hub_url,
+            namespace_roots,
+            net,
+            tick_period,
+        } = env;
+
+        let mut boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
+            .workers(WORKERS)
+            .namespace_roots(namespace_roots)
+            .chassis_handler(|ctx| Some(chassis_control_handler(Arc::clone(ctx.outbound))))
+            .build()?;
+
+        let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
+        let kind_frame_stats = boot
+            .registry
+            .kind_id(FrameStats::NAME)
+            .expect("FrameStats registered");
+
+        // Silent drop for `aether.sink.render` — desktop-designed
+        // components loaded on headless emit `DrawTriangle` every
+        // tick; without this sink, core's mailbox-resolution warn
+        // fires at the tick rate.
+        boot.registry.register_sink(
+            "aether.sink.render",
+            Arc::new(
+                |_kind: KindId,
+                 _kind_name: &str,
+                 _origin: Option<&str>,
+                 _sender,
+                 _bytes: &[u8],
+                 _count: u32| {},
+            ),
+        );
+        boot.registry.register_sink(
+            "aether.sink.camera",
+            Arc::new(
+                |_kind: KindId,
+                 _kind_name: &str,
+                 _origin: Option<&str>,
+                 _sender,
+                 _bytes: &[u8],
+                 _count: u32| {},
+            ),
+        );
+        // Audio nop sink — NoteOn/NoteOff fall through silently;
+        // SetMasterGain replies Err so agents fail fast rather than
+        // hang on a chassis with no audio device.
+        let kind_set_master_gain = boot
+            .registry
+            .kind_id(SetMasterGain::NAME)
+            .expect("SetMasterGain registered");
+        let outbound_for_audio_sink = Arc::clone(&boot.outbound);
+        boot.registry.register_sink(
+            "aether.sink.audio",
+            Arc::new(
+                move |kind: KindId,
+                      _kind_name: &str,
+                      _origin: Option<&str>,
+                      sender,
+                      _bytes: &[u8],
+                      _count: u32| {
+                    if kind == kind_set_master_gain {
+                        outbound_for_audio_sink.send_reply(
+                            sender,
+                            &SetMasterGainResult::Err {
+                                error: "unsupported on headless chassis — no audio device"
+                                    .to_owned(),
+                            },
+                        );
+                    }
+                },
+            ),
+        );
+
+        // Legacy ADR-0070 capabilities — io / net / log.
+        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
+        boot.add_capability(NetCapability::new(net))?;
+        boot.add_capability(LogCapability::new())?;
+
+        let tick_hz = (Duration::from_secs(1).as_nanos() / tick_period.as_nanos().max(1)) as u32;
+        tracing::info!(
+            target: "aether_substrate::boot",
+            workers = WORKERS,
+            tick_hz = tick_hz,
+            "componentless boot — load a component via aether.control.load_component",
+        );
+
+        // Hub connect AFTER every chassis sink is registered (issue #262).
+        let hub = boot.connect_hub(hub_url.as_deref())?;
+
+        let registry = Arc::clone(&boot.registry);
+        let mailer = Arc::clone(&boot.queue);
+
+        let driver = HeadlessTimerCapability {
+            boot,
+            kind_tick,
+            kind_frame_stats,
+            tick_period,
+            hub,
+        };
+
+        Builder::<HeadlessChassis, NoDriver>::new(registry, mailer)
+            .driver(driver)
+            .build()
+            .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))
+    }
 }

--- a/crates/aether-substrate-headless/src/driver.rs
+++ b/crates/aether-substrate-headless/src/driver.rs
@@ -1,0 +1,178 @@
+//! Headless chassis driver capability — ADR-0071 phase 5.
+//!
+//! Wraps the std-timer tick loop in a [`DriverCapability`] so the
+//! headless chassis composes the same way as desktop: passive
+//! capabilities + exactly one driver. The driver's `run()` body
+//! holds what was previously `HeadlessChassis::run` — a fixed-cadence
+//! tick generator (default 60 Hz, `AETHER_TICK_HZ` override) that
+//! pumps `Tick` mail to subscribed mailboxes, drains the mail queue,
+//! and emits frame-stats observation every
+//! [`frame_loop::LOG_EVERY_FRAMES`] frames.
+//!
+//! No `Send` bound on the driver capability or its running — the
+//! headless tick loop runs on the chassis main thread end-to-end (no
+//! winit, but the chassis_builder's single-threaded
+//! Builder→BuiltChassis→run path applies all the same).
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use aether_data::{Kind, KindId, encode_empty};
+use aether_kinds::Tick;
+use aether_substrate_core::capability::BootError;
+use aether_substrate_core::chassis_builder::{
+    DriverCapability, DriverCtx, DriverRunning, RunError,
+};
+use aether_substrate_core::{
+    HubClient, HubOutbound, InputSubscribers, Mailer, SubstrateBoot, frame_loop,
+    mail::{Mail, MailboxId},
+    subscribers_for,
+};
+
+/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
+/// component, the scheduler doesn't read this — it's retained on the
+/// hub-protocol wire for compatibility). The shared frame-loop
+/// policy (drain budget, frame-stats cadence) lives in
+/// `aether_substrate_core::frame_loop`.
+pub const WORKERS: usize = 2;
+pub const DEFAULT_TICK_HZ: u32 = 60;
+
+/// Parse `AETHER_TICK_HZ`. Unset → [`DEFAULT_TICK_HZ`]; non-positive
+/// or unparseable → log + fall back to default. Tests bypass this by
+/// constructing `HeadlessEnv` with a chosen `tick_period` directly.
+pub fn parse_tick_hz_env() -> u32 {
+    match std::env::var("AETHER_TICK_HZ") {
+        Ok(s) => s
+            .trim()
+            .parse::<u32>()
+            .ok()
+            .filter(|&hz| hz > 0)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    target: "aether_substrate::boot",
+                    value = %s,
+                    "AETHER_TICK_HZ unparseable or zero — falling back to default",
+                );
+                DEFAULT_TICK_HZ
+            }),
+        Err(_) => DEFAULT_TICK_HZ,
+    }
+}
+
+/// ADR-0071 driver capability for the headless chassis. Owns the
+/// pieces the timer loop needs at construction time, then `boot()`
+/// captures them on a [`HeadlessTimerRunning`] that drives the loop.
+pub struct HeadlessTimerCapability {
+    pub boot: SubstrateBoot,
+    pub kind_tick: KindId,
+    pub kind_frame_stats: KindId,
+    pub tick_period: Duration,
+    /// Held for the chassis lifetime so the hub reader + heartbeat
+    /// threads stay spawned. `None` when `AETHER_HUB_URL` was unset.
+    pub hub: Option<HubClient>,
+}
+
+pub struct HeadlessTimerRunning {
+    queue: Arc<Mailer>,
+    input_subscribers: InputSubscribers,
+    broadcast_mbox: MailboxId,
+    kind_tick: KindId,
+    kind_frame_stats: KindId,
+    tick_period: Duration,
+    outbound: Arc<HubOutbound>,
+    /// `SubstrateBoot` drops at the end of `run()` so its scheduler
+    /// joins workers and its `BootedChassis` (legacy ADR-0070
+    /// capabilities — io, net, log) tear down in reverse boot order
+    /// before the hub disconnects.
+    _boot: SubstrateBoot,
+    _hub: Option<HubClient>,
+}
+
+impl DriverCapability for HeadlessTimerCapability {
+    type Running = HeadlessTimerRunning;
+
+    fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
+        let HeadlessTimerCapability {
+            boot,
+            kind_tick,
+            kind_frame_stats,
+            tick_period,
+            hub,
+        } = self;
+
+        Ok(HeadlessTimerRunning {
+            queue: Arc::clone(&boot.queue),
+            input_subscribers: Arc::clone(&boot.input_subscribers),
+            broadcast_mbox: boot.broadcast_mbox,
+            kind_tick,
+            kind_frame_stats,
+            tick_period,
+            outbound: Arc::clone(&boot.outbound),
+            _boot: boot,
+            _hub: hub,
+        })
+    }
+}
+
+impl DriverRunning for HeadlessTimerRunning {
+    fn run(self: Box<Self>) -> Result<(), RunError> {
+        let HeadlessTimerRunning {
+            queue,
+            input_subscribers,
+            broadcast_mbox,
+            kind_tick,
+            kind_frame_stats,
+            tick_period,
+            outbound,
+            _boot,
+            _hub,
+        } = *self;
+
+        let started = Instant::now();
+        let mut frame: u64 = 0;
+        let mut next_deadline = Instant::now() + tick_period;
+        loop {
+            let now = Instant::now();
+            if now < next_deadline {
+                thread::sleep(next_deadline - now);
+            }
+            // Catch the deadline up from the current instant rather
+            // than the prior target — if a frame overruns (component
+            // deliver stalled, hub socket flushed slowly) we resume
+            // from now + period instead of trying to burn through
+            // backlog, which would just compound the stall.
+            next_deadline = Instant::now() + tick_period;
+
+            frame += 1;
+            let subs = subscribers_for(&input_subscribers, Tick::ID);
+            for mbox in subs {
+                queue.push(Mail::new(mbox, kind_tick, encode_empty::<Tick>(), 1));
+            }
+            // ADR-0063 (issue 427: shared `frame_loop::DRAIN_BUDGET`).
+            // Budget-aware drain. Dispatcher deaths or wedges abort
+            // the substrate cleanly via `fatal_abort`.
+            frame_loop::drain_or_abort(&queue, &outbound);
+
+            if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
+                frame_loop::emit_frame_stats(
+                    &queue,
+                    broadcast_mbox,
+                    broadcast_mbox,
+                    kind_frame_stats,
+                    frame,
+                    0,
+                );
+                let elapsed = started.elapsed().as_secs_f64().max(0.001);
+                tracing::info!(
+                    target: "aether_substrate::frame_loop",
+                    frame = frame,
+                    fps = frame as f64 / elapsed,
+                    "headless tick",
+                );
+            }
+        }
+        // The `loop` above never breaks — process exit is the only
+        // termination path (SIGTERM/SIGINT or `fatal_abort`).
+    }
+}

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -1,266 +1,29 @@
-// Headless chassis: std-timer tick driver, no window, no GPU. Boots
-// componentless (ADR-0010) and runs the same scheduler + control
-// plane as desktop; components are loaded at runtime via
-// `aether.control.load_component` over the hub. Desktop-only control
-// kinds (capture_frame, set_window_mode, platform_info) are handled
-// by `chassis::chassis_control_handler`, which replies with an
-// explicit `Err { error: "unsupported on headless" }` so callers
-// don't stall waiting for a reply that's never coming.
+// Headless chassis entry point.
+//
+// Reads chassis-relevant env vars into a `HeadlessEnv`, asks
+// `HeadlessChassis` to build itself (substrate-core internals, nop
+// chassis sinks, native capabilities, optional hub, std-timer
+// driver), and blocks on the resulting chassis until the process
+// exits. Per ADR-0071 phase 5 the timer loop body lives in
+// `driver::HeadlessTimerCapability`; this binary is the env-reading
+// edge plus a logging line plus the run call.
 
 mod chassis;
+mod driver;
 
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
+use chassis::{HeadlessChassis, HeadlessEnv};
 
-use aether_data::{Kind, KindId, encode_empty};
-use aether_kinds::{FrameStats, Tick};
-use aether_substrate_core::{
-    Chassis, InputSubscribers, Mailer, Scheduler, SubstrateBoot, frame_loop,
-    mail::{Mail, MailboxId},
-    subscribers_for,
-};
-
-/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
-/// component, the scheduler doesn't read this — it's retained on the
-/// hub-protocol wire for compatibility). The shared frame-loop
-/// policy (drain budget, frame-stats cadence) lives in
-/// `aether_substrate_core::frame_loop`.
-const WORKERS: usize = 2;
-const DEFAULT_TICK_HZ: u32 = 60;
-
-/// Headless chassis. Owns the tick loop + the bookkeeping every
-/// subsequent frame needs. `run(self)` takes ownership and drives
-/// the loop forever — the process exits on SIGTERM (hub-spawned
-/// substrates) or SIGINT (manual `cargo run`); there's no clean
-/// return path because there's no event source that can close.
-struct HeadlessChassis {
-    queue: Arc<Mailer>,
-    input_subscribers: InputSubscribers,
-    broadcast_mbox: MailboxId,
-    kind_tick: KindId,
-    kind_frame_stats: KindId,
-    tick_period: Duration,
-    /// ADR-0063: passed to `lifecycle::fatal_abort` for the final
-    /// `SubstrateDying` broadcast before exit.
-    outbound: Arc<aether_substrate_core::HubOutbound>,
-    // Held so the scheduler's worker threads + the hub's reader /
-    // heartbeat threads stay alive for the life of the chassis.
-    _scheduler: Scheduler,
-    _hub: Option<aether_substrate_core::HubClient>,
-}
-
-impl Chassis for HeadlessChassis {
-    const PROFILE: &'static str = "headless";
-
-    fn run(self) -> wasmtime::Result<()> {
-        let started = Instant::now();
-        let mut frame: u64 = 0;
-        let mut next_deadline = Instant::now() + self.tick_period;
-        loop {
-            let now = Instant::now();
-            if now < next_deadline {
-                thread::sleep(next_deadline - now);
-            }
-            // Catch the deadline up from the current instant rather
-            // than the prior target — if a frame overruns (component
-            // deliver stalled, hub socket flushed slowly) we resume
-            // from now + period instead of trying to burn through
-            // backlog, which would just compound the stall.
-            next_deadline = Instant::now() + self.tick_period;
-
-            frame += 1;
-            let subs = subscribers_for(&self.input_subscribers, Tick::ID);
-            for mbox in subs {
-                self.queue
-                    .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
-            }
-            // ADR-0063 (issue 427: shared `frame_loop::DRAIN_BUDGET`).
-            // Budget-aware drain. Dispatcher deaths or wedges abort
-            // the substrate cleanly via `fatal_abort`.
-            frame_loop::drain_or_abort(&self.queue, &self.outbound);
-
-            if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
-                frame_loop::emit_frame_stats(
-                    &self.queue,
-                    self.broadcast_mbox,
-                    self.broadcast_mbox,
-                    self.kind_frame_stats,
-                    frame,
-                    0,
-                );
-                let elapsed = started.elapsed().as_secs_f64().max(0.001);
-                tracing::info!(
-                    target: "aether_substrate::frame_loop",
-                    frame = frame,
-                    fps = frame as f64 / elapsed,
-                    "headless tick",
-                );
-            }
-        }
-    }
-}
-
-fn parse_tick_hz_env() -> u32 {
-    match std::env::var("AETHER_TICK_HZ") {
-        Ok(s) => s
-            .trim()
-            .parse::<u32>()
-            .ok()
-            .filter(|&hz| hz > 0)
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    target: "aether_substrate::boot",
-                    value = %s,
-                    "AETHER_TICK_HZ unparseable or zero — falling back to default",
-                );
-                DEFAULT_TICK_HZ
-            }),
-        Err(_) => DEFAULT_TICK_HZ,
-    }
-}
+use aether_substrate_core::Chassis;
 
 fn main() -> wasmtime::Result<()> {
-    // Per issue 464, this `main()` is the env-reading edge. Read every
-    // chassis-relevant env var into a config struct and thread it
-    // through the substrate-core APIs explicitly. Substrate-core
-    // itself never reads env from now on.
-    let hub_url = std::env::var("AETHER_HUB_URL").ok();
-    let net_config = aether_substrate_core::capabilities::net::NetConfig::from_env();
-    let namespace_roots = aether_substrate_core::capabilities::io::NamespaceRoots::from_env();
-
-    let mut boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
-        .workers(WORKERS)
-        .namespace_roots(namespace_roots)
-        .chassis_handler(|ctx| Some(chassis::chassis_control_handler(Arc::clone(ctx.outbound))))
-        .build()?;
-
-    let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
-    let kind_frame_stats = boot
-        .registry
-        .kind_id(FrameStats::NAME)
-        .expect("FrameStats registered");
-
-    // Silent drop for `aether.sink.render` mail. A desktop-designed
-    // component loaded on a headless substrate will emit `DrawTriangle`
-    // every tick; without this sink, core's mailbox-resolution warn
-    // fires at the tick rate and buries every other engine_logs entry.
-    boot.registry.register_sink(
-        "aether.sink.render",
-        Arc::new(
-            |_kind: KindId,
-             _kind_name: &str,
-             _origin: Option<&str>,
-             _sender,
-             _bytes: &[u8],
-             _count: u32| {},
-        ),
-    );
-    // Same deal for `aether.sink.camera` — a desktop-designed camera
-    // component will emit camera updates every tick. Headless has no
-    // GPU to upload to, so silently discard.
-    boot.registry.register_sink(
-        "aether.sink.camera",
-        Arc::new(
-            |_kind: KindId,
-             _kind_name: &str,
-             _origin: Option<&str>,
-             _sender,
-             _bytes: &[u8],
-             _count: u32| {},
-        ),
-    );
-    // `aether.audio.*` per ADR-0039 Phase 2. Headless has no audio
-    // device, so NoteOn / NoteOff are discarded silently (keeping the
-    // mailbox resolvable so desktop-designed music components loaded
-    // on headless don't warn-storm). SetMasterGain replies Err so
-    // agents attempting to control audio on a chassis that can't
-    // produce it fail fast rather than hang.
-    let kind_set_master_gain = boot
-        .registry
-        .kind_id(aether_kinds::SetMasterGain::NAME)
-        .expect("SetMasterGain registered");
-    let outbound_for_audio_sink = Arc::clone(&boot.outbound);
-    boot.registry.register_sink(
-        "aether.sink.audio",
-        Arc::new(
-            move |kind: KindId,
-                  _kind_name: &str,
-                  _origin: Option<&str>,
-                  sender,
-                  _bytes: &[u8],
-                  _count: u32| {
-                if kind == kind_set_master_gain {
-                    outbound_for_audio_sink.send_reply(
-                        sender,
-                        &aether_kinds::SetMasterGainResult::Err {
-                            error: "unsupported on headless chassis — no audio device".to_owned(),
-                        },
-                    );
-                }
-                // NoteOn / NoteOff fall through silently.
-            },
-        ),
-    );
-
-    // `aether.io.*` per ADR-0041. Same capability as desktop —
-    // the io path is purely I/O, no GPU or window surface, so
-    // there's nothing chassis-specific to diverge on. ADR-0070
-    // phase 3 wraps it as a native capability with fail-fast boot
-    // semantics (ADR-0063); pre-phase-3 behavior was log-and-skip
-    // on adapter init failure.
-    boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
-        boot.namespace_roots.clone(),
-    ))?;
-
-    // `aether.net.fetch`: ADR-0043 substrate HTTP egress. Headless
-    // runs the asset pipeline, so net is first-class here — same
-    // shape as desktop. Deny-by-default via `AETHER_NET_ALLOWLIST`;
-    // `AETHER_NET_DISABLE=1` swaps to a nop adapter that replies
-    // `Disabled`. The `NetConfig` was built from env at the top of
-    // `main` (issue 464). ADR-0070 phase 3 wraps it as a native
-    // capability with its own dispatcher thread.
-    boot.add_capability(aether_substrate_core::capabilities::NetCapability::new(
-        net_config,
-    ))?;
-
-    // `aether.sink.log`: ADR-0060. Same capability as desktop — guest
-    // log mail is independent of GPU / windowing, so headless wires
-    // it identically.
-    boot.add_capability(aether_substrate_core::capabilities::LogCapability::new())?;
-
-    let tick_hz = parse_tick_hz_env();
-    let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
-    tracing::info!(
-        target: "aether_substrate::boot",
-        workers = WORKERS,
-        tick_hz = tick_hz,
-        "componentless boot — load a component via aether.control.load_component",
-    );
-
-    // Connect to the hub LAST, after every chassis sink is registered.
-    // Before this returns no hub-driven `load_component` can race
-    // ahead of the chassis setup and bind a chassis sink name to a
-    // component (issue #262). Must happen before moving fields out of
-    // `boot` below — connect_hub borrows `&boot`. Per issue 464,
-    // `hub_url` was read from env at the top of `main`.
-    let hub = boot.connect_hub(hub_url.as_deref())?;
-
-    let chassis = HeadlessChassis {
-        queue: boot.queue,
-        input_subscribers: boot.input_subscribers,
-        broadcast_mbox: boot.broadcast_mbox,
-        kind_tick,
-        kind_frame_stats,
-        tick_period,
-        outbound: boot.outbound,
-        _scheduler: boot.scheduler,
-        _hub: hub,
-    };
+    let env = HeadlessEnv::from_env();
+    let chassis = HeadlessChassis::build(env)?;
     tracing::info!(
         target: "aether_substrate::boot",
         profile = HeadlessChassis::PROFILE,
         "chassis initialised",
     );
-    chassis.run()
+    chassis
+        .run()
+        .map_err(|e| wasmtime::Error::msg(format!("chassis run: {e}")))
 }


### PR DESCRIPTION
## Summary

ADR-0071 phase 5 — headless driver extraction. Same shape as
phase 3's desktop extraction, smaller diff. main.rs shrinks from
266 lines to 29; the std-timer tick loop body moves into a new
driver.rs wrapped in HeadlessTimerCapability + HeadlessTimerRunning.
HeadlessChassis::build(env) is the new construction site.

## What's in

- New module crates/aether-substrate-headless/src/driver.rs:
  - HeadlessTimerCapability owns the SubstrateBoot, kind ids,
    tick period, hub client at construction time.
    HeadlessTimerRunning holds the loop's working state plus the
    SubstrateBoot + hub on the running for proper teardown order.
  - DriverRunning::run holds what was previously
    HeadlessChassis::run — the fixed-cadence tick generator
    pumping Tick mail to subscribers, draining the mail queue, and
    emitting frame-stats observation every LOG_EVERY_FRAMES
    frames.
  - WORKERS const, DEFAULT_TICK_HZ const, parse_tick_hz_env helper
    all moved verbatim from main.rs.
- crates/aether-substrate-headless/src/chassis.rs:
  - HeadlessChassis is now a unit marker struct with const
    PROFILE = "headless". Chassis::run on the struct returns an
    error directing callers to use BuiltChassis::run; phase 7
    will retire the trait method once every chassis migrates.
  - HeadlessEnv config struct + HeadlessEnv::from_env (single
    env-reading edge per ADR-0070, issue 464).
  - HeadlessChassis::build(env) inherent method assembles
    SubstrateBoot, registers the nop render / camera / audio
    sinks (keeping mailbox names resolvable so desktop-designed
    components loaded on headless don't warn-storm), adds the
    legacy ADR-0070 native capabilities (io, net, log), connects
    the hub, wraps the timer in HeadlessTimerCapability, and hands
    it to the chassis_builder Builder.
- crates/aether-substrate-headless/src/main.rs collapses from 266
  to 29 lines.

## What's deferred

- Trait redefinition (Chassis::Driver / Env / build) — happens in
  phase 7 (or later) once Hub also migrates. HeadlessChassis::build
  is an inherent method through the migration window.
- Capabilities migrating from boot.add_capability to
  chassis_builder::Builder.with — same as desktop's phase 3.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (all suites pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)