### PR TITLE
refactor(actor): extract Actor super-trait + rename Capability → NativeActor (issue 525)

### DIFF
--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -1,0 +1,42 @@
+//! ADR-0074 §Decision: actors are the unified primitive that
+//! components and capabilities collapse onto. Issue 525 Phase 3 lifts
+//! the symmetric bits — `NAMESPACE` and `FRAME_BARRIER` — onto a
+//! transport-agnostic super-trait here so the substrate-side
+//! `NativeActor` and the wasm-side `WasmActor` (Phase 4) can both
+//! extend it.
+//!
+//! What's NOT here: lifecycle (`init` / `boot` / `Drop`). Lifecycle
+//! signatures need transport-specific ctx types
+//! (`ChassisCtx<'_>` vs `InitCtx<'_, WasmTransport>`) and one of them
+//! is fallible while the other (currently) is infallible — keeping
+//! them on the lifecycle subtraits keeps `Actor` itself ctx-free.
+
+/// The symmetric trait that every actor implements: name + scheduling
+/// class. Lifecycle methods (`boot` for native, `init` for wasm) live
+/// on the per-transport subtraits (`NativeActor`, `WasmActor`).
+///
+/// Pre-issue-525-Phase-3 these consts lived directly on
+/// `aether_substrate::Capability` (post-issue-525-Phase-3
+/// `NativeActor`); the lift makes them accessible to the wasm-side
+/// `Component` trait too without each side re-declaring the same
+/// surface. `aether-component::Component` still declares its own
+/// `NAMESPACE` independently today (Phase 1B); Phase 4 folds
+/// `Component` onto `WasmActor: Actor` so the const is sourced from
+/// the same trait both sides.
+pub trait Actor: Sized + Send + 'static {
+    /// The recipient name this actor claims. For native capabilities
+    /// it's the chassis-owned mailbox name (`aether.<name>`); for wasm
+    /// components it's the default name `load_component` registers
+    /// under when the load payload omits an explicit override.
+    const NAMESPACE: &'static str;
+
+    /// ADR-0074 §Decision 5 scheduling class. `true` means this actor
+    /// participates in the per-frame drain barrier — the chassis
+    /// frame loop waits for the dispatcher's inbox to quiesce before
+    /// submitting the next render frame, so any mail a peer sent
+    /// this frame is integrated before submit. Defaults to `false`
+    /// (free-running). Today only `RenderCapability` overrides;
+    /// future drawing-side capabilities and any wasm component that
+    /// wants per-frame coupling will too.
+    const FRAME_BARRIER: bool = false;
+}

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -36,6 +36,7 @@
 
 extern crate alloc;
 
+mod actor;
 mod ctx;
 pub mod handle;
 mod mail;
@@ -44,6 +45,7 @@ mod slot;
 mod sync;
 mod transport;
 
+pub use actor::Actor;
 pub use ctx::{Ctx, DropCtx, InitCtx};
 pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
 pub use sink::{KindId, Mailbox, resolve, resolve_mailbox};

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -526,13 +526,15 @@ impl HubClientCapability {
     }
 }
 
-impl Capability for HubClientCapability {
+impl aether_substrate::Actor for HubClientCapability {
     /// The hub-client cap dials a TCP socket; it does not claim a
     /// chassis mailbox. The `NAMESPACE` const is required by the
     /// trait (issue 525 Phase 1) but never address-resolved, so the
     /// value here is purely diagnostic.
     const NAMESPACE: &'static str = "chassis.hub_client";
+}
 
+impl Capability for HubClientCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let url = match self.url.as_deref() {
             Some(u) if !u.is_empty() => u.to_owned(),

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -42,6 +42,8 @@ use std::thread::{self, JoinHandle};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
+use aether_actor::Actor;
+
 use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::{ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
@@ -814,13 +816,15 @@ impl AudioCapability {
     }
 }
 
-impl Capability for AudioCapability {
+impl Actor for AudioCapability {
     /// Components mail `aether.audio.{note_on,note_off,set_master_gain}`
     /// (kind ids) to this mailbox; the synth pulls from here. The
     /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.audio";
+}
 
+impl Capability for AudioCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -24,6 +24,8 @@
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
+use aether_actor::Actor;
+
 use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::handle_sink;
 use crate::handle_store::HandleStore;
@@ -60,14 +62,16 @@ impl HandleCapability {
     }
 }
 
-impl Capability for HandleCapability {
+impl Actor for HandleCapability {
     /// Components mail `aether.handle.{publish,release,pin,unpin}`
     /// (kind ids) to this mailbox; the SDK's `Ctx::publish` /
     /// `Handle<K>::Drop` pair both resolve through here. The
     /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.handle";
+}
 
+impl Capability for HandleCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -30,6 +30,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
+use aether_actor::Actor;
+
 use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
@@ -594,13 +596,15 @@ impl IoCapability {
     }
 }
 
-impl Capability for IoCapability {
+impl Actor for IoCapability {
     /// Components mail `aether.io.{read,write,delete,list}` (kind ids)
     /// to this mailbox; the SDK helpers in `aether-component::io`
     /// resolve through here. The `aether.<name>` form is the
     /// post-ADR-0074 Phase 5 convention for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.io";
+}
 
+impl Capability for IoCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -27,6 +27,8 @@
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
+use aether_actor::Actor;
+
 use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::log_sink;
 use crate::native_transport::NativeTransport;
@@ -67,13 +69,15 @@ impl LogCapability {
     }
 }
 
-impl Capability for LogCapability {
+impl Actor for LogCapability {
     /// Components mail `aether.log` (kind id) to this mailbox; the
     /// SDK's `MailSubscriber` resolves through here. The
     /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
     /// for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.log";
+}
 
+impl Capability for LogCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailbox_id = claim.id;

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use aether_actor::Actor;
+
 use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
@@ -467,13 +469,15 @@ impl NetCapability {
     }
 }
 
-impl Capability for NetCapability {
+impl Actor for NetCapability {
     /// Components mail `aether.net.{fetch,cancel}` (kind ids) to this
     /// mailbox; the SDK helpers in `aether-component::net` resolve
     /// through here. The `aether.<name>` form is the post-ADR-0074
     /// Phase 5 convention for chassis-owned mailboxes.
     const NAMESPACE: &'static str = "aether.net";
+}
 
+impl Capability for NetCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
         let mailer: Arc<Mailer> = ctx.mail_send_handle();

--- a/crates/aether-substrate/src/capabilities/render.rs
+++ b/crates/aether-substrate/src/capabilities/render.rs
@@ -39,6 +39,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 
+use aether_actor::Actor;
 use aether_data::Kind;
 use aether_kinds::{Camera, DRAW_TRIANGLE_BYTES, DrawTriangle};
 
@@ -311,7 +312,7 @@ impl RenderCapability {
     }
 }
 
-impl Capability for RenderCapability {
+impl Actor for RenderCapability {
     /// Components mail `aether.draw_triangle` and `aether.camera`
     /// (kind ids) to this mailbox; the GPU recorder pulls from here.
     /// The `aether.<name>` form is the post-ADR-0074 Phase 5
@@ -325,7 +326,9 @@ impl Capability for RenderCapability {
     /// the frame would land in the *next* frame's `frame_vertices`,
     /// dropping a triangle the component meant for this frame.
     const FRAME_BARRIER: bool = true;
+}
 
+impl Capability for RenderCapability {
     fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
         let claim = ctx.claim_frame_bound_mailbox::<Self>()?;
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -34,6 +34,8 @@ use std::sync::mpsc;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use aether_actor::Actor;
+
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::{KindId, MailboxId, ReplyTo};
 use crate::mailer::Mailer;
@@ -224,65 +226,49 @@ impl From<wasmtime::Error> for BootError {
     }
 }
 
-/// A native capability: chassis-policy code that owns one or more
-/// mailboxes plus the state behind them. Each capability is
-/// `boot()`-ed once during chassis startup; teardown happens through
-/// the cap's own [`Drop`] impl when the chassis-owned `Box<Self>`
-/// drops (issue 525 Phase 2 collapsed the prior `Self` / `Self::Running`
-/// pair into one struct, retiring `RunningCapability::shutdown` in
-/// favour of `Drop`).
+/// A native actor: chassis-policy code that owns one or more
+/// mailboxes plus the state behind them. Each cap is `boot()`-ed
+/// once during chassis startup; teardown happens through the cap's
+/// own [`Drop`] impl when the chassis-owned `Box<Self>` drops
+/// (issue 525 Phase 2).
+///
+/// Renamed from `Capability` to `NativeActor` in issue 525 Phase 3:
+/// the cap is the chassis-side leaf of the unified [`Actor`] trait,
+/// the wasm-side leaf is `Component` (renaming to `WasmActor` in
+/// Phase 4). The [`Actor`] super-trait owns the symmetric bits
+/// (`NAMESPACE`, `FRAME_BARRIER`); `NativeActor` adds the
+/// chassis-side lifecycle method.
 ///
 /// Implementors author one struct per cap. The struct typically holds
 /// `Option<JoinHandle<()>>`, an `Option<SinkSender>` (drives channel-
 /// drop shutdown), and the cap's `Arc<NativeTransport>` — `boot()`
 /// fills these from `None` to `Some` and returns the same `self`. The
 /// `Drop` impl drops the sender first to break the channel and then
-/// joins the thread, mirroring the prior `RunningCapability::shutdown`
-/// body.
-pub trait Capability: Send + Sized + 'static {
-    /// The recipient name this capability claims at boot — the same
-    /// string components address with `Mailbox<K>::send` on the wire.
-    /// Issue 525 Phase 1: declared on the trait so the cap's own type
-    /// is the single source of truth, retiring the per-cap free
-    /// `pub const X_MAILBOX_NAME` consts that mirrored this field.
-    /// Each in-tree cap declares its `aether.<name>` namespace per the
-    /// post-ADR-0074 Phase 5 convention; test fixtures with
-    /// parameterized names declare a placeholder and bypass via
-    /// [`ChassisCtx::claim_mailbox_with_override`] +
-    /// friends.
-    const NAMESPACE: &'static str;
-
-    /// ADR-0074 §Decision 5 scheduling class. `true` means this
-    /// capability participates in the per-frame drain barrier — the
-    /// chassis frame loop waits for the dispatcher's inbox to quiesce
-    /// before submitting the next render frame, so any mail a
-    /// component sent this frame is integrated before submit.
-    /// Defaults to `false` (free-running). Today only `RenderCapability`
-    /// overrides; future drawing-side capabilities will too.
-    ///
-    /// The const is paired with [`ChassisCtx::claim_frame_bound_mailbox`]:
-    /// frame-bound capabilities must claim their inbox through that
-    /// method so the chassis collects the per-mailbox pending counter
-    /// the barrier reads. The trait const itself is the static marker
-    /// used by Phase 4's cross-class `wait_reply` guard.
-    const FRAME_BARRIER: bool = false;
-
-    /// Wire the capability into the chassis. The pre-boot `self`
-    /// carries any constructor config (read by [`Self::new`]-style
-    /// builders); `boot` claims mailboxes through `ctx`, spawns the
-    /// dispatcher thread, and returns the same `self` with its
-    /// runtime-state fields populated. On error the chassis aborts
-    /// already-booted caps via their [`Drop`] impls.
+/// joins the thread.
+pub trait NativeActor: Actor {
+    /// Wire the cap into the chassis. The pre-boot `self` carries any
+    /// constructor config (read by `Self::new`-style builders); `boot`
+    /// claims mailboxes through `ctx`, spawns the dispatcher thread,
+    /// and returns the same `self` with its runtime-state fields
+    /// populated. On error the chassis aborts already-booted caps via
+    /// their [`Drop`] impls.
     fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError>;
 }
 
-/// Marker trait for type-erased capability storage in [`BootedChassis`]
+/// Backwards-compatibility alias for [`NativeActor`]. Lets the
+/// substrate's existing `crate::Capability` re-export keep resolving
+/// while consumers migrate to the new name. New code should prefer
+/// `NativeActor` directly; this alias is purely an ergonomic on-ramp
+/// during issue 525's phased rollout.
+pub use NativeActor as Capability;
+
+/// Marker trait for type-erased actor storage in [`BootedChassis`]
 /// and the [`crate::chassis_builder`] passive list. Implemented blanket
-/// for every [`Capability`]; carries no methods of its own — teardown
-/// runs through the cap's [`Drop`] impl when the `Box<dyn ActorErased>`
-/// drops (issue 525 Phase 2).
+/// for every [`NativeActor`]; carries no methods of its own —
+/// teardown runs through the cap's [`Drop`] impl when the
+/// `Box<dyn ActorErased>` drops (issue 525 Phase 2).
 pub trait ActorErased: Send {}
-impl<C: Capability> ActorErased for C {}
+impl<C: NativeActor> ActorErased for C {}
 
 /// Kernel-side handle bundle exposed to a capability during its
 /// `boot()` call. Shared (`&mut`) across every `boot()` in the
@@ -944,11 +930,14 @@ mod tests {
         }
     }
 
-    impl Capability for EchoCapability {
+    impl Actor for EchoCapability {
         // Placeholder: parameterized fixtures bypass the type-level
         // namespace via `claim_mailbox_with_override` below, so no
         // production code observes this string.
         const NAMESPACE: &'static str = "test.echo.placeholder";
+    }
+
+    impl Capability for EchoCapability {
         fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
             let claim = ctx.claim_mailbox_with_override(self.name)?;
             *self.receiver.lock().unwrap() = Some(claim.receiver);
@@ -1075,8 +1064,10 @@ mod tests {
         struct FallbackCap {
             should_succeed: bool,
         }
-        impl Capability for FallbackCap {
+        impl Actor for FallbackCap {
             const NAMESPACE: &'static str = "test.fallback.placeholder";
+        }
+        impl Capability for FallbackCap {
             fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
                 let handler: FallbackRouter = Arc::new(|_env: &Envelope| true);
                 ctx.claim_fallback_router(handler)?;
@@ -1107,8 +1098,10 @@ mod tests {
         struct ProbeCap {
             captured: Arc<Mutex<Option<Arc<Mailer>>>>,
         }
-        impl Capability for ProbeCap {
+        impl Actor for ProbeCap {
             const NAMESPACE: &'static str = "test.probe.placeholder";
+        }
+        impl Capability for ProbeCap {
             fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
                 *self.captured.lock().unwrap() = Some(ctx.mail_send_handle());
                 Ok(self)

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -604,6 +604,7 @@ impl<C: Chassis> PassiveChassis<C> {
 mod tests {
     use super::*;
     use crate::capability::Envelope;
+    use aether_actor::Actor;
     use std::sync::Mutex;
 
     /// Fixture chassis for passive-build tests. `type Driver` is the
@@ -654,10 +655,13 @@ mod tests {
         }
     }
 
-    impl Capability for EchoCap {
+    impl Actor for EchoCap {
         // Placeholder: parameterized fixtures bypass the type-level
         // namespace via `claim_mailbox_with_override` below.
         const NAMESPACE: &'static str = "test.echo.placeholder";
+    }
+
+    impl Capability for EchoCap {
         fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
             let claim = ctx.claim_mailbox_with_override(self.name)?;
             *self.receiver.lock().unwrap() = Some(claim.receiver);
@@ -778,8 +782,10 @@ mod tests {
         struct ProbeCap {
             flag: Arc<std::sync::atomic::AtomicBool>,
         }
-        impl Capability for ProbeCap {
+        impl Actor for ProbeCap {
             const NAMESPACE: &'static str = "test.probe.placeholder";
+        }
+        impl Capability for ProbeCap {
             fn boot(self, _ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
                 Ok(self)
             }

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -54,11 +54,12 @@ pub mod render;
 pub mod reply_table;
 pub mod scheduler;
 
+pub use aether_actor::Actor;
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
     ActorErased, BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx,
-    DropOnShutdownClaim, Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, SinkSender,
-    WedgedFrameBound,
+    DropOnShutdownClaim, Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, NativeActor,
+    SinkSender, WedgedFrameBound,
 };
 pub use chassis::Chassis;
 pub use chassis_builder::{


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525 references the parent issue this PR is one phase of; auto-close happens on the last phase only -->
## Summary

Phase 3 of issue #525's actor unification. The symmetric bits (`NAMESPACE`, `FRAME_BARRIER`) lift onto a new transport-agnostic `Actor` super-trait in `aether-actor`; the substrate's `Capability` becomes `NativeActor: Actor`, and a backwards-compatibility alias keeps the old `Capability` name resolving during the transition.

What lands:

- New `aether_actor::Actor` trait carrying `const NAMESPACE` and `const FRAME_BARRIER`. Lifecycle methods stay on the per-transport subtraits — `Actor` itself is ctx-free so the wasm-side `WasmActor` (Phase 4) can extend it without dragging chassis types in.
- `aether_substrate::capability::Capability` renamed to `NativeActor` and now extends `Actor`. The trait body shrinks to just the lifecycle method `fn boot(self, ctx) -> Result<Self, BootError>`. The old `Capability` name is preserved as `pub use NativeActor as Capability` so existing consumers compile unchanged.
- Each in-tree cap (log, handle, io, net, audio, render) splits its prior `impl Capability` block into `impl Actor` (consts) + `impl Capability` (boot). Same for `HubClientCapability` and the test fixtures (`EchoCapability`/`FallbackCap`/`ProbeCap` in `capability.rs::tests` and `EchoCap`/`ProbeCap` in `chassis_builder.rs::tests`).
- `Actor` re-exported from `aether_substrate` lib root for one-import ergonomics.

Phase 4 (Component → WasmActor + opt-in Replaceable) is the next phase. The deferred Phase 2b (static factory + typed-config registry on ChassisBuilder) stays parked.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` (1088 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)