### PR TITLE
refactor(render): encoder methods + chassis cutover (ADR-0071 phase C2)

### DIFF
--- a/crates/aether-substrate-core/src/capabilities/render.rs
+++ b/crates/aether-substrate-core/src/capabilities/render.rs
@@ -34,7 +34,10 @@ use std::time::Duration;
 use aether_kinds::DRAW_TRIANGLE_BYTES;
 
 use crate::capability::{BootError, Capability, ChassisCtx, Envelope, RunningCapability};
-use crate::render::{IDENTITY_VIEW_PROJ, Pipeline, Targets};
+use crate::render::{
+    CaptureMeta, IDENTITY_VIEW_PROJ, Pipeline, RenderError, Targets, build_main_pipeline,
+    finish_capture, prepare_capture_copy, record_main_pass,
+};
 
 pub const RENDER_SINK_NAME: &str = "aether.sink.render";
 pub const CAMERA_SINK_NAME: &str = "aether.sink.camera";
@@ -136,6 +139,33 @@ pub struct RenderGpu {
     pub color_format: wgpu::TextureFormat,
 }
 
+impl RenderGpu {
+    /// Build the standard render pipeline + offscreen targets at the
+    /// given size and pass [`Self`] to [`RenderRunning::install_gpu`].
+    /// `polygon_mode` is `Fill` for the normal case; desktop's
+    /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
+    /// pipeline draws as wireframe instead of building a separate
+    /// overlay pipeline.
+    pub fn new(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        color_format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+        polygon_mode: wgpu::PolygonMode,
+    ) -> Self {
+        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
+        let targets = Targets::new(&device, color_format, width, height);
+        Self {
+            device,
+            queue,
+            pipeline,
+            targets: Mutex::new(targets),
+            color_format,
+        }
+    }
+}
+
 impl RenderRunning {
     /// Post-boot accessor for the accumulator state. Used by drivers
     /// reading via the chassis_builder typed lookup once render
@@ -161,11 +191,121 @@ impl RenderRunning {
     }
 
     /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
-    /// hasn't been called yet. Encoder-level methods (added in
-    /// ADR-0071 phase C2) use this; today only the chassis-side glue
-    /// reaches in.
+    /// hasn't been called yet. Chassis-side glue that needs raw
+    /// access to the pipeline's bind group layouts (e.g. desktop's
+    /// wireframe overlay pipeline construction) reaches in here.
     pub fn gpu(&self) -> Option<&RenderGpu> {
         self.gpu.get()
+    }
+
+    fn expect_gpu(&self) -> &RenderGpu {
+        self.gpu.get().expect(
+            "RenderRunning::install_gpu must be called before encoder-level methods. \
+             Desktop installs in winit's resumed; test-bench installs after build_passive.",
+        )
+    }
+
+    /// Drain the current frame's accumulated vertices, read the
+    /// latest camera view-proj, and record the main render pass into
+    /// `encoder`. Each call consumes the accumulator (subsequent
+    /// inbound mail builds the next frame). `extra_pipelines` are
+    /// drawn after the main pipeline inside the same render pass —
+    /// desktop passes a wireframe overlay pipeline here when
+    /// `AETHER_WIREFRAME=overlay`; test-bench passes `&[]`.
+    pub fn record_frame(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        extra_pipelines: &[&wgpu::RenderPipeline],
+    ) -> Result<(), RenderError> {
+        let gpu = self.expect_gpu();
+        let cap = self.handles.frame_vertices.lock().unwrap().capacity();
+        let vertices = std::mem::replace(
+            &mut *self.handles.frame_vertices.lock().unwrap(),
+            Vec::with_capacity(cap),
+        );
+        let view_proj = *self.handles.camera_state.lock().unwrap();
+        let targets = gpu.targets.lock().unwrap();
+        record_main_pass(
+            &gpu.queue,
+            encoder,
+            &gpu.pipeline,
+            &targets,
+            &vertices,
+            &view_proj,
+            extra_pipelines,
+        )
+    }
+
+    /// Encode a copy of the offscreen color target into a readback
+    /// buffer. Pair with [`Self::finish_capture`] after submit. The
+    /// readback buffer is reallocated on size mismatch with the
+    /// current offscreen, so any sequence of resize → record_frame →
+    /// record_capture_copy → submit → finish_capture works.
+    pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
+        let gpu = self.expect_gpu();
+        let mut targets = gpu.targets.lock().unwrap();
+        prepare_capture_copy(&gpu.device, &mut targets, encoder)
+    }
+
+    /// Map the readback buffer prepared by [`Self::record_capture_copy`]
+    /// and return the encoded PNG. Call after the encoder containing
+    /// the matching `record_capture_copy` has been submitted.
+    pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
+        let gpu = self.expect_gpu();
+        let targets = gpu.targets.lock().unwrap();
+        finish_capture(&gpu.device, &targets, meta)
+    }
+
+    /// Resize the offscreen color + depth targets. Idempotent on
+    /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
+    pub fn resize(&self, width: u32, height: u32) {
+        let gpu = self.expect_gpu();
+        let mut targets = gpu.targets.lock().unwrap();
+        targets.resize(&gpu.device, width, height);
+    }
+
+    /// Cloned `Arc<wgpu::Device>`. Drivers that need the device for
+    /// their own pipelines (e.g. desktop's wireframe overlay pipeline,
+    /// swapchain blit) clone here.
+    pub fn device(&self) -> Arc<wgpu::Device> {
+        Arc::clone(&self.expect_gpu().device)
+    }
+
+    /// Cloned `Arc<wgpu::Queue>`. Drivers submit through this; the
+    /// shared queue means render's `record_frame` writes and the
+    /// driver's swapchain submit go through the same submission
+    /// order.
+    pub fn queue(&self) -> Arc<wgpu::Queue> {
+        Arc::clone(&self.expect_gpu().queue)
+    }
+
+    /// Format the offscreen color target was created with. Capture's
+    /// BGRA-vs-RGBA decision keys on this; desktop's swapchain blit
+    /// matches its surface format against this to pick a direct copy
+    /// vs a manual swizzle.
+    pub fn color_format(&self) -> wgpu::TextureFormat {
+        self.expect_gpu().color_format
+    }
+
+    /// Current offscreen color target dimensions. Drivers reading
+    /// after a `resize` see the new dimensions immediately.
+    pub fn color_size(&self) -> (u32, u32) {
+        let targets = self.expect_gpu().targets.lock().unwrap();
+        (targets.width(), targets.height())
+    }
+
+    /// Run `f` with a borrow of the offscreen color texture. Used by
+    /// desktop's swapchain blit: the closure body holds the targets
+    /// mutex, so any encoder commands recorded inside are sequenced
+    /// against any concurrent resize. Test-bench reaches the
+    /// offscreen via the capture path and doesn't need this.
+    pub fn with_color_texture<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&wgpu::Texture) -> R,
+    {
+        let gpu = self.expect_gpu();
+        let targets = gpu.targets.lock().unwrap();
+        f(targets.color_texture())
     }
 }
 

--- a/crates/aether-substrate-desktop/src/driver.rs
+++ b/crates/aether-substrate-desktop/src/driver.rs
@@ -17,7 +17,6 @@
 //! every passive in reverse boot order via `BootedPassives::Drop`.
 
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -49,7 +48,7 @@ use winit::monitor::{MonitorHandle, VideoModeHandle};
 use winit::window::{Fullscreen, Window, WindowId};
 
 use crate::chassis::UserEvent;
-use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
+use crate::render::Gpu;
 
 /// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
 /// component, the scheduler doesn't read this — it's retained on the
@@ -74,13 +73,11 @@ pub struct App {
     kind_mouse_move: aether_data::KindId,
     kind_window_size: aether_data::KindId,
     kind_frame_stats: aether_data::KindId,
-    frame_vertices: Arc<Mutex<Vec<u8>>>,
-    /// Latest `aether.camera` payload seen by the camera sink
-    /// (column-major `view_proj` matrix). Read by the render loop
-    /// each frame and uploaded to the GPU uniform before drawing.
-    /// Initialised to identity so components that emit
-    /// clip-space-ish world coords render pre-camera.
-    camera_state: Arc<Mutex<[f32; 16]>>,
+    /// Cloned out of `RenderRunning` at driver boot. Source-of-truth
+    /// lives in core's `RenderCapability`; the app holds a clone so
+    /// `Gpu::new` can install wgpu state and the per-frame loop can
+    /// call `record_frame` / `record_capture_copy` / `finish_capture`.
+    render_running: Arc<RenderRunning>,
     triangles_rendered: Arc<AtomicU64>,
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
@@ -525,7 +522,10 @@ impl ApplicationHandler<UserEvent> for App {
             }
         }
         let window = Arc::new(event_loop.create_window(attrs).expect("create_window"));
-        self.gpu = Some(Gpu::new(Arc::clone(&window)));
+        self.gpu = Some(Gpu::new(
+            Arc::clone(&window),
+            Arc::clone(&self.render_running),
+        ));
         window.request_redraw();
         let initial_size = window.inner_size();
         self.window = Some(window);
@@ -565,15 +565,10 @@ impl ApplicationHandler<UserEvent> for App {
                     }
                 }
                 frame_loop::drain_or_abort(&self.queue, &self.outbound);
-                let verts = std::mem::replace(
-                    &mut *self.frame_vertices.lock().unwrap(),
-                    Vec::with_capacity(VERTEX_BUFFER_BYTES),
-                );
-                let view_proj = *self.camera_state.lock().unwrap();
                 if let Some(gpu) = self.gpu.as_mut() {
                     match pending_capture {
                         Some(req) => {
-                            let result = match gpu.render_and_capture(&verts, &view_proj) {
+                            let result = match gpu.render_and_capture() {
                                 Ok(png) => CaptureFrameResult::Ok { png },
                                 Err(error) => CaptureFrameResult::Err { error },
                             };
@@ -583,7 +578,7 @@ impl ApplicationHandler<UserEvent> for App {
                             self.outbound.send_reply(req.reply_to, &result);
                         }
                         None => {
-                            gpu.render(&verts, &view_proj);
+                            gpu.render();
                         }
                     }
                 } else if let Some(req) = pending_capture {
@@ -738,12 +733,12 @@ impl DriverCapability for DesktopDriverCapability {
         // this driver, so its `RenderRunning` is in the typed map;
         // pull the accumulator handles for the per-frame loop to
         // read.
-        let render: Arc<RenderRunning> = ctx.expect();
+        let render_running: Arc<RenderRunning> = ctx.expect();
         let RenderHandles {
-            frame_vertices,
-            camera_state,
+            frame_vertices: _,
+            camera_state: _,
             triangles_rendered,
-        } = render.handles();
+        } = render_running.handles();
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
         let kind_key = boot.registry.kind_id(Key::NAME).expect("Key registered");
@@ -779,8 +774,7 @@ impl DriverCapability for DesktopDriverCapability {
             kind_mouse_move,
             kind_window_size,
             kind_frame_stats,
-            frame_vertices,
-            camera_state,
+            render_running: Arc::clone(&render_running),
             triangles_rendered: Arc::clone(&triangles_rendered),
             capture_queue,
             outbound: Arc::clone(&boot.outbound),

--- a/crates/aether-substrate-desktop/src/render.rs
+++ b/crates/aether-substrate-desktop/src/render.rs
@@ -1,28 +1,21 @@
-// wgpu plumbing for the desktop chassis. Owns the device/queue/surface
-// plus the shared `core::render::Pipeline` + `Targets` (issue 421);
-// each frame the main thread hands in a byte blob drained from the
-// render sink plus the latest camera view_proj. The render path goes
-// through `core::render::record_main_pass` which uploads + draws into
-// the offscreen target; we then optionally blit the offscreen into
-// the swapchain and present.
-//
-// Capture path: `prepare_capture_copy` reads from the offscreen
-// texture (not the swapchain), so captures are independent of window
-// state. Non-capture frames pay nothing beyond the one extra texture
-// copy per frame.
+// Desktop wgpu plumbing. ADR-0071 phase C2: pipeline + targets moved
+// into core's `RenderRunning` (via `RenderGpu` + `install_gpu`); this
+// file now owns only the desktop-specific surface + swapchain config
+// + optional wireframe overlay pipeline. Each frame creates an
+// encoder, asks `render_running.record_frame(...)` to record the
+// shared offscreen pass, optionally records a capture copy, copies
+// offscreen → swapchain, submits, and presents.
 //
 // Wireframe (`AETHER_WIREFRAME=line|overlay`) is desktop-only — a
 // dev-affordance for inspecting triangulation on the windowed
-// chassis. `Line` re-builds the main pipeline with `PolygonMode::Line`;
-// `Overlay` keeps filled rendering and adds a second draw inside the
-// same pass via `record_main_pass`'s `extra_pipelines` slice.
+// chassis. `Line` builds RenderGpu with `PolygonMode::Line` so the
+// main pipeline draws as wires; `Overlay` keeps Fill and adds a
+// second pipeline as an extra in `record_frame`.
 
 use std::sync::Arc;
 
-use aether_substrate_core::render::{
-    self, CaptureMeta, Pipeline, RenderError, Targets, build_main_pipeline, finish_capture,
-    prepare_capture_copy, record_main_pass, vertex_buffer_layout,
-};
+use aether_substrate_core::capabilities::{RenderGpu, RenderRunning};
+use aether_substrate_core::render::{self, RenderError, vertex_buffer_layout};
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
@@ -58,8 +51,6 @@ fn fs_main() -> @location(0) vec4<f32> {
 
 pub struct Gpu {
     pub surface: wgpu::Surface<'static>,
-    pub device: wgpu::Device,
-    pub queue: wgpu::Queue,
     pub config: wgpu::SurfaceConfiguration,
     /// Snapshot of the adapter chosen at `new()` — `AdapterInfo` plus
     /// the resolved `Limits`. Retained so `platform_info` can report
@@ -68,13 +59,16 @@ pub struct Gpu {
     /// anyway).
     pub adapter_info: wgpu::AdapterInfo,
     pub limits: wgpu::Limits,
-    pipeline: Pipeline,
-    targets: Targets,
+    /// Cloned out of [`RenderGpu`] at install for ergonomic access on
+    /// the surface/submit path. Source of truth lives inside
+    /// `RenderRunning` post-install.
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     /// Wireframe overlay pipeline. `Some` only when `AETHER_WIREFRAME`
-    /// is set to `1` / `overlay`. The main pipeline always draws
-    /// first; this one then redraws the same vertex buffer in
-    /// `PolygonMode::Line` over the top so geometry is legible.
+    /// is `1` / `overlay`. `record_frame` draws this after the main
+    /// pipeline as an extra inside the same render pass.
     wire_pipeline: Option<wgpu::RenderPipeline>,
+    render_running: Arc<RenderRunning>,
 }
 
 /// Wireframe rendering mode, set at boot via `AETHER_WIREFRAME`.
@@ -104,7 +98,7 @@ impl WireframeMode {
 }
 
 impl Gpu {
-    pub fn new(window: Arc<Window>) -> Self {
+    pub fn new(window: Arc<Window>, render_running: Arc<RenderRunning>) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let surface = instance
@@ -155,6 +149,9 @@ impl Gpu {
         }))
         .expect("request_device");
 
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+
         let size = window.inner_size();
         let caps = surface.get_capabilities(&adapter);
         // Prefer sRGB so the clear color matches intuition.
@@ -179,20 +176,28 @@ impl Gpu {
         };
         surface.configure(&device, &config);
 
-        let targets = Targets::new(&device, format, config.width, config.height);
         let polygon_mode = if wireframe_mode == WireframeMode::Line {
             wgpu::PolygonMode::Line
         } else {
             wgpu::PolygonMode::Fill
         };
-        let pipeline = build_main_pipeline(&device, &queue, format, polygon_mode);
+        render_running.install_gpu(RenderGpu::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            config.width,
+            config.height,
+            polygon_mode,
+        ));
 
         // Wireframe overlay pipeline: same vertex/uniform layout, but
         // `PolygonMode::Line` and a flat dark fragment color so the
-        // wires read against any filled color underneath. A small
-        // negative depth bias lifts the lines toward the camera so
-        // they aren't z-fought by the filled triangles they trace.
+        // wires read against any filled color underneath. Built post-
+        // install so it can borrow the bind group + pipeline layouts
+        // from the installed RenderGpu's pipeline.
         let wire_pipeline = if wireframe_mode == WireframeMode::Overlay {
+            let installed = render_running.gpu().expect("install_gpu just succeeded");
+            let pipeline_layout = &installed.pipeline.pipeline_layout;
             let wire_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("wireframe shader"),
                 source: wgpu::ShaderSource::Wgsl(WIREFRAME_WGSL.into()),
@@ -201,7 +206,7 @@ impl Gpu {
             Some(
                 device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                     label: Some("wireframe overlay pipeline"),
-                    layout: Some(&pipeline.pipeline_layout),
+                    layout: Some(pipeline_layout),
                     vertex: wgpu::VertexState {
                         module: &wire_shader,
                         entry_point: Some("vs_main"),
@@ -249,14 +254,13 @@ impl Gpu {
 
         Self {
             surface,
-            device,
-            queue,
             config,
             adapter_info,
             limits,
-            pipeline,
-            targets,
+            device,
+            queue,
             wire_pipeline,
+            render_running,
         }
     }
 
@@ -267,12 +271,12 @@ impl Gpu {
         self.config.width = size.width;
         self.config.height = size.height;
         self.surface.configure(&self.device, &self.config);
-        self.targets
-            .resize(&self.device, self.config.width, self.config.height);
+        self.render_running
+            .resize(self.config.width, self.config.height);
     }
 
-    pub fn render(&mut self, vertices: &[u8], view_proj: &[f32; 16]) {
-        let _ = self.render_impl(vertices, view_proj, false);
+    pub fn render(&mut self) {
+        let _ = self.render_impl(false);
     }
 
     /// Variant of `render` that also copies the offscreen texture into
@@ -280,28 +284,19 @@ impl Gpu {
     /// capture-path failure, returns `Err(reason)`; the frame itself
     /// still renders and (if the surface is available) presents, since
     /// capture is a side channel.
-    pub fn render_and_capture(
-        &mut self,
-        vertices: &[u8],
-        view_proj: &[f32; 16],
-    ) -> Result<Vec<u8>, String> {
-        self.render_impl(vertices, view_proj, true)
+    pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
+        self.render_impl(true)
             .ok_or_else(|| "capture did not produce a result".to_owned())?
     }
 
-    /// Draw `vertices` into the offscreen target with `view_proj` as
-    /// the camera uniform, optionally encode a capture copy, then
-    /// best-effort blit to the swapchain and present. Returns
-    /// `Some(Ok(png))` / `Some(Err(reason))` when `capture` is set;
-    /// `None` when `capture` is false or the capture path couldn't
-    /// allocate. Surface unavailability does *not* prevent capture —
-    /// offscreen is the source of truth.
-    fn render_impl(
-        &mut self,
-        vertices: &[u8],
-        view_proj: &[f32; 16],
-        capture: bool,
-    ) -> Option<Result<Vec<u8>, String>> {
+    /// Draw the current accumulator vertices into the offscreen target
+    /// with the latest camera view-proj, optionally encode a capture
+    /// copy, then best-effort blit to the swapchain and present.
+    /// Returns `Some(Ok(png))` / `Some(Err(reason))` when `capture` is
+    /// set; `None` when `capture` is false or the capture path
+    /// couldn't allocate. Surface unavailability does *not* prevent
+    /// capture — offscreen is the source of truth.
+    fn render_impl(&mut self, capture: bool) -> Option<Result<Vec<u8>, String>> {
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -317,15 +312,10 @@ impl Gpu {
             }
             None => &[],
         };
-        match record_main_pass(
-            &self.queue,
-            &mut encoder,
-            &self.pipeline,
-            &self.targets,
-            vertices,
-            view_proj,
-            extra_pipelines,
-        ) {
+        match self
+            .render_running
+            .record_frame(&mut encoder, extra_pipelines)
+        {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return None,
         }
@@ -333,12 +323,8 @@ impl Gpu {
         // Capture path: the copy runs against the offscreen texture,
         // which is unaffected by whether a swapchain image is available
         // this frame. That decouples capture from window visibility.
-        let capture_meta: Option<CaptureMeta> = if capture {
-            Some(prepare_capture_copy(
-                &self.device,
-                &mut self.targets,
-                &mut encoder,
-            ))
+        let capture_meta = if capture {
+            Some(self.render_running.record_capture_copy(&mut encoder))
         } else {
             None
         };
@@ -349,25 +335,28 @@ impl Gpu {
         // still resolve.
         let surface_tex = self.acquire_surface_texture();
         if let Some(tex) = surface_tex.as_ref() {
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: self.targets.color_texture(),
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: &tex.texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width: self.targets.width(),
-                    height: self.targets.height(),
-                    depth_or_array_layers: 1,
-                },
-            );
+            let (w, h) = self.render_running.color_size();
+            self.render_running.with_color_texture(|src| {
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: src,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &tex.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: w,
+                        height: h,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            });
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
@@ -375,7 +364,7 @@ impl Gpu {
             tex.present();
         }
 
-        capture_meta.map(|meta| finish_capture(&self.device, &self.targets, &meta))
+        capture_meta.map(|meta| self.render_running.finish_capture(&meta))
     }
 
     /// Try to get the current swapchain texture. Reconfigures the

--- a/crates/aether-substrate-test-bench/src/chassis.rs
+++ b/crates/aether-substrate-test-bench/src/chassis.rs
@@ -31,7 +31,8 @@ use aether_substrate_core::chassis_builder::{Builder, BuiltChassis, NeverDriver,
 use aether_substrate_core::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
-        LogCapability, RenderCapability, RenderConfig, RenderHandles, io::NamespaceRoots,
+        LogCapability, RenderCapability, RenderConfig, RenderHandles, RenderRunning,
+        io::NamespaceRoots,
     },
     capture::{
         CaptureQueue, begin_capture_request, reply_unsupported_platform_info,
@@ -217,6 +218,11 @@ pub struct TestBenchBuild {
     pub passive: PassiveChassis<TestBenchChassis>,
     pub boot: SubstrateBoot,
     pub render_handles: RenderHandles,
+    /// The [`RenderRunning`] handle the embedder calls
+    /// [`RenderRunning::install_gpu`] on once it has a wgpu device +
+    /// queue, plus encoder-level methods (`record_frame`, etc.)
+    /// thereafter. Cloned out of `passive` for ergonomic access.
+    pub render_running: Arc<RenderRunning>,
     pub kind_tick: KindId,
     pub kind_frame_stats: KindId,
     pub hub: Option<HubClient>,
@@ -282,6 +288,7 @@ impl TestBenchChassis {
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
 
+        let render_running: Arc<RenderRunning> = passive.capability();
         let hub = aether_hub::connect_hub_client(&boot, hub_url.as_deref())?;
 
         // The chassis-control closure already cloned `events_tx`;
@@ -296,6 +303,7 @@ impl TestBenchChassis {
             passive,
             boot,
             render_handles,
+            render_running,
             kind_tick,
             kind_frame_stats,
             hub,

--- a/crates/aether-substrate-test-bench/src/main.rs
+++ b/crates/aether-substrate-test-bench/src/main.rs
@@ -25,7 +25,7 @@ use aether_substrate_core::{
 use aether_substrate_test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
-    render::{Gpu, VERTEX_BUFFER_BYTES},
+    render::Gpu,
 };
 
 /// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
@@ -83,6 +83,7 @@ fn main() -> wasmtime::Result<()> {
         passive,
         mut boot,
         render_handles,
+        render_running,
         kind_tick,
         kind_frame_stats,
         hub,
@@ -94,7 +95,7 @@ fn main() -> wasmtime::Result<()> {
     boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
 
     let (width, height) = parse_size_env();
-    let gpu = Gpu::new(width, height);
+    let gpu = Gpu::new(width, height, render_running);
     tracing::info!(
         target: "aether_substrate::boot",
         adapter = %gpu.adapter_info.name,
@@ -223,15 +224,9 @@ fn run_frame(
     }
     frame_loop::drain_or_abort(queue, outbound);
 
-    let verts = std::mem::replace(
-        &mut *render_handles.frame_vertices.lock().unwrap(),
-        Vec::with_capacity(VERTEX_BUFFER_BYTES),
-    );
-    let view_proj = *render_handles.camera_state.lock().unwrap();
-
     match capture_queue.take() {
         Some(req) => {
-            let result = match gpu.render_and_capture(&verts, &view_proj) {
+            let result = match gpu.render_and_capture() {
                 Ok(png) => CaptureFrameResult::Ok { png },
                 Err(error) => CaptureFrameResult::Err { error },
             };
@@ -241,7 +236,7 @@ fn run_frame(
             outbound.send_reply(req.reply_to, &result);
         }
         None => {
-            gpu.render(&verts, &view_proj);
+            gpu.render();
         }
     }
 

--- a/crates/aether-substrate-test-bench/src/render.rs
+++ b/crates/aether-substrate-test-bench/src/render.rs
@@ -1,16 +1,15 @@
-// wgpu plumbing for the test-bench chassis. Owns the device/queue
-// plus the shared `core::render::Pipeline` + `Targets` (issue 421);
-// no surface, no presentation. Each frame the main thread hands in
-// a byte blob drained from the render sink plus the latest camera
-// view_proj; render() forwards both to `core::render::record_main_pass`
-// which uploads them and emits one draw call into the offscreen.
+// Test-bench wgpu shim. ADR-0071 phase C2: pipeline + targets moved
+// into core's `RenderRunning` (via `RenderGpu` + `install_gpu`); this
+// file is now a thin wrapper that acquires the wgpu device/queue at
+// construction and drives encoder creation + submit on each frame
+// against `RenderRunning`'s encoder-level methods.
 
-use aether_substrate_core::render::{
-    self, CaptureMeta, Pipeline, RenderError, Targets, build_main_pipeline, finish_capture,
-    prepare_capture_copy, record_main_pass,
-};
+use std::sync::Arc;
 
-pub use render::VERTEX_BUFFER_BYTES;
+use aether_substrate_core::capabilities::{RenderGpu, RenderRunning};
+use aether_substrate_core::render::RenderError;
+
+pub use aether_substrate_core::render::VERTEX_BUFFER_BYTES;
 
 /// Render target format. Test-bench commits to RGBA at init since
 /// there's no surface to query, which keeps the readback path swizzle-
@@ -18,30 +17,26 @@ pub use render::VERTEX_BUFFER_BYTES;
 const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 
 pub struct Gpu {
-    pub device: wgpu::Device,
-    pub queue: wgpu::Queue,
-    /// Snapshot of the adapter chosen at `new()`. Kept for
-    /// diagnostics — desktop also exposes this for `platform_info`,
-    /// which test-bench replies `Err` to (window-only operation), but
-    /// the field is cheap and lets the boot log report adapter info.
     pub adapter_info: wgpu::AdapterInfo,
     /// Resolved adapter limits. Kept for diagnostics; desktop uses
     /// the equivalent for `platform_info` which test-bench replies
     /// `Err` to.
     #[allow(dead_code)]
     pub limits: wgpu::Limits,
-    pipeline: Pipeline,
-    targets: Targets,
+    /// Cloned out of [`RenderGpu`] at install for ergonomic access on
+    /// the submit path; the source-of-truth lives inside `RenderRunning`.
+    queue: Arc<wgpu::Queue>,
+    device: Arc<wgpu::Device>,
+    render_running: Arc<RenderRunning>,
 }
 
 impl Gpu {
-    /// Initialise wgpu with no presentation surface. `width` and
-    /// `height` size the offscreen color + depth targets — they're
-    /// the dimensions every captured frame will report. wgpu picks
-    /// an adapter via `request_adapter` with `compatible_surface:
-    /// None`; on CI runners this resolves to whatever Vulkan/Metal/
-    /// DX12 driver is available (ADR-0067 driver fallback policy).
-    pub fn new(width: u32, height: u32) -> Self {
+    /// Initialise wgpu with no presentation surface, build the shared
+    /// pipeline + targets via [`RenderGpu::new`], install them on
+    /// `render_running` so encoder methods on the running can read
+    /// them. `width` and `height` size the offscreen color + depth
+    /// targets — the dimensions every captured frame will report.
+    pub fn new(width: u32, height: u32, render_running: Arc<RenderRunning>) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -63,89 +58,70 @@ impl Gpu {
         }))
         .expect("request_device");
 
-        let targets = Targets::new(&device, COLOR_FORMAT, width, height);
-        let pipeline = build_main_pipeline(&device, &queue, COLOR_FORMAT, wgpu::PolygonMode::Fill);
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+
+        render_running.install_gpu(RenderGpu::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            COLOR_FORMAT,
+            width,
+            height,
+            wgpu::PolygonMode::Fill,
+        ));
 
         Self {
-            device,
-            queue,
             adapter_info,
             limits,
-            pipeline,
-            targets,
+            queue,
+            device,
+            render_running,
         }
     }
 
     /// Resize the offscreen target. Test-bench has no surface, so a
     /// resize just reallocates the offscreen color + depth textures
-    /// and invalidates the readback buffer. Scenario scripts that
-    /// need a different aspect ratio can mail an advance-style
-    /// control to trigger this — for v1 the size is fixed at boot.
+    /// and invalidates the readback buffer.
     #[allow(dead_code)] // wired in PR2 alongside test_bench.advance kinds
     pub fn resize(&mut self, width: u32, height: u32) {
-        self.targets.resize(&self.device, width, height);
+        self.render_running.resize(width, height);
     }
 
-    pub fn render(&mut self, vertices: &[u8], view_proj: &[f32; 16]) {
-        let _ = self.render_impl(vertices, view_proj, false);
+    /// Draw the current accumulator's vertices into the offscreen
+    /// target with the latest camera view-proj. No presentation step
+    /// — desktop's swapchain blit is omitted because there's no
+    /// surface.
+    pub fn render(&mut self) {
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("frame encoder"),
+            });
+        match self.render_running.record_frame(&mut encoder, &[]) {
+            Ok(()) => {}
+            Err(RenderError::VertexBufferOverflow { .. }) => return,
+        }
+        self.queue.submit(std::iter::once(encoder.finish()));
     }
 
     /// Variant of `render` that also copies the offscreen texture
     /// into a readback buffer, maps it, and returns an encoded PNG.
     /// On any capture-path failure, returns `Err(reason)`; the frame
     /// still rendered to the offscreen — capture is a side channel.
-    pub fn render_and_capture(
-        &mut self,
-        vertices: &[u8],
-        view_proj: &[f32; 16],
-    ) -> Result<Vec<u8>, String> {
-        self.render_impl(vertices, view_proj, true)
-            .ok_or_else(|| "capture did not produce a result".to_owned())?
-    }
-
-    /// Draw `vertices` into the offscreen target with `view_proj` as
-    /// the camera uniform, optionally encode a capture copy. Returns
-    /// `Some(Ok(png))` / `Some(Err(reason))` when `capture` is set;
-    /// `None` when `capture` is false or the capture path couldn't
-    /// allocate. There is no presentation step — desktop's swapchain
-    /// blit is omitted because there's no surface.
-    fn render_impl(
-        &mut self,
-        vertices: &[u8],
-        view_proj: &[f32; 16],
-        capture: bool,
-    ) -> Option<Result<Vec<u8>, String>> {
+    pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("frame encoder"),
             });
-
-        match record_main_pass(
-            &self.queue,
-            &mut encoder,
-            &self.pipeline,
-            &self.targets,
-            vertices,
-            view_proj,
-            &[],
-        ) {
+        match self.render_running.record_frame(&mut encoder, &[]) {
             Ok(()) => {}
-            Err(RenderError::VertexBufferOverflow { .. }) => return None,
+            Err(RenderError::VertexBufferOverflow { .. }) => {
+                return Err("vertex buffer overflow — capture skipped".to_owned());
+            }
         }
-
-        let capture_meta: Option<CaptureMeta> = if capture {
-            Some(prepare_capture_copy(
-                &self.device,
-                &mut self.targets,
-                &mut encoder,
-            ))
-        } else {
-            None
-        };
-
+        let meta = self.render_running.record_capture_copy(&mut encoder);
         self.queue.submit(std::iter::once(encoder.finish()));
-
-        capture_meta.map(|meta| finish_capture(&self.device, &self.targets, &meta))
+        self.render_running.finish_capture(&meta)
     }
 }

--- a/crates/aether-substrate-test-bench/src/test_bench.rs
+++ b/crates/aether-substrate-test-bench/src/test_bench.rs
@@ -41,7 +41,7 @@ use aether_substrate_core::{
 
 use crate::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use crate::events::{ChassisEvent, EventReceiver, channel as event_channel};
-use crate::render::{Gpu, VERTEX_BUFFER_BYTES};
+use crate::render::Gpu;
 
 /// Default offscreen target dimensions when the caller picks
 /// `start()` (no explicit size). 800x600 matches the scenario harness
@@ -109,8 +109,10 @@ pub struct TestBench {
     events_rx: EventReceiver,
 
     gpu: Gpu,
-    frame_vertices: Arc<Mutex<Vec<u8>>>,
-    camera_state: Arc<Mutex<[f32; 16]>>,
+    /// `triangles_rendered` is read on the FrameStats emit path; the
+    /// other accumulator handles (`frame_vertices` / `camera_state`)
+    /// retired post-C2 because `RenderRunning::record_frame` drains
+    /// them internally.
     triangles_rendered: Arc<AtomicU64>,
 
     input_subscribers: InputSubscribers,
@@ -262,6 +264,7 @@ impl TestBench {
             passive,
             mut boot,
             render_handles,
+            render_running,
             kind_tick,
             kind_frame_stats,
             hub: _hub,
@@ -287,7 +290,7 @@ impl TestBench {
             );
         }
 
-        let gpu = Gpu::new(width, height);
+        let gpu = Gpu::new(width, height, render_running);
 
         let queue = Arc::clone(&boot.queue);
         let outbound = Arc::clone(&boot.outbound);
@@ -303,8 +306,6 @@ impl TestBench {
             capture_queue,
             events_rx,
             gpu,
-            frame_vertices: render_handles.frame_vertices,
-            camera_state: render_handles.camera_state,
             triangles_rendered: render_handles.triangles_rendered,
             input_subscribers,
             broadcast_mbox,
@@ -615,15 +616,9 @@ impl TestBench {
         }
         frame_loop::drain_or_abort(&self.queue, &self.outbound);
 
-        let verts = std::mem::replace(
-            &mut *self.frame_vertices.lock().unwrap(),
-            Vec::with_capacity(VERTEX_BUFFER_BYTES),
-        );
-        let view_proj = *self.camera_state.lock().unwrap();
-
         match self.capture_queue.take() {
             Some(req) => {
-                let result = match self.gpu.render_and_capture(&verts, &view_proj) {
+                let result = match self.gpu.render_and_capture() {
                     Ok(png) => CaptureFrameResult::Ok { png },
                     Err(error) => CaptureFrameResult::Err { error },
                 };
@@ -633,7 +628,7 @@ impl TestBench {
                 self.outbound.send_reply(req.reply_to, &result);
             }
             None => {
-                self.gpu.render(&verts, &view_proj);
+                self.gpu.render();
             }
         }
 


### PR DESCRIPTION
## Summary

Adds the encoder-level methods ADR-0071 specced for `RenderRunning` (`record_frame`, `record_capture_copy`, `finish_capture`, `resize`, `device`, `queue`, `color_format`, `color_size`, `with_color_texture`) plus a `RenderGpu::new` builder, and cuts both production chassis over to use them via `install_gpu`.

## What changed

**core (`aether-substrate-core/src/capabilities/render.rs`):**
- `RenderGpu::new(device, queue, color_format, width, height, polygon_mode)` builds the pipeline + targets.
- `RenderRunning` exposes 9 encoder-level methods that read the installed `RenderGpu`. `record_frame` internally drains the accumulator (frame_vertices) and reads camera_state, so chassis don't thread these through every call. Capture path: `record_capture_copy` → submit → `finish_capture`. Surface blit (desktop) uses `with_color_texture(|src| ...)` closure to access the offscreen texture under the targets mutex.

**Test-bench:**
- `Gpu::new(width, height, render_running)` acquires the wgpu device + queue, constructs `RenderGpu`, calls `install_gpu`. The `Gpu` wrapper becomes thin (~150 → ~120 lines): just adapter info, encoder lifecycle, submit. `render()` / `render_and_capture()` drop their `verts` + `view_proj` args.
- `TestBench` struct drops `frame_vertices` and `camera_state` (drained internally by record_frame). `TestBenchBuild` exposes `render_running: Arc<RenderRunning>` so the embedder can install.

**Desktop:**
- `Gpu::new(window, render_running)` acquires a surface-compatible device, configures swapchain, calls `install_gpu`, then builds the wireframe overlay pipeline post-install using the installed `RenderGpu`'s `pipeline_layout`. Same shape post-cutover for present + capture.
- The `App` struct drops `frame_vertices` / `camera_state` fields in favor of a single `render_running` clone.

## How install_gpu accommodates winit 0.30

`OnceLock<RenderGpu>` lets desktop install in `resumed` (the only place winit 0.30 hands back a window), while test-bench installs immediately after `build_passive` returns. Either path lands at the same encoder methods on `RenderRunning`. Lock-free reads post-install via `OnceLock::get()`.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (71 test suites, 0 failures, no flake this run)

## Phase C3 next

Chassis-side `Gpu` wrappers are now thin. Test-bench's `render.rs` is a candidate for inlining; desktop's keeps surface + swapchain + wireframe + adapter diagnostics. Final cleanup PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)