### PR TITLE
feat(actor): sdk primitives for actor-typed sender API (issue 533 phase 1)

### DIFF
--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -40,3 +40,33 @@ pub trait Actor: Sized + Send + 'static {
     /// wants per-frame coupling will too.
     const FRAME_BARRIER: bool = false;
 }
+
+/// Marker: only one instance of this actor can be live per substrate.
+/// Required by `Ctx::send_to::<R>` so the type → mailbox lookup is
+/// unambiguous — the substrate enforces "at most one Singleton actor
+/// per `R::NAMESPACE`" at registration time, and senders address by
+/// type rather than by name.
+///
+/// Chassis caps and synthetic actors like `HubBroadcast` are always
+/// singletons. User components are singletons when their cdylib loads
+/// at the default name (`R::NAMESPACE` from the wasm custom section);
+/// multi-instance loads use `ctx.resolve_actor::<R>(name)` instead and
+/// don't go through the singleton path. ADR-0075 §Decision 1.
+pub trait Singleton: Actor {}
+
+/// Per-handler-kind marker: `R: HandlesKind<K>` means actor `R` has
+/// a `#[handler]` method accepting kind `K`. Auto-emitted by the
+/// `#[handlers]` proc-macro alongside the dispatch table — one impl
+/// per handler kind. Authors never write these by hand.
+///
+/// Gates `Ctx::send_to::<R>(&K)` and `ActorMailbox<R, T>::send::<K>` so
+/// the compiler rejects sends to a kind the receiver doesn't handle.
+/// The single source of truth is the handler list on the actor's
+/// `impl` block; adding a `#[handler]` updates senders' compile-time
+/// checks automatically. ADR-0075 §Decision 1.
+///
+/// Blanket impls (e.g. `impl<T: Into<DrawTriangle>> HandlesKind<T> for
+/// RenderCapability`) are an opt-in extension if a real conversion case
+/// wants them; the default macro emission is strict so wire bytes stay
+/// obvious.
+pub trait HandlesKind<K: aether_data::Kind>: Actor {}

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -18,9 +18,12 @@ use core::marker::PhantomData;
 
 use aether_data::{Kind, Schema};
 
+use crate::actor::{Actor, HandlesKind, Singleton};
 use crate::handle::{self, Handle, SyncHandleError};
 use crate::mail::ReplyTo;
-use crate::sink::{KindId, Mailbox, resolve, resolve_mailbox};
+use crate::sink::{
+    ActorMailbox, KindId, Mailbox, resolve, resolve_actor, resolve_actor_named, resolve_mailbox,
+};
 use crate::transport::MailTransport;
 
 /// Init-only capability handle. The type split between `InitCtx` and
@@ -204,6 +207,36 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
         let bytes = payload.encode_into_bytes();
         self.transport
             .reply_mail(sender.raw(), kind.raw(), &bytes, 1);
+    }
+
+    /// ADR-0075 singleton path: send `payload` to the unique instance of
+    /// actor `R`, addressed by `R::NAMESPACE`. Compile-checked against
+    /// `R: Singleton + HandlesKind<K>` so wrong-receiver and wrong-kind
+    /// sends are caught at the call site instead of silent runtime
+    /// warn-drops.
+    ///
+    /// During the migration (Phases 1–3) this lives alongside the
+    /// kind-typed `Ctx::send(&sink, &payload)`. Phase 4 retires the old
+    /// form and renames `send_to` → `send`.
+    pub fn send_to<R, K>(&self, payload: &K)
+    where
+        R: Singleton + HandlesKind<K>,
+        K: Kind,
+    {
+        resolve_actor::<R, T>().send(self.transport, payload);
+    }
+
+    /// ADR-0075 multi-instance path: resolve a typed `ActorMailbox<R, T>`
+    /// from a runtime instance name. The string surfaces ONCE per
+    /// handle; subsequent sends through the returned handle are
+    /// string-free and compile-checked against `R: HandlesKind<K>`.
+    ///
+    /// Use this when addressing one of several live instances of the
+    /// same actor type (e.g. `"player_1"` vs `"player_2"`). For
+    /// singletons (chassis caps, uniquely-loaded user components),
+    /// `send_to::<R>(&payload)` skips the explicit handle entirely.
+    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<R, T> {
+        resolve_actor_named::<R, T>(name)
     }
 }
 

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -45,10 +45,12 @@ mod slot;
 mod sync;
 mod transport;
 
-pub use actor::Actor;
+pub use actor::{Actor, HandlesKind, Singleton};
 pub use ctx::{Ctx, DropCtx, InitCtx};
 pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
-pub use sink::{KindId, Mailbox, resolve, resolve_mailbox};
+pub use sink::{
+    ActorMailbox, KindId, Mailbox, resolve, resolve_actor, resolve_actor_named, resolve_mailbox,
+};
 pub use slot::Slot;
 pub use sync::{WaitError, decode_wait_reply, wait_reply};
 pub use transport::MailTransport;

--- a/crates/aether-actor/src/sink.rs
+++ b/crates/aether-actor/src/sink.rs
@@ -166,6 +166,139 @@ pub const fn resolve_mailbox<K: Kind, T: MailTransport>(mailbox_name: &str) -> M
     Mailbox::__new(mailbox_id_from_name(mailbox_name).0, K::ID.0)
 }
 
+/// Phantom-typed receiver-actor handle. ADR-0075's actor-typed sender
+/// API: `ActorMailbox<R, T>` addresses the mailbox of receiver actor `R`,
+/// not a single kind. Lives alongside [`Mailbox<K, T>`] during the
+/// migration — Phase 4 retires the kind-typed form and renames this
+/// to `Mailbox`.
+///
+/// Multi-kind by construction: `send::<K>` is gated on `R: HandlesKind<K>`,
+/// so the same `ActorMailbox<RenderCapability, T>` accepts both
+/// `&DrawTriangle` and `&Camera` (instead of needing two `Mailbox<K>`
+/// declarations as today). Wrong-kind sends are compile errors.
+///
+/// Built two ways:
+///
+/// - Singleton path: senders never construct one explicitly. Inside
+///   `Ctx::send_to::<R>(&kind)` the SDK resolves the singleton mailbox
+///   from `R::NAMESPACE` and dispatches in one call.
+/// - Multi-instance path: `Ctx::resolve_actor::<R>(name)` returns an
+///   `ActorMailbox<R, T>` value that the caller stores; subsequent sends
+///   go through `actor_mailbox.send(transport, &kind)` and are
+///   string-free.
+pub struct ActorMailbox<R, T: MailTransport> {
+    mailbox: u64,
+    _r: PhantomData<fn() -> R>,
+    _t: PhantomData<fn() -> T>,
+}
+
+impl<R, T: MailTransport> Copy for ActorMailbox<R, T> {}
+impl<R, T: MailTransport> Clone for ActorMailbox<R, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<R, T: MailTransport> ActorMailbox<R, T> {
+    /// Not part of the public API; the const builders go through here
+    /// so the field stays private.
+    #[doc(hidden)]
+    pub const fn __new(mailbox: u64) -> Self {
+        ActorMailbox {
+            mailbox,
+            _r: PhantomData,
+            _t: PhantomData,
+        }
+    }
+
+    /// Raw mailbox id. Exposed for callers that need it for a
+    /// host fn the SDK doesn't yet wrap.
+    pub fn mailbox(self) -> u64 {
+        self.mailbox
+    }
+}
+
+impl<R: crate::Actor, T: MailTransport> ActorMailbox<R, T> {
+    /// Send a single payload of kind `K` to actor `R`. Compile-checked
+    /// against `R: HandlesKind<K>` — wrong-kind sends are rejected at
+    /// the call site.
+    ///
+    /// Wire shape (cast or postcard) follows `Kind::encode_into_bytes`
+    /// — same single source of truth as the kind-typed `Mailbox::send`
+    /// per issue #240.
+    ///
+    /// ```compile_fail
+    /// use aether_actor::{Actor, ActorMailbox, HandlesKind, Singleton, MailTransport};
+    /// use aether_data::Kind;
+    ///
+    /// // Two kinds; the receiver only handles the first.
+    /// struct KindOk;
+    /// impl Kind for KindOk {
+    ///     const NAME: &'static str = "doctest.ok";
+    ///     const ID: aether_data::KindId = aether_data::KindId(1);
+    /// }
+    /// struct KindWrong;
+    /// impl Kind for KindWrong {
+    ///     const NAME: &'static str = "doctest.wrong";
+    ///     const ID: aether_data::KindId = aether_data::KindId(2);
+    /// }
+    /// struct R;
+    /// impl Actor for R { const NAMESPACE: &'static str = "doctest"; }
+    /// impl Singleton for R {}
+    /// impl HandlesKind<KindOk> for R {}     // R handles KindOk only
+    ///
+    /// struct T;
+    /// impl MailTransport for T {
+    ///     fn send_mail(&self, _: u64, _: u64, _: &[u8], _: u32) -> u32 { 0 }
+    ///     fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 { 0 }
+    ///     fn save_state(&self, _: u32, _: &[u8]) -> u32 { 0 }
+    ///     fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 { -1 }
+    ///     fn prev_correlation(&self) -> u64 { 0 }
+    /// }
+    ///
+    /// let h: ActorMailbox<R, T> = aether_actor::resolve_actor::<R, T>();
+    /// let t = T;
+    /// h.send(&t, &KindWrong);   // ← compile error: R does not impl HandlesKind<KindWrong>
+    /// ```
+    pub fn send<K>(self, transport: &T, payload: &K)
+    where
+        R: crate::HandlesKind<K>,
+        K: Kind,
+    {
+        let bytes = payload.encode_into_bytes();
+        transport.send_mail(self.mailbox, K::ID.0, &bytes, 1);
+    }
+
+    /// Send a slice of payloads as a contiguous batch. Cast-only —
+    /// see [`Mailbox::send_many`] for the wire-shape rationale.
+    pub fn send_many<K>(self, transport: &T, payloads: &[K])
+    where
+        R: crate::HandlesKind<K>,
+        K: Kind + bytemuck::NoUninit,
+    {
+        let bytes: &[u8] = bytemuck::cast_slice(payloads);
+        transport.send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32);
+    }
+}
+
+/// Resolve an actor by its `Actor::NAMESPACE`, producing a typed
+/// `ActorMailbox<R, T>` for the singleton instance. Pure compile-time
+/// construction — the mailbox id is `mailbox_id_from_name(R::NAMESPACE)`.
+///
+/// For multi-instance actors loaded under a non-default name, use
+/// [`resolve_actor_named`] (or `Ctx::resolve_actor`) instead.
+pub const fn resolve_actor<R: crate::Actor, T: MailTransport>() -> ActorMailbox<R, T> {
+    ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0)
+}
+
+/// Resolve a multi-instance actor by runtime name, producing a typed
+/// `ActorMailbox<R, T>`. The string surfaces ONCE per handle; subsequent
+/// sends through the returned handle are string-free and compile-checked
+/// against `R: HandlesKind<K>`.
+pub fn resolve_actor_named<R: crate::Actor, T: MailTransport>(name: &str) -> ActorMailbox<R, T> {
+    ActorMailbox::__new(mailbox_id_from_name(name).0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +350,124 @@ mod tests {
         let s: Mailbox<FakeKind, NoopTransport> = Mailbox::__new(3u64, 11);
         assert_eq!(s.mailbox(), 3u64);
         assert_eq!(s.kind(), 11);
+    }
+
+    /// ADR-0075 actor-typed sender API. `ActorMailbox<R, T>` is keyed on
+    /// the receiver actor `R`; `send::<K>` is gated on `R: HandlesKind<K>`
+    /// so wrong-kind sends are rejected at the call site.
+    mod actor_typed_send {
+        use super::super::{ActorMailbox, resolve_actor, resolve_actor_named};
+        use crate::actor::{Actor, HandlesKind, Singleton};
+        use crate::transport::MailTransport;
+        use ::aether_data::{Kind, mailbox_id_from_name};
+        use alloc::vec::Vec;
+        use core::cell::RefCell;
+
+        /// Cast-shaped kind — overrides `encode_into_bytes` so the
+        /// default-panic doesn't trip.
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct PingKind {
+            tag: u32,
+        }
+        unsafe impl bytemuck::Zeroable for PingKind {}
+        unsafe impl bytemuck::Pod for PingKind {}
+        impl Kind for PingKind {
+            const NAME: &'static str = "test.actor_typed.ping";
+            const ID: ::aether_data::KindId = ::aether_data::KindId(0x1111_2222_3333_4444);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+        }
+
+        /// Singleton receiver. `HandlesKind<PingKind>` opens the gate.
+        struct PingActor;
+        impl Actor for PingActor {
+            const NAMESPACE: &'static str = "test.ping_actor";
+        }
+        impl Singleton for PingActor {}
+        impl HandlesKind<PingKind> for PingActor {}
+
+        #[derive(Clone)]
+        struct RecordedSend {
+            recipient: u64,
+            kind: u64,
+            bytes: Vec<u8>,
+            count: u32,
+        }
+
+        /// Recording transport so we can inspect what `send::<K>`
+        /// actually plumbed through. `RefCell` is fine — the SDK is
+        /// single-threaded per actor, and these tests run on one thread.
+        struct RecordingTransport {
+            sends: RefCell<Vec<RecordedSend>>,
+        }
+        impl RecordingTransport {
+            fn new() -> Self {
+                RecordingTransport {
+                    sends: RefCell::new(Vec::new()),
+                }
+            }
+            fn snapshot(&self) -> Vec<RecordedSend> {
+                self.sends.borrow().clone()
+            }
+        }
+        impl MailTransport for RecordingTransport {
+            fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+                self.sends.borrow_mut().push(RecordedSend {
+                    recipient,
+                    kind,
+                    bytes: bytes.to_vec(),
+                    count,
+                });
+                0
+            }
+            fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 {
+                0
+            }
+            fn save_state(&self, _: u32, _: &[u8]) -> u32 {
+                0
+            }
+            fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 {
+                -1
+            }
+            fn prev_correlation(&self) -> u64 {
+                0
+            }
+        }
+        // Single-threaded test stub — Send + Sync needed because the
+        // SDK trait requires them. Real transports (WasmTransport ZST,
+        // NativeTransport) carry these properly.
+        unsafe impl Send for RecordingTransport {}
+        unsafe impl Sync for RecordingTransport {}
+
+        #[test]
+        fn resolve_actor_addresses_namespace() {
+            let h: ActorMailbox<PingActor, RecordingTransport> = resolve_actor::<PingActor, _>();
+            assert_eq!(h.mailbox(), mailbox_id_from_name(PingActor::NAMESPACE).0);
+        }
+
+        #[test]
+        fn resolve_actor_named_addresses_runtime_name() {
+            let h: ActorMailbox<PingActor, RecordingTransport> =
+                resolve_actor_named::<PingActor, _>("instance_42");
+            assert_eq!(h.mailbox(), mailbox_id_from_name("instance_42").0);
+        }
+
+        #[test]
+        fn actor_mailbox_send_records_recipient_and_kind() {
+            let transport = RecordingTransport::new();
+            let h: ActorMailbox<PingActor, RecordingTransport> = resolve_actor::<PingActor, _>();
+            let payload = PingKind { tag: 0xCAFE_BABE };
+            h.send(&transport, &payload);
+
+            let snap = transport.snapshot();
+            assert_eq!(snap.len(), 1);
+            let entry = &snap[0];
+            assert_eq!(entry.recipient, mailbox_id_from_name(PingActor::NAMESPACE).0);
+            assert_eq!(entry.kind, PingKind::ID.0);
+            assert_eq!(entry.bytes.len(), core::mem::size_of::<PingKind>());
+            assert_eq!(entry.count, 1);
+        }
     }
 }

--- a/crates/aether-actor/src/sink.rs
+++ b/crates/aether-actor/src/sink.rs
@@ -464,7 +464,10 @@ mod tests {
             let snap = transport.snapshot();
             assert_eq!(snap.len(), 1);
             let entry = &snap[0];
-            assert_eq!(entry.recipient, mailbox_id_from_name(PingActor::NAMESPACE).0);
+            assert_eq!(
+                entry.recipient,
+                mailbox_id_from_name(PingActor::NAMESPACE).0
+            );
             assert_eq!(entry.kind, PingKind::ID.0);
             assert_eq!(entry.bytes.len(), core::mem::size_of::<PingKind>());
             assert_eq!(entry.count, 1);

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -194,8 +194,9 @@ pub type Handle<K> = aether_actor::handle::Handle<K, WasmTransport>;
 // Re-exports — these types have no transport coupling, so they pass
 // through unchanged from the SDK.
 pub use aether_actor::{
-    DISPATCH_HANDLED, DISPATCH_UNKNOWN_KIND, KindId, Mail, MailTransport as MailTransportTrait,
-    NO_REPLY_HANDLE, PriorState, ReplyTo, Slot, WaitError, decode_wait_reply, resolve, wait_reply,
+    DISPATCH_HANDLED, DISPATCH_UNKNOWN_KIND, HandlesKind, KindId, Mail,
+    MailTransport as MailTransportTrait, NO_REPLY_HANDLE, PriorState, ReplyTo, Singleton, Slot,
+    WaitError, decode_wait_reply, resolve, wait_reply,
 };
 
 /// Wasm-flavoured `resolve_mailbox` — pins `T = WasmTransport` so the

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -927,8 +927,24 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
         }
     };
 
+    // ADR-0075: emit one `impl HandlesKind<K> for Self {}` per handler
+    // kind. Auto-generated marker impls gate `Ctx::send_to::<R>(&K)` and
+    // `ActorMailbox<R, T>::send::<K>` so wrong-kind sends are compile
+    // errors at the call site. The handler list above is the single
+    // source of truth — adding a `#[handler]` automatically updates
+    // senders' compile-time checks.
+    let handles_kind_impls = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        quote! {
+            impl #impl_generics ::aether_component::HandlesKind<#kind_ty>
+                for #self_ty #where_clause {}
+        }
+    });
+
     Ok(quote! {
         #actor_impl
+
+        #(#handles_kind_impls)*
 
         impl #impl_generics #trait_path for #self_ty #where_clause {
             #wrapped_init


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #525, #533 reference parent ADR + tracker -->
## Summary

Phase 1 of issue #533 (ADR-0075). Lands the additive SDK surface for the actor-typed sender API. The kind-typed `Mailbox<K>` path is unchanged — the new API lives alongside it during the migration; nothing breaks.

## What's added

**`aether-actor`:**
- `Singleton` marker trait — gates `Ctx::send_to::<R>` so the type → mailbox lookup is unambiguous.
- `HandlesKind<K: Kind>: Actor` trait — auto-emitted by `#[handlers]`, one impl per handler kind.
- `ActorMailbox<R, T>` — typed handle keyed on the receiver actor (not the kind). `send::<K>` is gated on `R: HandlesKind<K>`.
- `resolve_actor::<R, T>()` for singletons; `resolve_actor_named::<R, T>(name)` for multi-instance handles.
- `Ctx::send_to::<R, K>(&K)` — singleton path, address by `R::NAMESPACE`.
- `Ctx::resolve_actor::<R>(name) -> ActorMailbox<R, T>` — multi-instance, name surfaces once.

**`aether-data-derive`:**
- `#[handlers]` now emits one `impl HandlesKind<K> for Self {}` per `#[handler] fn on_x(_, _, k: K)` it sees. Single source of truth; adding a `#[handler]` automatically updates senders' compile-time checks.

**`aether-component`:**
- Re-exports `Singleton` + `HandlesKind` so component crates pick them up via `aether_component::*`.

## What's NOT here (deferred to Phase 2)

The ADR called for `NativeActor::boot` to become a static factory in Phase 1 (the parked Phase 2b from issue #525). On closer inspection, the boot signature change requires reworking how each cap acquires its config (HandleStore, RenderHandles, etc.) — which is exactly what the chassis cap facade pattern in Phase 2 does. Doing it in Phase 1 means churning every cap construction without the facade pattern in place. Better to do it once in Phase 2.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] New routing test (`actor_mailbox_send_records_recipient_and_kind`) — recording transport asserts `send_mail` receives the right recipient + kind id.
- [x] New `resolve_actor` / `resolve_actor_named` tests — verify the mailbox id derivation.
- [x] New compile_fail doctest on `ActorMailbox::send` — demonstrates wrong-kind sends are rejected at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)