### PR TITLE
docs: sweep stale aether-mail refs and pre-ADR-0071 Chassis description (issue 511)

### DIFF
--- a/crates/aether-component/Cargo.toml
+++ b/crates/aether-component/Cargo.toml
@@ -36,7 +36,7 @@ aether-kinds = { path = "../aether-kinds" }
 bytemuck = { version = "1", features = ["derive"] }
 # ADR-0040 typed-state roundtrip tests derive `Serialize`/`Deserialize`
 # on fixture kinds; pull serde in as a dev-dep so tests don't rely on
-# the transitive re-export from aether-mail.
+# a transitive re-export.
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 # Issue #243: `#[derive(Kind)]` test fixtures (in `#[cfg(test)]` modules
 # of `src/lib.rs` + `src/handle.rs`) emit `inventory::submit!` on

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -94,10 +94,10 @@ pub const DISPATCH_HANDLED: u32 = 0;
 pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 
 /// Re-exports the `#[handlers]` macro relies on at expansion sites
-/// that don't depend on `aether-mail` directly (e.g., component
+/// that don't depend on `aether-data` directly (e.g., component
 /// crates that only pull in `aether-component`). Keeping the macro's
 /// emitted paths rooted at `::aether_component::__macro_internals`
-/// removes the "add aether-mail to your Cargo.toml" boilerplate that
+/// removes the "add aether-data to your Cargo.toml" boilerplate that
 /// `::aether_data::...` paths would otherwise force on every consumer.
 ///
 /// Not part of the public API; the macro is the only intended caller.

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -1,5 +1,5 @@
 //! Proc-macro home for `#[derive(Kind)]` and `#[derive(Schema)]` per
-//! ADR-0019 / ADR-0031 / ADR-0032. Kept separate from `aether-mail`
+//! ADR-0019 / ADR-0031 / ADR-0032. Kept separate from `aether-data`
 //! because Rust requires proc-macro crates to opt into
 //! `proc-macro = true` and forbids them from exporting non-macro
 //! items; pairing them in the same crate would force every consumer

--- a/crates/aether-data-derive/tests/derive.rs
+++ b/crates/aether-data-derive/tests/derive.rs
@@ -196,7 +196,7 @@ fn enum_emits_each_variant_shape_with_sequential_discriminants() {
 
 // ADR-0045 typed handle: the derive doesn't have to know about
 // `Ref<K>` syntactically — the hand-rolled `Schema` impl in
-// aether-mail dispatches through the existing trait. These tests
+// aether-data dispatches through the existing trait. These tests
 // pin that integration: a struct with a `Ref<K>` field gets a
 // `SchemaType::Ref` arm in its layout, the parent's CastEligible
 // flips to false (refs force postcard), and the wire roundtrips
@@ -321,7 +321,7 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
 }
 
 // Issue #232 — `BTreeMap<K, V>` is the deterministic map type for
-// derived kind schemas. The Schema impl in `aether-mail` lands a
+// derived kind schemas. The Schema impl in `aether-data` lands a
 // `SchemaType::Map`; the derive does no special-casing, so this is
 // trait-dispatch end-to-end.
 

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -237,9 +237,10 @@ fn variant_to_shape(v: &EnumVariant) -> crate::schema::VariantShape {
 
 /// Domain tag prefixed to every kind-id hash input so the `Kind::ID`
 /// space is disjoint from `MailboxId`. Must stay byte-identical to
-/// `aether_data::KIND_DOMAIN`; duplicated here for the same reason
-/// `fnv1a_64` is (aether-mail depends on hub-protocol, not the
-/// other way around).
+/// `crate::hash::KIND_DOMAIN`; duplicated here at module scope for
+/// the same reason `fnv1a_64_prefixed` is (the canonical-bytes path
+/// hashes `KIND_DOMAIN ++ bytes` without reaching across module
+/// boundaries).
 pub(crate) const KIND_DOMAIN: &[u8] = b"kind:";
 
 use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
@@ -269,11 +270,10 @@ pub fn kind_id_from_shape(shape: &crate::schema::KindShape) -> u64 {
 }
 
 /// FNV-1a 64 over `prefix ++ payload`, mirrored from
-/// `aether_data::fnv1a_64_prefixed`. Duplicated here because
-/// `aether-mail` depends on `aether-hub-protocol`, not the other way
-/// around — same offset basis and prime, identical output. Exposed at
-/// crate scope so the hub's canonical-bytes path can hash
-/// `KIND_DOMAIN ++ bytes` without a transient `Vec<u8>`.
+/// `crate::hash::fnv1a_64_prefixed`. Duplicated at module scope so
+/// the canonical-bytes path can hash `KIND_DOMAIN ++ bytes` without
+/// a transient `Vec<u8>` — same offset basis and prime, identical
+/// output.
 pub(crate) const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf29ce484222325;
     let mut i = 0;

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -3,7 +3,7 @@
 //! Each type is `#[repr(transparent)]` over a `u64` (postcard
 //! wire-identical to a raw u64; cast-shape kinds keep their
 //! `#[repr(C)]` layout) and exposes a `pub const TYPE_ID: u64`
-//! that downstream `Schema` impls (in `aether-mail`) emit as
+//! that downstream `Schema` impls (in `aether-data`) emit as
 //! `SchemaType::TypeId(Self::TYPE_ID)`. The hub's encoder/decoder
 //! dispatch on the `TYPE_ID` value to translate JSON (tagged-string
 //! form per ADR-0064) ↔ postcard (u64 varint) at the wire boundary.
@@ -136,7 +136,7 @@ pub struct MailboxId(pub u64);
 
 impl MailboxId {
     /// Stable type id — FNV-1a of `TYPE_DOMAIN ++ TYPE_NAME`. The
-    /// `Schema` impl (in `aether-mail`) emits this as
+    /// `Schema` impl (in `aether-data`) emits this as
     /// `SchemaType::TypeId(...)`; the hub's codec arms key on it to
     /// pick the JSON/postcard translation.
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.mailbox_id");

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -6,11 +6,16 @@
 //! peripherals (window, GPU, TCP listener, event loop) live in the
 //! chassis crate that binds this as a dependency. See ADR-0035.
 //!
-//! The `Chassis` trait (lifecycle + capabilities) is universal but
-//! intentionally narrow: `const KIND`, `const CAPABILITIES`, and
-//! `fn run(self) -> Result<()>`. Chassis-specific control kinds
-//! (desktop's `capture_frame` / `set_window_mode` / `platform_info`,
-//! hub's future routing/operator kinds) ride through
+//! The `Chassis` trait (ADR-0035, redefined by ADR-0071) is universal
+//! but intentionally narrow: `const PROFILE` (the chassis's stable
+//! identifier — `"desktop"`, `"headless"`, `"hub"`, `"test-bench"`),
+//! `type Driver: DriverCapability` (the capability that owns the main
+//! thread), `type Env` (resolved-config bag), and
+//! `fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError>`.
+//! The chassis instance you `run()` is the [`BuiltChassis<Self>`] the
+//! trait method returns, not a value of `Self` itself. Chassis-specific
+//! control kinds (desktop's `capture_frame` / `set_window_mode` /
+//! `platform_info`, hub's future routing/operator kinds) ride through
 //! `ControlPlane::chassis_handler` — the fallback closure core's
 //! dispatch falls into for unknown kinds. That keeps any single
 //! chassis from having to implement `Unsupported` stubs for

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -3,9 +3,9 @@
 
 use aether_data::{EngineId, SessionToken};
 /// Addressing token for any mailbox — component or substrate-owned sink.
-/// ADR-0065 hoisted the canonical home into `aether_mail`; this remains
-/// re-exported under the `aether_substrate::mail::MailboxId` path
-/// so existing call sites compile unchanged.
+/// ADR-0065 hoisted the canonical home into `aether_data` (per ADR-0069);
+/// this remains re-exported under the `aether_substrate::mail::MailboxId`
+/// path so existing call sites compile unchanged.
 pub use aether_data::{KindId, MailboxId};
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The


### PR DESCRIPTION
## Summary

Closes #511 (audit Q06).

- Replaces `aether-mail` mentions with `aether-data` / `aether-data-derive` in current-state docstrings across `aether-data-derive`, `aether-data`, `aether-component`, and `aether-substrate/src/mail.rs`.
- Rewrites `aether-substrate/src/lib.rs` `Chassis` description to match the ADR-0071 shape (`PROFILE` + `type Driver: DriverCapability` + `type Env` + `fn build`). The old paragraph described pre-ADR-0071 (`const KIND` / `const CAPABILITIES` / `fn run`) and contradicted `chassis.rs`.

## Decisions worth flagging

- **Proc-macro hygienic identifiers** (`__aether_mail`, etc. in `aether-data-derive/src/lib.rs`) left as-is. They're emitted-token names with no public surface impact, and the values they hold are still `Mail<'_>` — the variable name remains semantically accurate.
- **ADR text untouched** — historical record per ADR-0073.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- Docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- pr-body-ok: b — '#511' is the deliberate Closes-keyword reference required for issue auto-close -->