### PR TITLE
feat(actor): chassis cap facade pattern + log pilot (issue 533 PR C)

### DIFF
--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -1,72 +1,15 @@
-//! ADR-0074 §Decision: actors are the unified primitive that
-//! components and capabilities collapse onto. Issue 525 Phase 3 lifts
-//! the symmetric bits — `NAMESPACE` and `FRAME_BARRIER` — onto a
-//! transport-agnostic super-trait here so the substrate-side
-//! `NativeActor` and the wasm-side `WasmActor` (Phase 4) can both
-//! extend it.
+//! Marker traits for the actor model. Re-exported from `aether-data`
+//! (`pub use aether_data::Actor;` etc.).
 //!
-//! What's NOT here: lifecycle (`init` / `boot` / `Drop`). Lifecycle
-//! signatures need transport-specific ctx types
-//! (`ChassisCtx<'_>` vs `InitCtx<'_, WasmTransport>`) and one of them
-//! is fallible while the other (currently) is infallible — keeping
-//! them on the lifecycle subtraits keeps `Actor` itself ctx-free.
+//! These were originally declared here, but ADR-0075's facade pattern
+//! puts chassis cap structs in `aether-kinds`, which forced a move to
+//! break the dependency cycle (`aether-actor` → `aether-kinds` for
+//! `aether.control.subscribe_input`, `aether-kinds` → `aether-actor`
+//! for the marker traits). The traits themselves are pure compile-time
+//! markers with no transport machinery, so `aether-data` (the
+//! universal data layer) is a fitting home — and both `aether-actor`
+//! and `aether-kinds` depend on `aether-data`, no cycle.
+//!
+//! See `aether_data::actor` for the trait definitions.
 
-/// The symmetric trait that every actor implements: name + scheduling
-/// class. Lifecycle methods (`boot` for native, `init` for wasm) live
-/// on the per-transport subtraits (`NativeActor`, `WasmActor`).
-///
-/// Pre-issue-525-Phase-3 these consts lived directly on
-/// `aether_substrate::Capability` (post-issue-525-Phase-3
-/// `NativeActor`); the lift makes them accessible to the wasm-side
-/// `Component` trait too without each side re-declaring the same
-/// surface. `aether-component::Component` still declares its own
-/// `NAMESPACE` independently today (Phase 1B); Phase 4 folds
-/// `Component` onto `WasmActor: Actor` so the const is sourced from
-/// the same trait both sides.
-pub trait Actor: Sized + Send + 'static {
-    /// The recipient name this actor claims. For native capabilities
-    /// it's the chassis-owned mailbox name (`aether.<name>`); for wasm
-    /// components it's the default name `load_component` registers
-    /// under when the load payload omits an explicit override.
-    const NAMESPACE: &'static str;
-
-    /// ADR-0074 §Decision 5 scheduling class. `true` means this actor
-    /// participates in the per-frame drain barrier — the chassis
-    /// frame loop waits for the dispatcher's inbox to quiesce before
-    /// submitting the next render frame, so any mail a peer sent
-    /// this frame is integrated before submit. Defaults to `false`
-    /// (free-running). Today only `RenderCapability` overrides;
-    /// future drawing-side capabilities and any wasm component that
-    /// wants per-frame coupling will too.
-    const FRAME_BARRIER: bool = false;
-}
-
-/// Marker: only one instance of this actor can be live per substrate.
-/// Required by `Ctx::send_to::<R>` so the type → mailbox lookup is
-/// unambiguous — the substrate enforces "at most one Singleton actor
-/// per `R::NAMESPACE`" at registration time, and senders address by
-/// type rather than by name.
-///
-/// Chassis caps and synthetic actors like `HubBroadcast` are always
-/// singletons. User components are singletons when their cdylib loads
-/// at the default name (`R::NAMESPACE` from the wasm custom section);
-/// multi-instance loads use `ctx.resolve_actor::<R>(name)` instead and
-/// don't go through the singleton path. ADR-0075 §Decision 1.
-pub trait Singleton: Actor {}
-
-/// Per-handler-kind marker: `R: HandlesKind<K>` means actor `R` has
-/// a `#[handler]` method accepting kind `K`. Auto-emitted by the
-/// `#[actor]` proc-macro alongside the dispatch table — one impl
-/// per handler kind. Authors never write these by hand.
-///
-/// Gates `Ctx::send_to::<R>(&K)` and `ActorMailbox<R, T>::send::<K>` so
-/// the compiler rejects sends to a kind the receiver doesn't handle.
-/// The single source of truth is the handler list on the actor's
-/// `impl` block; adding a `#[handler]` updates senders' compile-time
-/// checks automatically. ADR-0075 §Decision 1.
-///
-/// Blanket impls (e.g. `impl<T: Into<DrawTriangle>> HandlesKind<T> for
-/// RenderCapability`) are an opt-in extension if a real conversion case
-/// wants them; the default macro emission is strict so wire bytes stay
-/// obvious.
-pub trait HandlesKind<K: aether_data::Kind>: Actor {}
+pub use aether_data::{Actor, HandlesKind, Singleton};

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -1096,7 +1096,7 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     let handles_kind_impls = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         quote! {
-            impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+            impl #impl_generics ::aether_data::HandlesKind<#kind_ty>
                 for #self_ty #where_clause {}
         }
     });
@@ -1125,17 +1125,14 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     Ok(quote! {
         #(#handles_kind_impls)*
 
-        impl #impl_generics #self_ty #where_clause {
-            /// Dispatch a single mail to the matching `#[handler]`.
-            /// Returns `Some(())` on match + decode success, `None` for
-            /// unknown kinds or decode failure. Auto-emitted by `#[actor]`
-            /// on a native (chassis cap) inherent impl.
-            #[doc(hidden)]
-            pub fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()> {
+        impl #impl_generics ::aether_data::Dispatch for #self_ty #where_clause {
+            fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()> {
                 #(#dispatch_arms)*
                 None
             }
+        }
 
+        impl #impl_generics #self_ty #where_clause {
             #(#handler_methods_tokens)*
             #(#helper_methods_tokens)*
         }

--- a/crates/aether-data-derive/tests/native_actor.rs
+++ b/crates/aether-data-derive/tests/native_actor.rs
@@ -2,15 +2,15 @@
 // path (PR B of issue 533). Verifies:
 //
 //   - `HandlesKind<K>` impls land for each `#[handler]` method.
-//   - `__dispatch(kind: u64, payload: &[u8]) -> Option<()>` routes
-//     payloads to the matching handler and returns `None` for
-//     unknown kinds.
+//   - `Dispatch::__dispatch(kind: u64, payload: &[u8]) -> Option<()>`
+//     routes payloads to the matching handler and returns `None`
+//     for unknown kinds.
 //
 // Compiles native-only — `aether-data-derive` runs as a proc-macro
 // crate, so these tests exercise the generated code on the host.
 
 use aether_actor::Actor;
-use aether_data::Kind;
+use aether_data::{Dispatch, Kind};
 use bytemuck::{Pod, Zeroable};
 
 /// Two distinct cast-shape kinds the test cap handles.

--- a/crates/aether-data/src/actor.rs
+++ b/crates/aether-data/src/actor.rs
@@ -1,0 +1,83 @@
+//! Marker traits for the actor model. Pure compile-time markers — no
+//! transport machinery, no lifecycle methods, just identity (`Actor`),
+//! singleton-ness (`Singleton`), and per-handler-kind gating
+//! (`HandlesKind`).
+//!
+//! These live in `aether-data` (the universal data layer, ADR-0069)
+//! rather than in `aether-actor` (the SDK) because both `aether-kinds`
+//! (chassis cap facades, ADR-0075 §Decision 3) and `aether-actor`
+//! (the transport-aware machinery) need to reference them. Putting
+//! them in `aether-actor` would force `aether-kinds` to depend on
+//! `aether-actor`, but `aether-actor` already depends on `aether-kinds`
+//! for the `aether.control.subscribe_input` kind — that's a cycle.
+//!
+//! `aether-actor` re-exports these (`pub use aether_data::Actor`) so
+//! existing SDK consumers see no API change.
+
+/// The symmetric trait every actor implements: name + scheduling class.
+/// Lifecycle methods (`boot` for native chassis caps, `init` for wasm
+/// components) live on per-transport subtraits; this trait stays
+/// ctx-free so the same shape applies to both sides.
+pub trait Actor: Sized + Send + 'static {
+    /// The recipient name this actor claims. For native capabilities
+    /// it's the chassis-owned mailbox name (`aether.<name>`); for wasm
+    /// components it's the default name `load_component` registers
+    /// under when the load payload omits an explicit override.
+    const NAMESPACE: &'static str;
+
+    /// ADR-0074 §Decision 5 scheduling class. `true` means this actor
+    /// participates in the per-frame drain barrier — the chassis frame
+    /// loop waits for the dispatcher's inbox to quiesce before
+    /// submitting the next render frame, so any mail a peer sent this
+    /// frame is integrated before submit. Defaults to `false`
+    /// (free-running). Today only `RenderCapability` overrides; future
+    /// drawing-side capabilities and any wasm component that wants
+    /// per-frame coupling will too.
+    const FRAME_BARRIER: bool = false;
+}
+
+/// Marker: only one instance of this actor can be live per substrate.
+/// Required by `Ctx::send_to::<R>` so the type → mailbox lookup is
+/// unambiguous — the substrate enforces "at most one Singleton actor
+/// per `R::NAMESPACE`" at registration time, and senders address by
+/// type rather than by name.
+///
+/// Chassis caps and synthetic actors like `HubBroadcast` are always
+/// singletons. User components are singletons when their cdylib loads
+/// at the default name (`R::NAMESPACE` from the wasm custom section);
+/// multi-instance loads use `ctx.resolve_actor::<R>(name)` instead and
+/// don't go through the singleton path. ADR-0075 §Decision 1.
+pub trait Singleton: Actor {}
+
+/// Per-handler-kind marker: `R: HandlesKind<K>` means actor `R` has a
+/// `#[handler]` method accepting kind `K`. Auto-emitted by the
+/// `#[actor]` proc-macro alongside the dispatch table — one impl per
+/// handler kind. Authors never write these by hand.
+///
+/// Gates `Ctx::send_to::<R>(&K)` and `ActorMailbox<R, T>::send::<K>` so
+/// the compiler rejects sends to a kind the receiver doesn't handle.
+/// The single source of truth is the handler list on the actor's
+/// `impl` block; adding a `#[handler]` updates senders' compile-time
+/// checks automatically. ADR-0075 §Decision 1.
+///
+/// Blanket impls (e.g. `impl<T: Into<DrawTriangle>> HandlesKind<T> for
+/// RenderCapability`) are an opt-in extension if a real conversion case
+/// wants them; the default macro emission is strict so wire bytes stay
+/// obvious.
+pub trait HandlesKind<K: crate::Kind>: Actor {}
+
+/// Runtime dispatch entry-point. Auto-emitted by `#[actor]` on
+/// native chassis-cap inherent impls. Routes a single mail (matched
+/// by kind id) to the corresponding `#[handler]` method.
+///
+/// Lives here (not in `aether-actor`) so chassis-cap facades in
+/// `aether-kinds` can implement it without picking up an `aether-actor`
+/// dependency — see [`Actor`] for the cycle context.
+///
+/// Returns `Some(())` on match + decode success, `None` on unknown
+/// kind or decode failure. The chassis-side dispatcher logs misses
+/// separately (kind-id + cap-namespace) so the strict-receiver
+/// surface stays observable.
+pub trait Dispatch {
+    fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()>;
+}

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -41,6 +41,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::fmt;
 
+pub mod actor;
 pub mod canonical;
 pub mod hash;
 pub mod ids;
@@ -49,6 +50,7 @@ pub mod tag_bits;
 pub mod tagged_id;
 pub mod wire_id;
 
+pub use actor::{Actor, Dispatch, HandlesKind, Singleton};
 pub use hash::{
     KIND_DOMAIN, MAILBOX_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
     mailbox_id_from_name,

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -15,7 +15,10 @@ extern crate alloc;
 
 pub mod descriptors;
 pub mod keycode;
+pub mod log;
 pub mod mailboxes;
+
+pub use log::{ErasedLogBackend, LogBackend, LogCapability};
 
 use bytemuck::{Pod, Zeroable};
 

--- a/crates/aether-kinds/src/log.rs
+++ b/crates/aether-kinds/src/log.rs
@@ -1,0 +1,105 @@
+//! ADR-0075 §Decision 3 chassis-cap facade for the `aether.log`
+//! mailbox. The cap and its [`LogBackend`] trait live here so wasm
+//! senders can address the cap by type (`ctx.send::<LogCapability>`)
+//! without pulling in any substrate-only types — the concrete backend
+//! (with its `tracing` machinery, `cpal` device, wgpu state, etc.)
+//! lives in `aether-substrate` and impls [`LogBackend`] there.
+//!
+//! The orphan rule lets `#[actor]` emit `HandlesKind<LogEvent> for
+//! LogCapability<B>` here because the cap is local to this crate.
+//! The substrate's concrete `LogTracingBackend` implements
+//! [`LogBackend`]; runtime dispatch threads dispatch through the
+//! cap's macro-emitted [`crate::Dispatch`] impl which delegates to
+//! whichever backend is installed.
+
+use crate::LogEvent;
+use aether_data::Actor;
+
+/// Substrate-side surface a chassis installs at boot. The chassis
+/// reaches the runtime state (e.g. `tracing` subscriber, log facade
+/// registration) through this trait — the cap struct itself just
+/// holds the backend and forwards.
+///
+/// `Send + 'static` so the dispatcher thread can own the
+/// [`LogCapability<B>`] (which owns `B`) for the cap's lifetime.
+pub trait LogBackend: Send + 'static {
+    /// Handle one decoded `LogEvent` envelope. Called from the
+    /// chassis-side dispatcher thread for every `aether.log` mail
+    /// the cap receives. ADR-0060 / ADR-0070 Phase 3 keep the
+    /// substrate-side body as "decode level + emit through the
+    /// `log` facade so `tracing`'s `tracing-log` integration lifts
+    /// it back up." Delegated through this trait so the runtime
+    /// state lives in `aether-substrate`.
+    fn on_log_event(&mut self, event: LogEvent);
+}
+
+/// Default backend used for sender-side type resolution. Senders
+/// write `LogCapability` (defaulting to [`ErasedLogBackend`]); the
+/// chassis installs `LogCapability<LogTracingBackend>` at boot. Type
+/// erased at the routing boundary — runtime dispatch reads
+/// `LogCapability::<ErasedLogBackend>::NAMESPACE` (which doesn't
+/// depend on `B`) to look up the registered instance.
+///
+/// All methods `unreachable!()` because no instance of this type is
+/// ever installed at runtime — it exists purely for the compile-time
+/// `Singleton + HandlesKind<LogEvent>` check on the sender side.
+pub struct ErasedLogBackend;
+
+impl LogBackend for ErasedLogBackend {
+    fn on_log_event(&mut self, _event: LogEvent) {
+        unreachable!("ErasedLogBackend used at runtime — chassis must install a real backend")
+    }
+}
+
+/// `aether.log` mailbox cap. Wasm senders address it as
+/// `ctx.send::<LogCapability>(&log_event)` — the type-level resolution
+/// uses the default `ErasedLogBackend`, runtime dispatch routes by
+/// `NAMESPACE` to whichever concrete `LogCapability<B>` the chassis
+/// registered.
+///
+/// The substrate constructs `LogCapability::new(backend)` with a
+/// concrete `B: LogBackend` (today: `LogTracingBackend`) and hands it
+/// to the chassis builder. The chassis spawns a dispatcher thread
+/// that owns the cap and routes inbound envelopes through the
+/// macro-emitted [`aether_data::Dispatch`] impl.
+pub struct LogCapability<B: LogBackend = ErasedLogBackend> {
+    backend: B,
+}
+
+impl<B: LogBackend> LogCapability<B> {
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+impl<B: LogBackend> Actor for LogCapability<B> {
+    /// Components mail `aether.log` (kind id) to this mailbox; the
+    /// SDK's `MailSubscriber` resolves through here. The
+    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
+    /// for chassis-owned mailboxes.
+    const NAMESPACE: &'static str = "aether.log";
+}
+
+impl<B: LogBackend> aether_data::Singleton for LogCapability<B> {}
+
+/// `#[actor]` on the inherent impl emits:
+///   - `impl<B: LogBackend> HandlesKind<LogEvent> for LogCapability<B>`
+///   - `impl<B: LogBackend> Dispatch for LogCapability<B>` with a
+///     decode-and-route body that calls `self.on_log_event(decoded)`.
+///
+/// The handler bodies are thin delegations to the backend trait — the
+/// substantive logging work lives substrate-side.
+#[aether_data::actor]
+impl<B: LogBackend> LogCapability<B> {
+    /// Forward a decoded log event to the backend.
+    ///
+    /// # Agent
+    /// Components mail `aether.log` `LogEvent { level, target, message }`
+    /// to this mailbox. The substrate's backend (`LogTracingBackend`)
+    /// re-emits the event through the host's `tracing` pipeline so
+    /// `engine_logs` (ADR-0023) sees it.
+    #[aether_data::handler]
+    fn on_log_event(&mut self, event: LogEvent) {
+        self.backend.on_log_event(event);
+    }
+}

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -17,15 +17,15 @@ use std::sync::Arc;
 
 use aether_data::Kind;
 use aether_kinds::{
-    Advance, CaptureFrame, PlatformInfo, SetWindowMode, SetWindowModeResult, SetWindowTitle,
-    SetWindowTitleResult, WindowMode,
+    Advance, CaptureFrame, LogCapability, PlatformInfo, SetWindowMode, SetWindowModeResult,
+    SetWindowTitle, SetWindowTitleResult, WindowMode,
 };
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
-        AudioCapability, IoCapability, LogCapability, NetCapability, RenderCapability,
+        AudioCapability, IoCapability, LogTracingBackend, NetCapability, RenderCapability,
         RenderConfig, audio::AudioConfig as AudioConf, io::NamespaceRoots,
         net::NetConfig as NetConf,
     },
@@ -349,7 +349,7 @@ impl DesktopChassis {
         // claims its mailboxes after every other chassis sink.
         Builder::<DesktopChassis>::new(registry, mailer)
             .with_aborter(aborter)
-            .with(LogCapability::new())
+            .with_facade(LogCapability::new(LogTracingBackend::new()))
             .with(IoCapability::new(namespace_roots))
             .with(NetCapability::new(net))
             .with(AudioCapability::new(audio))

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -15,15 +15,16 @@ use std::time::Duration;
 
 use aether_data::{Kind, KindId};
 use aether_kinds::{
-    Advance, CaptureFrame, FrameStats, PlatformInfo, SetMasterGain, SetMasterGainResult,
-    SetWindowMode, SetWindowTitle, Tick,
+    Advance, CaptureFrame, FrameStats, LogCapability, PlatformInfo, SetMasterGain,
+    SetMasterGainResult, SetWindowMode, SetWindowTitle, Tick,
 };
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, ReplyTo, SubstrateBoot,
     capabilities::{
-        IoCapability, LogCapability, NetCapability, io::NamespaceRoots, net::NetConfig as NetConf,
+        IoCapability, LogTracingBackend, NetCapability, io::NamespaceRoots,
+        net::NetConfig as NetConf,
     },
     capture::{
         reply_unsupported_advance, reply_unsupported_capture_frame,
@@ -230,7 +231,7 @@ impl HeadlessChassis {
         // through the log capture.
         Builder::<HeadlessChassis>::new(registry, mailer)
             .with_aborter(aborter)
-            .with(LogCapability::new())
+            .with_facade(LogCapability::new(LogTracingBackend::new()))
             .with(IoCapability::new(namespace_roots))
             .with(NetCapability::new(net))
             .driver(driver)

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -23,15 +23,15 @@ use std::sync::{Arc, Mutex};
 use crate::hub::HubClient;
 use aether_data::{Kind, KindId};
 use aether_kinds::{
-    Advance, AdvanceResult, CaptureFrame, FrameStats, PlatformInfo, SetWindowMode, SetWindowTitle,
-    Tick,
+    Advance, AdvanceResult, CaptureFrame, FrameStats, LogCapability, PlatformInfo, SetWindowMode,
+    SetWindowTitle, Tick,
 };
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
-        LogCapability, RenderCapability, RenderConfig, RenderHandles, io::NamespaceRoots,
+        LogTracingBackend, RenderCapability, RenderConfig, RenderHandles, io::NamespaceRoots,
     },
     capture::{
         CaptureQueue, begin_capture_request, reply_unsupported_platform_info,
@@ -282,7 +282,7 @@ impl TestBenchChassis {
 
         let passive =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
-                .with(LogCapability::new())
+                .with_facade(LogCapability::new(LogTracingBackend::new()))
                 .with(render_cap)
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -1,15 +1,14 @@
-//! ADR-0070 Phase 3: guest-log sink as a native capability.
-//! ADR-0074 Phase 2a: first capability migrated onto the unified
-//! actor SDK. Channel-drop + join lifecycle (no `Arc<AtomicBool>`
-//! polling); owns a [`NativeTransport`] instance the dispatcher
-//! thread uses to talk to the rest of the substrate via the same
-//! `Sink<K, _>` / `wait_reply` machinery the wasm guest path uses.
+//! ADR-0075 §Decision 3: substrate-side backend for the
+//! [`aether_kinds::LogCapability`] facade. The cap's facade lives in
+//! `aether-kinds` (so wasm senders can address it without pulling in
+//! substrate-only types); this module provides the concrete backend
+//! the chassis installs at boot.
 //!
-//! Counterpart to the `MailSubscriber` in `aether-component`: decodes
-//! `aether.log` mail the guest sent to `aether.log` and re-emits
-//! the event through the host's existing tracing pipeline so it shows
-//! up in `engine_logs` (ADR-0023) and on stderr alongside native-side
-//! logs.
+//! Pre-ADR-0075 the cap and the dispatcher lifecycle both lived here.
+//! ADR-0075 split them: the cap is now a thin generic in
+//! `aether-kinds`, the dispatcher loop moved into the chassis-side
+//! [`crate::capability::ChassisCtx::spawn_actor_dispatcher`] helper,
+//! and this file is just the substrate-side `LogBackend` impl.
 //!
 //! Bridging via the `log` crate facade (rather than `tracing::event!`)
 //! is load-bearing — see [`crate::log_sink`] for the rationale.
@@ -17,155 +16,64 @@
 //! guest-supplied target is dynamic, so we route through `log::log!`
 //! and let `tracing-subscriber`'s `tracing-log` integration lift each
 //! record back into the tracing pipeline.
-//!
-//! Chassis-conditional, NOT universal: desktop, headless, and the
-//! test bench register the log capability; the hub chassis does
-//! not (no shipped hub chassis hosts components today). Each chassis
-//! main calls `boot.add_capability(LogCapability::new())?` after
-//! [`crate::SubstrateBoot::build`] returns.
 
-use std::sync::Arc;
-use std::thread::{self, JoinHandle};
+use aether_kinds::{LogBackend, LogEvent};
 
-use aether_actor::Actor;
-
-use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
 use crate::log_sink;
-use crate::native_transport::NativeTransport;
 
-/// Native capability owning the ADR-0060 guest-log sink. Boots a
-/// single dispatcher thread that pulls envelopes from the
-/// `aether.log` mailbox and routes the bytes through
-/// [`log_sink::handle_log_mail`] for postcard-decode + log-facade
-/// emit.
-///
-/// Post-issue-525-Phase-2 the cap is one struct: pre-boot fields are
-/// empty (no constructor config), runtime fields are populated by
-/// `boot` and dropped via [`Drop`]. Stateless beyond the per-actor
-/// transport — the global tracing subscriber (set up by
-/// [`crate::log_capture::init`] during the shared boot) is what
-/// actually receives the bridged log records.
+/// `LogBackend` impl that bridges decoded `LogEvent` mail through the
+/// `log` facade so the chassis's existing `tracing-log` subscriber
+/// re-emits it. Stateless beyond what the global subscriber owns —
+/// every cap instance shares the process-wide `tracing` plumbing set
+/// up by [`crate::log_capture::init`] during chassis boot.
 #[derive(Default)]
-pub struct LogCapability {
-    thread: Option<JoinHandle<()>>,
-    /// Drop-on-shutdown breaks the channel. Held in an `Option` so
-    /// the [`Drop`] impl can take it before joining the thread; the
-    /// registry's handler can no longer upgrade its
-    /// [`std::sync::Weak`] back-reference, the inbox's last sender
-    /// is gone, and the dispatcher's `recv_blocking()` returns
-    /// `None` on its next iteration.
-    sink_sender: Option<SinkSender>,
-    /// The actor's transport. The dispatcher thread holds an
-    /// `Arc::clone`, so this field exists to keep the same
-    /// transport reachable from chassis-side code that wants to
-    /// inspect or coordinate with this actor (none today; the
-    /// extension point is here without thread-local plumbing).
-    _transport: Option<Arc<NativeTransport>>,
-}
+pub struct LogTracingBackend;
 
-impl LogCapability {
+impl LogTracingBackend {
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 
-impl Actor for LogCapability {
-    /// Components mail `aether.log` (kind id) to this mailbox; the
-    /// SDK's `MailSubscriber` resolves through here. The
-    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
-    /// for chassis-owned mailboxes.
-    const NAMESPACE: &'static str = "aether.log";
-}
-
-impl Capability for LogCapability {
-    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
-        let mailbox_id = claim.id;
-
-        // ADR-0074 §Decision: `&self` trait, owned transport. The
-        // capability constructs its `NativeTransport` once at boot
-        // and clones the `Arc` into the dispatcher thread; the
-        // dispatcher uses `transport.recv_blocking()` to pull from
-        // its own inbox without thread-local plumbing. Going through
-        // `from_ctx` wires the chassis's frame-bound set + aborter
-        // into the transport so the cross-class `wait_reply` guard
-        // (ADR-0074 §Decision 5) is live for any future log-side
-        // sync calls — `LogCapability::FRAME_BARRIER` is the default
-        // `false`, so the guard treats this caller as free-running.
-        let transport = Arc::new(NativeTransport::from_ctx(
-            ctx,
-            mailbox_id,
-            Self::FRAME_BARRIER,
-        ));
-        transport.install_inbox(claim.receiver);
-        let dispatcher_transport = Arc::clone(&transport);
-
-        let thread = thread::Builder::new()
-            .name("aether-log-sink".into())
-            .spawn(move || {
-                // Channel-drop + join: pull until the sender side
-                // disconnects. Worst-case shutdown latency is the
-                // OS scheduler's wakeup, not a 100ms poll interval.
-                while let Some(env) = dispatcher_transport.recv_blocking() {
-                    log_sink::handle_log_mail(&env.payload);
-                }
-            })
-            .map_err(|e| BootError::Other(Box::new(e)))?;
-
-        self.thread = Some(thread);
-        self.sink_sender = Some(claim.sink_sender);
-        self._transport = Some(transport);
-        Ok(self)
-    }
-}
-
-impl Drop for LogCapability {
-    fn drop(&mut self) {
-        // Drop the strong sender first to break the channel.
-        self.sink_sender.take();
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
-        }
+impl LogBackend for LogTracingBackend {
+    fn on_log_event(&mut self, event: LogEvent) {
+        log_sink::handle_log_mail_decoded(event);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::thread;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::capability::ChassisBuilder;
     use crate::mailer::Mailer;
     use crate::registry::{MailboxEntry, Registry};
-    use aether_data::Kind;
-    use aether_kinds::LogEvent;
+    use aether_data::{Actor, Kind};
+    use aether_kinds::LogCapability;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
-    /// End-to-end: boot the capability, push an `aether.log` mail at
-    /// the registered sink, the dispatcher thread runs
-    /// `handle_log_mail` (which on a test runner with no global
-    /// tracing subscriber drops the record silently — what we're
-    /// asserting is that the dispatch path doesn't panic and that
-    /// shutdown joins cleanly).
-    ///
-    /// Post-ADR-0074: shutdown latency is bounded by `recv()`
-    /// returning on channel disconnect, not by a polling interval.
-    /// Channel-drop should land well under the 500ms test budget.
+    /// End-to-end: boot the facade cap, push an `aether.log` mail at
+    /// the registered mailbox, the dispatcher thread runs the
+    /// macro-emitted `Dispatch::__dispatch` which delegates to the
+    /// backend's `on_log_event`. Test asserts dispatch + clean
+    /// shutdown without hanging.
     #[test]
     fn capability_routes_log_event_through_dispatcher() {
         let (registry, mailer) = fresh_substrate();
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
+            .with_facade(LogCapability::new(LogTracingBackend::new()))
             .build()
             .expect("capability boots");
 
         let id = registry
-            .lookup(LogCapability::NAMESPACE)
-            .expect("sink registered");
+            .lookup(<LogCapability<LogTracingBackend> as Actor>::NAMESPACE)
+            .expect("mailbox registered");
         let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
             panic!("expected sink entry");
         };
@@ -194,20 +102,26 @@ mod tests {
         );
     }
 
-    /// Builder rejects a duplicate claim if the well-known sink name
+    /// Builder rejects a duplicate claim if the well-known mailbox name
     /// was already registered.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
+        use crate::capability::BootError;
+
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(
+            <LogCapability<LogTracingBackend> as Actor>::NAMESPACE,
+            Arc::new(|_, _, _, _, _, _| {}),
+        );
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
+            .with_facade(LogCapability::new(LogTracingBackend::new()))
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == LogCapability::NAMESPACE
+            BootError::MailboxAlreadyClaimed { ref name }
+                if name == <LogCapability<LogTracingBackend> as Actor>::NAMESPACE
         ));
     }
 }

--- a/crates/aether-substrate/src/capabilities/mod.rs
+++ b/crates/aether-substrate/src/capabilities/mod.rs
@@ -29,7 +29,7 @@ pub mod render;
 pub use audio::{AudioCapability, AudioConfig};
 pub use handle::HandleCapability;
 pub use io::IoCapability;
-pub use log::LogCapability;
+pub use log::LogTracingBackend;
 pub use net::NetCapability;
 #[cfg(feature = "render")]
 pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles};

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -29,12 +29,15 @@
 use std::collections::HashSet;
 use std::error::Error as StdError;
 use std::fmt;
+use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, RwLock};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use aether_actor::Actor;
+use aether_data::Dispatch;
 
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::{KindId, MailboxId, ReplyTo};
@@ -624,6 +627,115 @@ impl<'a> ChassisCtx<'a> {
     }
 }
 
+/// Chassis-side handle for a facade-cap dispatcher (ADR-0075).
+///
+/// The chassis owns this; the cap (with its [`Dispatch`] impl) lives
+/// inside the dispatcher thread. Dropping the handle drops the
+/// [`SinkSender`] (channel disconnects), the dispatcher's `recv()`
+/// returns `Err(Disconnected)`, the thread exits, and the captured
+/// cap drops with it — running its `Drop` impl on the dispatcher
+/// thread (where any backend resource cleanup happens).
+///
+/// `PhantomData<C>` ties the handle to the cap type for storage
+/// hygiene without holding the cap (the dispatcher thread does).
+/// Boxed as `dyn ActorErased` in the chassis's `running` vec.
+pub struct FacadeHandle<C: 'static> {
+    thread: Option<JoinHandle<()>>,
+    /// Drop-on-shutdown breaks the channel. `Option` so [`Drop`] can
+    /// `take()` it before joining the thread; once gone, the
+    /// registry's `Weak` upgrade fails on subsequent sends and the
+    /// dispatcher's `recv()` returns `Err(Disconnected)`.
+    sink_sender: Option<SinkSender>,
+    _cap: PhantomData<fn() -> C>,
+}
+
+impl<C: 'static> Drop for FacadeHandle<C> {
+    fn drop(&mut self) {
+        // Sender first — that's what disconnects the channel and lets
+        // the dispatcher thread exit. Joining a still-alive sender
+        // would hang.
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+// `FacadeHandle<C>` is itself the chassis-stored entry — the cap C
+// lives inside the dispatcher thread. `Send` is the only ActorErased
+// requirement; the handle's fields (`Option<JoinHandle>`,
+// `Option<SinkSender>`, PhantomData) are all `Send`.
+impl<C: 'static> ActorErased for FacadeHandle<C> {}
+
+impl<'a> ChassisCtx<'a> {
+    /// Claim a mailbox for a facade-style chassis cap and spawn a
+    /// dispatcher thread that owns the cap and routes inbound mail
+    /// through its [`Dispatch`] impl. ADR-0075 §Decision 3.
+    ///
+    /// The cap is moved into the thread; the returned [`FacadeHandle`]
+    /// owns the [`SinkSender`] + [`JoinHandle`]. On chassis shutdown
+    /// the handle drops, the channel disconnects, the thread exits,
+    /// and the cap's `Drop` runs on the dispatcher thread (so any
+    /// backend cleanup that touches non-Send resources stays on the
+    /// owning thread).
+    ///
+    /// Today this is the path PR C wires for [`aether_kinds::LogCapability`];
+    /// PR D migrates the rest of the chassis caps onto it.
+    pub fn spawn_actor_dispatcher<C>(&mut self, cap: C) -> Result<FacadeHandle<C>, BootError>
+    where
+        C: Actor + Dispatch + Send + 'static,
+    {
+        let claim = self.claim_mailbox_drop_on_shutdown_with_override(C::NAMESPACE)?;
+        let DropOnShutdownClaim {
+            id: _,
+            receiver,
+            sink_sender,
+        } = claim;
+
+        let mut owned = cap;
+        let thread = thread::Builder::new()
+            .name(alloc_thread_name::<C>())
+            .spawn(move || {
+                // Channel-drop + join: pull until the sender side
+                // disconnects. Worst-case shutdown latency is the OS
+                // scheduler's wakeup, not a polling interval. The
+                // strict-receiver miss path (None from __dispatch)
+                // logs at the chassis-side dispatcher rather than the
+                // SDK so the warning carries the cap's namespace.
+                while let Ok(env) = receiver.recv() {
+                    if owned.__dispatch(env.kind.0, &env.payload).is_none() {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            actor = C::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "facade cap dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                }
+                // `owned` drops here on thread exit, running the cap's
+                // `Drop` impl (which in turn drops the backend, which
+                // typically owns the resource cleanup).
+            })
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+
+        Ok(FacadeHandle {
+            thread: Some(thread),
+            sink_sender: Some(sink_sender),
+            _cap: PhantomData,
+        })
+    }
+}
+
+/// Build a stable `aether-actor-<namespace>` thread name for the
+/// dispatcher. Namespaces are `&'static str`, so allocating once at
+/// boot is fine — most chassis have ≤ 7 caps total.
+fn alloc_thread_name<C: Actor>() -> String {
+    let mut name = String::with_capacity("aether-actor-".len() + C::NAMESPACE.len());
+    name.push_str("aether-actor-");
+    name.push_str(C::NAMESPACE);
+    name
+}
+
 /// Type-erased boot trampoline so [`ChassisBuilder`] can collect
 /// heterogeneous capability types into one `Vec`. Each entry, when
 /// invoked, takes the ctx, calls the underlying `Capability::boot`,
@@ -686,6 +798,25 @@ impl ChassisBuilder {
         self.pending.push(Box::new(move |ctx| {
             let booted = cap.boot(ctx)?;
             Ok(Box::new(booted) as Box<dyn ActorErased>)
+        }));
+        self
+    }
+
+    /// Append a facade-style cap (ADR-0075 §Decision 3): the chassis
+    /// claims the mailbox and runs the dispatcher; the cap is purely
+    /// an `Actor + Dispatch` value carrying its backend. Boot order
+    /// is declaration order, same as [`Self::with`].
+    ///
+    /// PR C wires [`aether_kinds::LogCapability<LogTracingBackend>`]
+    /// through this; PR D migrates the rest of the chassis caps onto
+    /// it.
+    pub fn with_facade<C>(mut self, cap: C) -> Self
+    where
+        C: Actor + Dispatch + Send + 'static,
+    {
+        self.pending.push(Box::new(move |ctx| {
+            let handle = ctx.spawn_actor_dispatcher(cap)?;
+            Ok(Box::new(handle) as Box<dyn ActorErased>)
         }));
         self
     }
@@ -822,6 +953,34 @@ impl BootedChassis {
         );
         let booted = cap.boot(&mut ctx)?;
         self.running.push(Box::new(booted));
+        Ok(())
+    }
+
+    /// Boot one more facade-style cap into an already-built chassis.
+    /// Counterpart to [`Self::add`] for [`ChassisBuilder::with_facade`]
+    /// caps. Used by chassis mains that compose chassis-conditional
+    /// caps (today: the bundle hooks `LogCapability`,
+    /// `IoCapability`, etc. on top of `SubstrateBoot::build`'s
+    /// universal set).
+    pub fn add_facade<C>(
+        &mut self,
+        registry: &Arc<Registry>,
+        mailer: &Arc<Mailer>,
+        cap: C,
+    ) -> Result<(), BootError>
+    where
+        C: Actor + Dispatch + Send + 'static,
+    {
+        let mut ctx = ChassisCtx::new(
+            registry,
+            mailer,
+            &mut self._fallback,
+            &mut self.frame_bound_pending,
+            &self.frame_bound_set,
+            &self.aborter,
+        );
+        let handle = ctx.spawn_actor_dispatcher(cap)?;
+        self.running.push(Box::new(handle));
         Ok(())
     }
 

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -29,12 +29,16 @@ use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
-use crate::capability::{BootError, Capability, ChassisCtx, FallbackRouter, MailboxClaim};
+use crate::capability::{
+    BootError, Capability, ChassisCtx, FacadeHandle, FallbackRouter, MailboxClaim,
+};
 use crate::chassis::Chassis;
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::MailboxId;
 use crate::mailer::Mailer;
 use crate::registry::Registry;
+use aether_actor::Actor;
+use aether_data::Dispatch;
 
 /// Failure mode raised by [`DriverRunning::run`].
 #[derive(Debug)]
@@ -148,6 +152,26 @@ impl<C: Capability + Sync> DynShutdown for ArcShutdown<C> {
                 );
             }
         }
+    }
+}
+
+/// Concrete adapter for an ADR-0075 facade cap. The chassis owns the
+/// [`FacadeHandle`]; the cap itself lives in the dispatcher thread.
+/// On shutdown the handle drops, severing the channel and joining the
+/// thread; the captured cap drops there. There's no `TypedRunnings`
+/// entry because the cap value isn't reachable from the chassis side
+/// (drivers that need to talk to the cap should use mail).
+struct FacadeShutdown<C: 'static> {
+    handle: Option<FacadeHandle<C>>,
+}
+
+impl<C: 'static> DynShutdown for FacadeShutdown<C> {
+    fn shutdown_dyn(mut self: Box<Self>) {
+        // Drop the handle eagerly: drops SinkSender, channel
+        // disconnects, dispatcher thread exits, cap drops. Equivalent
+        // to letting `Box<Self>` drop, but explicit so the order is
+        // documented.
+        self.handle.take();
     }
 }
 
@@ -284,6 +308,18 @@ where
     })
 }
 
+fn make_facade_passive_boot<C>(cap: C) -> PassiveBoot
+where
+    C: Actor + Dispatch + Send + 'static,
+{
+    Box::new(move |ctx, _runnings| {
+        let handle = ctx.spawn_actor_dispatcher(cap)?;
+        Ok(Box::new(FacadeShutdown {
+            handle: Some(handle),
+        }) as Box<dyn DynShutdown>)
+    })
+}
+
 fn make_driver_boot<D: DriverCapability>(driver: D) -> DriverBoot {
     Box::new(move |ctx| {
         let running = driver.boot(ctx)?;
@@ -348,6 +384,17 @@ impl<C: Chassis> Builder<C, NoDriver> {
         self
     }
 
+    /// Append an ADR-0075 facade-style cap (cap impls `Actor +
+    /// Dispatch`, chassis owns the dispatcher thread). Booted in
+    /// declaration order alongside [`Self::with`].
+    pub fn with_facade<P>(mut self, cap: P) -> Self
+    where
+        P: Actor + Dispatch + Send + 'static,
+    {
+        self.passives.push(make_facade_passive_boot::<P>(cap));
+        self
+    }
+
     /// Supply the chassis's driver. Transitions to [`HasDriver`] —
     /// further `.driver(_)` calls are forbidden by the type system.
     /// Per ADR-0071 the driver type is fixed by `C::Driver`, so the
@@ -386,6 +433,16 @@ impl<C: Chassis> Builder<C, HasDriver> {
         P: Capability + Sync,
     {
         self.passives.push(make_passive_boot::<P>(cap));
+        self
+    }
+
+    /// Append an ADR-0075 facade-style cap after the driver was
+    /// supplied. Booted before the driver in declaration order.
+    pub fn with_facade<P>(mut self, cap: P) -> Self
+    where
+        P: Actor + Dispatch + Send + 'static,
+    {
+        self.passives.push(make_facade_passive_boot::<P>(cap));
         self
     }
 

--- a/crates/aether-substrate/src/log_sink.rs
+++ b/crates/aether-substrate/src/log_sink.rs
@@ -23,10 +23,12 @@
 use aether_kinds::LogEvent;
 
 /// Decode a single `aether.log` payload and emit through the
-/// `log::log!` facade. Called by
-/// [`crate::capabilities::log::LogCapability`]'s dispatcher thread;
-/// tests can call it directly to exercise the decode path without
-/// spinning up a capability.
+/// `log::log!` facade. Pre-ADR-0075 this was the dispatcher's whole
+/// body; post-ADR-0075 the chassis dispatcher decodes via the cap's
+/// macro-emitted `Dispatch::__dispatch` which calls
+/// [`handle_log_mail_decoded`] directly. This raw-bytes form remains
+/// for tests that want to exercise the decode + warn-on-garbage path.
+#[cfg(test)]
 pub(crate) fn handle_log_mail(bytes: &[u8]) {
     let event: LogEvent = match postcard::from_bytes(bytes) {
         Ok(e) => e,
@@ -40,6 +42,13 @@ pub(crate) fn handle_log_mail(bytes: &[u8]) {
             return;
         }
     };
+    handle_log_mail_decoded(event);
+}
+
+/// Emit an already-decoded `LogEvent` through the `log::log!` facade.
+/// Called from the substrate-side `LogTracingBackend::on_log_event`
+/// after the macro-emitted `Dispatch::__dispatch` decoded the bytes.
+pub(crate) fn handle_log_mail_decoded(event: LogEvent) {
     let level = match event.level {
         0 => log::Level::Trace,
         1 => log::Level::Debug,


### PR DESCRIPTION
## Summary

PR C of issue 533 / ADR-0075. Pilots the chassis cap facade pattern on the simplest cap (Log); PR D migrates the rest.

The cap struct (`LogCapability<B>`) and its `LogBackend` trait live in `aether-kinds` so wasm senders can address it by type without pulling in substrate-only types. `LogTracingBackend` (the runtime state with the `tracing` plumbing) lives in `aether-substrate`. The chassis owns the dispatcher thread via a new `with_facade` builder method.

## Design notes

**Trait family moved to `aether-data`.** The natural shape (cap in `aether-kinds`, marker traits in `aether-actor`) would have introduced a dep cycle (`aether-actor` already depends on `aether-kinds` for `aether.control.subscribe_input`). Per discussion, moved `Actor` / `Singleton` / `HandlesKind` (and a new `Dispatch` trait) down to `aether-data` where they're more honestly placed — they're pure markers with no transport machinery, and both `aether-actor` and `aether-kinds` already depend on `aether-data`. `aether-actor` re-exports them so SDK ergonomics are unchanged.

Marked as a stopgap; we can revisit a permanent home once things settle.

**`Dispatch` trait, not an inherent method.** PR B emitted an inherent `__dispatch` from `#[actor]`. Generic chassis helpers can't bound on inherent methods, so this PR switches the macro to emit `impl Dispatch for <cap>` instead. The native_actor test imports `Dispatch` to keep using `cap.__dispatch(...)`.

**Chassis owns the dispatcher thread.** Pre-PR-C every cap hand-rolled `thread::spawn` inside its `boot()`. ADR-0075 §Decision 3 / memory note "per-cap thread spawning is an artifact" lifts that boilerplate to a chassis-side helper:

- `ChassisCtx::spawn_actor_dispatcher<C: Actor + Dispatch>(cap)` claims the mailbox, spawns the dispatcher thread, returns a `FacadeHandle<C>`.
- `ChassisBuilder::with_facade` and `Builder::with_facade` (chassis_builder.rs) wrap the spawn helper into the builder chain.
- The cap moves into the dispatcher thread; the chassis stores only the `FacadeHandle` (JoinHandle + SinkSender). Drop chain: handle drops → SinkSender drops → channel disconnects → thread exits → cap drops on the thread (so backend cleanup happens where it's allowed to).

**Backend trait IS the state.** No separate `Running` / `Inner` (issue 525 Phase 2 collapsed those; reintroducing them was rejected). `LogTracingBackend` IS the state-bearing struct. For Log there's no per-instance state, so the backend is unit-shaped — caps with real state (Render's wgpu device, Handle's Arc<HandleStore>) get there in PR D.

**LogCapability does NOT impl `NativeActor`.** Pre-compact memory said "trivial NativeActor::boot returning self," but that's dead weight under the facade pattern — the chassis owns boot/dispatcher lifecycle. The cap impls `Actor + Singleton + Dispatch` (latter two via `#[actor]`), nothing else. `NativeActor` stays for non-facade caps until PR D migrates them.

## What's NOT in this PR (per memory file)

- `NativeActor::boot` signature is unchanged. Static-factory shift (parked Phase 2b from issue 525) stays parked.
- No deferred-backend-construction chassis API. Logged in memory; PR D adds it when the first non-trivial backend (Handle / Render) needs it.
- No migration of Handle / Audio / Io / Net / Render. Those keep their existing `Capability` impls; PR D mechanical.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` all green (~1300 tests)
- [x] `cargo check --target wasm32-unknown-unknown` for camera + mesh-viewer + test-fixture-probe components clean
- [x] `aether-substrate-bundle` integration tests pass (capture frame round-trip, tick subscription, replace_component, frame_stats broadcast at 120-tick cadence — all green)
- [ ] Manual smoke against MCP harness (deferred to user review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)