### PR TITLE
test(component): cover sync.rs sentinel branches + per-impl mappings (issue 512)

### DIFF
--- a/crates/aether-component/src/handle.rs
+++ b/crates/aether-component/src/handle.rs
@@ -258,6 +258,7 @@ impl crate::sync::WaitError for SyncHandleError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
     use serde::Deserialize;
 
@@ -314,5 +315,29 @@ mod tests {
         }
         // Suppress Drop's host-fn call.
         core::mem::forget(handle);
+    }
+
+    /// `SyncHandleError` is the [`crate::sync::WaitError`] impl the
+    /// handle `sync_*` wrappers use, so the four trait constructors
+    /// must land on the matching enum variants.
+    #[test]
+    fn wait_error_mapping_for_sync_handle_error() {
+        use crate::sync::WaitError;
+        assert_eq!(
+            <SyncHandleError as WaitError>::timeout(),
+            SyncHandleError::Timeout
+        );
+        assert_eq!(
+            <SyncHandleError as WaitError>::buffer_too_small(),
+            SyncHandleError::BufferTooSmall
+        );
+        assert_eq!(
+            <SyncHandleError as WaitError>::cancelled(),
+            SyncHandleError::Cancelled
+        );
+        assert_eq!(
+            <SyncHandleError as WaitError>::decode("schema drift".to_string()),
+            SyncHandleError::Decode("schema drift".to_string())
+        );
     }
 }

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -329,4 +329,27 @@ mod tests {
         assert_ne!(IO_MAILBOX_NAME, "io");
         assert_ne!(IO_MAILBOX_NAME, "aether.io");
     }
+
+    /// `SyncIoError` is the [`crate::sync::WaitError`] impl the IO
+    /// `*_sync` wrappers use, so the four trait constructors must
+    /// land on the matching enum variants. A future enum reorder
+    /// would otherwise silently re-route a sentinel rc to the wrong
+    /// failure mode.
+    #[test]
+    fn wait_error_mapping_for_sync_io_error() {
+        use crate::sync::WaitError;
+        assert_eq!(<SyncIoError as WaitError>::timeout(), SyncIoError::Timeout);
+        assert_eq!(
+            <SyncIoError as WaitError>::buffer_too_small(),
+            SyncIoError::BufferTooSmall
+        );
+        assert_eq!(
+            <SyncIoError as WaitError>::cancelled(),
+            SyncIoError::Cancelled
+        );
+        assert_eq!(
+            <SyncIoError as WaitError>::decode("schema drift".to_string()),
+            SyncIoError::Decode("schema drift".to_string())
+        );
+    }
 }

--- a/crates/aether-component/src/net.rs
+++ b/crates/aether-component/src/net.rs
@@ -237,4 +237,28 @@ mod tests {
         assert_ne!(NET_MAILBOX_NAME, "net");
         assert_ne!(NET_MAILBOX_NAME, "aether.net");
     }
+
+    /// `SyncNetError` is the [`crate::sync::WaitError`] impl that
+    /// [`fetch_blocking`] uses, so the four trait constructors must
+    /// land on the matching enum variants.
+    #[test]
+    fn wait_error_mapping_for_sync_net_error() {
+        use crate::sync::WaitError;
+        assert_eq!(
+            <SyncNetError as WaitError>::timeout(),
+            SyncNetError::Timeout
+        );
+        assert_eq!(
+            <SyncNetError as WaitError>::buffer_too_small(),
+            SyncNetError::BufferTooSmall
+        );
+        assert_eq!(
+            <SyncNetError as WaitError>::cancelled(),
+            SyncNetError::Cancelled
+        );
+        assert_eq!(
+            <SyncNetError as WaitError>::decode("schema drift".to_string()),
+            SyncNetError::Decode("schema drift".to_string())
+        );
+    }
 }

--- a/crates/aether-component/src/sync.rs
+++ b/crates/aether-component/src/sync.rs
@@ -52,6 +52,20 @@ where
             expected_correlation,
         )
     };
+    decode_wait_reply::<K, E>(rc, &buf)
+}
+
+/// Pure rc → `Result<K, E>` mapping extracted from [`wait_reply`] so
+/// the four sentinel branches and the unexpected-rc fallback are
+/// testable on host targets (the FFI shim `raw::wait_reply` panics
+/// off-wasm). The happy path postcard-decodes `&buf[..rc as usize]`,
+/// matching what the in-FFI version does after the host fn writes
+/// `rc` bytes into the scratch buffer.
+pub(crate) fn decode_wait_reply<K, E>(rc: i32, buf: &[u8]) -> Result<K, E>
+where
+    K: serde::de::DeserializeOwned,
+    E: WaitError,
+{
     match rc {
         -1 => Err(E::timeout()),
         -2 => Err(E::buffer_too_small()),
@@ -63,5 +77,138 @@ where
         _ => Err(E::decode(alloc::format!(
             "unexpected wait_reply return: {rc}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    // Per-impl mapping tests cover `SyncIoError`, `SyncHandleError`,
+    // and `SyncNetError`. They live in their owning modules' test
+    // blocks so each enum's variant set stays next to its definition.
+    // The helper-level tests below exercise the rc → branch mapping
+    // itself via a dummy `WaitError` that just records which
+    // constructor fired.
+
+    /// Tag-recording stub `WaitError` so [`decode_wait_reply`] tests
+    /// can assert which sentinel branch the helper picked without
+    /// depending on any of the three production enums.
+    #[derive(Debug, PartialEq, Eq)]
+    enum DummyTag {
+        Timeout,
+        BufferTooSmall,
+        Cancelled,
+        Decode(String),
+    }
+
+    impl WaitError for DummyTag {
+        fn timeout() -> Self {
+            DummyTag::Timeout
+        }
+        fn buffer_too_small() -> Self {
+            DummyTag::BufferTooSmall
+        }
+        fn cancelled() -> Self {
+            DummyTag::Cancelled
+        }
+        fn decode(message: String) -> Self {
+            DummyTag::Decode(message)
+        }
+    }
+
+    /// Tiny payload type — postcard-encodes to a single byte so the
+    /// happy-path test can hand-craft the buffer without pulling in
+    /// any of the substrate kinds. Lives behind `Deserialize` only;
+    /// the helper doesn't need `Kind` (the kind id only flows into
+    /// the FFI call, which the extracted helper sidesteps).
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Payload(u8);
+
+    #[test]
+    fn rc_minus_one_maps_to_timeout() {
+        let res = decode_wait_reply::<Payload, DummyTag>(-1, &[]);
+        assert_eq!(res, Err(DummyTag::Timeout));
+    }
+
+    #[test]
+    fn rc_minus_two_maps_to_buffer_too_small() {
+        let res = decode_wait_reply::<Payload, DummyTag>(-2, &[]);
+        assert_eq!(res, Err(DummyTag::BufferTooSmall));
+    }
+
+    #[test]
+    fn rc_minus_three_maps_to_cancelled() {
+        let res = decode_wait_reply::<Payload, DummyTag>(-3, &[]);
+        assert_eq!(res, Err(DummyTag::Cancelled));
+    }
+
+    #[test]
+    fn unexpected_negative_rc_maps_to_decode() {
+        // -4 isn't a documented sentinel; it should fall through to
+        // the catch-all decode branch with a diagnostic that names
+        // the rc, so a future substrate-side sentinel addition is
+        // visible in the error.
+        let res = decode_wait_reply::<Payload, DummyTag>(-4, &[]);
+        match res {
+            Err(DummyTag::Decode(msg)) => {
+                assert!(
+                    msg.contains("-4"),
+                    "expected unexpected-rc message to mention -4, got {msg:?}"
+                );
+                assert!(
+                    msg.contains("unexpected wait_reply return"),
+                    "expected unexpected-rc message to be tagged, got {msg:?}"
+                );
+            }
+            other => panic!("expected DummyTag::Decode for rc=-4, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nonnegative_rc_postcard_decodes_buffer_prefix() {
+        // postcard encoding of `Payload(0x42)` is the single byte
+        // `0x42`; rc=1 tells the helper to decode the first byte.
+        // Trailing bytes in the buffer must be ignored — the FFI
+        // contract is that the host fn wrote exactly `rc` bytes.
+        let buf = [0x42u8, 0xff, 0xff];
+        let res = decode_wait_reply::<Payload, DummyTag>(1, &buf);
+        assert_eq!(res, Ok(Payload(0x42)));
+    }
+
+    #[test]
+    fn nonnegative_rc_decode_failure_maps_to_decode_variant() {
+        // postcard's varint decoder rejects an empty slice for a
+        // u8-shaped payload. The error message is postcard's, so we
+        // only assert the variant + that *some* message landed.
+        let res = decode_wait_reply::<Payload, DummyTag>(0, &[]);
+        match res {
+            Err(DummyTag::Decode(msg)) => {
+                assert!(!msg.is_empty(), "decode error message should be non-empty");
+            }
+            other => panic!("expected DummyTag::Decode for empty buffer, got {other:?}"),
+        }
+    }
+
+    /// Confirms each constructor on the trait is wired to a distinct
+    /// `DummyTag` variant — guards against a future trait-method
+    /// rename silently re-pointing one of the rc branches.
+    #[test]
+    fn dummy_wait_error_constructors_are_distinct() {
+        let tags = [
+            DummyTag::timeout(),
+            DummyTag::buffer_too_small(),
+            DummyTag::cancelled(),
+            DummyTag::decode(String::from("x")),
+        ];
+        // All four must be pairwise distinct.
+        for (i, a) in tags.iter().enumerate() {
+            for (j, b) in tags.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "constructors {i} and {j} produced the same tag");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #512 (audit Q02).

- Extracts the rc → `Result` mapping out of FFI-bound `wait_reply` into `pub(crate) fn decode_wait_reply` so the four sentinel branches and the unexpected-rc fallback are exercisable on host targets (the FFI shim `raw::wait_reply` panics off-wasm).
- Adds tests in `sync.rs` against a dummy `WaitError` impl that tags which branch fired — covers `-1` → Timeout, `-2` → BufferTooSmall, `-3` → Cancelled, `n>=0` → happy path, unexpected-rc → Decode("…").
- Adds per-impl mapping tests in `io.rs`, `handle.rs`, `net.rs` so each `WaitError` impl asserts its variant mapping next to its enum.

Behaviour identical — the FFI-bound `wait_reply` calls the new helper after the host fn writes bytes into the scratch buffer.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p aether-component`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- pr-body-ok: b — '#512' is the deliberate Closes-keyword reference required for issue auto-close -->