### PR TITLE
refactor(render): drop redundant device + queue clones from chassis Gpu (ADR-0071 phase C3)

### DIFF
--- a/crates/aether-substrate-desktop/src/render.rs
+++ b/crates/aether-substrate-desktop/src/render.rs
@@ -59,11 +59,6 @@ pub struct Gpu {
     /// anyway).
     pub adapter_info: wgpu::AdapterInfo,
     pub limits: wgpu::Limits,
-    /// Cloned out of [`RenderGpu`] at install for ergonomic access on
-    /// the surface/submit path. Source of truth lives inside
-    /// `RenderRunning` post-install.
-    device: Arc<wgpu::Device>,
-    queue: Arc<wgpu::Queue>,
     /// Wireframe overlay pipeline. `Some` only when `AETHER_WIREFRAME`
     /// is `1` / `overlay`. `record_frame` draws this after the main
     /// pipeline as an extra inside the same render pass.
@@ -257,8 +252,6 @@ impl Gpu {
             config,
             adapter_info,
             limits,
-            device,
-            queue,
             wire_pipeline,
             render_running,
         }
@@ -270,7 +263,8 @@ impl Gpu {
         }
         self.config.width = size.width;
         self.config.height = size.height;
-        self.surface.configure(&self.device, &self.config);
+        self.surface
+            .configure(&self.render_running.device(), &self.config);
         self.render_running
             .resize(self.config.width, self.config.height);
     }
@@ -297,11 +291,11 @@ impl Gpu {
     /// couldn't allocate. Surface unavailability does *not* prevent
     /// capture — offscreen is the source of truth.
     fn render_impl(&mut self, capture: bool) -> Option<Result<Vec<u8>, String>> {
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("frame encoder"),
-            });
+        let device = self.render_running.device();
+        let queue = self.render_running.queue();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("frame encoder"),
+        });
 
         let wire_ref = self.wire_pipeline.as_ref();
         let extras_storage: [&wgpu::RenderPipeline; 1];
@@ -359,7 +353,7 @@ impl Gpu {
             });
         }
 
-        self.queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(std::iter::once(encoder.finish()));
         if let Some(tex) = surface_tex {
             tex.present();
         }
@@ -375,11 +369,13 @@ impl Gpu {
         match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(t) => Some(t),
             wgpu::CurrentSurfaceTexture::Suboptimal(t) => {
-                self.surface.configure(&self.device, &self.config);
+                self.surface
+                    .configure(&self.render_running.device(), &self.config);
                 Some(t)
             }
             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
-                self.surface.configure(&self.device, &self.config);
+                self.surface
+                    .configure(&self.render_running.device(), &self.config);
                 None
             }
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => None,

--- a/crates/aether-substrate-test-bench/src/render.rs
+++ b/crates/aether-substrate-test-bench/src/render.rs
@@ -1,8 +1,9 @@
-// Test-bench wgpu shim. ADR-0071 phase C2: pipeline + targets moved
-// into core's `RenderRunning` (via `RenderGpu` + `install_gpu`); this
-// file is now a thin wrapper that acquires the wgpu device/queue at
-// construction and drives encoder creation + submit on each frame
-// against `RenderRunning`'s encoder-level methods.
+// Test-bench wgpu shim. ADR-0071 phase C3: pipeline + targets +
+// device + queue ownership all live inside core's `RenderRunning`
+// (via `RenderGpu` + `install_gpu`). What's left in this file is the
+// thinnest reasonable wrapper: device acquisition (offscreen, no
+// surface), and per-frame helpers that wrap encoder lifecycle around
+// `RenderRunning`'s encoder-level methods.
 
 use std::sync::Arc;
 
@@ -23,10 +24,6 @@ pub struct Gpu {
     /// `Err` to.
     #[allow(dead_code)]
     pub limits: wgpu::Limits,
-    /// Cloned out of [`RenderGpu`] at install for ergonomic access on
-    /// the submit path; the source-of-truth lives inside `RenderRunning`.
-    queue: Arc<wgpu::Queue>,
-    device: Arc<wgpu::Device>,
     render_running: Arc<RenderRunning>,
 }
 
@@ -58,12 +55,9 @@ impl Gpu {
         }))
         .expect("request_device");
 
-        let device = Arc::new(device);
-        let queue = Arc::new(queue);
-
         render_running.install_gpu(RenderGpu::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
+            Arc::new(device),
+            Arc::new(queue),
             COLOR_FORMAT,
             width,
             height,
@@ -73,8 +67,6 @@ impl Gpu {
         Self {
             adapter_info,
             limits,
-            queue,
-            device,
             render_running,
         }
     }
@@ -92,16 +84,16 @@ impl Gpu {
     /// — desktop's swapchain blit is omitted because there's no
     /// surface.
     pub fn render(&mut self) {
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("frame encoder"),
-            });
+        let device = self.render_running.device();
+        let queue = self.render_running.queue();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("frame encoder"),
+        });
         match self.render_running.record_frame(&mut encoder, &[]) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return,
         }
-        self.queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(std::iter::once(encoder.finish()));
     }
 
     /// Variant of `render` that also copies the offscreen texture
@@ -109,11 +101,11 @@ impl Gpu {
     /// On any capture-path failure, returns `Err(reason)`; the frame
     /// still rendered to the offscreen — capture is a side channel.
     pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("frame encoder"),
-            });
+        let device = self.render_running.device();
+        let queue = self.render_running.queue();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("frame encoder"),
+        });
         match self.render_running.record_frame(&mut encoder, &[]) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => {
@@ -121,7 +113,7 @@ impl Gpu {
             }
         }
         let meta = self.render_running.record_capture_copy(&mut encoder);
-        self.queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(std::iter::once(encoder.finish()));
         self.render_running.finish_capture(&meta)
     }
 }


### PR DESCRIPTION
## Summary

Final phase of ADR-0071 render extraction. After C2 each chassis's `Gpu` wrapper held cloned `Arc<wgpu::Device>` + `Arc<wgpu::Queue>` as convenience fields, but `RenderRunning` exposes both via `.device()` / `.queue()` (cheap Arc clones). Dropping the redundant fields makes `RenderRunning` the unambiguous source-of-truth for wgpu device/queue.

## What changed

**Test-bench:** `Gpu` shrinks to `{ adapter_info, limits, render_running }`. The per-frame `render()` / `render_and_capture()` fetch device + queue from `render_running` once at call entry. ~17 lines removed.

**Desktop:** `Gpu` shrinks to `{ surface, config, adapter_info, limits, wire_pipeline, render_running }` — surface + swapchain config are genuinely chassis-specific (no surface on test-bench), `wire_pipeline` is the optional wireframe overlay. Render path + surface reconfigure paths fetch from `render_running` on demand. ~15 lines removed.

## Where things stand on ADR-0071's render extraction

- ✅ C1: scaffolded `RenderGpu` + `install_gpu` setter (PR 496)
- ✅ C2: encoder-level methods on `RenderRunning`; both chassis cut over (PR 497)
- ✅ C3: redundant device/queue clones dropped; `RenderRunning` is sole source-of-truth (this PR)

The `Gpu` wrapper structs in both chassis are now thin enough to have one job each — test-bench: device acquisition + 3 thin per-frame helpers; desktop: surface management + wireframe overlay setup. The shared wgpu pipeline, targets, encoder-level draw recording, and capture readback all live in core's `RenderCapability` per ADR-0071's spec.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (clean, no flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)