### PR TITLE
refactor(actor): rename #[handlers] to #[actor] (issue 533 prep)

### DIFF
--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -56,7 +56,7 @@ pub trait Singleton: Actor {}
 
 /// Per-handler-kind marker: `R: HandlesKind<K>` means actor `R` has
 /// a `#[handler]` method accepting kind `K`. Auto-emitted by the
-/// `#[handlers]` proc-macro alongside the dispatch table — one impl
+/// `#[actor]` proc-macro alongside the dispatch table — one impl
 /// per handler kind. Authors never write these by hand.
 ///
 /// Gates `Ctx::send_to::<R>(&K)` and `ActorMailbox<R, T>::send::<K>` so

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -140,7 +140,7 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
         }
     }
 
-    /// Not part of the public API; called only by the `#[handlers]`
+    /// Not part of the public API; called only by the `#[actor]`
     /// dispatcher. Accepts `None` or `Some(ReplyTo)` — the dispatcher
     /// passes `mail.reply_to()` verbatim so component-origin and
     /// broadcast mail (which have no reply target) land as `None`.

--- a/crates/aether-actor/src/handle.rs
+++ b/crates/aether-actor/src/handle.rs
@@ -16,7 +16,7 @@
 //! Each helper takes a `&T` transport reference explicitly. ADR-0074
 //! §Decision: the trait takes `&self`, the actor binding is
 //! type-system-tracked through the reference, no thread-locals or
-//! globals. From inside a `#[handlers]` method the natural call shape
+//! globals. From inside a `#[actor]` method the natural call shape
 //! is `ctx.publish(...)` — the `Ctx` already holds the transport
 //! borrow, so the user doesn't have to thread it through.
 //!
@@ -25,7 +25,7 @@
 //! ```ignore
 //! use aether_component::{Component, Ctx, InitCtx};
 //!
-//! #[handlers]
+//! #[actor]
 //! impl Component for MyComp {
 //!     fn init(_ctx: &mut InitCtx<'_>) -> Result<Self, BootError> { Ok(Self) }
 //!

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -55,7 +55,7 @@ pub use slot::Slot;
 pub use sync::{WaitError, decode_wait_reply, wait_reply};
 pub use transport::MailTransport;
 
-/// Return code the `#[handlers]`-synthesized dispatcher sends back up
+/// Return code the `#[actor]`-synthesized dispatcher sends back up
 /// through `receive_p32` when a `#[handler]` arm matched (or the
 /// `#[fallback]` ran, which by definition handles anything). Propagated
 /// verbatim by the consumer's FFI shim.
@@ -68,7 +68,7 @@ pub const DISPATCH_HANDLED: u32 = 0;
 /// `aether_substrate_bundle::component::DISPATCH_UNKNOWN_KIND` by value.
 pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 
-/// Re-exports the `#[handlers]` macro relies on at expansion sites
+/// Re-exports the `#[actor]` macro relies on at expansion sites
 /// that don't depend on `aether-data` directly. Keeping the macro's
 /// emitted paths rooted at `::aether_component::__macro_internals` (which
 /// re-exports this module) removes the "add aether-data to your

--- a/crates/aether-actor/src/mail.rs
+++ b/crates/aether-actor/src/mail.rs
@@ -225,7 +225,7 @@ impl<'a> Mail<'a> {
     /// derive baked into `Kind::decode_from_bytes` — cast for
     /// `#[repr(C)]` + `Pod` types, postcard for schema-shaped types.
     /// This is the canonical receive-side decode and what the
-    /// `#[handlers]` dispatcher calls on every typed handler;
+    /// `#[actor]` dispatcher calls on every typed handler;
     /// `decode` / `decode_typed` / `decode_slice` / `decode_slice_typed`
     /// remain as low-level escape hatches for fallback handlers that
     /// want explicit wire-shape control.

--- a/crates/aether-camera-component/src/lib.rs
+++ b/crates/aether-camera-component/src/lib.rs
@@ -38,7 +38,7 @@ use aether_camera::{
     CameraCreate, CameraDestroy, CameraOrbitSet, CameraSetActive, CameraSetMode, CameraTopdownSet,
     ModeInit, OrbitParams, TopdownParams,
 };
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor};
 use aether_kinds::{Camera, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
 
@@ -243,7 +243,7 @@ pub struct CameraComponent {
 ///   camera in place.
 ///
 /// Use `capture_frame` between sends to verify each change.
-#[handlers]
+#[actor]
 impl Component for CameraComponent {
     const NAMESPACE: &'static str = "camera";
 

--- a/crates/aether-component/examples/caller.rs
+++ b/crates/aether-component/examples/caller.rs
@@ -7,10 +7,10 @@
 //! trip is visible to the driving Claude session.
 //!
 //! ADR-0033 phase 3: each kind gets its own `#[handler]` method on
-//! the `#[handlers]`-decorated impl; `Mailbox<K>` still carries the
+//! the `#[actor]`-decorated impl; `Mailbox<K>` still carries the
 //! send-side mailbox name (data, not type).
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor};
 use aether_data::{Kind, Schema};
 use aether_kinds::Tick;
 use bytemuck::{Pod, Zeroable};
@@ -42,7 +42,7 @@ pub struct Caller {
     next_seq: u32,
 }
 
-#[handlers]
+#[actor]
 impl Component for Caller {
     const NAMESPACE: &'static str = "caller";
 

--- a/crates/aether-component/examples/echoer.rs
+++ b/crates/aether-component/examples/echoer.rs
@@ -2,12 +2,12 @@
 //! handles). Receives `demo.request { seq }` and replies with
 //! `demo.response { seq }` to whatever component sent it.
 //!
-//! ADR-0033 phase 3: uses `#[handlers]` as the only receive path.
+//! ADR-0033 phase 3: uses `#[actor]` as the only receive path.
 //! The synthesized dispatcher reads `ctx.reply_to()` (threaded from the
-//! inbound mail by `#[handlers]`) so the handler body never touches
+//! inbound mail by `#[actor]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, KindId, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, actor};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -29,7 +29,7 @@ pub struct Echoer {
     response: KindId<Response>,
 }
 
-#[handlers]
+#[actor]
 impl Component for Echoer {
     const NAMESPACE: &'static str = "echoer";
 

--- a/crates/aether-component/examples/handle_demo.rs
+++ b/crates/aether-component/examples/handle_demo.rs
@@ -22,7 +22,7 @@
 //! thin RAII wrapper over the same wire surface as `io::*` and
 //! `net::*`.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor, resolve_mailbox};
 use aether_data::Ref;
 use aether_kinds::Tick;
 
@@ -50,7 +50,7 @@ pub struct HandleDemo {
     fired: bool,
 }
 
-#[handlers]
+#[actor]
 impl Component for HandleDemo {
     const NAMESPACE: &'static str = "handle_demo";
 

--- a/crates/aether-component/examples/hello.rs
+++ b/crates/aether-component/examples/hello.rs
@@ -10,13 +10,13 @@
 //! clip-space-only version until a camera component starts driving
 //! `aether.camera`.
 //!
-//! ADR-0033 shape: `#[handlers]` on the `impl Component` block emits
+//! ADR-0033 shape: `#[actor]` on the `impl Component` block emits
 //! both the dispatcher and the `aether.kinds.inputs` section entries.
 //! Per-handler rustdoc (with an optional `# Agent` section) feeds
 //! MCP via the same section so the harness sees typed capabilities
 //! plus author-written intent for each inbox.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, actor};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
@@ -62,7 +62,7 @@ pub struct Hello {
 /// if the frame goes solid color the tick path stalled. Send
 /// `aether.ping` with an incrementing `seq` to exercise reply-to-
 /// sender; the matching `aether.pong` lands back at your session.
-#[handlers]
+#[actor]
 impl Component for Hello {
     const NAMESPACE: &'static str = "hello";
 

--- a/crates/aether-component/examples/input_logger.rs
+++ b/crates/aether-component/examples/input_logger.rs
@@ -10,11 +10,11 @@
 //! MouseButton).
 //!
 //! ADR-0033 phase 3: each input kind has its own `#[handler]`
-//! method. `#[handlers]` auto-subscribes every `K::IS_INPUT` handler
+//! method. `#[actor]` auto-subscribes every `K::IS_INPUT` handler
 //! kind at init, so the test harness just loads the component and
 //! starts driving input — no manual `subscribe_input` needed.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor};
 use aether_data::{Kind, Schema};
 use aether_kinds::{Key, MouseButton, MouseMove, Tick};
 use bytemuck::{Pod, Zeroable};
@@ -31,7 +31,7 @@ pub struct InputLogger {
     observe: Mailbox<InputObserved>,
 }
 
-#[handlers]
+#[actor]
 impl Component for InputLogger {
     const NAMESPACE: &'static str = "input_logger";
 

--- a/crates/aether-component/examples/postcard_echoer.rs
+++ b/crates/aether-component/examples/postcard_echoer.rs
@@ -6,14 +6,14 @@
 //! so the receive landed observably.
 //!
 //! Pairs with the cast-shaped `echoer.rs` example to demonstrate that
-//! `#[handlers]` dispatches both wire shapes from the same impl block
+//! `#[actor]` dispatches both wire shapes from the same impl block
 //! with no per-handler annotation — wire shape is picked at the kind's
 //! `Kind` derive site (cast for `#[repr(C)]` + `Pod`, postcard
 //! otherwise) and routed through `Kind::decode_from_bytes`. Compiles
 //! to wasm; load via `mcp__aether-hub__load_component` and send
 //! `demo.postcard_request` to verify the dispatch.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ pub struct PostcardEchoer {
     broadcast: Mailbox<PostcardObserved>,
 }
 
-#[handlers]
+#[actor]
 impl Component for PostcardEchoer {
     const NAMESPACE: &'static str = "postcard_echoer";
 

--- a/crates/aether-component/examples/save_counter.rs
+++ b/crates/aether-component/examples/save_counter.rs
@@ -21,9 +21,7 @@
 //! 3. `terminate_substrate`, spawn another, observe the count
 //!    bumped by one.
 
-use aether_component::{
-    BootError, Component, Ctx, InitCtx, Mailbox, handlers, io, resolve_mailbox,
-};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor, io, resolve_mailbox};
 use aether_kinds::{IoError, Tick};
 
 /// Broadcast payload the Claude session (or any component listening
@@ -61,7 +59,7 @@ pub struct SaveCounter {
 /// # Agent
 /// `spawn_substrate` with this component and poll `receive_mail`;
 /// each fresh instance bumps the counter by one.
-#[handlers]
+#[actor]
 impl Component for SaveCounter {
     const NAMESPACE: &'static str = "save_counter";
 

--- a/crates/aether-component/src/io.rs
+++ b/crates/aether-component/src/io.rs
@@ -15,7 +15,7 @@
 //! use aether_component::io;
 //! use aether_kinds::{ReadResult, IoError};
 //!
-//! #[handlers]
+//! #[actor]
 //! impl Component for MySaveLoader {
 //!     fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError> {
 //!         io::read("save", "slot1.bin");

--- a/crates/aether-component/src/lib.rs
+++ b/crates/aether-component/src/lib.rs
@@ -35,7 +35,7 @@
 //! (reply-to-sender), ADR-0014 (Component trait + Mail), ADR-0015
 //! (lifecycle hooks), ADR-0016 (state-across-replace), ADR-0024
 //! (`_p32` FFI), ADR-0030 (compile-time kind ids), ADR-0033
-//! (`#[handlers]`), ADR-0040 (kind-typed state), ADR-0041 (file
+//! (`#[actor]`), ADR-0040 (kind-typed state), ADR-0041 (file
 //! I/O), ADR-0042 (sync wait_reply), ADR-0043 (HTTP egress),
 //! ADR-0045 (typed handles), ADR-0058 (`aether.sink.*` namespace),
 //! ADR-0060 (tracing→mail bridge), ADR-0074 (this restructure).
@@ -213,13 +213,13 @@ pub use aether_actor::handle;
 pub use aether_actor::handle::SyncHandleError;
 
 /// ADR-0033 attribute macros. Applied to `impl Component for C`
-/// blocks: `#[handlers]` at the impl level; `#[handler]` on each
-/// typed handler method; `#[fallback]` on an optional catchall.
-/// Forwarded from `aether-data-derive` so the full component
-/// vocabulary sits behind one `use aether_component::*` line.
-pub use aether_data::{fallback, handler, handlers};
+/// blocks: `#[actor]` at the impl level; `#[handler]` on each typed
+/// handler method; `#[fallback]` on an optional catchall. Forwarded
+/// from `aether-data-derive` so the full component vocabulary sits
+/// behind one `use aether_component::*` line.
+pub use aether_data::{actor, fallback, handler};
 
-/// Re-exports the `#[handlers]` macro relies on at expansion sites
+/// Re-exports the `#[actor]` macro relies on at expansion sites
 /// that don't depend on `aether-data` directly. The macro emits
 /// `::aether_component::__macro_internals::*` paths so the consumer
 /// crate only needs `aether-component` in its dependency list; this
@@ -240,7 +240,7 @@ pub use aether_actor::Actor;
 /// User-implemented WASM component. ADR-0014 commits to `Self`-is-state —
 /// cached kind ids, cached sinks, and any domain fields live on the
 /// implementor. `init` runs once before any `receive`; receive is
-/// driven by the synthesised `__aether_dispatch` from `#[handlers]`.
+/// driven by the synthesised `__aether_dispatch` from `#[actor]`.
 ///
 /// Renamed from `Component` to `WasmActor` in issue 525 Phase 4 — the
 /// wasm-side leaf of the unified [`Actor`] trait, mirroring the
@@ -262,7 +262,7 @@ pub use aether_actor::Actor;
 /// `WasmTransport` via the `Ctx` / `InitCtx` / `DropCtx` aliases.
 pub trait WasmActor: Actor {
     /// Runs once. Resolve kinds and sinks via `ctx` and return the
-    /// initial component state. ADR-0033: `#[handlers]` prepends
+    /// initial component state. ADR-0033: `#[actor]` prepends
     /// `ctx.subscribe_input::<K>()` for every `K::IS_INPUT` handler
     /// kind so the user body never needs to do it by hand.
     ///
@@ -340,16 +340,16 @@ pub trait Replaceable: WasmActor {
 /// - `extern "C" fn init(mailbox_id: u64) -> u32` — builds an
 ///   `InitCtx`, calls `T::init`, stashes the result in the slot.
 /// - `extern "C" fn receive(kind, ptr, byte_len, count, sender) -> u32`
-///   — builds `Ctx` and `Mail`, calls the `#[handlers]`-synthesized
+///   — builds `Ctx` and `Mail`, calls the `#[actor]`-synthesized
 ///   `__aether_dispatch` on the stashed instance.
 /// - `#[link_section = "aether.kinds.inputs"]` static that pins the
 ///   component's handler manifest into the wasm custom section the
 ///   substrate reads at `load_component`. The manifest *bytes* are
 ///   emitted as associated consts on `T`'s inherent impl by
-///   `#[handlers]`; this macro is the only place they get a
+///   `#[actor]`; this macro is the only place they get a
 ///   `link_section` attribute, which means the section can only land
 ///   in the cdylib root that calls `export!()` — never in transitive
-///   rlib pulls of a `#[handlers]`-using crate (issue 442).
+///   rlib pulls of a `#[actor]`-using crate (issue 442).
 /// - `#[link_section = "aether.namespace"]` static that pins the
 ///   component's `Component::NAMESPACE` bytes (issue 525 Phase 1B).
 ///   The substrate reads this at `load_component` and uses it as the
@@ -395,10 +395,10 @@ macro_rules! __export_internal {
         // ADR-0033 / issue 442: pin the component's `aether.kinds.inputs`
         // bytes into the cdylib's wasm custom section. The const data
         // (`__AETHER_INPUTS_MANIFEST_LEN` / `__AETHER_INPUTS_MANIFEST`)
-        // is emitted by `#[handlers]` on the type's inherent impl;
+        // is emitted by `#[actor]` on the type's inherent impl;
         // section emission lives here so it only fires in the cdylib
         // root crate (where `export!()` is invoked) and never in
-        // transitive rlib pulls of a `#[handlers]`-using crate, which
+        // transitive rlib pulls of a `#[actor]`-using crate, which
         // would otherwise stack duplicate Component records and fail
         // the substrate's manifest reader.
         #[cfg(target_arch = "wasm32")]
@@ -431,7 +431,7 @@ macro_rules! __export_internal {
         /// # Safety
         /// Called exactly once by the substrate before any `receive`.
         /// Receives the component's own mailbox id (ADR-0030 Phase 2)
-        /// so `#[handlers]`'s synthesized `init` prologue can self-
+        /// so `#[actor]`'s synthesized `init` prologue can self-
         /// address `subscribe_input` for every `K::IS_INPUT` handler
         /// kind. ADR-0060: also installs `MailSubscriber` as the global
         /// `tracing` default before user `init` runs, so logging from
@@ -481,7 +481,7 @@ macro_rules! __export_internal {
         /// (ADR-0013) or `NO_REPLY_HANDLE` for mail with no
         /// meaningful reply target. Exported under the `_p32` suffix
         /// per ADR-0024 Phase 1. Returns the `u32` the
-        /// `#[handlers]`-synthesized `__aether_dispatch` produces —
+        /// `#[actor]`-synthesized `__aether_dispatch` produces —
         /// `DISPATCH_HANDLED` on match, `DISPATCH_UNKNOWN_KIND` on a
         /// strict-receiver miss (ADR-0033 §Strict receivers).
         #[unsafe(export_name = "receive_p32")]

--- a/crates/aether-component/tests/handlers_manifest.rs
+++ b/crates/aether-component/tests/handlers_manifest.rs
@@ -1,10 +1,10 @@
-//! Issue 442 regression: `#[handlers]` emits the
+//! Issue 442 regression: `#[actor]` emits the
 //! `aether.kinds.inputs` payload as associated consts on the
 //! component type's inherent impl, NOT as `#[link_section]` statics.
 //! `aether_component::export!()` is the only place that pins those
 //! bytes into the wasm custom section, so the section can only land
 //! in the cdylib root that calls `export!()` — never in transitive
-//! rlib pulls of a `#[handlers]`-using crate.
+//! rlib pulls of a `#[actor]`-using crate.
 //!
 //! Pre-issue-442 the macro emitted N separate `#[link_section]`
 //! statics, one per handler/fallback/component-doc record, gated on
@@ -17,7 +17,7 @@
 
 #![allow(dead_code)]
 
-use aether_component::{BootError, Component, Ctx, DropCtx, InitCtx, handlers};
+use aether_component::{BootError, Component, Ctx, DropCtx, InitCtx, actor};
 use aether_data::Kind;
 use aether_data::{INPUTS_SECTION_VERSION, InputsRecord};
 use bytemuck::{Pod, Zeroable};
@@ -39,11 +39,11 @@ struct Ping {
 // `crate-type = ["cdylib"]` and only build for `wasm32-unknown-unknown`
 // — the test exercises the const path host-side. Maintenance is the
 // usual SDK-surface cadence: when `Component` / `Ctx` / `Mail` /
-// `#[handlers]` change shape, this fixture moves with every other
+// `#[actor]` change shape, this fixture moves with every other
 // component in the workspace.
 struct ManifestProbe;
 
-#[handlers]
+#[actor]
 impl Component for ManifestProbe {
     const NAMESPACE: &'static str = "manifest_probe";
 

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -84,7 +84,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     // the substrate carried it as raw cast bytes (and the user has
     // `#[derive(Pod, Zeroable)]`); anything else is postcard-shaped
     // (and the user has `#[derive(Serialize, Deserialize)]`). The
-    // dispatcher in `#[handlers]` calls `Kind::decode_from_bytes` via
+    // dispatcher in `#[actor]` calls `Kind::decode_from_bytes` via
     // `Mail::decode_kind::<K>()`; emitting the body per-impl here is
     // what lets that one call site compile against types whose Pod /
     // Deserialize bounds are disjoint.
@@ -679,7 +679,7 @@ fn to_screaming_snake_case(s: &str) -> String {
     out
 }
 
-// ADR-0033 phase 3: `#[handlers]` on an `impl Component for C` block
+// ADR-0033 phase 3: `#[actor]` on an `impl Component for C` block
 // is the one receive path for every component. The macro emits:
 //
 //   (a) An inherent method `__aether_dispatch(&mut self, ctx, mail)
@@ -707,7 +707,7 @@ fn to_screaming_snake_case(s: &str) -> String {
 //       bytes into the wasm custom section is emitted by
 //       `aether_component::export!()` in the cdylib root crate, NOT
 //       here. Sections only land where `export!()` runs (the cdylib
-//       root); transitive rlib pulls of a `#[handlers]`-using crate
+//       root); transitive rlib pulls of a `#[actor]`-using crate
 //       carry only the const data and contribute no section bytes —
 //       which is what keeps duplicate Component records from stacking
 //       when a cdylib deps on a sibling cdylib's rlib output.
@@ -723,12 +723,28 @@ fn to_screaming_snake_case(s: &str) -> String {
 // comment — the `# Agent` heading sits alongside `# Safety`/`# Examples`
 // as a conventional reader-specific section.
 
+/// Outer attribute on an `impl WasmActor for X` (or `impl Component for X`)
+/// block. Reads the `#[handler]` / `#[fallback]` methods inside, then emits:
+///
+/// - One `impl HandlesKind<K> for X` per handler kind (gates type-driven
+///   sender bounds — ADR-0075).
+/// - The dispatch table inherent method `__aether_dispatch` that the
+///   `export!` shim's `receive_p32` calls.
+/// - The `aether.kinds.inputs` manifest consts (substrate reads them via
+///   the wasm custom section the cdylib's `export!` pins in).
+/// - The `Actor`-trait const re-routing (NAMESPACE / FRAME_BARRIER from
+///   the impl block flow into a sibling `impl Actor`).
+///
+/// Renamed from `#[actor]` in PR A of issue 533. Same behavior; the
+/// new name reads as "decorate this actor's impl" — natural now that the
+/// macro applies to any actor (and will extend to native chassis caps in
+/// a follow-up).
 #[proc_macro_attribute]
-pub fn handlers(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn actor(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
         return syn::Error::new(
             proc_macro2::Span::call_site(),
-            "#[handlers] takes no arguments",
+            "#[actor] takes no arguments",
         )
         .to_compile_error()
         .into();
@@ -742,13 +758,13 @@ pub fn handlers(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn handler(_attr: TokenStream, _item: TokenStream) -> TokenStream {
-    // Real logic runs inside `#[handlers]` (the enclosing impl-block
+    // Real logic runs inside `#[actor]` (the enclosing impl-block
     // attribute scans for #[handler] markers). This standalone shim
     // only exists so rustc accepts `#[handler]` syntactically outside
     // macro expansion and so rust-analyzer doesn't redline it.
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "#[handler] may only appear inside a `#[handlers] impl Component for T` block",
+        "#[handler] may only appear inside a `#[actor] impl WasmActor for T` block",
     )
     .to_compile_error()
     .into()
@@ -757,11 +773,11 @@ pub fn handler(_attr: TokenStream, _item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn fallback(_attr: TokenStream, _item: TokenStream) -> TokenStream {
     // Same story as `#[handler]` — marker attribute consumed by the
-    // enclosing `#[handlers]` scan. Standalone invocation is a
+    // enclosing `#[actor]` scan. Standalone invocation is a
     // compile-time error.
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "#[fallback] may only appear inside a `#[handlers] impl Component for T` block",
+        "#[fallback] may only appear inside a `#[actor] impl WasmActor for T` block",
     )
     .to_compile_error()
     .into()
@@ -782,7 +798,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     if item.trait_.is_none() {
         return Err(syn::Error::new_spanned(
             &item,
-            "#[handlers] must wrap `impl Component for T` — not an inherent impl",
+            "#[actor] must wrap `impl Component for T` — not an inherent impl",
         ));
     }
     let self_ty = &item.self_ty;
@@ -803,7 +819,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
     // Issue 525 Phase 1B: pass-through trait consts (today: NAMESPACE,
     // FRAME_BARRIER) so each component declares them inside its
-    // `#[handlers] impl Component for C` block alongside `init` /
+    // `#[actor] impl WasmActor for C` block alongside `init` /
     // `#[handler]` methods.
     let mut consts: Vec<syn::ImplItemConst> = Vec::new();
 
@@ -812,7 +828,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
             ImplItem::Type(it) if it.ident == "Kinds" => {
                 return Err(syn::Error::new_spanned(
                     it,
-                    "#[handlers] synthesizes `type Kinds` from the #[handler] methods; remove this declaration",
+                    "#[actor] synthesizes `type Kinds` from the #[handler] methods; remove this declaration",
                 ));
             }
             ImplItem::Const(c) => {
@@ -860,7 +876,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
                 } else if name == "receive" {
                     return Err(syn::Error::new_spanned(
                         &f,
-                        "#[handlers] synthesizes `fn receive`; remove this definition",
+                        "#[actor] synthesizes `fn receive`; remove this definition",
                     ));
                 } else {
                     helpers.push(f);
@@ -869,7 +885,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
-                    "unexpected item in #[handlers] impl (only fns and the synthesized `type Kinds` are allowed)",
+                    "unexpected item in #[actor] impl (only fns and the synthesized `type Kinds` are allowed)",
                 ));
             }
         }
@@ -878,14 +894,14 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
     let init_method = init_method.ok_or_else(|| {
         syn::Error::new_spanned(
             self_ty,
-            "#[handlers] requires `fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError>`",
+            "#[actor] requires `fn init(ctx: &mut InitCtx<'_>) -> Result<Self, BootError>`",
         )
     })?;
 
     if handlers.is_empty() && fallback.is_none() {
         return Err(syn::Error::new_spanned(
             self_ty,
-            "#[handlers] requires at least one #[handler] method or a #[fallback] method",
+            "#[actor] requires at least one #[handler] method or a #[fallback] method",
         ));
     }
 
@@ -912,7 +928,7 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
 
     // Issue 525 Phase 4: trait consts (NAMESPACE, FRAME_BARRIER) live
     // on the `Actor` super-trait, not `Component` / `WasmActor`. Route
-    // any const items the user declared inside `#[handlers] impl
+    // any const items the user declared inside `#[actor] impl
     // Component for X` to a sibling `impl ::aether_component::Actor`
     // block so satisfying `WasmActor: Actor` works without making the
     // user split the impl manually.
@@ -1088,7 +1104,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// `aether_component::export!()` reads these consts and emits the
 /// `#[unsafe(link_section = "aether.kinds.inputs")]` static in the
 /// cdylib root crate. Keeping the section emission out of this macro
-/// is what prevents the section from stacking when a `#[handlers]`-
+/// is what prevents the section from stacking when a `#[actor]`-
 /// using crate is pulled in as a wasm32 rlib by another cdylib (a
 /// rlib that doesn't call `export!()` contributes no section bytes).
 fn build_inputs_manifest_consts(
@@ -1220,7 +1236,7 @@ fn build_inputs_manifest_consts(
 /// name. `#[used]` keeps the symbol in the rlib's object file but
 /// doesn't cross the rlib→cdylib boundary under `--gc-sections`. The
 /// `aether.kinds.inputs` section survives only because
-/// `#[handlers]` emits it here, in the consumer's own compilation
+/// `#[actor]` emits it here, in the consumer's own compilation
 /// unit. We apply the same trick to `aether.kinds`.
 ///
 /// The bytes are computed via trait dispatch on `<K as Kind>::NAME`

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -1,4 +1,4 @@
-//! `InputsRecord` const-fn encoders (ADR-0033). The `#[handlers]`
+//! `InputsRecord` const-fn encoders (ADR-0033). The `#[actor]`
 //! macro emits one postcard-compatible byte array per handler /
 //! fallback / component-doc record, length-prefixed with the section
 //! version tag, and drops the bytes into the `aether.kinds.inputs`

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -61,13 +61,13 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 /// Re-exported derive macros from `aether-data-derive`. Behind the
 /// `derive` feature so `cargo build` on a guest that hand-writes
 /// `impl Kind` doesn't pay the proc-macro compile cost. The
-/// `#[handlers]` / `#[handler]` / `#[fallback]` attribute macros
+/// `#[actor]` / `#[handler]` / `#[fallback]` attribute macros
 /// (ADR-0033) ride in the same crate because adding a second proc-
 /// macro crate would double consumer compile cost for no separation
 /// gain — both derives and attributes expand into the same runtime
 /// surface.
 #[cfg(feature = "derive")]
-pub use aether_data_derive::{Kind, Schema, fallback, handler, handlers};
+pub use aether_data_derive::{Kind, Schema, actor, fallback, handler};
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`) and a `u64` id derived from
@@ -78,7 +78,7 @@ pub use aether_data_derive::{Kind, Schema, fallback, handler, handlers};
 ///
 /// `IS_STREAM` marks the kind as a substrate-published input stream
 /// (`Tick`, `Key`, `MouseMove`, `MouseButton` — ADR-0021). Defaults
-/// to `false`; `#[handlers]` auto-subscribes a component's mailbox to
+/// to `false`; `#[actor]` auto-subscribes a component's mailbox to
 /// every `K::IS_STREAM` handler kind before the user's `init` body
 /// runs (ADR-0033 phase 3), so components writing
 /// `#[handler] fn on_tick(..., tick: Tick)` don't need to send
@@ -99,11 +99,11 @@ pub trait Kind {
     /// `Kind` derive auto-implements this with the right body for the
     /// type's wire shape (cast for `#[repr(C)]` + `Pod`, postcard
     /// otherwise). Hand-rolled `Kind` impls that don't participate in
-    /// `#[handlers]` receive dispatch can leave the default — it
+    /// `#[actor]` receive dispatch can leave the default — it
     /// returns `None`, which the SDK surfaces as a strict-receiver
     /// miss (`DISPATCH_UNKNOWN_KIND`).
     ///
-    /// The dispatcher synthesised by `#[handlers]` calls this through
+    /// The dispatcher synthesised by `#[actor]` calls this through
     /// `Mail::decode_kind::<K>()`, which hands `bytes` already sliced
     /// to the substrate-supplied `byte_len` so the decoder is bounded
     /// by the actual frame and can't read past the substrate-written

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -751,7 +751,7 @@ impl<'de> Deserialize<'de> for VariantLabel {
 /// `Kind::ID` (so the record is self-identifying), the Rust type
 /// label, and the parallel-shape `LabelNode` tree. Paired with the
 /// matching `SchemaShape` record from `aether.kinds` by id, not by
-/// declaration order — any emitter (the Kind derive, `#[handlers]`
+/// declaration order — any emitter (the Kind derive, `#[actor]`
 /// retention, a third-party shared-rlib wrapper) can write records
 /// in any order and the reader will rejoin them correctly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -779,7 +779,7 @@ pub enum InputsRecord {
     },
     /// A `#[fallback]` method's presence and optional description.
     Fallback { doc: Option<Cow<'static, str>> },
-    /// Component-wide rustdoc lifted from the `#[handlers]` impl block.
+    /// Component-wide rustdoc lifted from the `#[actor]` impl block.
     Component { doc: Cow<'static, str> },
 }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -29,7 +29,7 @@ use bytemuck::{Pod, Zeroable};
 /// Per-frame signal from the substrate's frame loop. Empty payload —
 /// elapsed-time is parked until a subscriber actually needs it.
 ///
-/// ADR-0033 handler dispatch (`#[handlers]` synthesized
+/// ADR-0033 handler dispatch (`#[actor]` synthesized
 /// `__aether_dispatch`) decodes every typed handler via
 /// `Mail::decode_typed::<K>()`, which requires `K: AnyBitPattern`.
 /// Zero-sized unit kinds like `Tick` trivially satisfy that through
@@ -487,7 +487,7 @@ mod control_plane {
     /// into this shape so the hub can store and the MCP harness can
     /// render without a second parser. Empty `handlers` + `None`
     /// fallback + `None` doc describes a component that shipped
-    /// without the `#[handlers]` macro (ADR-0027 shape) — the hub can
+    /// without the `#[actor]` macro (ADR-0027 shape) — the hub can
     /// tell those apart from a truly empty receive surface.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
     pub struct ComponentCapabilities {

--- a/crates/aether-mesh-viewer-component/src/lib.rs
+++ b/crates/aether-mesh-viewer-component/src/lib.rs
@@ -31,7 +31,7 @@
 //! 4. Every `aether.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, io};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor, io};
 use aether_kinds::{DrawTriangle, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
@@ -69,7 +69,7 @@ pub struct MeshViewer {
 /// to swap the cached mesh. Iterate on a DSL by writing the new source
 /// via `aether.io.write` and re-sending `aether.mesh.load` against the
 /// same path.
-#[handlers]
+#[actor]
 impl Component for MeshViewer {
     const NAMESPACE: &'static str = "mesh_viewer";
 

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -363,7 +363,7 @@ pub struct LoadComponentResponse {
     /// Receive-side capability surface the component advertised via
     /// `aether.kinds.inputs` (ADR-0033). Empty `handlers` + no
     /// fallback + no doc describes a component that shipped without
-    /// the `#[handlers]` macro — still loadable, just opaque to
+    /// the `#[actor]` macro — still loadable, just opaque to
     /// `describe_component`.
     pub capabilities: ComponentCapabilitiesWire,
 }

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -694,7 +694,7 @@ impl Hub {
     }
 
     #[tool(
-        description = "Describe a loaded component's receive-side capabilities (ADR-0033). Returns the component's name, its top-level author-written documentation, the set of kinds it typed-handles (id, name, optional per-handler doc), and whether it has a `#[fallback]` catchall (with the fallback's own optional doc). The capability set is parsed from the component's `aether.kinds.inputs` wasm custom section at `load_component` / `replace_component` time. Strict receivers — components without a fallback — are distinguishable via `fallback: null` in the response. Components predating the `#[handlers]` macro ship with empty fields since they have no structured capability surface to advertise."
+        description = "Describe a loaded component's receive-side capabilities (ADR-0033). Returns the component's name, its top-level author-written documentation, the set of kinds it typed-handles (id, name, optional per-handler doc), and whether it has a `#[fallback]` catchall (with the fallback's own optional doc). The capability set is parsed from the component's `aether.kinds.inputs` wasm custom section at `load_component` / `replace_component` time. Strict receivers — components without a fallback — are distinguishable via `fallback: null` in the response. Components predating the `#[actor]` macro ship with empty fields since they have no structured capability surface to advertise."
     )]
     pub(super) async fn describe_component(
         &self,

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -13,7 +13,7 @@ use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
 const MAIL_OFFSET: u32 = 1024;
 
-/// Sentinel the ADR-0033 `#[handlers]` dispatcher returns from
+/// Sentinel the ADR-0033 `#[actor]` dispatcher returns from
 /// `receive_p32` when mail arrives with a kind id the component has
 /// no typed handler for and no fallback. Substrate-side, the
 /// scheduler turns this into a `tracing::warn!` so the unhandled

--- a/crates/aether-substrate/src/control/mod.rs
+++ b/crates/aether-substrate/src/control/mod.rs
@@ -283,7 +283,7 @@ impl ControlPlane {
 
         // ADR-0033: read the receive-side capability surface from the
         // sibling `aether.kinds.inputs` section. Absence is not an
-        // error — components predating the `#[handlers]` macro ship
+        // error — components predating the `#[actor]` macro ship
         // an empty `ComponentCapabilities` and the hub treats them as
         // opaque (no structured receive vocabulary to show MCP).
         let capabilities = match kind_manifest::read_inputs_from_bytes(&payload.wasm) {

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -44,7 +44,7 @@ pub struct SubstrateCtx {
     /// silently drop, matching the broadcast semantics.
     pub outbound: Arc<HubOutbound>,
     /// ADR-0021 subscriber sets, shared with the platform-event
-    /// publisher in `main.rs`. `#[handlers]`-decorated components
+    /// publisher in `main.rs`. `#[actor]`-decorated components
     /// auto-subscribe every `K::IS_INPUT` handler kind by mailing
     /// `aether.control.subscribe_input` from the init prologue the
     /// macro prepends (ADR-0033 phase 3), which the control plane

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -95,7 +95,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // guest side via the `Kind` derive's `const ID`. The host fn and
     // its `KIND_NOT_FOUND` sentinel are gone. Input-stream auto-
     // subscribe (the side-effect that used to ride this host fn)
-    // moved to the guest SDK — ADR-0033 phase 3 has `#[handlers]`
+    // moved to the guest SDK — ADR-0033 phase 3 has `#[actor]`
     // prepend `ctx.subscribe_input::<K>()` for every `K::IS_INPUT`
     // handler kind to the user's `init` body.
 

--- a/crates/aether-substrate/src/kind_manifest.rs
+++ b/crates/aether-substrate/src/kind_manifest.rs
@@ -12,7 +12,7 @@
 // records carry their `kind_id` inline (v0x03 field), so the reader
 // indexes labels by id and looks up per shape. Pairing is robust
 // against emit order, duplicates, and mixed emitters (the Kind derive,
-// `#[handlers]` retention for kinds defined in rlib dependencies, and
+// `#[actor]` retention for kinds defined in rlib dependencies, and
 // future external sources of kind metadata).
 //
 // Pre-v0x03 labels lacked `kind_id` and were paired by declaration
@@ -673,7 +673,7 @@ mod tests {
 
     #[test]
     fn duplicate_kinds_records_tolerated_under_by_id_pairing() {
-        // `#[handlers]` retention emits both an `aether.kinds` and an
+        // `#[actor]` retention emits both an `aether.kinds` and an
         // `aether.kinds.labels` record per handler kind; when the
         // defining crate also emits via `Kind` derive, a kind ends up
         // with duplicate records in both sections. The by-id merge
@@ -747,7 +747,7 @@ mod tests {
 
     #[test]
     fn sokoban_load_level_single_field_has_name() {
-        // Regression: `#[handlers]` retention historically wrote kinds
+        // Regression: `#[actor]` retention historically wrote kinds
         // records into `aether.kinds` without parallel labels records
         // into `aether.kinds.labels`, desyncing the old by-index
         // pairing. `demo.sokoban.load_level`'s single `id` field came

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -631,7 +631,7 @@ mod tests {
     /// second registration of the same structural kind with stripped
     /// names (e.g. reconstructed from a component's `aether.kinds`
     /// canonical bytes) must be accepted as idempotent because both
-    /// produce the same kind id. This is the path `#[handlers]`
+    /// produce the same kind id. This is the path `#[actor]`
     /// consumer-crate retention relies on for cross-crate kinds that
     /// duplicate boot-registered ones.
     #[test]

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -15,7 +15,7 @@
 //!   `capture_frame` scenarios can observe pre-mail effects in the
 //!   captured PNG.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers, resolve_mailbox};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor, resolve_mailbox};
 use aether_kinds::{DrawTriangle, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
 
@@ -54,7 +54,7 @@ pub struct Probe {
     render: SetRender,
 }
 
-#[handlers]
+#[actor]
 impl Component for Probe {
     const NAMESPACE: &'static str = "test_fixture_probe";
 

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -12,7 +12,7 @@
 //! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
 use aether_camera::{CameraTopdownSet, TopdownParams};
-use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, actor};
 use aether_data::{Kind, Schema};
 use aether_kinds::{DrawTriangle, Key, Tick, Vertex, keycode};
 use bytemuck::{Pod, Zeroable};
@@ -137,7 +137,7 @@ pub struct Sokoban {
 /// - `SokobanLoadLevel { id }` — switch levels. Out-of-range is a
 ///   no-op.
 /// - `SokobanReset` — reload the active level.
-#[handlers]
+#[actor]
 impl Component for Sokoban {
     const NAMESPACE: &'static str = "sokoban";
 

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -45,7 +45,7 @@
 //! That's as shape-y as this first pass gets; proper X / O glyphs
 //! are a rendering-polish pass for later.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, Mailbox, actor};
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, GameState, LAST_MOVE_NONE, MoveResult, PLAYER_X, PlayMove, SERVER,
 };
@@ -125,7 +125,7 @@ impl Default for TicTacToeClient {
 /// `tic_tac_toe.play_move` directly against the `tic_tac_toe` server
 /// component; the board updates the same way either route. Use
 /// `capture_frame` to verify rendering.
-#[handlers]
+#[actor]
 impl Component for TicTacToeClient {
     const NAMESPACE: &'static str = "tic_tac_toe_client";
 

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -22,7 +22,7 @@
 //! on the trunk for those without pulling in this crate's
 //! `Component` impl. Per ADR-0066.
 
-use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, handlers};
+use aether_component::{BootError, Component, Ctx, InitCtx, KindId, Mailbox, actor};
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, CLIENT_OBSERVER, GAME_DRAW, GAME_PLAYING, GAME_WON_O, GAME_WON_X, GameState,
     MOVE_CELL_OCCUPIED, MOVE_GAME_OVER, MOVE_OK, MOVE_OUT_OF_BOUNDS, MoveResult, PLAYER_NONE,
@@ -55,7 +55,7 @@ pub struct TicTacToe {
 /// sent the move — that's the broadcast path the hub fans out to
 /// every session. Send `tic_tac_toe.reset` (empty payload) to start a
 /// fresh game.
-#[handlers]
+#[actor]
 impl Component for TicTacToe {
     const NAMESPACE: &'static str = "tic_tac_toe";
 

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -4,7 +4,7 @@
 //! live in the sibling `aether-demo-tic-tac-toe-server` cdylib;
 //! consumers (e.g. `aether-demo-tic-tac-toe-client`) depend on this
 //! crate for the wire shapes without pulling in the server's
-//! `#[handlers]` section emissions, which would stack on top of their
+//! `#[actor]` section emissions, which would stack on top of their
 //! own and trip the substrate's "duplicate Component record" check
 //! (issue 442).
 //!


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #533 references parent tracker -->
## Summary

Pure rename. The proc-macro that decorates an actor's `impl` block was named `#[handlers]` because it processes `#[handler]` methods. With the macro about to extend to native chassis caps too (issue #533 PR B), `#[actor]` reads as "decorate this actor's impl" — natural across both wasm components and native caps.

Inner `#[handler]` and `#[fallback]` attributes stay unchanged; those are semantic markers within the actor block.

## What changed

- `aether-data-derive`: proc-macro export renamed from `handlers` to `actor`. Internal error messages and doc comments updated.
- `aether-data` and `aether-component`: re-exports updated.
- Every consumer (components, examples, tests, demos): `#[handlers]` → `#[actor]` and import lines updated.

35 files touched, mostly mechanical.

## What's next

PR B extends `#[actor]` to support native chassis caps — applies to inherent impls, emits `HandlesKind<K>` impls + a generic `__dispatch(kind, payload)` fn that the substrate's `NativeActor::boot` calls from its thread loop.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] No new tests — the existing `#[actor]`-using component tests cover the rename mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)