### PR TITLE
refactor(core): redefine Chassis trait per ADR-0071 spec (phase 2 close)

### DIFF
--- a/crates/aether-hub/Cargo.toml
+++ b/crates/aether-hub/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 # - the engine-facing TCP listener and per-connection read-loop,
 # - the rmcp-driven MCP transport + tool surface,
 # - the engine / session / spawn / log registries the hub coordinates,
-# - the `HubServerCapability` driver and `HubChassis` builder shape.
+# - the `HubServerDriverCapability` driver and `HubChassis` builder shape.
 #
 # Generic length-prefixed framing helpers live in `aether-codec::frame`
 # — they're codec-shaped machinery, not hub-specific. The

--- a/crates/aether-hub/src/chassis.rs
+++ b/crates/aether-hub/src/chassis.rs
@@ -112,7 +112,7 @@ impl HubChassis {
         let sessions = SessionRegistry::new();
         let pending = PendingSpawns::new();
         let logs = LogStore::new();
-        let loopback = LoopbackEngine::boot(&registry).map_err(wasmtime_to_boot_error)?;
+        let loopback = LoopbackEngine::boot(&registry)?;
         let state = HubState::new(
             registry.clone(),
             sessions.clone(),
@@ -144,13 +144,6 @@ impl HubChassis {
             .driver(driver)
             .build()
     }
-}
-
-/// Wrap a `wasmtime::Error` (from `LoopbackEngine::boot`) into a
-/// [`BootError`] so the chassis trait method can return a uniform
-/// error type per ADR-0071.
-fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
-    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }
 
 /// ADR-0071 driver capability for the hub chassis. Owns the tokio

--- a/crates/aether-hub/src/chassis.rs
+++ b/crates/aether-hub/src/chassis.rs
@@ -57,15 +57,11 @@ pub struct HubChassis;
 
 impl Chassis for HubChassis {
     const PROFILE: &'static str = "hub";
+    type Driver = HubServerCapability;
+    type Env = HubEnv;
 
-    /// Inert by design: callers must build via [`HubChassis::build`]
-    /// to construct a [`BuiltChassis<HubChassis>`] and call
-    /// [`BuiltChassis::run`] on it. Keeps the trait satisfied without
-    /// re-introducing the pre-Builder direct-`run` shape.
-    fn run(self) -> wasmtime::Result<()> {
-        Err(wasmtime::Error::msg(
-            "HubChassis is built via HubChassis::build(env); use the returned BuiltChassis::run()",
-        ))
+    fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        Self::build_inner(env)
     }
 }
 
@@ -105,8 +101,9 @@ impl HubChassis {
     /// chassis_builder [`Builder`]. The hub chassis has no passive
     /// capabilities of its own today; future passives (an in-process
     /// log capability, etc.) compose via `Builder::with` between
-    /// `new()` and `driver()`.
-    pub fn build(env: HubEnv) -> wasmtime::Result<BuiltChassis<HubChassis>> {
+    /// `new()` and `driver()`. The trait method [`Chassis::build`]
+    /// forwards here.
+    fn build_inner(env: HubEnv) -> Result<BuiltChassis<HubChassis>, BootError> {
         let HubEnv {
             engine_addr,
             mcp_addr,
@@ -115,7 +112,7 @@ impl HubChassis {
         let sessions = SessionRegistry::new();
         let pending = PendingSpawns::new();
         let logs = LogStore::new();
-        let loopback = LoopbackEngine::boot(&registry)?;
+        let loopback = LoopbackEngine::boot(&registry).map_err(wasmtime_to_boot_error)?;
         let state = HubState::new(
             registry.clone(),
             sessions.clone(),
@@ -146,8 +143,14 @@ impl HubChassis {
         Builder::<HubChassis, NoDriver>::new(registry_arc, mailer_arc)
             .driver(driver)
             .build()
-            .map_err(|e: BootError| wasmtime::Error::msg(format!("hub chassis build: {e}")))
     }
+}
+
+/// Wrap a `wasmtime::Error` (from `LoopbackEngine::boot`) into a
+/// [`BootError`] so the chassis trait method can return a uniform
+/// error type per ADR-0071.
+fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
+    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }
 
 /// ADR-0071 driver capability for the hub chassis. Owns the tokio

--- a/crates/aether-hub/src/chassis.rs
+++ b/crates/aether-hub/src/chassis.rs
@@ -2,7 +2,7 @@
 //!
 //! Builder-shape adoption: [`HubChassis`] is a `Chassis` marker,
 //! [`HubEnv`] carries resolved listener addresses, and
-//! [`HubServerCapability`] is the driver. [`HubChassis::build`]
+//! [`HubServerDriverCapability`] is the driver. [`HubChassis::build`]
 //! returns a `BuiltChassis<HubChassis>` whose `run()` blocks the
 //! calling thread on the tokio coordinator.
 //!
@@ -16,7 +16,7 @@
 //! and test-bench.
 //!
 //! ADR-0070 phase 5 / ADR-0071 phase 7d-2 will move
-//! [`HubServerCapability`] (and the underlying engine / mcp /
+//! [`HubServerDriverCapability`] (and the underlying engine / mcp /
 //! session / registry / log_store / loopback / spawn modules) out of
 //! this binary crate into a new `aether-hub` library crate. This PR
 //! lands the Capability shape in place; the relocation is mechanical
@@ -57,7 +57,7 @@ pub struct HubChassis;
 
 impl Chassis for HubChassis {
     const PROFILE: &'static str = "hub";
-    type Driver = HubServerCapability;
+    type Driver = HubServerDriverCapability;
     type Env = HubEnv;
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
@@ -96,7 +96,7 @@ impl HubChassis {
     /// Build a hub chassis: stand up the engine / session / spawn /
     /// log stores, boot the in-process [`LoopbackEngine`] (which
     /// constructs its own `SubstrateBoot` and registers it under
-    /// `HUB_SELF_ENGINE_ID`), build the [`HubServerCapability`]
+    /// `HUB_SELF_ENGINE_ID`), build the [`HubServerDriverCapability`]
     /// driver, and assemble a [`BuiltChassis<HubChassis>`] via the
     /// chassis_builder [`Builder`]. The hub chassis has no passive
     /// capabilities of its own today; future passives (an in-process
@@ -129,7 +129,7 @@ impl HubChassis {
         let registry_arc = Arc::clone(&loopback.boot.registry);
         let mailer_arc = Arc::clone(&loopback.boot.queue);
 
-        let driver = HubServerCapability {
+        let driver = HubServerDriverCapability {
             engine_addr,
             mcp_addr,
             registry,
@@ -153,7 +153,7 @@ impl HubChassis {
 /// `rt.block_on(coordinator)` and returns when either listener exits
 /// or a shutdown signal arrives, after running the children-cleanup
 /// + boot-drop sequence.
-pub struct HubServerCapability {
+pub struct HubServerDriverCapability {
     engine_addr: SocketAddr,
     mcp_addr: SocketAddr,
     registry: EngineRegistry,
@@ -164,10 +164,10 @@ pub struct HubServerCapability {
     loopback: LoopbackEngine,
 }
 
-/// Post-boot handle for [`HubServerCapability`]. Holds the constructed
+/// Post-boot handle for [`HubServerDriverCapability`]. Holds the constructed
 /// tokio runtime + every state handle the coordinator needs. `run`
 /// drains the runtime and returns once shutdown completes.
-pub struct HubServerRunning {
+pub struct HubServerDriverRunning {
     rt: Runtime,
     engine_addr: SocketAddr,
     mcp_addr: SocketAddr,
@@ -179,15 +179,15 @@ pub struct HubServerRunning {
     loopback: LoopbackEngine,
 }
 
-impl DriverCapability for HubServerCapability {
-    type Running = HubServerRunning;
+impl DriverCapability for HubServerDriverCapability {
+    type Running = HubServerDriverRunning;
 
     fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(|e| BootError::Other(Box::new(e)))?;
-        let HubServerCapability {
+        let HubServerDriverCapability {
             engine_addr,
             mcp_addr,
             registry,
@@ -197,7 +197,7 @@ impl DriverCapability for HubServerCapability {
             state,
             loopback,
         } = self;
-        Ok(HubServerRunning {
+        Ok(HubServerDriverRunning {
             rt,
             engine_addr,
             mcp_addr,
@@ -211,9 +211,9 @@ impl DriverCapability for HubServerCapability {
     }
 }
 
-impl DriverRunning for HubServerRunning {
+impl DriverRunning for HubServerDriverRunning {
     fn run(self: Box<Self>) -> Result<(), RunError> {
-        let HubServerRunning {
+        let HubServerDriverRunning {
             rt,
             engine_addr,
             mcp_addr,

--- a/crates/aether-hub/src/lib.rs
+++ b/crates/aether-hub/src/lib.rs
@@ -24,7 +24,7 @@
 //! Plus the hub coordinator itself (ADR-0071 phase 7d-2 relocated
 //! these from the `aether-substrate-hub` binary crate):
 //!
-//! - [`HubChassis`] / [`HubServerCapability`] — Chassis marker +
+//! - [`HubChassis`] / [`HubServerDriverCapability`] — Chassis marker +
 //!   driver capability that owns the tokio runtime + listeners.
 //! - [`run_engine_listener`] — the engine-facing TCP listener loop.
 //! - [`run_mcp_server`] — the rmcp-driven MCP transport on
@@ -74,7 +74,7 @@ pub mod wire;
 
 pub use aether_codec::{DecodeError, EncodeError, decode_schema, encode_schema};
 pub use aether_substrate_core::Chassis;
-pub use chassis::{HubChassis, HubEnv, HubServerCapability, HubServerRunning};
+pub use chassis::{HubChassis, HubEnv, HubServerDriverCapability, HubServerDriverRunning};
 pub use engine::READ_TIMEOUT;
 pub use log_store::{LogStore, ReadResult as LogReadResult};
 pub use loopback::{HUB_SELF_ENGINE_ID, LoopbackEngine, LoopbackHandle};

--- a/crates/aether-substrate-core/src/capabilities/mod.rs
+++ b/crates/aether-substrate-core/src/capabilities/mod.rs
@@ -11,7 +11,7 @@
 //!   feature), `render` + `camera` (gated by `render` feature). All
 //!   chassis-conditional; chassis mains call
 //!   [`crate::SubstrateBoot::add_capability`] after boot.
-//! - Phase 4–5: `HubClientCapability` and `HubServerCapability` land
+//! - Phase 4–5: `HubClientCapability` and `HubServerDriverCapability` land
 //!   in the new `aether-hub` crate, not here, so the substrate ends
 //!   with zero hub knowledge.
 //!

--- a/crates/aether-substrate-core/src/capability.rs
+++ b/crates/aether-substrate-core/src/capability.rs
@@ -119,6 +119,17 @@ impl From<NameConflict> for BootError {
     }
 }
 
+/// Forward wasmtime errors raised during chassis boot
+/// (`SubstrateBoot::build`, `add_capability`, hub-client connect, etc.)
+/// into [`BootError::Other`]. Any wasmtime error during boot is
+/// definitionally a boot error — chassis trait impls can `?` the
+/// wasmtime call directly without per-call `.map_err` glue.
+impl From<wasmtime::Error> for BootError {
+    fn from(e: wasmtime::Error) -> Self {
+        BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
+    }
+}
+
 /// A native capability: chassis-policy code that owns one or more
 /// mailboxes plus the state behind them. Each capability is
 /// `boot()`-ed once during chassis startup and `shutdown()`-ed once

--- a/crates/aether-substrate-core/src/chassis.rs
+++ b/crates/aether-substrate-core/src/chassis.rs
@@ -1,53 +1,78 @@
-//! The ADR-0035 universal `Chassis` trait, refined by ADR-0071.
+//! The ADR-0035 universal `Chassis` trait, redefined by ADR-0071.
 //!
-//! Each chassis binary implements it over whatever peripheral layer
-//! it has — winit + wgpu for desktop, a std timer + stdio for
-//! headless, a TCP listener + MCP surface for hub, etc. The trait
-//! stays deliberately narrow: identity (`PROFILE`) plus lifecycle
-//! (`run`). Chassis-specific control-plane kinds (e.g. desktop's
-//! `capture_frame` / `set_window_mode` / `platform_info`) ride
-//! through `ControlPlane::chassis_handler`, not through trait
-//! methods — that keeps any single chassis from having to implement
-//! `Unsupported` stubs for operations it doesn't support.
+//! Each chassis binary impls it over whatever peripheral layer it has
+//! — winit + wgpu for desktop, a std timer + stdio for headless, a
+//! TCP listener + MCP surface for hub, an embedder-driven manual
+//! loop for test-bench. The trait carries identity (`PROFILE`) and
+//! the build entry point (`type Driver`, `type Env`, `fn build`)
+//! that produces a [`BuiltChassis`]; the chassis instance you `run()`
+//! is the [`BuiltChassis<Self>`], not a value of `Self` itself.
 //!
-//! Consumed at boot: `main()` constructs a concrete chassis + hands
-//! it the core state it needs, then calls `chassis.run()` which
-//! takes ownership and drives the event loop to termination.
-//!
-//! ADR-0071 phase 2A renames the previous `KIND` const to `PROFILE`
+//! ADR-0071 phase 2 renamed the previous `KIND` const to `PROFILE`
 //! (avoiding the data-layer `Kind` / `KindId` / `KindShape` /
-//! `KindLabels` clobber) and removes the `CAPABILITIES` const + the
-//! associated `ChassisCapabilities` struct. The flag-shaped const
-//! was right for ADR-0035's hardcoded chassis but gets wrong post-
-//! ADR-0071 since a chassis can in principle compose any combination
-//! of capabilities, not just the original `(gpu, window,
-//! tcp_listener)` set. Self-describing introspection — a runtime
-//! method on the chassis returning the actual booted capability
-//! list — is the planned replacement; tracked as follow-on work.
-//!
-//! Phases 3-7 of ADR-0071 replace each chassis's `run()` body with a
-//! `DriverCapability`-driven path; once that lands the trait
-//! collapses further to identity-only.
+//! `KindLabels` clobber), removed the `CAPABILITIES` const + the
+//! associated `ChassisCapabilities` struct, and lifted the per-
+//! chassis inherent `build(env)` into a trait method backed by
+//! `type Driver` + `type Env` associated types. The pre-ADR-0071
+//! `fn run(self)` slot is gone — the chassis you ran was always
+//! the [`BuiltChassis<C>`] anyway, and the indirection through a
+//! trait method that immediately delegated added no value.
 
-/// The lifecycle contract a chassis implements. Every concrete
-/// chassis is `Sized` (binary crates pick exactly one at compile
-/// time), so `PROFILE` is a compile-time const and `run(self)` takes
-/// ownership.
-pub trait Chassis: Sized {
+use crate::capability::BootError;
+use crate::chassis_builder::{BuiltChassis, DriverCapability};
+
+/// The composition contract a concrete chassis implements. Each
+/// chassis declares its driver and the env-shaped config it takes
+/// at build time; the trait method [`Self::build`] consumes the env
+/// and returns a [`BuiltChassis<Self>`] whose [`BuiltChassis::run`]
+/// blocks the calling thread on the driver loop.
+///
+/// `Sized + 'static` matches ADR-0071: every chassis binary picks
+/// exactly one chassis at compile time (it's a unit struct), and
+/// `'static` lets `BuiltChassis<Self>` / `PassiveChassis<Self>` be
+/// stored in long-lived owners without lifetime gymnastics.
+///
+/// **Passive chassis** (test-bench: no driver, embedder drives the
+/// loop) still impl this trait so [`BuiltChassis<Self>`] /
+/// `PassiveChassis<Self>` can be parameterised by the chassis kind;
+/// they declare a phantom [`DriverCapability`] for `type Driver`
+/// (`crate::capability::NeverDriver`) and have `fn build` error
+/// pointing callers at the chassis's inherent `build_passive` —
+/// the trait method is never reached on passive chassis but its
+/// presence keeps the trait shape uniform across the workspace.
+pub trait Chassis: Sized + 'static {
     /// Stable identifier for this chassis. Used in boot logs and
     /// wherever the chassis needs to identify itself to an observer.
-    /// `"desktop"`, `"headless"`, `"hub"`, etc.
+    /// `"desktop"`, `"headless"`, `"hub"`, `"test-bench"`.
     ///
     /// Renamed from the ADR-0035 `KIND` const by ADR-0071 to avoid
     /// clobbering the data layer's `Kind` vocabulary.
     const PROFILE: &'static str;
 
-    /// Take ownership of the chassis and drive its event loop to
-    /// termination. Returns when the event source exits cleanly
-    /// (desktop: winit close; headless: SIGTERM or shutdown mail;
-    /// hub: all connections drained). Propagates any unrecoverable
-    /// startup or runtime error as `wasmtime::Result<()>` — matches
-    /// `main()`'s current return shape so binaries can `chassis.run()?`
-    /// without glue.
-    fn run(self) -> wasmtime::Result<()>;
+    /// The driver capability that owns this chassis's main thread.
+    /// Desktop's winit driver, headless's std-timer driver, hub's
+    /// listener-and-MCP driver. Passive chassis (test-bench)
+    /// declare [`crate::capability::NeverDriver`] here.
+    type Driver: DriverCapability;
+
+    /// Resolved-config bag the chassis takes at build time. Each
+    /// chassis defines its own concrete shape because chassis
+    /// genuinely take different inputs (desktop needs a winit
+    /// `EventLoop`, headless doesn't); a uniform `ChassisEnv`
+    /// trait would just push the per-chassis differences down a
+    /// level.
+    ///
+    /// `main()` populates the env from environment variables (today)
+    /// or layered config (CLI > env > TOML > defaults, future).
+    type Env;
+
+    /// Build the chassis from resolved config. Stands up substrate
+    /// internals, boots passive capabilities, wires the driver, and
+    /// returns the [`BuiltChassis<Self>`] whose [`BuiltChassis::run`]
+    /// blocks until the driver exits.
+    ///
+    /// Passive chassis return an error pointing callers at the
+    /// chassis's inherent `build_passive` instead — the trait method
+    /// shape exists for trait uniformity, not for invocation.
+    fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError>;
 }

--- a/crates/aether-substrate-core/src/chassis_builder.rs
+++ b/crates/aether-substrate-core/src/chassis_builder.rs
@@ -81,6 +81,36 @@ pub trait DriverRunning: 'static {
     fn run(self: Box<Self>) -> Result<(), RunError>;
 }
 
+/// Phantom [`DriverCapability`] for passive chassis (test-bench, future
+/// embedder-driven chassis kinds). The [`Chassis`](crate::chassis::Chassis)
+/// trait requires `type Driver: DriverCapability`; passive chassis
+/// declare this as their driver to satisfy the bound, but the value is
+/// never instantiated (the `Builder<C, NoDriver>` path produces a
+/// [`PassiveChassis<C>`] without ever resolving `C::Driver`). Its `boot`
+/// is `unreachable!()` — reaching it implies someone tried to drive a
+/// chassis that has no driver, which is a programmer error rather than
+/// a runtime condition.
+pub struct NeverDriver;
+
+impl DriverCapability for NeverDriver {
+    type Running = NeverDriverRunning;
+    fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
+        unreachable!(
+            "NeverDriver is a phantom for passive chassis; it should never be booted. \
+             Build the chassis via its inherent `build_passive(env)` instead."
+        );
+    }
+}
+
+/// Running-side of [`NeverDriver`]; same unreachability contract.
+pub struct NeverDriverRunning;
+
+impl DriverRunning for NeverDriverRunning {
+    fn run(self: Box<Self>) -> Result<(), RunError> {
+        unreachable!("NeverDriverRunning::run is never called by design");
+    }
+}
+
 /// Type-erased shutdown adapter for a passive [`Capability::Running`]
 /// stored in the builder's shutdown queue. Single-threaded path, so
 /// no `Send` bound — the adapter never crosses threads (the chassis
@@ -283,11 +313,11 @@ impl<C: Chassis> Builder<C, NoDriver> {
 
     /// Supply the chassis's driver. Transitions to [`HasDriver`] —
     /// further `.driver(_)` calls are forbidden by the type system.
-    pub fn driver<D>(mut self, driver: D) -> Builder<C, HasDriver>
-    where
-        D: DriverCapability,
-    {
-        self.driver = Some(make_driver_boot::<D>(driver));
+    /// Per ADR-0071 the driver type is fixed by `C::Driver`, so the
+    /// builder rejects mismatched driver types at the call site
+    /// rather than at boot.
+    pub fn driver(mut self, driver: C::Driver) -> Builder<C, HasDriver> {
+        self.driver = Some(make_driver_boot::<C::Driver>(driver));
         Builder {
             registry: self.registry,
             mailer: self.mailer,
@@ -489,12 +519,28 @@ mod tests {
     use crate::capability::Envelope;
     use std::sync::Mutex;
 
-    /// Fixture chassis used only by the tests in this module.
+    /// Fixture chassis for passive-build tests. `type Driver` is the
+    /// phantom [`NeverDriver`] since these tests use `build_passive`.
     struct TestChassis;
     impl Chassis for TestChassis {
         const PROFILE: &'static str = "test";
-        fn run(self) -> wasmtime::Result<()> {
-            Ok(())
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests");
+        }
+    }
+
+    /// Fixture chassis for driver-build tests. Generic over the
+    /// concrete `DriverCapability` so each test can pair the chassis
+    /// type with whatever driver it's exercising.
+    struct DrivenTestChassis<D: DriverCapability>(PhantomData<fn() -> D>);
+    impl<D: DriverCapability + 'static> Chassis for DrivenTestChassis<D> {
+        const PROFILE: &'static str = "test-driven";
+        type Driver = D;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("DrivenTestChassis is driven by Builder::new directly in unit tests");
         }
     }
 
@@ -579,7 +625,7 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let chassis = Builder::<TestChassis, NoDriver>::new(registry, mailer)
+        let chassis = Builder::<DrivenTestChassis<EchoDriver>, NoDriver>::new(registry, mailer)
             .with(EchoCap { name: "test.echo" })
             .driver(EchoDriver {
                 ran: Arc::clone(&ran),
@@ -692,7 +738,7 @@ mod tests {
             }
         }
 
-        let chassis = Builder::<TestChassis, NoDriver>::new(registry, mailer)
+        let chassis = Builder::<DrivenTestChassis<CaptureDriver>, NoDriver>::new(registry, mailer)
             .with(EchoCap { name: "test.echo" })
             .driver(CaptureDriver {
                 captured: Arc::clone(&captured),

--- a/crates/aether-substrate-core/src/lib.rs
+++ b/crates/aether-substrate-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use capability::{
 pub use chassis::Chassis;
 pub use chassis_builder::{
     Builder, BuilderState, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, HasDriver,
-    NoDriver, PassiveChassis, RunError,
+    NeverDriver, NeverDriverRunning, NoDriver, PassiveChassis, RunError,
 };
 pub use component::Component;
 pub use control::{AETHER_CONTROL, ChassisControlHandler, ControlPlane};

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -186,18 +186,11 @@ pub struct DesktopChassis;
 
 impl Chassis for DesktopChassis {
     const PROFILE: &'static str = "desktop";
+    type Driver = crate::driver::DesktopDriverCapability;
+    type Env = DesktopEnv;
 
-    fn run(self) -> wasmtime::Result<()> {
-        // ADR-0071 phase 3: the `DesktopChassis` is constructed via
-        // `Self::build(env)?.run()`. The legacy `Chassis::run` slot
-        // stays on the trait until every chassis migrates so the
-        // existing test-bench / headless / hub paths keep working;
-        // hitting it on `DesktopChassis` means `main()` (or a test)
-        // tried to call the legacy run path on the marker struct
-        // rather than `BuiltChassis::run`.
-        Err(wasmtime::Error::msg(
-            "DesktopChassis is built via build(env) — call run() on the BuiltChassis<DesktopChassis> instead",
-        ))
+    fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        Self::build_inner(env)
     }
 }
 
@@ -280,8 +273,9 @@ impl DesktopChassis {
     /// winit event loop.
     ///
     /// Phase 3 keeps capabilities on the `boot.add_capability` path;
-    /// phase 4+ migrate them to chassis_builder `.with()`.
-    pub fn build(env: DesktopEnv) -> wasmtime::Result<BuiltChassis<DesktopChassis>> {
+    /// phase 4+ migrate them to chassis_builder `.with()`. The
+    /// trait method [`Chassis::build`] forwards here.
+    fn build_inner(env: DesktopEnv) -> Result<BuiltChassis<DesktopChassis>, BootError> {
         let DesktopEnv {
             event_loop,
             capture_queue,
@@ -310,7 +304,8 @@ impl DesktopChassis {
                     ))
                 }
             })
-            .build()?;
+            .build()
+            .map_err(wasmtime_to_boot_error)?;
 
         // Render + camera sinks (ADR-0071 phase 4 / Option B): one
         // capability owning both mailboxes + accumulator state. The
@@ -321,15 +316,20 @@ impl DesktopChassis {
         // lookup hooks up once render migrates onto `.with()`.
         let render_cap = RenderCapability::new(RenderConfig::default());
         let render_handles = render_cap.handles();
-        boot.add_capability(render_cap)?;
+        boot.add_capability(render_cap)
+            .map_err(wasmtime_to_boot_error)?;
 
         // Legacy ADR-0070 capabilities — kept on the existing path
         // through phase 3 and 4 (Option B). Phase 4.5+ migrate them
         // (and render) to chassis_builder `.with()`.
-        boot.add_capability(AudioCapability::new(audio))?;
-        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
-        boot.add_capability(NetCapability::new(net))?;
-        boot.add_capability(LogCapability::new())?;
+        boot.add_capability(AudioCapability::new(audio))
+            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))
+            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(NetCapability::new(net))
+            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(LogCapability::new())
+            .map_err(wasmtime_to_boot_error)?;
 
         tracing::info!(
             target: "aether_substrate::boot",
@@ -346,7 +346,8 @@ impl DesktopChassis {
         // that prefer Builder-pipeline composition can swap in
         // `aether_hub::HubClientCapability` instead (the free fn is
         // a thin wrapper around the same path).
-        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())?;
+        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())
+            .map_err(wasmtime_to_boot_error)?;
 
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
@@ -368,6 +369,12 @@ impl DesktopChassis {
         Builder::<DesktopChassis, NoDriver>::new(registry, mailer)
             .driver(driver)
             .build()
-            .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))
     }
+}
+
+/// Wrap a `wasmtime::Error` (from `SubstrateBoot::build` /
+/// `connect_hub_client`) into a [`BootError`] so the chassis trait
+/// method can return a uniform error type per ADR-0071.
+fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
+    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }

--- a/crates/aether-substrate-desktop/src/chassis.rs
+++ b/crates/aether-substrate-desktop/src/chassis.rs
@@ -304,8 +304,7 @@ impl DesktopChassis {
                     ))
                 }
             })
-            .build()
-            .map_err(wasmtime_to_boot_error)?;
+            .build()?;
 
         // Render + camera sinks (ADR-0071 phase 4 / Option B): one
         // capability owning both mailboxes + accumulator state. The
@@ -316,20 +315,15 @@ impl DesktopChassis {
         // lookup hooks up once render migrates onto `.with()`.
         let render_cap = RenderCapability::new(RenderConfig::default());
         let render_handles = render_cap.handles();
-        boot.add_capability(render_cap)
-            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(render_cap)?;
 
         // Legacy ADR-0070 capabilities — kept on the existing path
         // through phase 3 and 4 (Option B). Phase 4.5+ migrate them
         // (and render) to chassis_builder `.with()`.
-        boot.add_capability(AudioCapability::new(audio))
-            .map_err(wasmtime_to_boot_error)?;
-        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))
-            .map_err(wasmtime_to_boot_error)?;
-        boot.add_capability(NetCapability::new(net))
-            .map_err(wasmtime_to_boot_error)?;
-        boot.add_capability(LogCapability::new())
-            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(AudioCapability::new(audio))?;
+        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
+        boot.add_capability(NetCapability::new(net))?;
+        boot.add_capability(LogCapability::new())?;
 
         tracing::info!(
             target: "aether_substrate::boot",
@@ -346,8 +340,7 @@ impl DesktopChassis {
         // that prefer Builder-pipeline composition can swap in
         // `aether_hub::HubClientCapability` instead (the free fn is
         // a thin wrapper around the same path).
-        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())
-            .map_err(wasmtime_to_boot_error)?;
+        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())?;
 
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
@@ -370,11 +363,4 @@ impl DesktopChassis {
             .driver(driver)
             .build()
     }
-}
-
-/// Wrap a `wasmtime::Error` (from `SubstrateBoot::build` /
-/// `connect_hub_client`) into a [`BootError`] so the chassis trait
-/// method can return a uniform error type per ADR-0071.
-fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
-    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }

--- a/crates/aether-substrate-desktop/src/main.rs
+++ b/crates/aether-substrate-desktop/src/main.rs
@@ -16,7 +16,8 @@ use aether_substrate_desktop::{Chassis, DesktopChassis, DesktopEnv};
 
 fn main() -> wasmtime::Result<()> {
     let env = DesktopEnv::from_env()?;
-    let chassis = DesktopChassis::build(env)?;
+    let chassis = DesktopChassis::build(env)
+        .map_err(|e| wasmtime::Error::msg(format!("chassis build: {e}")))?;
     tracing::info!(
         target: "aether_substrate::boot",
         profile = DesktopChassis::PROFILE,

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -78,11 +78,11 @@ pub struct HeadlessChassis;
 
 impl Chassis for HeadlessChassis {
     const PROFILE: &'static str = "headless";
+    type Driver = crate::driver::HeadlessTimerCapability;
+    type Env = HeadlessEnv;
 
-    fn run(self) -> wasmtime::Result<()> {
-        Err(wasmtime::Error::msg(
-            "HeadlessChassis is built via build(env) — call run() on the BuiltChassis<HeadlessChassis> instead",
-        ))
+    fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        Self::build_inner(env)
     }
 }
 
@@ -125,8 +125,9 @@ impl HeadlessChassis {
     /// `boot.add_capability` path, connect the hub, then wrap the
     /// timer in a [`HeadlessTimerCapability`] and hand it to the
     /// chassis_builder [`Builder`]. Returns a [`BuiltChassis`] whose
-    /// [`BuiltChassis::run`] blocks on the tick loop.
-    pub fn build(env: HeadlessEnv) -> wasmtime::Result<BuiltChassis<HeadlessChassis>> {
+    /// [`BuiltChassis::run`] blocks on the tick loop. The trait
+    /// method [`Chassis::build`] forwards here.
+    fn build_inner(env: HeadlessEnv) -> Result<BuiltChassis<HeadlessChassis>, BootError> {
         let HeadlessEnv {
             hub_url,
             namespace_roots,
@@ -138,7 +139,8 @@ impl HeadlessChassis {
             .workers(WORKERS)
             .namespace_roots(namespace_roots)
             .chassis_handler(|ctx| Some(chassis_control_handler(Arc::clone(ctx.outbound))))
-            .build()?;
+            .build()
+            .map_err(wasmtime_to_boot_error)?;
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
         let kind_frame_stats = boot
@@ -203,9 +205,12 @@ impl HeadlessChassis {
         );
 
         // Legacy ADR-0070 capabilities — io / net / log.
-        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
-        boot.add_capability(NetCapability::new(net))?;
-        boot.add_capability(LogCapability::new())?;
+        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))
+            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(NetCapability::new(net))
+            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(LogCapability::new())
+            .map_err(wasmtime_to_boot_error)?;
 
         let tick_hz = (Duration::from_secs(1).as_nanos() / tick_period.as_nanos().max(1)) as u32;
         tracing::info!(
@@ -217,7 +222,8 @@ impl HeadlessChassis {
 
         // Hub connect AFTER every chassis sink is registered (issue #262).
         // Post-ADR-0070 phase 4: hub client lives in `aether-hub`.
-        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())?;
+        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())
+            .map_err(wasmtime_to_boot_error)?;
 
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
@@ -233,6 +239,13 @@ impl HeadlessChassis {
         Builder::<HeadlessChassis, NoDriver>::new(registry, mailer)
             .driver(driver)
             .build()
-            .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))
     }
+}
+
+/// Wrap a `wasmtime::Error` (from `SubstrateBoot::build` /
+/// `connect_hub_client` / `boot.add_capability`) into a [`BootError`]
+/// so the chassis trait method can return a uniform error type per
+/// ADR-0071.
+fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
+    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }

--- a/crates/aether-substrate-headless/src/chassis.rs
+++ b/crates/aether-substrate-headless/src/chassis.rs
@@ -139,8 +139,7 @@ impl HeadlessChassis {
             .workers(WORKERS)
             .namespace_roots(namespace_roots)
             .chassis_handler(|ctx| Some(chassis_control_handler(Arc::clone(ctx.outbound))))
-            .build()
-            .map_err(wasmtime_to_boot_error)?;
+            .build()?;
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
         let kind_frame_stats = boot
@@ -205,12 +204,9 @@ impl HeadlessChassis {
         );
 
         // Legacy ADR-0070 capabilities — io / net / log.
-        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))
-            .map_err(wasmtime_to_boot_error)?;
-        boot.add_capability(NetCapability::new(net))
-            .map_err(wasmtime_to_boot_error)?;
-        boot.add_capability(LogCapability::new())
-            .map_err(wasmtime_to_boot_error)?;
+        boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
+        boot.add_capability(NetCapability::new(net))?;
+        boot.add_capability(LogCapability::new())?;
 
         let tick_hz = (Duration::from_secs(1).as_nanos() / tick_period.as_nanos().max(1)) as u32;
         tracing::info!(
@@ -222,8 +218,7 @@ impl HeadlessChassis {
 
         // Hub connect AFTER every chassis sink is registered (issue #262).
         // Post-ADR-0070 phase 4: hub client lives in `aether-hub`.
-        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())
-            .map_err(wasmtime_to_boot_error)?;
+        let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())?;
 
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
@@ -240,12 +235,4 @@ impl HeadlessChassis {
             .driver(driver)
             .build()
     }
-}
-
-/// Wrap a `wasmtime::Error` (from `SubstrateBoot::build` /
-/// `connect_hub_client` / `boot.add_capability`) into a [`BootError`]
-/// so the chassis trait method can return a uniform error type per
-/// ADR-0071.
-fn wasmtime_to_boot_error(e: wasmtime::Error) -> BootError {
-    BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
 }

--- a/crates/aether-substrate-headless/src/main.rs
+++ b/crates/aether-substrate-headless/src/main.rs
@@ -17,7 +17,8 @@ use aether_substrate_core::Chassis;
 
 fn main() -> wasmtime::Result<()> {
     let env = HeadlessEnv::from_env();
-    let chassis = HeadlessChassis::build(env)?;
+    let chassis = HeadlessChassis::build(env)
+        .map_err(|e| wasmtime::Error::msg(format!("chassis build: {e}")))?;
     tracing::info!(
         target: "aether_substrate::boot",
         profile = HeadlessChassis::PROFILE,

--- a/crates/aether-substrate-hub/src/main.rs
+++ b/crates/aether-substrate-hub/src/main.rs
@@ -13,7 +13,8 @@
 use aether_hub::{Chassis, HubChassis, HubEnv};
 
 fn main() -> wasmtime::Result<()> {
-    let chassis = HubChassis::build(HubEnv::from_env())?;
+    let chassis = HubChassis::build(HubEnv::from_env())
+        .map_err(|e| wasmtime::Error::msg(format!("chassis build: {e}")))?;
     eprintln!(
         "aether-substrate-hub: chassis initialised (profile={})",
         HubChassis::PROFILE,

--- a/crates/aether-substrate-hub/src/main.rs
+++ b/crates/aether-substrate-hub/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Reads chassis-relevant env vars into a [`HubEnv`], asks the
 //! [`HubChassis`] to build itself (engine + session + spawn + log
-//! stores, in-process loopback substrate, [`HubServerCapability`]
+//! stores, in-process loopback substrate, [`HubServerDriverCapability`]
 //! driver), and blocks on the resulting chassis until either listener
 //! exits or a SIGINT/SIGTERM arrives. ADR-0071 phase 7d collapsed
 //! every step the prior `main()` body did inline (and the further

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -27,7 +27,9 @@ use aether_kinds::{
     Tick,
 };
 use aether_substrate_core::capability::BootError;
-use aether_substrate_core::chassis_builder::{Builder, NoDriver, PassiveChassis};
+use aether_substrate_core::chassis_builder::{
+    Builder, BuiltChassis, NeverDriver, NoDriver, PassiveChassis,
+};
 use aether_substrate_core::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
@@ -137,12 +139,24 @@ pub struct TestBenchChassis;
 
 impl Chassis for TestBenchChassis {
     const PROFILE: &'static str = "test-bench";
+    /// Phantom driver — test-bench is passive (the embedder is the
+    /// driver). Declaring [`NeverDriver`] satisfies the trait bound;
+    /// the value is never instantiated because TestBench's build
+    /// path goes through `Builder::<_, NoDriver>::build_passive`.
+    type Driver = NeverDriver;
+    type Env = TestBenchEnv;
 
-    fn run(self) -> wasmtime::Result<()> {
-        Err(wasmtime::Error::msg(
-            "TestBenchChassis is built via build_passive(env); the embedder drives the loop \
-             (binary main() loops on events_rx; in-process TestBench dispatches per-call)",
-        ))
+    /// Inert by design — test-bench is a passive chassis. Callers
+    /// that try to drive it through the trait method get an error
+    /// pointing at [`TestBenchChassis::build_passive`], which is
+    /// the actual entry point. The trait method exists so
+    /// `Builder<TestBenchChassis, _>` can still parameterise over
+    /// `Chassis` per ADR-0071.
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        Err(BootError::Other(Box::new(std::io::Error::other(
+            "TestBenchChassis has no driver; use TestBenchChassis::build_passive(env) instead \
+             (the binary main() loops on events_rx; the in-process TestBench dispatches per-call)",
+        ))))
     }
 }
 


### PR DESCRIPTION
## Summary

ADR-0071 phase 2 said *"Land driver-capability traits + builder type-state + Chassis redefinition + BuiltChassis<C> / PassiveChassis<C> scaffolding."* Driver traits, builder type-state, BuiltChassis/PassiveChassis all shipped in PR 484. The Chassis redefinition piece didn't. This PR closes it as written.

## What changed

- **Chassis trait** (`aether-substrate-core/src/chassis.rs`) now matches ADR-0071's Decision section: `Sized + 'static`, with `const PROFILE`, `type Driver: DriverCapability`, `type Env`, and `fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError>`. Drops the legacy `fn run(self) -> wasmtime::Result<()>` stub that every concrete chassis was erroring out of.
- **Builder::driver** tightens from generic `<D: DriverCapability>` to `C::Driver`. A chassis can only be paired with the driver type its trait impl declares — type-safe at the call site instead of runtime.
- **NeverDriver / NeverDriverRunning** added to `chassis_builder` as the phantom DriverCapability for passive chassis. TestBench (today's only passive chassis) declares it as `type Driver` to satisfy the trait bound; its `fn build` returns an error pointing at `build_passive`. The trait method is unreachable on passive chassis but its presence keeps the trait shape uniform across the workspace and lets `Builder<C: Chassis, _>` stay generic.
- **Each chassis's** inherent `build` becomes a private `build_inner` called from the trait impl. `wasmtime::Error` from `SubstrateBoot::build` / `add_capability` / `connect_hub_client` maps to `BootError::Other` at the trait boundary.
- **Each main()** maps `BootError` back to `wasmtime::Error` so the return shape is unchanged.

## Why this is bigger than it looks

ADR-0071's full vision (declarative `Chassis::builder().with(cap).with(cap).driver(d).build().run()` chains) is still mid-migration — production chassis still use the legacy `boot.add_capability` path. Phases B (capability composition migration) and C (render extraction completion) of the discussed plan land that. This PR is phase A: get the trait shape itself to match the spec so subsequent phases land on a stable surface.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (one Mesa render flake on first sokoban scenario run, clean on retry — known macOS flake unrelated to this PR)
- [x] cargo check --target wasm32-unknown-unknown -p aether-camera-component

🤖 Generated with [Claude Code](https://claude.com/claude-code)