### PR TITLE
refactor(substrate): cross-class wait_reply guard (issue 509 phase 4)

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -323,6 +323,13 @@ impl DesktopChassis {
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
         let namespace_roots = boot.namespace_roots.clone();
+        // ADR-0074 §Decision 5: production chassis configures the
+        // cross-class `wait_reply` aborter to broadcast
+        // `SubstrateDying` before exit. Built before `boot` moves
+        // into the driver.
+        let aborter: Arc<dyn aether_substrate::lifecycle::FatalAborter> = Arc::new(
+            aether_substrate::lifecycle::OutboundFatalAborter::new(Arc::clone(&boot.outbound)),
+        );
 
         let driver = DesktopDriverCapability {
             event_loop,
@@ -341,6 +348,7 @@ impl DesktopChassis {
         // through the log capture; render last among passives so it
         // claims its mailboxes after every other chassis sink.
         Builder::<DesktopChassis>::new(registry, mailer)
+            .with_aborter(aborter)
             .with(LogCapability::new())
             .with(IoCapability::new(namespace_roots))
             .with(NetCapability::new(net))

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -209,6 +209,12 @@ impl HeadlessChassis {
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
         let namespace_roots = boot.namespace_roots.clone();
+        // ADR-0074 §Decision 5: production chassis configures the
+        // cross-class `wait_reply` aborter to broadcast
+        // `SubstrateDying` before exit.
+        let aborter: Arc<dyn aether_substrate::lifecycle::FatalAborter> = Arc::new(
+            aether_substrate::lifecycle::OutboundFatalAborter::new(Arc::clone(&boot.outbound)),
+        );
 
         let driver = HeadlessTimerCapability {
             boot,
@@ -223,6 +229,7 @@ impl HeadlessChassis {
         // order — log first so other capabilities' boot tracing routes
         // through the log capture.
         Builder::<HeadlessChassis>::new(registry, mailer)
+            .with_aborter(aborter)
             .with(LogCapability::new())
             .with(IoCapability::new(namespace_roots))
             .with(NetCapability::new(net))

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -826,7 +826,11 @@ impl Capability for AudioCapability {
         let mailbox_id = claim.id;
         let config = self.config;
 
-        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        let transport = Arc::new(NativeTransport::from_ctx(
+            ctx,
+            mailbox_id,
+            Self::FRAME_BARRIER,
+        ));
         transport.install_inbox(claim.receiver);
         let dispatcher_transport = Arc::clone(&transport);
 

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -91,7 +91,11 @@ impl Capability for HandleCapability {
         // and clones the `Arc` into the dispatcher thread; the
         // dispatcher uses `transport.recv_blocking()` to pull from
         // its own inbox without thread-local plumbing.
-        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        let transport = Arc::new(NativeTransport::from_ctx(
+            ctx,
+            mailbox_id,
+            Self::FRAME_BARRIER,
+        ));
         transport.install_inbox(claim.receiver);
         let dispatcher_transport = Arc::clone(&transport);
 

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -618,7 +618,11 @@ impl Capability for IoCapability {
             "io adapters registered",
         );
 
-        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        let transport = Arc::new(NativeTransport::from_ctx(
+            ctx,
+            mailbox_id,
+            Self::FRAME_BARRIER,
+        ));
         transport.install_inbox(claim.receiver);
         let dispatcher_transport = Arc::clone(&transport);
 

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -82,15 +82,23 @@ impl Capability for LogCapability {
 
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown(LOG_SINK_NAME)?;
-        let mailer = ctx.mail_send_handle();
         let mailbox_id = claim.id;
 
         // ADR-0074 §Decision: `&self` trait, owned transport. The
         // capability constructs its `NativeTransport` once at boot
         // and clones the `Arc` into the dispatcher thread; the
         // dispatcher uses `transport.recv_blocking()` to pull from
-        // its own inbox without thread-local plumbing.
-        let transport = Arc::new(NativeTransport::new(mailer, mailbox_id));
+        // its own inbox without thread-local plumbing. Going through
+        // `from_ctx` wires the chassis's frame-bound set + aborter
+        // into the transport so the cross-class `wait_reply` guard
+        // (ADR-0074 §Decision 5) is live for any future log-side
+        // sync calls — `LogCapability::FRAME_BARRIER` is the default
+        // `false`, so the guard treats this caller as free-running.
+        let transport = Arc::new(NativeTransport::from_ctx(
+            ctx,
+            mailbox_id,
+            Self::FRAME_BARRIER,
+        ));
         transport.install_inbox(claim.receiver);
         let dispatcher_transport = Arc::clone(&transport);
 

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -480,7 +480,11 @@ impl Capability for NetCapability {
         let default_timeout = self.config.default_timeout;
         let adapter = build_net_adapter(self.config);
 
-        let transport = Arc::new(NativeTransport::new(Arc::clone(&mailer), mailbox_id));
+        let transport = Arc::new(NativeTransport::from_ctx(
+            ctx,
+            mailbox_id,
+            Self::FRAME_BARRIER,
+        ));
         transport.install_inbox(claim.receiver);
         let dispatcher_transport = Arc::clone(&transport);
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -26,13 +26,15 @@
 //! - No sinks are migrated yet — `crate::capabilities` is an empty
 //!   submodule placeholder that future PRs populate.
 
+use std::collections::HashSet;
 use std::error::Error as StdError;
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::{KindId, MailboxId, ReplyTo};
 use crate::mailer::Mailer;
 use crate::registry::{NameConflict, Registry};
@@ -274,6 +276,27 @@ pub struct ChassisCtx<'a> {
     /// frame loop can wait on them via
     /// [`BootedChassis::drain_frame_bound`].
     frame_bound_pending: &'a mut Vec<(MailboxId, Arc<AtomicU64>)>,
+    /// Membership view of the same set the `frame_bound_pending` Vec
+    /// covers, shared with every [`crate::NativeTransport`] built
+    /// against this chassis. Capabilities clone the [`Arc`] into their
+    /// transport at boot; the transport's cross-class `wait_reply`
+    /// guard reads it (with a brief read-lock) to classify the
+    /// recipient of an outbound request as frame-bound or
+    /// free-running. [`Self::claim_frame_bound_mailbox`] inserts the
+    /// claimed mailbox id here in addition to pushing onto the
+    /// pending-counter list.
+    frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
+    /// Indirection over [`crate::lifecycle::fatal_abort`] cloned into
+    /// every [`crate::NativeTransport`] this ctx builds, so the
+    /// cross-class `wait_reply` guard (ADR-0074 §Decision 5) can
+    /// abort without each capability needing to plumb
+    /// [`crate::HubOutbound`] itself. Defaults to
+    /// [`PanicAborter`] when the chassis builder doesn't override —
+    /// production drivers swap in
+    /// [`crate::lifecycle::OutboundFatalAborter`] via
+    /// [`ChassisBuilder::with_aborter`] /
+    /// [`crate::chassis_builder::Builder::with_aborter`].
+    aborter: &'a Arc<dyn FatalAborter>,
 }
 
 impl<'a> ChassisCtx<'a> {
@@ -284,12 +307,16 @@ impl<'a> ChassisCtx<'a> {
         mailer: &'a Arc<Mailer>,
         fallback: &'a mut Option<FallbackRouter>,
         frame_bound_pending: &'a mut Vec<(MailboxId, Arc<AtomicU64>)>,
+        frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
+        aborter: &'a Arc<dyn FatalAborter>,
     ) -> Self {
         Self {
             registry,
             mailer,
             fallback,
             frame_bound_pending,
+            frame_bound_set,
+            aborter,
         }
     }
 
@@ -466,6 +493,12 @@ impl<'a> ChassisCtx<'a> {
             ),
         )?;
         self.frame_bound_pending.push((id, Arc::clone(&pending)));
+        // Mirror the membership into the shared set so each
+        // capability's [`crate::NativeTransport`] can resolve "is the
+        // recipient of this `wait_reply` frame-bound?" with a single
+        // read-lock — without each transport having to scan the
+        // pending-counter Vec on every check.
+        self.frame_bound_set.write().unwrap().insert(id);
         Ok(FrameBoundClaim {
             id,
             receiver: rx,
@@ -510,6 +543,22 @@ impl<'a> ChassisCtx<'a> {
         self.frame_bound_pending
     }
 
+    /// Clone the chassis's shared frame-bound membership set. Read by
+    /// [`crate::NativeTransport::from_ctx`] so the cross-class
+    /// `wait_reply` guard can classify each outbound recipient.
+    /// Capabilities that just want to send mail don't need this.
+    pub fn frame_bound_set(&self) -> Arc<RwLock<HashSet<MailboxId>>> {
+        Arc::clone(self.frame_bound_set)
+    }
+
+    /// Clone the chassis's [`FatalAborter`]. Read by
+    /// [`crate::NativeTransport::from_ctx`] so the cross-class
+    /// `wait_reply` guard has somewhere to abort to without each
+    /// transport plumbing [`crate::HubOutbound`] itself.
+    pub fn fatal_aborter(&self) -> Arc<dyn FatalAborter> {
+        Arc::clone(self.aborter)
+    }
+
     /// Install the fallback-router handler. At most one capability
     /// may claim the slot; a second call returns
     /// [`BootError::FallbackRouterAlreadyClaimed`].
@@ -545,6 +594,7 @@ pub struct ChassisBuilder {
     registry: Arc<Registry>,
     mailer: Arc<Mailer>,
     pending: Vec<BootFn>,
+    aborter: Arc<dyn FatalAborter>,
 }
 
 impl ChassisBuilder {
@@ -553,12 +603,31 @@ impl ChassisBuilder {
     /// (TestBench rewrite) folds substrate construction into the
     /// builder; until then, the existing `SubstrateBoot::build` is
     /// the construction site.
+    ///
+    /// Defaults the cross-class `wait_reply` aborter to
+    /// [`PanicAborter`] — appropriate for tests and embedder-driven
+    /// chassis. Production drivers swap in
+    /// [`crate::lifecycle::OutboundFatalAborter`] via
+    /// [`Self::with_aborter`] before `build()`.
     pub fn new(registry: Arc<Registry>, mailer: Arc<Mailer>) -> Self {
         Self {
             registry,
             mailer,
             pending: Vec::new(),
+            aborter: Arc::new(PanicAborter),
         }
+    }
+
+    /// Override the default [`PanicAborter`] with a chassis-supplied
+    /// [`FatalAborter`]. Production drivers (desktop, headless) call
+    /// this with an [`crate::lifecycle::OutboundFatalAborter`] cloned
+    /// from their [`crate::HubOutbound`] so a cross-class
+    /// `wait_reply` violation broadcasts `SubstrateDying` before
+    /// process exit. Single-call: a second invocation overwrites the
+    /// prior aborter.
+    pub fn with_aborter(mut self, aborter: Arc<dyn FatalAborter>) -> Self {
+        self.aborter = aborter;
+        self
     }
 
     /// Append a capability. Boot order is declaration order.
@@ -581,13 +650,22 @@ impl ChassisBuilder {
             registry,
             mailer,
             pending,
+            aborter,
         } = self;
         let mut fallback: Option<FallbackRouter> = None;
         let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
+        let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> =
+            Arc::new(RwLock::new(HashSet::new()));
         let mut booted: Vec<Box<dyn RunningCapability>> = Vec::with_capacity(pending.len());
         for boot in pending {
-            let mut ctx =
-                ChassisCtx::new(&registry, &mailer, &mut fallback, &mut frame_bound_pending);
+            let mut ctx = ChassisCtx::new(
+                &registry,
+                &mailer,
+                &mut fallback,
+                &mut frame_bound_pending,
+                &frame_bound_set,
+                &aborter,
+            );
             match boot(&mut ctx) {
                 Ok(running) => booted.push(running),
                 Err(e) => {
@@ -602,6 +680,8 @@ impl ChassisBuilder {
             running: booted,
             _fallback: fallback,
             frame_bound_pending,
+            frame_bound_set,
+            aborter,
         })
     }
 }
@@ -622,6 +702,17 @@ pub struct BootedChassis {
     /// §Decision 5 the frame loop waits on these alongside component
     /// drains so render submit sees fully-integrated state.
     frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,
+    /// Membership view of the frame-bound mailbox set. Shared with
+    /// every [`crate::NativeTransport`] booted under this chassis;
+    /// also threaded into [`Self::add`] so post-build capabilities
+    /// see (and contribute to) the same set.
+    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
+    /// Aborter cloned into every [`crate::NativeTransport`] this
+    /// chassis builds. Defaulted to [`PanicAborter`] by
+    /// [`ChassisBuilder::new`]; production drivers swap in
+    /// [`crate::lifecycle::OutboundFatalAborter`] via
+    /// [`ChassisBuilder::with_aborter`].
+    aborter: Arc<dyn FatalAborter>,
 }
 
 impl fmt::Debug for BootedChassis {
@@ -671,6 +762,8 @@ impl BootedChassis {
             mailer,
             &mut self._fallback,
             &mut self.frame_bound_pending,
+            &self.frame_bound_set,
+            &self.aborter,
         );
         let running = cap.boot(&mut ctx)?;
         self.running.push(Box::new(running));

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -21,17 +21,18 @@
 //!   chassis can nominate a real driver type rather than a stub.
 
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, RwLock};
 
 use crate::capability::{
     BootError, Capability, ChassisCtx, FallbackRouter, MailboxClaim, RunningCapability,
 };
 use crate::chassis::Chassis;
+use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::MailboxId;
 use crate::mailer::Mailer;
 use crate::registry::Registry;
@@ -297,21 +298,39 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     mailer: Arc<Mailer>,
     passives: Vec<PassiveBoot>,
     driver: Option<DriverBoot>,
+    aborter: Arc<dyn FatalAborter>,
     _chassis: PhantomData<fn() -> C>,
     _state: PhantomData<fn() -> S>,
 }
 
 impl<C: Chassis> Builder<C, NoDriver> {
     /// Construct a fresh builder against the given substrate handles.
+    /// Defaults the cross-class `wait_reply` aborter to
+    /// [`PanicAborter`]; production drivers swap in
+    /// [`crate::lifecycle::OutboundFatalAborter`] via
+    /// [`Self::with_aborter`] before `build()` / `build_passive()`.
     pub fn new(registry: Arc<Registry>, mailer: Arc<Mailer>) -> Self {
         Self {
             registry,
             mailer,
             passives: Vec::new(),
             driver: None,
+            aborter: Arc::new(PanicAborter),
             _chassis: PhantomData,
             _state: PhantomData,
         }
+    }
+
+    /// Override the default [`PanicAborter`] with a chassis-supplied
+    /// [`FatalAborter`]. Mirrors
+    /// [`crate::ChassisBuilder::with_aborter`]; production drivers
+    /// (desktop, headless) call this before `build()` so a cross-class
+    /// `wait_reply` violation broadcasts `SubstrateDying` before
+    /// process exit. Single-call: a second invocation overwrites the
+    /// prior aborter.
+    pub fn with_aborter(mut self, aborter: Arc<dyn FatalAborter>) -> Self {
+        self.aborter = aborter;
+        self
     }
 
     /// Append a passive capability. Boot order is declaration order;
@@ -338,6 +357,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             mailer: self.mailer,
             passives: self.passives,
             driver: self.driver,
+            aborter: self.aborter,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -347,7 +367,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// and returns a [`PassiveChassis`] whose embedder is responsible
     /// for driving the loop manually (TestBench).
     pub fn build_passive(self) -> Result<PassiveChassis<C>, BootError> {
-        let booted = boot_passives(&self.registry, &self.mailer, self.passives)?;
+        let booted = boot_passives(&self.registry, &self.mailer, &self.aborter, self.passives)?;
         Ok(PassiveChassis {
             booted,
             _chassis: PhantomData,
@@ -378,17 +398,20 @@ impl<C: Chassis> Builder<C, HasDriver> {
             mailer,
             passives,
             driver,
+            aborter,
             ..
         } = self;
         let driver_boot = driver.expect("HasDriver state implies driver was supplied");
 
-        let mut booted = boot_passives(&registry, &mailer, passives)?;
+        let mut booted = boot_passives(&registry, &mailer, &aborter, passives)?;
         let driver_running = {
             let chassis_ctx = ChassisCtx::new(
                 &registry,
                 &mailer,
                 &mut booted.fallback,
                 &mut booted.frame_bound_pending,
+                &booted.frame_bound_set,
+                &booted.aborter,
             );
             let mut driver_ctx = DriverCtx::new(chassis_ctx, &booted.runnings);
             driver_boot(&mut driver_ctx)?
@@ -413,6 +436,17 @@ struct BootedPassives {
     /// [`DriverCtx::frame_bound_pending`] (the driver stashes a clone
     /// for its frame loop).
     frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,
+    /// Membership view of the same set; shared with every
+    /// [`crate::NativeTransport`] booted under this chassis so the
+    /// cross-class `wait_reply` guard can classify recipients.
+    /// Populated alongside `frame_bound_pending` by
+    /// [`ChassisCtx::claim_frame_bound_mailbox`].
+    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
+    /// Cloned into every `ChassisCtx` and onto every booted
+    /// [`crate::NativeTransport`] so the cross-class `wait_reply`
+    /// guard has somewhere to abort to. Inherited from the
+    /// [`Builder`]'s configured aborter.
+    aborter: Arc<dyn FatalAborter>,
 }
 
 impl BootedPassives {
@@ -440,14 +474,23 @@ impl Drop for BootedPassives {
 fn boot_passives(
     registry: &Arc<Registry>,
     mailer: &Arc<Mailer>,
+    aborter: &Arc<dyn FatalAborter>,
     passives: Vec<PassiveBoot>,
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
     let mut runnings = TypedRunnings::new();
     let mut fallback: Option<FallbackRouter> = None;
     let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
+    let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
     for boot in passives {
-        let mut ctx = ChassisCtx::new(registry, mailer, &mut fallback, &mut frame_bound_pending);
+        let mut ctx = ChassisCtx::new(
+            registry,
+            mailer,
+            &mut fallback,
+            &mut frame_bound_pending,
+            &frame_bound_set,
+            aborter,
+        );
         match boot(&mut ctx, &mut runnings) {
             Ok(shutdown) => shutdowns.push(shutdown),
             Err(e) => {
@@ -463,6 +506,8 @@ fn boot_passives(
         runnings,
         fallback,
         frame_bound_pending,
+        frame_bound_set,
+        aborter: Arc::clone(aborter),
     })
 }
 

--- a/crates/aether-substrate/src/lifecycle.rs
+++ b/crates/aether-substrate/src/lifecycle.rs
@@ -12,6 +12,16 @@
 //! here we've already decided the substrate is going down, and any
 //! caller-side cleanup would race the hub's reaping of the engine
 //! anyway.
+//!
+//! [`FatalAborter`] is the indirection that lets call sites that
+//! don't naturally hold a [`HubOutbound`] (the cross-class wait_reply
+//! guard in [`crate::native_transport`], future ADR-0074 §Decision-7
+//! checks) request an abort without plumbing outbound through every
+//! layer. Production chassis construct an [`OutboundFatalAborter`];
+//! tests use [`PanicAborter`] so a misuse panics the test thread
+//! instead of `process::exit`-ing the test runner.
+
+use std::sync::Arc;
 
 use aether_kinds::SubstrateDying;
 
@@ -60,4 +70,53 @@ pub fn fatal_abort(outbound: &HubOutbound, reason: String) -> ! {
     crate::log_capture::flush_now();
 
     std::process::exit(FATAL_EXIT_CODE);
+}
+
+/// Indirection over [`fatal_abort`] for call sites that don't
+/// naturally hold a [`HubOutbound`]. The chassis injects one of these
+/// into [`crate::ChassisCtx`]; capabilities thread it into their
+/// [`crate::NativeTransport`] so the cross-class `wait_reply` guard
+/// (ADR-0074 §Decision 5) can abort without each capability needing
+/// to plumb outbound itself.
+///
+/// Implementors must be `Send + Sync` so the aborter can be cloned
+/// into capability dispatcher threads, and the [`Self::abort`] method
+/// must be diverging — the chassis is going down, no caller-side
+/// cleanup runs after.
+pub trait FatalAborter: Send + Sync + 'static {
+    fn abort(&self, reason: String) -> !;
+}
+
+/// Production [`FatalAborter`] backed by [`fatal_abort`]. Holds the
+/// chassis's [`HubOutbound`] so the abort emits a final
+/// `SubstrateDying` broadcast before `process::exit`. Constructed by
+/// chassis drivers (desktop, headless) that already own outbound.
+pub struct OutboundFatalAborter {
+    outbound: Arc<HubOutbound>,
+}
+
+impl OutboundFatalAborter {
+    pub fn new(outbound: Arc<HubOutbound>) -> Self {
+        Self { outbound }
+    }
+}
+
+impl FatalAborter for OutboundFatalAborter {
+    fn abort(&self, reason: String) -> ! {
+        fatal_abort(&self.outbound, reason);
+    }
+}
+
+/// Test [`FatalAborter`] that panics instead of `process::exit`-ing.
+/// Lets a `#[should_panic]` test assert the cross-class guard fires
+/// without taking down the whole test runner. Also the default for
+/// chassis built without an explicit aborter (tests, the TestBench
+/// in-process driver) so an abort surfaces as a panic the harness
+/// catches.
+pub struct PanicAborter;
+
+impl FatalAborter for PanicAborter {
+    fn abort(&self, reason: String) -> ! {
+        panic!("aether-substrate fatal abort: {reason}");
+    }
 }

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -15,16 +15,17 @@
 //! `aether_component::WasmTransport` (a ZST) the same way; both
 //! impls share the SDK in `aether-actor`.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 use aether_actor::MailTransport;
 
-use crate::capability::Envelope;
+use crate::capability::{ChassisCtx, Envelope};
+use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::{KindId, Mail, MailboxId, ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
 
@@ -69,7 +70,50 @@ pub struct NativeTransport {
     /// Monotonic correlation counter — atomic so `&self` can mint
     /// new ids without `&mut`.
     correlation: AtomicU64,
+    /// ADR-0074 §Decision 5 cross-class `wait_reply` guard. `true`
+    /// means this transport's owning capability declared
+    /// `Capability::FRAME_BARRIER = true`; combined with the
+    /// `frame_bound_set` lookup below, [`Self::wait_reply`] aborts
+    /// when a frame-bound caller blocks on a free-running recipient
+    /// (which would wedge the per-frame drain barrier waiting on a
+    /// thread that doesn't synchronize with frames).
+    caller_frame_bound: bool,
+    /// Membership view of the chassis's frame-bound mailbox set.
+    /// Read on each [`Self::wait_reply`] to classify the recipient
+    /// of the prior `send_mail`. Cloned from
+    /// [`ChassisCtx::frame_bound_set`] at boot; the chassis adds
+    /// entries as additional frame-bound capabilities boot, so this
+    /// view stays current across the chassis lifetime.
+    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
+    /// Indirection over [`crate::lifecycle::fatal_abort`] — invoked
+    /// by [`Self::wait_reply`] on cross-class violation. Cloned from
+    /// [`ChassisCtx::fatal_aborter`] at boot.
+    aborter: Arc<dyn FatalAborter>,
+    /// Tracks `correlation_id → recipient_mailbox` for outbound
+    /// requests so [`Self::wait_reply`] can resolve the recipient
+    /// when checking the cross-class guard. Populated by
+    /// [`Self::send_mail`] (every send, since fire-and-forget vs
+    /// request/reply isn't distinguishable at this layer); pruned
+    /// by [`Self::wait_reply`] when the matching reply arrives or
+    /// the deadline expires. Bounded by the cleanup pass in
+    /// `wait_reply`'s exit paths plus an opportunistic cap (see
+    /// `MAX_PENDING_RECIPIENTS`); a runaway sender that never paired
+    /// a wait would otherwise leak entries here.
+    pending_recipients: Mutex<HashMap<u64, MailboxId>>,
 }
+
+/// Soft cap on [`NativeTransport::pending_recipients`]. A
+/// fire-and-forget `send_mail` (one with no paired `wait_reply`)
+/// leaves an entry in the map indefinitely; the cap stops a runaway
+/// sender from growing the map without bound. Picked large enough
+/// to comfortably exceed any realistic burst of in-flight requests
+/// from a single capability — the cross-class guard is preventive,
+/// not load-bearing for normal traffic. When the cap is hit the
+/// oldest entry is dropped (insertion order; we accept that the
+/// pruned correlation will silently skip the guard if its reply
+/// ever lands, which is strictly less safe than aborting but no
+/// worse than the pre-guard baseline).
+const MAX_PENDING_RECIPIENTS: usize = 1024;
 
 impl NativeTransport {
     /// Build a fresh transport. Pair `self_mailbox` with the id the
@@ -79,14 +123,74 @@ impl NativeTransport {
     /// separately via [`Self::install_inbox`] so capabilities that
     /// build the transport before pulling the receiver out of their
     /// claim aren't forced into a specific construction order.
-    pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
+    ///
+    /// `caller_frame_bound`, `frame_bound_set`, and `aborter` wire
+    /// the ADR-0074 §Decision 5 cross-class `wait_reply` guard.
+    /// Capabilities authored under a [`crate::ChassisCtx`] should
+    /// prefer [`Self::from_ctx`], which inherits the chassis's
+    /// shared set + aborter automatically; the explicit constructor
+    /// is for harnesses that don't go through a chassis (TestBench
+    /// internals) or for tests that want to substitute a custom
+    /// aborter.
+    pub fn new(
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+        caller_frame_bound: bool,
+        frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
+        aborter: Arc<dyn FatalAborter>,
+    ) -> Self {
         Self {
             mailer,
             self_mailbox,
             inbox: OnceLock::new(),
             overflow: Mutex::new(VecDeque::new()),
             correlation: AtomicU64::new(0),
+            caller_frame_bound,
+            frame_bound_set,
+            aborter,
+            pending_recipients: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Convenience constructor that pulls the cross-class guard
+    /// state (frame-bound set + aborter) from a [`ChassisCtx`]. The
+    /// natural call site is inside a [`crate::Capability::boot`]:
+    ///
+    /// ```ignore
+    /// let claim = ctx.claim_mailbox_drop_on_shutdown(NAME)?;
+    /// let transport = NativeTransport::from_ctx(ctx, claim.id, Self::FRAME_BARRIER);
+    /// ```
+    ///
+    /// Capabilities that don't migrate to this constructor in the
+    /// same PR keep using [`Self::new_for_test`] (or call
+    /// [`Self::new`] explicitly with their chosen guard state); the
+    /// guard is a no-op for non-frame-bound callers and the
+    /// PanicAborter default is harmless for production caps that
+    /// never call `wait_reply`.
+    pub fn from_ctx(ctx: &ChassisCtx<'_>, self_mailbox: MailboxId, frame_bound: bool) -> Self {
+        Self::new(
+            ctx.mail_send_handle(),
+            self_mailbox,
+            frame_bound,
+            ctx.frame_bound_set(),
+            ctx.fatal_aborter(),
+        )
+    }
+
+    /// Test-only constructor that disables the cross-class guard
+    /// (non-frame-bound caller, empty set, [`PanicAborter`]). Lets
+    /// existing unit tests construct a transport without naming
+    /// every guard parameter; not appropriate for production
+    /// capabilities, which should go through [`Self::from_ctx`] so
+    /// the guard wires to the chassis's shared state.
+    pub fn new_for_test(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
+        Self::new(
+            mailer,
+            self_mailbox,
+            false,
+            Arc::new(RwLock::new(HashSet::new())),
+            Arc::new(PanicAborter),
+        )
     }
 
     /// Install the receiver half of the actor's inbox so
@@ -159,11 +263,26 @@ const ERR_NO_INBOX_I32: i32 = 100;
 impl MailTransport for NativeTransport {
     fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
         let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
+        let recipient_id = MailboxId(recipient);
         let reply_to =
             ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
-        let mail = Mail::new(MailboxId(recipient), KindId(kind), bytes.to_vec(), count)
+        let mail = Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count)
             .with_reply_to(reply_to)
             .with_origin(self.self_mailbox);
+        // Record `correlation -> recipient` for the cross-class
+        // `wait_reply` guard. We record on every send (the FFI here
+        // can't tell fire-and-forget from request/reply) and let
+        // `wait_reply` prune. The opportunistic cap below stops a
+        // runaway sender that never paired a wait from leaking.
+        {
+            let mut pending = self.pending_recipients.lock().unwrap();
+            if pending.len() >= MAX_PENDING_RECIPIENTS
+                && let Some(&drop_key) = pending.keys().next()
+            {
+                pending.remove(&drop_key);
+            }
+            pending.insert(correlation, recipient_id);
+        }
         self.mailer.push(mail);
         0
     }
@@ -208,10 +327,39 @@ impl MailTransport for NativeTransport {
             return -ERR_NO_INBOX_I32;
         };
 
+        // ADR-0074 §Decision 5 cross-class guard: a frame-bound
+        // caller blocking on a free-running recipient would wedge
+        // the per-frame drain barrier waiting on a thread that
+        // doesn't synchronize with frames. Detect at the call site
+        // and abort with a specific diagnostic instead of letting
+        // `drain_frame_bound_or_abort` time out further downstream
+        // with a less actionable "dispatcher wedged" reason. The
+        // guard is preventive — today no in-tree capability calls
+        // `wait_reply` cross-class — so the early return path is
+        // for future-cap correctness, not current behavior.
+        if self.caller_frame_bound
+            && expected_correlation != ReplyTo::NO_CORRELATION
+            && let Some(recipient) = self
+                .pending_recipients
+                .lock()
+                .unwrap()
+                .get(&expected_correlation)
+                .copied()
+            && !self.frame_bound_set.read().unwrap().contains(&recipient)
+        {
+            self.aborter.abort(format!(
+                "frame-bound actor {} attempted wait_reply on free-running recipient {} \
+                 (correlation {expected_correlation}, expected_kind {expected_kind}) — \
+                 forbidden by ADR-0074 §Decision 5: blocking on a free-running actor would \
+                 wedge the per-frame drain barrier",
+                self.self_mailbox, recipient,
+            ));
+        }
+
         let timeout = Duration::from_millis(timeout_ms as u64);
         let deadline = Instant::now() + timeout;
 
-        loop {
+        let rc = loop {
             // Drain overflow first — a previous `wait_reply` may
             // have parked envelopes that match this kind /
             // correlation. Mirrors `SubstrateCtx::wait_reply` on
@@ -224,7 +372,7 @@ impl MailTransport for NativeTransport {
                 pos.and_then(|i| overflow.remove(i))
             };
             if let Some(env) = from_overflow {
-                return write_payload(&env, out);
+                break write_payload(&env, out);
             }
 
             // No overflow match — pull from the inbox with whatever
@@ -238,16 +386,28 @@ impl MailTransport for NativeTransport {
             match recv_outcome {
                 Ok(env) => {
                     if matches_filter(&env, expected_kind, expected_correlation) {
-                        return write_payload(&env, out);
+                        break write_payload(&env, out);
                     }
                     self.overflow.lock().unwrap().push_back(env);
                     // Loop continues — try again with whatever time
                     // is left on the deadline.
                 }
-                Err(RecvTimeoutError::Timeout) => return -1,
-                Err(RecvTimeoutError::Disconnected) => return -3,
+                Err(RecvTimeoutError::Timeout) => break -1,
+                Err(RecvTimeoutError::Disconnected) => break -3,
             }
+        };
+
+        // Whatever the outcome, drop the recipient tracking entry
+        // for this correlation — we won't need it again. (Keeps the
+        // `pending_recipients` map bounded by the actual rate of
+        // unpaired sends rather than total send volume.)
+        if expected_correlation != ReplyTo::NO_CORRELATION {
+            self.pending_recipients
+                .lock()
+                .unwrap()
+                .remove(&expected_correlation);
         }
+        rc
     }
 
     fn prev_correlation(&self) -> u64 {
@@ -320,7 +480,7 @@ mod tests {
         );
         let recipient = registry.lookup("test.sink").unwrap();
 
-        let transport = NativeTransport::new(mailer, MailboxId(99));
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(99));
 
         assert_eq!(transport.prev_correlation(), 0);
         assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
@@ -334,7 +494,7 @@ mod tests {
     #[test]
     fn wait_reply_without_inbox_returns_no_inbox_sentinel() {
         let (_registry, mailer) = fresh_substrate();
-        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
         let mut buf = [0u8; 16];
         let rc = transport.wait_reply(0, &mut buf, 1, 0);
         assert_eq!(rc, -ERR_NO_INBOX_I32);
@@ -346,7 +506,7 @@ mod tests {
     #[test]
     fn reply_mail_and_save_state_are_tracked_stubs() {
         let (_registry, mailer) = fresh_substrate();
-        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
         assert_eq!(transport.reply_mail(0, 0, &[], 0), ERR_NOT_IMPLEMENTED);
         assert_eq!(transport.save_state(0, &[]), ERR_NOT_IMPLEMENTED);
     }
@@ -356,7 +516,7 @@ mod tests {
     #[should_panic(expected = "install_inbox called twice")]
     fn install_inbox_twice_panics() {
         let (_registry, mailer) = fresh_substrate();
-        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
         let (_tx1, rx1) = mpsc::channel::<Envelope>();
         let (_tx2, rx2) = mpsc::channel::<Envelope>();
         transport.install_inbox(rx1);
@@ -368,12 +528,192 @@ mod tests {
     #[test]
     fn wait_reply_times_out_when_inbox_quiet() {
         let (_registry, mailer) = fresh_substrate();
-        let transport = NativeTransport::new(mailer, MailboxId(1));
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
         let (_tx, rx) = mpsc::channel::<Envelope>();
         transport.install_inbox(rx);
         let mut buf = [0u8; 16];
         // 1ms is enough — no sender ever pushes.
         let rc = transport.wait_reply(0, &mut buf, 1, 0);
         assert_eq!(rc, -1);
+    }
+
+    /// Build a transport with the cross-class guard wired: caller
+    /// classification is configurable, and the chassis's
+    /// frame-bound set is shared so tests can pre-populate it to
+    /// classify recipients. Aborter is [`PanicAborter`] so a
+    /// triggered abort surfaces as `should_panic` rather than
+    /// `process::exit`-ing the test runner.
+    fn transport_with_guard(
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+        caller_frame_bound: bool,
+        frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
+    ) -> NativeTransport {
+        NativeTransport::new(
+            mailer,
+            self_mailbox,
+            caller_frame_bound,
+            frame_bound_set,
+            Arc::new(PanicAborter),
+        )
+    }
+
+    /// ADR-0074 §Decision 5: a frame-bound caller blocking on a
+    /// free-running recipient must abort. Verified via the
+    /// PanicAborter — the panic message names both mailboxes plus
+    /// the ADR.
+    #[test]
+    #[should_panic(expected = "forbidden by ADR-0074")]
+    fn cross_class_wait_reply_aborts_when_caller_frame_bound_and_recipient_free_running() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
+        registry.register_sink(
+            "test.free.running",
+            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                let _ = tx.send(Envelope {
+                    kind,
+                    kind_name: kind_name.to_owned(),
+                    origin: origin.map(str::to_owned),
+                    sender,
+                    payload: payload.to_vec(),
+                    count,
+                });
+            }),
+        );
+        let recipient = registry.lookup("test.free.running").unwrap();
+
+        // Empty frame-bound set => recipient classifies as free-running.
+        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
+        let transport =
+            transport_with_guard(Arc::clone(&mailer), MailboxId(99), true, frame_bound_set);
+        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx_inbox);
+
+        // Send first to record the recipient against a correlation id.
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        let correlation = transport.prev_correlation();
+
+        // wait_reply should abort before timing out.
+        let mut buf = [0u8; 16];
+        transport.wait_reply(1, &mut buf, 1, correlation);
+    }
+
+    /// Same shape as the abort test, but the recipient is
+    /// pre-registered as frame-bound. Guard sees same-class and
+    /// lets `wait_reply` proceed to its normal `-1` timeout.
+    #[test]
+    fn cross_class_wait_reply_does_not_abort_when_recipient_also_frame_bound() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
+        registry.register_sink(
+            "test.frame.bound",
+            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                let _ = tx.send(Envelope {
+                    kind,
+                    kind_name: kind_name.to_owned(),
+                    origin: origin.map(str::to_owned),
+                    sender,
+                    payload: payload.to_vec(),
+                    count,
+                });
+            }),
+        );
+        let recipient = registry.lookup("test.frame.bound").unwrap();
+
+        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
+        // Pre-populate recipient as frame-bound (mirroring what
+        // `claim_frame_bound_mailbox` would do).
+        frame_bound_set.write().unwrap().insert(recipient);
+
+        let transport = transport_with_guard(
+            Arc::clone(&mailer),
+            MailboxId(99),
+            true,
+            Arc::clone(&frame_bound_set),
+        );
+        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx_inbox);
+
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        let correlation = transport.prev_correlation();
+
+        let mut buf = [0u8; 16];
+        // Same-class: no abort, just normal timeout (1ms).
+        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
+        assert_eq!(rc, -1);
+    }
+
+    /// Free-running caller never trips the guard regardless of
+    /// recipient class — only frame-bound callers care about being
+    /// blocked across a class boundary.
+    #[test]
+    fn cross_class_wait_reply_does_not_abort_when_caller_free_running() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
+        registry.register_sink(
+            "test.any",
+            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                let _ = tx.send(Envelope {
+                    kind,
+                    kind_name: kind_name.to_owned(),
+                    origin: origin.map(str::to_owned),
+                    sender,
+                    payload: payload.to_vec(),
+                    count,
+                });
+            }),
+        );
+        let recipient = registry.lookup("test.any").unwrap();
+
+        // Empty set — recipient is free-running. Caller is also
+        // free-running. Guard must be inert.
+        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
+        let transport =
+            transport_with_guard(Arc::clone(&mailer), MailboxId(99), false, frame_bound_set);
+        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx_inbox);
+
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        let correlation = transport.prev_correlation();
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
+        assert_eq!(rc, -1);
+    }
+
+    /// `pending_recipients` is cleaned up after `wait_reply` exits
+    /// (success, timeout, disconnect) so fire-and-forget senders
+    /// don't leak entries past their correlation horizon.
+    #[test]
+    fn wait_reply_prunes_pending_recipient_on_timeout() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
+        registry.register_sink(
+            "test.prune",
+            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+                let _ = tx.send(Envelope {
+                    kind,
+                    kind_name: kind_name.to_owned(),
+                    origin: origin.map(str::to_owned),
+                    sender,
+                    payload: payload.to_vec(),
+                    count,
+                });
+            }),
+        );
+        let recipient = registry.lookup("test.prune").unwrap();
+
+        let transport = NativeTransport::new_for_test(Arc::clone(&mailer), MailboxId(99));
+        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx_inbox);
+
+        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
+        let correlation = transport.prev_correlation();
+        assert_eq!(transport.pending_recipients.lock().unwrap().len(), 1);
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
+        assert_eq!(rc, -1);
+        assert_eq!(transport.pending_recipients.lock().unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 of ADR-0074 (issue 509). Adds the cross-class wait_reply guard so a frame-bound caller blocking on a free-running recipient aborts with a specific diagnostic instead of wedging the per-frame drain barrier downstream. No active callers today (no in-tree capability calls wait_reply); this lands the infrastructure so future capability-to-capability sync calls fail loud rather than silent-wedge.

- New FatalAborter indirection in lifecycle.rs (OutboundFatalAborter for production, PanicAborter for tests). Desktop + headless drivers wire OutboundFatalAborter via a new ChassisBuilder::with_aborter setter.
- ChassisCtx and both builders thread a shared frame_bound_set + aborter through every passive boot. claim_frame_bound_mailbox now mirrors the mailbox id into the membership set.
- NativeTransport tracks correlation -> recipient on every send_mail (bounded), classifies the recipient at wait_reply time, and routes through the aborter on cross-class violation. Existing test sites move to NativeTransport::new_for_test (guard inert by default).
- All five capabilities (log, handle, audio, io, net) migrate to NativeTransport::from_ctx, which inherits the chassis's guard wiring automatically.

Issue 509 stays open — Phase 5 (wire rename) lands the closing PR.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace (1078 passed, 0 failed)
- [x] 4 new unit tests in native_transport.rs cover: cross-class abort fires, same-class skips abort, free-running caller skips abort, pending_recipients pruned on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)