### PR TITLE
refactor(substrate): channel-drop lifecycle for audio/io/net capabilities (issue 509)

### DIFF
--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -17,8 +17,15 @@
 //! Threading: the capability spawns one OS thread that builds the
 //! `cpal::Stream` and runs the mail-dispatch loop. cpal's `Stream`
 //! is `!Send` on macOS, so the stream is constructed on, owned by,
-//! and dropped from the same thread; only `JoinHandle<()>` and
-//! `Arc<AtomicBool>` (both `Send`) cross thread boundaries.
+//! and dropped from the same thread.
+//!
+//! ADR-0074 Phase 2c: lifecycle is channel-drop + join, mirroring
+//! [`crate::capabilities::log::LogCapability`]. The dispatcher pulls
+//! envelopes from a [`NativeTransport`]; shutdown drops the
+//! [`SinkSender`] strong handle, the channel disconnects, and
+//! `recv_blocking()` returns `None`. Worst-case shutdown latency is
+//! the OS scheduler's recv() wakeup rather than a 100ms poll
+//! interval.
 //!
 //! Boot error policy: cpal init failure is **not** fatal. Audio is
 //! a peripheral, not infrastructure — a CI machine without an audio
@@ -30,26 +37,21 @@
 
 use std::f32::consts::TAU;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
 use crate::mail::{ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
+use crate::native_transport::NativeTransport;
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::{NoteOff, NoteOn, SetMasterGain, SetMasterGainResult};
 
 /// Recipient name the audio capability claims. ADR-0058 places
 /// chassis-owned sinks under `aether.sink.*`.
 pub const AUDIO_SINK_NAME: &str = "aether.sink.audio";
-
-/// Polling interval for the dispatcher's shutdown check.
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Capacity of the event queue between the sink dispatcher and the
 /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -802,24 +804,31 @@ impl AudioCapability {
     }
 }
 
-/// Running handle returned by [`AudioCapability::boot`]. Holds only
-/// `Send` types — the cpal pipeline (with its `!Send`-on-macOS
-/// `Stream`) lives entirely on the dispatcher thread.
+/// Running handle returned by [`AudioCapability::boot`]. Holds the
+/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
+/// drives channel-drop shutdown, and the actor's
+/// [`NativeTransport`] (kept alive for the dispatcher thread's
+/// lifetime via the `Arc` clone the spawn closure holds). The cpal
+/// pipeline (with its `!Send`-on-macOS `Stream`) lives entirely on
+/// the dispatcher thread and tears down when the thread exits.
 pub struct AudioRunning {
     thread: Option<JoinHandle<()>>,
-    shutdown_flag: Arc<AtomicBool>,
+    sink_sender: Option<SinkSender>,
+    _transport: Arc<NativeTransport>,
 }
 
 impl Capability for AudioCapability {
     type Running = AudioRunning;
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox(AUDIO_SINK_NAME)?;
-        let mailer = ctx.mail_send_handle();
-        let receiver = claim.receiver;
-        let shutdown_flag = Arc::new(AtomicBool::new(false));
-        let thread_flag = Arc::clone(&shutdown_flag);
+        let claim = ctx.claim_mailbox_drop_on_shutdown(AUDIO_SINK_NAME)?;
+        let mailer: Arc<Mailer> = ctx.mail_send_handle();
+        let mailbox_id = claim.id;
         let config = self.config;
+
+        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        transport.install_inbox(claim.receiver);
+        let dispatcher_transport = Arc::clone(&transport);
 
         let thread = thread::Builder::new()
             .name("aether-audio-sink".into())
@@ -848,20 +857,17 @@ impl Capability for AudioCapability {
                 };
                 let audio_sender = pipeline.as_ref().map(|p| p.sender.clone());
 
-                while !thread_flag.load(Ordering::Relaxed) {
-                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
-                        Ok(env) => {
-                            dispatch_audio_mail(
-                                &mailer,
-                                audio_sender.as_ref(),
-                                env.kind,
-                                env.sender,
-                                &env.payload,
-                            );
-                        }
-                        Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
-                    }
+                // Channel-drop + join: pull until the sender side
+                // disconnects. Worst-case shutdown latency is the
+                // OS scheduler's wakeup, not a 100ms poll interval.
+                while let Some(env) = dispatcher_transport.recv_blocking() {
+                    dispatch_audio_mail(
+                        &mailer,
+                        audio_sender.as_ref(),
+                        env.kind,
+                        env.sender,
+                        &env.payload,
+                    );
                 }
                 // pipeline drops here, cpal stream tears down on thread exit.
                 drop(pipeline);
@@ -870,7 +876,8 @@ impl Capability for AudioCapability {
 
         Ok(AudioRunning {
             thread: Some(thread),
-            shutdown_flag,
+            sink_sender: Some(claim.sink_sender),
+            _transport: transport,
         })
     }
 }
@@ -879,9 +886,11 @@ impl RunningCapability for AudioRunning {
     fn shutdown(self: Box<Self>) {
         let AudioRunning {
             mut thread,
-            shutdown_flag,
+            mut sink_sender,
+            _transport,
         } = *self;
-        shutdown_flag.store(true, Ordering::Relaxed);
+        // Drop the strong sender first to break the channel.
+        sink_sender.take();
         if let Some(t) = thread.take() {
             let _ = t.join();
         }

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -18,24 +18,22 @@
 //! filesystem misconfiguration will see the error loudly at startup
 //! rather than silently lose the io sink.
 //!
-//! Threading: single dispatcher thread, `AtomicBool` +
-//! `recv_timeout(100ms)` shutdown — same shape as the other
-//! capabilities. Adapter calls run synchronously on the dispatcher
-//! thread; ADR-0041 flagged a future host-fn fast path for asset-
-//! sized streaming.
+//! Threading: single dispatcher thread on a channel-drop + join
+//! lifecycle (ADR-0074 Phase 2d, mirroring
+//! [`crate::capabilities::log::LogCapability`]). Adapter calls run
+//! synchronously on the dispatcher thread; ADR-0041 flagged a future
+//! host-fn fast path for asset-sized streaming.
 
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
+use crate::native_transport::NativeTransport;
 use aether_data::{Kind, KindId};
 use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
@@ -44,9 +42,6 @@ use aether_kinds::{
 /// Recipient name the io capability claims. ADR-0058 places
 /// chassis-owned sinks under `aether.sink.*`.
 pub const IO_SINK_NAME: &str = "aether.sink.io";
-
-/// Polling interval for the dispatcher's shutdown check.
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
@@ -591,19 +586,24 @@ impl IoCapability {
     }
 }
 
-/// Running handle returned by [`IoCapability::boot`]. Same shape as
-/// the other dispatcher-thread capabilities.
+/// Running handle returned by [`IoCapability::boot`]. Holds the
+/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
+/// drives channel-drop shutdown, and the actor's
+/// [`NativeTransport`] (kept alive for the dispatcher thread's
+/// lifetime via the `Arc` clone the spawn closure holds).
 pub struct IoRunning {
     thread: Option<JoinHandle<()>>,
-    shutdown_flag: Arc<AtomicBool>,
+    sink_sender: Option<SinkSender>,
+    _transport: Arc<NativeTransport>,
 }
 
 impl Capability for IoCapability {
     type Running = IoRunning;
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox(IO_SINK_NAME)?;
-        let mailer = ctx.mail_send_handle();
+        let claim = ctx.claim_mailbox_drop_on_shutdown(IO_SINK_NAME)?;
+        let mailer: Arc<Mailer> = ctx.mail_send_handle();
+        let mailbox_id = claim.id;
         let (registry, roots) = build_registry(self.roots).map_err(|e| {
             BootError::Other(Box::new(std::io::Error::new(
                 e.kind(),
@@ -618,34 +618,26 @@ impl Capability for IoCapability {
             "io adapters registered",
         );
 
-        let shutdown_flag = Arc::new(AtomicBool::new(false));
-        let thread_flag = Arc::clone(&shutdown_flag);
-        let receiver = claim.receiver;
+        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        transport.install_inbox(claim.receiver);
+        let dispatcher_transport = Arc::clone(&transport);
 
         let thread = thread::Builder::new()
             .name("aether-io-sink".into())
             .spawn(move || {
-                while !thread_flag.load(Ordering::Relaxed) {
-                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
-                        Ok(env) => {
-                            dispatch_io_mail(
-                                &registry,
-                                &mailer,
-                                env.kind,
-                                env.sender,
-                                &env.payload,
-                            );
-                        }
-                        Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
-                    }
+                // Channel-drop + join: pull until the sender side
+                // disconnects. Worst-case shutdown latency is the
+                // OS scheduler's wakeup, not a 100ms poll interval.
+                while let Some(env) = dispatcher_transport.recv_blocking() {
+                    dispatch_io_mail(&registry, &mailer, env.kind, env.sender, &env.payload);
                 }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
         Ok(IoRunning {
             thread: Some(thread),
-            shutdown_flag,
+            sink_sender: Some(claim.sink_sender),
+            _transport: transport,
         })
     }
 }
@@ -654,9 +646,11 @@ impl RunningCapability for IoRunning {
     fn shutdown(self: Box<Self>) {
         let IoRunning {
             mut thread,
-            shutdown_flag,
+            mut sink_sender,
+            _transport,
         } = *self;
-        shutdown_flag.store(true, Ordering::Relaxed);
+        // Drop the strong sender first to break the channel.
+        sink_sender.take();
         if let Some(t) = thread.take() {
             let _ = t.join();
         }

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -24,14 +24,13 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability};
+use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
+use crate::native_transport::NativeTransport;
 use aether_data::{Kind, KindId};
 use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
@@ -47,9 +46,6 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 /// and the fetch itself supplies no `timeout_ms`. 30s matches
 /// ADR-0043 §4.
 pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
-
-/// Polling interval for the dispatcher's shutdown check.
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Adapter-facing request shape. Converted from the wire `Fetch`
 /// kind by the dispatcher before handing to the adapter.
@@ -463,51 +459,54 @@ impl NetCapability {
     }
 }
 
-/// Running handle returned by [`NetCapability::boot`]. Same shape as
-/// the other dispatcher-thread capabilities.
+/// Running handle returned by [`NetCapability::boot`]. Holds the
+/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
+/// drives channel-drop shutdown, and the actor's
+/// [`NativeTransport`] (kept alive for the dispatcher thread's
+/// lifetime via the `Arc` clone the spawn closure holds).
 pub struct NetRunning {
     thread: Option<JoinHandle<()>>,
-    shutdown_flag: Arc<AtomicBool>,
+    sink_sender: Option<SinkSender>,
+    _transport: Arc<NativeTransport>,
 }
 
 impl Capability for NetCapability {
     type Running = NetRunning;
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox(NET_SINK_NAME)?;
-        let mailer = ctx.mail_send_handle();
+        let claim = ctx.claim_mailbox_drop_on_shutdown(NET_SINK_NAME)?;
+        let mailer: Arc<Mailer> = ctx.mail_send_handle();
+        let mailbox_id = claim.id;
         let default_timeout = self.config.default_timeout;
         let adapter = build_net_adapter(self.config);
 
-        let shutdown_flag = Arc::new(AtomicBool::new(false));
-        let thread_flag = Arc::clone(&shutdown_flag);
-        let receiver = claim.receiver;
+        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        transport.install_inbox(claim.receiver);
+        let dispatcher_transport = Arc::clone(&transport);
 
         let thread = thread::Builder::new()
             .name("aether-net-sink".into())
             .spawn(move || {
-                while !thread_flag.load(Ordering::Relaxed) {
-                    match receiver.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
-                        Ok(env) => {
-                            dispatch_net_mail(
-                                adapter.as_ref(),
-                                &mailer,
-                                env.kind,
-                                env.sender,
-                                &env.payload,
-                                default_timeout,
-                            );
-                        }
-                        Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
-                    }
+                // Channel-drop + join: pull until the sender side
+                // disconnects. Worst-case shutdown latency is the
+                // OS scheduler's wakeup, not a 100ms poll interval.
+                while let Some(env) = dispatcher_transport.recv_blocking() {
+                    dispatch_net_mail(
+                        adapter.as_ref(),
+                        &mailer,
+                        env.kind,
+                        env.sender,
+                        &env.payload,
+                        default_timeout,
+                    );
                 }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
         Ok(NetRunning {
             thread: Some(thread),
-            shutdown_flag,
+            sink_sender: Some(claim.sink_sender),
+            _transport: transport,
         })
     }
 }
@@ -516,9 +515,11 @@ impl RunningCapability for NetRunning {
     fn shutdown(self: Box<Self>) {
         let NetRunning {
             mut thread,
-            shutdown_flag,
+            mut sink_sender,
+            _transport,
         } = *self;
-        shutdown_flag.store(true, Ordering::Relaxed);
+        // Drop the strong sender first to break the channel.
+        sink_sender.take();
         if let Some(t) = thread.take() {
             let _ = t.join();
         }


### PR DESCRIPTION
ADR-0074 Phase 2c/2d/2e. AudioCapability, IoCapability, and NetCapability each migrate onto the channel-drop + join shutdown lifecycle, mirroring LogCapability (PR 519) and HandleCapability (PR 520). Three near-identical mechanical diffs — bundled in one PR because the pattern is fully established and per-cap diffs read cleaner side-by-side than three sequential PRs.

## Summary
- audio: claim_mailbox_drop_on_shutdown + recv_blocking; cpal pipeline still constructs and tears down on the dispatcher thread (cpal::Stream is !Send on macOS); channel-drop preserves that ownership
- io: claim_mailbox_drop_on_shutdown + recv_blocking
- net: claim_mailbox_drop_on_shutdown + recv_blocking
- All three Running structs grow SinkSender + Arc<NativeTransport> instead of Arc<AtomicBool>; shutdown drops the strong sender first to break the channel, then joins
- Reply paths unchanged — Mailer::send_reply direct, same as PR 520

## What's left after this lands
- Render is the only capability still on the AtomicBool pattern. Phase 3 retires camera as a separate mailbox and folds it into render — structural work that needs ADR-0074 §Phase 3 design revisited before implementation.
- The typed ctx.reply SDK pattern (NativeTransport::reply_mail still a stub) is queued for a separate refactor that touches all four reply-bearing capabilities together.

## Test plan
- [x] cargo test --workspace (1084 passed)
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] All capability tests pass with channel-drop semantics