### PR TITLE
feat(test-bench): rewire as PassiveChassis (ADR-0071 phase 6)

### DIFF
--- a/crates/aether-substrate-core/src/capabilities/render.rs
+++ b/crates/aether-substrate-core/src/capabilities/render.rs
@@ -45,15 +45,22 @@ const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// the maximum bytes the render accumulator will hold before
 /// truncating with a warn — desktop and test-bench both pass
 /// [`crate::render::VERTEX_BUFFER_BYTES`].
-#[derive(Clone, Copy, Debug)]
+///
+/// `observed_kinds`, when set, has every inbound mail's kind name
+/// pushed to it from both the render and camera dispatchers — used
+/// by the in-process test-bench to assert what kinds the sinks
+/// have seen. Production chassis leave it `None` (zero overhead).
+#[derive(Clone)]
 pub struct RenderConfig {
     pub vertex_buffer_bytes: usize,
+    pub observed_kinds: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl Default for RenderConfig {
     fn default() -> Self {
         Self {
             vertex_buffer_bytes: crate::render::VERTEX_BUFFER_BYTES,
+            observed_kinds: None,
         }
     }
 }
@@ -134,12 +141,16 @@ impl Capability for RenderCapability {
             let cap = config.vertex_buffer_bytes;
             let receiver = render_claim.receiver;
             let flag = Arc::clone(&shutdown_flag);
+            let observed = config.observed_kinds.clone();
             thread::Builder::new()
                 .name("aether-render-sink".into())
                 .spawn(move || {
                     while !flag.load(Ordering::Relaxed) {
                         match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
                             Ok(env) => {
+                                if let Some(obs) = &observed {
+                                    obs.lock().unwrap().push(env.kind_name.clone());
+                                }
                                 dispatch_render_envelope(
                                     &frame_vertices,
                                     &triangles_rendered,
@@ -159,12 +170,16 @@ impl Capability for RenderCapability {
             let camera_state = Arc::clone(&handles.camera_state);
             let receiver = camera_claim.receiver;
             let flag = Arc::clone(&shutdown_flag);
+            let observed = config.observed_kinds.clone();
             thread::Builder::new()
                 .name("aether-camera-sink".into())
                 .spawn(move || {
                     while !flag.load(Ordering::Relaxed) {
                         match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
                             Ok(env) => {
+                                if let Some(obs) = &observed {
+                                    obs.lock().unwrap().push(env.kind_name.clone());
+                                }
                                 dispatch_camera_envelope(&camera_state, &env);
                             }
                             Err(RecvTimeoutError::Timeout) => {}
@@ -324,6 +339,7 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         let cap = RenderCapability::new(RenderConfig {
             vertex_buffer_bytes: DRAW_TRIANGLE_BYTES * 2,
+            ..RenderConfig::default()
         });
         let handles = cap.handles();
 

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -1,6 +1,9 @@
-//! Test-bench chassis-registered control-plane handler (ADR-0067).
+//! Test-bench chassis-registered control-plane handler (ADR-0067)
+//! plus the ADR-0071 phase 6 [`TestBenchChassis`] marker +
+//! [`TestBenchEnv`] config + [`TestBenchChassis::build_passive`]
+//! entry point.
 //!
-//! Owns three custom kinds:
+//! Custom control-plane kinds:
 //!
 //! - `aether.control.capture_frame` — same two-phase resolve / push
 //!   / handoff desktop uses, but the handoff target is the chassis
@@ -15,22 +18,35 @@
 //!   reply `Err` with an "unsupported on test-bench chassis" message.
 //!   Same fail-fast shape headless uses on these.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use aether_data::{Kind, KindId};
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowTitle,
+    Advance, AdvanceResult, CaptureFrame, FrameStats, PlatformInfo, SetWindowMode, SetWindowTitle,
+    Tick,
 };
+use aether_substrate_core::capability::BootError;
+use aether_substrate_core::chassis_builder::{Builder, NoDriver, PassiveChassis};
 use aether_substrate_core::{
-    ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo,
+    Chassis, ChassisControlHandler, HubClient, HubOutbound, Mailer, Registry, ReplyTo,
+    SubstrateBoot,
+    capabilities::{
+        LogCapability, RenderCapability, RenderConfig, RenderHandles, io::NamespaceRoots,
+    },
     capture::{
         CaptureQueue, begin_capture_request, reply_unsupported_platform_info,
         reply_unsupported_window_mode, reply_unsupported_window_title,
     },
     control::decode_payload,
+    render::VERTEX_BUFFER_BYTES,
 };
 
 use crate::events::{ChassisEvent, EventSender};
+
+/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
+/// component, the scheduler doesn't read this — it's retained on the
+/// hub-protocol wire for compatibility).
+pub const WORKERS: usize = 2;
 
 const UNSUPPORTED_WINDOW: &str = "unsupported on test-bench chassis — no window peripherals (set_window_mode, set_window_title, \
      platform_info are desktop-only)";
@@ -108,5 +124,171 @@ fn handle_advance(events: &EventSender, outbound: &HubOutbound, sender: ReplyTo,
                 error: "test-bench chassis shutting down — advance aborted".to_owned(),
             },
         );
+    }
+}
+
+/// ADR-0071 marker type for the test-bench chassis. Carries no
+/// fields — the chassis instance is the [`PassiveChassis<TestBenchChassis>`]
+/// returned by [`Self::build_passive`]. Test-bench is the embedder-
+/// driven (no-driver) chassis: the binary's `main()` and the
+/// in-process [`crate::TestBench`] both build through this and drive
+/// their own event loops on top.
+pub struct TestBenchChassis;
+
+impl Chassis for TestBenchChassis {
+    const PROFILE: &'static str = "test-bench";
+
+    fn run(self) -> wasmtime::Result<()> {
+        Err(wasmtime::Error::msg(
+            "TestBenchChassis is built via build_passive(env); the embedder drives the loop \
+             (binary main() loops on events_rx; in-process TestBench dispatches per-call)",
+        ))
+    }
+}
+
+/// Bag of resolved configs the test-bench chassis takes at build
+/// time. Constructed by the embedder — the binary's `main()` reads
+/// env vars; the in-process [`crate::TestBench`] takes builder
+/// args. `events_tx` is captured into the chassis-control closure;
+/// the matching `events_rx` rides on [`TestBenchBuild`] for the
+/// embedder to drive.
+pub struct TestBenchEnv {
+    /// Substrate identity for the hub `Hello` handshake (e.g.
+    /// `"test-bench"`). Used by both binary and in-process API.
+    pub name: String,
+    /// Substrate version for the hub `Hello`. Typically
+    /// `env!("CARGO_PKG_VERSION")` from the binary; in-process API
+    /// supplies the same.
+    pub version: String,
+    /// Number of workers for the wire-stable `EngineInfo.workers`
+    /// field. Defaults to [`WORKERS`].
+    pub workers: usize,
+    /// Override for the io adapter's filesystem roots; `None` reads
+    /// from env via [`NamespaceRoots::from_env`]. The in-process
+    /// API uses `Some(tempdir-based)` for isolation; the binary
+    /// passes `None`.
+    pub namespace_roots: Option<NamespaceRoots>,
+    /// Hub URL for `connect_hub`. Binary reads `AETHER_HUB_URL`;
+    /// in-process API typically passes `None`.
+    pub hub_url: Option<String>,
+    /// Optional observation log: when `Some`, both render and
+    /// camera dispatchers push every inbound mail's kind name to it.
+    /// In-process API uses this to assert what the sinks have seen;
+    /// binary passes `None` for zero overhead.
+    pub observed_kinds: Option<Arc<Mutex<Vec<String>>>>,
+    /// Sender side of the chassis event channel. Cloned into the
+    /// chassis-control handler closure; the matching receiver rides
+    /// on [`TestBenchBuild`].
+    pub events_tx: EventSender,
+    /// Capture-handoff slot the chassis-control handler writes
+    /// into; the embedder's frame loop drains it on each
+    /// `RedrawRequested`-equivalent step.
+    pub capture_queue: CaptureQueue,
+}
+
+/// Output of [`TestBenchChassis::build_passive`]. Bundles the
+/// `PassiveChassis<TestBenchChassis>` (holding the booted Log +
+/// Render passives via chassis_builder typed lookup) with the
+/// substrate handles the embedder needs to drive its event loop —
+/// queue, outbound, kind ids, render accumulator handles, the hub
+/// client.
+///
+/// `boot` is exposed so the embedder can call
+/// `boot.add_capability(...)` for io / etc. with whatever failure
+/// semantics it wants (binary uses `?`; in-process API silent-skips
+/// io on systems without writable default roots).
+///
+/// The embedder owns the matching `EventReceiver` for whichever
+/// `EventSender` it passed into [`TestBenchEnv`]; the build does
+/// not need to thread it through.
+pub struct TestBenchBuild {
+    pub passive: PassiveChassis<TestBenchChassis>,
+    pub boot: SubstrateBoot,
+    pub render_handles: RenderHandles,
+    pub kind_tick: KindId,
+    pub kind_frame_stats: KindId,
+    pub hub: Option<HubClient>,
+}
+
+impl TestBenchChassis {
+    /// Build the test-bench chassis: stand up substrate-core
+    /// internals via [`SubstrateBoot::builder`], boot Log + Render
+    /// as passives via the chassis_builder [`Builder`], connect the
+    /// hub if `env.hub_url` is set, and return a [`TestBenchBuild`]
+    /// the embedder takes ownership of. The embedder is responsible
+    /// for any further capability adds (io with whatever failure
+    /// semantics it wants), GPU creation, loopback attach, and
+    /// driving the event loop.
+    pub fn build_passive(env: TestBenchEnv) -> wasmtime::Result<TestBenchBuild> {
+        let TestBenchEnv {
+            name,
+            version,
+            workers,
+            namespace_roots,
+            hub_url,
+            observed_kinds,
+            events_tx,
+            capture_queue,
+        } = env;
+
+        let mut builder = SubstrateBoot::builder(&name, &version)
+            .workers(workers)
+            .chassis_handler({
+                let cq = capture_queue.clone();
+                let tx = events_tx.clone();
+                move |ctx| {
+                    Some(chassis_control_handler(
+                        cq,
+                        tx,
+                        Arc::clone(ctx.registry),
+                        Arc::clone(ctx.queue),
+                        Arc::clone(ctx.outbound),
+                    ))
+                }
+            });
+        if let Some(roots) = namespace_roots {
+            builder = builder.namespace_roots(roots);
+        }
+        let boot = builder.build()?;
+
+        let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
+        let kind_frame_stats = boot
+            .registry
+            .kind_id(FrameStats::NAME)
+            .expect("FrameStats registered");
+
+        let render_cap = RenderCapability::new(RenderConfig {
+            vertex_buffer_bytes: VERTEX_BUFFER_BYTES,
+            observed_kinds,
+        });
+        let render_handles = render_cap.handles();
+
+        let passive = Builder::<TestBenchChassis, NoDriver>::new(
+            Arc::clone(&boot.registry),
+            Arc::clone(&boot.queue),
+        )
+        .with(LogCapability::new())
+        .with(render_cap)
+        .build_passive()
+        .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
+
+        let hub = boot.connect_hub(hub_url.as_deref())?;
+
+        // The chassis-control closure already cloned `events_tx`;
+        // dropping the local copy lets the receiver hang up cleanly
+        // once every chassis_control_handler clone is released. The
+        // embedder retains its own `EventSender` clone if it wants
+        // to send synthetic events; otherwise the chassis_control
+        // closure is the only sender.
+        drop(events_tx);
+
+        Ok(TestBenchBuild {
+            passive,
+            boot,
+            render_handles,
+            kind_tick,
+            kind_frame_stats,
+            hub,
+        })
     }
 }

--- a/crates/aether-substrate-test-bench/src/lib.rs
+++ b/crates/aether-substrate-test-bench/src/lib.rs
@@ -30,4 +30,6 @@ pub use aether_substrate_core::{
     subscribers_for,
 };
 
-pub use chassis::chassis_control_handler;
+pub use chassis::{
+    TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS, chassis_control_handler,
+};

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -1,262 +1,97 @@
-// Test-bench chassis binary (ADR-0067). GPU-capable, no window, no
-// winit. wgpu initialises without a presentation surface; every
-// frame renders into an offscreen color target paired with a depth
-// target; capture_frame reads back from that same offscreen.
+// Test-bench chassis binary entry point.
 //
-// Tick driver is control-mail (ADR-0067): the chassis loop blocks
-// waiting for `aether.test_bench.advance { ticks }` events from the
-// chassis-control handler. Each Advance runs `ticks` complete
-// frames (Tick fanout → drain → render-or-capture), then replies
-// with `AdvanceResult::Ok`. Capture-frame requests wake the loop
-// for one drain → render-with-capture cycle without dispatching
-// Tick (capture observes; advance ticks). With no Advance, the
-// world doesn't tick — the chassis is fully deterministic.
-
-mod chassis;
-mod events;
-mod render;
+// Reads chassis-relevant env vars into a `TestBenchEnv`, asks
+// `TestBenchChassis::build_passive` to assemble the substrate +
+// passive capabilities (Log + Render) via the chassis_builder
+// `Builder`, adds the io capability on the legacy
+// `boot.add_capability` path, creates the offscreen `Gpu`, then
+// drives the events_rx loop on the main thread. The chassis is
+// embedder-driven (no `DriverCapability`) — `main()` IS the driver.
+//
+// In-process counterpart lives in `aether-substrate-test-bench::TestBench`
+// (the `TestBench::start()` API ADR-0067 introduced); both paths
+// share `TestBenchChassis::build_passive`.
 
 use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use aether_data::{Kind, encode_empty};
-use aether_kinds::{AdvanceResult, CaptureFrameResult, FrameStats, Tick};
+use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
 use aether_substrate_core::{
-    Chassis, HubOutbound, InputSubscribers, Mailer, Scheduler, SubstrateBoot,
-    capabilities::{RenderCapability, RenderConfig},
-    capture::CaptureQueue,
-    frame_loop,
-    mail::{Mail, MailboxId},
+    Chassis, capabilities::IoCapability, capture::CaptureQueue, frame_loop, mail::Mail,
     subscribers_for,
 };
-
-use crate::events::{ChassisEvent, EventReceiver};
-use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
-
-/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
-/// component, the scheduler doesn't read this — it's retained on the
-/// hub-protocol wire for compatibility). The shared frame-loop
-/// policy (drain budget, frame-stats cadence) lives in
-/// `aether_substrate_core::frame_loop`.
-const WORKERS: usize = 2;
-
-/// Default offscreen target size when `AETHER_TEST_BENCH_SIZE` is
-/// unset. 800x600 matches the scenario harness convention — large
-/// enough that `min_non_bg_pixels` thresholds discriminate, small
-/// enough that capture readback is cheap.
-const DEFAULT_WIDTH: u32 = 800;
-const DEFAULT_HEIGHT: u32 = 600;
-
-/// Test-bench chassis. Owns the event loop, the GPU, the shared
-/// frame state (vertex buffer, camera matrix), and the capture
-/// queue. `run(self)` blocks on the event receiver — the loop
-/// returns only when every sender has been dropped (chassis
-/// shutdown). Process exit on SIGTERM (hub-spawned) is caught by
-/// the chassis-control handler dropping its sender; SIGINT (manual
-/// run) terminates the process directly.
-struct TestBenchChassis {
-    queue: Arc<Mailer>,
-    input_subscribers: InputSubscribers,
-    broadcast_mbox: MailboxId,
-    kind_tick: aether_data::KindId,
-    kind_frame_stats: aether_data::KindId,
-    gpu: Gpu,
-    frame_vertices: Arc<Mutex<Vec<u8>>>,
-    camera_state: Arc<Mutex<[f32; 16]>>,
-    triangles_rendered: Arc<AtomicU64>,
-    capture_queue: CaptureQueue,
-    outbound: Arc<HubOutbound>,
-    events_rx: EventReceiver,
-    _scheduler: Scheduler,
-    _hub: Option<aether_substrate_core::HubClient>,
-}
-
-impl Chassis for TestBenchChassis {
-    const PROFILE: &'static str = "test-bench";
-
-    fn run(mut self) -> wasmtime::Result<()> {
-        let started = Instant::now();
-        let mut frame: u64 = 0;
-        // `recv()` returns Err only when every sender has been
-        // dropped — that's chassis shutdown, exit the loop cleanly.
-        while let Ok(event) = self.events_rx.recv() {
-            match event {
-                ChassisEvent::Advance { reply_to, ticks } => {
-                    for _ in 0..ticks {
-                        frame += 1;
-                        self.run_frame(frame, started, /* dispatch_tick */ true);
-                    }
-                    self.outbound.send_reply(
-                        reply_to,
-                        &AdvanceResult::Ok {
-                            ticks_completed: ticks,
-                        },
-                    );
-                }
-                ChassisEvent::CaptureRequested => {
-                    frame += 1;
-                    self.run_frame(frame, started, /* dispatch_tick */ false);
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl TestBenchChassis {
-    /// Run one frame: optionally dispatch `Tick` to subscribers,
-    /// drain the queue with the ADR-0063 budget, take any pending
-    /// capture and render-with-capture (otherwise plain render),
-    /// emit periodic frame_stats. Any death or wedge mid-drain
-    /// aborts the chassis cleanly via `lifecycle::fatal_abort`.
-    fn run_frame(&mut self, frame: u64, started: Instant, dispatch_tick: bool) {
-        if dispatch_tick {
-            let subs = subscribers_for(&self.input_subscribers, Tick::ID);
-            for mbox in subs {
-                self.queue
-                    .push(Mail::new(mbox, self.kind_tick, encode_empty::<Tick>(), 1));
-            }
-        }
-        frame_loop::drain_or_abort(&self.queue, &self.outbound);
-
-        // Drain accumulated vertices and the latest camera. Replace
-        // the vertex buffer with an empty same-capacity Vec so the
-        // 4 MiB allocation isn't rebuilt every frame.
-        let verts = std::mem::replace(
-            &mut *self.frame_vertices.lock().unwrap(),
-            Vec::with_capacity(VERTEX_BUFFER_BYTES),
-        );
-        let view_proj = *self.camera_state.lock().unwrap();
-
-        match self.capture_queue.take() {
-            Some(req) => {
-                let result = match self.gpu.render_and_capture(&verts, &view_proj) {
-                    Ok(png) => CaptureFrameResult::Ok { png },
-                    Err(error) => CaptureFrameResult::Err { error },
-                };
-                for mail in req.after_mails {
-                    self.queue.push(mail);
-                }
-                self.outbound.send_reply(req.reply_to, &result);
-            }
-            None => {
-                self.gpu.render(&verts, &view_proj);
-            }
-        }
-
-        if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
-            let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-            frame_loop::emit_frame_stats(
-                &self.queue,
-                self.broadcast_mbox,
-                self.broadcast_mbox,
-                self.kind_frame_stats,
-                frame,
-                triangles,
-            );
-            let elapsed = started.elapsed().as_secs_f64().max(0.001);
-            tracing::info!(
-                target: "aether_substrate::frame_loop",
-                frame = frame,
-                fps = frame as f64 / elapsed,
-                triangles,
-                "test-bench frame",
-            );
-        }
-    }
-}
+use aether_substrate_test_bench::{
+    TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
+    events::{self, ChassisEvent},
+    render::{Gpu, VERTEX_BUFFER_BYTES},
+};
 
 /// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
 /// missing/unparseable input with a warn log so scenario scripts can
 /// see what dimensions they actually got.
 fn parse_size_env() -> (u32, u32) {
+    use aether_substrate_test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH};
     let raw = match std::env::var("AETHER_TEST_BENCH_SIZE") {
         Ok(s) => s,
         Err(_) => return (DEFAULT_WIDTH, DEFAULT_HEIGHT),
     };
-    let trimmed = raw.trim();
-    if let Some((w, h)) = trimmed.split_once('x')
-        && let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>())
-        && w > 0
-        && h > 0
-    {
-        return (w, h);
+    match raw.split_once('x') {
+        Some((w, h)) => match (w.parse::<u32>(), h.parse::<u32>()) {
+            (Ok(w), Ok(h)) if w > 0 && h > 0 => (w, h),
+            _ => {
+                tracing::warn!(
+                    target: "aether_substrate::boot",
+                    value = %raw,
+                    "AETHER_TEST_BENCH_SIZE unparseable — falling back to default",
+                );
+                (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+            }
+        },
+        None => {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                "AETHER_TEST_BENCH_SIZE missing 'x' separator — falling back to default",
+            );
+            (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        }
     }
-    tracing::warn!(
-        target: "aether_substrate::boot",
-        value = %raw,
-        "AETHER_TEST_BENCH_SIZE unparseable — falling back to default 800x600",
-    );
-    (DEFAULT_WIDTH, DEFAULT_HEIGHT)
 }
 
 fn main() -> wasmtime::Result<()> {
     let capture_queue = CaptureQueue::new();
     let (events_tx, events_rx) = events::channel();
 
-    // Per issue 464, this `main()` is the env-reading edge. Read
-    // `AETHER_HUB_URL` and the namespace roots once and thread them
-    // through substrate-core's APIs explicitly.
+    // Per issue 464, this `main()` is the env-reading edge.
     let hub_url = std::env::var("AETHER_HUB_URL").ok();
     let namespace_roots = aether_substrate_core::capabilities::io::NamespaceRoots::from_env();
 
-    let mut boot = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
-        .workers(WORKERS)
-        .namespace_roots(namespace_roots)
-        .chassis_handler({
-            let cq = capture_queue.clone();
-            let tx = events_tx.clone();
-            move |ctx| {
-                Some(chassis::chassis_control_handler(
-                    cq,
-                    tx,
-                    Arc::clone(ctx.registry),
-                    Arc::clone(ctx.queue),
-                    Arc::clone(ctx.outbound),
-                ))
-            }
-        })
-        .build()?;
+    let env = TestBenchEnv {
+        name: "test-bench".to_owned(),
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        workers: WORKERS,
+        namespace_roots: Some(namespace_roots),
+        hub_url,
+        observed_kinds: None,
+        events_tx,
+        capture_queue: capture_queue.clone(),
+    };
 
-    let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
-    let kind_frame_stats = boot
-        .registry
-        .kind_id(FrameStats::NAME)
-        .expect("FrameStats registered");
+    let TestBenchBuild {
+        passive,
+        mut boot,
+        render_handles,
+        kind_tick,
+        kind_frame_stats,
+        hub,
+    } = TestBenchChassis::build_passive(env)?;
 
-    // Render + camera sinks (ADR-0071 phase 4 / Option B). One
-    // capability owns both mailboxes + the accumulator state shared
-    // with the test-bench frame loop. Pull the handles before the
-    // capability moves into boot — chassis_builder typed lookup
-    // hooks up once render migrates onto `.with()` in a later phase.
-    let render_cap = RenderCapability::new(RenderConfig {
-        vertex_buffer_bytes: VERTEX_BUFFER_BYTES,
-    });
-    let render_handles = render_cap.handles();
-    boot.add_capability(render_cap)?;
-    let frame_vertices = render_handles.frame_vertices;
-    let camera_state = render_handles.camera_state;
-    let triangles_rendered = render_handles.triangles_rendered;
-
-    // `aether.sink.io` per ADR-0041. Same capability as desktop and
-    // headless — io is purely I/O, no GPU or window surface to
-    // diverge on. ADR-0070 phase 3 wraps it as a native capability
-    // with fail-fast boot semantics (ADR-0063).
-    boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
-        boot.namespace_roots.clone(),
-    ))?;
-
-    // `aether.sink.log` per ADR-0060. Same capability as desktop and
-    // headless — guest log mail is independent of GPU / windowing.
-    boot.add_capability(aether_substrate_core::capabilities::LogCapability::new())?;
-
-    // ADR-0067 sink set is render + camera + io + log. Audio is
-    // skipped (no cpal — scenarios don't need audio output and
-    // skipping it removes a flaky-driver surface on CI runners).
-    // Net is also out for v1 — scenarios don't need network
-    // egress, and including it would add a real I/O side channel.
+    // Io capability on the legacy `boot.add_capability` path —
+    // the binary fails fast on adapter init failure (the in-process
+    // API silent-skips for systems without writable default roots).
+    boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height);
@@ -268,38 +103,165 @@ fn main() -> wasmtime::Result<()> {
         width,
         height,
         workers = WORKERS,
+        profile = TestBenchChassis::PROFILE,
         "test-bench componentless boot — drive ticks via aether.test_bench.advance",
     );
 
-    let hub = boot.connect_hub(hub_url.as_deref())?;
-
-    // The chassis owns its receiver; the chassis-control handler
-    // already holds a clone of the sender (captured into the boot
-    // closure above). Drop the local `events_tx` so the receiver
-    // hangs up cleanly when every chassis_control_handler clone is
-    // released — matches the ADR-0063 lifecycle.
-    drop(events_tx);
-
-    let chassis = TestBenchChassis {
-        queue: boot.queue,
-        input_subscribers: boot.input_subscribers,
-        broadcast_mbox: boot.broadcast_mbox,
+    drive_events_loop(
+        events_rx,
+        capture_queue,
+        boot,
+        passive,
+        render_handles,
+        gpu,
         kind_tick,
         kind_frame_stats,
-        gpu,
-        frame_vertices,
-        camera_state,
-        triangles_rendered,
-        capture_queue,
-        outbound: boot.outbound,
-        events_rx,
-        _scheduler: boot.scheduler,
-        _hub: hub,
-    };
-    tracing::info!(
-        target: "aether_substrate::boot",
-        profile = TestBenchChassis::PROFILE,
-        "chassis initialised",
+        hub,
+    )
+}
+
+/// Drive the chassis event loop on the main thread. Embedder is the
+/// driver — runs until every `EventSender` clone drops (clean
+/// shutdown via the chassis_control handler clones being released)
+/// or a fatal abort tears the process down.
+#[allow(clippy::too_many_arguments)]
+fn drive_events_loop(
+    events_rx: events::EventReceiver,
+    capture_queue: CaptureQueue,
+    boot: aether_substrate_core::SubstrateBoot,
+    passive: aether_substrate_core::PassiveChassis<TestBenchChassis>,
+    render_handles: aether_substrate_core::capabilities::RenderHandles,
+    mut gpu: Gpu,
+    kind_tick: aether_data::KindId,
+    kind_frame_stats: aether_data::KindId,
+    hub: Option<aether_substrate_core::HubClient>,
+) -> wasmtime::Result<()> {
+    let queue = Arc::clone(&boot.queue);
+    let outbound = Arc::clone(&boot.outbound);
+    let input_subscribers = Arc::clone(&boot.input_subscribers);
+    let broadcast_mbox = boot.broadcast_mbox;
+    let started = Instant::now();
+    let mut frame: u64 = 0;
+
+    while let Ok(event) = events_rx.recv() {
+        match event {
+            ChassisEvent::Advance { reply_to, ticks } => {
+                for _ in 0..ticks {
+                    frame += 1;
+                    run_frame(
+                        frame,
+                        started,
+                        true,
+                        &queue,
+                        &outbound,
+                        &input_subscribers,
+                        broadcast_mbox,
+                        kind_tick,
+                        kind_frame_stats,
+                        &capture_queue,
+                        &render_handles,
+                        &mut gpu,
+                    );
+                }
+                outbound.send_reply(
+                    reply_to,
+                    &AdvanceResult::Ok {
+                        ticks_completed: ticks,
+                    },
+                );
+            }
+            ChassisEvent::CaptureRequested => {
+                frame += 1;
+                run_frame(
+                    frame,
+                    started,
+                    false,
+                    &queue,
+                    &outbound,
+                    &input_subscribers,
+                    broadcast_mbox,
+                    kind_tick,
+                    kind_frame_stats,
+                    &capture_queue,
+                    &render_handles,
+                    &mut gpu,
+                );
+            }
+        }
+    }
+
+    // Drop ordering: passive (chassis_builder Log + Render shut
+    // down) → boot (legacy capabilities + scheduler join) → hub
+    // (reader + heartbeat threads). Listed last-first since locals
+    // drop in reverse declaration order.
+    drop(passive);
+    drop(boot);
+    drop(hub);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_frame(
+    frame: u64,
+    started: Instant,
+    dispatch_tick: bool,
+    queue: &Arc<aether_substrate_core::Mailer>,
+    outbound: &Arc<aether_substrate_core::HubOutbound>,
+    input_subscribers: &aether_substrate_core::InputSubscribers,
+    broadcast_mbox: aether_substrate_core::MailboxId,
+    kind_tick: aether_data::KindId,
+    kind_frame_stats: aether_data::KindId,
+    capture_queue: &CaptureQueue,
+    render_handles: &aether_substrate_core::capabilities::RenderHandles,
+    gpu: &mut Gpu,
+) {
+    if dispatch_tick {
+        let subs = subscribers_for(input_subscribers, Tick::ID);
+        for mbox in subs {
+            queue.push(Mail::new(mbox, kind_tick, encode_empty::<Tick>(), 1));
+        }
+    }
+    frame_loop::drain_or_abort(queue, outbound);
+
+    let verts = std::mem::replace(
+        &mut *render_handles.frame_vertices.lock().unwrap(),
+        Vec::with_capacity(VERTEX_BUFFER_BYTES),
     );
-    chassis.run()
+    let view_proj = *render_handles.camera_state.lock().unwrap();
+
+    match capture_queue.take() {
+        Some(req) => {
+            let result = match gpu.render_and_capture(&verts, &view_proj) {
+                Ok(png) => CaptureFrameResult::Ok { png },
+                Err(error) => CaptureFrameResult::Err { error },
+            };
+            for mail in req.after_mails {
+                queue.push(mail);
+            }
+            outbound.send_reply(req.reply_to, &result);
+        }
+        None => {
+            gpu.render(&verts, &view_proj);
+        }
+    }
+
+    if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
+        let triangles = render_handles.triangles_rendered.load(Ordering::Relaxed);
+        frame_loop::emit_frame_stats(
+            queue,
+            broadcast_mbox,
+            broadcast_mbox,
+            kind_frame_stats,
+            frame,
+            triangles,
+        );
+        let elapsed = started.elapsed().as_secs_f64().max(0.001);
+        tracing::info!(
+            target: "aether_substrate::frame_loop",
+            frame = frame,
+            fps = frame as f64 / elapsed,
+            triangles,
+            "test-bench frame",
+        );
+    }
 }

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -26,26 +26,21 @@ use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, encode_empty, encode_struct};
 use aether_hub_protocol::{ClaudeAddress, EngineToHub, SessionToken, Uuid};
-use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, DRAW_TRIANGLE_BYTES, FrameStats, Tick,
-};
+use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, Tick};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_substrate_core::{
-    HubOutbound, InputSubscribers, Mailer, ReplyTarget, ReplyTo, SubstrateBoot,
-    capabilities::io::NamespaceRoots,
+    HubOutbound, InputSubscribers, Mailer, PassiveChassis, ReplyTarget, ReplyTo, SubstrateBoot,
+    capabilities::{IoCapability, io::NamespaceRoots},
     capture::CaptureQueue,
     frame_loop,
     mail::{Mail, MailboxId},
     subscribers_for,
 };
 
-use crate::chassis;
+use crate::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use crate::events::{ChassisEvent, EventReceiver, channel as event_channel};
 use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
-use aether_substrate_core::render::IDENTITY_VIEW_PROJ;
-
-const WORKERS: usize = 2;
 
 /// Default offscreen target dimensions when the caller picks
 /// `start()` (no explicit size). 800x600 matches the scenario harness
@@ -149,6 +144,13 @@ pub struct TestBench {
     /// Lifetime guard. Boot owns the scheduler; dropping the
     /// TestBench drops the boot which joins the worker threads.
     _boot: SubstrateBoot,
+
+    /// `PassiveChassis<TestBenchChassis>` holding the booted Log +
+    /// Render passives via the chassis_builder typed map. Held for
+    /// the bench's lifetime so the passives' dispatcher threads
+    /// stay alive; drops in reverse declaration order before
+    /// `_boot`, so render+log shut down before the scheduler joins.
+    _passive: PassiveChassis<TestBenchChassis>,
 }
 
 /// Fixed UUID used as the `SessionToken` for in-process replies.
@@ -236,27 +238,33 @@ impl TestBench {
     ) -> Result<Self, TestBenchError> {
         let capture_queue = CaptureQueue::new();
         let (events_tx, events_rx) = event_channel();
+        let observed_kinds = Arc::new(Mutex::new(Vec::<String>::new()));
 
-        let mut builder = SubstrateBoot::builder("test-bench", env!("CARGO_PKG_VERSION"))
-            .workers(WORKERS)
-            .chassis_handler({
-                let cq = capture_queue.clone();
-                let tx = events_tx.clone();
-                move |ctx| {
-                    Some(chassis::chassis_control_handler(
-                        cq,
-                        tx,
-                        Arc::clone(ctx.registry),
-                        Arc::clone(ctx.queue),
-                        Arc::clone(ctx.outbound),
-                    ))
-                }
-            });
-        if let Some(roots) = namespace_roots {
-            builder = builder.namespace_roots(roots);
-        }
-        let mut boot = builder
-            .build()
+        // ADR-0071 phase 6: substrate boot + Log + Render passives go
+        // through `TestBenchChassis::build_passive` — the same path
+        // the binary uses. The build hands back the SubstrateBoot for
+        // io / further capability adds plus the render handles the
+        // bench's frame loop reads each tick.
+        let env = TestBenchEnv {
+            name: "test-bench".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            workers: WORKERS,
+            namespace_roots,
+            // In-process bench doesn't dial a hub; replies route to
+            // the loopback attached below.
+            hub_url: None,
+            observed_kinds: Some(Arc::clone(&observed_kinds)),
+            events_tx,
+            capture_queue: capture_queue.clone(),
+        };
+        let TestBenchBuild {
+            passive,
+            mut boot,
+            render_handles,
+            kind_tick,
+            kind_frame_stats,
+            hub: _hub,
+        } = TestBenchChassis::build_passive(env)
             .map_err(|e| TestBenchError::Boot(e.to_string()))?;
 
         // Attach a loopback to the boot's outbound. Replies the
@@ -264,46 +272,20 @@ impl TestBench {
         let (loopback_tx, loopback_rx) = mpsc::channel::<EngineToHub>();
         boot.outbound.attach(loopback_tx);
 
-        let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
-        let kind_frame_stats = boot
-            .registry
-            .kind_id(FrameStats::NAME)
-            .expect("FrameStats registered");
-
-        let observed_kinds = Arc::new(Mutex::new(Vec::<String>::new()));
-
-        let frame_vertices = Arc::new(Mutex::new(Vec::<u8>::with_capacity(VERTEX_BUFFER_BYTES)));
-        let triangles_rendered = Arc::new(AtomicU64::new(0));
-        register_render_sink(&boot, &frame_vertices, &triangles_rendered, &observed_kinds);
-
-        let camera_state = Arc::new(Mutex::new(IDENTITY_VIEW_PROJ));
-        register_camera_sink(&boot, &camera_state, &observed_kinds);
-
-        // Build the IO capability against the boot's namespace
-        // roots — either the override the caller supplied via
-        // `TestBench::builder().namespace_roots(...)` or the env-
-        // derived defaults. Per issue 464, this path no longer reads
-        // env directly. Silent-skip on adapter init failure preserves
-        // pre-Phase-3 behavior so tests on systems without writable
-        // default roots don't fail at the harness layer; tests that
-        // care about io supply tempdir roots via the builder.
-        if let Err(e) = boot.add_capability(aether_substrate_core::capabilities::IoCapability::new(
-            boot.namespace_roots.clone(),
-        )) {
+        // Io capability on the legacy `boot.add_capability` path.
+        // Silent-skip on adapter init failure preserves pre-Phase-3
+        // behavior so tests on systems without writable default roots
+        // don't fail at the harness layer; tests that care about io
+        // supply tempdir roots via the builder.
+        if let Err(e) = boot.add_capability(IoCapability::new(boot.namespace_roots.clone())) {
             tracing::warn!(
                 target: "aether_substrate::io",
                 error = %e,
                 "io capability boot failed in TestBench (expected on systems without writable default roots)",
             );
         }
-        boot.add_capability(aether_substrate_core::capabilities::LogCapability::new())
-            .expect("log capability boot");
 
         let gpu = Gpu::new(width, height);
-
-        // Drop the local events_tx so events_rx hangs up cleanly
-        // once every chassis_control_handler clone is released.
-        drop(events_tx);
 
         let queue = Arc::clone(&boot.queue);
         let outbound = Arc::clone(&boot.outbound);
@@ -319,9 +301,9 @@ impl TestBench {
             capture_queue,
             events_rx,
             gpu,
-            frame_vertices,
-            camera_state,
-            triangles_rendered,
+            frame_vertices: render_handles.frame_vertices,
+            camera_state: render_handles.camera_state,
+            triangles_rendered: render_handles.triangles_rendered,
             input_subscribers,
             broadcast_mbox,
             kind_tick,
@@ -333,6 +315,7 @@ impl TestBench {
             stashed_replies: HashMap::new(),
             observed_kinds,
             _boot: boot,
+            _passive: passive,
         })
     }
 
@@ -684,87 +667,6 @@ fn correlation_of(frame: &EngineToHub) -> Option<u64> {
         }
         _ => None,
     }
-}
-
-fn register_render_sink(
-    boot: &SubstrateBoot,
-    frame_vertices: &Arc<Mutex<Vec<u8>>>,
-    triangles_rendered: &Arc<AtomicU64>,
-    observed_kinds: &Arc<Mutex<Vec<String>>>,
-) {
-    let verts_for_sink = Arc::clone(frame_vertices);
-    let tris_for_sink = Arc::clone(triangles_rendered);
-    let observed_for_sink = Arc::clone(observed_kinds);
-    boot.registry.register_sink(
-        "aether.sink.render",
-        Arc::new(
-            move |_kind: KindId,
-                  kind_name: &str,
-                  _origin: Option<&str>,
-                  _sender: ReplyTo,
-                  bytes: &[u8],
-                  _count: u32| {
-                observed_for_sink.lock().unwrap().push(kind_name.to_owned());
-                let mut verts = verts_for_sink.lock().unwrap();
-                let available = VERTEX_BUFFER_BYTES.saturating_sub(verts.len());
-                let write_len = bytes.len().min(available);
-                let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-                if write_len > 0 {
-                    verts.extend_from_slice(&bytes[..write_len]);
-                    tris_for_sink
-                        .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-                }
-                if write_len < bytes.len() {
-                    tracing::warn!(
-                        target: "aether_substrate::render",
-                        accepted_bytes = write_len,
-                        dropped_bytes = bytes.len() - write_len,
-                        cap = VERTEX_BUFFER_BYTES,
-                        "render sink dropped triangles beyond fixed vertex buffer",
-                    );
-                }
-            },
-        ),
-    );
-}
-
-fn register_camera_sink(
-    boot: &SubstrateBoot,
-    camera_state: &Arc<Mutex<[f32; 16]>>,
-    observed_kinds: &Arc<Mutex<Vec<String>>>,
-) {
-    let cam_for_sink = Arc::clone(camera_state);
-    let observed_for_sink = Arc::clone(observed_kinds);
-    boot.registry.register_sink(
-        "aether.sink.camera",
-        Arc::new(
-            move |_kind: KindId,
-                  kind_name: &str,
-                  _origin: Option<&str>,
-                  _sender: ReplyTo,
-                  bytes: &[u8],
-                  _count: u32| {
-                observed_for_sink.lock().unwrap().push(kind_name.to_owned());
-                if bytes.len() != 64 {
-                    tracing::warn!(
-                        target: "aether_substrate::camera",
-                        got = bytes.len(),
-                        expected = 64,
-                        "camera sink: payload length mismatch, dropping",
-                    );
-                    return;
-                }
-                match bytemuck::try_pod_read_unaligned::<[f32; 16]>(bytes) {
-                    Ok(mat) => *cam_for_sink.lock().unwrap() = mat,
-                    Err(e) => tracing::warn!(
-                        target: "aether_substrate::camera",
-                        error = %e,
-                        "camera sink: cast failed, dropping",
-                    ),
-                }
-            },
-        ),
-    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

ADR-0071 phase 6 — both the test-bench binary and the in-process
TestBench API (ADR-0067) build through TestBenchChassis::build_passive,
returning a PassiveChassis&lt;TestBenchChassis&gt; that holds Log + Render
as passives. Each embedder drives its own event loop on top — the
binary's main() loops on events_rx.recv(), the in-process TestBench
dispatches per-call. Test-bench is the canonical embedder-driven (no-
driver) chassis the chassis_builder PassiveChassis path was designed
for.

## What's in

- aether-substrate-core/src/capabilities/render.rs:
  - RenderConfig gains an optional `observed_kinds: Option<Arc<Mutex<Vec<String>>>>`
    field. Both render and camera dispatchers push every inbound
    mail's kind name into it when set; `None` is zero overhead.
    Lets RenderCapability cover both desktop / binary (no
    observation) and the in-process TestBench (which uses
    observation to satisfy `count_observed` / `observed_kinds()`)
    without bespoke sink handlers.
- aether-substrate-test-bench/src/chassis.rs:
  - TestBenchChassis is now a unit marker struct with const
    PROFILE = "test-bench". Chassis::run on the marker returns an
    error directing callers to use build_passive.
  - TestBenchEnv config struct (name, version, workers,
    namespace_roots, hub_url, observed_kinds, events_tx,
    capture_queue).
  - TestBenchChassis::build_passive(env) -> wasmtime::Result<TestBenchBuild>
    runs SubstrateBoot::builder, attaches the chassis-control
    handler, builds chassis_builder Builder<TestBenchChassis,
    NoDriver>::with(LogCapability)::with(RenderCapability)::build_passive,
    connects the hub if requested, returns the PassiveChassis +
    boot + render handles + kind ids + hub.
  - TestBenchBuild: bundles passive, boot, render_handles,
    kind_tick, kind_frame_stats, hub. The embedder owns the
    matching events_rx for whichever events_tx it passed in.
- aether-substrate-test-bench/src/main.rs:
  - Drops the TestBenchChassis struct + Chassis::run body. main()
    constructs TestBenchEnv from env vars, calls
    TestBenchChassis::build_passive, adds io via
    boot.add_capability with `?` (binary fails fast), creates Gpu,
    drives events_rx loop on the main thread.
- aether-substrate-test-bench/src/test_bench.rs:
  - start_inner migrated to TestBenchChassis::build_passive.
    Drops the bespoke register_render_sink + register_camera_sink
    helpers — RenderCapability with the observed_kinds hook covers
    them. Io still added via boot.add_capability with silent-skip
    (preserves pre-Phase-3 behavior on systems without writable
    default roots).
  - TestBench struct gains a `_passive: PassiveChassis<TestBenchChassis>`
    lifetime guard so the booted passives' dispatcher threads stay
    alive; drops in reverse declaration order before `_boot` so
    render+log shut down before the scheduler joins.

## What's deferred

- Chassis trait redefinition (Driver / Env / build associated
  items) — still parked. Phase 7 (or later) folds it once the hub
  also migrates.
- Capability migration to chassis_builder Builder.with() for io
  — per-embedder. Binary uses `?`, in-process silent-skips. Both
  stay on boot.add_capability for io's failure semantics.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (all suites pass; in-process
      TestBench's boot_advance_capture_round_trip + scenario
      harness exercise the new path end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)