### PR TITLE
refactor(actor): collapse Running into cap struct + Drop shutdown (issue 525)

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -33,7 +33,7 @@ use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, SubstrateBoot,
-    capabilities::{RenderHandles, RenderRunning},
+    capabilities::{RenderCapability, RenderHandles},
     frame_loop,
     mail::{Mail, MailboxId},
     subscribers_for,
@@ -71,11 +71,11 @@ pub struct App {
     kind_mouse_move: aether_data::KindId,
     kind_window_size: aether_data::KindId,
     kind_frame_stats: aether_data::KindId,
-    /// Cloned out of `RenderRunning` at driver boot. Source-of-truth
+    /// Cloned out of `RenderCapability` at driver boot. Source-of-truth
     /// lives in core's `RenderCapability`; the app holds a clone so
     /// `Gpu::new` can install wgpu state and the per-frame loop can
     /// call `record_frame` / `record_capture_copy` / `finish_capture`.
-    render_running: Arc<RenderRunning>,
+    render_running: Arc<RenderCapability>,
     triangles_rendered: Arc<AtomicU64>,
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
@@ -691,7 +691,7 @@ impl ApplicationHandler<UserEvent> for App {
 /// ADR-0071 driver capability for the desktop chassis. Owns the
 /// pieces the winit event-loop body needs at construction time, then
 /// `boot()`-builds the App + DriverRunning that drives the loop.
-/// `boot()` looks up [`RenderRunning`] via [`DriverCtx::expect`]
+/// `boot()` looks up [`RenderCapability`] via [`DriverCtx::expect`]
 /// (booted earlier in the `.with()` chain) and pulls the accumulator
 /// handles out of it.
 ///
@@ -739,10 +739,10 @@ impl DriverCapability for DesktopDriverCapability {
 
         // Look up RenderCapability's running via the chassis_builder
         // typed-store (ADR-0071). The render passive booted before
-        // this driver, so its `RenderRunning` is in the typed map;
+        // this driver, so its `RenderCapability` is in the typed map;
         // pull the accumulator handles for the per-frame loop to
         // read.
-        let render_running: Arc<RenderRunning> = ctx.expect();
+        let render_running: Arc<RenderCapability> = ctx.expect();
         let RenderHandles {
             frame_vertices: _,
             camera_state: _,

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -1,5 +1,5 @@
 // Desktop wgpu plumbing. ADR-0071 phase C2: pipeline + targets moved
-// into core's `RenderRunning` (via `RenderGpu` + `install_gpu`); this
+// into core's `RenderCapability` (via `RenderGpu` + `install_gpu`); this
 // file now owns only the desktop-specific surface + swapchain config
 // + optional wireframe overlay pipeline. Each frame creates an
 // encoder, asks `render_running.record_frame(...)` to record the
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use aether_substrate::capabilities::{RenderGpu, RenderRunning};
+use aether_substrate::capabilities::{RenderCapability, RenderGpu};
 use aether_substrate::render::{self, RenderError, vertex_buffer_layout};
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
@@ -63,7 +63,7 @@ pub struct Gpu {
     /// is `1` / `overlay`. `record_frame` draws this after the main
     /// pipeline as an extra inside the same render pass.
     wire_pipeline: Option<wgpu::RenderPipeline>,
-    render_running: Arc<RenderRunning>,
+    render_running: Arc<RenderCapability>,
 }
 
 /// Wireframe rendering mode, set at boot via `AETHER_WIREFRAME`.
@@ -93,7 +93,7 @@ impl WireframeMode {
 }
 
 impl Gpu {
-    pub fn new(window: Arc<Window>, render_running: Arc<RenderRunning>) -> Self {
+    pub fn new(window: Arc<Window>, render_running: Arc<RenderCapability>) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let surface = instance

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -51,8 +51,7 @@ use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{KindDescriptor, KindId, MailboxId};
 use aether_substrate::{
     BootError, Capability, ChassisCtx, EgressBackend, HubOutbound, LogEntry as SubstrateLogEntry,
-    LogLevel as SubstrateLogLevel, Mail, Mailer, Registry, ReplyTarget, ReplyTo, RunningCapability,
-    SubstrateBoot,
+    LogLevel as SubstrateLogLevel, Mail, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
 };
 use tokio::net::TcpListener;
 
@@ -480,12 +479,22 @@ fn unix_now() -> u64 {
 /// composition time. A successful connect calls
 /// `outbound.attach_backend(...)` which is what makes substrate-side
 /// egress flow upward through the TCP socket.
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`url`, `name`, `version`, `kinds`, `outbound`) is consumed by
+/// `boot` to produce the live `client`. The cap's [`Drop`] impl is a
+/// no-op — dropping the inner [`HubClient`] is enough; the writer
+/// thread observes the dropped channel and exits, the reader thread
+/// observes the closed socket and exits, and the heartbeat thread
+/// observes the closed channel and exits.
 pub struct HubClientCapability {
     url: Option<String>,
-    name: String,
-    version: String,
-    kinds: Vec<KindDescriptor>,
-    outbound: Arc<HubOutbound>,
+    name: Option<String>,
+    version: Option<String>,
+    kinds: Option<Vec<KindDescriptor>>,
+    outbound: Option<Arc<HubOutbound>>,
+    /// Live client populated by `boot` on a successful dial; `None`
+    /// when the constructor's `url` was `None` / empty.
+    pub client: Option<HubClient>,
 }
 
 impl HubClientCapability {
@@ -508,70 +517,59 @@ impl HubClientCapability {
     ) -> Self {
         Self {
             url,
-            name: name.into(),
-            version: version.into(),
-            kinds,
-            outbound,
+            name: Some(name.into()),
+            version: Some(version.into()),
+            kinds: Some(kinds),
+            outbound: Some(outbound),
+            client: None,
         }
     }
 }
 
-/// Post-boot handle for [`HubClientCapability`]. Holds the live
-/// [`HubClient`] (its `JoinHandle`s) when the capability successfully
-/// dialed; `None` when the constructor's `url` was `None` or empty.
-/// On chassis shutdown the [`RunningCapability::shutdown`] impl drops
-/// the client; the writer thread observes the dropped channel and
-/// exits, the reader thread observes the closed socket and exits, and
-/// the heartbeat thread observes the closed channel and exits.
-pub struct HubClientRunning {
-    pub client: Option<HubClient>,
-}
-
 impl Capability for HubClientCapability {
-    type Running = HubClientRunning;
-
     /// The hub-client cap dials a TCP socket; it does not claim a
     /// chassis mailbox. The `NAMESPACE` const is required by the
     /// trait (issue 525 Phase 1) but never address-resolved, so the
     /// value here is purely diagnostic.
     const NAMESPACE: &'static str = "chassis.hub_client";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let url = match self.url.as_deref() {
             Some(u) if !u.is_empty() => u.to_owned(),
-            _ => return Ok(HubClientRunning { client: None }),
+            _ => {
+                // No-op boot — preserves the pre-Phase-2 "boots cleanly
+                // without dialing" semantic. `client` stays `None`.
+                return Ok(self);
+            }
         };
         let registry = Arc::clone(ctx.registry());
         let queue = Arc::clone(ctx.mailer());
+        let name = self.name.take().expect("HubClientCapability::boot twice");
+        let version = self
+            .version
+            .take()
+            .expect("HubClientCapability::boot twice");
+        let kinds = self.kinds.take().expect("HubClientCapability::boot twice");
+        let outbound = self
+            .outbound
+            .take()
+            .expect("HubClientCapability::boot twice");
         let client = HubClient::connect(
             url.as_str(),
-            self.name,
-            self.version,
-            self.kinds,
+            name,
+            version,
+            kinds,
             registry,
             queue,
-            self.outbound,
+            outbound,
         )
         .map_err(|e| {
             BootError::Other(Box::new(io::Error::other(format!(
                 "hub connect to {url:?} failed: {e}"
             ))))
         })?;
-        Ok(HubClientRunning {
-            client: Some(client),
-        })
-    }
-}
-
-impl RunningCapability for HubClientRunning {
-    fn shutdown(self: Box<Self>) {
-        // Dropping the `HubClient` drops its writer/reader/heartbeat
-        // join handles, which detaches them — they exit naturally
-        // when the TCP socket closes or the outbound channel drains.
-        // No explicit join: chassis shutdown is best-effort about hub
-        // teardown (ADR-0063 fail-fast already handles the abort
-        // case via `flush_now`).
-        drop(self);
+        self.client = Some(client);
+        Ok(self)
     }
 }
 

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -111,7 +111,7 @@ pub struct TestBench {
     gpu: Gpu,
     /// `triangles_rendered` is read on the FrameStats emit path; the
     /// other accumulator handles (`frame_vertices` / `camera_state`)
-    /// retired post-C2 because `RenderRunning::record_frame` drains
+    /// retired post-C2 because `RenderCapability::record_frame` drains
     /// them internally.
     triangles_rendered: Arc<AtomicU64>,
 

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -31,8 +31,7 @@ use aether_substrate::chassis_builder::{Builder, BuiltChassis, NeverDriver, Pass
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
-        LogCapability, RenderCapability, RenderConfig, RenderHandles, RenderRunning,
-        io::NamespaceRoots,
+        LogCapability, RenderCapability, RenderConfig, RenderHandles, io::NamespaceRoots,
     },
     capture::{
         CaptureQueue, begin_capture_request, reply_unsupported_platform_info,
@@ -218,11 +217,11 @@ pub struct TestBenchBuild {
     pub passive: PassiveChassis<TestBenchChassis>,
     pub boot: SubstrateBoot,
     pub render_handles: RenderHandles,
-    /// The [`RenderRunning`] handle the embedder calls
-    /// [`RenderRunning::install_gpu`] on once it has a wgpu device +
+    /// The [`RenderCapability`] handle the embedder calls
+    /// [`RenderCapability::install_gpu`] on once it has a wgpu device +
     /// queue, plus encoder-level methods (`record_frame`, etc.)
     /// thereafter. Cloned out of `passive` for ergonomic access.
-    pub render_running: Arc<RenderRunning>,
+    pub render_running: Arc<RenderCapability>,
     pub kind_tick: KindId,
     pub kind_frame_stats: KindId,
     pub hub: Option<HubClient>,
@@ -288,7 +287,7 @@ impl TestBenchChassis {
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
 
-        let render_running: Arc<RenderRunning> = passive.capability();
+        let render_running: Arc<RenderCapability> = passive.capability();
         let hub = crate::hub::connect_hub_client(&boot, hub_url.as_deref())?;
 
         // The chassis-control closure already cloned `events_tx`;

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -1,13 +1,13 @@
 // Test-bench wgpu shim. ADR-0071 phase C3: pipeline + targets +
-// device + queue ownership all live inside core's `RenderRunning`
+// device + queue ownership all live inside core's `RenderCapability`
 // (via `RenderGpu` + `install_gpu`). What's left in this file is the
 // thinnest reasonable wrapper: device acquisition (offscreen, no
 // surface), and per-frame helpers that wrap encoder lifecycle around
-// `RenderRunning`'s encoder-level methods.
+// `RenderCapability`'s encoder-level methods.
 
 use std::sync::Arc;
 
-use aether_substrate::capabilities::{RenderGpu, RenderRunning};
+use aether_substrate::capabilities::{RenderCapability, RenderGpu};
 use aether_substrate::render::RenderError;
 
 pub use aether_substrate::render::VERTEX_BUFFER_BYTES;
@@ -24,7 +24,7 @@ pub struct Gpu {
     /// `Err` to.
     #[allow(dead_code)]
     pub limits: wgpu::Limits,
-    render_running: Arc<RenderRunning>,
+    render_running: Arc<RenderCapability>,
 }
 
 impl Gpu {
@@ -33,7 +33,7 @@ impl Gpu {
     /// `render_running` so encoder methods on the running can read
     /// them. `width` and `height` size the offscreen color + depth
     /// targets — the dimensions every captured frame will report.
-    pub fn new(width: u32, height: u32, render_running: Arc<RenderRunning>) -> Self {
+    pub fn new(width: u32, height: u32, render_running: Arc<RenderCapability>) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -42,7 +42,7 @@ use std::thread::{self, JoinHandle};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
+use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::{ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
 use crate::native_transport::NativeTransport;
@@ -790,43 +790,45 @@ fn dispatch_audio_mail(
 /// Native capability owning the ADR-0039 audio sink. Constructor
 /// takes an [`AudioConfig`] (resolved from env or built explicitly
 /// by the chassis main per issue 464).
+///
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`config`) lives alongside the runtime fields populated in
+/// `boot`. `Drop` runs the prior `shutdown` body. The cpal pipeline
+/// (with its `!Send`-on-macOS `Stream`) lives entirely on the
+/// dispatcher thread and tears down when the thread exits.
 pub struct AudioCapability {
-    config: AudioConfig,
+    config: Option<AudioConfig>,
+    thread: Option<JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    _transport: Option<Arc<NativeTransport>>,
 }
 
 impl AudioCapability {
     pub fn new(config: AudioConfig) -> Self {
-        Self { config }
+        Self {
+            config: Some(config),
+            thread: None,
+            sink_sender: None,
+            _transport: None,
+        }
     }
 }
 
-/// Running handle returned by [`AudioCapability::boot`]. Holds the
-/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
-/// drives channel-drop shutdown, and the actor's
-/// [`NativeTransport`] (kept alive for the dispatcher thread's
-/// lifetime via the `Arc` clone the spawn closure holds). The cpal
-/// pipeline (with its `!Send`-on-macOS `Stream`) lives entirely on
-/// the dispatcher thread and tears down when the thread exits.
-pub struct AudioRunning {
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    _transport: Arc<NativeTransport>,
-}
-
 impl Capability for AudioCapability {
-    type Running = AudioRunning;
-
     /// Components mail `aether.audio.{note_on,note_off,set_master_gain}`
     /// (kind ids) to this mailbox; the synth pulls from here. The
     /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.audio";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
-        let config = self.config;
+        let config = self
+            .config
+            .take()
+            .expect("AudioCapability::boot called twice — `config` already consumed");
 
         let transport = Arc::new(NativeTransport::from_ctx(
             ctx,
@@ -863,9 +865,6 @@ impl Capability for AudioCapability {
                 };
                 let audio_sender = pipeline.as_ref().map(|p| p.sender.clone());
 
-                // Channel-drop + join: pull until the sender side
-                // disconnects. Worst-case shutdown latency is the
-                // OS scheduler's wakeup, not a 100ms poll interval.
                 while let Some(env) = dispatcher_transport.recv_blocking() {
                     dispatch_audio_mail(
                         &mailer,
@@ -880,24 +879,18 @@ impl Capability for AudioCapability {
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(AudioRunning {
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            _transport: transport,
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        self._transport = Some(transport);
+        Ok(self)
     }
 }
 
-impl RunningCapability for AudioRunning {
-    fn shutdown(self: Box<Self>) {
-        let AudioRunning {
-            mut thread,
-            mut sink_sender,
-            _transport,
-        } = *self;
+impl Drop for AudioCapability {
+    fn drop(&mut self) {
         // Drop the strong sender first to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
     }

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -24,7 +24,7 @@
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
+use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::handle_sink;
 use crate::handle_store::HandleStore;
 use crate::mailer::Mailer;
@@ -34,8 +34,15 @@ use crate::native_transport::NativeTransport;
 /// single dispatcher thread that pulls envelopes from the
 /// `aether.handle` mailbox and routes them through
 /// [`handle_sink::dispatch`].
+///
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`store`) lives alongside the runtime fields populated in
+/// `boot`. `Drop` runs the prior `shutdown` body.
 pub struct HandleCapability {
     store: Arc<HandleStore>,
+    thread: Option<JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    _transport: Option<Arc<NativeTransport>>,
 }
 
 impl HandleCapability {
@@ -44,35 +51,16 @@ impl HandleCapability {
     /// `Ref<Handle>` resolution and capability-handled
     /// publish/release/pin/unpin observe the same entries.
     pub fn new(store: Arc<HandleStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            thread: None,
+            sink_sender: None,
+            _transport: None,
+        }
     }
 }
 
-/// Running handle returned by [`HandleCapability::boot`]. Holds the
-/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
-/// drives channel-drop shutdown, and the actor's
-/// [`NativeTransport`] (kept alive for the dispatcher thread's
-/// lifetime via the `Arc` clone the spawn closure holds).
-pub struct HandleRunning {
-    thread: Option<JoinHandle<()>>,
-    /// Drop-on-shutdown breaks the channel. Held by name so the
-    /// `RunningCapability::shutdown` impl can drop it explicitly
-    /// before joining the thread; the registry's handler can no
-    /// longer upgrade its [`std::sync::Weak`] back-reference, the
-    /// inbox's last sender is gone, and the dispatcher's
-    /// `recv_blocking()` returns `None` on its next iteration.
-    sink_sender: Option<SinkSender>,
-    /// The actor's transport. The dispatcher thread holds an
-    /// `Arc::clone`, so this field exists to keep the same transport
-    /// reachable from chassis-side code that wants to inspect or
-    /// coordinate with this actor (none today; the extension point is
-    /// here without thread-local plumbing).
-    _transport: Arc<NativeTransport>,
-}
-
 impl Capability for HandleCapability {
-    type Running = HandleRunning;
-
     /// Components mail `aether.handle.{publish,release,pin,unpin}`
     /// (kind ids) to this mailbox; the SDK's `Ctx::publish` /
     /// `Handle<K>::Drop` pair both resolve through here. The
@@ -80,17 +68,12 @@ impl Capability for HandleCapability {
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.handle";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
-        let store = self.store;
+        let store = Arc::clone(&self.store);
 
-        // ADR-0074 §Decision: `&self` trait, owned transport. The
-        // capability constructs its `NativeTransport` once at boot
-        // and clones the `Arc` into the dispatcher thread; the
-        // dispatcher uses `transport.recv_blocking()` to pull from
-        // its own inbox without thread-local plumbing.
         let transport = Arc::new(NativeTransport::from_ctx(
             ctx,
             mailbox_id,
@@ -102,33 +85,24 @@ impl Capability for HandleCapability {
         let thread = thread::Builder::new()
             .name("aether-handle-sink".into())
             .spawn(move || {
-                // Channel-drop + join: pull until the sender side
-                // disconnects. Worst-case shutdown latency is the
-                // OS scheduler's wakeup, not a 100ms poll interval.
                 while let Some(env) = dispatcher_transport.recv_blocking() {
                     handle_sink::dispatch(&store, &mailer, env.kind, env.sender, &env.payload);
                 }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(HandleRunning {
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            _transport: transport,
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        self._transport = Some(transport);
+        Ok(self)
     }
 }
 
-impl RunningCapability for HandleRunning {
-    fn shutdown(self: Box<Self>) {
-        let HandleRunning {
-            mut thread,
-            mut sink_sender,
-            _transport,
-        } = *self;
+impl Drop for HandleCapability {
+    fn drop(&mut self) {
         // Drop the strong sender first to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             // Join discards the thread's result; a panic on the
             // dispatcher already routed through the panic hook (issue
             // 321), so there's nothing further to surface here.

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
+use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
 use crate::native_transport::NativeTransport;
@@ -572,41 +572,44 @@ fn dispatch_io_mail(
 /// Native capability owning the ADR-0041 file-I/O sink. Constructor
 /// takes the resolved [`NamespaceRoots`] explicitly — the chassis
 /// main reads env (per issue 464) and passes the roots through.
+///
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`roots`) lives alongside the runtime fields populated in
+/// `boot`. `Drop` runs the prior `shutdown` body.
 pub struct IoCapability {
-    roots: NamespaceRoots,
+    roots: Option<NamespaceRoots>,
+    thread: Option<JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    _transport: Option<Arc<NativeTransport>>,
 }
 
 impl IoCapability {
     pub fn new(roots: NamespaceRoots) -> Self {
-        Self { roots }
+        Self {
+            roots: Some(roots),
+            thread: None,
+            sink_sender: None,
+            _transport: None,
+        }
     }
 }
 
-/// Running handle returned by [`IoCapability::boot`]. Holds the
-/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
-/// drives channel-drop shutdown, and the actor's
-/// [`NativeTransport`] (kept alive for the dispatcher thread's
-/// lifetime via the `Arc` clone the spawn closure holds).
-pub struct IoRunning {
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    _transport: Arc<NativeTransport>,
-}
-
 impl Capability for IoCapability {
-    type Running = IoRunning;
-
     /// Components mail `aether.io.{read,write,delete,list}` (kind ids)
     /// to this mailbox; the SDK helpers in `aether-component::io`
     /// resolve through here. The `aether.<name>` form is the
     /// post-ADR-0074 Phase 5 convention for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.io";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
-        let (registry, roots) = build_registry(self.roots).map_err(|e| {
+        let roots = self
+            .roots
+            .take()
+            .expect("IoCapability::boot called twice — `roots` already consumed");
+        let (registry, roots) = build_registry(roots).map_err(|e| {
             BootError::Other(Box::new(std::io::Error::new(
                 e.kind(),
                 format!("io adapter init failed: {e}"),
@@ -631,33 +634,24 @@ impl Capability for IoCapability {
         let thread = thread::Builder::new()
             .name("aether-io-sink".into())
             .spawn(move || {
-                // Channel-drop + join: pull until the sender side
-                // disconnects. Worst-case shutdown latency is the
-                // OS scheduler's wakeup, not a 100ms poll interval.
                 while let Some(env) = dispatcher_transport.recv_blocking() {
                     dispatch_io_mail(&registry, &mailer, env.kind, env.sender, &env.payload);
                 }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(IoRunning {
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            _transport: transport,
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        self._transport = Some(transport);
+        Ok(self)
     }
 }
 
-impl RunningCapability for IoRunning {
-    fn shutdown(self: Box<Self>) {
-        let IoRunning {
-            mut thread,
-            mut sink_sender,
-            _transport,
-        } = *self;
+impl Drop for IoCapability {
+    fn drop(&mut self) {
         // Drop the strong sender first to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
     }

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -27,7 +27,7 @@
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
+use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::log_sink;
 use crate::native_transport::NativeTransport;
 
@@ -37,11 +37,29 @@ use crate::native_transport::NativeTransport;
 /// [`log_sink::handle_log_mail`] for postcard-decode + log-facade
 /// emit.
 ///
-/// Stateless beyond the per-actor transport: the global tracing
-/// subscriber (set up by [`crate::log_capture::init`] during the
-/// shared boot) is what actually receives the bridged log records.
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot fields are
+/// empty (no constructor config), runtime fields are populated by
+/// `boot` and dropped via [`Drop`]. Stateless beyond the per-actor
+/// transport — the global tracing subscriber (set up by
+/// [`crate::log_capture::init`] during the shared boot) is what
+/// actually receives the bridged log records.
 #[derive(Default)]
-pub struct LogCapability {}
+pub struct LogCapability {
+    thread: Option<JoinHandle<()>>,
+    /// Drop-on-shutdown breaks the channel. Held in an `Option` so
+    /// the [`Drop`] impl can take it before joining the thread; the
+    /// registry's handler can no longer upgrade its
+    /// [`std::sync::Weak`] back-reference, the inbox's last sender
+    /// is gone, and the dispatcher's `recv_blocking()` returns
+    /// `None` on its next iteration.
+    sink_sender: Option<SinkSender>,
+    /// The actor's transport. The dispatcher thread holds an
+    /// `Arc::clone`, so this field exists to keep the same
+    /// transport reachable from chassis-side code that wants to
+    /// inspect or coordinate with this actor (none today; the
+    /// extension point is here without thread-local plumbing).
+    _transport: Option<Arc<NativeTransport>>,
+}
 
 impl LogCapability {
     pub fn new() -> Self {
@@ -49,38 +67,14 @@ impl LogCapability {
     }
 }
 
-/// Running handle returned by [`LogCapability::boot`]. Holds the
-/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
-/// drives channel-drop shutdown, and the actor's
-/// [`NativeTransport`] (kept alive for the dispatcher thread's
-/// lifetime via the `Arc` clone the spawn closure holds).
-pub struct LogRunning {
-    thread: Option<JoinHandle<()>>,
-    /// Drop-on-shutdown breaks the channel. Held by name so the
-    /// `RunningCapability::shutdown` impl can drop it explicitly
-    /// before joining the thread; the registry's handler can no
-    /// longer upgrade its [`std::sync::Weak`] back-reference, the
-    /// inbox's last sender is gone, and the dispatcher's
-    /// `recv_blocking()` returns `None` on its next iteration.
-    sink_sender: Option<SinkSender>,
-    /// The actor's transport. The dispatcher thread holds an
-    /// `Arc::clone`, so this field exists to keep the same
-    /// transport reachable from chassis-side code that wants to
-    /// inspect or coordinate with this actor (none today; the
-    /// extension point is here without thread-local plumbing).
-    _transport: Arc<NativeTransport>,
-}
-
 impl Capability for LogCapability {
-    type Running = LogRunning;
-
     /// Components mail `aether.log` (kind id) to this mailbox; the
     /// SDK's `MailSubscriber` resolves through here. The
     /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.log";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailbox_id = claim.id;
 
@@ -114,24 +108,18 @@ impl Capability for LogCapability {
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(LogRunning {
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            _transport: transport,
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        self._transport = Some(transport);
+        Ok(self)
     }
 }
 
-impl RunningCapability for LogRunning {
-    fn shutdown(self: Box<Self>) {
-        let LogRunning {
-            mut thread,
-            mut sink_sender,
-            _transport,
-        } = *self;
+impl Drop for LogCapability {
+    fn drop(&mut self) {
         // Drop the strong sender first to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
     }

--- a/crates/aether-substrate/src/capabilities/mod.rs
+++ b/crates/aether-substrate/src/capabilities/mod.rs
@@ -26,10 +26,10 @@ pub mod net;
 #[cfg(feature = "render")]
 pub mod render;
 #[cfg(feature = "audio")]
-pub use audio::{AudioCapability, AudioConfig, AudioRunning};
-pub use handle::{HandleCapability, HandleRunning};
-pub use io::{IoCapability, IoRunning};
-pub use log::{LogCapability, LogRunning};
-pub use net::{NetCapability, NetRunning};
+pub use audio::{AudioCapability, AudioConfig};
+pub use handle::HandleCapability;
+pub use io::IoCapability;
+pub use log::LogCapability;
+pub use net::NetCapability;
 #[cfg(feature = "render")]
-pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles, RenderRunning};
+pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles};

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use crate::capability::{BootError, Capability, ChassisCtx, RunningCapability, SinkSender};
+use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
 use crate::native_transport::NativeTransport;
@@ -445,42 +445,45 @@ fn dispatch_net_mail(
 /// Native capability owning the ADR-0043 net-egress sink. Constructor
 /// takes a [`NetConfig`] (resolved from env or built explicitly by
 /// the chassis main per issue 464).
+///
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`config`) lives alongside the runtime fields populated in
+/// `boot`. `Drop` runs the prior `shutdown` body.
 pub struct NetCapability {
-    config: NetConfig,
+    config: Option<NetConfig>,
+    thread: Option<JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    _transport: Option<Arc<NativeTransport>>,
 }
 
 impl NetCapability {
     pub fn new(config: NetConfig) -> Self {
-        Self { config }
+        Self {
+            config: Some(config),
+            thread: None,
+            sink_sender: None,
+            _transport: None,
+        }
     }
 }
 
-/// Running handle returned by [`NetCapability::boot`]. Holds the
-/// dispatcher's `JoinHandle`, the [`SinkSender`] strong handle that
-/// drives channel-drop shutdown, and the actor's
-/// [`NativeTransport`] (kept alive for the dispatcher thread's
-/// lifetime via the `Arc` clone the spawn closure holds).
-pub struct NetRunning {
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    _transport: Arc<NativeTransport>,
-}
-
 impl Capability for NetCapability {
-    type Running = NetRunning;
-
     /// Components mail `aether.net.{fetch,cancel}` (kind ids) to this
     /// mailbox; the SDK helpers in `aether-component::net` resolve
     /// through here. The `aether.<name>` form is the post-ADR-0074
     /// Phase 5 convention for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.net";
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();
         let mailbox_id = claim.id;
-        let default_timeout = self.config.default_timeout;
-        let adapter = build_net_adapter(self.config);
+        let config = self
+            .config
+            .take()
+            .expect("NetCapability::boot called twice — `config` already consumed");
+        let default_timeout = config.default_timeout;
+        let adapter = build_net_adapter(config);
 
         let transport = Arc::new(NativeTransport::from_ctx(
             ctx,
@@ -493,9 +496,6 @@ impl Capability for NetCapability {
         let thread = thread::Builder::new()
             .name("aether-net-sink".into())
             .spawn(move || {
-                // Channel-drop + join: pull until the sender side
-                // disconnects. Worst-case shutdown latency is the
-                // OS scheduler's wakeup, not a 100ms poll interval.
                 while let Some(env) = dispatcher_transport.recv_blocking() {
                     dispatch_net_mail(
                         adapter.as_ref(),
@@ -509,24 +509,18 @@ impl Capability for NetCapability {
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(NetRunning {
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            _transport: transport,
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        self._transport = Some(transport);
+        Ok(self)
     }
 }
 
-impl RunningCapability for NetRunning {
-    fn shutdown(self: Box<Self>) {
-        let NetRunning {
-            mut thread,
-            mut sink_sender,
-            _transport,
-        } = *self;
+impl Drop for NetCapability {
+    fn drop(&mut self) {
         // Drop the strong sender first to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
     }

--- a/crates/aether-substrate/src/capabilities/render.rs
+++ b/crates/aether-substrate/src/capabilities/render.rs
@@ -32,7 +32,7 @@
 //! pull the accumulator `Arc`s before the capability's `boot()` moves
 //! `self`. Once chassis composition migrates to the chassis_builder
 //! `Builder` (ADR-0071), drivers will read the same `Arc`s through
-//! `DriverCtx::expect::<RenderRunning>()` instead.
+//! `DriverCtx::expect::<RenderCapability>()` instead.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -42,9 +42,7 @@ use std::thread::{self, JoinHandle};
 use aether_data::Kind;
 use aether_kinds::{Camera, DRAW_TRIANGLE_BYTES, DrawTriangle};
 
-use crate::capability::{
-    BootError, Capability, ChassisCtx, Envelope, RunningCapability, SinkSender,
-};
+use crate::capability::{BootError, Capability, ChassisCtx, Envelope, SinkSender};
 use crate::render::{
     CaptureMeta, IDENTITY_VIEW_PROJ, Pipeline, RenderError, Targets, build_main_pipeline,
     finish_capture, prepare_capture_copy, record_main_pass,
@@ -75,13 +73,30 @@ impl Default for RenderConfig {
 }
 
 /// Render sink capability. Constructed before [`Capability::boot`];
-/// the accumulator `Arc`s are pre-allocated and exposed via
-/// [`Self::handles`] so a chassis using the legacy
-/// `boot.add_capability` path can capture them before the capability
-/// moves into boot.
+/// the accumulator `Arc`s are pre-allocated so the chassis frame
+/// loop and the dispatcher thread share the same backing storage.
+///
+/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+/// (`config`, `handles`) lives alongside the runtime fields populated
+/// in `boot` (`thread`, `sink_sender`, `gpu`). The encoder-level
+/// methods (`install_gpu`, `record_frame`, `record_capture_copy`,
+/// etc.) live as inherent methods directly on `RenderCapability` —
+/// drivers retrieve the cap via `DriverCtx::expect::<RenderCapability>()`
+/// and call those methods on the returned `Arc<RenderCapability>`.
 pub struct RenderCapability {
     config: RenderConfig,
     handles: RenderHandles,
+    thread: Option<JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    /// wgpu state, installed post-boot by the driver via
+    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
+    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
+    /// after [`Capability::boot`] has returned. Test-bench (no
+    /// surface) installs immediately after `build_passive`; desktop
+    /// installs in its `resumed` handler. Encoder-level methods
+    /// panic if called before install — in practice every code path
+    /// that calls them runs after the install site.
+    gpu: OnceLock<RenderGpu>,
 }
 
 /// Bundle of accumulator state shared between the capability's
@@ -104,7 +119,13 @@ impl RenderCapability {
             triangles_rendered: Arc::new(AtomicU64::new(0)),
             camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
         };
-        Self { config, handles }
+        Self {
+            config,
+            handles,
+            thread: None,
+            sink_sender: None,
+            gpu: OnceLock::new(),
+        }
     }
 
     /// Pre-boot accessor for the accumulator state. Cloned references
@@ -115,22 +136,7 @@ impl RenderCapability {
     }
 }
 
-pub struct RenderRunning {
-    handles: RenderHandles,
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    /// wgpu state, installed post-boot by the driver via
-    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
-    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
-    /// after [`Capability::boot`] has returned. Test-bench (no
-    /// surface) installs immediately after `build_passive`; desktop
-    /// installs in its `resumed` handler. Encoder-level methods
-    /// panic if called before install — in practice every code path
-    /// that calls them runs after the install site.
-    gpu: OnceLock<RenderGpu>,
-}
-
-/// Bundle of wgpu resources `RenderRunning` owns post-install.
+/// Bundle of wgpu resources `RenderCapability` owns post-install.
 /// Constructed by the driver from a wgpu device + queue obtained via
 /// `Adapter::request_device` (desktop: with surface compatibility;
 /// test-bench: offscreen-only). Holds the pipeline + offscreen
@@ -146,7 +152,7 @@ pub struct RenderGpu {
 
 impl RenderGpu {
     /// Build the standard render pipeline + offscreen targets at the
-    /// given size and pass [`Self`] to [`RenderRunning::install_gpu`].
+    /// given size and pass [`Self`] to [`RenderCapability::install_gpu`].
     /// `polygon_mode` is `Fill` for the normal case; desktop's
     /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
     /// pipeline draws as wireframe instead of building a separate
@@ -171,16 +177,7 @@ impl RenderGpu {
     }
 }
 
-impl RenderRunning {
-    /// Post-boot accessor for the accumulator state. Used by drivers
-    /// reading via the chassis_builder typed lookup once render
-    /// migrates onto the new builder; the legacy
-    /// `boot.add_capability` path uses [`RenderCapability::handles`]
-    /// instead.
-    pub fn handles(&self) -> RenderHandles {
-        self.handles.clone()
-    }
-
+impl RenderCapability {
     /// Install the wgpu resources the encoder-level methods read. The
     /// driver constructs [`RenderGpu`] once it has a device + queue —
     /// for desktop that's inside `resumed` after winit hands back a
@@ -192,7 +189,7 @@ impl RenderRunning {
         self.gpu
             .set(gpu)
             .ok()
-            .expect("RenderRunning::install_gpu called twice");
+            .expect("RenderCapability::install_gpu called twice");
     }
 
     /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
@@ -205,7 +202,7 @@ impl RenderRunning {
 
     fn expect_gpu(&self) -> &RenderGpu {
         self.gpu.get().expect(
-            "RenderRunning::install_gpu must be called before encoder-level methods. \
+            "RenderCapability::install_gpu must be called before encoder-level methods. \
              Desktop installs in winit's resumed; test-bench installs after build_passive.",
         )
     }
@@ -315,8 +312,6 @@ impl RenderRunning {
 }
 
 impl Capability for RenderCapability {
-    type Running = RenderRunning;
-
     /// Components mail `aether.draw_triangle` and `aether.camera`
     /// (kind ids) to this mailbox; the GPU recorder pulls from here.
     /// The `aether.<name>` form is the post-ADR-0074 Phase 5
@@ -331,16 +326,14 @@ impl Capability for RenderCapability {
     /// dropping a triangle the component meant for this frame.
     const FRAME_BARRIER: bool = true;
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-        let RenderCapability { config, handles } = self;
-
+    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_frame_bound_mailbox::<Self>()?;
 
-        let frame_vertices = Arc::clone(&handles.frame_vertices);
-        let triangles_rendered = Arc::clone(&handles.triangles_rendered);
-        let camera_state = Arc::clone(&handles.camera_state);
-        let cap_bytes = config.vertex_buffer_bytes;
-        let observed = config.observed_kinds.clone();
+        let frame_vertices = Arc::clone(&self.handles.frame_vertices);
+        let triangles_rendered = Arc::clone(&self.handles.triangles_rendered);
+        let camera_state = Arc::clone(&self.handles.camera_state);
+        let cap_bytes = self.config.vertex_buffer_bytes;
+        let observed = self.config.observed_kinds.clone();
         let pending = Arc::clone(&claim.pending);
         let receiver = claim.receiver;
 
@@ -348,7 +341,7 @@ impl Capability for RenderCapability {
             .name("aether-render-sink".into())
             .spawn(move || {
                 // Channel-drop + join: the sender lives on
-                // `RenderRunning.sink_sender`; shutdown drops it,
+                // `RenderCapability.sink_sender`; shutdown drops it,
                 // disconnecting the channel so `recv()` returns
                 // `Err(Disconnected)` and the loop exits.
                 while let Ok(env) = receiver.recv() {
@@ -371,26 +364,17 @@ impl Capability for RenderCapability {
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        Ok(RenderRunning {
-            handles,
-            thread: Some(thread),
-            sink_sender: Some(claim.sink_sender),
-            gpu: OnceLock::new(),
-        })
+        self.thread = Some(thread);
+        self.sink_sender = Some(claim.sink_sender);
+        Ok(self)
     }
 }
 
-impl RunningCapability for RenderRunning {
-    fn shutdown(self: Box<Self>) {
-        let RenderRunning {
-            handles: _,
-            mut thread,
-            mut sink_sender,
-            gpu: _,
-        } = *self;
+impl Drop for RenderCapability {
+    fn drop(&mut self) {
         // Drop the strong sender to break the channel.
-        sink_sender.take();
-        if let Some(t) = thread.take() {
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
         // gpu drops here; wgpu device/queue/pipeline/targets clean up

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -226,16 +226,20 @@ impl From<wasmtime::Error> for BootError {
 
 /// A native capability: chassis-policy code that owns one or more
 /// mailboxes plus the state behind them. Each capability is
-/// `boot()`-ed once during chassis startup and `shutdown()`-ed once
-/// during teardown.
+/// `boot()`-ed once during chassis startup; teardown happens through
+/// the cap's own [`Drop`] impl when the chassis-owned `Box<Self>`
+/// drops (issue 525 Phase 2 collapsed the prior `Self` / `Self::Running`
+/// pair into one struct, retiring `RunningCapability::shutdown` in
+/// favour of `Drop`).
 ///
-/// Implementors define `Self::Running` to describe the post-boot
-/// handle (typically a struct holding spawned thread joins, the
-/// retained mail-send handle, and any state shared with the
-/// dispatcher).
-pub trait Capability: Send + 'static {
-    type Running: RunningCapability;
-
+/// Implementors author one struct per cap. The struct typically holds
+/// `Option<JoinHandle<()>>`, an `Option<SinkSender>` (drives channel-
+/// drop shutdown), and the cap's `Arc<NativeTransport>` — `boot()`
+/// fills these from `None` to `Some` and returns the same `self`. The
+/// `Drop` impl drops the sender first to break the channel and then
+/// joins the thread, mirroring the prior `RunningCapability::shutdown`
+/// body.
+pub trait Capability: Send + Sized + 'static {
     /// The recipient name this capability claims at boot — the same
     /// string components address with `Mailbox<K>::send` on the wire.
     /// Issue 525 Phase 1: declared on the trait so the cap's own type
@@ -263,16 +267,22 @@ pub trait Capability: Send + 'static {
     /// used by Phase 4's cross-class `wait_reply` guard.
     const FRAME_BARRIER: bool = false;
 
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError>;
+    /// Wire the capability into the chassis. The pre-boot `self`
+    /// carries any constructor config (read by [`Self::new`]-style
+    /// builders); `boot` claims mailboxes through `ctx`, spawns the
+    /// dispatcher thread, and returns the same `self` with its
+    /// runtime-state fields populated. On error the chassis aborts
+    /// already-booted caps via their [`Drop`] impls.
+    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError>;
 }
 
-/// The post-boot handle returned by [`Capability::boot`]. The chassis
-/// owns it for the rest of the run; on shutdown the chassis calls
-/// `shutdown(self: Box<Self>)`, which is responsible for joining any
-/// dispatcher threads the capability spawned.
-pub trait RunningCapability: Send {
-    fn shutdown(self: Box<Self>);
-}
+/// Marker trait for type-erased capability storage in [`BootedChassis`]
+/// and the [`crate::chassis_builder`] passive list. Implemented blanket
+/// for every [`Capability`]; carries no methods of its own — teardown
+/// runs through the cap's [`Drop`] impl when the `Box<dyn ActorErased>`
+/// drops (issue 525 Phase 2).
+pub trait ActorErased: Send {}
+impl<C: Capability> ActorErased for C {}
 
 /// Kernel-side handle bundle exposed to a capability during its
 /// `boot()` call. Shared (`&mut`) across every `boot()` in the
@@ -631,9 +641,11 @@ impl<'a> ChassisCtx<'a> {
 /// Type-erased boot trampoline so [`ChassisBuilder`] can collect
 /// heterogeneous capability types into one `Vec`. Each entry, when
 /// invoked, takes the ctx, calls the underlying `Capability::boot`,
-/// and boxes the resulting `Running` handle.
+/// and boxes the resulting cap as [`ActorErased`] so the chassis can
+/// store every cap in one homogeneous `Vec`. Teardown runs through
+/// the cap's own [`Drop`] when the box drops (issue 525 Phase 2).
 type BootFn =
-    Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn RunningCapability>, BootError> + Send>;
+    Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn ActorErased>, BootError> + Send>;
 
 /// Declarative chassis composition. Capabilities are added in
 /// declaration order (ADR-0070 resolved decision 3); `build()` boots
@@ -686,15 +698,16 @@ impl ChassisBuilder {
         C: Capability,
     {
         self.pending.push(Box::new(move |ctx| {
-            let running = cap.boot(ctx)?;
-            Ok(Box::new(running) as Box<dyn RunningCapability>)
+            let booted = cap.boot(ctx)?;
+            Ok(Box::new(booted) as Box<dyn ActorErased>)
         }));
         self
     }
 
     /// Boot every capability. On the first error, already-booted
-    /// capabilities are shut down in reverse order before the error
-    /// propagates — no partial-boot state is ever returned.
+    /// capabilities are torn down in reverse order via their `Drop`
+    /// impls before the error propagates — no partial-boot state is
+    /// ever returned.
     pub fn build(self) -> Result<BootedChassis, BootError> {
         let ChassisBuilder {
             registry,
@@ -706,7 +719,7 @@ impl ChassisBuilder {
         let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
         let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> =
             Arc::new(RwLock::new(HashSet::new()));
-        let mut booted: Vec<Box<dyn RunningCapability>> = Vec::with_capacity(pending.len());
+        let mut booted: Vec<Box<dyn ActorErased>> = Vec::with_capacity(pending.len());
         for boot in pending {
             let mut ctx = ChassisCtx::new(
                 &registry,
@@ -717,10 +730,15 @@ impl ChassisBuilder {
                 &aborter,
             );
             match boot(&mut ctx) {
-                Ok(running) => booted.push(running),
+                Ok(actor) => booted.push(actor),
                 Err(e) => {
-                    while let Some(c) = booted.pop() {
-                        c.shutdown();
+                    // Drop in reverse boot order: pop runs each cap's
+                    // `Drop` (channel-drop + thread join) one at a
+                    // time, so a panic in one teardown doesn't strand
+                    // the others. Equivalent to letting the Vec drop,
+                    // but explicit so the order is documented.
+                    while let Some(actor) = booted.pop() {
+                        drop(actor);
                     }
                     return Err(e);
                 }
@@ -737,12 +755,13 @@ impl ChassisBuilder {
 }
 
 /// The output of [`ChassisBuilder::build`]. Holds every booted
-/// capability's `Running` handle plus the (optionally claimed)
-/// fallback router. On `shutdown` the capabilities are torn down in
-/// reverse boot order so later-booted state can rely on
-/// earlier-booted state during its own shutdown.
+/// capability (each merged Self-with-runtime-state per issue 525
+/// Phase 2) plus the (optionally claimed) fallback router. On
+/// `shutdown` the boxes are dropped in reverse boot order, running
+/// each cap's [`Drop`] impl so later-booted state can rely on
+/// earlier-booted state during its own teardown.
 pub struct BootedChassis {
-    running: Vec<Box<dyn RunningCapability>>,
+    running: Vec<Box<dyn ActorErased>>,
     /// Held for the lifetime of the chassis; Phase 4 will read this
     /// from `Mailer` dispatch. Today it's just owned-and-not-called.
     _fallback: Option<FallbackRouter>,
@@ -815,8 +834,8 @@ impl BootedChassis {
             &self.frame_bound_set,
             &self.aborter,
         );
-        let running = cap.boot(&mut ctx)?;
-        self.running.push(Box::new(running));
+        let booted = cap.boot(&mut ctx)?;
+        self.running.push(Box::new(booted));
         Ok(())
     }
 
@@ -865,16 +884,18 @@ impl BootedChassis {
         }
     }
 
-    /// Tear down every capability in reverse boot order. Idempotent
-    /// with [`Drop`] — calling `shutdown` first leaves [`Drop`] with
-    /// nothing to do.
+    /// Tear down every capability in reverse boot order by popping
+    /// each box and dropping it — the cap's `Drop` impl runs the
+    /// channel-drop + thread-join sequence the prior
+    /// `RunningCapability::shutdown` did. Idempotent with the
+    /// implicit `Drop` on `BootedChassis`.
     pub fn shutdown(mut self) {
         self.shutdown_in_place();
     }
 
     fn shutdown_in_place(&mut self) {
-        while let Some(c) = self.running.pop() {
-            c.shutdown();
+        while let Some(actor) = self.running.pop() {
+            drop(actor);
         }
     }
 }
@@ -883,9 +904,7 @@ impl Drop for BootedChassis {
     fn drop(&mut self) {
         // Forgotten-shutdown safety net: the chassis owner can drop
         // a `BootedChassis` without calling `shutdown` and still
-        // get its capability dispatcher threads joined. Phase 2's
-        // `HandleCapability` polls a flag every 100ms, so worst-case
-        // drop latency is one poll interval per capability.
+        // get every cap's `Drop` impl run in reverse boot order.
         self.shutdown_in_place();
     }
 }
@@ -899,40 +918,52 @@ mod tests {
 
     /// Test-only capability that claims one mailbox and records
     /// every envelope it receives plus whether shutdown ran.
+    /// Post-issue-525-Phase-2 the cap is one struct: pre-boot fields
+    /// (`name`, shared `log`/`shutdown_flag` handles) live alongside
+    /// the runtime `Option<Receiver>` populated in `boot`. `Drop`
+    /// runs the prior `shutdown` body.
     struct EchoCapability {
         name: &'static str,
         log: Arc<Mutex<Vec<Envelope>>>,
         shutdown_flag: Arc<Mutex<bool>>,
+        receiver: Mutex<Option<mpsc::Receiver<Envelope>>>,
     }
 
-    struct EchoRunning {
-        receiver: mpsc::Receiver<Envelope>,
-        log: Arc<Mutex<Vec<Envelope>>>,
-        shutdown_flag: Arc<Mutex<bool>>,
+    impl EchoCapability {
+        fn new(
+            name: &'static str,
+            log: Arc<Mutex<Vec<Envelope>>>,
+            shutdown_flag: Arc<Mutex<bool>>,
+        ) -> Self {
+            Self {
+                name,
+                log,
+                shutdown_flag,
+                receiver: Mutex::new(None),
+            }
+        }
     }
 
     impl Capability for EchoCapability {
-        type Running = EchoRunning;
         // Placeholder: parameterized fixtures bypass the type-level
         // namespace via `claim_mailbox_with_override` below, so no
         // production code observes this string.
         const NAMESPACE: &'static str = "test.echo.placeholder";
-        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
             let claim = ctx.claim_mailbox_with_override(self.name)?;
-            Ok(EchoRunning {
-                receiver: claim.receiver,
-                log: self.log,
-                shutdown_flag: self.shutdown_flag,
-            })
+            *self.receiver.lock().unwrap() = Some(claim.receiver);
+            Ok(self)
         }
     }
 
-    impl RunningCapability for EchoRunning {
-        fn shutdown(self: Box<Self>) {
+    impl Drop for EchoCapability {
+        fn drop(&mut self) {
             // Drain any pending envelopes synchronously so tests can
-            // assert against `log` after `shutdown` returns.
-            while let Ok(env) = self.receiver.try_recv() {
-                self.log.lock().unwrap().push(env);
+            // assert against `log` after the drop returns.
+            if let Some(rx) = self.receiver.lock().unwrap().take() {
+                while let Ok(env) = rx.try_recv() {
+                    self.log.lock().unwrap().push(env);
+                }
             }
             *self.shutdown_flag.lock().unwrap() = true;
         }
@@ -957,11 +988,11 @@ mod tests {
         let flag = Arc::new(Mutex::new(false));
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability {
-                name: "test.echo",
-                log: Arc::clone(&log),
-                shutdown_flag: Arc::clone(&flag),
-            })
+            .with(EchoCapability::new(
+                "test.echo",
+                Arc::clone(&log),
+                Arc::clone(&flag),
+            ))
             .build()
             .expect("build succeeds");
         assert_eq!(chassis.len(), 1);
@@ -988,11 +1019,7 @@ mod tests {
         let log = Arc::new(Mutex::new(Vec::new()));
         let flag = Arc::new(Mutex::new(false));
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability {
-                name: "test.collide",
-                log,
-                shutdown_flag: flag,
-            })
+            .with(EchoCapability::new("test.collide", log, flag))
             .build()
             .expect_err("build must reject duplicate claim");
         assert!(
@@ -1012,27 +1039,33 @@ mod tests {
         let log = Arc::new(Mutex::new(Vec::new()));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability {
-                name: "test.fail.first",
-                log: Arc::clone(&log),
-                shutdown_flag: Arc::clone(&first_flag),
-            })
-            .with(EchoCapability {
-                name: "test.fail.second",
-                log: Arc::clone(&log),
-                shutdown_flag: Arc::clone(&second_flag),
-            })
+            .with(EchoCapability::new(
+                "test.fail.first",
+                Arc::clone(&log),
+                Arc::clone(&first_flag),
+            ))
+            .with(EchoCapability::new(
+                "test.fail.second",
+                Arc::clone(&log),
+                Arc::clone(&second_flag),
+            ))
             .build()
             .expect_err("second capability must fail");
         assert!(matches!(err, BootError::MailboxAlreadyClaimed { .. }));
         assert!(
             *first_flag.lock().unwrap(),
-            "first capability shut down on boot abort"
+            "first capability dropped on boot abort"
         );
-        assert!(
-            !*second_flag.lock().unwrap(),
-            "second capability never booted"
-        );
+        // Post-issue-525-Phase-2: `second_flag` is set to `true` here
+        // too — the second EchoCapability value drops on the failed
+        // boot path, running its `Drop` impl. Pre-Phase-2 the flag
+        // was a "ran shutdown" proxy on the post-boot Running, which
+        // never existed for the second cap. The new semantic is "Drop
+        // ran" (on every constructed value, regardless of boot
+        // success), so we don't assert against `second_flag` here —
+        // the boot-aborted-cleanly check is `first_flag` plus the
+        // typed `BootError`.
+        let _ = second_flag;
     }
 
     #[test]
@@ -1042,22 +1075,17 @@ mod tests {
         struct FallbackCap {
             should_succeed: bool,
         }
-        struct FallbackRunning;
         impl Capability for FallbackCap {
-            type Running = FallbackRunning;
             const NAMESPACE: &'static str = "test.fallback.placeholder";
-            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
                 let handler: FallbackRouter = Arc::new(|_env: &Envelope| true);
                 ctx.claim_fallback_router(handler)?;
                 if self.should_succeed {
-                    Ok(FallbackRunning)
+                    Ok(self)
                 } else {
                     Err(BootError::Other("unreachable".into()))
                 }
             }
-        }
-        impl RunningCapability for FallbackRunning {
-            fn shutdown(self: Box<Self>) {}
         }
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
@@ -1079,17 +1107,12 @@ mod tests {
         struct ProbeCap {
             captured: Arc<Mutex<Option<Arc<Mailer>>>>,
         }
-        struct ProbeRunning;
         impl Capability for ProbeCap {
-            type Running = ProbeRunning;
             const NAMESPACE: &'static str = "test.probe.placeholder";
-            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
+            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
                 *self.captured.lock().unwrap() = Some(ctx.mail_send_handle());
-                Ok(ProbeRunning)
+                Ok(self)
             }
-        }
-        impl RunningCapability for ProbeRunning {
-            fn shutdown(self: Box<Self>) {}
         }
 
         let captured = Arc::new(Mutex::new(None));

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -1,13 +1,14 @@
 //! ADR-0071 Phase 2A: driver-capability traits + chassis builder
 //! type-state.
 //!
-//! Sibling to ADR-0070's [`Capability`] / [`RunningCapability`]
-//! family. A chassis composes passive capabilities (dispatcher-thread
-//! sinks per ADR-0070) plus exactly one [`DriverCapability`] that
-//! owns the chassis main thread. The type-state [`Builder`] enforces
-//! "exactly one driver" structurally; embedders that drive manually
-//! (TestBench, future embedded harnesses) build a [`PassiveChassis`]
-//! via the no-driver path.
+//! Sibling to ADR-0070's [`Capability`] family (post-issue-525-Phase-2:
+//! one struct per cap, `Drop` replaces `RunningCapability::shutdown`).
+//! A chassis composes passive capabilities (dispatcher-thread sinks
+//! per ADR-0070) plus exactly one [`DriverCapability`] that owns the
+//! chassis main thread. The type-state [`Builder`] enforces "exactly
+//! one driver" structurally; embedders that drive manually (TestBench,
+//! future embedded harnesses) build a [`PassiveChassis`] via the
+//! no-driver path.
 //!
 //! # Phase 2A scope
 //!
@@ -28,9 +29,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
-use crate::capability::{
-    BootError, Capability, ChassisCtx, FallbackRouter, MailboxClaim, RunningCapability,
-};
+use crate::capability::{BootError, Capability, ChassisCtx, FallbackRouter, MailboxClaim};
 use crate::chassis::Chassis;
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::MailboxId;
@@ -114,36 +113,38 @@ impl DriverRunning for NeverDriverRunning {
     }
 }
 
-/// Type-erased shutdown adapter for a passive [`Capability::Running`]
-/// stored in the builder's shutdown queue. Single-threaded path, so
-/// no `Send` bound — the adapter never crosses threads (the chassis
+/// Type-erased shutdown adapter for a passive [`Capability`] stored
+/// in the builder's shutdown queue. Single-threaded path, so no
+/// `Send` bound — the adapter never crosses threads (the chassis
 /// runs on the main thread end-to-end).
 trait DynShutdown {
     fn shutdown_dyn(self: Box<Self>);
 }
 
-/// Concrete adapter: holds the running as an [`Arc`] (so the same
+/// Concrete adapter: holds the booted cap as an [`Arc`] (so the same
 /// value can also live in the typed-running map for driver lookup)
 /// and on shutdown attempts to take exclusive ownership via
-/// [`Arc::try_unwrap`]. If outstanding clones remain — a driver
-/// retained one without dropping it before shutdown — the explicit
-/// `shutdown(Box<Self>)` call is skipped and the value tears down
-/// via Drop when refcounts hit zero.
-struct ArcShutdown<R: RunningCapability + Sync> {
-    arc: Arc<R>,
+/// [`Arc::try_unwrap`]. Post-issue-525-Phase-2 the cap's `Drop` impl
+/// replaces the prior `RunningCapability::shutdown`; whether teardown
+/// runs explicitly here or implicitly when the last `Arc` clone goes
+/// away, the same `Drop` body executes.
+struct ArcShutdown<C: Capability + Sync> {
+    arc: Arc<C>,
     name: &'static str,
 }
 
-impl<R: RunningCapability + Sync> DynShutdown for ArcShutdown<R> {
+impl<C: Capability + Sync> DynShutdown for ArcShutdown<C> {
     fn shutdown_dyn(self: Box<Self>) {
         let ArcShutdown { arc, name } = *self;
         match Arc::try_unwrap(arc) {
-            Ok(running) => Box::new(running).shutdown(),
+            // Cap drops at end of arm, running its `Drop` impl
+            // (channel-drop + thread join) eagerly.
+            Ok(_cap) => {}
             Err(_arc) => {
                 tracing::warn!(
                     target: "aether_substrate::chassis_builder",
                     capability = name,
-                    "skipped explicit shutdown — outstanding Arc clones; relying on Drop"
+                    "skipped eager shutdown — outstanding Arc clones; relying on Drop"
                 );
             }
         }
@@ -270,16 +271,15 @@ type DriverBoot = Box<dyn FnOnce(&mut DriverCtx<'_>) -> Result<Box<dyn DriverRun
 
 fn make_passive_boot<P>(cap: P) -> PassiveBoot
 where
-    P: Capability,
-    P::Running: Sync,
+    P: Capability + Sync,
 {
     Box::new(move |ctx, runnings| {
-        let running = cap.boot(ctx)?;
-        let arc = Arc::new(running);
+        let booted = cap.boot(ctx)?;
+        let arc = Arc::new(booted);
         runnings.insert(Arc::clone(&arc));
         Ok(Box::new(ArcShutdown {
             arc,
-            name: std::any::type_name::<P::Running>(),
+            name: std::any::type_name::<P>(),
         }) as Box<dyn DynShutdown>)
     })
 }
@@ -342,8 +342,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// before the driver.
     pub fn with<P>(mut self, cap: P) -> Self
     where
-        P: Capability,
-        P::Running: Sync,
+        P: Capability + Sync,
     {
         self.passives.push(make_passive_boot::<P>(cap));
         self
@@ -384,8 +383,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
     /// Booted before the driver in declaration order.
     pub fn with<P>(mut self, cap: P) -> Self
     where
-        P: Capability,
-        P::Running: Sync,
+        P: Capability + Sync,
     {
         self.passives.push(make_passive_boot::<P>(cap));
         self
@@ -568,14 +566,16 @@ impl<C: Chassis> fmt::Debug for PassiveChassis<C> {
 }
 
 impl<C: Chassis> PassiveChassis<C> {
-    /// Look up a booted passive's running by type. Panics if no
-    /// passive of type `R` was registered.
-    pub fn capability<R: RunningCapability + Sync + 'static>(&self) -> Arc<R> {
+    /// Look up a booted passive by type. Panics if no passive of type
+    /// `P` was registered. Post-issue-525-Phase-2 the type parameter
+    /// is the merged cap struct itself (the prior `Running` half no
+    /// longer exists as a distinct type).
+    pub fn capability<P: Capability + Sync>(&self) -> Arc<P> {
         self.booted.runnings.expect()
     }
 
     /// Soft variant of [`Self::capability`].
-    pub fn try_capability<R: RunningCapability + Sync + 'static>(&self) -> Option<Arc<R>> {
+    pub fn try_capability<P: Capability + Sync>(&self) -> Option<Arc<P>> {
         self.booted.runnings.try_get()
     }
 
@@ -633,33 +633,40 @@ mod tests {
 
     /// Test passive: claims one mailbox, records every envelope
     /// received, exposes recorded envelopes via the typed lookup.
+    /// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
+    /// (`name`) lives alongside the runtime fields populated in
+    /// `boot`. `Drop` runs the prior `shutdown` body.
     struct EchoCap {
         name: &'static str,
-    }
-
-    struct EchoRunning {
         receiver: Mutex<Option<std::sync::mpsc::Receiver<Envelope>>>,
         log: Mutex<Vec<Envelope>>,
         shutdown_flag: std::sync::atomic::AtomicBool,
     }
 
-    impl Capability for EchoCap {
-        type Running = EchoRunning;
-        // Placeholder: parameterized fixtures bypass the type-level
-        // namespace via `claim_mailbox_with_override` below.
-        const NAMESPACE: &'static str = "test.echo.placeholder";
-        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-            let claim = ctx.claim_mailbox_with_override(self.name)?;
-            Ok(EchoRunning {
-                receiver: Mutex::new(Some(claim.receiver)),
+    impl EchoCap {
+        fn new(name: &'static str) -> Self {
+            Self {
+                name,
+                receiver: Mutex::new(None),
                 log: Mutex::new(Vec::new()),
                 shutdown_flag: std::sync::atomic::AtomicBool::new(false),
-            })
+            }
         }
     }
 
-    impl RunningCapability for EchoRunning {
-        fn shutdown(self: Box<Self>) {
+    impl Capability for EchoCap {
+        // Placeholder: parameterized fixtures bypass the type-level
+        // namespace via `claim_mailbox_with_override` below.
+        const NAMESPACE: &'static str = "test.echo.placeholder";
+        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
+            let claim = ctx.claim_mailbox_with_override(self.name)?;
+            *self.receiver.lock().unwrap() = Some(claim.receiver);
+            Ok(self)
+        }
+    }
+
+    impl Drop for EchoCap {
+        fn drop(&mut self) {
             if let Some(rx) = self.receiver.lock().unwrap().take() {
                 while let Ok(env) = rx.try_recv() {
                     self.log.lock().unwrap().push(env);
@@ -701,12 +708,12 @@ mod tests {
     fn passive_build_exposes_capabilities_via_typed_lookup() {
         let (registry, mailer) = fresh_substrate();
         let passive = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap { name: "test.echo" })
+            .with(EchoCap::new("test.echo"))
             .build_passive()
             .expect("build_passive succeeds");
 
         assert_eq!(passive.len(), 1);
-        let echo: Arc<EchoRunning> = passive.capability();
+        let echo: Arc<EchoCap> = passive.capability();
         assert!(!echo.shutdown_flag.load(std::sync::atomic::Ordering::SeqCst));
     }
 
@@ -716,7 +723,7 @@ mod tests {
         let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let chassis = Builder::<DrivenTestChassis<EchoDriver>>::new(registry, mailer)
-            .with(EchoCap { name: "test.echo" })
+            .with(EchoCap::new("test.echo"))
             .driver(EchoDriver {
                 ran: Arc::clone(&ran),
             })
@@ -733,10 +740,8 @@ mod tests {
         registry.register_sink("test.collide", Arc::new(|_, _, _, _, _, _| {}));
 
         let err = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap { name: "test.fresh" })
-            .with(EchoCap {
-                name: "test.collide",
-            })
+            .with(EchoCap::new("test.fresh"))
+            .with(EchoCap::new("test.collide"))
             .build_passive()
             .expect_err("second passive must fail");
 
@@ -747,11 +752,11 @@ mod tests {
     fn passive_chassis_drop_runs_shutdowns() {
         let (registry, mailer) = fresh_substrate();
         let passive = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap { name: "test.echo" })
+            .with(EchoCap::new("test.echo"))
             .build_passive()
             .expect("build_passive succeeds");
 
-        let echo: Arc<EchoRunning> = passive.capability();
+        let echo: Arc<EchoCap> = passive.capability();
         // Drop the passive chassis. The internal Arc has refcount 2
         // (chassis + our `echo` clone). The chassis-side shutdown
         // call hits Arc::try_unwrap, sees an outstanding clone, and
@@ -773,18 +778,14 @@ mod tests {
         struct ProbeCap {
             flag: Arc<std::sync::atomic::AtomicBool>,
         }
-        struct ProbeRunning {
-            flag: Arc<std::sync::atomic::AtomicBool>,
-        }
         impl Capability for ProbeCap {
-            type Running = ProbeRunning;
             const NAMESPACE: &'static str = "test.probe.placeholder";
-            fn boot(self, _ctx: &mut ChassisCtx<'_>) -> Result<Self::Running, BootError> {
-                Ok(ProbeRunning { flag: self.flag })
+            fn boot(self, _ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
+                Ok(self)
             }
         }
-        impl RunningCapability for ProbeRunning {
-            fn shutdown(self: Box<Self>) {
+        impl Drop for ProbeCap {
+            fn drop(&mut self) {
                 self.flag.store(true, std::sync::atomic::Ordering::SeqCst);
             }
         }
@@ -809,16 +810,16 @@ mod tests {
     #[test]
     fn driver_ctx_expect_returns_passive_running() {
         let (registry, mailer) = fresh_substrate();
-        let captured: Arc<Mutex<Option<Arc<EchoRunning>>>> = Arc::new(Mutex::new(None));
+        let captured: Arc<Mutex<Option<Arc<EchoCap>>>> = Arc::new(Mutex::new(None));
 
         struct CaptureDriver {
-            captured: Arc<Mutex<Option<Arc<EchoRunning>>>>,
+            captured: Arc<Mutex<Option<Arc<EchoCap>>>>,
         }
         struct CaptureDriverRunning;
         impl DriverCapability for CaptureDriver {
             type Running = CaptureDriverRunning;
             fn boot(self, ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
-                let echo: Arc<EchoRunning> = ctx.expect();
+                let echo: Arc<EchoCap> = ctx.expect();
                 *self.captured.lock().unwrap() = Some(echo);
                 Ok(CaptureDriverRunning)
             }
@@ -830,7 +831,7 @@ mod tests {
         }
 
         let chassis = Builder::<DrivenTestChassis<CaptureDriver>>::new(registry, mailer)
-            .with(EchoCap { name: "test.echo" })
+            .with(EchoCap::new("test.echo"))
             .driver(CaptureDriver {
                 captured: Arc::clone(&captured),
             })

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -56,8 +56,8 @@ pub mod scheduler;
 
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
-    BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx, DropOnShutdownClaim,
-    Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, RunningCapability, SinkSender,
+    ActorErased, BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx,
+    DropOnShutdownClaim, Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, SinkSender,
     WedgedFrameBound,
 };
 pub use chassis::Chassis;


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525 references the parent issue this PR is one phase of; auto-close happens on the last phase only -->
## Summary

Phase 2 of issue #525's actor unification. Collapses each cap's `Running` struct into the cap struct itself and replaces `RunningCapability::shutdown` with `Drop`. Scoped to the structural drift-reduction win — the static-factory shift (`init` instead of `boot(self)`) and the typed-config registry on ChassisBuilder are deferred to a follow-up since they need a config-supply story for caps that take chassis-allocated state (HandleStore, RenderHandles, hub URL+name+version+kinds+outbound).

What lands:

- `Capability::boot(self, ctx) -> Result<Self, BootError>` — pre-boot self carries any constructor config; boot fills the runtime fields (`Option<JoinHandle>`, `Option<SinkSender>`, ...) on the same self and returns it. `type Running` retired.
- `RunningCapability` trait deleted. Each cap impls `Drop` instead; the channel-drop + thread-join body that lived in `shutdown` moves into `Drop::drop`.
- New `ActorErased: Send` marker trait, blanket-impl'd for every Capability. Chassis storage moves from `Vec<Box<dyn RunningCapability>>` to `Vec<Box<dyn ActorErased>>`. Reverse-popping the Vec runs each cap's Drop in reverse boot order — same teardown ordering as before.
- Render: `RenderRunning` collapses into `RenderCapability`. The encoder-level methods (`install_gpu`, `record_frame`, `record_capture_copy`, `finish_capture`, `resize`, `device`, `queue`, `with_color_texture`, `color_format`, `color_size`, `gpu`) now live as inherent methods on `RenderCapability`. Drivers retrieve via `DriverCtx::expect::<RenderCapability>()`.
- Hub: `HubClientCapability` + `HubClientRunning` collapsed; the `client: Option<HubClient>` field moves onto the cap.
- Test fixtures (capability.rs::tests, chassis_builder.rs::tests): `EchoCapability` / `FallbackCap` / `ProbeCap` collapsed accordingly. `boot_failure_shuts_down_already_booted_capabilities` updated to acknowledge that `Drop` runs unconditionally on the second cap (the pre-Phase-2 "never booted" semantic only worked because shutdown lived on a separate Running type).

ADR docs left untouched — they're historical records of the decision-time design, not a running snapshot of the post-Phase-2 reality.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` (1088 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)