### PR TITLE
docs(adr): flip 0070/0071 to Accepted with status updates

### DIFF
--- a/docs/adr/0070-native-capabilities-and-chassis-as-builder.md
+++ b/docs/adr/0070-native-capabilities-and-chassis-as-builder.md
@@ -1,7 +1,17 @@
 # ADR-0070: Native capabilities and chassis-as-builder
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-30
+- **Status updated:** 2026-05-01
+
+## Status update (2026-05-01)
+
+Every phase 1–6 PR shipped per the *Phasing* section. Two deviations from the *Decision* text are worth recording for future readers:
+
+1. **Bubble-up routing landed as `EgressBackend`, not as the `claim_fallback_router` slot.** The *Decision* text described a generic "fallback-router slot" — a single `fn(envelope) -> Routed | Dropped` callback the hub client claims so the substrate stays hub-agnostic. What actually shipped is `aether_substrate_core::EgressBackend`: a 7-method trait with named intents (`egress_to_session`, `egress_broadcast`, `egress_to_engine_mailbox`, `egress_unresolved_mail`, `egress_kinds_changed`, `egress_log_batch`, `is_connected`), implemented by `aether_hub::HubProtocolBackend`. Same outcome (substrate has zero hub knowledge; hub client provides the impl); cleaner shape (typed intents instead of one envelope callback). The `claim_fallback_router` slot in `ChassisCtx` is reachable but unused on the runtime path; a future cleanup ADR may retire it.
+2. **Hub crate framing dep retired by ADR-0072.** Line 87 says `aether-hub` "depends on `aether-hub-protocol` for framing." After ADR-0072, framing helpers live in `aether-codec::frame` and the hub channel wire vocabulary lives in `aether-hub::wire`. The `aether-hub-protocol` crate is retired; the dep edge described here doesn't exist anymore.
+
+Phase 7 ("sink kit ADR") remains explicitly deferred — to be picked up when a forcing function arrives.
 
 ## Context
 

--- a/docs/adr/0071-driver-capabilities-and-chassis-composition.md
+++ b/docs/adr/0071-driver-capabilities-and-chassis-composition.md
@@ -1,7 +1,18 @@
 # ADR-0071: Driver Capabilities and Chassis Composition
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-30
+- **Status updated:** 2026-05-01
+
+## Status update (2026-05-01)
+
+All seven phases shipped (PRs #485 through #498 over two days). Three deviations from the *Decision* text are worth recording for future readers:
+
+1. **Trait redefinition shipped in PR #494 (post phase 7), not in phase 2A.** The original phase-2A landing (PR #484) shipped the driver-capability traits + builder type-state + `BuiltChassis<C>` / `PassiveChassis<C>` + the `KIND` → `PROFILE` rename + the `CAPABILITIES` const removal — but kept the legacy `fn run(self) -> wasmtime::Result<()>` on `Chassis`. PR #494 finished the trait surface to match this ADR's *Trait shapes* section: `Sized + 'static`, `type Driver: DriverCapability`, `type Env`, `fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError>`, no `fn run`. Test-bench (passive chassis with no driver) declares a phantom `NeverDriver` to satisfy the bound; its trait method `build` errors with a pointer to `build_passive`.
+2. **The render capability extraction uses post-boot wgpu install, not eager construction.** The *Render capability* section (lines 218-247) sketched `RenderCapability` as owning `device: Arc<wgpu::Device>`, `queue: Arc<wgpu::Queue>`, `targets: Mutex<Targets>` etc. at construction time. winit 0.30's idioms strongly prefer lazy window creation inside `resumed`, which fires after `Capability::boot` returns — desktop's wgpu device requires surface compatibility with that window, so eager device acquisition isn't reachable on desktop. What shipped (PRs #496–#498): `RenderRunning` carries an `OnceLock<RenderGpu>` populated by the driver via `install_gpu(...)` once it has a device + queue. Test-bench installs immediately after `build_passive`; desktop installs in `resumed`. Encoder-level methods (`record_frame`, `record_capture_copy`, `finish_capture`, `resize`, `device`, `queue`, `with_color_texture`, `color_format`, `color_size`) read the installed `RenderGpu` lock-free via `OnceLock::get()`. Same outcome (RenderCapability owns wgpu state; chassis-side `Gpu` wrappers shrink to chassis-specific bits — surface + wireframe on desktop, device acquisition only on test-bench); accommodates winit's lifecycle without forcing eager window creation.
+3. **The phantom Hello-frame wire slot doesn't exist.** Line 47 says "Hub protocol's `Hello` frame currently carries these flags — for this ADR's transition window the hub sends placeholder/zeroed values; the slot stays on the wire (preserving frame layout) but the data is not load-bearing until self-description lands." `git log -S 'has_gpu' -- crates/aether-hub-protocol/src/types.rs` returns no commits — the `Hello` frame never had a CAPABILITIES field on the wire. The `CAPABILITIES` const was Rust-side only (an associated const on the `Chassis` trait), not a wire slot. The const was removed in phase 2A; no wire-format change happened or was needed.
+
+Self-describing chassis introspection, layered config (CLI > env > TOML > defaults), `#[derive(Chassis)]`, and hot-reload of chassis Env all remain as parked follow-on issues per the *Follow-on work* section.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Both ADRs reach **Accepted** after the phase-7 PR sequence (484–498) finished landing the work each one specced. Each ADR gains a "Status update (2026-05-01)" section documenting the deviations from the original Decision text that future readers should know about.

## ADR-0070 — Native capabilities and chassis-as-builder

Two recorded deviations:

1. **Bubble-up routing landed as `EgressBackend`, not as `claim_fallback_router`.** Same outcome (substrate has zero hub knowledge; hub client provides the impl); cleaner shape (typed intents instead of one envelope callback). The slot exists in `ChassisCtx` but is unused on the runtime path.
2. **Hub crate framing dep retired by ADR-0072.** Line 87's claim that aether-hub depends on aether-hub-protocol for framing no longer applies — aether-hub-protocol was retired and framing helpers moved to `aether-codec::frame`.

## ADR-0071 — Driver Capabilities and Chassis Composition

Three recorded deviations:

1. **Trait redefinition shipped in PR 494, not phase 2A.** Phase 2A (PR 484) shipped the driver-capability traits + builder type-state but kept the legacy `fn run` on `Chassis`. PR 494 finished the surface to match this ADR's spec exactly: `Sized + 'static`, `type Driver`, `type Env`, `fn build`. Test-bench uses a phantom `NeverDriver` for the bound.
2. **Render capability uses post-boot `install_gpu`, not eager construction.** winit 0.30 strongly prefers lazy window creation in `resumed`, after `Capability::boot` returns. PRs 496–498 landed `OnceLock<RenderGpu>` with `install_gpu` setter; encoder methods read lock-free via `OnceLock::get()`. Same outcome (RenderCapability owns wgpu state); accommodates winit without forcing eager window creation.
3. **Phantom Hello-frame wire slot.** Line 47 claimed the Hello frame carried CAPABILITIES flags that needed placeholder values during the transition; verified via `git log -S 'has_gpu'` — the field never existed on the wire. The `CAPABILITIES` const was Rust-side only.

ADR-0072 was already Accepted at authoring; no changes here.

## Test plan

Docs-only PR — no code changes, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)