### PR TITLE
refactor(actor): make WasmActor::init fallible (issue 531)

### DIFF
--- a/crates/aether-actor/src/handle.rs
+++ b/crates/aether-actor/src/handle.rs
@@ -27,7 +27,7 @@
 //!
 //! #[handlers]
 //! impl Component for MyComp {
-//!     fn init(_ctx: &mut InitCtx<'_>) -> Self { Self }
+//!     fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> { Ok(Self) }
 //!
 //!     #[handler]
 //!     fn on_tick(&mut self, ctx: &mut Ctx<'_>, _t: Tick) {

--- a/crates/aether-camera-component/src/lib.rs
+++ b/crates/aether-camera-component/src/lib.rs
@@ -38,7 +38,7 @@ use aether_camera::{
     CameraCreate, CameraDestroy, CameraOrbitSet, CameraSetActive, CameraSetMode, CameraTopdownSet,
     ModeInit, OrbitParams, TopdownParams,
 };
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
 use aether_kinds::{Camera, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
 
@@ -247,7 +247,7 @@ pub struct CameraComponent {
 impl Component for CameraComponent {
     const NAMESPACE: &'static str = "camera";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
         let mut cameras = HashMap::new();
         cameras.insert(
             "main".to_owned(),
@@ -255,12 +255,12 @@ impl Component for CameraComponent {
                 mode: ModeState::Orbit(OrbitState::from_params(&OrbitParams::default())),
             },
         );
-        CameraComponent {
+        Ok(CameraComponent {
             cameras,
             active: Some("main".to_owned()),
             aspect: DEFAULT_ASPECT,
             camera: ctx.resolve_mailbox::<Camera>("aether.render"),
-        }
+        })
     }
 
     /// Advance every camera's per-mode state, then publish the active

--- a/crates/aether-component/examples/caller.rs
+++ b/crates/aether-component/examples/caller.rs
@@ -10,7 +10,7 @@
 //! the `#[handlers]`-decorated impl; `Mailbox<K>` still carries the
 //! send-side mailbox name (data, not type).
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
 use aether_data::{Kind, Schema};
 use aether_kinds::Tick;
 use bytemuck::{Pod, Zeroable};
@@ -46,12 +46,12 @@ pub struct Caller {
 impl Component for Caller {
     const NAMESPACE: &'static str = "caller";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        Caller {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Caller {
             request: ctx.resolve_mailbox::<Request>("echoer"),
             observe: ctx.resolve_mailbox::<Observation>("hub.claude.broadcast"),
             next_seq: 0,
-        }
+        })
     }
 
     #[handler]

--- a/crates/aether-component/examples/echoer.rs
+++ b/crates/aether-component/examples/echoer.rs
@@ -7,7 +7,7 @@
 //! inbound mail by `#[handlers]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
-use aether_component::{Component, Ctx, InitCtx, KindId, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, handlers};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -33,10 +33,10 @@ pub struct Echoer {
 impl Component for Echoer {
     const NAMESPACE: &'static str = "echoer";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        Echoer {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Echoer {
             response: ctx.resolve::<Response>(),
-        }
+        })
     }
 
     #[handler]

--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -22,7 +22,7 @@
 //! thin RAII wrapper over the same wire surface as `io::*` and
 //! `net::*`.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
 use aether_data::Ref;
 use aether_kinds::Tick;
 
@@ -54,8 +54,8 @@ pub struct HandleDemo {
 impl Component for HandleDemo {
     const NAMESPACE: &'static str = "handle_demo";
 
-    fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        HandleDemo { fired: false }
+    fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(HandleDemo { fired: false })
     }
 
     /// First-tick: publish a `Note`, broadcast a `HeldNote` whose

--- a/crates/aether-component/examples/hello.rs
+++ b/crates/aether-component/examples/hello.rs
@@ -16,7 +16,7 @@
 //! MCP via the same section so the harness sees typed capabilities
 //! plus author-written intent for each inbox.
 
-use aether_component::{Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
@@ -66,11 +66,11 @@ pub struct Hello {
 impl Component for Hello {
     const NAMESPACE: &'static str = "hello";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        Hello {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Hello {
             pong: ctx.resolve::<Pong>(),
             render: ctx.resolve_mailbox::<DrawTriangle>("aether.render"),
-        }
+        })
     }
 
     /// Emits the configured triangle to the render sink every tick.

--- a/crates/aether-component/examples/input_logger.rs
+++ b/crates/aether-component/examples/input_logger.rs
@@ -14,7 +14,7 @@
 //! kind at init, so the test harness just loads the component and
 //! starts driving input — no manual `subscribe_input` needed.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
 use aether_data::{Kind, Schema};
 use aether_kinds::{Key, MouseButton, MouseMove, Tick};
 use bytemuck::{Pod, Zeroable};
@@ -35,10 +35,10 @@ pub struct InputLogger {
 impl Component for InputLogger {
     const NAMESPACE: &'static str = "input_logger";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        InputLogger {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(InputLogger {
             observe: ctx.resolve_mailbox::<InputObserved>("hub.claude.broadcast"),
-        }
+        })
     }
 
     #[handler]

--- a/crates/aether-component/examples/postcard_echoer.rs
+++ b/crates/aether-component/examples/postcard_echoer.rs
@@ -13,7 +13,7 @@
 //! to wasm; load via `mcp__aether-hub__load_component` and send
 //! `demo.postcard_request` to verify the dispatch.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
@@ -47,10 +47,10 @@ pub struct PostcardEchoer {
 impl Component for PostcardEchoer {
     const NAMESPACE: &'static str = "postcard_echoer";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        PostcardEchoer {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(PostcardEchoer {
             broadcast: ctx.resolve_mailbox::<PostcardObserved>("hub.claude.broadcast"),
-        }
+        })
     }
 
     /// Decoded postcard payload arrives as the third parameter. No

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -21,7 +21,9 @@
 //! 3. `terminate_substrate`, spawn another, observe the count
 //!    bumped by one.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers, io, resolve_mailbox};
+use aether_component::{
+    BootError, Component, Ctx, InitCtx, Mailbox, handlers, io, resolve_mailbox,
+};
 use aether_kinds::{IoError, Tick};
 
 /// Broadcast payload the Claude session (or any component listening
@@ -63,8 +65,8 @@ pub struct SaveCounter {
 impl Component for SaveCounter {
     const NAMESPACE: &'static str = "save_counter";
 
-    fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        SaveCounter { initialized: false }
+    fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(SaveCounter { initialized: false })
     }
 
     /// First tick drives the sync read → increment → write cycle.

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -17,9 +17,9 @@
 //!
 //! #[handlers]
 //! impl Component for MySaveLoader {
-//!     fn init(ctx: &mut InitCtx<'_>) -> Self {
+//!     fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
 //!         io::read("save", "slot1.bin");
-//!         Self { /* ... */ }
+//!         Ok(Self { /* ... */ })
 //!     }
 //!
 //!     #[handler]

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -45,6 +45,58 @@
 extern crate alloc;
 
 use aether_actor::MailTransport;
+use alloc::borrow::Cow;
+use alloc::string::String;
+
+/// Error returned by [`WasmActor::init`] when the component cannot
+/// start (config parse failure, required handle missing, malformed
+/// env var). The message rides the `init_failed_p32` host fn into
+/// the substrate, which surfaces it in `LoadResult::Err { error }`
+/// instead of the panic-hook path's generic "guest trapped during
+/// init" text. Issue 525 Phase 4b / issue 531.
+///
+/// Wraps a `Cow<'static, str>` so static-string callers don't
+/// allocate (`BootError::from("config missing")`) while owned
+/// strings still flow through (`BootError::from(format!("..."))`).
+#[derive(Debug, Clone)]
+pub struct BootError {
+    message: Cow<'static, str>,
+}
+
+impl BootError {
+    /// Construct a `BootError` from anything convertible to a
+    /// `Cow<'static, str>` — `&'static str` for compile-time messages,
+    /// `String` for `format!`-built diagnostics.
+    pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Borrow the error text. Used by the `export!` shim to copy
+    /// bytes into the substrate via `init_failed_p32`.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl core::fmt::Display for BootError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl From<&'static str> for BootError {
+    fn from(s: &'static str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for BootError {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
 
 pub mod io;
 pub mod log;
@@ -209,11 +261,19 @@ pub use aether_actor::Actor;
 /// `WasmTransport` via the `Ctx` / `InitCtx` / `DropCtx` aliases.
 pub trait WasmActor: Actor {
     /// Runs once. Resolve kinds and sinks via `ctx` and return the
-    /// initial component state. A failed `resolve` panics — see
-    /// ADR-0012 §2 ("loud at init"). ADR-0033: `#[handlers]` prepends
+    /// initial component state. ADR-0033: `#[handlers]` prepends
     /// `ctx.subscribe_input::<K>()` for every `K::IS_INPUT` handler
     /// kind so the user body never needs to do it by hand.
-    fn init(ctx: &mut InitCtx<'_>) -> Self;
+    ///
+    /// Returns `Result<Self, BootError>` so a component that hits an
+    /// unrecoverable startup condition (config parse failure, required
+    /// handle missing, malformed env var) can surface its own message
+    /// in `LoadResult::Err { error }` instead of the panic-hook path's
+    /// generic "guest trapped during init" text. Issue 525 Phase 4b /
+    /// issue 531. Most components have no meaningful failure mode and
+    /// return `Ok(Self { ... })` unconditionally. A failed `resolve`
+    /// inside `init` still panics — see ADR-0012 §2 ("loud at init").
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError>;
 
     /// Called once on the instance being dropped — both for
     /// `drop_component` and for the old instance of
@@ -375,16 +435,38 @@ macro_rules! __export_internal {
         /// kind. ADR-0060: also installs `MailSubscriber` as the global
         /// `tracing` default before user `init` runs, so logging from
         /// inside `init` reaches the substrate's `aether.log` sink.
+        ///
+        /// Returns `0` on success and non-zero when the component's
+        /// `init` returned `Err(BootError)`. On the `Err` path the
+        /// shim ships the error text to the substrate via the
+        /// `init_failed_p32` host fn before returning, so the
+        /// substrate surfaces the message in `LoadResult::Err`
+        /// instead of a generic instantiation error. Issue 525
+        /// Phase 4b / issue 531.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
             $crate::log::install_global_default();
             let mut ctx: $crate::InitCtx<'_> =
                 $crate::InitCtx::__new(&$crate::WASM_TRANSPORT, mailbox_id);
-            let instance = <$component as $crate::Component>::init(&mut ctx);
-            unsafe {
-                __AETHER_COMPONENT.set(instance);
+            match <$component as $crate::Component>::init(&mut ctx) {
+                Ok(instance) => {
+                    unsafe {
+                        __AETHER_COMPONENT.set(instance);
+                    }
+                    0
+                }
+                Err(err) => {
+                    let msg = err.message();
+                    let bytes = msg.as_bytes();
+                    unsafe {
+                        $crate::raw::init_failed(
+                            bytes.as_ptr().addr() as u32,
+                            bytes.len() as u32,
+                        );
+                    }
+                    1
+                }
             }
-            0
         }
 
         /// # Safety

--- a/crates/aether-component/src/raw.rs
+++ b/crates/aether-component/src/raw.rs
@@ -47,6 +47,15 @@ unsafe extern "C" {
     /// of this kind."
     #[link_name = "prev_correlation_p32"]
     pub fn prev_correlation() -> u64;
+    /// Issue 525 Phase 4b / issue 531: stage a `BootError` message
+    /// for the substrate to surface in `LoadResult::Err` after the
+    /// guest's `init` returns non-zero. The `export!` macro is the
+    /// only intended caller — user code returns `Err(BootError)`
+    /// from `WasmActor::init` and the macro plumbs the bytes
+    /// through this import. Bytes at `(ptr, len)` are copied out of
+    /// guest memory before the call returns.
+    #[link_name = "init_failed_p32"]
+    pub fn init_failed(ptr: u32, len: u32);
 }
 
 /// # Safety
@@ -93,4 +102,12 @@ pub unsafe fn wait_reply(
 #[cfg(not(target_arch = "wasm32"))]
 pub unsafe fn prev_correlation() -> u64 {
     panic!("aether-component: prev_correlation called on non-wasm target");
+}
+
+/// # Safety
+/// Host-target stub for the wasm `aether::init_failed` import.
+/// Always panics — callers on non-wasm targets are misusing the SDK.
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe fn init_failed(_ptr: u32, _len: u32) {
+    panic!("aether-component: init_failed called on non-wasm target");
 }

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -17,7 +17,7 @@
 
 #![allow(dead_code)]
 
-use aether_component::{Component, Ctx, DropCtx, InitCtx, handlers};
+use aether_component::{BootError, Component, Ctx, DropCtx, InitCtx, handlers};
 use aether_data::Kind;
 use aether_data::{INPUTS_SECTION_VERSION, InputsRecord};
 use bytemuck::{Pod, Zeroable};
@@ -47,8 +47,8 @@ struct ManifestProbe;
 impl Component for ManifestProbe {
     const NAMESPACE: &'static str = "manifest_probe";
 
-    fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        Self
+    fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self)
     }
 
     /// # Agent

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -878,7 +878,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     let init_method = init_method.ok_or_else(|| {
         syn::Error::new_spanned(
             self_ty,
-            "#[handlers] requires `fn init(ctx: &mut InitCtx<'_>) -> Self`",
+            "#[handlers] requires `fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError>`",
         )
     })?;
 

--- a/crates/aether-mesh-viewer-component/src/lib.rs
+++ b/crates/aether-mesh-viewer-component/src/lib.rs
@@ -31,7 +31,7 @@
 //! 4. Every `aether.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers, io};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, io};
 use aether_kinds::{DrawTriangle, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
@@ -73,11 +73,11 @@ pub struct MeshViewer {
 impl Component for MeshViewer {
     const NAMESPACE: &'static str = "mesh_viewer";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        MeshViewer {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(MeshViewer {
             triangles: Vec::new(),
             render: ctx.resolve_mailbox::<DrawTriangle>("aether.render"),
-        }
+        })
     }
 
     /// Re-emits every cached triangle to the render sink.

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -80,11 +80,30 @@ impl Component {
         // (ADR-0030 Phase 2). Falls back to the legacy `init()` shape
         // so raw-FFI components predating the Phase 2 ABI still load —
         // they just don't get auto-subscribe, which they never did.
+        //
+        // Issue 525 Phase 4b / issue 531: a non-zero return value
+        // means the guest's `WasmActor::init` returned `Err(BootError)`
+        // and staged the message via `init_failed_p32`. Drain the
+        // staged string off the ctx and surface it as a wasmtime
+        // error so the existing `dispatch_load_component` failure
+        // path reports it via `LoadResult::Err { error }` — same
+        // shape as a wasm trap, just with a more informative message.
         let mailbox_id = store.data().sender.0;
-        if let Ok(init) = instance.get_typed_func::<u64, u32>(&mut store, "init") {
-            init.call(&mut store, mailbox_id)?;
+        let init_rc = if let Ok(init) = instance.get_typed_func::<u64, u32>(&mut store, "init") {
+            Some(init.call(&mut store, mailbox_id)?)
         } else if let Ok(init) = instance.get_typed_func::<(), u32>(&mut store, "init") {
-            init.call(&mut store, ())?;
+            Some(init.call(&mut store, ())?)
+        } else {
+            None
+        };
+        if let Some(rc) = init_rc
+            && rc != 0
+        {
+            let msg =
+                store.data_mut().init_failure.take().unwrap_or_else(|| {
+                    format!("guest init returned {rc} without staging an error")
+                });
+            return Err(wasmtime::Error::msg(format!("guest init failed: {msg}")));
         }
 
         // ADR-0015 hook exports are optional. A component whose

--- a/crates/aether-substrate/src/control/tests.rs
+++ b/crates/aether-substrate/src/control/tests.rs
@@ -312,6 +312,53 @@ fn load_component_missing_import_does_not_reserve_name() {
     );
 }
 
+/// Issue 525 Phase 4b / issue 531: a wasm whose `init` returns a
+/// non-zero status after staging a `BootError` via
+/// `init_failed_p32` produces a `LoadResult::Err` whose `error`
+/// carries the staged message. Without the host-fn plumbing the
+/// guest's diagnostic would be lost in translation and the load
+/// would surface as a generic instantiation error.
+#[test]
+fn load_component_init_failure_surfaces_staged_message() {
+    let plane = make_plane();
+    // The static byte string at offset 0 is exactly 23 bytes;
+    // `init` calls `init_failed_p32(0, 23)` to stage it, then
+    // returns 1 to signal failure. `receive_p32` is exported so
+    // the module is well-formed; it would never run.
+    const WAT_INIT_FAILS: &str = r#"
+            (module
+                (import "aether" "init_failed_p32" (func $init_failed (param i32 i32)))
+                (memory (export "memory") 1)
+                (data (i32.const 0) "boot failed: bad config")
+                (func (export "init") (param i64) (result i32)
+                    i32.const 0
+                    i32.const 23
+                    call $init_failed
+                    i32.const 1)
+                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+                    i32.const 0))
+        "#;
+    let wasm = wat::parse_str(WAT_INIT_FAILS).unwrap();
+    let result = plane.handle_load(
+        &postcard::to_allocvec(&LoadComponent {
+            wasm,
+            name: Some("init_fails".into()),
+        })
+        .unwrap(),
+    );
+    let LoadResult::Err { error } = result else {
+        panic!("expected LoadResult::Err, got {result:?}");
+    };
+    assert!(
+        error.contains("boot failed: bad config"),
+        "staged BootError message should appear in LoadResult::Err, got: {error}",
+    );
+    assert!(
+        plane.registry.lookup("init_fails").is_none(),
+        "failed init must not leave a ghost mailbox",
+    );
+}
+
 /// ADR-0028 / ADR-0032 happy path: a component ships both its
 /// canonical `aether.kinds` record and the paired
 /// `aether.kinds.labels` sidecar. The substrate reads both and

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -70,6 +70,16 @@ pub struct SubstrateCtx {
     /// the replace; the substrate checks this after `on_replace` and
     /// surfaces the message back up the control plane.
     pub save_state_error: Option<String>,
+    /// Set by the `init_failed_p32` host fn when the guest's `init`
+    /// returns `Err(BootError)`. Issue 525 Phase 4b / issue 531: the
+    /// substrate reads this after `init` returns non-zero and
+    /// surfaces the message in `LoadResult::Err { error }`. The guest
+    /// stages the bytes here and returns 1 from its `init` shim;
+    /// `Component::instantiate` turns the staged message into a
+    /// `wasmtime::Error` so the existing load-failure path in
+    /// `dispatch_load_component` reports it like any other
+    /// instantiation error. None on the success path.
+    pub init_failure: Option<String>,
     /// ADR-0042 inbox machinery: the component's mpsc `Receiver`
     /// lives here (not on the dispatcher's stack) so the
     /// `wait_reply_p32` host fn can drain it directly, and a FIFO
@@ -115,6 +125,7 @@ impl SubstrateCtx {
             reply_table: ReplyTable::new(),
             saved_state: None,
             save_state_error: None,
+            init_failure: None,
             inbox_rx: Mutex::new(None),
             inbox_overflow: Mutex::new(VecDeque::new()),
             correlation_counter: Cell::new(1),

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -416,5 +416,39 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
         |caller: Caller<'_, SubstrateCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
+    // HOST_FN_OK: ADR-0002 / issue 531. The BootError plumbing
+    // can't ride a mail sink because mail is not dispatched until
+    // the component finishes booting — the `init` FFI call itself
+    // is the entry point, and a `Result::Err` returned from it
+    // needs a side channel to ship the error string back to the
+    // substrate before the FFI call returns. A host fn is the
+    // only mechanism that's available pre-`init`-completion.
+    //
+    // Issue 525 Phase 4b / issue 531: stage a `BootError` message
+    // for `Component::instantiate` to surface in `LoadResult::Err`
+    // after the guest's `init` returns non-zero. The bytes are
+    // copied out of guest memory before the call returns; OOB or
+    // missing-memory drops silently — the guest's non-zero return
+    // still triggers the failure path, just without a message
+    // (`Component::instantiate` falls back to a generic "init
+    // returned <rc> without staging an error" diagnostic).
+    linker.func_wrap(
+        "aether",
+        "init_failed_p32",
+        |mut caller: Caller<'_, SubstrateCtx>, ptr: u32, len: u32| {
+            let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
+                return;
+            };
+            let data = memory.data(&caller);
+            let start = ptr as usize;
+            let end = match start.checked_add(len as usize) {
+                Some(e) if e <= data.len() => e,
+                _ => return,
+            };
+            let msg = String::from_utf8_lossy(&data[start..end]).into_owned();
+            caller.data_mut().init_failure = Some(msg);
+        },
+    )?;
+
     Ok(())
 }

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -15,7 +15,7 @@
 //!   `capture_frame` scenarios can observe pre-mail effects in the
 //!   captured PNG.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
 use aether_kinds::{DrawTriangle, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
 
@@ -58,11 +58,11 @@ pub struct Probe {
 impl Component for Probe {
     const NAMESPACE: &'static str = "test_fixture_probe";
 
-    fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        Probe {
+    fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Probe {
             tick_count: 0,
             render: SetRender::default(),
-        }
+        })
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -12,7 +12,7 @@
 //! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
 use aether_camera::{CameraTopdownSet, TopdownParams};
-use aether_component::{Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
 use aether_data::{Kind, Schema};
 use aether_kinds::{DrawTriangle, Key, Tick, Vertex, keycode};
 use bytemuck::{Pod, Zeroable};
@@ -141,7 +141,7 @@ pub struct Sokoban {
 impl Component for Sokoban {
     const NAMESPACE: &'static str = "sokoban";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
         let mut me = Sokoban {
             state: SokobanState::default(),
             state_kind: ctx.resolve::<SokobanState>(),
@@ -156,7 +156,7 @@ impl Component for Sokoban {
             },
         };
         me.load_level(0);
-        me
+        Ok(me)
     }
 
     #[handler]

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -45,7 +45,7 @@
 //! That's as shape-y as this first pass gets; proper X / O glyphs
 //! are a rendering-polish pass for later.
 
-use aether_component::{Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, GameState, LAST_MOVE_NONE, MoveResult, PLAYER_X, PlayMove, SERVER,
 };
@@ -129,8 +129,8 @@ impl Default for TicTacToeClient {
 impl Component for TicTacToeClient {
     const NAMESPACE: &'static str = "tic_tac_toe_client";
 
-    fn init(_ctx: &mut InitCtx<'_>) -> Self {
-        TicTacToeClient::default()
+    fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(TicTacToeClient::default())
     }
 
     /// Cached copy of the latest authoritative state. Overwrites

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -22,7 +22,7 @@
 //! on the trunk for those without pulling in this crate's
 //! `Component` impl. Per ADR-0066.
 
-use aether_component::{Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, CLIENT_OBSERVER, GAME_DRAW, GAME_PLAYING, GAME_WON_O, GAME_WON_X, GameState,
     MOVE_CELL_OCCUPIED, MOVE_GAME_OVER, MOVE_OK, MOVE_OUT_OF_BOUNDS, MoveResult, PLAYER_NONE,
@@ -59,13 +59,13 @@ pub struct TicTacToe {
 impl Component for TicTacToe {
     const NAMESPACE: &'static str = "tic_tac_toe";
 
-    fn init(ctx: &mut InitCtx<'_>) -> Self {
-        TicTacToe {
+    fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
+        Ok(TicTacToe {
             state: GameState::new_game(),
             move_result_kind: ctx.resolve::<MoveResult>(),
             broadcast: ctx.resolve_mailbox::<GameState>("hub.claude.broadcast"),
             client_observer: ctx.resolve_mailbox::<GameState>(CLIENT_OBSERVER),
-        }
+        })
     }
 
     /// Applies a move if legal, then replies to the sender with the


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525 references the parent issue this PR closes -->
## Summary

Phase 4b of issue #525 — closes the actor-trait unification effort.

`WasmActor::init` now returns `Result<Self, BootError>`. A guest that hits an unrecoverable startup condition (config parse failure, required handle missing, malformed env var) ships its own diagnostic to the substrate via a new `init_failed_p32` host fn; the substrate surfaces the message in `LoadResult::Err { error }` instead of the panic-hook path's generic "guest trapped during init" text.

## Design choices

Both open questions in #531 resolved as recommended:

1. **`BootError` lives in `aether-component`** as a small `Cow<'static, str>` wrapper — wasm-side errors only need a string today, and a shared no_std type would have to be a subset of substrate's structured `BootError` enum anyway.
2. **New host-fn `init_failed_p32(ptr, len)`** stages the bytes; the macro calls it before the FFI shim returns 1, and `Component::instantiate` drains the staged message off `SubstrateCtx::init_failure` to build a `wasmtime::Error` that flows through the existing `dispatch_load_component` failure path. Out-parameter / second-export plumbing was rejected as more moving parts for no win.

## Migration

Every in-tree `WasmActor::init` impl now reads `fn init(ctx) -> Result<Self, BootError> { Ok(Self { ... }) }`. None of the migrated components had meaningful failure modes.

## Test plan

- [x] New `load_component_init_failure_surfaces_staged_message` test exercises a hand-rolled wasm that calls `init_failed_p32("boot failed: bad config")` then returns 1; asserts `LoadResult::Err { error }` carries the message and the registry has no ghost mailbox.
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] `cargo check -p aether-component --target wasm32-unknown-unknown` plus every wasm-cdylib crate (test-fixture-probe, camera, mesh-viewer, sokoban, tic-tac-toe-server, tic-tac-toe-client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)