### PR TITLE
feat(actor): extend #[actor] to native chassis-cap impls (issue 533 PR B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
 name = "aether-data-derive"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-actor",
  "aether-data",
  "bytemuck",
  "inventory",

--- a/crates/aether-data-derive/Cargo.toml
+++ b/crates/aether-data-derive/Cargo.toml
@@ -27,3 +27,6 @@ serde = { version = "1", features = ["derive"] }
 # crate. Tests run native, so unconditional dev-dep is fine — no wasm
 # build to skip.
 inventory = "0.3"
+# Issue 533 PR B: native-actor tests assert HandlesKind<K> impls land
+# on chassis cap inherent impls. The trait itself is in aether-actor.
+aether-actor = { path = "../aether-actor" }

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -795,12 +795,39 @@ struct FallbackFn {
 }
 
 fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
-    if item.trait_.is_none() {
-        return Err(syn::Error::new_spanned(
-            &item,
-            "#[actor] must wrap `impl Component for T` — not an inherent impl",
-        ));
+    if item.trait_.is_some() {
+        expand_wasm_actor(item)
+    } else {
+        expand_native_actor(item)
     }
+}
+
+/// Match `#[handler]`, `#[crate::handler]`, or `#[aether_data::handler]` —
+/// any path whose last segment is `handler`. Bare `is_ident("handler")`
+/// only matches the unqualified form, so qualified-path tests like
+/// `#[aether_data::handler]` would skip the macro silently.
+fn attr_is_handler(attr: &Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == "handler")
+}
+
+/// Same logic for `#[fallback]`.
+fn attr_is_fallback(attr: &Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == "fallback")
+}
+
+/// Wasm-actor expansion — `#[actor] impl WasmActor for X` (or
+/// the back-compat `impl Component for X`). Emits the full wasm
+/// surface: dispatch table referencing `aether_component::Ctx<'_>`,
+/// init wrapper, `aether.kinds.inputs` manifest consts, kind retention
+/// statics, plus the `HandlesKind<K>` and `Actor` impls common to both
+/// shapes.
+fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -836,8 +863,8 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
             }
             ImplItem::Fn(mut f) => {
                 let name = f.sig.ident.to_string();
-                let handler_attr_idx = f.attrs.iter().position(|a| a.path().is_ident("handler"));
-                let fallback_attr_idx = f.attrs.iter().position(|a| a.path().is_ident("fallback"));
+                let handler_attr_idx = f.attrs.iter().position(attr_is_handler);
+                let fallback_attr_idx = f.attrs.iter().position(attr_is_fallback);
 
                 if handler_attr_idx.is_some() && fallback_attr_idx.is_some() {
                     return Err(syn::Error::new_spanned(
@@ -987,6 +1014,162 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
 
         #kind_retention_statics
     })
+}
+
+/// Native-actor expansion — `#[actor] impl X` (inherent impl).
+/// Used for chassis cap facades in `aether-kinds` whose `NativeActor`
+/// impl lives in `aether-substrate` but whose marker / handler list
+/// must stay wasm-importable.
+///
+/// Emits:
+///   - `impl HandlesKind<K> for X` per `#[handler]` method.
+///   - A `__dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()>`
+///     fn that decodes payload and calls the matching handler.
+///     Substrate's `NativeActor::boot` calls this from the dispatcher
+///     thread loop.
+///   - The original handler methods, attribute-stripped, as inherent
+///     methods (so they're callable from `__dispatch` and from the
+///     backend trait impl that delegates to them).
+///
+/// Native handlers take `(&mut self, kind: K)` — no ctx parameter.
+/// Chassis caps that need to send mail or hold runtime state do so
+/// through the backend trait impl; the cap's handler body is just
+/// `self.backend.on_X(kind)` delegation.
+fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
+    let self_ty = &item.self_ty;
+    let generics = &item.generics;
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut handlers: Vec<NativeHandlerFn> = Vec::new();
+    let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
+
+    for impl_item in item.items {
+        match impl_item {
+            ImplItem::Fn(mut f) => {
+                let handler_attr_idx = f.attrs.iter().position(attr_is_handler);
+                if f.attrs.iter().any(attr_is_fallback) {
+                    return Err(syn::Error::new_spanned(
+                        &f,
+                        "#[fallback] is not supported on native chassis-cap impls (#[actor] on inherent impl) — \
+                         every kind a chassis cap accepts is declared via #[handler]",
+                    ));
+                }
+                if let Some(idx) = handler_attr_idx {
+                    let kind_ty = extract_native_handler_kind_type(&f.sig)?;
+                    f.attrs.remove(idx);
+                    handlers.push(NativeHandlerFn { method: f, kind_ty });
+                } else {
+                    helpers.push(f);
+                }
+            }
+            ImplItem::Const(_) => {
+                helpers.push(syn::ImplItemFn {
+                    attrs: Vec::new(),
+                    vis: syn::Visibility::Inherited,
+                    defaultness: None,
+                    sig: syn::parse_quote!(fn __unused_native_const_marker()),
+                    block: syn::parse_quote!({}),
+                });
+                // We don't actually keep the const — unsupported on native impls
+                return Err(syn::Error::new_spanned(
+                    self_ty,
+                    "associated consts are not supported on native chassis-cap impls (#[actor] on inherent impl); \
+                     declare them on the standalone `Actor` impl instead",
+                ));
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unexpected item in #[actor] inherent impl (only fns are allowed)",
+                ));
+            }
+        }
+    }
+
+    if handlers.is_empty() {
+        return Err(syn::Error::new_spanned(
+            self_ty,
+            "#[actor] inherent impl requires at least one #[handler] method",
+        ));
+    }
+
+    let handles_kind_impls = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        quote! {
+            impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+                for #self_ty #where_clause {}
+        }
+    });
+
+    // Dispatch body: one if-arm per handler. Each arm decodes the
+    // payload (returning early on decode failure for the matched kind
+    // — substrate-side dispatcher logs the miss separately) and calls
+    // the inherent handler method by its original ident.
+    let dispatch_arms = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        let method_ident = &h.method.sig.ident;
+        quote! {
+            if kind == <#kind_ty as ::aether_data::Kind>::ID.0 {
+                if let Some(__decoded) = <#kind_ty as ::aether_data::Kind>::decode_from_bytes(payload) {
+                    self.#method_ident(__decoded);
+                    return Some(());
+                }
+                return None;
+            }
+        }
+    });
+
+    let handler_methods_tokens = handlers.iter().map(|h| &h.method);
+    let helper_methods_tokens = helpers.iter();
+
+    Ok(quote! {
+        #(#handles_kind_impls)*
+
+        impl #impl_generics #self_ty #where_clause {
+            /// Dispatch a single mail to the matching `#[handler]`.
+            /// Returns `Some(())` on match + decode success, `None` for
+            /// unknown kinds or decode failure. Auto-emitted by `#[actor]`
+            /// on a native (chassis cap) inherent impl.
+            #[doc(hidden)]
+            pub fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()> {
+                #(#dispatch_arms)*
+                None
+            }
+
+            #(#handler_methods_tokens)*
+            #(#helper_methods_tokens)*
+        }
+    })
+}
+
+struct NativeHandlerFn {
+    method: syn::ImplItemFn,
+    kind_ty: Type,
+}
+
+/// Extract `K` from a native handler's second parameter (`arg: K`).
+/// Native handlers don't take a ctx; signature is `(&mut self, K)`.
+fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
+    if sig.inputs.len() != 2 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "native #[handler] method must have signature `(&mut self, arg: K)`",
+        ));
+    }
+    let first = &sig.inputs[0];
+    if !matches!(first, FnArg::Receiver(_)) {
+        return Err(syn::Error::new_spanned(
+            first,
+            "native #[handler] first parameter must be `&mut self`",
+        ));
+    }
+    let FnArg::Typed(pat_ty) = &sig.inputs[1] else {
+        return Err(syn::Error::new_spanned(
+            &sig.inputs[1],
+            "native #[handler] second parameter must be `arg: K`",
+        ));
+    };
+    Ok((*pat_ty.ty).clone())
 }
 
 /// Extract `K` from a handler method's third parameter (`arg: K`).

--- a/crates/aether-data-derive/tests/native_actor.rs
+++ b/crates/aether-data-derive/tests/native_actor.rs
@@ -1,0 +1,132 @@
+// Tests for `#[actor]` on inherent impls — the native chassis-cap
+// path (PR B of issue 533). Verifies:
+//
+//   - `HandlesKind<K>` impls land for each `#[handler]` method.
+//   - `__dispatch(kind: u64, payload: &[u8]) -> Option<()>` routes
+//     payloads to the matching handler and returns `None` for
+//     unknown kinds.
+//
+// Compiles native-only — `aether-data-derive` runs as a proc-macro
+// crate, so these tests exercise the generated code on the host.
+
+use aether_actor::Actor;
+use aether_data::Kind;
+use bytemuck::{Pod, Zeroable};
+
+/// Two distinct cast-shape kinds the test cap handles.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.native_actor.kind_a")]
+struct KindA {
+    tag: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.native_actor.kind_b")]
+struct KindB {
+    tag: u32,
+}
+
+/// A third kind the cap deliberately doesn't handle — used to verify
+/// `__dispatch` returns `None` for unknown kinds.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.native_actor.unhandled")]
+struct UnhandledKind {
+    tag: u32,
+}
+
+/// Backend trait — the substrate-side code impls this; the cap's
+/// handler bodies delegate to it. ADR-0075 facade pattern.
+trait FacadeBackend: Send + 'static {
+    fn on_kind_a(&mut self, k: KindA);
+    fn on_kind_b(&mut self, k: KindB);
+}
+
+/// Cap struct holding a backend. The `#[actor]` macro emits HandlesKind
+/// + __dispatch on this inherent impl.
+struct FacadeCap<B: FacadeBackend> {
+    backend: B,
+}
+
+impl<B: FacadeBackend> Actor for FacadeCap<B> {
+    const NAMESPACE: &'static str = "test.facade_cap";
+}
+
+#[aether_data::actor]
+impl<B: FacadeBackend> FacadeCap<B> {
+    #[aether_data::handler]
+    fn on_kind_a(&mut self, k: KindA) {
+        self.backend.on_kind_a(k);
+    }
+
+    #[aether_data::handler]
+    fn on_kind_b(&mut self, k: KindB) {
+        self.backend.on_kind_b(k);
+    }
+}
+
+/// Recording backend for the test — captures every handler call so
+/// the test can assert `__dispatch` routed to the right method.
+#[derive(Default)]
+struct RecordingBackend {
+    a_calls: Vec<KindA>,
+    b_calls: Vec<KindB>,
+}
+impl FacadeBackend for RecordingBackend {
+    fn on_kind_a(&mut self, k: KindA) {
+        self.a_calls.push(k);
+    }
+    fn on_kind_b(&mut self, k: KindB) {
+        self.b_calls.push(k);
+    }
+}
+
+#[test]
+fn dispatch_routes_kind_a_to_on_kind_a() {
+    let mut cap = FacadeCap {
+        backend: RecordingBackend::default(),
+    };
+    let payload = bytemuck::bytes_of(&KindA { tag: 42 });
+    let result = cap.__dispatch(KindA::ID.0, payload);
+    assert_eq!(result, Some(()));
+    assert_eq!(cap.backend.a_calls.len(), 1);
+    assert_eq!(cap.backend.a_calls[0].tag, 42);
+    assert!(cap.backend.b_calls.is_empty());
+}
+
+#[test]
+fn dispatch_routes_kind_b_to_on_kind_b() {
+    let mut cap = FacadeCap {
+        backend: RecordingBackend::default(),
+    };
+    let payload = bytemuck::bytes_of(&KindB { tag: 99 });
+    let result = cap.__dispatch(KindB::ID.0, payload);
+    assert_eq!(result, Some(()));
+    assert_eq!(cap.backend.b_calls.len(), 1);
+    assert_eq!(cap.backend.b_calls[0].tag, 99);
+    assert!(cap.backend.a_calls.is_empty());
+}
+
+#[test]
+fn dispatch_returns_none_for_unhandled_kind() {
+    let mut cap = FacadeCap {
+        backend: RecordingBackend::default(),
+    };
+    let payload = bytemuck::bytes_of(&UnhandledKind { tag: 1 });
+    let result = cap.__dispatch(UnhandledKind::ID.0, payload);
+    assert_eq!(result, None);
+    assert!(cap.backend.a_calls.is_empty());
+    assert!(cap.backend.b_calls.is_empty());
+}
+
+/// Type-level check: the macro emits `HandlesKind<KindA>` and
+/// `HandlesKind<KindB>` for the cap, gating type-driven sends. The
+/// fn body never runs — this is purely a trait-bound assertion.
+#[test]
+fn handles_kind_impls_compile_for_each_handler() {
+    fn assert_handles<R: aether_actor::HandlesKind<K>, K: Kind>() {}
+    assert_handles::<FacadeCap<RecordingBackend>, KindA>();
+    assert_handles::<FacadeCap<RecordingBackend>, KindB>();
+}


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #533 references parent tracker; bare #537 references the rename PR this stacks on -->
## Summary

PR B of issue #533. Extends `#[actor]` to support native chassis-cap impls (inherent impls) in `aether-kinds`. Stacks on PR #537 (rename `#[handlers]` → `#[actor]`).

The macro currently requires a trait target (`Component` / `WasmActor`). Native chassis caps need to declare their marker + handler list in `aether-kinds`, but the `NativeActor` impl lives in `aether-substrate` (uses substrate-side types). `aether-kinds` can't reference `NativeActor`, so the impl in `aether-kinds` has to be inherent.

## What's emitted for inherent impls

- One `impl HandlesKind<K> for Self` per `#[handler]` method — orphan rule satisfied since the cap type is local to `aether-kinds`.
- `__dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()>` that decodes the payload and calls the matching handler. Substrate's `NativeActor::boot` will call this from its dispatcher thread loop.
- The original handler methods (attribute-stripped) as inherent methods.

No `init` wrapper, no `aether.kinds.inputs` manifest, no link sections — those are wasm-only and skipped on the native path.

## Native handler signature

```rust
#[actor]
impl<B: FacadeBackend> FacadeCap<B> {
    #[handler]
    fn on_kind_a(&mut self, k: KindA) {
        self.backend.on_kind_a(k);
    }
}
```

`(&mut self, K)` — no ctx parameter. Caps that need to send mail or hold runtime state do so through the backend trait the cap delegates to. Wasm handlers keep their existing `(&mut self, ctx: &mut Ctx, K)` shape; the macro extracts the kind type from the last parameter regardless.

## Bonus fix

Attribute-path matching now accepts qualified forms like `#[aether_data::handler]`, not just bare `#[handler]`. Out-of-tree consumers and tests (this PR's `tests/native_actor.rs`) can use fully-qualified paths without silent macro skip.

## Test plan

- [x] New `tests/native_actor.rs` — hand-rolled facade cap with two handler kinds:
  - `dispatch_routes_kind_a_to_on_kind_a` / `dispatch_routes_kind_b_to_on_kind_b` — verifies dispatch hits the right handler.
  - `dispatch_returns_none_for_unhandled_kind` — verifies `None` for unknown kinds.
  - `handles_kind_impls_compile_for_each_handler` — type-level check that `HandlesKind<K>` impls land for each `#[handler]`.
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)