### PR TITLE
refactor(data): hoist identity types to aether-data (ADR-0071 phase 7c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "inventory",
  "postcard",
  "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -273,7 +274,6 @@ name = "aether-substrate-core"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-data",
- "aether-hub-protocol",
  "aether-kinds",
  "bytemuck",
  "cpal",

--- a/crates/aether-data/Cargo.toml
+++ b/crates/aether-data/Cargo.toml
@@ -14,6 +14,13 @@ aether-data-derive = { path = "../aether-data-derive", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+# ADR-0070 phase 4 follow-up (ADR-0071 phase 7c): identity types
+# `EngineId` / `SessionToken` are UUIDs at the wire boundary. Default
+# features off keeps `aether-data` no_std + alloc; the `serde` feature
+# wires uuid's serde impls (string for human-readable, bytes for
+# binary) so the wrapper newtypes derive Serialize/Deserialize without
+# extra plumbing.
+uuid = { version = "1", default-features = false, features = ["serde"] }
 
 # Native-side auto-collection of `#[derive(Kind)]` types into the
 # substrate's descriptor list (issue #243). `inventory` requires std

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ids;
 pub mod schema;
 pub mod tag_bits;
 pub mod tagged_id;
+pub mod wire_id;
 
 pub use hash::{
     KIND_DOMAIN, MAILBOX_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
@@ -55,6 +56,7 @@ pub use hash::{
 pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};
+pub use wire_id::{EngineId, SessionToken, Uuid};
 
 /// Re-exported derive macros from `aether-data-derive`. Behind the
 /// `derive` feature so `cargo build` on a guest that hand-writes

--- a/crates/aether-data/src/wire_id.rs
+++ b/crates/aether-data/src/wire_id.rs
@@ -1,0 +1,37 @@
+//! Wire-side identity types: `EngineId`, `SessionToken`, plus a
+//! re-export of `uuid::Uuid` so consumers don't have to add their own
+//! `uuid` dep.
+//!
+//! These were defined in `aether-hub-protocol` until ADR-0071 phase 7c
+//! moved them here. The hub channel still ships them on the wire, so
+//! `aether-hub-protocol` re-exports — anything that only needs the
+//! newtypes (substrate-core's `ReplyTarget`, the reply-table, the
+//! egress backend trait) reaches for `aether_data::EngineId` etc.
+//! without pulling in the framing crate.
+//!
+//! Both newtypes are `pub` tuple structs over `Uuid` so existing call
+//! sites that match `EngineId(uuid)` keep working unchanged.
+
+use serde::{Deserialize, Serialize};
+
+pub use uuid::Uuid;
+
+/// Hub-assigned stable identity for an engine connection. Fresh per
+/// connect; not preserved across reconnects (resume-with-id is a V1
+/// concern per ADR-0006).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EngineId(pub Uuid);
+
+/// Hub-minted routing handle for a Claude MCP session. The engine
+/// treats it as opaque bytes: it only echoes tokens the hub handed it
+/// on inbound mail back as the address on a reply. The hub validates
+/// on receipt; unknown/expired tokens produce an undeliverable status
+/// (per ADR-0008).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionToken(pub Uuid);
+
+impl SessionToken {
+    /// Placeholder used before session tracking lands at the hub.
+    /// Always treated as expired by the hub's validator.
+    pub const NIL: SessionToken = SessionToken(Uuid::nil());
+}

--- a/crates/aether-hub-protocol/src/lib.rs
+++ b/crates/aether-hub-protocol/src/lib.rs
@@ -17,8 +17,6 @@
 //! itself — frames + framing helpers — and is unambiguously host-side
 //! std code.
 
-pub use uuid::Uuid;
-
 mod types;
 pub use types::*;
 

--- a/crates/aether-hub-protocol/src/types.rs
+++ b/crates/aether-hub-protocol/src/types.rs
@@ -8,27 +8,13 @@
 
 use aether_data::{KindDescriptor, KindId, MailboxId};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
-/// Hub-assigned stable identity for an engine connection. Fresh per
-/// connect; not preserved across reconnects (resume-with-id is a V1
-/// concern per ADR-0006).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct EngineId(pub Uuid);
-
-/// Hub-minted routing handle for a Claude MCP session. The engine
-/// treats it as opaque bytes: it only echoes tokens the hub handed it
-/// on inbound mail back as the address on a reply. The hub validates
-/// on receipt; unknown/expired tokens produce an undeliverable status
-/// (per ADR-0008).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SessionToken(pub Uuid);
-
-impl SessionToken {
-    /// Placeholder used before session tracking lands at the hub.
-    /// Always treated as expired by the hub's validator.
-    pub const NIL: SessionToken = SessionToken(Uuid::nil());
-}
+// ADR-0071 phase 7c: identity types moved into `aether-data` so
+// substrate-core can drop its dep on this crate. Re-exported here so
+// the wire format and existing callers (the hub binary, MCP tooling,
+// integration tests) keep their `aether_hub_protocol::EngineId`
+// import paths working unchanged.
+pub use aether_data::{EngineId, SessionToken, Uuid};
 
 /// First frame the engine sends after the TCP connection is open.
 /// The hub replies with a `Welcome` carrying the assigned `EngineId`.

--- a/crates/aether-substrate-core/Cargo.toml
+++ b/crates/aether-substrate-core/Cargo.toml
@@ -23,7 +23,6 @@ audio = ["dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
 aether-data = { path = "../aether-data" }
-aether-hub-protocol = { path = "../aether-hub-protocol" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"
 postcard = { version = "1.1", features = ["alloc"] }

--- a/crates/aether-substrate-core/src/capabilities/handle.rs
+++ b/crates/aether-substrate-core/src/capabilities/handle.rs
@@ -133,7 +133,7 @@ mod tests {
     use std::time::Instant;
 
     use aether_data::{HandleId, Kind, KindId};
-    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_data::{SessionToken, Uuid};
     use aether_kinds::{HandlePublish, HandlePublishResult};
 
     use super::*;

--- a/crates/aether-substrate-core/src/capabilities/io.rs
+++ b/crates/aether-substrate-core/src/capabilities/io.rs
@@ -885,7 +885,7 @@ mod tests {
     // live.
 
     use crate::outbound::EgressEvent;
-    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_data::{SessionToken, Uuid};
     fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
         let adapter: Arc<dyn FileAdapter> =
             Arc::new(LocalFileAdapter::new(root.to_path_buf(), writable).unwrap());

--- a/crates/aether-substrate-core/src/capabilities/net.rs
+++ b/crates/aether-substrate-core/src/capabilities/net.rs
@@ -571,7 +571,7 @@ mod tests {
         }
     }
 
-    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_data::{SessionToken, Uuid};
 
     use crate::outbound::EgressEvent;
 

--- a/crates/aether-substrate-core/src/capture.rs
+++ b/crates/aether-substrate-core/src/capture.rs
@@ -230,7 +230,7 @@ pub fn reply_unsupported_capture_frame(outbound: &HubOutbound, sender: ReplyTo, 
 mod tests {
     use super::*;
     use crate::ReplyTarget;
-    use aether_hub_protocol::{SessionToken, Uuid};
+    use aether_data::{SessionToken, Uuid};
 
     fn reply_to(u: u128) -> ReplyTo {
         ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))

--- a/crates/aether-substrate-core/src/component.rs
+++ b/crates/aether-substrate-core/src/component.rs
@@ -559,7 +559,7 @@ mod tests {
     fn deliver_with_real_token_allocates_session_handle() {
         use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
-        use aether_hub_protocol::{SessionToken, Uuid};
+        use aether_data::{SessionToken, Uuid};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xaaaa));
@@ -600,7 +600,7 @@ mod tests {
         // session is the more specific reply target.
         use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::reply_table::ReplyEntry;
-        use aether_hub_protocol::{SessionToken, Uuid};
+        use aether_data::{SessionToken, Uuid};
 
         let mut component = instantiate(WAT_STORES_SENDER);
         let token = SessionToken(Uuid::from_u128(0xbbbb));
@@ -658,7 +658,7 @@ mod tests {
     fn reply_mail_emits_session_addressed_frame() {
         use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::outbound::EgressEvent;
-        use aether_hub_protocol::{SessionToken, Uuid};
+        use aether_data::{SessionToken, Uuid};
 
         let (ctx, rx, pong_id) = plane_ctx_for_reply();
         let mut component = instantiate_with_ctx(&wat_replies(pong_id.0), ctx);

--- a/crates/aether-substrate-core/src/handle_sink.rs
+++ b/crates/aether-substrate-core/src/handle_sink.rs
@@ -262,7 +262,7 @@ mod tests {
     /// hub-outbound path, which lands a typed `EngineMailFrame` we
     /// can decode in the test.
     fn session_reply_to() -> ReplyTo {
-        use aether_hub_protocol::{SessionToken, Uuid};
+        use aether_data::{SessionToken, Uuid};
         ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
     }
 

--- a/crates/aether-substrate-core/src/mail.rs
+++ b/crates/aether-substrate-core/src/mail.rs
@@ -1,12 +1,12 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
+use aether_data::{EngineId, SessionToken};
 /// Addressing token for any mailbox — component or substrate-owned sink.
 /// ADR-0065 hoisted the canonical home into `aether_mail`; this remains
 /// re-exported under the `aether_substrate_core::mail::MailboxId` path
 /// so existing call sites compile unchanged.
 pub use aether_data::{KindId, MailboxId};
-use aether_hub_protocol::{EngineId, SessionToken};
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The
 /// typed facade over this is ADR-0005 (mail typing system) and ADR-0019

--- a/crates/aether-substrate-core/src/outbound.rs
+++ b/crates/aether-substrate-core/src/outbound.rs
@@ -10,21 +10,22 @@
 // no longer constructs hub frames; the translation lives in the
 // `aether-hub` crate's `HubProtocolBackend`.
 //
-// Identity types (`SessionToken`, `EngineId`) are still imported from
-// `aether-hub-protocol` for now — moving those out of the substrate's
-// public API is its own subsequent refactor (ADR-0070 phase 4 follow-up).
+// Identity types (`SessionToken`, `EngineId`) live in `aether-data`
+// (ADR-0071 phase 7c) so substrate-core describes egress targets
+// without depending on the hub-protocol framing crate. ADR-0070's
+// "substrate-core has no hub knowledge" invariant is now satisfied:
+// no `aether-hub-protocol` dep remains in `Cargo.toml`.
 
 use std::sync::mpsc;
 use std::sync::{Arc, OnceLock};
 
-use aether_data::{KindDescriptor, KindId, MailboxId};
-use aether_hub_protocol::{EngineId, SessionToken};
+use aether_data::{EngineId, KindDescriptor, KindId, MailboxId, SessionToken};
 
 use crate::mail::{ReplyTarget, ReplyTo};
 
 /// Substrate-side mirror of the hub-protocol log entry shape (ADR-0023).
 /// Held by the log-capture ring and handed to the egress backend
-/// in batches; the hub backend converts to `aether_hub_protocol::LogEntry`
+/// in batches; the hub backend converts to `aether_data::LogEntry`
 /// at the wire boundary. Field shape matches the wire type so the
 /// conversion is a struct copy.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/aether-substrate-core/src/reply_table.rs
+++ b/crates/aether-substrate-core/src/reply_table.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 
-use aether_hub_protocol::SessionToken;
+use aether_data::SessionToken;
 
 use crate::mail::{MailboxId, ReplyTarget};
 
@@ -108,7 +108,7 @@ impl ReplyTable {
 
 #[cfg(test)]
 mod tests {
-    use aether_hub_protocol::Uuid;
+    use aether_data::Uuid;
 
     use super::*;
 


### PR DESCRIPTION
## Summary

Closes the ADR-0070 invariant for `aether-substrate-core`: it no longer depends on `aether-hub-protocol`.

The two identity newtypes (`EngineId`, `SessionToken`) and `Uuid` were defined in the framing crate but used pervasively by substrate-core's `ReplyTarget`, `ReplyTable`, egress backend trait, and tests. They're identity vocabulary, not framing — `aether-data` is their natural home alongside `MailboxId`, `KindId`, `HandleId`.

- `aether-data` gains a `wire_id` module with `EngineId` / `SessionToken` / `SessionToken::NIL` + a `pub use uuid::Uuid`. Adds `uuid = { default-features = false, features = ["serde"] }` — stays no_std + alloc.
- `aether-hub-protocol::types` re-exports the three names so existing callers (hub binary, MCP tooling, integration tests) keep working unchanged. The redundant `pub use uuid::Uuid` in lib.rs is dropped.
- Every `aether_hub_protocol::{...}` import in substrate-core is now `aether_data::{...}`. The dep is removed from `crates/aether-substrate-core/Cargo.toml` entirely.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo check --target wasm32-unknown-unknown -p aether-camera-component -p aether-mesh-viewer-component`

## Follow-on

- **Phase 7d:** `HubServerCapability` + hub binary refactor to the `Builder` shape (ADR-0070 phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)