### PR TITLE
refactor(actor): mailtransport &self + nativetransport + log migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
 name = "aether-substrate"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-actor",
  "aether-data",
  "aether-kinds",
  "bytemuck",

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -1,16 +1,17 @@
 //! Lifecycle capability handles — `InitCtx`, `Ctx`, `DropCtx`. All
-//! three are generic over `T: MailTransport` so their `send` / `reply`
-//! / `save_state` bodies dispatch through the consumer crate's
-//! transport impl. Existing wasm components see them via 1-arg type
-//! aliases in `aether-component` (`pub type Ctx<'a> = aether_actor::
-//! Ctx<'a, WasmTransport>`), so user code keeps writing `Ctx<'_>`.
+//! three are generic over `T: MailTransport` AND borrow a transport
+//! reference for the lifetime of the receive call. `send` / `reply`
+//! / `save_state` etc. dispatch through `self.transport` rather than
+//! a static-method trait — that's what lets `NativeTransport` carry
+//! per-actor state in regular fields instead of a thread-local.
 //!
-//! The split between the three handles is the same as today:
-//! `InitCtx` is init-only (resolve is a compile-time op now, but the
-//! handle threads the component's mailbox id and is the right place
-//! for input-stream subscriptions); `Ctx` is the per-receive vocabulary
-//! (send, reply, publish); `DropCtx` is the narrowed shutdown surface
-//! (send + save_state, no reply).
+//! Existing wasm components see them via 1-arg type aliases in
+//! `aether-component` (`pub type Ctx<'a> = aether_actor::Ctx<'a,
+//! WasmTransport>`), so user code keeps writing `Ctx<'_>`. The
+//! transport reference is supplied internally — for the wasm path
+//! that's `&WASM_TRANSPORT` (a `pub static` ZST defined in
+//! `aether-component`); for native that's the capability's owned
+//! `NativeTransport`.
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -27,25 +28,37 @@ use crate::transport::MailTransport;
 /// send?" (receive only) at compile time — calling `resolve` from a
 /// `&mut Ctx` is a type error, not a convention.
 ///
-/// The component's own mailbox id rides here — the substrate passes it
-/// into `init` at instantiation (ADR-0030 Phase 2) and the SDK uses
-/// it to self-address `aether.control.subscribe_input` mails for
-/// every `K::IS_INPUT` kind handled by the component.
+/// Carries a borrow of the actor's transport instance so `send` /
+/// `subscribe_input` / `publish` can dispatch through it without
+/// touching a thread-local. The component's own mailbox id rides
+/// here too — the substrate passes it into `init` at instantiation
+/// (ADR-0030 Phase 2) and the SDK uses it to self-address
+/// `aether.control.subscribe_input` mails for every `K::IS_INPUT`
+/// kind handled by the component.
 pub struct InitCtx<'a, T: MailTransport> {
+    transport: &'a T,
     mailbox: u64,
     _borrow: PhantomData<&'a ()>,
-    _t: PhantomData<fn() -> T>,
 }
 
-impl<T: MailTransport> InitCtx<'_, T> {
+impl<'a, T: MailTransport> InitCtx<'a, T> {
     /// Not part of the public API; called only by `export!`.
     #[doc(hidden)]
-    pub fn __new(mailbox: u64) -> Self {
+    pub fn __new(transport: &'a T, mailbox: u64) -> Self {
         InitCtx {
+            transport,
             mailbox,
             _borrow: PhantomData,
-            _t: PhantomData,
         }
+    }
+
+    /// Borrow the actor's transport. Exposed for advanced callers
+    /// (lower-level helpers that resolve a `Sink` and want to call
+    /// `Sink::send` directly with the transport ref); typical
+    /// component code goes through the `publish` / `subscribe_input`
+    /// methods on this handle instead.
+    pub fn transport(&self) -> &T {
+        self.transport
     }
 
     /// The component's own mailbox id — the value the substrate uses
@@ -75,7 +88,7 @@ impl<T: MailTransport> InitCtx<'_, T> {
         &self,
         value: &K,
     ) -> Result<Handle<K, T>, SyncHandleError> {
-        handle::publish::<K, T>(value)
+        handle::publish::<K, T>(self.transport, value)
     }
 
     /// Send `aether.control.subscribe_input` with this component's
@@ -90,7 +103,7 @@ impl<T: MailTransport> InitCtx<'_, T> {
             kind: <K as Kind>::ID,
             mailbox: ::aether_data::MailboxId(self.mailbox),
         };
-        resolve_sink::<SubscribeInput, T>("aether.control").send(&payload);
+        resolve_sink::<SubscribeInput, T>("aether.control").send(self.transport, &payload);
     }
 }
 
@@ -98,26 +111,29 @@ impl<T: MailTransport> InitCtx<'_, T> {
 /// Resolution is intentionally absent — runtime resolution after init
 /// is not a supported shape.
 ///
-/// ADR-0033: typed handlers receive `K` by value, so they no longer
-/// hold a `Mail<'_>` to call `mail.reply_to()` on. The synthesized
-/// dispatcher threads the inbound mail's sender onto `Ctx` via
-/// `__set_reply_to` before every handler call, and `Ctx::reply_to()`
-/// reads it back. `#[fallback]` methods still receive the raw
-/// `Mail<'_>` and can call `mail.reply_to()` directly.
+/// Holds the transport borrow so `ctx.send(&sink, &payload)` is the
+/// natural call shape inside a handler — no need for the user to
+/// thread a transport reference through every send. ADR-0033: typed
+/// handlers receive `K` by value, so they no longer hold a `Mail<'_>`
+/// to call `mail.reply_to()` on. The synthesized dispatcher threads
+/// the inbound mail's sender onto `Ctx` via `__set_reply_to` before
+/// every handler call, and `Ctx::reply_to()` reads it back.
+/// `#[fallback]` methods still receive the raw `Mail<'_>` and can
+/// call `mail.reply_to()` directly.
 pub struct Ctx<'a, T: MailTransport> {
+    transport: &'a T,
     sender: Option<u32>,
     _borrow: PhantomData<&'a ()>,
-    _t: PhantomData<fn() -> T>,
 }
 
-impl<T: MailTransport> Ctx<'_, T> {
+impl<'a, T: MailTransport> Ctx<'a, T> {
     /// Not part of the public API; called only by `export!`.
     #[doc(hidden)]
-    pub fn __new() -> Self {
+    pub fn __new(transport: &'a T) -> Self {
         Ctx {
+            transport,
             sender: None,
             _borrow: PhantomData,
-            _t: PhantomData,
         }
     }
 
@@ -128,6 +144,14 @@ impl<T: MailTransport> Ctx<'_, T> {
     #[doc(hidden)]
     pub fn __set_reply_to(&mut self, sender: Option<ReplyTo>) {
         self.sender = sender.map(|s| s.raw());
+    }
+
+    /// Borrow the actor's transport. Exposed for callers that want to
+    /// call `Sink::send` or one of the `handle::publish` family
+    /// helpers directly with the transport ref instead of going
+    /// through `Ctx::send` / `Ctx::publish`.
+    pub fn transport(&self) -> &T {
+        self.transport
     }
 
     /// Reply handle for the mail currently being dispatched. `None`
@@ -145,25 +169,24 @@ impl<T: MailTransport> Ctx<'_, T> {
     /// vocabulary, `Sink::send` is the universal one. Wire shape
     /// (cast or postcard) is the kind's, not the call's (issue #240).
     pub fn send<K: Kind>(&self, sink: &Sink<K, T>, payload: &K) {
-        sink.send(payload);
+        sink.send(self.transport, payload);
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —
     /// see [`Sink::send_many`] for the wire-shape rationale.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K, T>, payloads: &[K]) {
-        sink.send_many(payloads);
+        sink.send_many(self.transport, payloads);
     }
 
     /// Publish `value` into the substrate's handle store. Returns
-    /// the typed [`Handle<K>`] — its RAII drop fires
-    /// `HandleRelease` so the publisher's refcount goes back to
-    /// zero when the handle leaves scope. See [`handle::publish`]
-    /// for the synchronous round-trip semantics.
+    /// the typed [`Handle<K, T>`] — no auto-release on drop (see
+    /// [`Handle`] for the rationale); call `handle.release(ctx.transport())`
+    /// or let the substrate's LRU evict.
     pub fn publish<K: Kind + serde::Serialize>(
         &self,
         value: &K,
     ) -> Result<Handle<K, T>, SyncHandleError> {
-        handle::publish::<K, T>(value)
+        handle::publish::<K, T>(self.transport, value)
     }
 
     /// Reply to the Claude session that originated the inbound mail
@@ -179,7 +202,8 @@ impl<T: MailTransport> Ctx<'_, T> {
     /// derive-time autodetect as `Ctx::send`.
     pub fn reply<K: Kind>(&self, sender: ReplyTo, kind: KindId<K>, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        T::reply_mail(sender.raw(), kind.raw(), &bytes, 1);
+        self.transport
+            .reply_mail(sender.raw(), kind.raw(), &bytes, 1);
     }
 }
 
@@ -199,42 +223,47 @@ impl<T: MailTransport> Ctx<'_, T> {
 /// - No `resolve` — resolution belongs at init. There is no use case
 ///   for resolving at teardown.
 pub struct DropCtx<'a, T: MailTransport> {
+    transport: &'a T,
     _borrow: PhantomData<&'a ()>,
-    _t: PhantomData<fn() -> T>,
 }
 
-impl<T: MailTransport> DropCtx<'_, T> {
+impl<'a, T: MailTransport> DropCtx<'a, T> {
     /// Not part of the public API; called only by `export!`.
     #[doc(hidden)]
-    pub fn __new() -> Self {
+    pub fn __new(transport: &'a T) -> Self {
         DropCtx {
+            transport,
             _borrow: PhantomData,
-            _t: PhantomData,
         }
+    }
+
+    /// Borrow the actor's transport. Same shape as
+    /// [`Ctx::transport`].
+    pub fn transport(&self) -> &T {
+        self.transport
     }
 
     /// Send a single payload during a shutdown hook. Wire shape (cast
     /// or postcard) follows `Kind::encode_into_bytes`.
     pub fn send<K: Kind>(&self, sink: &Sink<K, T>, payload: &K) {
-        sink.send(payload);
+        sink.send(self.transport, payload);
     }
 
     /// Send a slice of payloads during a shutdown hook. Cast-only —
     /// see [`Sink::send_many`] for the wire-shape rationale.
     pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Sink<K, T>, payloads: &[K]) {
-        sink.send_many(payloads);
+        sink.send_many(self.transport, payloads);
     }
 
     /// Publish `value` into the substrate's handle store during a
     /// shutdown hook. Common pattern at `on_replace`: pin the
     /// returned handle so the cached bytes survive the hand-off
-    /// to the next instance, then drop it (`Handle::pin` followed
-    /// by drop releases the local guard but keeps the entry).
+    /// to the next instance, then drop it.
     pub fn publish<K: Kind + serde::Serialize>(
         &self,
         value: &K,
     ) -> Result<Handle<K, T>, SyncHandleError> {
-        handle::publish::<K, T>(value)
+        handle::publish::<K, T>(self.transport, value)
     }
 
     /// Deposit a migration bundle for the substrate to hand to the
@@ -253,7 +282,7 @@ impl<T: MailTransport> DropCtx<'_, T> {
     /// bundle is discarded on plain drops — `drop_component` has no
     /// successor to hand it to (ADR-0016 §5).
     pub fn save_state(&mut self, version: u32, bytes: &[u8]) {
-        let status = T::save_state(version, bytes);
+        let status = self.transport.save_state(version, bytes);
         if status != 0 {
             panic!("aether-actor: save_state failed (status {status})");
         }
@@ -297,19 +326,19 @@ mod tests {
     /// to the test; not a public surface.
     struct NoopTransport;
     impl MailTransport for NoopTransport {
-        fn send_mail(_: u64, _: u64, _: &[u8], _: u32) -> u32 {
+        fn send_mail(&self, _: u64, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn reply_mail(_: u32, _: u64, _: &[u8], _: u32) -> u32 {
+        fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn save_state(_: u32, _: &[u8]) -> u32 {
+        fn save_state(&self, _: u32, _: &[u8]) -> u32 {
             0
         }
-        fn wait_reply(_: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
+        fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
             -1
         }
-        fn prev_correlation() -> u64 {
+        fn prev_correlation(&self) -> u64 {
             0
         }
     }
@@ -317,10 +346,11 @@ mod tests {
     /// `DropCtx::__new()` must be callable without special setup so
     /// the `export!` macro can build one inside a `#[no_mangle]` shim.
     /// The accessor covered here just verifies the constructor type
-    /// is well-formed; send/send_many require a real FFI and are not
-    /// unit-testable on host.
+    /// is well-formed; send/send_many require a real transport and
+    /// are not unit-testable on host.
     #[test]
     fn drop_ctx_constructor_well_formed() {
-        let _ctx: DropCtx<'_, NoopTransport> = DropCtx::__new();
+        let transport = NoopTransport;
+        let _ctx: DropCtx<'_, NoopTransport> = DropCtx::__new(&transport);
     }
 }

--- a/crates/aether-actor/src/handle.rs
+++ b/crates/aether-actor/src/handle.rs
@@ -10,8 +10,15 @@
 //! actors mail one of the four typed request kinds and either fire
 //! and forget or block on the paired `*Result` reply. Helpers here
 //! are generic over `T: MailTransport` so the wasm guest path
-//! (`WasmTransport`) and the future native path (`NativeTransport`)
-//! share one code body.
+//! (`WasmTransport`) and the native path (`NativeTransport`) share
+//! one code body.
+//!
+//! Each helper takes a `&T` transport reference explicitly. ADR-0074
+//! §Decision: the trait takes `&self`, the actor binding is
+//! type-system-tracked through the reference, no thread-locals or
+//! globals. From inside a `#[handlers]` method the natural call shape
+//! is `ctx.publish(...)` — the `Ctx` already holds the transport
+//! borrow, so the user doesn't have to thread it through.
 //!
 //! Quick tour (wasm guest):
 //!
@@ -30,11 +37,10 @@
 //!             held: handle.as_ref(),
 //!             ..
 //!         };
-//!         BROADCAST.send(&outer);
-//!         // `handle` drops here → fire-and-forget HandleRelease,
-//!         // refcount goes to zero, entry stays in the substrate's
-//!         // store subject to LRU eviction. Pin if the cached bytes
-//!         // need to outlive the local guard.
+//!         BROADCAST.send(ctx.transport(), &outer);
+//!         // No auto-release on drop — the substrate's LRU evicts
+//!         // forgotten handles. Call `handle.release(ctx.transport())`
+//!         // for prompt cleanup.
 //!     }
 //! }
 //! ```
@@ -85,23 +91,18 @@ pub enum SyncHandleError {
     Decode(String),
 }
 
-/// Typed wrapper around a substrate-side handle id. Carries an RAII
-/// drop-release: when the value goes out of scope, a fire-and-forget
-/// `HandleRelease` mail tells the substrate to drop one reference.
-/// `K` is phantom — the underlying id is type-agnostic on the wire,
-/// but `as_ref` pulls `K::ID` so the resulting `Ref::Handle` carries
-/// the right kind id.
+/// Typed wrapper around a substrate-side handle id. `K` is phantom —
+/// the underlying id is type-agnostic on the wire, but `as_ref` pulls
+/// `K::ID` so the resulting `Ref::Handle` carries the right kind id.
+/// `T` is also phantom — held to enforce that the sync helper methods
+/// receive a transport of the same flavor the handle was minted on.
 ///
-/// Not `Copy` / `Clone`. Cloning a refcounted handle without an
-/// inc-ref would cause a double-release on drop; if an actor needs
-/// multiple references it pins the handle and reads the raw id via
-/// `Handle::id`.
-///
-/// `T: MailTransport` is on the type so `Drop` and the inherent
-/// `release` / `pin` / `unpin` methods can dispatch through the
-/// right transport without the caller threading it. `Handle<K, T>`
-/// in `aether-component` is aliased to `Handle<K, WasmTransport>`,
-/// so user code keeps writing `Handle<MyKind>`.
+/// Cloning a refcounted handle without an inc-ref would cause double
+/// release issues with the prior auto-Drop design — that auto-release
+/// is gone now (the substrate's LRU eviction handles forgotten
+/// handles), so we could in principle make `Handle` `Copy`. Left
+/// non-Copy for now to keep callsites explicit; a future PR can lift
+/// the restriction if tests show real-world friction.
 pub struct Handle<K, T: MailTransport> {
     id: u64,
     _k: PhantomData<fn() -> K>,
@@ -121,9 +122,7 @@ impl<K, T: MailTransport> Handle<K, T> {
     }
 
     /// Raw handle id. Exposed for hand-rolled callers that need to
-    /// pass the id through host fns the SDK doesn't yet wrap, or to
-    /// detach the handle from its RAII guard via
-    /// [`core::mem::forget`].
+    /// pass the id through host fns the SDK doesn't yet wrap.
     pub fn id(&self) -> u64 {
         self.id
     }
@@ -131,27 +130,26 @@ impl<K, T: MailTransport> Handle<K, T> {
     /// Drop the publisher's reference. Sync — blocks the actor
     /// thread until the substrate replies, with a 5s default
     /// timeout. Returns `Err(Handle(UnknownHandle))` if the entry
-    /// has already been evicted; otherwise `Ok(())`. Use the
-    /// implicit `Drop` if you don't care about errors during
-    /// teardown.
-    pub fn release(self) -> Result<(), SyncHandleError> {
-        let id = self.id;
-        // Suppress the Drop impl so we don't release twice.
-        core::mem::forget(self);
-        sync_release::<T>(id)
+    /// has already been evicted; otherwise `Ok(())`.
+    ///
+    /// Unlike the prior design, `Handle::Drop` is now a no-op —
+    /// the substrate's LRU eviction handles forgotten handles. Call
+    /// this method explicitly when you want prompt cleanup.
+    pub fn release(self, transport: &T) -> Result<(), SyncHandleError> {
+        sync_release::<T>(transport, self.id)
     }
 
     /// Pin against LRU eviction. Useful when the publisher wants to
     /// release its local guard (drop the `Handle`) but keep the
     /// cached bytes available — pin first, then drop.
-    pub fn pin(&self) -> Result<(), SyncHandleError> {
-        sync_pin::<T>(self.id)
+    pub fn pin(&self, transport: &T) -> Result<(), SyncHandleError> {
+        sync_pin::<T>(transport, self.id)
     }
 
     /// Clear the pinned flag. Doesn't drop the entry; only makes
     /// it eligible for LRU eviction once `refcount == 0`.
-    pub fn unpin(&self) -> Result<(), SyncHandleError> {
-        sync_unpin::<T>(self.id)
+    pub fn unpin(&self, transport: &T) -> Result<(), SyncHandleError> {
+        sync_unpin::<T>(transport, self.id)
     }
 }
 
@@ -171,17 +169,12 @@ impl<K: Kind, T: MailTransport> Handle<K, T> {
     }
 }
 
-impl<K, T: MailTransport> Drop for Handle<K, T> {
-    fn drop(&mut self) {
-        // Fire-and-forget: a panicking wait would poison teardown.
-        // The substrate's release dispatch is idempotent — calling
-        // it on an already-released id saturates harmlessly.
-        let req = HandleRelease {
-            id: ::aether_data::HandleId(self.id),
-        };
-        resolve_sink::<HandleRelease, T>(HANDLE_SINK_NAME).send(&req);
-    }
-}
+// ADR-0074 §Decision: no auto-release on Drop. The prior design's
+// `impl Drop for Handle` fired a fire-and-forget `HandleRelease` mail
+// through a static `Sink::send` — that pattern doesn't survive the
+// `&self` trait refactor (Drop has no transport ref to send through).
+// The substrate's LRU eviction is the safety net; explicit
+// `handle.release(transport)` is the prompt-cleanup path.
 
 /// Postcard-encode `value` and round-trip a `HandlePublish` request
 /// through the `"aether.sink.handle"` sink. Returns the typed
@@ -192,6 +185,7 @@ impl<K, T: MailTransport> Drop for Handle<K, T> {
 /// Shared by `InitCtx::publish` / `Ctx::publish` / `DropCtx::publish`
 /// — keep the wire shape and timeouts in one place.
 pub fn publish<K: Kind + Serialize, T: MailTransport>(
+    transport: &T,
     value: &K,
 ) -> Result<Handle<K, T>, SyncHandleError> {
     let bytes = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
@@ -199,52 +193,68 @@ pub fn publish<K: Kind + Serialize, T: MailTransport>(
         kind_id: K::ID,
         bytes,
     };
-    resolve_sink::<HandlePublish, T>(HANDLE_SINK_NAME).send(&req);
-    let correlation = T::prev_correlation();
-    let result: HandlePublishResult =
-        wait_reply::<_, SyncHandleError, T>(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
+    resolve_sink::<HandlePublish, T>(HANDLE_SINK_NAME).send(transport, &req);
+    let correlation = transport.prev_correlation();
+    let result: HandlePublishResult = wait_reply::<_, SyncHandleError, T>(
+        transport,
+        DEFAULT_TIMEOUT_MS,
+        SMALL_REPLY_CAP,
+        correlation,
+    )?;
     match result {
         HandlePublishResult::Ok { id, .. } => Ok(Handle::__from_id(id.0)),
         HandlePublishResult::Err { error, .. } => Err(SyncHandleError::Handle(error)),
     }
 }
 
-fn sync_release<T: MailTransport>(id: u64) -> Result<(), SyncHandleError> {
+fn sync_release<T: MailTransport>(transport: &T, id: u64) -> Result<(), SyncHandleError> {
     let req = HandleRelease {
         id: ::aether_data::HandleId(id),
     };
-    resolve_sink::<HandleRelease, T>(HANDLE_SINK_NAME).send(&req);
-    let correlation = T::prev_correlation();
-    let result: HandleReleaseResult =
-        wait_reply::<_, SyncHandleError, T>(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
+    resolve_sink::<HandleRelease, T>(HANDLE_SINK_NAME).send(transport, &req);
+    let correlation = transport.prev_correlation();
+    let result: HandleReleaseResult = wait_reply::<_, SyncHandleError, T>(
+        transport,
+        DEFAULT_TIMEOUT_MS,
+        SMALL_REPLY_CAP,
+        correlation,
+    )?;
     match result {
         HandleReleaseResult::Ok { .. } => Ok(()),
         HandleReleaseResult::Err { error, .. } => Err(SyncHandleError::Handle(error)),
     }
 }
 
-fn sync_pin<T: MailTransport>(id: u64) -> Result<(), SyncHandleError> {
+fn sync_pin<T: MailTransport>(transport: &T, id: u64) -> Result<(), SyncHandleError> {
     let req = HandlePin {
         id: ::aether_data::HandleId(id),
     };
-    resolve_sink::<HandlePin, T>(HANDLE_SINK_NAME).send(&req);
-    let correlation = T::prev_correlation();
-    let result: HandlePinResult =
-        wait_reply::<_, SyncHandleError, T>(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
+    resolve_sink::<HandlePin, T>(HANDLE_SINK_NAME).send(transport, &req);
+    let correlation = transport.prev_correlation();
+    let result: HandlePinResult = wait_reply::<_, SyncHandleError, T>(
+        transport,
+        DEFAULT_TIMEOUT_MS,
+        SMALL_REPLY_CAP,
+        correlation,
+    )?;
     match result {
         HandlePinResult::Ok { .. } => Ok(()),
         HandlePinResult::Err { error, .. } => Err(SyncHandleError::Handle(error)),
     }
 }
 
-fn sync_unpin<T: MailTransport>(id: u64) -> Result<(), SyncHandleError> {
+fn sync_unpin<T: MailTransport>(transport: &T, id: u64) -> Result<(), SyncHandleError> {
     let req = HandleUnpin {
         id: ::aether_data::HandleId(id),
     };
-    resolve_sink::<HandleUnpin, T>(HANDLE_SINK_NAME).send(&req);
-    let correlation = T::prev_correlation();
-    let result: HandleUnpinResult =
-        wait_reply::<_, SyncHandleError, T>(DEFAULT_TIMEOUT_MS, SMALL_REPLY_CAP, correlation)?;
+    resolve_sink::<HandleUnpin, T>(HANDLE_SINK_NAME).send(transport, &req);
+    let correlation = transport.prev_correlation();
+    let result: HandleUnpinResult = wait_reply::<_, SyncHandleError, T>(
+        transport,
+        DEFAULT_TIMEOUT_MS,
+        SMALL_REPLY_CAP,
+        correlation,
+    )?;
     match result {
         HandleUnpinResult::Ok { .. } => Ok(()),
         HandleUnpinResult::Err { error, .. } => Err(SyncHandleError::Handle(error)),
@@ -273,10 +283,9 @@ mod tests {
     use alloc::vec;
     use serde::Deserialize;
 
-    /// Off-target we can't exercise the FFI host calls (`raw::send_mail`
-    /// and friends panic with the host-target stub). Pin the wire
-    /// shape by encoding the request kinds and asserting the bytes
-    /// round-trip into the same kinds.
+    /// Off-target we can't exercise the full FFI round-trip (`raw::*`
+    /// host stubs panic). Pin the wire shape by encoding the request
+    /// kinds and asserting the bytes round-trip into the same kinds.
     #[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
     #[kind(name = "test.handle.payload")]
     #[allow(dead_code)]
@@ -307,24 +316,23 @@ mod tests {
         assert_eq!(decoded.id, ::aether_data::HandleId(0xDEAD));
     }
 
-    /// Stub transport for the host-side `as_ref` test — `Drop` would
-    /// call `T::send_mail`, which we suppress via `mem::forget`.
-    /// Lives next to the test that uses it; not a public surface.
+    /// Stub transport for the host-side `as_ref` test. Lives next to
+    /// the test that uses it; not a public surface.
     struct NoopTransport;
     impl MailTransport for NoopTransport {
-        fn send_mail(_: u64, _: u64, _: &[u8], _: u32) -> u32 {
+        fn send_mail(&self, _: u64, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn reply_mail(_: u32, _: u64, _: &[u8], _: u32) -> u32 {
+        fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn save_state(_: u32, _: &[u8]) -> u32 {
+        fn save_state(&self, _: u32, _: &[u8]) -> u32 {
             0
         }
-        fn wait_reply(_: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
+        fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
             -1
         }
-        fn prev_correlation() -> u64 {
+        fn prev_correlation(&self) -> u64 {
             0
         }
     }
@@ -343,8 +351,6 @@ mod tests {
             }
             Ref::Inline(_) => panic!("as_ref should produce Handle, not Inline"),
         }
-        // Suppress Drop's host-fn call.
-        core::mem::forget(handle);
     }
 
     /// `SyncHandleError` is the [`crate::sync::WaitError`] impl the

--- a/crates/aether-actor/src/sink.rs
+++ b/crates/aether-actor/src/sink.rs
@@ -112,14 +112,23 @@ impl<K: Kind, T: MailTransport> Sink<K, T> {
 impl<K: Kind, T: MailTransport> Sink<K, T> {
     /// Send a single typed payload. The substrate's `count` field is 1.
     ///
+    /// `transport` is the actor-bound `MailTransport` instance — the
+    /// `&self`-receiver design means each send call carries an
+    /// explicit transport reference, so the actor's identity (and per-
+    /// actor state like the correlation counter on `NativeTransport`)
+    /// is type-system-tracked rather than hidden in a thread-local.
+    /// `WasmTransport` is a ZST, so passing `&WASM_TRANSPORT` from
+    /// `aether-component` is free; `NativeTransport` rides on the
+    /// capability that owns it.
+    ///
     /// Issue #240: routes through `Kind::encode_into_bytes`, which the
     /// derive specializes to either a bytemuck cast or a postcard
     /// encode based on whether the type carries `#[repr(C)]`. One call
     /// site for both wire shapes — the wire choice is the kind's, not
     /// the call's.
-    pub fn send(self, payload: &K) {
+    pub fn send(self, transport: &T, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        T::send_mail(self.mailbox, self.kind, &bytes, 1);
+        transport.send_mail(self.mailbox, self.kind, &bytes, 1);
     }
 }
 
@@ -131,9 +140,9 @@ impl<K: Kind + bytemuck::NoUninit, T: MailTransport> Sink<K, T> {
     /// shape (ADR-0019 §6 fixes the batch wire as raw bytes). A
     /// component that wants to fan out N postcard payloads calls
     /// `send` in a loop.
-    pub fn send_many(self, payloads: &[K]) {
+    pub fn send_many(self, transport: &T, payloads: &[K]) {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        T::send_mail(self.mailbox, self.kind, bytes, payloads.len() as u32);
+        transport.send_mail(self.mailbox, self.kind, bytes, payloads.len() as u32);
     }
 }
 
@@ -174,19 +183,19 @@ mod tests {
     /// to the tests that need it; not a public surface.
     struct NoopTransport;
     impl MailTransport for NoopTransport {
-        fn send_mail(_: u64, _: u64, _: &[u8], _: u32) -> u32 {
+        fn send_mail(&self, _: u64, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn reply_mail(_: u32, _: u64, _: &[u8], _: u32) -> u32 {
+        fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 {
             0
         }
-        fn save_state(_: u32, _: &[u8]) -> u32 {
+        fn save_state(&self, _: u32, _: &[u8]) -> u32 {
             0
         }
-        fn wait_reply(_: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
+        fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
             -1
         }
-        fn prev_correlation() -> u64 {
+        fn prev_correlation(&self) -> u64 {
             0
         }
     }

--- a/crates/aether-actor/src/sync.rs
+++ b/crates/aether-actor/src/sync.rs
@@ -32,11 +32,16 @@ pub trait WaitError {
 }
 
 /// Allocate a `capacity`-sized scratch buffer in actor memory, park
-/// on `T::wait_reply` for a mail of kind `K` with the given
+/// on `transport.wait_reply` for a mail of kind `K` with the given
 /// `expected_correlation`, and postcard-decode the written bytes.
 /// Replaces the per-family duplicates that previously lived in
 /// `io.rs`, `handle.rs`, and inline in `net::fetch_blocking`.
+///
+/// `transport` is the actor-bound `MailTransport` instance — see
+/// `transport.rs` for the `&self` receiver design and how it
+/// type-system-tracks the actor binding.
 pub fn wait_reply<K, E, T>(
+    transport: &T,
     timeout_ms: u32,
     capacity: usize,
     expected_correlation: u64,
@@ -47,7 +52,7 @@ where
     T: MailTransport,
 {
     let mut buf: Vec<u8> = vec![0u8; capacity];
-    let rc = T::wait_reply(K::ID.0, &mut buf, timeout_ms, expected_correlation);
+    let rc = transport.wait_reply(K::ID.0, &mut buf, timeout_ms, expected_correlation);
     decode_wait_reply::<K, E>(rc, &buf)
 }
 

--- a/crates/aether-actor/src/transport.rs
+++ b/crates/aether-actor/src/transport.rs
@@ -2,17 +2,18 @@
 //! crossing the actor↔chassis boundary is funnelled through one
 //! `MailTransport` impl chosen at compile time by the consumer crate
 //! — `aether-component`'s `WasmTransport` (delegates to `_p32` host
-//! fns) for WASM guests, `aether-substrate`'s future `NativeTransport`
-//! (delegates to in-process mpsc) for native capabilities.
+//! fns) for WASM guests, `aether-substrate`'s `NativeTransport`
+//! (owned by each native capability) for native actors.
 //!
-//! Trait methods are associated functions, not `&self` methods. The
-//! transport carries no per-actor state — addressing rides on the
-//! `Sink<K, T>` / `Ctx<'_, T>` / `Mail<'_>` arguments, and any
-//! per-thread plumbing the native side needs (current actor's mpsc
-//! sender, etc.) lives behind a thread-local that the impl reads on
-//! call. WASM has no threads so the lookup degrades to a global; the
-//! function-pointer indirection is the only call-site cost over
-//! today's `unsafe { raw::send_mail(...) }`.
+//! Trait methods take `&self`, not associated functions. WasmTransport
+//! is a ZST, so its `&self` is unused and the dispatch lowers to a
+//! direct call to the matching host fn — no overhead. NativeTransport
+//! is a regular struct each capability owns, holding the per-actor
+//! state (mailer + self mailbox + inbox + correlation counter +
+//! overflow queue) directly as fields. No thread-locals, no
+//! install/uninstall ceremony — the type system carries the actor
+//! binding through the `&T` references threaded into `Sink::send`,
+//! `Ctx<'a, T>`, and the `wait_reply` / handle helpers.
 
 /// The five operations every transport must provide. Signatures
 /// mirror the `_p32` FFI in `aether-component::raw` byte-for-byte —
@@ -32,16 +33,16 @@ pub trait MailTransport {
     /// Return `0` on success; non-zero is reserved for transport-
     /// specific failure surfaces. Today only the wasm transport
     /// returns non-zero (substrate-side `register` lookup miss); the
-    /// native transport will collapse the `Result` channel-send
-    /// failure into the same scalar.
-    fn send_mail(recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32;
+    /// native transport collapses any channel-send failure into the
+    /// same scalar.
+    fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32;
 
     /// Reply to the originator of the mail currently being dispatched
     /// (ADR-0013). `sender` is the per-instance handle the dispatcher
     /// threaded onto `Ctx` at receive time; the substrate routes it
     /// to the right Claude session, sibling component, or remote
     /// engine mailbox.
-    fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32;
+    fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32;
 
     /// Deposit a migration bundle for a future replacement instance
     /// (ADR-0016). Only meaningful inside `on_replace`. `bytes` are
@@ -49,7 +50,11 @@ pub trait MailTransport {
     /// caller is free to drop the slice on return. Returns `0` on
     /// success; non-zero on substrate rejection (today: 1 MiB cap
     /// exceeded, or internal OOB — both component bugs).
-    fn save_state(version: u32, bytes: &[u8]) -> u32;
+    ///
+    /// Native actors don't have a `replace_component`-style hot
+    /// reload path (only wasm components do). The native transport
+    /// returns a non-zero error sentinel so a misuse is loud.
+    fn save_state(&self, version: u32, bytes: &[u8]) -> u32;
 
     /// Block the actor's thread until a mail of `expected_kind` (and,
     /// when `expected_correlation != 0`, also that correlation id)
@@ -63,6 +68,7 @@ pub trait MailTransport {
     /// for future sentinels and surfaces through `WaitError::decode`
     /// in the SDK wrapper so a reader sees the unknown rc by name.
     fn wait_reply(
+        &self,
         expected_kind: u64,
         out: &mut [u8],
         timeout_ms: u32,
@@ -73,5 +79,5 @@ pub trait MailTransport {
     /// `send_mail` call (ADR-0042). `0` before any send. Sync
     /// wrappers use it to filter `wait_reply` to "the reply for the
     /// request I just sent" rather than "any reply of this kind."
-    fn prev_correlation() -> u64;
+    fn prev_correlation(&self) -> u64;
 }

--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -88,10 +88,12 @@ impl Component for HandleDemo {
         // forwards to a Claude session the local guard would have
         // been released and the entry could be evicted under
         // pressure — pin it so the cached bytes survive.
-        let _ = handle.pin();
-        BROADCAST.send(&outer);
-        // `handle` drops here → fire-and-forget HandleRelease;
-        // the pin keeps the cached entry alive past release.
+        let _ = handle.pin(ctx.transport());
+        BROADCAST.send(ctx.transport(), &outer);
+        // `handle` drops here without auto-release (ADR-0074: Drop
+        // is no-op now; substrate's LRU evicts forgotten handles).
+        // The pin keeps the cached entry alive past the local
+        // handle's drop so the broadcast recipient can resolve it.
     }
 }
 

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -72,7 +72,7 @@ impl Component for SaveCounter {
     /// this. Watch `receive_mail` for a `demo.save_counter.count`
     /// frame after the component loads.
     #[handler]
-    fn on_tick(&mut self, _ctx: &mut Ctx<'_>, _tick: Tick) {
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _tick: Tick) {
         if self.initialized {
             return;
         }
@@ -86,7 +86,7 @@ impl Component for SaveCounter {
             &next.to_le_bytes(),
             IO_TIMEOUT_MS,
         );
-        BROADCAST.send(&Count { count: next });
+        BROADCAST.send(ctx.transport(), &Count { count: next });
     }
 }
 

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -48,7 +48,7 @@ use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
 
-use crate::{WasmTransport, resolve_sink};
+use crate::{WASM_TRANSPORT, WasmTransport, resolve_sink};
 
 /// Mailbox name the substrate registers its I/O sink under (ADR-0041,
 /// namespaced under `aether.sink.*` per ADR-0058). Exposed so
@@ -107,12 +107,12 @@ pub fn list(namespace: &str, prefix: &str) {
 }
 
 fn send<K: Kind>(value: &K) -> u64 {
-    resolve_sink::<K>(IO_MAILBOX_NAME).send(value);
+    resolve_sink::<K>(IO_MAILBOX_NAME).send(&WASM_TRANSPORT, value);
     // ADR-0042: capture the correlation the substrate just minted so
     // the sync wrappers can filter on it. For the async helpers
     // (`read` / `write` / `delete` / `list`), this is harmless noise —
     // they don't wait.
-    WasmTransport::prev_correlation()
+    WASM_TRANSPORT.prev_correlation()
 }
 
 /// ADR-0042: errors surfaced by the `*_sync` wrappers. The first three
@@ -163,6 +163,7 @@ pub fn read_sync(namespace: &str, path: &str, timeout_ms: u32) -> Result<Vec<u8>
         path: path.to_string(),
     });
     let reply: ReadResult = wait_reply::<ReadResult, SyncIoError, WasmTransport>(
+        &WASM_TRANSPORT,
         timeout_ms,
         READ_REPLY_CAP,
         correlation,
@@ -188,6 +189,7 @@ pub fn write_sync(
         bytes: bytes.to_vec(),
     });
     match wait_reply::<WriteResult, SyncIoError, WasmTransport>(
+        &WASM_TRANSPORT,
         timeout_ms,
         SMALL_REPLY_CAP,
         correlation,
@@ -206,6 +208,7 @@ pub fn delete_sync(namespace: &str, path: &str, timeout_ms: u32) -> Result<(), S
         path: path.to_string(),
     });
     match wait_reply::<DeleteResult, SyncIoError, WasmTransport>(
+        &WASM_TRANSPORT,
         timeout_ms,
         SMALL_REPLY_CAP,
         correlation,
@@ -228,6 +231,7 @@ pub fn list_sync(
         prefix: prefix.to_string(),
     });
     match wait_reply::<ListResult, SyncIoError, WasmTransport>(
+        &WASM_TRANSPORT,
         timeout_ms,
         LIST_REPLY_CAP,
         correlation,

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -52,17 +52,26 @@ pub mod net;
 pub mod raw;
 
 /// ZST `MailTransport` impl for the WASM guest path. Each method
-/// forwards to the matching `raw::*` host-fn import. The trait
-/// methods are associated functions (no `&self`), so this type is
-/// instantiated only at the type-system level — there is no runtime
-/// allocation or pointer indirection.
+/// forwards to the matching `raw::*` host-fn import. The `&self`
+/// receiver is unused — `WasmTransport` carries no per-instance
+/// state because the FFI imports are global to the wasm instance —
+/// so there's no overhead beyond the host-fn call itself.
 ///
-/// Phase 2 introduces `aether_substrate::NativeTransport` for native
-/// capabilities; both impls share the same SDK in `aether-actor`.
+/// `aether_substrate::NativeTransport` is the native counterpart;
+/// both impls share the same SDK in `aether-actor` and the same
+/// trait surface.
 pub struct WasmTransport;
 
+/// Process-wide `WasmTransport` instance. The type is a ZST, so
+/// this `static` occupies zero bytes; its only purpose is giving
+/// `&WASM_TRANSPORT` callers (the `export!`-emitted Ctx/InitCtx/
+/// DropCtx constructors, the `io` / `net` / `log` helper modules,
+/// component examples) a stable address to borrow without each
+/// call site having to write `&WasmTransport` inline.
+pub static WASM_TRANSPORT: WasmTransport = WasmTransport;
+
 impl MailTransport for WasmTransport {
-    fn send_mail(recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+    fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
         unsafe {
             raw::send_mail(
                 recipient,
@@ -74,7 +83,7 @@ impl MailTransport for WasmTransport {
         }
     }
 
-    fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
+    fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
         unsafe {
             raw::reply_mail(
                 sender,
@@ -86,11 +95,12 @@ impl MailTransport for WasmTransport {
         }
     }
 
-    fn save_state(version: u32, bytes: &[u8]) -> u32 {
+    fn save_state(&self, version: u32, bytes: &[u8]) -> u32 {
         unsafe { raw::save_state(version, bytes.as_ptr().addr() as u32, bytes.len() as u32) }
     }
 
     fn wait_reply(
+        &self,
         expected_kind: u64,
         out: &mut [u8],
         timeout_ms: u32,
@@ -107,7 +117,7 @@ impl MailTransport for WasmTransport {
         }
     }
 
-    fn prev_correlation() -> u64 {
+    fn prev_correlation(&self) -> u64 {
         unsafe { raw::prev_correlation() }
     }
 }
@@ -283,7 +293,8 @@ macro_rules! export {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
             $crate::log::install_global_default();
-            let mut ctx: $crate::InitCtx<'_> = $crate::InitCtx::__new(mailbox_id);
+            let mut ctx: $crate::InitCtx<'_> =
+                $crate::InitCtx::__new(&$crate::WASM_TRANSPORT, mailbox_id);
             let instance = <$component as $crate::Component>::init(&mut ctx);
             unsafe {
                 __AETHER_COMPONENT.set(instance);
@@ -316,7 +327,7 @@ macro_rules! export {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::Ctx<'_> = $crate::Ctx::__new();
+            let mut ctx: $crate::Ctx<'_> = $crate::Ctx::__new(&$crate::WASM_TRANSPORT);
             let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
             instance.__aether_dispatch(&mut ctx, mail)
         }
@@ -329,7 +340,7 @@ macro_rules! export {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::DropCtx<'_> = $crate::DropCtx::__new();
+            let mut ctx: $crate::DropCtx<'_> = $crate::DropCtx::__new(&$crate::WASM_TRANSPORT);
             <$component as $crate::Component>::on_replace(instance, &mut ctx);
             0
         }
@@ -342,7 +353,7 @@ macro_rules! export {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::DropCtx<'_> = $crate::DropCtx::__new();
+            let mut ctx: $crate::DropCtx<'_> = $crate::DropCtx::__new(&$crate::WASM_TRANSPORT);
             <$component as $crate::Component>::on_drop(instance, &mut ctx);
             0
         }
@@ -358,7 +369,7 @@ macro_rules! export {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::Ctx<'_> = $crate::Ctx::__new();
+            let mut ctx: $crate::Ctx<'_> = $crate::Ctx::__new(&$crate::WASM_TRANSPORT);
             let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
             <$component as $crate::Component>::on_rehydrate(instance, &mut ctx, prior);
             0

--- a/crates/aether-component/src/log.rs
+++ b/crates/aether-component/src/log.rs
@@ -98,7 +98,7 @@ impl Subscriber for MailSubscriber {
             target,
             message,
         };
-        resolve_sink::<LogEvent>("aether.sink.log").send(&payload);
+        resolve_sink::<LogEvent>("aether.sink.log").send(&crate::WASM_TRANSPORT, &payload);
     }
 }
 

--- a/crates/aether-component/src/net.rs
+++ b/crates/aether-component/src/net.rs
@@ -37,7 +37,7 @@ use alloc::vec::Vec;
 use aether_actor::{MailTransport, WaitError, wait_reply};
 use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
-use crate::{WasmTransport, resolve_sink};
+use crate::{WASM_TRANSPORT, WasmTransport, resolve_sink};
 
 /// Mailbox name the substrate registers its net sink under (ADR-0043,
 /// namespaced under `aether.sink.*` per ADR-0058). Exposed so
@@ -139,10 +139,14 @@ impl WaitError for SyncNetError {
 /// assert_eq!(resp.status, 200);
 /// ```
 pub fn fetch_blocking(fetch: &Fetch, timeout_ms: u32) -> Result<FetchResponse, SyncNetError> {
-    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(fetch);
-    let correlation = WasmTransport::prev_correlation();
-    let reply: FetchResult =
-        wait_reply::<_, SyncNetError, WasmTransport>(timeout_ms, FETCH_REPLY_CAP, correlation)?;
+    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(&WASM_TRANSPORT, fetch);
+    let correlation = WASM_TRANSPORT.prev_correlation();
+    let reply: FetchResult = wait_reply::<_, SyncNetError, WasmTransport>(
+        &WASM_TRANSPORT,
+        timeout_ms,
+        FETCH_REPLY_CAP,
+        correlation,
+    )?;
 
     match reply {
         FetchResult::Ok {
@@ -165,7 +169,7 @@ pub fn fetch_blocking(fetch: &Fetch, timeout_ms: u32) -> Result<FetchResponse, S
 /// typed + named counterpart to [`fetch_blocking`]; `ctx.send` on a
 /// user-built `Sink<Fetch>` does the same thing.
 pub fn fetch(fetch: &Fetch) {
-    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(fetch);
+    resolve_sink::<Fetch>(NET_MAILBOX_NAME).send(&WASM_TRANSPORT, fetch);
 }
 
 /// Tiny constructor for the common "GET with no headers or body"

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -22,6 +22,13 @@ render = ["dep:wgpu", "dep:png"]
 audio = ["dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
+# ADR-0074 Phase 2: target-agnostic actor SDK. Capabilities own a
+# `NativeTransport` instance (in `crate::native_transport`) and pass
+# `&self.transport` into the SDK's `Sink<K, T>` / `wait_reply` /
+# `Ctx<'_, T>` machinery — same shape the wasm guest path uses
+# through `WasmTransport`. The trait takes `&self` so per-actor
+# state lives in struct fields, not a thread-local.
+aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -1,4 +1,9 @@
 //! ADR-0070 Phase 3: guest-log sink as a native capability.
+//! ADR-0074 Phase 2a: first capability migrated onto the unified
+//! actor SDK. Channel-drop + join lifecycle (no `Arc<AtomicBool>`
+//! polling); owns a [`NativeTransport`] instance the dispatcher
+//! thread uses to talk to the rest of the substrate via the same
+//! `Sink<K, _>` / `wait_reply` machinery the wasm guest path uses.
 //!
 //! Counterpart to the `MailSubscriber` in `aether-component`: decodes
 //! `aether.log` mail the guest sent to `aether.sink.log` and re-emits
@@ -20,13 +25,11 @@
 //! [`crate::SubstrateBoot::build`] returns.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
 use crate::log_sink;
+use crate::native_transport::NativeTransport;
 
 /// Recipient name the log capability claims. Components mail
 /// `aether.log` (kind id) to this mailbox; the SDK's
@@ -34,20 +37,15 @@ use crate::log_sink;
 /// chassis-owned sinks under `aether.sink.*`.
 pub const LOG_SINK_NAME: &str = "aether.sink.log";
 
-/// Polling interval for the dispatcher's shutdown check. Same shape
-/// as `HandleCapability`; see ADR-0070 §"Threading model".
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
-
 /// Native capability owning the ADR-0060 guest-log sink. Boots a
 /// single dispatcher thread that pulls envelopes from the
 /// `aether.sink.log` mailbox and routes the bytes through
 /// [`log_sink::handle_log_mail`] for postcard-decode + log-facade
 /// emit.
 ///
-/// Stateless: the capability holds no per-instance config, and the
-/// global tracing subscriber (set up by [`crate::log_capture::init`]
-/// during the shared boot) is what actually receives the bridged
-/// log records.
+/// Stateless beyond the per-actor transport: the global tracing
+/// subscriber (set up by [`crate::log_capture::init`] during the
+/// shared boot) is what actually receives the bridged log records.
 #[derive(Default)]
 pub struct LogCapability {}
 
@@ -57,39 +55,61 @@ impl LogCapability {
     }
 }
 
-/// Running handle returned by [`LogCapability::boot`]. Same shape
-/// as `HandleRunning`: dispatcher thread + shutdown flag the thread
-/// polls.
+/// Running handle returned by [`LogCapability::boot`]. Holds the
+/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
+/// drives channel-drop shutdown, and the actor's
+/// [`NativeTransport`] (kept alive for the dispatcher thread's
+/// lifetime via the `Arc` clone the spawn closure holds).
 pub struct LogRunning {
     thread: Option<JoinHandle<()>>,
-    shutdown_flag: Arc<AtomicBool>,
+    /// Drop-on-shutdown breaks the channel. Held by name so the
+    /// `RunningCapability::shutdown` impl can drop it explicitly
+    /// before joining the thread; the registry's handler can no
+    /// longer upgrade its [`std::sync::Weak`] back-reference, the
+    /// inbox's last sender is gone, and the dispatcher's
+    /// `recv_blocking()` returns `None` on its next iteration.
+    sink_sender: Option<SinkSender>,
+    /// The actor's transport. The dispatcher thread holds an
+    /// `Arc::clone`, so this field exists to keep the same
+    /// transport reachable from chassis-side code that wants to
+    /// inspect or coordinate with this actor (none today; the
+    /// extension point is here without thread-local plumbing).
+    _transport: Arc<NativeTransport>,
 }
 
 impl Capability for LogCapability {
     type Running = LogRunning;
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox(LOG_SINK_NAME)?;
-        let shutdown_flag = Arc::new(AtomicBool::new(false));
-        let thread_flag = Arc::clone(&shutdown_flag);
-        let receiver = claim.receiver;
+        let claim = ctx.claim_mailbox_drop_on_shutdown(LOG_SINK_NAME)?;
+        let mailer = ctx.mail_send_handle();
+        let mailbox_id = claim.id;
+
+        // ADR-0074 §Decision: `&self` trait, owned transport. The
+        // capability constructs its `NativeTransport` once at boot
+        // and clones the `Arc` into the dispatcher thread; the
+        // dispatcher uses `transport.recv_blocking()` to pull from
+        // its own inbox without thread-local plumbing.
+        let transport = Arc::new(NativeTransport::new(mailer, mailbox_id));
+        transport.install_inbox(claim.receiver);
+        let dispatcher_transport = Arc::clone(&transport);
 
         let thread = thread::Builder::new()
             .name("aether-log-sink".into())
             .spawn(move || {
-                while !thread_flag.load(Ordering::Relaxed) {
-                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
-                        Ok(env) => log_sink::handle_log_mail(&env.payload),
-                        Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
-                    }
+                // Channel-drop + join: pull until the sender side
+                // disconnects. Worst-case shutdown latency is the
+                // OS scheduler's wakeup, not a 100ms poll interval.
+                while let Some(env) = dispatcher_transport.recv_blocking() {
+                    log_sink::handle_log_mail(&env.payload);
                 }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
         Ok(LogRunning {
             thread: Some(thread),
-            shutdown_flag,
+            sink_sender: Some(claim.sink_sender),
+            _transport: transport,
         })
     }
 }
@@ -98,9 +118,11 @@ impl RunningCapability for LogRunning {
     fn shutdown(self: Box<Self>) {
         let LogRunning {
             mut thread,
-            shutdown_flag,
+            mut sink_sender,
+            _transport,
         } = *self;
-        shutdown_flag.store(true, Ordering::Relaxed);
+        // Drop the strong sender first to break the channel.
+        sink_sender.take();
         if let Some(t) = thread.take() {
             let _ = t.join();
         }
@@ -109,7 +131,8 @@ impl RunningCapability for LogRunning {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use super::*;
     use crate::capability::ChassisBuilder;
@@ -128,6 +151,10 @@ mod tests {
     /// tracing subscriber drops the record silently — what we're
     /// asserting is that the dispatch path doesn't panic and that
     /// shutdown joins cleanly).
+    ///
+    /// Post-ADR-0074: shutdown latency is bounded by `recv()`
+    /// returning on channel disconnect, not by a polling interval.
+    /// Channel-drop should land well under the 500ms test budget.
     #[test]
     fn capability_routes_log_event_through_dispatcher() {
         let (registry, mailer) = fresh_substrate();
@@ -156,21 +183,17 @@ mod tests {
             1,
         );
 
-        // Give the dispatcher a moment to drain. recv_timeout means
-        // worst-case latency is one poll interval; test budget is
-        // 200ms.
         thread::sleep(Duration::from_millis(50));
         let start = Instant::now();
         chassis.shutdown();
         assert!(
             start.elapsed() < Duration::from_millis(500),
-            "shutdown should complete within a poll interval"
+            "shutdown should complete promptly via channel-drop"
         );
     }
 
     /// Builder rejects a duplicate claim if the well-known sink name
-    /// was already registered. Same protection as `HandleCapability`'s
-    /// duplicate-claim test.
+    /// was already registered.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (registry, mailer) = fresh_substrate();

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -61,6 +61,47 @@ pub struct MailboxClaim {
     pub receiver: mpsc::Receiver<Envelope>,
 }
 
+/// Result returned from [`ChassisCtx::claim_mailbox_drop_on_shutdown`].
+///
+/// Same as [`MailboxClaim`] plus a strong [`SinkSender`] the
+/// capability is expected to drop during shutdown to break the
+/// channel — the channel-drop + join lifecycle ADR-0074 §Decision 5
+/// settles on. The registry's sink-handler closure holds only a
+/// [`std::sync::Weak`] back-reference, so once the strong handle
+/// goes away, in-flight deliveries warn-drop and the dispatcher's
+/// `recv()` returns `Err(Disconnected)`.
+///
+/// Phase 2a: `LogCapability` is the first consumer; the other
+/// capabilities continue with `claim_mailbox` + `Arc<AtomicBool>`
+/// polling until their own migration PRs land.
+#[derive(Debug)]
+pub struct DropOnShutdownClaim {
+    pub id: MailboxId,
+    pub receiver: mpsc::Receiver<Envelope>,
+    pub sink_sender: SinkSender,
+}
+
+/// Strong handle to the inbound `Sender<Envelope>` for a mailbox
+/// claimed via [`ChassisCtx::claim_mailbox_drop_on_shutdown`]. Held
+/// by the capability for the lifetime of its dispatcher thread;
+/// dropping it disconnects the channel and lets the dispatcher's
+/// `recv()` return `Err(Disconnected)` immediately.
+#[derive(Debug)]
+pub struct SinkSender {
+    // Held purely for its `Drop` side effect. When this `Arc` drops
+    // and refcount hits zero, the inner `Sender` drops, the channel
+    // disconnects, and the dispatcher exits its `recv()` loop.
+    _inner: Arc<mpsc::Sender<Envelope>>,
+}
+
+impl SinkSender {
+    /// Internal constructor — only
+    /// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] builds these.
+    pub(crate) fn new(inner: Arc<mpsc::Sender<Envelope>>) -> Self {
+        Self { _inner: inner }
+    }
+}
+
 /// Generic fallback-router handler: invoked by substrate dispatch when a
 /// local mailbox lookup misses. Phase 1 stores the handler but does
 /// not call it; Phase 4 wires `Mailer::push` to consult the slot in
@@ -218,6 +259,72 @@ impl<'a> ChassisCtx<'a> {
             ),
         )?;
         Ok(MailboxClaim { id, receiver: rx })
+    }
+
+    /// Variant of [`Self::claim_mailbox`] that returns a strong
+    /// [`SinkSender`] alongside the receiver. The registry holds
+    /// only a [`std::sync::Weak`] reference to the sender, so when
+    /// the capability drops the `SinkSender` (during shutdown), the
+    /// channel disconnects and the dispatcher's `recv()` returns
+    /// `Err(Disconnected)`.
+    ///
+    /// Use this when the capability wants the channel-drop + join
+    /// shutdown lifecycle (ADR-0074 §Decision) instead of an
+    /// `Arc<AtomicBool>` polling flag. Phase 2a wires
+    /// `LogCapability` onto this; the other native capabilities
+    /// migrate one PR at a time per the issue 509 plan.
+    pub fn claim_mailbox_drop_on_shutdown(
+        &mut self,
+        name: &str,
+    ) -> Result<DropOnShutdownClaim, BootError> {
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        // Strong Arc rides on `DropOnShutdownClaim.sink_sender` and
+        // lives for the capability's lifetime. The registry handler
+        // only upgrades a `Weak` per call, so when the capability
+        // drops its strong handle, the inner `Sender` also drops
+        // and the dispatcher's `recv()` returns `Err(Disconnected)`.
+        let tx = Arc::new(tx);
+        let weak = Arc::downgrade(&tx);
+        let id = self.registry.try_register_sink(
+            name.to_owned(),
+            Arc::new(
+                move |kind: KindId,
+                      kind_name: &str,
+                      origin: Option<&str>,
+                      sender: ReplyTo,
+                      payload: &[u8],
+                      count: u32| {
+                    let Some(tx) = weak.upgrade() else {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            kind = kind_name,
+                            "capability mailbox sender dropped — mail discarded"
+                        );
+                        return;
+                    };
+                    let env = Envelope {
+                        kind,
+                        kind_name: kind_name.to_owned(),
+                        origin: origin.map(str::to_owned),
+                        sender,
+                        payload: payload.to_vec(),
+                        count,
+                    };
+                    if tx.send(env).is_err() {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            kind = kind_name,
+                            "capability mailbox receiver dropped — mail discarded"
+                        );
+                    }
+                },
+            ),
+        )?;
+        Ok(DropOnShutdownClaim {
+            id,
+            receiver: rx,
+            sink_sender: SinkSender::new(tx),
+        })
     }
 
     /// Clone-able mail-send handle. Capabilities stash this into

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -45,6 +45,7 @@ pub mod log_capture;
 pub mod log_sink;
 pub mod mail;
 pub mod mailer;
+pub mod native_transport;
 pub mod outbound;
 pub mod panic_hook;
 pub mod registry;
@@ -55,8 +56,8 @@ pub mod scheduler;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
-    BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx, Envelope, FallbackRouter,
-    MailboxClaim, RunningCapability,
+    BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx, DropOnShutdownClaim,
+    Envelope, FallbackRouter, MailboxClaim, RunningCapability, SinkSender,
 };
 pub use chassis::Chassis;
 pub use chassis_builder::{
@@ -69,6 +70,7 @@ pub use ctx::SubstrateCtx;
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
+pub use native_transport::NativeTransport;
 pub use outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, LogEntry, LogLevel, RecordingBackend,
 };

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -1,0 +1,379 @@
+//! ADR-0074 §Decision: native-side `MailTransport` implementation.
+//!
+//! [`NativeTransport`] is a regular struct each capability owns. It
+//! holds the per-actor state — mailer + self mailbox + inbox +
+//! correlation counter + wait-overflow queue — directly as fields,
+//! reached via `&self` on every trait method. No thread-locals, no
+//! install/uninstall ceremony, no RefCell runtime borrow checks.
+//! The actor binding is type-system-tracked through the `&T`
+//! references the SDK threads into `Sink::send`, `Ctx<'a, T>`, the
+//! `wait_reply` helper, and the typed-handle module.
+//!
+//! Capabilities build their `NativeTransport` at boot and pass
+//! `&self.transport` (or thread it through to a worker) wherever an
+//! `&T` is needed. The wasm-guest path uses
+//! `aether_component::WasmTransport` (a ZST) the same way; both
+//! impls share the SDK in `aether-actor`.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use aether_actor::MailTransport;
+
+use crate::capability::Envelope;
+use crate::mail::{KindId, Mail, MailboxId, ReplyTarget, ReplyTo};
+use crate::mailer::Mailer;
+
+/// Owned `MailTransport` impl for a native actor. Each capability
+/// constructs one at boot via [`NativeTransport::new`] and holds it
+/// for the lifetime of its dispatcher thread; SDK helpers receive
+/// `&self.transport` references.
+///
+/// The five trait methods read/mutate the struct's fields directly:
+///
+/// - `send_mail` — mints a fresh correlation id (atomic
+///   monotonic counter), wraps the bytes in a [`Mail`] with
+///   `ReplyTarget::Component(self.self_mailbox)` so any reply
+///   routes back here, and pushes through the shared
+///   `Arc<Mailer>`.
+/// - `reply_mail` — Phase 2b stub. Native capabilities that need
+///   to reply to a sender (handle, audio, io, net) gain this when
+///   they migrate; log doesn't reply.
+/// - `save_state` — permanent stub. Native actors don't have a
+///   `replace_component`-style hot reload path; `save_state` is a
+///   wasm-component concept (ADR-0016).
+/// - `wait_reply` — pulls from `self.inbox` with timeout, filters
+///   by `(kind, correlation)`, parks non-matching envelopes into
+///   `self.overflow` for a future `wait_reply` to find, mirrors the
+///   wasm side's `SubstrateCtx::wait_reply` semantics.
+/// - `prev_correlation` — reads the atomic counter.
+pub struct NativeTransport {
+    mailer: Arc<Mailer>,
+    self_mailbox: MailboxId,
+    /// Owned by `wait_reply`; held in a `Mutex` so the `&self`
+    /// receiver can take exclusive access. Wrapped in `OnceLock`
+    /// so the inbox can be installed lazily after construction
+    /// (capabilities sometimes have to thread the receiver through
+    /// a builder before the transport sees it). `OnceLock::get()`
+    /// returns `None` until [`NativeTransport::install_inbox`] runs;
+    /// `wait_reply` returns the `ERR_NO_INBOX` sentinel in that
+    /// case.
+    inbox: OnceLock<Mutex<Receiver<Envelope>>>,
+    /// Mismatched envelopes a previous `wait_reply` pulled but
+    /// didn't return; consulted before the next `recv_timeout`.
+    overflow: Mutex<VecDeque<Envelope>>,
+    /// Monotonic correlation counter — atomic so `&self` can mint
+    /// new ids without `&mut`.
+    correlation: AtomicU64,
+}
+
+impl NativeTransport {
+    /// Build a fresh transport. Pair `self_mailbox` with the id the
+    /// `MailboxClaim` returned (the substrate routes replies back
+    /// to it via the `ReplyTarget::Component(self_mailbox)` tag the
+    /// transport stamps onto outbound mail). The inbox is installed
+    /// separately via [`Self::install_inbox`] so capabilities that
+    /// build the transport before pulling the receiver out of their
+    /// claim aren't forced into a specific construction order.
+    pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
+        Self {
+            mailer,
+            self_mailbox,
+            inbox: OnceLock::new(),
+            overflow: Mutex::new(VecDeque::new()),
+            correlation: AtomicU64::new(0),
+        }
+    }
+
+    /// Install the receiver half of the actor's inbox so
+    /// `wait_reply` has somewhere to pull from. Called once per
+    /// transport, before any `wait_reply` invocation. Subsequent
+    /// calls panic — the slot is single-claim by construction.
+    pub fn install_inbox(&self, inbox: Receiver<Envelope>) {
+        self.inbox
+            .set(Mutex::new(inbox))
+            .unwrap_or_else(|_| panic!("NativeTransport::install_inbox called twice"));
+    }
+
+    /// The mailbox id the substrate routes inbound mail through to
+    /// reach this actor. Exposed for capabilities that need to
+    /// publish their address to peers without going through the
+    /// transport's send path.
+    pub fn self_mailbox(&self) -> MailboxId {
+        self.self_mailbox
+    }
+
+    /// Block until the next envelope arrives on this actor's inbox.
+    /// Returns `None` when the channel disconnects (the channel-drop
+    /// shutdown signal — capability's `RunningCapability::shutdown`
+    /// dropped its [`crate::capability::SinkSender`], the registry
+    /// handler can no longer upgrade its [`std::sync::Weak`], the
+    /// inbox's last sender is gone) or when no inbox is installed.
+    ///
+    /// The natural shape for a dispatcher loop:
+    ///
+    /// ```ignore
+    /// while let Some(env) = transport.recv_blocking() {
+    ///     handle_envelope(env);
+    /// }
+    /// ```
+    ///
+    /// Distinct from [`MailTransport::wait_reply`], which filters by
+    /// `(kind, correlation)` and returns when a *specific* reply
+    /// arrives — `recv_blocking` is for the dispatcher's "next
+    /// thing, whatever it is" main loop.
+    pub fn recv_blocking(&self) -> Option<Envelope> {
+        let inbox = self.inbox.get()?;
+        // The mutex guard stays held across `recv()`. Dispatcher
+        // threads are single-tasked while parked here; nothing else
+        // on this thread contends.
+        inbox.lock().unwrap().recv().ok()
+    }
+
+    /// Non-blocking variant of [`Self::recv_blocking`]. Returns
+    /// `None` for "no envelope available right now" or "channel
+    /// disconnected" or "no inbox installed". A capability that
+    /// needs to distinguish drains via repeated calls until `None`.
+    pub fn try_recv(&self) -> Option<Envelope> {
+        let inbox = self.inbox.get()?;
+        inbox.lock().unwrap().try_recv().ok()
+    }
+}
+
+/// Return code surfaced from `send_mail` / `reply_mail` /
+/// `save_state` for a no-op or unsupported call. Distinct from
+/// substrate-rejected `1` so callers can tell "not implemented" from
+/// "rejected by recipient lookup".
+const ERR_NOT_IMPLEMENTED: u32 = 0xFFFF_FF00;
+
+/// Negative sentinel for `wait_reply` when no inbox is installed.
+/// Picked outside the documented `-1`/`-2`/`-3` range so the SDK's
+/// `decode_wait_reply` falls into the unknown-rc branch and surfaces
+/// "no inbox installed" by name in the error.
+const ERR_NO_INBOX_I32: i32 = 100;
+
+impl MailTransport for NativeTransport {
+    fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+        let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
+        let reply_to =
+            ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
+        let mail = Mail::new(MailboxId(recipient), KindId(kind), bytes.to_vec(), count)
+            .with_reply_to(reply_to)
+            .with_origin(self.self_mailbox);
+        self.mailer.push(mail);
+        0
+    }
+
+    fn reply_mail(&self, _sender: u32, _kind: u64, _bytes: &[u8], _count: u32) -> u32 {
+        // ADR-0074 Phase 2b: the first capability that needs reply
+        // is handle (round-trips `Handle{Publish,Release,Pin,Unpin}Result`
+        // back to the sender). Until then, the bare-bytes →
+        // `Mailer::send_reply` bridge isn't worth designing. Log
+        // doesn't reply.
+        tracing::error!(
+            target: "aether_substrate::native_transport",
+            "NativeTransport::reply_mail not yet implemented — Phase 2b lands this when handle migrates"
+        );
+        ERR_NOT_IMPLEMENTED
+    }
+
+    fn save_state(&self, _version: u32, _bytes: &[u8]) -> u32 {
+        // Native actors don't have a `replace_component`-style hot
+        // reload path (only wasm components do, ADR-0016). The trait
+        // method is part of the unified SDK signature; the native
+        // impl returns an error sentinel so a misuse is loud.
+        tracing::error!(
+            target: "aether_substrate::native_transport",
+            "NativeTransport::save_state called — native actors don't migrate"
+        );
+        ERR_NOT_IMPLEMENTED
+    }
+
+    fn wait_reply(
+        &self,
+        expected_kind: u64,
+        out: &mut [u8],
+        timeout_ms: u32,
+        expected_correlation: u64,
+    ) -> i32 {
+        let Some(inbox_mutex) = self.inbox.get() else {
+            tracing::error!(
+                target: "aether_substrate::native_transport",
+                "wait_reply called without an installed inbox — install_inbox must run first"
+            );
+            return -ERR_NO_INBOX_I32;
+        };
+
+        let timeout = Duration::from_millis(timeout_ms as u64);
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            // Drain overflow first — a previous `wait_reply` may
+            // have parked envelopes that match this kind /
+            // correlation. Mirrors `SubstrateCtx::wait_reply` on
+            // the wasm side (component.rs).
+            let from_overflow = {
+                let mut overflow = self.overflow.lock().unwrap();
+                let pos = overflow
+                    .iter()
+                    .position(|env| matches_filter(env, expected_kind, expected_correlation));
+                pos.and_then(|i| overflow.remove(i))
+            };
+            if let Some(env) = from_overflow {
+                return write_payload(&env, out);
+            }
+
+            // No overflow match — pull from the inbox with whatever
+            // time is left on the deadline. The mutex guard stays
+            // held across `recv_timeout`; the dispatcher thread is
+            // single-tasked while parked here, so no other code on
+            // this thread contends with the lock.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let recv_outcome = inbox_mutex.lock().unwrap().recv_timeout(remaining);
+
+            match recv_outcome {
+                Ok(env) => {
+                    if matches_filter(&env, expected_kind, expected_correlation) {
+                        return write_payload(&env, out);
+                    }
+                    self.overflow.lock().unwrap().push_back(env);
+                    // Loop continues — try again with whatever time
+                    // is left on the deadline.
+                }
+                Err(RecvTimeoutError::Timeout) => return -1,
+                Err(RecvTimeoutError::Disconnected) => return -3,
+            }
+        }
+    }
+
+    fn prev_correlation(&self) -> u64 {
+        self.correlation.load(Ordering::Acquire)
+    }
+}
+
+fn matches_filter(env: &Envelope, expected_kind: u64, expected_correlation: u64) -> bool {
+    env.kind.0 == expected_kind
+        && (expected_correlation == ReplyTo::NO_CORRELATION
+            || env.sender.correlation_id == expected_correlation)
+}
+
+/// Copy `env.payload` into `out` and return the number of bytes
+/// written, matching the wasm `wait_reply_p32` ABI:
+/// `>= 0` = bytes written, `-2` = payload too large for the buffer
+/// (envelope is dropped — wasm re-parks but native callers should
+/// retry with a bigger buffer).
+fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
+    if env.payload.len() > out.len() {
+        tracing::warn!(
+            target: "aether_substrate::native_transport",
+            payload_len = env.payload.len(),
+            buffer_len = out.len(),
+            "wait_reply buffer too small — envelope dropped"
+        );
+        return -2;
+    }
+    out[..env.payload.len()].copy_from_slice(&env.payload);
+    env.payload.len() as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Registry;
+    use crate::scheduler::ComponentTable;
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+    use std::sync::mpsc;
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new());
+        let components: ComponentTable = Arc::new(RwLock::new(HashMap::new()));
+        mailer.wire(Arc::clone(&registry), components);
+        (registry, mailer)
+    }
+
+    /// `prev_correlation` returns 0 before any send and tracks the
+    /// monotonic counter as `send_mail` mints new ids.
+    #[test]
+    fn prev_correlation_tracks_send_mail_minting() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
+        // Register a sink so push routes somewhere instead of
+        // hitting the unknown-recipient warn.
+        registry.register_sink(
+            "test.sink",
+            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                let _ = tx.send(Envelope {
+                    kind,
+                    kind_name: kind_name.to_owned(),
+                    origin: origin.map(str::to_owned),
+                    sender,
+                    payload: payload.to_vec(),
+                    count,
+                });
+            }),
+        );
+        let recipient = registry.lookup("test.sink").unwrap();
+
+        let transport = NativeTransport::new(mailer, MailboxId(99));
+
+        assert_eq!(transport.prev_correlation(), 0);
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        assert_eq!(transport.prev_correlation(), 1);
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        assert_eq!(transport.prev_correlation(), 2);
+    }
+
+    /// `wait_reply` with no inbox installed returns the no-inbox
+    /// negative sentinel.
+    #[test]
+    fn wait_reply_without_inbox_returns_no_inbox_sentinel() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0, &mut buf, 1, 0);
+        assert_eq!(rc, -ERR_NO_INBOX_I32);
+    }
+
+    /// `reply_mail` and `save_state` are tracked stubs — Phase 2a
+    /// pins their behaviour so a future implementation is a
+    /// straight diff against the test.
+    #[test]
+    fn reply_mail_and_save_state_are_tracked_stubs() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new(mailer, MailboxId(1));
+        assert_eq!(transport.reply_mail(0, 0, &[], 0), ERR_NOT_IMPLEMENTED);
+        assert_eq!(transport.save_state(0, &[]), ERR_NOT_IMPLEMENTED);
+    }
+
+    /// `install_inbox` is single-claim — a second install panics.
+    #[test]
+    #[should_panic(expected = "install_inbox called twice")]
+    fn install_inbox_twice_panics() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let (_tx1, rx1) = mpsc::channel::<Envelope>();
+        let (_tx2, rx2) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx1);
+        transport.install_inbox(rx2);
+    }
+
+    /// `wait_reply` returns the `-1` timeout sentinel when no
+    /// envelope arrives within the deadline.
+    #[test]
+    fn wait_reply_times_out_when_inbox_quiet() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let (_tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+        let mut buf = [0u8; 16];
+        // 1ms is enough — no sender ever pushes.
+        let rc = transport.wait_reply(0, &mut buf, 1, 0);
+        assert_eq!(rc, -1);
+    }
+}

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -75,11 +75,14 @@ impl Component for Probe {
     /// `receive_mail` for `aether.test_fixture.tick_observed` to see
     /// the count climbing.
     #[handler]
-    fn on_tick(&mut self, _ctx: &mut Ctx<'_>, _: Tick) {
+    fn on_tick(&mut self, ctx: &mut Ctx<'_>, _: Tick) {
         self.tick_count += 1;
-        BROADCAST.send(&TickObserved {
-            count: self.tick_count,
-        });
+        BROADCAST.send(
+            ctx.transport(),
+            &TickObserved {
+                count: self.tick_count,
+            },
+        );
         if self.render.visible != 0 {
             let r = self.render.r as f32 / 255.0;
             let g = self.render.g as f32 / 255.0;
@@ -92,9 +95,12 @@ impl Component for Probe {
                 g,
                 b,
             };
-            RENDER.send(&DrawTriangle {
-                verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
-            });
+            RENDER.send(
+                ctx.transport(),
+                &DrawTriangle {
+                    verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
+                },
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces closed PR #518 with the actor-state design discussed in chat: `MailTransport` trait takes `&self`, `NativeTransport` is a regular struct each capability owns, and the log capability migrates onto the unified actor SDK with channel-drop + join lifecycle.

## What changed

### `MailTransport` &self

Trait methods all take `&self` now. `WasmTransport` stays a ZST — its `&self` is unused, body is still the direct host-fn call, zero overhead. The change opens the design for `NativeTransport` to hold per-actor state in struct fields rather than a thread-local.

### SDK threading

- `Sink::send` takes `&T` explicitly: `sink.send(&transport, &payload)`
- `Ctx<'a, T>`, `InitCtx<'a, T>`, `DropCtx<'a, T>` all hold `&'a T` references
- `ctx.send(&sink, &payload)` shortcut still works — internally dispatches through `self.transport`
- `wait_reply` and the `handle::publish` family of helpers take `&T` as their first arg
- `Handle<K, T>` no longer auto-releases on Drop (Drop has no transport ref); explicit `handle.release(transport)` is the prompt-cleanup path; substrate LRU eviction is the safety net

### `NativeTransport` (owned struct, not thread-local)

```
pub struct NativeTransport {
    mailer: Arc<Mailer>,
    self_mailbox: MailboxId,
    inbox: OnceLock<Mutex<Receiver<Envelope>>>,
    correlation: AtomicU64,
    overflow: Mutex<VecDeque<Envelope>>,
}
```

Capabilities construct one at boot (`NativeTransport::new(mailer, mailbox_id)`), call `install_inbox(receiver)` once, and pass `&self.transport` (or `Arc::clone` into a worker thread) wherever an `&T` is needed.

`recv_blocking()` and `try_recv()` are inherent methods — distinct from `wait_reply` which filters by (kind, correlation). The dispatcher's natural loop is `while let Some(env) = transport.recv_blocking() { ... }`.

`reply_mail` is a tracked stub until handle migrates in Phase 2b. `save_state` stays a permanent stub — native actors don't migrate.

### `ChassisCtx::claim_mailbox_drop_on_shutdown`

New opt-in entry point. Registry holds `Weak`, capability holds the strong `SinkSender`; drop on shutdown disconnects the channel. The dispatcher's `recv()` returns `Err(Disconnected)`, the loop exits, the thread joins. No `Arc<AtomicBool>`, no `recv_timeout` polling, no worst-case-100ms shutdown latency.

The original `claim_mailbox` API is unchanged — handle/audio/io/net/render keep their existing flag-polling shape and migrate one PR at a time per the issue 509 plan.

### `LogCapability`

First consumer of the new shape. Owns its `NativeTransport` instance, dispatcher loop is `while let Some(env) = transport.recv_blocking() { handle_log_mail(&env.payload) }`, shutdown drops `sink_sender` then joins.

## Why this replaces PR #518

PR #518's `NativeTransport` used a thread-local `ActorContext` because the trait had static methods (no `&self`). User pushback: thread-local is a workaround for the wrong trait shape. This PR fixes the foundation — trait `&self` + owned struct — so the actor binding is type-system-tracked through the `&T` references rather than hidden in a thread-local with install/uninstall ceremony. The other Phase 2 migrations (handle/audio/io/net) and Phase 3+ build on this corrected shape.

## Why no auto-close

Multiple phases remain in issue 509: Phase 2b/c/d/e (handle, audio, io, net migrations) + Phase 3 (render collapse) + Phase 4 (host-side wait_reply + cross-class guard) + Phase 5 (wire rename). The issue stays open until the last one ships.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` — no failures (5 new NativeTransport unit tests, log capability tests still pass)
- [x] `cargo check -p aether-component (and 5 in-tree component cdylibs) --target wasm32-unknown-unknown` clean
- [x] `cargo test -p aether-scenario` — all 8 integration tests pass

<!-- pr-body-ok: b — 'issue 509' is the intentional cross-reference to the implementation tracker; '#518' is the closed earlier attempt being replaced; auto-close would be wrong (multiple phases remain) -->