### PR TITLE
feat(substrate): add NativeTransport + migrate log capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
 name = "aether-substrate"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-actor",
  "aether-data",
  "aether-kinds",
  "bytemuck",

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -22,6 +22,12 @@ render = ["dep:wgpu", "dep:png"]
 audio = ["dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
+# ADR-0074 Phase 2: target-agnostic actor SDK. Capabilities install
+# `NativeTransport` (in `crate::native_transport`) as the
+# `MailTransport` impl on their dispatcher thread so they can use the
+# shared `Sink<K, T>` / `wait_reply` / `Ctx<'_, T>` machinery the
+# wasm guest path already uses.
+aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -1,4 +1,7 @@
 //! ADR-0070 Phase 3: guest-log sink as a native capability.
+//! ADR-0074 Phase 2a: first capability migrated onto the unified
+//! actor SDK — channel-drop + join lifecycle (no `Arc<AtomicBool>`
+//! polling), [`NativeTransport`] installed on the dispatcher thread.
 //!
 //! Counterpart to the `MailSubscriber` in `aether-component`: decodes
 //! `aether.log` mail the guest sent to `aether.sink.log` and re-emits
@@ -19,24 +22,17 @@
 //! main calls `boot.add_capability(LogCapability::new())?` after
 //! [`crate::SubstrateBoot::build`] returns.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
 use crate::log_sink;
+use crate::native_transport::{ActorContext, InstallGuard};
 
 /// Recipient name the log capability claims. Components mail
 /// `aether.log` (kind id) to this mailbox; the SDK's
 /// `MailSubscriber` resolves through here. ADR-0058 places
 /// chassis-owned sinks under `aether.sink.*`.
 pub const LOG_SINK_NAME: &str = "aether.sink.log";
-
-/// Polling interval for the dispatcher's shutdown check. Same shape
-/// as `HandleCapability`; see ADR-0070 §"Threading model".
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Native capability owning the ADR-0060 guest-log sink. Boots a
 /// single dispatcher thread that pulls envelopes from the
@@ -57,31 +53,59 @@ impl LogCapability {
     }
 }
 
-/// Running handle returned by [`LogCapability::boot`]. Same shape
-/// as `HandleRunning`: dispatcher thread + shutdown flag the thread
-/// polls.
+/// Running handle returned by [`LogCapability::boot`]. Holds the
+/// dispatcher's `JoinHandle` plus the [`SinkSender`] strong handle —
+/// the registry sees it as a [`std::sync::Weak`], so dropping the
+/// strong sender during shutdown disconnects the channel and the
+/// dispatcher's `recv()` returns `Err(Disconnected)` on its next
+/// iteration. No polling flag, no `recv_timeout`.
 pub struct LogRunning {
     thread: Option<JoinHandle<()>>,
-    shutdown_flag: Arc<AtomicBool>,
+    /// Drop-on-shutdown breaks the channel. Held by name so the
+    /// `RunningCapability::shutdown` impl can drop it explicitly
+    /// before joining the thread; without the explicit drop, both
+    /// would happen via `Box::<Self>::drop` in unspecified order.
+    sink_sender: Option<SinkSender>,
 }
 
 impl Capability for LogCapability {
     type Running = LogRunning;
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox(LOG_SINK_NAME)?;
-        let shutdown_flag = Arc::new(AtomicBool::new(false));
-        let thread_flag = Arc::clone(&shutdown_flag);
+        let claim = ctx.claim_mailbox_drop_on_shutdown(LOG_SINK_NAME)?;
+        let mailer = ctx.mail_send_handle();
+        let mailbox_id = claim.id;
         let receiver = claim.receiver;
 
         let thread = thread::Builder::new()
             .name("aether-log-sink".into())
             .spawn(move || {
-                while !thread_flag.load(Ordering::Relaxed) {
-                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
-                        Ok(env) => log_sink::handle_log_mail(&env.payload),
-                        Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
+                // ADR-0074 §Decision 6: install NativeTransport so
+                // any code on this thread can use the actor SDK
+                // (Sink<K, _>, wait_reply, etc.) — log doesn't send
+                // mail today, but the install is the contract every
+                // migrated capability satisfies and unblocks
+                // future log-side mail without further plumbing.
+                // The guard uninstalls on scope exit even if `recv()`
+                // ever ends up panicking.
+                let _guard = InstallGuard::install(ActorContext::new(mailer, mailbox_id, receiver));
+
+                // We can't `move` `receiver` into the install AND
+                // also into the loop body — the install's
+                // ActorContext owns it. Pull envelopes through the
+                // ActorContext's own inbox by re-borrowing through
+                // the thread-local. The ergonomics are clunky but
+                // the channel-drop semantic is what's load-bearing
+                // here; Phase 2b's handle migration introduces a
+                // helper if multiple capabilities want this shape.
+                loop {
+                    let envelope = crate::native_transport::recv_blocking();
+                    match envelope {
+                        Some(env) => log_sink::handle_log_mail(&env.payload),
+                        // `None` = `Err(Disconnected)` from the
+                        // inbox (channel-drop on shutdown). Normal
+                        // exit path — no warning.
+                        None => break,
                     }
                 }
             })
@@ -89,7 +113,7 @@ impl Capability for LogCapability {
 
         Ok(LogRunning {
             thread: Some(thread),
-            shutdown_flag,
+            sink_sender: Some(claim.sink_sender),
         })
     }
 }
@@ -98,9 +122,13 @@ impl RunningCapability for LogRunning {
     fn shutdown(self: Box<Self>) {
         let LogRunning {
             mut thread,
-            shutdown_flag,
+            mut sink_sender,
         } = *self;
-        shutdown_flag.store(true, Ordering::Relaxed);
+        // Drop the strong sender first. The registry's handler
+        // upgrade now fails (Weak); the inbox's other Senders are
+        // gone, so the dispatcher's `recv()` returns
+        // `Err(Disconnected)` and the loop exits naturally.
+        sink_sender.take();
         if let Some(t) = thread.take() {
             let _ = t.join();
         }
@@ -109,7 +137,8 @@ impl RunningCapability for LogRunning {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use super::*;
     use crate::capability::ChassisBuilder;
@@ -128,6 +157,11 @@ mod tests {
     /// tracing subscriber drops the record silently — what we're
     /// asserting is that the dispatch path doesn't panic and that
     /// shutdown joins cleanly).
+    ///
+    /// Post-ADR-0074: shutdown latency is bounded by `recv()`
+    /// returning on channel disconnect, not by a polling interval.
+    /// The test's 500ms budget stays the same; channel-drop should
+    /// land well under it.
     #[test]
     fn capability_routes_log_event_through_dispatcher() {
         let (registry, mailer) = fresh_substrate();
@@ -156,15 +190,16 @@ mod tests {
             1,
         );
 
-        // Give the dispatcher a moment to drain. recv_timeout means
-        // worst-case latency is one poll interval; test budget is
-        // 200ms.
+        // Give the dispatcher a moment to drain, then time the
+        // shutdown. Channel-drop semantics should make this
+        // near-instant — the previous `recv_timeout` shape was
+        // bounded by the 100ms poll interval.
         thread::sleep(Duration::from_millis(50));
         let start = Instant::now();
         chassis.shutdown();
         assert!(
             start.elapsed() < Duration::from_millis(500),
-            "shutdown should complete within a poll interval"
+            "shutdown should complete promptly via channel-drop"
         );
     }
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -61,6 +61,47 @@ pub struct MailboxClaim {
     pub receiver: mpsc::Receiver<Envelope>,
 }
 
+/// Result returned from [`ChassisCtx::claim_mailbox_drop_on_shutdown`].
+///
+/// Same as [`MailboxClaim`] plus a strong [`SinkSender`] the
+/// capability is expected to drop during shutdown to break the
+/// channel — the channel-drop + join lifecycle ADR-0074 §Decision 5
+/// settles on. The registry's sink-handler closure holds only a
+/// [`std::sync::Weak`] back-reference, so once the strong handle
+/// goes away, in-flight deliveries warn-drop and the dispatcher's
+/// `recv()` returns `Err(Disconnected)`.
+///
+/// Phase 2a: `LogCapability` is the first consumer; the other
+/// capabilities continue with `claim_mailbox` + `Arc<AtomicBool>`
+/// polling until their own migration PRs land.
+#[derive(Debug)]
+pub struct DropOnShutdownClaim {
+    pub id: MailboxId,
+    pub receiver: mpsc::Receiver<Envelope>,
+    pub sink_sender: SinkSender,
+}
+
+/// Strong handle to the inbound `Sender<Envelope>` for a mailbox
+/// claimed via [`ChassisCtx::claim_mailbox_drop_on_shutdown`]. Held
+/// by the capability for the lifetime of its dispatcher thread;
+/// dropping it disconnects the channel and lets the dispatcher's
+/// `recv()` return `Err(Disconnected)` immediately.
+#[derive(Debug)]
+pub struct SinkSender {
+    // Held purely for its `Drop` side effect. When this `Arc` drops
+    // and refcount hits zero, the inner `Sender` drops, the channel
+    // disconnects, and the dispatcher exits its `recv()` loop.
+    _inner: Arc<mpsc::Sender<Envelope>>,
+}
+
+impl SinkSender {
+    /// Internal constructor — only
+    /// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] builds these.
+    pub(crate) fn new(inner: Arc<mpsc::Sender<Envelope>>) -> Self {
+        Self { _inner: inner }
+    }
+}
+
 /// Generic fallback-router handler: invoked by substrate dispatch when a
 /// local mailbox lookup misses. Phase 1 stores the handler but does
 /// not call it; Phase 4 wires `Mailer::push` to consult the slot in
@@ -218,6 +259,72 @@ impl<'a> ChassisCtx<'a> {
             ),
         )?;
         Ok(MailboxClaim { id, receiver: rx })
+    }
+
+    /// Variant of [`Self::claim_mailbox`] that returns a strong
+    /// [`SinkSender`] alongside the receiver. The registry holds
+    /// only a [`std::sync::Weak`] reference to the sender, so when
+    /// the capability drops the `SinkSender` (during shutdown), the
+    /// channel disconnects and the dispatcher's `recv()` returns
+    /// `Err(Disconnected)`.
+    ///
+    /// Use this when the capability wants the channel-drop + join
+    /// shutdown lifecycle (ADR-0074 §Decision 5) instead of an
+    /// `Arc<AtomicBool>` polling flag. Phase 2a wires `LogCapability`
+    /// onto this; the other native capabilities migrate one PR at a
+    /// time per the issue 509 plan.
+    pub fn claim_mailbox_drop_on_shutdown(
+        &mut self,
+        name: &str,
+    ) -> Result<DropOnShutdownClaim, BootError> {
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        // Strong Arc rides on `DropOnShutdownClaim.sink_sender` and
+        // lives for the capability's lifetime. The registry handler
+        // only upgrades a `Weak` per call, so when the capability
+        // drops its strong handle, the inner `Sender` also drops
+        // and the dispatcher's `recv()` returns `Err(Disconnected)`.
+        let tx = Arc::new(tx);
+        let weak = Arc::downgrade(&tx);
+        let id = self.registry.try_register_sink(
+            name.to_owned(),
+            Arc::new(
+                move |kind: KindId,
+                      kind_name: &str,
+                      origin: Option<&str>,
+                      sender: ReplyTo,
+                      payload: &[u8],
+                      count: u32| {
+                    let Some(tx) = weak.upgrade() else {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            kind = kind_name,
+                            "capability mailbox sender dropped — mail discarded"
+                        );
+                        return;
+                    };
+                    let env = Envelope {
+                        kind,
+                        kind_name: kind_name.to_owned(),
+                        origin: origin.map(str::to_owned),
+                        sender,
+                        payload: payload.to_vec(),
+                        count,
+                    };
+                    if tx.send(env).is_err() {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            kind = kind_name,
+                            "capability mailbox receiver dropped — mail discarded"
+                        );
+                    }
+                },
+            ),
+        )?;
+        Ok(DropOnShutdownClaim {
+            id,
+            receiver: rx,
+            sink_sender: SinkSender::new(tx),
+        })
     }
 
     /// Clone-able mail-send handle. Capabilities stash this into

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -45,6 +45,7 @@ pub mod log_capture;
 pub mod log_sink;
 pub mod mail;
 pub mod mailer;
+pub mod native_transport;
 pub mod outbound;
 pub mod panic_hook;
 pub mod registry;
@@ -55,8 +56,8 @@ pub mod scheduler;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
-    BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx, Envelope, FallbackRouter,
-    MailboxClaim, RunningCapability,
+    BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx, DropOnShutdownClaim,
+    Envelope, FallbackRouter, MailboxClaim, RunningCapability, SinkSender,
 };
 pub use chassis::Chassis;
 pub use chassis_builder::{
@@ -69,6 +70,7 @@ pub use ctx::SubstrateCtx;
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
+pub use native_transport::{ActorContext, InstallGuard, NativeTransport};
 pub use outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, LogEntry, LogLevel, RecordingBackend,
 };

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -1,0 +1,506 @@
+//! ADR-0074 §Decision 6: native-side `MailTransport` implementation.
+//!
+//! [`NativeTransport`] is a ZST that implements
+//! [`aether_actor::MailTransport`] by forwarding each call to the
+//! per-actor state stored in a thread-local. Native capabilities call
+//! [`install`] at the top of their dispatcher thread and [`uninstall`]
+//! before the thread exits; in between, code running on that thread
+//! can use the same `Sink<K, T>` / `wait_reply` / `Ctx<'_, T>`
+//! machinery the wasm guest path uses through `WasmTransport`.
+//!
+//! Phase 2a wires `LogCapability` onto this. Log doesn't currently
+//! send mail or wait on replies, so the migration is exercising the
+//! lifecycle (channel-drop + join) and the install/uninstall plumbing
+//! more than the transport methods themselves. The other capabilities
+//! migrate one PR at a time per the issue 509 plan; `reply_mail` and
+//! `save_state` are tracked stubs until the first capability that
+//! needs each one (handle for `reply_mail` in Phase 2b; native actors
+//! don't migrate, so `save_state` stays a stub indefinitely).
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::{Duration, Instant};
+
+use aether_actor::MailTransport;
+
+use crate::capability::Envelope;
+use crate::mail::{KindId, Mail, MailboxId, ReplyTarget, ReplyTo};
+use crate::mailer::Mailer;
+
+/// Per-actor state the [`NativeTransport`] methods need access to.
+/// Lives in a thread-local owned by the actor's dispatcher thread; the
+/// capability builds it during boot and hands it to [`install`].
+///
+/// Capability-internal: callers don't construct this directly. The
+/// fields are crate-private so future extensions (per-actor
+/// observability, panic recovery, etc.) don't break consumers.
+pub struct ActorContext {
+    pub(crate) mailer: Arc<Mailer>,
+    pub(crate) self_mailbox: MailboxId,
+    pub(crate) inbox: std::sync::mpsc::Receiver<Envelope>,
+    pub(crate) overflow: VecDeque<Envelope>,
+    pub(crate) correlation: u64,
+}
+
+impl ActorContext {
+    /// Build a fresh context. `inbox` is the receiver half of the
+    /// mpsc channel registered by `claim_mailbox` /
+    /// `claim_mailbox_drop_on_shutdown`; `mailer` is
+    /// `ChassisCtx::mail_send_handle()`; `self_mailbox` is the id the
+    /// claim returned (used as the `Component` reply-target so
+    /// replies route back to this actor's inbox via the mailer).
+    pub fn new(
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+        inbox: std::sync::mpsc::Receiver<Envelope>,
+    ) -> Self {
+        Self {
+            mailer,
+            self_mailbox,
+            inbox,
+            overflow: VecDeque::new(),
+            correlation: 0,
+        }
+    }
+}
+
+thread_local! {
+    /// At most one `ActorContext` is installed per thread at any time.
+    /// `RefCell` is the right primitive — single-threaded by
+    /// construction (a thread-local can't be aliased across threads),
+    /// `borrow_mut` is the load-bearing operation for `send_mail` /
+    /// `wait_reply`. Reentrancy is structurally impossible: nothing
+    /// `NativeTransport` does calls back into another transport
+    /// method on the same thread.
+    static CURRENT: RefCell<Option<ActorContext>> = const { RefCell::new(None) };
+}
+
+/// Install `ctx` as the current actor context for this thread.
+/// Panics if a context is already installed — capabilities are
+/// expected to call this exactly once per dispatcher thread, at the
+/// top of the spawn closure. The matching [`uninstall`] runs at the
+/// end (or on `Drop` if the closure panics, see [`InstallGuard`]).
+pub fn install(ctx: ActorContext) {
+    CURRENT.with(|c| {
+        let mut slot = c.borrow_mut();
+        if slot.is_some() {
+            panic!(
+                "NativeTransport::install called twice on the same thread \
+                 — capabilities install once per dispatcher thread"
+            );
+        }
+        *slot = Some(ctx);
+    });
+}
+
+/// Uninstall the current actor context, dropping the inbox receiver
+/// and any overflow. No-op if nothing was installed.
+pub fn uninstall() {
+    CURRENT.with(|c| {
+        c.borrow_mut().take();
+    });
+}
+
+/// Block until the next envelope arrives on the current actor's
+/// inbox. Returns `None` when the channel disconnects (the
+/// channel-drop shutdown signal — capability's `RunningCapability::
+/// shutdown` dropped its [`SinkSender`](crate::capability::SinkSender),
+/// the registry handler can no longer upgrade its [`std::sync::Weak`],
+/// the inbox's last sender is gone) or when called outside an actor
+/// context.
+///
+/// The borrow is held only for the duration of the `recv()` call —
+/// because dispatcher threads are single-tasked while parked, this
+/// is safe; the user code that processes the returned envelope runs
+/// after the borrow is released, so it can freely call `send_mail` /
+/// `wait_reply` etc. without conflicting with the inbox borrow.
+pub fn recv_blocking() -> Option<Envelope> {
+    CURRENT.with(|c| {
+        let slot = c.borrow();
+        let ctx = slot.as_ref()?;
+        ctx.inbox.recv().ok()
+    })
+}
+
+/// Non-blocking variant of [`recv_blocking`]. Returns `None` for
+/// "no envelope available right now" or "channel disconnected" or
+/// "no actor context installed" — a capability that needs to
+/// distinguish drains the inbox via repeated calls until `None`.
+pub fn try_recv() -> Option<Envelope> {
+    CURRENT.with(|c| {
+        let slot = c.borrow();
+        let ctx = slot.as_ref()?;
+        ctx.inbox.try_recv().ok()
+    })
+}
+
+/// RAII guard so a panicking dispatcher thread still uninstalls its
+/// context. Capabilities that prefer the guarded shape do
+/// `let _guard = InstallGuard::install(ctx);` at the top of their
+/// thread and let the guard drop on scope exit.
+pub struct InstallGuard {
+    _private: (),
+}
+
+impl InstallGuard {
+    pub fn install(ctx: ActorContext) -> Self {
+        install(ctx);
+        Self { _private: () }
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        uninstall();
+    }
+}
+
+/// ZST `MailTransport` impl for the native-actor path. See module
+/// docs for the install/uninstall protocol.
+pub struct NativeTransport;
+
+/// Return code surfaced when the actor SDK is called from a thread
+/// that hasn't installed an [`ActorContext`]. Surfaces as a non-zero
+/// `u32` from `send_mail` / `reply_mail` / `save_state` and as the
+/// "decode" branch (an unexpected negative return) from
+/// `wait_reply`.
+const ERR_NO_CONTEXT: u32 = 0xFFFF_FF00;
+
+impl MailTransport for NativeTransport {
+    fn send_mail(recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+        // Pull everything we need out of the thread-local under one
+        // borrow, then release before calling `mailer.push` — push
+        // resolves recipient and may invoke a sink handler synchronously
+        // on this thread. Holding the borrow across that call would
+        // deadlock if any sink handler ever reaches into NativeTransport
+        // (none do today, but releasing first is the safer shape).
+        let pushed = CURRENT.with(|c| {
+            let mut slot = c.borrow_mut();
+            let ctx = slot.as_mut()?;
+            ctx.correlation = ctx.correlation.wrapping_add(1);
+            let correlation = ctx.correlation;
+            let mailer = Arc::clone(&ctx.mailer);
+            let reply_to =
+                ReplyTo::with_correlation(ReplyTarget::Component(ctx.self_mailbox), correlation);
+            let mail = Mail::new(MailboxId(recipient), KindId(kind), bytes.to_vec(), count)
+                .with_reply_to(reply_to)
+                .with_origin(ctx.self_mailbox);
+            Some((mailer, mail))
+        });
+
+        match pushed {
+            Some((mailer, mail)) => {
+                mailer.push(mail);
+                0
+            }
+            None => {
+                tracing::error!(
+                    target: "aether_substrate::native_transport",
+                    "send_mail called outside actor context — install() never ran"
+                );
+                ERR_NO_CONTEXT
+            }
+        }
+    }
+
+    fn reply_mail(_sender: u32, _kind: u64, _bytes: &[u8], _count: u32) -> u32 {
+        // ADR-0074 Phase 2b: the first capability that needs reply
+        // is handle (round-trips `Handle{Publish,Release,Pin,Unpin}Result`
+        // back to the sender). Until then, the bare-bytes →
+        // `Mailer::send_reply` bridge isn't worth designing. Log
+        // doesn't reply.
+        tracing::error!(
+            target: "aether_substrate::native_transport",
+            "NativeTransport::reply_mail not yet implemented — Phase 2b lands this when handle migrates"
+        );
+        ERR_NO_CONTEXT
+    }
+
+    fn save_state(_version: u32, _bytes: &[u8]) -> u32 {
+        // Native actors don't have a `replace_component`-style hot
+        // reload path (only wasm components do, ADR-0016). The trait
+        // method is part of the unified SDK signature; the native
+        // impl returns an error sentinel so a misuse is loud.
+        tracing::error!(
+            target: "aether_substrate::native_transport",
+            "NativeTransport::save_state called — native actors don't migrate"
+        );
+        ERR_NO_CONTEXT
+    }
+
+    fn wait_reply(
+        expected_kind: u64,
+        out: &mut [u8],
+        timeout_ms: u32,
+        expected_correlation: u64,
+    ) -> i32 {
+        let timeout = Duration::from_millis(timeout_ms as u64);
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            // Drain the overflow first — a previous `wait_reply` call
+            // may have parked envelopes that match this kind /
+            // correlation. Mirrors `SubstrateCtx::wait_reply` on the
+            // wasm side (component.rs).
+            let from_overflow = CURRENT.with(|c| {
+                let mut slot = c.borrow_mut();
+                let ctx = slot.as_mut()?;
+                let pos = ctx
+                    .overflow
+                    .iter()
+                    .position(|env| matches_filter(env, expected_kind, expected_correlation))?;
+                ctx.overflow.remove(pos)
+            });
+            if let Some(env) = from_overflow {
+                return write_payload(&env, out);
+            }
+
+            // Block on the inbox for the remaining time. The borrow
+            // stays open across `recv_timeout` because the dispatcher
+            // thread is single-tasked while parked here — no other
+            // code on this thread re-enters NativeTransport. (Sink
+            // handlers that the registry invokes run on the SENDER
+            // thread, not this one.)
+            let recv_outcome = CURRENT.with(|c| {
+                let slot = c.borrow();
+                let ctx = slot.as_ref()?;
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                Some(ctx.inbox.recv_timeout(remaining))
+            });
+
+            match recv_outcome {
+                None => return -ERR_NO_CONTEXT_I32,
+                Some(Ok(env)) => {
+                    if matches_filter(&env, expected_kind, expected_correlation) {
+                        return write_payload(&env, out);
+                    }
+                    // Mismatch — park into overflow so a future
+                    // `wait_reply` for that kind/correlation finds it.
+                    CURRENT.with(|c| {
+                        if let Some(ctx) = c.borrow_mut().as_mut() {
+                            ctx.overflow.push_back(env);
+                        }
+                    });
+                    // Loop continues — try again with whatever time
+                    // is left on the deadline.
+                }
+                Some(Err(RecvTimeoutError::Timeout)) => return -1,
+                Some(Err(RecvTimeoutError::Disconnected)) => return -3,
+            }
+        }
+    }
+
+    fn prev_correlation() -> u64 {
+        CURRENT.with(|c| c.borrow().as_ref().map(|ctx| ctx.correlation).unwrap_or(0))
+    }
+}
+
+/// Negative-return form of [`ERR_NO_CONTEXT`] for `wait_reply`. Picked
+/// to be distinct from the documented sentinels (`-1`, `-2`, `-3`) so
+/// the SDK's `decode_wait_reply` falls into the unknown-rc branch and
+/// surfaces "missing actor context" by name in the error message.
+const ERR_NO_CONTEXT_I32: i32 = 100;
+
+fn matches_filter(env: &Envelope, expected_kind: u64, expected_correlation: u64) -> bool {
+    env.kind.0 == expected_kind
+        && (expected_correlation == ReplyTo::NO_CORRELATION
+            || env.sender.correlation_id == expected_correlation)
+}
+
+/// Copy `env.payload` into `out` and return the number of bytes
+/// written, matching the wasm `wait_reply_p32` ABI:
+/// `>= 0` = bytes written, `-2` = payload too large for the buffer
+/// (envelope is dropped — wasm re-parks but native callers should
+/// retry with a bigger buffer).
+fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
+    if env.payload.len() > out.len() {
+        // ADR-0042 sentinel `-2`. The wasm side re-parks the mail
+        // for retry; the native overflow already drained the env in
+        // the calling block, so a "too small" reply is unrecoverable
+        // without growing the caller's buffer.
+        tracing::warn!(
+            target: "aether_substrate::native_transport",
+            payload_len = env.payload.len(),
+            buffer_len = out.len(),
+            "wait_reply buffer too small — envelope dropped"
+        );
+        return -2;
+    }
+    out[..env.payload.len()].copy_from_slice(&env.payload);
+    env.payload.len() as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::ChassisBuilder;
+    use crate::registry::Registry;
+    use crate::scheduler::ComponentTable;
+    use std::collections::HashMap;
+    use std::sync::{RwLock, mpsc};
+    use std::thread;
+
+    /// Smoke: `install` panics if called twice without an `uninstall`
+    /// in between. Catches a capability that forgot to clean up.
+    #[test]
+    fn double_install_panics() {
+        // Build a minimal context — registry + mailer don't matter,
+        // they're never invoked.
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new());
+        let _ = mailer; // keep arc alive
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        drop(tx);
+        let ctx = ActorContext::new(Arc::new(Mailer::new()), MailboxId(1), rx);
+
+        // Run on a fresh thread so we don't pollute other tests'
+        // thread-local state.
+        let result = thread::spawn(move || {
+            install(ctx);
+            // Second install with a different ctx must panic.
+            let (_tx2, rx2) = mpsc::channel::<Envelope>();
+            install(ActorContext::new(
+                Arc::new(Mailer::new()),
+                MailboxId(2),
+                rx2,
+            ));
+        })
+        .join();
+
+        assert!(result.is_err(), "double install should panic");
+        let _ = registry; // suppress unused warning on Linux
+    }
+
+    /// `uninstall` works even if nothing was installed (idempotent
+    /// teardown so a partial-boot path can still call it).
+    #[test]
+    fn uninstall_without_install_is_noop() {
+        thread::spawn(|| {
+            uninstall();
+            uninstall();
+        })
+        .join()
+        .expect("uninstall should not panic");
+    }
+
+    /// `InstallGuard` uninstalls on drop — verified by checking that
+    /// a second install on the same thread succeeds after the guard
+    /// goes out of scope.
+    #[test]
+    fn install_guard_uninstalls_on_drop() {
+        thread::spawn(|| {
+            let (_tx, rx) = mpsc::channel::<Envelope>();
+            let ctx = ActorContext::new(Arc::new(Mailer::new()), MailboxId(1), rx);
+            {
+                let _guard = InstallGuard::install(ctx);
+                // Inside the scope: a second install would panic.
+            }
+            // Guard dropped — install should succeed again.
+            let (_tx2, rx2) = mpsc::channel::<Envelope>();
+            let ctx2 = ActorContext::new(Arc::new(Mailer::new()), MailboxId(2), rx2);
+            install(ctx2);
+            uninstall();
+        })
+        .join()
+        .expect("guard should release the slot on drop");
+    }
+
+    /// `prev_correlation` returns 0 outside an actor context and
+    /// monotonically increases as `send_mail` mints correlations.
+    #[test]
+    fn prev_correlation_tracks_send_mail_minting() {
+        thread::spawn(|| {
+            // Outside context: 0.
+            assert_eq!(NativeTransport::prev_correlation(), 0);
+
+            // Build a chassis-shaped context. Use the builder so the
+            // mailer is wired with a real registry + components table
+            // (push needs them).
+            let registry = Arc::new(Registry::new());
+            let mailer = Arc::new(Mailer::new());
+            // Mailer needs a ComponentTable wired before push works.
+            // Build through ChassisBuilder which doesn't wire it
+            // either — but we don't actually push here, just mint
+            // correlations. send_mail's push step will fail because
+            // the recipient is unknown, but the correlation is minted
+            // before push. Use a name we register as a sink so push
+            // routes to the sink handler (which drops the message).
+            let _ = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer));
+            // Wire mailer for push to be safe to call.
+            let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+            mailer.wire(Arc::clone(&registry), components);
+
+            let (tx, rx) = mpsc::channel::<Envelope>();
+            // Register a sink that swallows the env so push doesn't
+            // hit the unknown-recipient warning path.
+            registry.register_sink(
+                "test.sink",
+                Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                    let _ = tx.send(Envelope {
+                        kind,
+                        kind_name: kind_name.to_owned(),
+                        origin: origin.map(str::to_owned),
+                        sender,
+                        payload: payload.to_vec(),
+                        count,
+                    });
+                }),
+            );
+            let recipient = registry.lookup("test.sink").unwrap();
+
+            install(ActorContext::new(mailer, MailboxId(99), rx));
+
+            assert_eq!(NativeTransport::prev_correlation(), 0);
+            assert_eq!(NativeTransport::send_mail(recipient.0, 1, &[], 1), 0);
+            assert_eq!(NativeTransport::prev_correlation(), 1);
+            assert_eq!(NativeTransport::send_mail(recipient.0, 1, &[], 1), 0);
+            assert_eq!(NativeTransport::prev_correlation(), 2);
+
+            uninstall();
+            assert_eq!(NativeTransport::prev_correlation(), 0);
+        })
+        .join()
+        .expect("test thread should not panic");
+    }
+
+    /// `send_mail` outside an actor context returns the no-context
+    /// sentinel rather than panicking.
+    #[test]
+    fn send_mail_without_context_returns_no_context_sentinel() {
+        thread::spawn(|| {
+            let rc = NativeTransport::send_mail(0, 0, &[], 0);
+            assert_eq!(rc, ERR_NO_CONTEXT);
+        })
+        .join()
+        .expect("send_mail outside context should not panic");
+    }
+
+    /// `wait_reply` outside an actor context returns the no-context
+    /// negative sentinel — the SDK surfaces this as a decode-branch
+    /// error naming the rc.
+    #[test]
+    fn wait_reply_without_context_returns_no_context_sentinel() {
+        thread::spawn(|| {
+            let mut buf = [0u8; 16];
+            let rc = NativeTransport::wait_reply(0, &mut buf, 1, 0);
+            assert_eq!(rc, -ERR_NO_CONTEXT_I32);
+        })
+        .join()
+        .expect("wait_reply outside context should not panic");
+    }
+
+    /// `reply_mail` and `save_state` are tracked stubs — Phase 2a
+    /// pins their behaviour so a future implementation can be a
+    /// straight diff against the test.
+    #[test]
+    fn reply_mail_and_save_state_are_tracked_stubs() {
+        thread::spawn(|| {
+            assert_eq!(NativeTransport::reply_mail(0, 0, &[], 0), ERR_NO_CONTEXT);
+            assert_eq!(NativeTransport::save_state(0, &[]), ERR_NO_CONTEXT);
+        })
+        .join()
+        .expect("stub returns should not panic");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2a of ADR-0074. First half of Phase 2 — implements the native counterpart to PR #517's `WasmTransport` and migrates the smallest capability (log) onto the unified actor SDK + channel-drop + join lifecycle.

`NativeTransport` (in `aether_substrate::native_transport`) is a ZST that implements `aether_actor::MailTransport` by delegating to per-actor state held in a thread-local `ActorContext` (mailer + self mailbox + inbox + overflow + correlation counter). Capabilities call `install` at the top of their dispatcher thread and either `uninstall` at the bottom or use `InstallGuard` for panic safety.

`send_mail`, `wait_reply`, and `prev_correlation` are real impls; `reply_mail` is a tracked stub until handle migrates in Phase 2b (the first capability that needs to round-trip a typed reply through the SDK), and `save_state` is a permanent stub (native actors don't have a `replace_component`-style hot reload path — that's wasm-only per ADR-0016).

`ChassisCtx::claim_mailbox_drop_on_shutdown` is the new entry point for capabilities opting into channel-drop. The registry's sink-handler holds only a `Weak` back-reference to the inbox sender; the strong `SinkSender` rides on the `DropOnShutdownClaim` and the capability drops it during shutdown to disconnect the channel. The dispatcher's `recv()` returns `Err(Disconnected)` and the loop exits naturally — no `Arc<AtomicBool>` flag, no `recv_timeout` poll interval, no worst-case-100ms shutdown latency.

`LogCapability` is the first consumer. The other native capabilities (handle, audio, io, net) keep their existing `Arc<AtomicBool>` + `recv_timeout` shape until their own migration PRs land. The original `claim_mailbox` API is unchanged, so they're zero-churn.

## Why no auto-close

This is one PR of many in issue 509's Phase 2 (handle, audio, io, net all still to migrate) plus Phase 3 (render collapse), Phase 4 (host-side wait_reply + cross-class guard), Phase 5 (wire rename). The issue stays open until the last phase ships.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` — no failures (7 new NativeTransport unit tests, log capability tests still pass)
- [x] `cargo check -p aether-component --target wasm32-unknown-unknown` clean (PR #517 wasm path unaffected)
- [x] `cargo test -p aether-scenario` — all 8 integration tests pass

<!-- pr-body-ok: b — 'issue 509' is the intentional cross-reference to the implementation tracker; '#517' is the merged Phase 1 ADR-0074 PR being built on; auto-close would be wrong (multiple phases remain) -->