### PR TITLE
refactor(actor): add NAMESPACE const to Component trait (issue 525)

### DIFF
--- a/crates/aether-camera-component/src/lib.rs
+++ b/crates/aether-camera-component/src/lib.rs
@@ -245,6 +245,8 @@ pub struct CameraComponent {
 /// Use `capture_frame` between sends to verify each change.
 #[handlers]
 impl Component for CameraComponent {
+    const NAMESPACE: &'static str = "camera";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         let mut cameras = HashMap::new();
         cameras.insert(

--- a/crates/aether-component/examples/caller.rs
+++ b/crates/aether-component/examples/caller.rs
@@ -44,6 +44,8 @@ pub struct Caller {
 
 #[handlers]
 impl Component for Caller {
+    const NAMESPACE: &'static str = "caller";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Caller {
             request: ctx.resolve_mailbox::<Request>("echoer"),

--- a/crates/aether-component/examples/echoer.rs
+++ b/crates/aether-component/examples/echoer.rs
@@ -31,6 +31,8 @@ pub struct Echoer {
 
 #[handlers]
 impl Component for Echoer {
+    const NAMESPACE: &'static str = "echoer";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Echoer {
             response: ctx.resolve::<Response>(),

--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -52,6 +52,8 @@ pub struct HandleDemo {
 
 #[handlers]
 impl Component for HandleDemo {
+    const NAMESPACE: &'static str = "handle_demo";
+
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
         HandleDemo { fired: false }
     }

--- a/crates/aether-component/examples/hello.rs
+++ b/crates/aether-component/examples/hello.rs
@@ -64,6 +64,8 @@ pub struct Hello {
 /// sender; the matching `aether.pong` lands back at your session.
 #[handlers]
 impl Component for Hello {
+    const NAMESPACE: &'static str = "hello";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         Hello {
             pong: ctx.resolve::<Pong>(),

--- a/crates/aether-component/examples/input_logger.rs
+++ b/crates/aether-component/examples/input_logger.rs
@@ -33,6 +33,8 @@ pub struct InputLogger {
 
 #[handlers]
 impl Component for InputLogger {
+    const NAMESPACE: &'static str = "input_logger";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         InputLogger {
             observe: ctx.resolve_mailbox::<InputObserved>("hub.claude.broadcast"),

--- a/crates/aether-component/examples/postcard_echoer.rs
+++ b/crates/aether-component/examples/postcard_echoer.rs
@@ -45,6 +45,8 @@ pub struct PostcardEchoer {
 
 #[handlers]
 impl Component for PostcardEchoer {
+    const NAMESPACE: &'static str = "postcard_echoer";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         PostcardEchoer {
             broadcast: ctx.resolve_mailbox::<PostcardObserved>("hub.claude.broadcast"),

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -61,6 +61,8 @@ pub struct SaveCounter {
 /// each fresh instance bumps the counter by one.
 #[handlers]
 impl Component for SaveCounter {
+    const NAMESPACE: &'static str = "save_counter";
+
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
         SaveCounter { initialized: false }
     }

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -191,6 +191,17 @@ pub mod __macro_internals {
 /// `aether-substrate` and writes against
 /// `aether_actor::Ctx<'_, NativeTransport>` directly.
 pub trait Component: Sized + 'static {
+    /// Default mailbox name the substrate registers this component
+    /// under when `load_component` doesn't supply an explicit name
+    /// (issue 525 Phase 1B). The macro emits this string into the
+    /// cdylib's `aether.namespace` wasm custom section so the loader
+    /// reads it without instantiating the module.
+    ///
+    /// Multi-instance loads still work: pass an explicit `name` to
+    /// `load_component` and the override wins. The default applies
+    /// only when `name` is `None`.
+    const NAMESPACE: &'static str;
+
     /// Runs once. Resolve kinds and sinks via `ctx` and return the
     /// initial component state. A failed `resolve` panics — see
     /// ADR-0012 §2 ("loud at init"). ADR-0033: `#[handlers]` prepends
@@ -251,6 +262,12 @@ pub trait Component: Sized + 'static {
 ///   `link_section` attribute, which means the section can only land
 ///   in the cdylib root that calls `export!()` — never in transitive
 ///   rlib pulls of a `#[handlers]`-using crate (issue 442).
+/// - `#[link_section = "aether.namespace"]` static that pins the
+///   component's `Component::NAMESPACE` bytes (issue 525 Phase 1B).
+///   The substrate reads this at `load_component` and uses it as the
+///   default mailbox name when the load payload omits an explicit
+///   `name`. Same one-place-per-cdylib invariant as the inputs
+///   section — emit only here, never in transitive rlib pulls.
 ///
 /// Only one component per guest crate. A second `export!` call in
 /// the same crate is a duplicate-symbol compile error on the shared
@@ -281,6 +298,27 @@ macro_rules! export {
         #[unsafe(link_section = "aether.kinds.inputs")]
         static __AETHER_INPUTS_SECTION: [u8; <$component>::__AETHER_INPUTS_MANIFEST_LEN] =
             <$component>::__AETHER_INPUTS_MANIFEST;
+
+        // Issue 525 Phase 1B: pin the component's `Component::NAMESPACE`
+        // bytes into a sibling `aether.namespace` custom section. The
+        // substrate reads this at load time as the default mailbox
+        // name when the load payload omits an explicit `name`. Length
+        // is taken via `len()` so the const-array type is known at
+        // compile time without a per-component associated const.
+        #[cfg(target_arch = "wasm32")]
+        #[used]
+        #[unsafe(link_section = "aether.namespace")]
+        static __AETHER_NAMESPACE_SECTION: [u8; <$component as $crate::Component>::NAMESPACE
+            .len()] = {
+            let bytes = <$component as $crate::Component>::NAMESPACE.as_bytes();
+            let mut out = [0u8; <$component as $crate::Component>::NAMESPACE.len()];
+            let mut i = 0;
+            while i < bytes.len() {
+                out[i] = bytes[i];
+                i += 1;
+            }
+            out
+        };
 
         /// # Safety
         /// Called exactly once by the substrate before any `receive`.

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -45,6 +45,8 @@ struct ManifestProbe;
 
 #[handlers]
 impl Component for ManifestProbe {
+    const NAMESPACE: &'static str = "manifest_probe";
+
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
         Self
     }

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -801,6 +801,11 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     let mut handlers: Vec<HandlerFn> = Vec::new();
     let mut fallback: Option<FallbackFn> = None;
     let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
+    // Issue 525 Phase 1B: pass-through trait consts (today: NAMESPACE,
+    // FRAME_BARRIER) so each component declares them inside its
+    // `#[handlers] impl Component for C` block alongside `init` /
+    // `#[handler]` methods.
+    let mut consts: Vec<syn::ImplItemConst> = Vec::new();
 
     for impl_item in item.items {
         match impl_item {
@@ -809,6 +814,9 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
                     it,
                     "#[handlers] synthesizes `type Kinds` from the #[handler] methods; remove this declaration",
                 ));
+            }
+            ImplItem::Const(c) => {
+                consts.push(c);
             }
             ImplItem::Fn(mut f) => {
                 let name = f.sig.ident.to_string();
@@ -902,8 +910,12 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
         build_inputs_manifest_consts(&handlers, fallback.as_ref(), &component_doc);
     let kind_retention_statics = build_kinds_section_retention_statics(self_ty, &handlers);
 
+    let const_tokens = consts.iter();
+
     Ok(quote! {
         impl #impl_generics #trait_path for #self_ty #where_clause {
+            #(#const_tokens)*
+
             #wrapped_init
 
             #(#lifecycle_methods)*

--- a/crates/aether-mesh-viewer-component/src/lib.rs
+++ b/crates/aether-mesh-viewer-component/src/lib.rs
@@ -71,6 +71,8 @@ pub struct MeshViewer {
 /// same path.
 #[handlers]
 impl Component for MeshViewer {
+    const NAMESPACE: &'static str = "mesh_viewer";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         MeshViewer {
             triangles: Vec::new(),

--- a/crates/aether-substrate/src/control/mod.rs
+++ b/crates/aether-substrate/src/control/mod.rs
@@ -300,10 +300,26 @@ impl ControlPlane {
             }
         };
 
-        let name = payload.name.unwrap_or_else(|| {
-            let n = self.default_name_counter.fetch_add(1, Ordering::Relaxed);
-            format!("component_{n}")
-        });
+        // Issue 525 Phase 1B: when the load payload omits an
+        // explicit name, prefer the component's `aether.namespace`
+        // section over a generic `component_N` slot. The section
+        // carries `Component::NAMESPACE` verbatim, so a load with no
+        // name still produces a stable, addressable name. Multi-
+        // instance loads stay possible by passing an explicit
+        // `name` — the override always wins. Sectionless wasm (built
+        // pre-Phase-1B) falls back to the counter so old binaries
+        // load unchanged.
+        let name = match payload.name {
+            Some(n) => n,
+            None => match kind_manifest::read_namespace_from_bytes(&payload.wasm) {
+                Ok(Some(declared)) => declared,
+                Ok(None) => {
+                    let n = self.default_name_counter.fetch_add(1, Ordering::Relaxed);
+                    format!("component_{n}")
+                }
+                Err(error) => return LoadResult::Err { error },
+            },
+        };
 
         // ADR-0029: mailbox ids are name-derived (FNV-1a 64), so we
         // can compute the id without touching the registry. That lets

--- a/crates/aether-substrate/src/kind_manifest.rs
+++ b/crates/aether-substrate/src/kind_manifest.rs
@@ -58,6 +58,15 @@ pub const MANIFEST_SECTION: &str = "aether.kinds";
 /// anonymous field names.
 pub const LABELS_SECTION: &str = "aether.kinds.labels";
 
+/// Default-mailbox-name section. Issue 525 Phase 1B: each component
+/// declares `Component::NAMESPACE` and `export!()` pins the bytes
+/// here; substrate's `load_component` reads the section as the default
+/// recipient name when the load payload omits an explicit `name`. The
+/// payload is the raw UTF-8 bytes — no version prefix, no postcard
+/// wrapper, since it's a single fixed-shape string with no anticipated
+/// evolution.
+pub const NAMESPACE_SECTION: &str = "aether.namespace";
+
 /// Wire versions accepted in `aether.kinds`. The shape record's bytes
 /// are `Kind::ID` hash input, so the format is pinned indefinitely at
 /// 0x03's canonical-bytes layout — any change there would shift every
@@ -155,6 +164,28 @@ fn decode_kinds_records(data: &[u8], out: &mut Vec<(KindShape, bool)>) -> Result
         }
     }
     Ok(())
+}
+
+/// Read the component's [`NAMESPACE_SECTION`] payload (issue 525
+/// Phase 1B) as a UTF-8 string. Returns `None` when the section is
+/// absent (component built against a pre-Phase-1B SDK, or built with a
+/// hand-rolled `export!` shim) so callers fall back to a derived
+/// name. Returns an `Err` only on malformed UTF-8 — the substrate
+/// surfaces that as a load failure rather than silently using a
+/// different name.
+pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> {
+    for payload in Parser::new(0).parse_all(wasm) {
+        let payload = payload.map_err(|e| format!("wasmparser: {e}"))?;
+        let Payload::CustomSection(reader) = payload else {
+            continue;
+        };
+        if reader.name() == NAMESPACE_SECTION {
+            return std::str::from_utf8(reader.data())
+                .map(|s| Some(s.to_owned()))
+                .map_err(|e| format!("{NAMESPACE_SECTION}: invalid UTF-8: {e}"));
+        }
+    }
+    Ok(None)
 }
 
 /// Decode the component's `aether.kinds.inputs` section (ADR-0033)

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -56,6 +56,8 @@ pub struct Probe {
 
 #[handlers]
 impl Component for Probe {
+    const NAMESPACE: &'static str = "test_fixture_probe";
+
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
         Probe {
             tick_count: 0,

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -139,6 +139,8 @@ pub struct Sokoban {
 /// - `SokobanReset` — reload the active level.
 #[handlers]
 impl Component for Sokoban {
+    const NAMESPACE: &'static str = "sokoban";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         let mut me = Sokoban {
             state: SokobanState::default(),

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -127,6 +127,8 @@ impl Default for TicTacToeClient {
 /// `capture_frame` to verify rendering.
 #[handlers]
 impl Component for TicTacToeClient {
+    const NAMESPACE: &'static str = "tic_tac_toe_client";
+
     fn init(_ctx: &mut InitCtx<'_>) -> Self {
         TicTacToeClient::default()
     }

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -57,6 +57,8 @@ pub struct TicTacToe {
 /// fresh game.
 #[handlers]
 impl Component for TicTacToe {
+    const NAMESPACE: &'static str = "tic_tac_toe";
+
     fn init(ctx: &mut InitCtx<'_>) -> Self {
         TicTacToe {
             state: GameState::new_game(),


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525 references the parent issue this PR is one phase of; auto-close happens on the last phase only -->
## Summary

Phase 1B of issue #525's actor unification — completes Phase 1 (Phase 1A landed in PR 526). Each component now declares its default mailbox name on the `Component` trait via `const NAMESPACE`, with the `export!()` macro emitting the bytes into an `aether.namespace` wasm custom section. Substrate's `load_component` reads the section as the default recipient name when `payload.name` is None; explicit names still win for multi-instance loads.

- `Component::NAMESPACE` is required (no default). Every in-tree component (the seven examples plus `aether-test-fixture-probe`, `aether-camera-component`, `aether-mesh-viewer-component`, the three demos) declares its value.
- `export!()` pins `Component::NAMESPACE` into a sibling `aether.namespace` custom section next to the existing `aether.kinds.inputs` pin. Same one-place-per-cdylib invariant: emitted only at the cdylib root, never in transitive rlibs.
- `#[handlers]` macro now allows pass-through `const` items (today: NAMESPACE; tomorrow: FRAME_BARRIER and the rest of the Actor super-trait surface).
- `kind_manifest::read_namespace_from_bytes` walks the wasm and returns the section as a UTF-8 string; malformed UTF-8 surfaces as a load failure, absent section falls back to the `component_N` counter (back-compat for old binaries).
- All six component wasm artifacts rebuilt; `aether.namespace` section verified present (`strings | grep` shows `aether.namespacecamera` etc.).

Phase 1 of issue #525 is now complete. Phase 2 (collapse Running into the cap struct) is the next phase.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] `cargo build --target wasm32-unknown-unknown --release` for all six component cdylibs

🤖 Generated with [Claude Code](https://claude.com/claude-code)