### PR TITLE
feat(actor): native handlers can take a sender arg (issue 533 PR D1)

### DIFF
--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -1055,9 +1055,13 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                     ));
                 }
                 if let Some(idx) = handler_attr_idx {
-                    let kind_ty = extract_native_handler_kind_type(&f.sig)?;
+                    let (kind_ty, takes_sender) = extract_native_handler_kind_type(&f.sig)?;
                     f.attrs.remove(idx);
-                    handlers.push(NativeHandlerFn { method: f, kind_ty });
+                    handlers.push(NativeHandlerFn {
+                        method: f,
+                        kind_ty,
+                        takes_sender,
+                    });
                 } else {
                     helpers.push(f);
                 }
@@ -1105,13 +1109,25 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     // payload (returning early on decode failure for the matched kind
     // — substrate-side dispatcher logs the miss separately) and calls
     // the inherent handler method by its original ident.
+    //
+    // Two call shapes:
+    //   - `takes_sender = true` → forward the dispatcher's `sender`
+    //     argument as the second arg. Used by reply-bearing caps
+    //     (Handle, Audio, Io, Net, ...) — issue 533 PR D1.
+    //   - `takes_sender = false` → drop sender on the floor.
+    //     Fire-and-forget caps (Log) keep the 2-arg signature.
     let dispatch_arms = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         let method_ident = &h.method.sig.ident;
+        let call = if h.takes_sender {
+            quote! { self.#method_ident(__sender, __decoded); }
+        } else {
+            quote! { self.#method_ident(__decoded); }
+        };
         quote! {
             if kind == <#kind_ty as ::aether_data::Kind>::ID.0 {
                 if let Some(__decoded) = <#kind_ty as ::aether_data::Kind>::decode_from_bytes(payload) {
-                    self.#method_ident(__decoded);
+                    #call
                     return Some(());
                 }
                 return None;
@@ -1126,7 +1142,16 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
         #(#handles_kind_impls)*
 
         impl #impl_generics ::aether_data::Dispatch for #self_ty #where_clause {
-            fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()> {
+            fn __dispatch(
+                &mut self,
+                __sender: ::aether_data::ReplyTo,
+                kind: u64,
+                payload: &[u8],
+            ) -> Option<()> {
+                // `__sender` is shadowed-bind so dispatch arms that
+                // forward it stay readable. Underscore prefix avoids
+                // shadowing user identifiers when no handler takes it.
+                let _ = &__sender;
                 #(#dispatch_arms)*
                 None
             }
@@ -1142,15 +1167,29 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
 struct NativeHandlerFn {
     method: syn::ImplItemFn,
     kind_ty: Type,
+    /// `true` for 3-arg `(&mut self, sender: ReplyTo, mail: K)` — the
+    /// dispatcher forwards the envelope's `sender` through to the
+    /// handler. `false` for 2-arg `(&mut self, mail: K)` — sender is
+    /// ignored (fire-and-forget caps like Log).
+    takes_sender: bool,
 }
 
-/// Extract `K` from a native handler's second parameter (`arg: K`).
-/// Native handlers don't take a ctx; signature is `(&mut self, K)`.
-fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
-    if sig.inputs.len() != 2 {
+/// Extract `K` from a native handler's signature. Accepts two shapes:
+///   - 2-arg `(&mut self, mail: K)` — fire-and-forget handler, sender
+///     is ignored when the dispatcher invokes it.
+///   - 3-arg `(&mut self, sender: ReplyTo, mail: K)` — reply-bearing
+///     handler, sender is the envelope's reply target. The macro
+///     trusts the second arg's name/type and forwards the dispatcher's
+///     `sender` through to it.
+///
+/// Returns the kind type plus a `takes_sender` flag the caller uses
+/// to pick the right dispatch-arm shape.
+fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<(Type, bool)> {
+    if sig.inputs.len() != 2 && sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
-            "native #[handler] method must have signature `(&mut self, arg: K)`",
+            "native #[handler] method must have signature `(&mut self, arg: K)` \
+             or `(&mut self, sender: ::aether_data::ReplyTo, arg: K)`",
         ));
     }
     let first = &sig.inputs[0];
@@ -1160,13 +1199,15 @@ fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
             "native #[handler] first parameter must be `&mut self`",
         ));
     }
-    let FnArg::Typed(pat_ty) = &sig.inputs[1] else {
+    let takes_sender = sig.inputs.len() == 3;
+    let kind_arg_idx = if takes_sender { 2 } else { 1 };
+    let FnArg::Typed(pat_ty) = &sig.inputs[kind_arg_idx] else {
         return Err(syn::Error::new_spanned(
-            &sig.inputs[1],
-            "native #[handler] second parameter must be `arg: K`",
+            &sig.inputs[kind_arg_idx],
+            "native #[handler] kind parameter must be a typed `arg: K`",
         ));
     };
-    Ok((*pat_ty.ty).clone())
+    Ok(((*pat_ty.ty).clone(), takes_sender))
 }
 
 /// Extract `K` from a handler method's third parameter (`arg: K`).

--- a/crates/aether-data-derive/tests/native_actor.rs
+++ b/crates/aether-data-derive/tests/native_actor.rs
@@ -1,16 +1,19 @@
 // Tests for `#[actor]` on inherent impls — the native chassis-cap
-// path (PR B of issue 533). Verifies:
+// path (issue 533 PR B + PR D1). Verifies:
 //
 //   - `HandlesKind<K>` impls land for each `#[handler]` method.
-//   - `Dispatch::__dispatch(kind: u64, payload: &[u8]) -> Option<()>`
+//   - `Dispatch::__dispatch(sender, kind, payload) -> Option<()>`
 //     routes payloads to the matching handler and returns `None`
 //     for unknown kinds.
+//   - Both 2-arg `(&mut self, K)` and 3-arg
+//     `(&mut self, sender: ReplyTo, K)` handler signatures are
+//     supported (issue 533 PR D1).
 //
 // Compiles native-only — `aether-data-derive` runs as a proc-macro
 // crate, so these tests exercise the generated code on the host.
 
 use aether_actor::Actor;
-use aether_data::{Dispatch, Kind};
+use aether_data::{Dispatch, Kind, ReplyTarget, ReplyTo, SessionToken, Uuid};
 use bytemuck::{Pod, Zeroable};
 
 /// Two distinct cast-shape kinds the test cap handles.
@@ -39,9 +42,14 @@ struct UnhandledKind {
 
 /// Backend trait — the substrate-side code impls this; the cap's
 /// handler bodies delegate to it. ADR-0075 facade pattern.
+///
+/// `on_kind_b` takes a `sender` to exercise the 3-arg `#[handler]`
+/// signature added in issue 533 PR D1; `on_kind_a` keeps the
+/// fire-and-forget 2-arg shape so both paths are covered in one
+/// fixture.
 trait FacadeBackend: Send + 'static {
     fn on_kind_a(&mut self, k: KindA);
-    fn on_kind_b(&mut self, k: KindB);
+    fn on_kind_b(&mut self, sender: ReplyTo, k: KindB);
 }
 
 /// Cap struct holding a backend. The `#[actor]` macro emits HandlesKind
@@ -56,14 +64,16 @@ impl<B: FacadeBackend> Actor for FacadeCap<B> {
 
 #[aether_data::actor]
 impl<B: FacadeBackend> FacadeCap<B> {
+    /// 2-arg native handler — sender ignored.
     #[aether_data::handler]
     fn on_kind_a(&mut self, k: KindA) {
         self.backend.on_kind_a(k);
     }
 
+    /// 3-arg native handler — sender forwarded to the backend.
     #[aether_data::handler]
-    fn on_kind_b(&mut self, k: KindB) {
-        self.backend.on_kind_b(k);
+    fn on_kind_b(&mut self, sender: ReplyTo, k: KindB) {
+        self.backend.on_kind_b(sender, k);
     }
 }
 
@@ -72,15 +82,19 @@ impl<B: FacadeBackend> FacadeCap<B> {
 #[derive(Default)]
 struct RecordingBackend {
     a_calls: Vec<KindA>,
-    b_calls: Vec<KindB>,
+    b_calls: Vec<(ReplyTo, KindB)>,
 }
 impl FacadeBackend for RecordingBackend {
     fn on_kind_a(&mut self, k: KindA) {
         self.a_calls.push(k);
     }
-    fn on_kind_b(&mut self, k: KindB) {
-        self.b_calls.push(k);
+    fn on_kind_b(&mut self, sender: ReplyTo, k: KindB) {
+        self.b_calls.push((sender, k));
     }
+}
+
+fn session_sender(token: u128) -> ReplyTo {
+    ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(token))))
 }
 
 #[test]
@@ -89,7 +103,7 @@ fn dispatch_routes_kind_a_to_on_kind_a() {
         backend: RecordingBackend::default(),
     };
     let payload = bytemuck::bytes_of(&KindA { tag: 42 });
-    let result = cap.__dispatch(KindA::ID.0, payload);
+    let result = cap.__dispatch(ReplyTo::NONE, KindA::ID.0, payload);
     assert_eq!(result, Some(()));
     assert_eq!(cap.backend.a_calls.len(), 1);
     assert_eq!(cap.backend.a_calls[0].tag, 42);
@@ -97,15 +111,18 @@ fn dispatch_routes_kind_a_to_on_kind_a() {
 }
 
 #[test]
-fn dispatch_routes_kind_b_to_on_kind_b() {
+fn dispatch_routes_kind_b_to_on_kind_b_with_sender() {
     let mut cap = FacadeCap {
         backend: RecordingBackend::default(),
     };
+    let sender = session_sender(0xfeed_beef);
     let payload = bytemuck::bytes_of(&KindB { tag: 99 });
-    let result = cap.__dispatch(KindB::ID.0, payload);
+    let result = cap.__dispatch(sender, KindB::ID.0, payload);
     assert_eq!(result, Some(()));
     assert_eq!(cap.backend.b_calls.len(), 1);
-    assert_eq!(cap.backend.b_calls[0].tag, 99);
+    let (recorded_sender, recorded_kind) = cap.backend.b_calls[0];
+    assert_eq!(recorded_sender, sender);
+    assert_eq!(recorded_kind.tag, 99);
     assert!(cap.backend.a_calls.is_empty());
 }
 
@@ -115,7 +132,7 @@ fn dispatch_returns_none_for_unhandled_kind() {
         backend: RecordingBackend::default(),
     };
     let payload = bytemuck::bytes_of(&UnhandledKind { tag: 1 });
-    let result = cap.__dispatch(UnhandledKind::ID.0, payload);
+    let result = cap.__dispatch(ReplyTo::NONE, UnhandledKind::ID.0, payload);
     assert_eq!(result, None);
     assert!(cap.backend.a_calls.is_empty());
     assert!(cap.backend.b_calls.is_empty());

--- a/crates/aether-data/src/actor.rs
+++ b/crates/aether-data/src/actor.rs
@@ -74,10 +74,17 @@ pub trait HandlesKind<K: crate::Kind>: Actor {}
 /// `aether-kinds` can implement it without picking up an `aether-actor`
 /// dependency — see [`Actor`] for the cycle context.
 ///
+/// `sender` carries the envelope's reply target and correlation id
+/// (issue 533 PR D1). `#[handler]` methods that need to reply declare
+/// a 3-arg signature `(&mut self, sender: ReplyTo, mail: K)`; the
+/// macro routes `sender` through to those handlers and ignores it
+/// for 2-arg `(&mut self, mail: K)` handlers (fire-and-forget caps
+/// like Log).
+///
 /// Returns `Some(())` on match + decode success, `None` on unknown
 /// kind or decode failure. The chassis-side dispatcher logs misses
 /// separately (kind-id + cap-namespace) so the strict-receiver
 /// surface stays observable.
 pub trait Dispatch {
-    fn __dispatch(&mut self, kind: u64, payload: &[u8]) -> Option<()>;
+    fn __dispatch(&mut self, sender: crate::ReplyTo, kind: u64, payload: &[u8]) -> Option<()>;
 }

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -45,6 +45,7 @@ pub mod actor;
 pub mod canonical;
 pub mod hash;
 pub mod ids;
+pub mod mail;
 pub mod schema;
 pub mod tag_bits;
 pub mod tagged_id;
@@ -56,6 +57,7 @@ pub use hash::{
     mailbox_id_from_name,
 };
 pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
+pub use mail::{ReplyTarget, ReplyTo};
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};
 pub use wire_id::{EngineId, SessionToken, Uuid};

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -1,0 +1,91 @@
+//! Reply-routing types shared by every mail-bearing surface (ADR-0008,
+//! ADR-0037, ADR-0042). Lives in `aether-data` so chassis caps in
+//! `aether-kinds` can name the substrate's reply target type from
+//! their `#[handler]` signatures (ADR-0075 / issue 533 PR D).
+//!
+//! `aether-substrate` re-exports these from `aether_substrate::mail`
+//! so existing call sites compile unchanged. Wasm components see a
+//! different `ReplyTo` (a u32 FFI handle in `aether-actor::mail`); the
+//! two types share a name but serve different sides of the boundary.
+
+use crate::{EngineId, MailboxId, SessionToken};
+
+/// Where a reply-bearing mail should route when the recipient
+/// answers. Strictly a routing hint: mail is pushed at a recipient,
+/// not sent from a mailbox.
+///
+/// `None` is the default — broadcast / substrate-generated mail with
+/// no meaningful reply target. `Session` tags mail that arrived from
+/// a Claude MCP session, so replies route back to that session
+/// (ADR-0008). `EngineMailbox` tags mail bubbled up from a component
+/// on another engine, so replies route to the originating engine's
+/// mailbox (ADR-0037 Phase 2). `Component` tags sink-bound mail that
+/// a local component pushed through `SubstrateCtx::send`, so sink
+/// reply paths (ADR-0041's io sink is the motivating case) can route
+/// the `*Result` back to the component via the mailer rather than
+/// the hub.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ReplyTarget {
+    None,
+    Session(SessionToken),
+    EngineMailbox {
+        engine_id: EngineId,
+        mailbox_id: MailboxId,
+    },
+    Component(MailboxId),
+}
+
+/// Reply-routing info for a substrate-side `Mail`. `target` describes
+/// where a reply goes; `correlation_id` is an opaque `u64` the
+/// original sender attached so it can identify its specific request
+/// among replies of the same kind. The mailer auto-echoes
+/// `correlation_id` when constructing a reply via `send_reply`, so
+/// reply-bearing sinks don't need per-sink echo code. `0` means "no
+/// correlation"; waits with `expected_correlation == 0` match any
+/// correlation (backward-compat and for non-correlating callers like
+/// broadcasts and input mail).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ReplyTo {
+    pub target: ReplyTarget,
+    pub correlation_id: u64,
+}
+
+impl ReplyTo {
+    /// Sentinel for no correlation. Using the explicit constant makes
+    /// call sites self-documenting; a plain `0` in code comments as
+    /// "why zero?" whereas `NO_CORRELATION` makes the intent obvious.
+    pub const NO_CORRELATION: u64 = 0;
+
+    /// `ReplyTo` with no target and no correlation.
+    pub const NONE: ReplyTo = ReplyTo {
+        target: ReplyTarget::None,
+        correlation_id: Self::NO_CORRELATION,
+    };
+
+    /// Reply target alone, no correlation. Short form for mail paths
+    /// that want to address a reply but don't participate in the
+    /// ADR-0042 correlation scheme (the hub's inbound session mail
+    /// today — a future change could have sessions carry correlation
+    /// when the MCP send_mail tool grows to expose it).
+    pub fn to(target: ReplyTarget) -> Self {
+        Self {
+            target,
+            correlation_id: Self::NO_CORRELATION,
+        }
+    }
+
+    /// Target + correlation. The common sync-wrapper shape.
+    pub fn with_correlation(target: ReplyTarget, correlation_id: u64) -> Self {
+        Self {
+            target,
+            correlation_id,
+        }
+    }
+
+    /// Whether the reply target is `None`. Existing callers that were
+    /// pattern-matching on the pre-refactor `ReplyTo::None` variant
+    /// use this instead.
+    pub fn is_none(&self) -> bool {
+        matches!(self.target, ReplyTarget::None)
+    }
+}

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -703,7 +703,10 @@ impl<'a> ChassisCtx<'a> {
                 // logs at the chassis-side dispatcher rather than the
                 // SDK so the warning carries the cap's namespace.
                 while let Ok(env) = receiver.recv() {
-                    if owned.__dispatch(env.kind.0, &env.payload).is_none() {
+                    if owned
+                        .__dispatch(env.sender, env.kind.0, &env.payload)
+                        .is_none()
+                    {
                         tracing::warn!(
                             target: "aether_substrate::capability",
                             actor = C::NAMESPACE,

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -1,12 +1,17 @@
 // Mail envelope types. Owned by value because mails cross thread
 // boundaries through the scheduler's queue.
 
-use aether_data::{EngineId, SessionToken};
 /// Addressing token for any mailbox — component or substrate-owned sink.
 /// ADR-0065 hoisted the canonical home into `aether_data` (per ADR-0069);
 /// this remains re-exported under the `aether_substrate::mail::MailboxId`
 /// path so existing call sites compile unchanged.
 pub use aether_data::{KindId, MailboxId};
+/// Reply-routing types — ADR-0075 / issue 533 PR D1 hoisted these into
+/// `aether-data` so chassis caps in `aether-kinds` can name them from
+/// `#[handler]` signatures. This module re-exports them so existing
+/// `aether_substrate::mail::{ReplyTo, ReplyTarget}` call sites compile
+/// unchanged.
+pub use aether_data::{ReplyTarget, ReplyTo};
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The
 /// typed facade over this is ADR-0005 (mail typing system) and ADR-0019
@@ -16,86 +21,6 @@ pub use aether_data::{KindId, MailboxId};
 /// pattern (`#[repr(transparent)]` over `u64`, so the wire shape is
 /// unchanged).
 pub type MailKind = KindId;
-
-/// Where a reply-bearing mail should route when the recipient
-/// answers. Strictly a routing hint: mail is pushed at a recipient,
-/// not sent from a mailbox.
-///
-/// `None` is the default — broadcast / substrate-generated mail
-/// with no meaningful reply target. `Session` tags mail that
-/// arrived from a Claude MCP session, so replies route back to
-/// that session (ADR-0008). `EngineMailbox` tags mail bubbled up
-/// from a component on another engine, so replies route to the
-/// originating engine's mailbox (ADR-0037 Phase 2). `Component`
-/// tags sink-bound mail that a local component pushed through
-/// `SubstrateCtx::send`, so sink reply paths (ADR-0041's io sink is
-/// the motivating case) can route the `*Result` back to the
-/// component via the mailer rather than the hub.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ReplyTarget {
-    None,
-    Session(SessionToken),
-    EngineMailbox {
-        engine_id: EngineId,
-        mailbox_id: MailboxId,
-    },
-    Component(MailboxId),
-}
-
-/// Reply-routing info for a `Mail` (ADR-0008, ADR-0037, ADR-0042).
-/// The `target` describes where a reply goes; `correlation_id` is an
-/// opaque u64 the original sender attached so it can identify its
-/// specific request among replies of the same kind. The mailer
-/// auto-echoes `correlation_id` when constructing a reply via
-/// `send_reply`, so reply-bearing sinks (the io sink today) don't
-/// need per-sink echo code. `0` means "no correlation"; waits with
-/// `expected_correlation == 0` match any correlation (backward-compat
-/// and for non-correlating callers like broadcasts and input mail).
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ReplyTo {
-    pub target: ReplyTarget,
-    pub correlation_id: u64,
-}
-
-impl ReplyTo {
-    /// Sentinel for no correlation. Using the explicit constant makes
-    /// call sites self-documenting; a plain `0` in code comments as
-    /// "why zero?" whereas `NO_CORRELATION` makes the intent obvious.
-    pub const NO_CORRELATION: u64 = 0;
-
-    /// `ReplyTo` with no target and no correlation.
-    pub const NONE: ReplyTo = ReplyTo {
-        target: ReplyTarget::None,
-        correlation_id: Self::NO_CORRELATION,
-    };
-
-    /// Reply target alone, no correlation. Short form for mail paths
-    /// that want to address a reply but don't participate in the
-    /// ADR-0042 correlation scheme (the hub's inbound session mail
-    /// today — a future change could have sessions carry correlation
-    /// when the MCP send_mail tool grows to expose it).
-    pub fn to(target: ReplyTarget) -> Self {
-        Self {
-            target,
-            correlation_id: Self::NO_CORRELATION,
-        }
-    }
-
-    /// Target + correlation. The common sync-wrapper shape.
-    pub fn with_correlation(target: ReplyTarget, correlation_id: u64) -> Self {
-        Self {
-            target,
-            correlation_id,
-        }
-    }
-
-    /// Whether the reply target is `None`. Existing callers that
-    /// were pattern-matching on the pre-refactor `ReplyTo::None`
-    /// variant use this instead.
-    pub fn is_none(&self) -> bool {
-        matches!(self.target, ReplyTarget::None)
-    }
-}
 
 /// The transport envelope. `payload` is the exact byte layout the kind
 /// implies; `count` is the number of items the layout implies, where


### PR DESCRIPTION
## Summary

PR D1 of issue 533 / ADR-0075. Prep for the reply-bearing chassis caps (Handle, Audio, Io, Net) PR D2+ will migrate. Today's native `#[handler]` only supports `(&mut self, K)`; reply-bearing caps need access to the envelope's sender to call `mailer.send_reply(sender, ...)`.

## Changes

- **Move `ReplyTarget` + `ReplyTo`** from `aether-substrate::mail` to `aether-data::mail` so chassis caps in `aether-kinds` can name them in handler signatures. `aether-substrate::mail` re-exports them so existing call sites compile unchanged.
- **Widen `Dispatch::__dispatch`** to `(&mut self, sender: ReplyTo, kind: u64, payload: &[u8])`.
- **Extend `#[actor]`** to accept native handlers with the 3-arg shape `(&mut self, sender: ReplyTo, mail: K)`. The macro detects per-handler; 2-arg handlers (Log) keep working unchanged in the same impl block. Fire-and-forget caps don't pay any boilerplate cost.
- **`ChassisCtx::spawn_actor_dispatcher`** forwards `env.sender` to `__dispatch`.
- **`native_actor` test fixture** now exercises both shapes — `KindA` via 2-arg, `KindB` via 3-arg with a `ReplyTo::Session(...)` sender.

## What's NOT in this PR

- No consumer migration. Log keeps its 2-arg signature; no chassis cap moves.
- PR D2 picks up Handle as the first reply-bearing cap on the new shape (and the deferred-construction chassis-builder API the memory file flagged).

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` all green
- [x] `cargo check --target wasm32-unknown-unknown` for camera + mesh-viewer + test-fixture-probe components clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)