### PR TITLE
refactor(actor): add NAMESPACE const to Capability trait (issue 525)

### DIFF
--- a/crates/aether-kinds/src/mailboxes.rs
+++ b/crates/aether-kinds/src/mailboxes.rs
@@ -1,10 +1,12 @@
 //! Typed `MailboxId` constants for the well-known mailbox names in the
-//! substrate vocabulary. The names themselves are scattered across the
-//! codebase as `&'static str` constants (`AETHER_CONTROL`,
-//! `HANDLE_MAILBOX_NAME`, `AETHER_DIAGNOSTICS`, etc.) — those keep their
-//! string form for log-message interpolation. This module is the typed
-//! companion: anywhere a `MailboxId` is being compared or constructed
-//! against a well-known mailbox, prefer one of these constants over
+//! substrate vocabulary. Substrate-side capabilities each declare
+//! their `&'static str` recipient name as `<X>Capability::NAMESPACE`
+//! (issue 525 Phase 1); the SDK side mirrors them as free
+//! `pub const X_MAILBOX_NAME` strings (`aether-component::io`,
+//! `aether-component::net`, `aether-actor::handle`) for use in
+//! `Mailbox::resolve(...)` calls. This module is the typed companion:
+//! anywhere a `MailboxId` is being compared or constructed against a
+//! well-known mailbox, prefer one of these constants over
 //! `mailbox_id_from_name("...")` so the resolution happens at compile
 //! time and the call site is one symbol instead of a name + hash
 //! invocation.

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -530,6 +530,12 @@ pub struct HubClientRunning {
 impl Capability for HubClientCapability {
     type Running = HubClientRunning;
 
+    /// The hub-client cap dials a TCP socket; it does not claim a
+    /// chassis mailbox. The `NAMESPACE` const is required by the
+    /// trait (issue 525 Phase 1) but never address-resolved, so the
+    /// value here is purely diagnostic.
+    const NAMESPACE: &'static str = "chassis.hub_client";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
         let url = match self.url.as_deref() {
             Some(u) if !u.is_empty() => u.to_owned(),

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -49,10 +49,6 @@ use crate::native_transport::NativeTransport;
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::{NoteOff, NoteOn, SetMasterGain, SetMasterGainResult};
 
-/// Recipient name the audio capability claims. ADR-0058 places
-/// chassis-owned sinks under `aether.sink.*`.
-pub const AUDIO_MAILBOX_NAME: &str = "aether.audio";
-
 /// Capacity of the event queue between the sink dispatcher and the
 /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
 /// 100-note-per-second stream; overflow is warn-dropped, which the
@@ -820,8 +816,14 @@ pub struct AudioRunning {
 impl Capability for AudioCapability {
     type Running = AudioRunning;
 
+    /// Components mail `aether.audio.{note_on,note_off,set_master_gain}`
+    /// (kind ids) to this mailbox; the synth pulls from here. The
+    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
+    /// for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.audio";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown(AUDIO_MAILBOX_NAME)?;
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
         let config = self.config;
@@ -1062,7 +1064,7 @@ mod tests {
             .build()
             .expect("audio capability boots");
         assert!(
-            registry.lookup(AUDIO_MAILBOX_NAME).is_some(),
+            registry.lookup(AudioCapability::NAMESPACE).is_some(),
             "sink mailbox registered"
         );
         chassis.shutdown();
@@ -1073,7 +1075,7 @@ mod tests {
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(AUDIO_MAILBOX_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(AudioCapability::new(AudioConfig {
@@ -1084,7 +1086,7 @@ mod tests {
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == AUDIO_MAILBOX_NAME
+            BootError::MailboxAlreadyClaimed { ref name } if name == AudioCapability::NAMESPACE
         ));
     }
 }

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -30,13 +30,6 @@ use crate::handle_store::HandleStore;
 use crate::mailer::Mailer;
 use crate::native_transport::NativeTransport;
 
-/// Recipient name the handle capability claims. Components mail
-/// `aether.handle.{publish,release,pin,unpin}` (kind ids) to this
-/// mailbox; the SDK's `Ctx::publish` / `Handle<K>::Drop` pair both
-/// resolve through here. ADR-0058 places chassis-owned sinks under
-/// `aether.sink.*`.
-pub const HANDLE_MAILBOX_NAME: &str = "aether.handle";
-
 /// Native capability owning the ADR-0045 typed-handle sink. Boots a
 /// single dispatcher thread that pulls envelopes from the
 /// `aether.handle` mailbox and routes them through
@@ -80,8 +73,15 @@ pub struct HandleRunning {
 impl Capability for HandleCapability {
     type Running = HandleRunning;
 
+    /// Components mail `aether.handle.{publish,release,pin,unpin}`
+    /// (kind ids) to this mailbox; the SDK's `Ctx::publish` /
+    /// `Handle<K>::Drop` pair both resolve through here. The
+    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
+    /// for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.handle";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown(HANDLE_MAILBOX_NAME)?;
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
         let store = self.store;
@@ -199,7 +199,7 @@ mod tests {
 
         // Resolve the sink the capability registered.
         let id = registry
-            .lookup(HANDLE_MAILBOX_NAME)
+            .lookup(HandleCapability::NAMESPACE)
             .expect("sink registered");
         let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
             panic!("expected sink entry");
@@ -278,11 +278,11 @@ mod tests {
     /// Builder rejects a duplicate claim if the well-known sink name
     /// was already registered. Guards against the side-by-side window
     /// where a phase-2 PR didn't clean up its legacy
-    /// `register_sink(HANDLE_MAILBOX_NAME, ...)` call.
+    /// `register_sink(HandleCapability::NAMESPACE, ...)` call.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (store, mailer, registry, _rx) = fresh_substrate();
-        registry.register_sink(HANDLE_MAILBOX_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(HandleCapability::new(Arc::clone(&store)))
@@ -290,7 +290,7 @@ mod tests {
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == HANDLE_MAILBOX_NAME
+            BootError::MailboxAlreadyClaimed { ref name } if name == HandleCapability::NAMESPACE
         ));
     }
 }

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -39,10 +39,6 @@ use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
 
-/// Recipient name the io capability claims. ADR-0058 places
-/// chassis-owned sinks under `aether.sink.*`.
-pub const IO_MAILBOX_NAME: &str = "aether.io";
-
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
 /// chassis dispatcher can forward an adapter failure without
@@ -600,8 +596,14 @@ pub struct IoRunning {
 impl Capability for IoCapability {
     type Running = IoRunning;
 
+    /// Components mail `aether.io.{read,write,delete,list}` (kind ids)
+    /// to this mailbox; the SDK helpers in `aether-component::io`
+    /// resolve through here. The `aether.<name>` form is the
+    /// post-ADR-0074 Phase 5 convention for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.io";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown(IO_MAILBOX_NAME)?;
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
         let (registry, roots) = build_registry(self.roots).map_err(|e| {
@@ -942,7 +944,7 @@ mod tests {
             .build()
             .expect("io capability boots");
         assert!(
-            registry.lookup(IO_MAILBOX_NAME).is_some(),
+            registry.lookup(IoCapability::NAMESPACE).is_some(),
             "sink mailbox registered"
         );
         chassis.shutdown();
@@ -981,7 +983,7 @@ mod tests {
     fn duplicate_claim_rejects_with_typed_error() {
         let root = scratch_root("collide");
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(IO_MAILBOX_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(IoCapability::new(roots_under(&root)))
@@ -989,7 +991,7 @@ mod tests {
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == IO_MAILBOX_NAME
+            BootError::MailboxAlreadyClaimed { ref name } if name == IoCapability::NAMESPACE
         ));
         cleanup(&root);
     }

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -31,12 +31,6 @@ use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, Si
 use crate::log_sink;
 use crate::native_transport::NativeTransport;
 
-/// Recipient name the log capability claims. Components mail
-/// `aether.log` (kind id) to this mailbox; the SDK's
-/// `MailSubscriber` resolves through here. ADR-0058 places
-/// chassis-owned sinks under `aether.sink.*`.
-pub const LOG_MAILBOX_NAME: &str = "aether.log";
-
 /// Native capability owning the ADR-0060 guest-log sink. Boots a
 /// single dispatcher thread that pulls envelopes from the
 /// `aether.log` mailbox and routes the bytes through
@@ -80,8 +74,14 @@ pub struct LogRunning {
 impl Capability for LogCapability {
     type Running = LogRunning;
 
+    /// Components mail `aether.log` (kind id) to this mailbox; the
+    /// SDK's `MailSubscriber` resolves through here. The
+    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
+    /// for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.log";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown(LOG_MAILBOX_NAME)?;
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailbox_id = claim.id;
 
         // ADR-0074 §Decision: `&self` trait, owned transport. The
@@ -171,7 +171,9 @@ mod tests {
             .build()
             .expect("capability boots");
 
-        let id = registry.lookup(LOG_MAILBOX_NAME).expect("sink registered");
+        let id = registry
+            .lookup(LogCapability::NAMESPACE)
+            .expect("sink registered");
         let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
             panic!("expected sink entry");
         };
@@ -205,7 +207,7 @@ mod tests {
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(LOG_MAILBOX_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with(LogCapability::new())
@@ -213,7 +215,7 @@ mod tests {
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == LOG_MAILBOX_NAME
+            BootError::MailboxAlreadyClaimed { ref name } if name == LogCapability::NAMESPACE
         ));
     }
 }

--- a/crates/aether-substrate/src/capabilities/mod.rs
+++ b/crates/aether-substrate/src/capabilities/mod.rs
@@ -26,12 +26,10 @@ pub mod net;
 #[cfg(feature = "render")]
 pub mod render;
 #[cfg(feature = "audio")]
-pub use audio::{AUDIO_MAILBOX_NAME, AudioCapability, AudioConfig, AudioRunning};
-pub use handle::{HANDLE_MAILBOX_NAME, HandleCapability, HandleRunning};
-pub use io::{IO_MAILBOX_NAME, IoCapability, IoRunning};
-pub use log::{LOG_MAILBOX_NAME, LogCapability, LogRunning};
-pub use net::{NET_MAILBOX_NAME, NetCapability, NetRunning};
+pub use audio::{AudioCapability, AudioConfig, AudioRunning};
+pub use handle::{HandleCapability, HandleRunning};
+pub use io::{IoCapability, IoRunning};
+pub use log::{LogCapability, LogRunning};
+pub use net::{NetCapability, NetRunning};
 #[cfg(feature = "render")]
-pub use render::{
-    RENDER_MAILBOX_NAME, RenderCapability, RenderConfig, RenderGpu, RenderHandles, RenderRunning,
-};
+pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles, RenderRunning};

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -34,10 +34,6 @@ use crate::native_transport::NativeTransport;
 use aether_data::{Kind, KindId};
 use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
-/// Recipient name the net capability claims. ADR-0058 places
-/// chassis-owned sinks under `aether.sink.*`.
-pub const NET_MAILBOX_NAME: &str = "aether.net";
-
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
 pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
@@ -473,8 +469,14 @@ pub struct NetRunning {
 impl Capability for NetCapability {
     type Running = NetRunning;
 
+    /// Components mail `aether.net.{fetch,cancel}` (kind ids) to this
+    /// mailbox; the SDK helpers in `aether-component::net` resolve
+    /// through here. The `aether.<name>` form is the post-ADR-0074
+    /// Phase 5 convention for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.net";
+
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown(NET_MAILBOX_NAME)?;
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
         let default_timeout = self.config.default_timeout;
@@ -626,7 +628,7 @@ mod tests {
             .build()
             .expect("net capability boots");
         assert!(
-            registry.lookup(NET_MAILBOX_NAME).is_some(),
+            registry.lookup(NetCapability::NAMESPACE).is_some(),
             "sink mailbox registered"
         );
         chassis.shutdown();
@@ -637,7 +639,7 @@ mod tests {
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(NET_MAILBOX_NAME, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(NetCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
         let config = NetConfig {
             disabled: true,
             ..NetConfig::default()
@@ -649,7 +651,7 @@ mod tests {
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == NET_MAILBOX_NAME
+            BootError::MailboxAlreadyClaimed { ref name } if name == NetCapability::NAMESPACE
         ));
     }
 

--- a/crates/aether-substrate/src/capabilities/render.rs
+++ b/crates/aether-substrate/src/capabilities/render.rs
@@ -50,8 +50,6 @@ use crate::render::{
     finish_capture, prepare_capture_copy, record_main_pass,
 };
 
-pub const RENDER_MAILBOX_NAME: &str = "aether.render";
-
 /// Configuration for [`RenderCapability`]. `vertex_buffer_bytes` is
 /// the maximum bytes the render accumulator will hold before
 /// truncating with a warn — desktop and test-bench both pass
@@ -319,6 +317,13 @@ impl RenderRunning {
 impl Capability for RenderCapability {
     type Running = RenderRunning;
 
+    /// Components mail `aether.draw_triangle` and `aether.camera`
+    /// (kind ids) to this mailbox; the GPU recorder pulls from here.
+    /// The `aether.<name>` form is the post-ADR-0074 Phase 5
+    /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
+    /// folded the camera mailbox into render under this name.
+    const NAMESPACE: &'static str = "aether.render";
+
     /// Render is the one chassis-owned actor that participates in the
     /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
     /// a `DrawTriangle` mail in flight when the chassis driver records
@@ -329,7 +334,7 @@ impl Capability for RenderCapability {
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
         let RenderCapability { config, handles } = self;
 
-        let claim = ctx.claim_frame_bound_mailbox(RENDER_MAILBOX_NAME)?;
+        let claim = ctx.claim_frame_bound_mailbox::<Self>()?;
 
         let frame_vertices = Arc::clone(&handles.frame_vertices);
         let triangles_rendered = Arc::clone(&handles.triangles_rendered);
@@ -503,7 +508,7 @@ mod tests {
             .build()
             .expect("build succeeds");
         assert_eq!(chassis.len(), 1);
-        assert!(registry.lookup(RENDER_MAILBOX_NAME).is_some());
+        assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
         // Camera mailbox retired (ADR-0074 §Decision 7).
         assert!(registry.lookup("aether.sink.camera").is_none());
     }
@@ -522,7 +527,7 @@ mod tests {
         let one_triangle = vec![0u8; DRAW_TRIANGLE_BYTES];
         deliver(
             &registry,
-            RENDER_MAILBOX_NAME,
+            RenderCapability::NAMESPACE,
             <DrawTriangle as Kind>::ID,
             &one_triangle,
         );
@@ -561,7 +566,7 @@ mod tests {
         let payload = vec![0u8; DRAW_TRIANGLE_BYTES * 5];
         deliver(
             &registry,
-            RENDER_MAILBOX_NAME,
+            RenderCapability::NAMESPACE,
             <DrawTriangle as Kind>::ID,
             &payload,
         );
@@ -597,7 +602,12 @@ mod tests {
             2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         ];
         let bytes: &[u8] = bytemuck::cast_slice(&mat);
-        deliver(&registry, RENDER_MAILBOX_NAME, <Camera as Kind>::ID, bytes);
+        deliver(
+            &registry,
+            RenderCapability::NAMESPACE,
+            <Camera as Kind>::ID,
+            bytes,
+        );
 
         for _ in 0..50 {
             if handles.camera_state.lock().unwrap()[0] == 2.0 {
@@ -624,7 +634,7 @@ mod tests {
         // 16 bytes — wrong length, should be 64.
         deliver(
             &registry,
-            RENDER_MAILBOX_NAME,
+            RenderCapability::NAMESPACE,
             <Camera as Kind>::ID,
             &[1u8; 16],
         );

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -236,6 +236,18 @@ impl From<wasmtime::Error> for BootError {
 pub trait Capability: Send + 'static {
     type Running: RunningCapability;
 
+    /// The recipient name this capability claims at boot — the same
+    /// string components address with `Mailbox<K>::send` on the wire.
+    /// Issue 525 Phase 1: declared on the trait so the cap's own type
+    /// is the single source of truth, retiring the per-cap free
+    /// `pub const X_MAILBOX_NAME` consts that mirrored this field.
+    /// Each in-tree cap declares its `aether.<name>` namespace per the
+    /// post-ADR-0074 Phase 5 convention; test fixtures with
+    /// parameterized names declare a placeholder and bypass via
+    /// [`ChassisCtx::claim_mailbox_with_override`] +
+    /// friends.
+    const NAMESPACE: &'static str;
+
     /// ADR-0074 §Decision 5 scheduling class. `true` means this
     /// capability participates in the per-frame drain barrier — the
     /// chassis frame loop waits for the dispatcher's inbox to quiesce
@@ -320,8 +332,22 @@ impl<'a> ChassisCtx<'a> {
         }
     }
 
+    /// Register an mpsc-fed sink under `C::NAMESPACE` and return both
+    /// its derived [`MailboxId`] (ADR-0029 hash) and the receiver.
+    /// The capability's own type is the single source of truth for
+    /// the recipient name (issue 525 Phase 1).
+    ///
+    /// Tests that need a parameterized name (one fixture, many
+    /// claims) reach for [`Self::claim_mailbox_with_override`].
+    pub fn claim_mailbox<C: Capability>(&mut self) -> Result<MailboxClaim, BootError> {
+        self.claim_mailbox_with_override(C::NAMESPACE)
+    }
+
     /// Register an mpsc-fed sink under `name` and return both its
     /// derived [`MailboxId`] (ADR-0029 hash) and the receiver.
+    /// Escape hatch for tests with parameterized names; production
+    /// caps go through [`Self::claim_mailbox`] so the cap's own
+    /// `NAMESPACE` is authoritative.
     ///
     /// The closure registered with the registry forwards every
     /// delivery into the sender side of the mpsc pair, so the
@@ -330,7 +356,7 @@ impl<'a> ChassisCtx<'a> {
     /// capability drops it; the matching sender lives in the sink
     /// closure stored on the registry until the registry itself is
     /// dropped.
-    pub fn claim_mailbox(&mut self, name: &str) -> Result<MailboxClaim, BootError> {
+    pub fn claim_mailbox_with_override(&mut self, name: &str) -> Result<MailboxClaim, BootError> {
         let (tx, rx) = mpsc::channel::<Envelope>();
         let tx = Arc::new(tx);
         let id = self.registry.try_register_sink(
@@ -364,10 +390,21 @@ impl<'a> ChassisCtx<'a> {
     }
 
     /// Variant of [`Self::claim_mailbox`] that returns a strong
-    /// [`SinkSender`] alongside the receiver. The registry holds
-    /// only a [`std::sync::Weak`] reference to the sender, so when
-    /// the capability drops the `SinkSender` (during shutdown), the
-    /// channel disconnects and the dispatcher's `recv()` returns
+    /// [`SinkSender`] alongside the receiver. Claims under
+    /// `C::NAMESPACE`. See
+    /// [`Self::claim_mailbox_drop_on_shutdown_with_override`] for the
+    /// arbitrary-name escape hatch.
+    pub fn claim_mailbox_drop_on_shutdown<C: Capability>(
+        &mut self,
+    ) -> Result<DropOnShutdownClaim, BootError> {
+        self.claim_mailbox_drop_on_shutdown_with_override(C::NAMESPACE)
+    }
+
+    /// Variant of [`Self::claim_mailbox_with_override`] that returns
+    /// a strong [`SinkSender`] alongside the receiver. The registry
+    /// holds only a [`std::sync::Weak`] reference to the sender, so
+    /// when the capability drops the `SinkSender` (during shutdown),
+    /// the channel disconnects and the dispatcher's `recv()` returns
     /// `Err(Disconnected)`.
     ///
     /// Use this when the capability wants the channel-drop + join
@@ -375,7 +412,7 @@ impl<'a> ChassisCtx<'a> {
     /// `Arc<AtomicBool>` polling flag. Phase 2a wires
     /// `LogCapability` onto this; the other native capabilities
     /// migrate one PR at a time per the issue 509 plan.
-    pub fn claim_mailbox_drop_on_shutdown(
+    pub fn claim_mailbox_drop_on_shutdown_with_override(
         &mut self,
         name: &str,
     ) -> Result<DropOnShutdownClaim, BootError> {
@@ -430,7 +467,17 @@ impl<'a> ChassisCtx<'a> {
     }
 
     /// Variant of [`Self::claim_mailbox_drop_on_shutdown`] for
-    /// frame-bound capabilities (ADR-0074 §Decision 5). In addition
+    /// frame-bound capabilities. Claims under `C::NAMESPACE`. See
+    /// [`Self::claim_frame_bound_mailbox_with_override`] for the
+    /// arbitrary-name escape hatch.
+    pub fn claim_frame_bound_mailbox<C: Capability>(
+        &mut self,
+    ) -> Result<FrameBoundClaim, BootError> {
+        self.claim_frame_bound_mailbox_with_override(C::NAMESPACE)
+    }
+
+    /// Variant of [`Self::claim_mailbox_drop_on_shutdown_with_override`]
+    /// for frame-bound capabilities (ADR-0074 §Decision 5). In addition
     /// to the channel-drop shutdown machinery, the registered sink
     /// handler increments a `pending` counter on every accepted send;
     /// the capability's dispatcher must decrement after each
@@ -443,7 +490,10 @@ impl<'a> ChassisCtx<'a> {
     /// on the [`Capability`] impl. See
     /// [`crate::capabilities::render::RenderCapability`] for the
     /// reference shape.
-    pub fn claim_frame_bound_mailbox(&mut self, name: &str) -> Result<FrameBoundClaim, BootError> {
+    pub fn claim_frame_bound_mailbox_with_override(
+        &mut self,
+        name: &str,
+    ) -> Result<FrameBoundClaim, BootError> {
         let (tx, rx) = mpsc::channel::<Envelope>();
         let tx = Arc::new(tx);
         let weak = Arc::downgrade(&tx);
@@ -863,8 +913,12 @@ mod tests {
 
     impl Capability for EchoCapability {
         type Running = EchoRunning;
+        // Placeholder: parameterized fixtures bypass the type-level
+        // namespace via `claim_mailbox_with_override` below, so no
+        // production code observes this string.
+        const NAMESPACE: &'static str = "test.echo.placeholder";
         fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-            let claim = ctx.claim_mailbox(self.name)?;
+            let claim = ctx.claim_mailbox_with_override(self.name)?;
             Ok(EchoRunning {
                 receiver: claim.receiver,
                 log: self.log,
@@ -991,6 +1045,7 @@ mod tests {
         struct FallbackRunning;
         impl Capability for FallbackCap {
             type Running = FallbackRunning;
+            const NAMESPACE: &'static str = "test.fallback.placeholder";
             fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
                 let handler: FallbackRouter = Arc::new(|_env: &Envelope| true);
                 ctx.claim_fallback_router(handler)?;
@@ -1027,6 +1082,7 @@ mod tests {
         struct ProbeRunning;
         impl Capability for ProbeCap {
             type Running = ProbeRunning;
+            const NAMESPACE: &'static str = "test.probe.placeholder";
             fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
                 *self.captured.lock().unwrap() = Some(ctx.mail_send_handle());
                 Ok(ProbeRunning)

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -199,8 +199,12 @@ impl<'a> DriverCtx<'a> {
         Self { inner, runnings }
     }
 
+    /// Drivers don't impl `Capability`, so they have no `NAMESPACE`
+    /// const to delegate against — claim by explicit name. The
+    /// passive-side equivalent is [`ChassisCtx::claim_mailbox`] (typed)
+    /// or [`ChassisCtx::claim_mailbox_with_override`] (escape hatch).
     pub fn claim_mailbox(&mut self, name: &str) -> Result<MailboxClaim, BootError> {
-        self.inner.claim_mailbox(name)
+        self.inner.claim_mailbox_with_override(name)
     }
 
     pub fn mail_send_handle(&self) -> Arc<Mailer> {
@@ -641,8 +645,11 @@ mod tests {
 
     impl Capability for EchoCap {
         type Running = EchoRunning;
+        // Placeholder: parameterized fixtures bypass the type-level
+        // namespace via `claim_mailbox_with_override` below.
+        const NAMESPACE: &'static str = "test.echo.placeholder";
         fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-            let claim = ctx.claim_mailbox(self.name)?;
+            let claim = ctx.claim_mailbox_with_override(self.name)?;
             Ok(EchoRunning {
                 receiver: Mutex::new(Some(claim.receiver)),
                 log: Mutex::new(Vec::new()),
@@ -771,6 +778,7 @@ mod tests {
         }
         impl Capability for ProbeCap {
             type Running = ProbeRunning;
+            const NAMESPACE: &'static str = "test.probe.placeholder";
             fn boot(self, _ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
                 Ok(ProbeRunning { flag: self.flag })
             }


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525 references the parent issue this PR is one phase of; auto-close happens on the last phase only -->
## Summary

Phase 1A of issue #525's actor unification. Each substrate capability now declares its mailbox name on the trait via `const NAMESPACE`, retiring the per-cap free `pub const X_MAILBOX_NAME` consts. The cap's own type is the single source of truth for the recipient name.

- `Capability::NAMESPACE` is required (no default). Each in-tree cap (`log`, `handle`, `io`, `net`, `audio`, `render`, plus `HubClientCapability`) declares its `aether.<name>` value per the post-ADR-0074 Phase 5 convention.
- `ChassisCtx::claim_mailbox::<C>()` / `claim_mailbox_drop_on_shutdown::<C>()` / `claim_frame_bound_mailbox::<C>()` delegate to `C::NAMESPACE`. The original `&str`-taking variants moved to `_with_override(name)` as the test escape hatch (and for `DriverCtx::claim_mailbox`, since drivers don't impl `Capability`).
- Test fixtures with parameterized names (`EchoCapability`, `FallbackCap`, `ProbeCap`) declare a placeholder `NAMESPACE` and call `_with_override`.
- The free `pub const LOG_MAILBOX_NAME` / `HANDLE_MAILBOX_NAME` / `IO_MAILBOX_NAME` / `NET_MAILBOX_NAME` / `AUDIO_MAILBOX_NAME` / `RENDER_MAILBOX_NAME` consts and their `mod.rs` re-exports are dropped. Internal callers go through `LogCapability::NAMESPACE` etc.

Phase 1B (Component-side NAMESPACE + `load_component` default-from-section reading) is the next PR.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)