### PR TITLE
feat(actor): migrate Io and Net caps onto facade pattern (issue 533 PR D3)

### DIFF
--- a/crates/aether-kinds/src/io.rs
+++ b/crates/aether-kinds/src/io.rs
@@ -1,0 +1,111 @@
+//! ADR-0075 chassis-cap facade for the `aether.io` mailbox (issue
+//! 533 PR D3). The cap and its [`IoBackend`] trait live here so
+//! wasm senders can address the cap by type
+//! (`ctx.send::<IoCapability>(&read)`) without pulling in the
+//! substrate-only adapter machinery — the concrete backend (with
+//! `AdapterRegistry`, `LocalFileAdapter`, namespace roots) lives in
+//! `aether-substrate` and impls [`IoBackend`] there.
+
+use crate::{Delete, List, Read, Write};
+use aether_data::{Actor, ReplyTo};
+
+/// Substrate-side surface a chassis installs at boot. All four
+/// methods are reply-bearing — the backend uses `sender` to route
+/// the paired `*Result` through `Mailer::send_reply`.
+///
+/// `Send + 'static` so the dispatcher thread can own the cap.
+pub trait IoBackend: Send + 'static {
+    /// Read bytes from `(namespace, path)`. Reply `ReadResult`
+    /// echoing the namespace + path on both arms.
+    fn on_read(&mut self, sender: ReplyTo, mail: Read);
+
+    /// Write bytes to `(namespace, path)`. Reply `WriteResult`
+    /// echoing namespace + path; the bytes are dropped from the
+    /// echo to keep mb-scale writes from producing mb-scale replies.
+    fn on_write(&mut self, sender: ReplyTo, mail: Write);
+
+    /// Delete a path under `namespace`. Reply `DeleteResult`.
+    fn on_delete(&mut self, sender: ReplyTo, mail: Delete);
+
+    /// List entries under `(namespace, prefix)`. Reply `ListResult`.
+    fn on_list(&mut self, sender: ReplyTo, mail: List);
+}
+
+/// Default backend used for sender-side type resolution. Senders
+/// write `IoCapability` (defaulting to [`ErasedIoBackend`]); the
+/// chassis installs `IoCapability<AdapterIoBackend>` at boot.
+pub struct ErasedIoBackend;
+
+impl IoBackend for ErasedIoBackend {
+    fn on_read(&mut self, _sender: ReplyTo, _mail: Read) {
+        unreachable!("ErasedIoBackend used at runtime — chassis must install a real backend")
+    }
+    fn on_write(&mut self, _sender: ReplyTo, _mail: Write) {
+        unreachable!("ErasedIoBackend used at runtime — chassis must install a real backend")
+    }
+    fn on_delete(&mut self, _sender: ReplyTo, _mail: Delete) {
+        unreachable!("ErasedIoBackend used at runtime — chassis must install a real backend")
+    }
+    fn on_list(&mut self, _sender: ReplyTo, _mail: List) {
+        unreachable!("ErasedIoBackend used at runtime — chassis must install a real backend")
+    }
+}
+
+/// `aether.io` mailbox cap.
+pub struct IoCapability<B: IoBackend = ErasedIoBackend> {
+    backend: B,
+}
+
+impl<B: IoBackend> IoCapability<B> {
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+impl<B: IoBackend> Actor for IoCapability<B> {
+    /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.io";
+}
+
+impl<B: IoBackend> aether_data::Singleton for IoCapability<B> {}
+
+#[aether_data::actor]
+impl<B: IoBackend> IoCapability<B> {
+    /// Read bytes from a logical namespace path.
+    ///
+    /// # Agent
+    /// Reply: `ReadResult`. Echoes namespace + path on both arms.
+    #[aether_data::handler]
+    fn on_read(&mut self, sender: ReplyTo, mail: Read) {
+        self.backend.on_read(sender, mail);
+    }
+
+    /// Write bytes to a logical namespace path. Atomic via tmp+rename
+    /// in the local file adapter; semantics may differ in future
+    /// adapters (cloud, in-memory).
+    ///
+    /// # Agent
+    /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
+    #[aether_data::handler]
+    fn on_write(&mut self, sender: ReplyTo, mail: Write) {
+        self.backend.on_write(sender, mail);
+    }
+
+    /// Delete a path under a namespace.
+    ///
+    /// # Agent
+    /// Reply: `DeleteResult`. Echoes namespace + path.
+    #[aether_data::handler]
+    fn on_delete(&mut self, sender: ReplyTo, mail: Delete) {
+        self.backend.on_delete(sender, mail);
+    }
+
+    /// List entries under a namespace prefix.
+    ///
+    /// # Agent
+    /// Reply: `ListResult`. Echoes namespace + prefix.
+    #[aether_data::handler]
+    fn on_list(&mut self, sender: ReplyTo, mail: List) {
+        self.backend.on_list(sender, mail);
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -15,12 +15,16 @@ extern crate alloc;
 
 pub mod descriptors;
 pub mod handle;
+pub mod io;
 pub mod keycode;
 pub mod log;
 pub mod mailboxes;
+pub mod net;
 
 pub use handle::{ErasedHandleBackend, HandleBackend, HandleCapability};
+pub use io::{ErasedIoBackend, IoBackend, IoCapability};
 pub use log::{ErasedLogBackend, LogBackend, LogCapability};
+pub use net::{ErasedNetBackend, NetBackend, NetCapability};
 
 use bytemuck::{Pod, Zeroable};
 

--- a/crates/aether-kinds/src/net.rs
+++ b/crates/aether-kinds/src/net.rs
@@ -1,0 +1,69 @@
+//! ADR-0075 chassis-cap facade for the `aether.net` mailbox (issue
+//! 533 PR D3). The cap and its [`NetBackend`] trait live here so
+//! wasm senders can address the cap by type
+//! (`ctx.send::<NetCapability>(&fetch)`) without pulling in
+//! substrate-only types — the concrete backend (HTTP adapter, env-
+//! resolved config) lives in `aether-substrate` and impls
+//! [`NetBackend`] there.
+
+use crate::Fetch;
+use aether_data::{Actor, ReplyTo};
+
+/// Substrate-side surface a chassis installs at boot. Reply-bearing
+/// like Handle and Io: the backend uses `sender` to route the paired
+/// `FetchResult` through `Mailer::send_reply`.
+///
+/// `Send + 'static` so the dispatcher thread can own the cap (which
+/// owns `B`) for the cap's lifetime.
+pub trait NetBackend: Send + 'static {
+    /// Run a fetch request synchronously on the dispatcher thread
+    /// and reply with a [`crate::FetchResult`]. ADR-0043 §2 flags
+    /// in-thread sync fetches as the head-of-line blocking source
+    /// to fix via a multi-threaded dispatcher; the trait shape
+    /// stays unchanged when that lands.
+    fn on_fetch(&mut self, sender: ReplyTo, mail: Fetch);
+}
+
+/// Default backend used for sender-side type resolution. Senders
+/// write `NetCapability` (defaulting to [`ErasedNetBackend`]); the
+/// chassis installs `NetCapability<UreqNetBackend>` (or the disabled
+/// stub when the chassis declines net access). `unreachable!()`
+/// because no instance of this type is ever installed at runtime.
+pub struct ErasedNetBackend;
+
+impl NetBackend for ErasedNetBackend {
+    fn on_fetch(&mut self, _sender: ReplyTo, _mail: Fetch) {
+        unreachable!("ErasedNetBackend used at runtime — chassis must install a real backend")
+    }
+}
+
+/// `aether.net` mailbox cap.
+pub struct NetCapability<B: NetBackend = ErasedNetBackend> {
+    backend: B,
+}
+
+impl<B: NetBackend> NetCapability<B> {
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+impl<B: NetBackend> Actor for NetCapability<B> {
+    /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.net";
+}
+
+impl<B: NetBackend> aether_data::Singleton for NetCapability<B> {}
+
+#[aether_data::actor]
+impl<B: NetBackend> NetCapability<B> {
+    /// Run a fetch request and reply with the response.
+    ///
+    /// # Agent
+    /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
+    /// long-running fetches block other net mail until they finish.
+    #[aether_data::handler]
+    fn on_fetch(&mut self, sender: ReplyTo, mail: Fetch) {
+        self.backend.on_fetch(sender, mail);
+    }
+}

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -17,9 +17,9 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use aether_data::{Kind, encode_empty};
-use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
+use aether_kinds::{AdvanceResult, CaptureFrameResult, IoCapability, Tick};
 use aether_substrate::{
-    Chassis, capabilities::IoCapability, capture::CaptureQueue, frame_loop, mail::Mail,
+    Chassis, capabilities::IoAdapterBackend, capture::CaptureQueue, frame_loop, mail::Mail,
     subscribers_for,
 };
 use aether_substrate_bundle::test_bench::{
@@ -89,10 +89,11 @@ fn main() -> wasmtime::Result<()> {
         hub,
     } = TestBenchChassis::build_passive(env)?;
 
-    // Io capability on the legacy `boot.add_capability` path —
+    // Io facade on the `boot.add_facade` path (ADR-0075) —
     // the binary fails fast on adapter init failure (the in-process
     // API silent-skips for systems without writable default roots).
-    boot.add_capability(IoCapability::new(boot.namespace_roots.clone()))?;
+    let io_backend = IoAdapterBackend::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue))?;
+    boot.add_facade(IoCapability::new(io_backend))?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height, render_running);

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -17,15 +17,15 @@ use std::sync::Arc;
 
 use aether_data::Kind;
 use aether_kinds::{
-    Advance, CaptureFrame, LogCapability, PlatformInfo, SetWindowMode, SetWindowModeResult,
-    SetWindowTitle, SetWindowTitleResult, WindowMode,
+    Advance, CaptureFrame, IoCapability, LogCapability, NetCapability, PlatformInfo, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, WindowMode,
 };
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, Mailer, Registry, ReplyTo, SubstrateBoot,
     capabilities::{
-        AudioCapability, IoCapability, LogTracingBackend, NetCapability, RenderCapability,
+        AudioCapability, IoAdapterBackend, LogTracingBackend, NetAdapterBackend, RenderCapability,
         RenderConfig, audio::AudioConfig as AudioConf, io::NamespaceRoots,
         net::NetConfig as NetConf,
     },
@@ -347,11 +347,14 @@ impl DesktopChassis {
         // order — log first so other capabilities' boot tracing routes
         // through the log capture; render last among passives so it
         // claims its mailboxes after every other chassis sink.
+        let io_backend = IoAdapterBackend::new(namespace_roots, Arc::clone(&mailer))
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let net_backend = NetAdapterBackend::new(net, Arc::clone(&mailer));
         Builder::<DesktopChassis>::new(registry, mailer)
             .with_aborter(aborter)
             .with_facade(LogCapability::new(LogTracingBackend::new()))
-            .with(IoCapability::new(namespace_roots))
-            .with(NetCapability::new(net))
+            .with_facade(IoCapability::new(io_backend))
+            .with_facade(NetCapability::new(net_backend))
             .with(AudioCapability::new(audio))
             .with(RenderCapability::new(RenderConfig::default()))
             .driver(driver)

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -15,15 +15,15 @@ use std::time::Duration;
 
 use aether_data::{Kind, KindId};
 use aether_kinds::{
-    Advance, CaptureFrame, FrameStats, LogCapability, PlatformInfo, SetMasterGain,
-    SetMasterGainResult, SetWindowMode, SetWindowTitle, Tick,
+    Advance, CaptureFrame, FrameStats, IoCapability, LogCapability, NetCapability, PlatformInfo,
+    SetMasterGain, SetMasterGainResult, SetWindowMode, SetWindowTitle, Tick,
 };
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
 use aether_substrate::{
     Chassis, ChassisControlHandler, HubOutbound, ReplyTo, SubstrateBoot,
     capabilities::{
-        IoCapability, LogTracingBackend, NetCapability, io::NamespaceRoots,
+        IoAdapterBackend, LogTracingBackend, NetAdapterBackend, io::NamespaceRoots,
         net::NetConfig as NetConf,
     },
     capture::{
@@ -229,11 +229,14 @@ impl HeadlessChassis {
         // chassis_builder `.with()` chain. Boot order is declaration
         // order — log first so other capabilities' boot tracing routes
         // through the log capture.
+        let io_backend = IoAdapterBackend::new(namespace_roots, Arc::clone(&mailer))
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let net_backend = NetAdapterBackend::new(net, Arc::clone(&mailer));
         Builder::<HeadlessChassis>::new(registry, mailer)
             .with_aborter(aborter)
             .with_facade(LogCapability::new(LogTracingBackend::new()))
-            .with(IoCapability::new(namespace_roots))
-            .with(NetCapability::new(net))
+            .with_facade(IoCapability::new(io_backend))
+            .with_facade(NetCapability::new(net_backend))
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -30,9 +30,10 @@ use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, Tic
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use crate::hub::HubProtocolBackend;
+use aether_kinds::IoCapability;
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, PassiveChassis, ReplyTarget, ReplyTo, SubstrateBoot,
-    capabilities::{IoCapability, io::NamespaceRoots},
+    capabilities::{IoAdapterBackend, io::NamespaceRoots},
     capture::CaptureQueue,
     frame_loop,
     mail::{Mail, MailboxId},
@@ -286,17 +287,28 @@ impl TestBench {
         boot.outbound
             .attach_backend(Arc::new(HubProtocolBackend::new(loopback_tx)));
 
-        // Io capability on the legacy `boot.add_capability` path.
-        // Silent-skip on adapter init failure preserves pre-Phase-3
-        // behavior so tests on systems without writable default roots
-        // don't fail at the harness layer; tests that care about io
-        // supply tempdir roots via the builder.
-        if let Err(e) = boot.add_capability(IoCapability::new(boot.namespace_roots.clone())) {
-            tracing::warn!(
-                target: "aether_substrate::io",
-                error = %e,
-                "io capability boot failed in TestBench (expected on systems without writable default roots)",
-            );
+        // Io facade on the `boot.add_facade` path (ADR-0075 / issue
+        // 533 PR D3). Silent-skip on adapter init failure preserves
+        // pre-PR-D3 behavior so tests on systems without writable
+        // default roots don't fail at the harness layer; tests that
+        // care about io supply tempdir roots via the builder.
+        match IoAdapterBackend::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue)) {
+            Ok(io_backend) => {
+                if let Err(e) = boot.add_facade(IoCapability::new(io_backend)) {
+                    tracing::warn!(
+                        target: "aether_substrate::io",
+                        error = %e,
+                        "io facade boot failed in TestBench (expected on systems without writable default roots)",
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::io",
+                    error = %e,
+                    "io adapter init failed in TestBench (expected on systems without writable default roots)",
+                );
+            }
         }
 
         let gpu = Gpu::new(width, height, render_running);

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -177,6 +177,23 @@ impl SubstrateBoot {
             .add(&self.registry, &self.queue, cap)
             .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
     }
+
+    /// Boot one more facade-style cap into the already-built chassis.
+    /// Counterpart to [`Self::add_capability`] for ADR-0075 facade
+    /// caps; the chassis owns the dispatcher thread and the cap moves
+    /// into it.
+    pub fn add_facade<C>(&mut self, cap: C) -> wasmtime::Result<()>
+    where
+        C: aether_actor::Actor + aether_data::Dispatch + Send + 'static,
+    {
+        let chassis = self
+            .chassis
+            .as_mut()
+            .expect("SubstrateBoot::build always installs a BootedChassis");
+        chassis
+            .add_facade(&self.registry, &self.queue, cap)
+            .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
+    }
 }
 
 impl<'a> SubstrateBootBuilder<'a> {

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -1,45 +1,39 @@
-//! ADR-0070 Phase 3 (part 2): file I/O sink as a native capability.
+//! ADR-0070 Phase 3 (part 2) + ADR-0075 §Decision 3: file I/O backend
+//! behind the [`aether_kinds::IoCapability`] facade (issue 533 PR D3).
 //!
-//! Owns the full ADR-0041 stack — `FileAdapter` trait, `LocalFileAdapter`,
-//! `AdapterRegistry`, env-driven `NamespaceRoots`, the `aether.io`
-//! mailbox claim, and the dispatcher thread that decodes inbound
-//! `Read` / `Write` / `Delete` / `List` mail and drives the matching
-//! adapter. Chassis mains resolve a [`NamespaceRoots`] (typically via
-//! [`NamespaceRoots::from_env`]) and pass it to [`IoCapability::new`];
-//! everything below the capability boundary is private.
-//!
-//! The trait deliberately stays small. Adding a backend is "impl
-//! four methods" (`read` / `write` / `delete` / `list`), not
-//! "refactor the sink."
+//! Owns the full ADR-0041 stack — `FileAdapter` trait,
+//! `LocalFileAdapter`, `AdapterRegistry`, env-driven `NamespaceRoots`,
+//! and the [`IoBackend`] impl the chassis installs at boot. Chassis
+//! mains resolve a [`NamespaceRoots`] (typically via
+//! [`NamespaceRoots::from_env`]), construct an [`IoAdapterBackend`],
+//! and hand it to `IoCapability::new(...)`. Everything below the
+//! capability boundary is private.
 //!
 //! Boot error policy: per ADR-0063 fail-fast, adapter init failure
-//! aborts the chassis. Pre-Phase-3-part-2 behavior was log-and-skip;
-//! the capability tightens this to a typed `BootError`. Operators with
-//! filesystem misconfiguration will see the error loudly at startup
-//! rather than silently lose the io sink.
+//! surfaces at [`IoAdapterBackend::new`] (returns
+//! `std::io::Result`) rather than at chassis-builder time. Chassis
+//! mains propagate via `?` to the same fail-fast outcome; operators
+//! with filesystem misconfiguration see the error at startup.
 //!
-//! Threading: single dispatcher thread on a channel-drop + join
-//! lifecycle (ADR-0074 Phase 2d, mirroring
-//! [`crate::capabilities::log::LogCapability`]). Adapter calls run
-//! synchronously on the dispatcher thread; ADR-0041 flagged a future
-//! host-fn fast path for asset-sized streaming.
+//! Threading: chassis-side dispatcher thread per ADR-0075 — the
+//! macro-emitted `Dispatch` impl on `IoCapability<IoAdapterBackend>`
+//! pulls envelopes from the `aether.io` mailbox and routes them to
+//! the matching backend method. Adapter calls run synchronously on
+//! the dispatcher thread; ADR-0041 flagged a future host-fn fast path
+//! for asset-sized streaming.
 
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread::{self, JoinHandle};
 
-use aether_actor::Actor;
-
-use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
-use crate::mail::ReplyTo;
-use crate::mailer::Mailer;
-use crate::native_transport::NativeTransport;
-use aether_data::{Kind, KindId};
+use aether_data::ReplyTo;
 use aether_kinds::{
-    Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
+    Delete, DeleteResult, IoBackend, IoError, List, ListResult, Read, ReadResult, Write,
+    WriteResult,
 };
+
+use crate::mailer::Mailer;
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
@@ -335,290 +329,24 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
     build_registry(NamespaceRoots::from_env())
 }
 
-/// Demultiplex one envelope's payload to the matching per-kind
-/// adapter call. The dispatcher thread invokes this for each
-/// envelope it receives.
-///
-/// The reply router is `Mailer::send_reply`, not
-/// `HubOutbound::send_reply`, so session / engine-mailbox /
-/// local-component replies all funnel through one path. Component-
-/// originated mail (`ReplyTo::Component`) pushes the reply back
-/// into the requesting component's inbox; session / engine mail
-/// hands off to the hub outbound as before.
-///
-/// Adapter calls run synchronously on the dispatcher thread —
-/// fine for save/config (KB-MB files). Asset-sized workloads
-/// should not ride this path; ADR-0041 flags a future host-fn fast
-/// path for zero-copy streaming reads.
-fn dispatch_io_mail(
-    registry: &AdapterRegistry,
-    mailer: &Mailer,
-    kind: KindId,
-    sender: ReplyTo,
-    bytes: &[u8],
-) {
-    // Decode-failure helper: the request couldn't be parsed, so we
-    // have no namespace/path to echo. Send the reply with empty
-    // strings in the echo fields — the `AdapterError` text carries
-    // the decode diagnostic, and empty-string echo is a loud signal
-    // that the request itself was malformed.
-    match kind {
-        <Read as Kind>::ID => {
-            let req: Read = match postcard::from_bytes(bytes) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::io",
-                        error = %e,
-                        "read: decode failed, replying Err",
-                    );
-                    mailer.send_reply(
-                        sender,
-                        &ReadResult::Err {
-                            namespace: String::new(),
-                            path: String::new(),
-                            error: IoError::AdapterError(format!("decode failed: {e}")),
-                        },
-                    );
-                    return;
-                }
-            };
-            let Some(adapter) = registry.get(&req.namespace) else {
-                mailer.send_reply(
-                    sender,
-                    &ReadResult::Err {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                        error: IoError::UnknownNamespace,
-                    },
-                );
-                return;
-            };
-            let _ = match adapter.read(&req.path) {
-                Ok(bytes) => mailer.send_reply(
-                    sender,
-                    &ReadResult::Ok {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                        bytes,
-                    },
-                ),
-                Err(error) => mailer.send_reply(
-                    sender,
-                    &ReadResult::Err {
-                        namespace: req.namespace,
-                        path: req.path,
-                        error,
-                    },
-                ),
-            };
-        }
-        <Write as Kind>::ID => {
-            let req: Write = match postcard::from_bytes(bytes) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::io",
-                        error = %e,
-                        "write: decode failed, replying Err",
-                    );
-                    mailer.send_reply(
-                        sender,
-                        &WriteResult::Err {
-                            namespace: String::new(),
-                            path: String::new(),
-                            error: IoError::AdapterError(format!("decode failed: {e}")),
-                        },
-                    );
-                    return;
-                }
-            };
-            let Some(adapter) = registry.get(&req.namespace) else {
-                mailer.send_reply(
-                    sender,
-                    &WriteResult::Err {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                        error: IoError::UnknownNamespace,
-                    },
-                );
-                return;
-            };
-            let _ = match adapter.write(&req.path, &req.bytes) {
-                Ok(()) => mailer.send_reply(
-                    sender,
-                    &WriteResult::Ok {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                    },
-                ),
-                Err(error) => mailer.send_reply(
-                    sender,
-                    &WriteResult::Err {
-                        namespace: req.namespace,
-                        path: req.path,
-                        error,
-                    },
-                ),
-            };
-        }
-        <Delete as Kind>::ID => {
-            let req: Delete = match postcard::from_bytes(bytes) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::io",
-                        error = %e,
-                        "delete: decode failed, replying Err",
-                    );
-                    mailer.send_reply(
-                        sender,
-                        &DeleteResult::Err {
-                            namespace: String::new(),
-                            path: String::new(),
-                            error: IoError::AdapterError(format!("decode failed: {e}")),
-                        },
-                    );
-                    return;
-                }
-            };
-            let Some(adapter) = registry.get(&req.namespace) else {
-                mailer.send_reply(
-                    sender,
-                    &DeleteResult::Err {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                        error: IoError::UnknownNamespace,
-                    },
-                );
-                return;
-            };
-            let _ = match adapter.delete(&req.path) {
-                Ok(()) => mailer.send_reply(
-                    sender,
-                    &DeleteResult::Ok {
-                        namespace: req.namespace.clone(),
-                        path: req.path.clone(),
-                    },
-                ),
-                Err(error) => mailer.send_reply(
-                    sender,
-                    &DeleteResult::Err {
-                        namespace: req.namespace,
-                        path: req.path,
-                        error,
-                    },
-                ),
-            };
-        }
-        <List as Kind>::ID => {
-            let req: List = match postcard::from_bytes(bytes) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::io",
-                        error = %e,
-                        "list: decode failed, replying Err",
-                    );
-                    mailer.send_reply(
-                        sender,
-                        &ListResult::Err {
-                            namespace: String::new(),
-                            prefix: String::new(),
-                            error: IoError::AdapterError(format!("decode failed: {e}")),
-                        },
-                    );
-                    return;
-                }
-            };
-            let Some(adapter) = registry.get(&req.namespace) else {
-                mailer.send_reply(
-                    sender,
-                    &ListResult::Err {
-                        namespace: req.namespace.clone(),
-                        prefix: req.prefix.clone(),
-                        error: IoError::UnknownNamespace,
-                    },
-                );
-                return;
-            };
-            let _ = match adapter.list(&req.prefix) {
-                Ok(entries) => mailer.send_reply(
-                    sender,
-                    &ListResult::Ok {
-                        namespace: req.namespace.clone(),
-                        prefix: req.prefix.clone(),
-                        entries,
-                    },
-                ),
-                Err(error) => mailer.send_reply(
-                    sender,
-                    &ListResult::Err {
-                        namespace: req.namespace,
-                        prefix: req.prefix,
-                        error,
-                    },
-                ),
-            };
-        }
-        _ => {
-            tracing::warn!(
-                target: "aether_substrate::io",
-                kind = %kind,
-                "io sink received unknown kind — dropping",
-            );
-        }
-    }
+/// Substrate-side state for the io cap. Holds the resolved adapter
+/// registry + namespace roots and the chassis [`Arc<Mailer>`] for
+/// routing replies. The dispatcher thread owns this through the
+/// macro-emitted `Dispatch` impl on `aether_kinds::IoCapability<Self>`.
+pub struct IoAdapterBackend {
+    registry: Arc<AdapterRegistry>,
+    mailer: Arc<Mailer>,
 }
 
-/// Native capability owning the ADR-0041 file-I/O sink. Constructor
-/// takes the resolved [`NamespaceRoots`] explicitly — the chassis
-/// main reads env (per issue 464) and passes the roots through.
-///
-/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
-/// (`roots`) lives alongside the runtime fields populated in
-/// `boot`. `Drop` runs the prior `shutdown` body.
-pub struct IoCapability {
-    roots: Option<NamespaceRoots>,
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    _transport: Option<Arc<NativeTransport>>,
-}
-
-impl IoCapability {
-    pub fn new(roots: NamespaceRoots) -> Self {
-        Self {
-            roots: Some(roots),
-            thread: None,
-            sink_sender: None,
-            _transport: None,
-        }
-    }
-}
-
-impl Actor for IoCapability {
-    /// Components mail `aether.io.{read,write,delete,list}` (kind ids)
-    /// to this mailbox; the SDK helpers in `aether-component::io`
-    /// resolve through here. The `aether.<name>` form is the
-    /// post-ADR-0074 Phase 5 convention for chassis-owned mailboxes.
-    const NAMESPACE: &'static str = "aether.io";
-}
-
-impl Capability for IoCapability {
-    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
-        let mailer: Arc<Mailer> = ctx.mail_send_handle();
-        let mailbox_id = claim.id;
-        let roots = self
-            .roots
-            .take()
-            .expect("IoCapability::boot called twice — `roots` already consumed");
-        let (registry, roots) = build_registry(roots).map_err(|e| {
-            BootError::Other(Box::new(std::io::Error::new(
-                e.kind(),
-                format!("io adapter init failed: {e}"),
-            )))
-        })?;
+impl IoAdapterBackend {
+    /// Construct from explicit [`NamespaceRoots`] (resolved by the
+    /// chassis main, typically via [`NamespaceRoots::from_env`]) and
+    /// the chassis's [`Mailer`]. Returns `Err(std::io::Error)` if the
+    /// adapter registry can't be built — chassis mains propagate via
+    /// `?` so misconfiguration aborts the chassis at startup
+    /// (ADR-0063 fail-fast).
+    pub fn new(roots: NamespaceRoots, mailer: Arc<Mailer>) -> std::io::Result<Self> {
+        let (registry, roots) = build_registry(roots)?;
         tracing::info!(
             target: "aether_substrate::io",
             save = %roots.save.display(),
@@ -626,38 +354,122 @@ impl Capability for IoCapability {
             config = %roots.config.display(),
             "io adapters registered",
         );
+        Ok(Self { registry, mailer })
+    }
 
-        let transport = Arc::new(NativeTransport::from_ctx(
-            ctx,
-            mailbox_id,
-            Self::FRAME_BARRIER,
-        ));
-        transport.install_inbox(claim.receiver);
-        let dispatcher_transport = Arc::clone(&transport);
-
-        let thread = thread::Builder::new()
-            .name("aether-io-sink".into())
-            .spawn(move || {
-                while let Some(env) = dispatcher_transport.recv_blocking() {
-                    dispatch_io_mail(&registry, &mailer, env.kind, env.sender, &env.payload);
-                }
-            })
-            .map_err(|e| BootError::Other(Box::new(e)))?;
-
-        self.thread = Some(thread);
-        self.sink_sender = Some(claim.sink_sender);
-        self._transport = Some(transport);
-        Ok(self)
+    /// Construct from an explicit pre-built registry. Used by tests
+    /// that supply a save-only registry against a tempdir.
+    #[cfg(test)]
+    pub fn from_registry(registry: Arc<AdapterRegistry>, mailer: Arc<Mailer>) -> Self {
+        Self { registry, mailer }
     }
 }
 
-impl Drop for IoCapability {
-    fn drop(&mut self) {
-        // Drop the strong sender first to break the channel.
-        self.sink_sender.take();
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
-        }
+impl IoBackend for IoAdapterBackend {
+    fn on_read(&mut self, sender: ReplyTo, mail: Read) {
+        let Some(adapter) = self.registry.get(&mail.namespace) else {
+            self.mailer.send_reply(
+                sender,
+                &ReadResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                },
+            );
+            return;
+        };
+        let reply = match adapter.read(&mail.path) {
+            Ok(bytes) => ReadResult::Ok {
+                namespace: mail.namespace,
+                path: mail.path,
+                bytes,
+            },
+            Err(error) => ReadResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error,
+            },
+        };
+        self.mailer.send_reply(sender, &reply);
+    }
+
+    fn on_write(&mut self, sender: ReplyTo, mail: Write) {
+        let Some(adapter) = self.registry.get(&mail.namespace) else {
+            self.mailer.send_reply(
+                sender,
+                &WriteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                },
+            );
+            return;
+        };
+        let reply = match adapter.write(&mail.path, &mail.bytes) {
+            Ok(()) => WriteResult::Ok {
+                namespace: mail.namespace,
+                path: mail.path,
+            },
+            Err(error) => WriteResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error,
+            },
+        };
+        self.mailer.send_reply(sender, &reply);
+    }
+
+    fn on_delete(&mut self, sender: ReplyTo, mail: Delete) {
+        let Some(adapter) = self.registry.get(&mail.namespace) else {
+            self.mailer.send_reply(
+                sender,
+                &DeleteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                },
+            );
+            return;
+        };
+        let reply = match adapter.delete(&mail.path) {
+            Ok(()) => DeleteResult::Ok {
+                namespace: mail.namespace,
+                path: mail.path,
+            },
+            Err(error) => DeleteResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error,
+            },
+        };
+        self.mailer.send_reply(sender, &reply);
+    }
+
+    fn on_list(&mut self, sender: ReplyTo, mail: List) {
+        let Some(adapter) = self.registry.get(&mail.namespace) else {
+            self.mailer.send_reply(
+                sender,
+                &ListResult::Err {
+                    namespace: mail.namespace,
+                    prefix: mail.prefix,
+                    error: IoError::UnknownNamespace,
+                },
+            );
+            return;
+        };
+        let reply = match adapter.list(&mail.prefix) {
+            Ok(entries) => ListResult::Ok {
+                namespace: mail.namespace,
+                prefix: mail.prefix,
+                entries,
+            },
+            Err(error) => ListResult::Err {
+                namespace: mail.namespace,
+                prefix: mail.prefix,
+                error,
+            },
+        };
+        self.mailer.send_reply(sender, &reply);
     }
 }
 
@@ -666,8 +478,10 @@ mod tests {
     use std::env::temp_dir;
 
     use super::*;
-    use crate::capability::ChassisBuilder;
+    use crate::capability::{BootError, ChassisBuilder};
     use crate::registry::Registry;
+    use aether_data::{Actor, Kind};
+    use aether_kinds::IoCapability;
 
     /// Manual tempdir helper to avoid pulling in the `tempfile`
     /// crate. Caller cleans up via [`cleanup`] after the test asserts.
@@ -931,30 +745,37 @@ mod tests {
         postcard::from_bytes(&payload).unwrap()
     }
 
-    /// Boot the capability against a fresh tempdir; assert the sink
+    /// Boot the cap against a fresh tempdir; assert the mailbox
     /// is registered.
     #[test]
-    fn capability_boots_and_registers_sink() {
+    fn capability_boots_and_registers_mailbox() {
         let root = scratch_root("boots");
         let (registry, mailer) = fresh_substrate();
+        let backend =
+            IoAdapterBackend::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(IoCapability::new(roots_under(&root)))
+            .with_facade(IoCapability::new(backend))
             .build()
             .expect("io capability boots");
         assert!(
-            registry.lookup(IoCapability::NAMESPACE).is_some(),
-            "sink mailbox registered"
+            registry
+                .lookup(<IoCapability<IoAdapterBackend> as Actor>::NAMESPACE)
+                .is_some(),
+            "io mailbox registered"
         );
         chassis.shutdown();
         cleanup(&root);
     }
 
-    /// Boot fails with a typed [`BootError::Other`] when the adapter
-    /// registry can't be built. Provoke `LocalFileAdapter::new`
-    /// failure by pointing the save root at a regular file rather
-    /// than a directory.
+    /// Backend init fails when the adapter registry can't be built —
+    /// provoke `LocalFileAdapter::new` failure by pointing the save
+    /// root at a regular file rather than a directory. Pre-PR-D3 this
+    /// surfaced as `BootError::Other` from `IoCapability::boot`; the
+    /// facade pattern moves the error to construction time
+    /// (`IoAdapterBackend::new` returns `std::io::Result`), so the
+    /// chassis main propagates it via `?` to the same fail-fast result.
     #[test]
-    fn boot_fails_with_typed_error_when_adapter_init_fails() {
+    fn backend_init_fails_when_adapter_init_fails() {
         let root = scratch_root("init-fails");
         let save_path = root.join("save_is_actually_a_file");
         std::fs::write(&save_path, b"not a dir").unwrap();
@@ -966,12 +787,12 @@ mod tests {
         std::fs::create_dir_all(&roots.assets).unwrap();
         std::fs::create_dir_all(&roots.config).unwrap();
 
-        let (registry, mailer) = fresh_substrate();
-        let err = ChassisBuilder::new(registry, mailer)
-            .with(IoCapability::new(roots))
-            .build()
-            .expect_err("save root being a file must fail");
-        assert!(matches!(err, BootError::Other(_)));
+        let (_, mailer) = fresh_substrate();
+        let result = IoAdapterBackend::new(roots, mailer);
+        assert!(
+            result.is_err(),
+            "save root being a file must fail backend init"
+        );
         cleanup(&root);
     }
 
@@ -981,34 +802,42 @@ mod tests {
     fn duplicate_claim_rejects_with_typed_error() {
         let root = scratch_root("collide");
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(
+            <IoCapability<IoAdapterBackend> as Actor>::NAMESPACE,
+            Arc::new(|_, _, _, _, _, _| {}),
+        );
 
+        let backend =
+            IoAdapterBackend::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(IoCapability::new(roots_under(&root)))
+            .with_facade(IoCapability::new(backend))
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == IoCapability::NAMESPACE
+            BootError::MailboxAlreadyClaimed { ref name }
+                if name == <IoCapability<IoAdapterBackend> as Actor>::NAMESPACE
         ));
         cleanup(&root);
     }
 
     #[test]
-    fn dispatch_read_ok_replies_with_bytes() {
-        let root = scratch_root("dispatch-read");
+    fn backend_read_ok_replies_with_bytes() {
+        let root = scratch_root("backend-read");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save")
             .unwrap()
             .write("slot.bin", &[9, 9, 9])
             .unwrap();
-        let req = postcard::to_allocvec(&Read {
-            namespace: "save".to_string(),
-            path: "slot.bin".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_read(
+            session_sender(),
+            Read {
+                namespace: "save".to_string(),
+                path: "slot.bin".to_string(),
+            },
+        );
         match decode_reply::<ReadResult>(&rx) {
             ReadResult::Ok {
                 namespace,
@@ -1025,25 +854,24 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_read_unknown_namespace_replies_err() {
-        let root = scratch_root("dispatch-ns");
+    fn backend_read_unknown_namespace_replies_err() {
+        let root = scratch_root("backend-ns");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Read {
-            namespace: "nope".to_string(),
-            path: "x.bin".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_read(
+            session_sender(),
+            Read {
+                namespace: "nope".to_string(),
+                path: "x.bin".to_string(),
+            },
+        );
         match decode_reply::<ReadResult>(&rx) {
             ReadResult::Err {
                 namespace,
                 path,
                 error: IoError::UnknownNamespace,
             } => {
-                // Echoed fields survive the unknown-namespace path —
-                // the dispatcher pulls them from the decoded request
-                // before looking up the adapter.
                 assert_eq!(namespace, "nope");
                 assert_eq!(path, "x.bin");
             }
@@ -1053,16 +881,18 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_read_not_found_replies_err() {
-        let root = scratch_root("dispatch-nf");
+    fn backend_read_not_found_replies_err() {
+        let root = scratch_root("backend-nf");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Read {
-            namespace: "save".to_string(),
-            path: "ghost.bin".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Read as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_read(
+            session_sender(),
+            Read {
+                namespace: "save".to_string(),
+                path: "ghost.bin".to_string(),
+            },
+        );
         assert!(matches!(
             decode_reply::<ReadResult>(&rx),
             ReadResult::Err {
@@ -1074,17 +904,20 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_write_ok_persists_bytes() {
-        let root = scratch_root("dispatch-write");
+    fn backend_write_ok_persists_bytes() {
+        let root = scratch_root("backend-write");
         let reg = build_save_only_registry(&root, true);
+        let reg_clone = Arc::clone(&reg);
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Write {
-            namespace: "save".to_string(),
-            path: "slot.bin".to_string(),
-            bytes: vec![1, 2, 3],
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Write as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_write(
+            session_sender(),
+            Write {
+                namespace: "save".to_string(),
+                path: "slot.bin".to_string(),
+                bytes: vec![1, 2, 3],
+            },
+        );
         match decode_reply::<WriteResult>(&rx) {
             WriteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
@@ -1093,24 +926,26 @@ mod tests {
             WriteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
         }
         assert_eq!(
-            reg.get("save").unwrap().read("slot.bin").unwrap(),
+            reg_clone.get("save").unwrap().read("slot.bin").unwrap(),
             vec![1, 2, 3]
         );
         cleanup(&root);
     }
 
     #[test]
-    fn dispatch_write_read_only_namespace_replies_forbidden() {
-        let root = scratch_root("dispatch-ro");
+    fn backend_write_read_only_namespace_replies_forbidden() {
+        let root = scratch_root("backend-ro");
         let reg = build_save_only_registry(&root, false);
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Write {
-            namespace: "save".to_string(),
-            path: "slot.bin".to_string(),
-            bytes: vec![],
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Write as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_write(
+            session_sender(),
+            Write {
+                namespace: "save".to_string(),
+                path: "slot.bin".to_string(),
+                bytes: vec![],
+            },
+        );
         assert!(matches!(
             decode_reply::<WriteResult>(&rx),
             WriteResult::Err {
@@ -1122,17 +957,20 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_delete_then_read_surfaces_not_found() {
-        let root = scratch_root("dispatch-del");
+    fn backend_delete_then_read_surfaces_not_found() {
+        let root = scratch_root("backend-del");
         let reg = build_save_only_registry(&root, true);
+        let reg_clone = Arc::clone(&reg);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("x.bin", b"x").unwrap();
-        let req = postcard::to_allocvec(&Delete {
-            namespace: "save".to_string(),
-            path: "x.bin".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <Delete as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_delete(
+            session_sender(),
+            Delete {
+                namespace: "save".to_string(),
+                path: "x.bin".to_string(),
+            },
+        );
         match decode_reply::<DeleteResult>(&rx) {
             DeleteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
@@ -1141,25 +979,27 @@ mod tests {
             DeleteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
         }
         assert!(matches!(
-            reg.get("save").unwrap().read("x.bin"),
+            reg_clone.get("save").unwrap().read("x.bin"),
             Err(IoError::NotFound)
         ));
         cleanup(&root);
     }
 
     #[test]
-    fn dispatch_list_returns_sorted_entries() {
-        let root = scratch_root("dispatch-list");
+    fn backend_list_returns_sorted_entries() {
+        let root = scratch_root("backend-list");
         let reg = build_save_only_registry(&root, true);
         let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("b.bin", b"").unwrap();
         reg.get("save").unwrap().write("a.bin", b"").unwrap();
-        let req = postcard::to_allocvec(&List {
-            namespace: "save".to_string(),
-            prefix: "".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(&reg, &mailer, <List as Kind>::ID, session_sender(), &req);
+        let mut backend = IoAdapterBackend::from_registry(reg, mailer);
+        backend.on_list(
+            session_sender(),
+            List {
+                namespace: "save".to_string(),
+                prefix: "".to_string(),
+            },
+        );
         match decode_reply::<ListResult>(&rx) {
             ListResult::Ok {
                 namespace,
@@ -1175,18 +1015,13 @@ mod tests {
         cleanup(&root);
     }
 
-    #[test]
-    fn dispatch_unknown_kind_id_does_not_reply() {
-        // An unrelated kind id hitting the io sink should warn-drop,
-        // not panic, and must not produce a reply (nothing for the
-        // sender to be waiting on).
-        let root = scratch_root("dispatch-unknown");
-        let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
-        dispatch_io_mail(&reg, &mailer, KindId(0xdead_beef), session_sender(), &[]);
-        assert!(rx.try_recv().is_err(), "unexpected reply on unknown kind");
-        cleanup(&root);
-    }
+    // Pre-PR-D3 dispatch tests for "unknown kind id" and "malformed
+    // payload bytes" hit the dispatcher's catch-all warn-drop path
+    // and the per-kind decode-failure branch respectively. Under the
+    // facade pattern both go through the macro-emitted
+    // `Dispatch::__dispatch` miss path: chassis-side warn log + no
+    // reply (sender's wait_reply times out). Behaviour matches Handle
+    // PR D2; consistent across every facade cap.
 
     /// End-to-end: a component pushes a `Read` at the io sink and
     /// receives the `ReadResult` via `Mailer::send_reply` →
@@ -1271,17 +1106,17 @@ mod tests {
             .insert(caller_mailbox, Arc::clone(&entry));
 
         // Dispatch a Read with sender = Component(caller_mailbox).
-        let req = postcard::to_allocvec(&Read {
-            namespace: "save".to_string(),
-            path: "slot.bin".to_string(),
-        })
-        .unwrap();
-        dispatch_io_mail(
-            &reg,
-            &mailer,
-            <Read as Kind>::ID,
-            ReplyTo::to(crate::mail::ReplyTarget::Component(caller_mailbox)),
-            &req,
+        // Call the backend directly — the chassis dispatcher's macro-
+        // emitted `Dispatch::__dispatch` would route the same way, but
+        // staying out of the chassis here keeps the test focused on
+        // the reply-routing path.
+        let mut backend = IoAdapterBackend::from_registry(reg, Arc::clone(&mailer));
+        backend.on_read(
+            ReplyTo::to(aether_data::ReplyTarget::Component(caller_mailbox)),
+            Read {
+                namespace: "save".to_string(),
+                path: "slot.bin".to_string(),
+            },
         );
 
         // Wait for the reply to reach receive.
@@ -1298,38 +1133,6 @@ mod tests {
             "component received a kind id different from ReadResult",
         );
 
-        cleanup(&root);
-    }
-
-    #[test]
-    fn dispatch_malformed_payload_replies_adapter_error_with_empty_echo() {
-        // Bytes that don't postcard-decode as `Read`. Dispatcher
-        // must fall through to the decode-error branch and reply
-        // with `IoError::AdapterError` rather than hang. Echo
-        // fields are empty strings because the dispatcher has no
-        // parsed request to pull them from — loud signal that the
-        // request itself was malformed.
-        let root = scratch_root("dispatch-mal");
-        let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
-        dispatch_io_mail(
-            &reg,
-            &mailer,
-            <Read as Kind>::ID,
-            session_sender(),
-            &[0xffu8; 4],
-        );
-        match decode_reply::<ReadResult>(&rx) {
-            ReadResult::Err {
-                namespace,
-                path,
-                error: IoError::AdapterError(_),
-            } => {
-                assert_eq!(namespace, "");
-                assert_eq!(path, "");
-            }
-            other => panic!("expected Err AdapterError with empty echo, got {other:?}"),
-        }
         cleanup(&root);
     }
 }

--- a/crates/aether-substrate/src/capabilities/mod.rs
+++ b/crates/aether-substrate/src/capabilities/mod.rs
@@ -28,8 +28,8 @@ pub mod render;
 #[cfg(feature = "audio")]
 pub use audio::{AudioCapability, AudioConfig};
 pub use handle::HandleStoreBackend;
-pub use io::IoCapability;
+pub use io::IoAdapterBackend;
 pub use log::LogTracingBackend;
-pub use net::NetCapability;
+pub use net::NetAdapterBackend;
 #[cfg(feature = "render")]
 pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles};

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -1,40 +1,30 @@
-//! ADR-0070 Phase 3 (part 3): network egress sink as a native
-//! capability.
+//! ADR-0070 Phase 3 (part 3) + ADR-0075 §Decision 3: net-egress
+//! backend behind the [`aether_kinds::NetCapability`] facade.
 //!
 //! Owns the full HTTP egress stack — `NetAdapter` trait, the `ureq`-
-//! backed `UreqNetAdapter`, env-driven `NetConfig`, the
-//! `aether.net` mailbox claim, and the dispatcher thread that
-//! decodes `Fetch` envelopes and invokes the adapter. Chassis mains
-//! resolve a [`NetConfig`] (typically via [`NetConfig::from_env`])
-//! and pass it to [`NetCapability::new`]; everything below the
+//! backed `UreqNetAdapter`, env-driven `NetConfig`, and the
+//! `NetBackend` impl the chassis installs at boot. Chassis mains
+//! resolve a [`NetConfig`] (typically via [`NetConfig::from_env`]),
+//! pass it to [`NetAdapterBackend::new`], and hand the resulting
+//! backend to `NetCapability::new(...)`. Everything below the
 //! capability boundary is private.
 //!
 //! v1 semantics (ADR-0043):
-//! - Blocking on the sink dispatch thread (one request at a time).
+//! - Blocking on the dispatcher thread (one request at a time).
 //! - Buffered request + response bodies; streaming is deferred.
 //! - Deny-by-default allowlist via `AETHER_NET_ALLOWLIST`.
 //! - Response size capped at `AETHER_NET_MAX_BODY_BYTES` (16MB).
 //! - Default request timeout 30s, per-request override via
 //!   `Fetch.timeout_ms`.
-//!
-//! Permissioning by env var is the stopgap until the capabilities
-//! ADR lands; this module's surface doesn't change when that
-//! arrives — the allowlist source moves from process env to
-//! per-component declarations gated at `load_component`.
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use aether_actor::Actor;
+use aether_data::ReplyTo;
+use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetBackend, NetError};
 
-use crate::capability::{BootError, Capability, ChassisCtx, SinkSender};
-use crate::mail::ReplyTo;
 use crate::mailer::Mailer;
-use crate::native_transport::NativeTransport;
-use aether_data::{Kind, KindId};
-use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -46,7 +36,7 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
 
 /// Adapter-facing request shape. Converted from the wire `Fetch`
-/// kind by the dispatcher before handing to the adapter.
+/// kind by the backend before handing to the adapter.
 pub struct FetchRequest {
     pub url: String,
     pub method: HttpMethod,
@@ -56,7 +46,7 @@ pub struct FetchRequest {
 }
 
 /// Adapter-facing response shape. Converted to the wire
-/// `FetchResult::Ok` by the dispatcher.
+/// `FetchResult::Ok` by the backend.
 pub struct FetchResponse {
     pub status: u16,
     pub headers: Vec<HttpHeader>,
@@ -66,7 +56,7 @@ pub struct FetchResponse {
 /// HTTP backend. One method — `fetch` — takes a validated request
 /// and returns the response or a structured error. The adapter is
 /// responsible for allowlist enforcement, URL validation, body
-/// caps, and timeout application; the dispatcher just moves bytes
+/// caps, and timeout application; the backend just moves bytes
 /// between wire and adapter.
 pub trait NetAdapter: Send + Sync {
     fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError>;
@@ -87,7 +77,7 @@ impl NetAdapter for DisabledNetAdapter {
 /// `ureq`-backed adapter. Holds the shared agent, the allowlist
 /// (empty = deny all), the response cap, and the `require_https`
 /// flag. Thread-safe: `ureq::Agent` is cheaply cloneable and
-/// internally synchronised, so the same adapter drives the sink
+/// internally synchronised, so the same adapter drives the backend
 /// from one dispatch thread today and would parallelise cleanly
 /// behind a multi-thread dispatcher later.
 pub struct UreqNetAdapter {
@@ -241,7 +231,7 @@ fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
 /// mains read env vars (`AETHER_NET_DISABLE`, `AETHER_NET_ALLOWLIST`,
 /// `AETHER_NET_REQUIRE_HTTPS`, `AETHER_NET_MAX_BODY_BYTES`,
 /// `AETHER_NET_TIMEOUT_MS`) into a `NetConfig` and pass it to
-/// [`NetCapability::new`]. Tests build a `NetConfig` directly,
+/// [`NetAdapterBackend::new`]. Tests build a `NetConfig` directly,
 /// never touching process env (issue 464).
 #[derive(Clone, Debug)]
 pub struct NetConfig {
@@ -264,10 +254,6 @@ pub struct NetConfig {
 }
 
 impl Default for NetConfig {
-    /// Conservative default: enabled, empty allowlist (deny all),
-    /// no require-https, default body cap and timeout. Tests that
-    /// want a closed adapter typically construct
-    /// `NetConfig { disabled: true, ..Default::default() }`.
     fn default() -> Self {
         Self {
             disabled: false,
@@ -294,10 +280,7 @@ impl NetConfig {
     }
 }
 
-/// Build a net adapter from explicit configuration. `disabled`
-/// short-circuits to a `DisabledNetAdapter`; otherwise constructs a
-/// `UreqNetAdapter` with the supplied allowlist / https-flag /
-/// body-cap. Per issue 464, this is the explicit-config entry point.
+/// Build a net adapter from explicit configuration.
 pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
     if config.disabled {
         tracing::info!(
@@ -322,9 +305,7 @@ pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
     ))
 }
 
-/// Env-driven wrapper around [`build_net_adapter`]. Resolves
-/// [`NetConfig::from_env`] then delegates. Kept for callers that
-/// don't need to thread config through their own struct.
+/// Env-driven wrapper around [`build_net_adapter`].
 pub fn build_default_adapter() -> Arc<dyn NetAdapter> {
     build_net_adapter(NetConfig::from_env())
 }
@@ -369,172 +350,85 @@ fn parse_default_timeout_env() -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-/// Demultiplex one envelope's payload to `Fetch` dispatch. The
-/// dispatcher thread invokes this for each envelope it receives.
+/// Substrate-side state for the net cap. Holds the resolved adapter,
+/// the chassis [`Arc<Mailer>`] for routing replies, and the default
+/// per-request timeout applied when `Fetch.timeout_ms` is `None`.
 ///
-/// The reply router is `Mailer::send_reply`, so session / engine-
-/// mailbox / local-component replies all funnel through one path —
-/// identical to the io sink.
-///
-/// `default_timeout` is the fallback applied when an incoming
-/// `Fetch` has `timeout_ms: None`.
-///
-/// Fetches run synchronously on the dispatcher thread — ADR-0043
-/// §2 flags this as the head-of-line blocking source to fix via a
-/// multi-threaded dispatcher ADR.
-fn dispatch_net_mail(
-    adapter: &dyn NetAdapter,
-    mailer: &Mailer,
-    kind: KindId,
-    sender: ReplyTo,
-    bytes: &[u8],
+/// The dispatcher thread owns this through the macro-emitted
+/// `Dispatch` impl on `aether_kinds::NetCapability<Self>`; the
+/// chassis stores only the `FacadeHandle` wrapper.
+pub struct NetAdapterBackend {
+    adapter: Arc<dyn NetAdapter>,
+    mailer: Arc<Mailer>,
     default_timeout: Duration,
-) {
-    if kind != <Fetch as Kind>::ID {
-        tracing::warn!(
-            target: "aether_substrate::net",
-            kind = %kind,
-            "net sink received unknown kind — dropping",
-        );
-        return;
-    }
-
-    let req: Fetch = match postcard::from_bytes(bytes) {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(
-                target: "aether_substrate::net",
-                error = %e,
-                "fetch: decode failed, replying Err",
-            );
-            mailer.send_reply(
-                sender,
-                &FetchResult::Err {
-                    url: String::new(),
-                    error: NetError::AdapterError(format!("decode failed: {e}")),
-                },
-            );
-            return;
-        }
-    };
-
-    let timeout = req
-        .timeout_ms
-        .map(|ms| Duration::from_millis(ms as u64))
-        .unwrap_or(default_timeout);
-
-    let url = req.url.clone();
-    let adapter_req = FetchRequest {
-        url: req.url,
-        method: req.method,
-        headers: req.headers,
-        body: req.body,
-        timeout,
-    };
-
-    let reply = match adapter.fetch(adapter_req) {
-        Ok(r) => FetchResult::Ok {
-            url,
-            status: r.status,
-            headers: r.headers,
-            body: r.body,
-        },
-        Err(error) => FetchResult::Err { url, error },
-    };
-    mailer.send_reply(sender, &reply);
 }
 
-/// Native capability owning the ADR-0043 net-egress sink. Constructor
-/// takes a [`NetConfig`] (resolved from env or built explicitly by
-/// the chassis main per issue 464).
-///
-/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
-/// (`config`) lives alongside the runtime fields populated in
-/// `boot`. `Drop` runs the prior `shutdown` body.
-pub struct NetCapability {
-    config: Option<NetConfig>,
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    _transport: Option<Arc<NativeTransport>>,
-}
-
-impl NetCapability {
-    pub fn new(config: NetConfig) -> Self {
-        Self {
-            config: Some(config),
-            thread: None,
-            sink_sender: None,
-            _transport: None,
-        }
-    }
-}
-
-impl Actor for NetCapability {
-    /// Components mail `aether.net.{fetch,cancel}` (kind ids) to this
-    /// mailbox; the SDK helpers in `aether-component::net` resolve
-    /// through here. The `aether.<name>` form is the post-ADR-0074
-    /// Phase 5 convention for chassis-owned mailboxes.
-    const NAMESPACE: &'static str = "aether.net";
-}
-
-impl Capability for NetCapability {
-    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-        let claim = ctx.claim_mailbox_drop_on_shutdown::<Self>()?;
-        let mailer: Arc<Mailer> = ctx.mail_send_handle();
-        let mailbox_id = claim.id;
-        let config = self
-            .config
-            .take()
-            .expect("NetCapability::boot called twice — `config` already consumed");
+impl NetAdapterBackend {
+    /// Construct from a [`NetConfig`] (resolved by the chassis main
+    /// — typically via [`NetConfig::from_env`]) and the chassis's
+    /// [`Mailer`]. The adapter is built immediately so any
+    /// configuration error surfaces at chassis-builder time, not at
+    /// first fetch.
+    pub fn new(config: NetConfig, mailer: Arc<Mailer>) -> Self {
         let default_timeout = config.default_timeout;
-        let adapter = build_net_adapter(config);
+        Self {
+            adapter: build_net_adapter(config),
+            mailer,
+            default_timeout,
+        }
+    }
 
-        let transport = Arc::new(NativeTransport::from_ctx(
-            ctx,
-            mailbox_id,
-            Self::FRAME_BARRIER,
-        ));
-        transport.install_inbox(claim.receiver);
-        let dispatcher_transport = Arc::clone(&transport);
-
-        let thread = thread::Builder::new()
-            .name("aether-net-sink".into())
-            .spawn(move || {
-                while let Some(env) = dispatcher_transport.recv_blocking() {
-                    dispatch_net_mail(
-                        adapter.as_ref(),
-                        &mailer,
-                        env.kind,
-                        env.sender,
-                        &env.payload,
-                        default_timeout,
-                    );
-                }
-            })
-            .map_err(|e| BootError::Other(Box::new(e)))?;
-
-        self.thread = Some(thread);
-        self.sink_sender = Some(claim.sink_sender);
-        self._transport = Some(transport);
-        Ok(self)
+    /// Construct from an explicit adapter. Used by tests that supply
+    /// a stub.
+    pub fn from_adapter(
+        adapter: Arc<dyn NetAdapter>,
+        mailer: Arc<Mailer>,
+        default_timeout: Duration,
+    ) -> Self {
+        Self {
+            adapter,
+            mailer,
+            default_timeout,
+        }
     }
 }
 
-impl Drop for NetCapability {
-    fn drop(&mut self) {
-        // Drop the strong sender first to break the channel.
-        self.sink_sender.take();
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
-        }
+impl NetBackend for NetAdapterBackend {
+    fn on_fetch(&mut self, sender: ReplyTo, mail: Fetch) {
+        let timeout = mail
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64))
+            .unwrap_or(self.default_timeout);
+
+        let url = mail.url.clone();
+        let adapter_req = FetchRequest {
+            url: mail.url,
+            method: mail.method,
+            headers: mail.headers,
+            body: mail.body,
+            timeout,
+        };
+
+        let reply = match self.adapter.fetch(adapter_req) {
+            Ok(r) => FetchResult::Ok {
+                url,
+                status: r.status,
+                headers: r.headers,
+                body: r.body,
+            },
+            Err(error) => FetchResult::Err { url, error },
+        };
+        self.mailer.send_reply(sender, &reply);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capability::ChassisBuilder;
+    use crate::capability::{BootError, ChassisBuilder};
     use crate::registry::Registry;
+    use aether_data::{Actor, Kind};
+    use aether_kinds::NetCapability;
     use std::sync::Mutex;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
@@ -576,12 +470,12 @@ mod tests {
         }
     }
 
-    use aether_data::{SessionToken, Uuid};
+    use aether_data::{ReplyTarget, SessionToken, Uuid};
 
     use crate::outbound::EgressEvent;
 
     fn session_sender() -> ReplyTo {
-        ReplyTo::to(crate::mail::ReplyTarget::Session(SessionToken(Uuid::nil())))
+        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
     }
 
     fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
@@ -601,7 +495,7 @@ mod tests {
     fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
         rx: &std::sync::mpsc::Receiver<EgressEvent>,
     ) -> K {
-        let event = rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap();
+        let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();
         let EgressEvent::ToSession {
             kind_name, payload, ..
         } = event
@@ -612,66 +506,75 @@ mod tests {
         postcard::from_bytes(&payload).unwrap()
     }
 
-    /// Boot the capability against a default disabled NetConfig and
-    /// confirm the sink is registered.
+    /// Boot the cap against a default disabled NetConfig and confirm
+    /// the mailbox is registered.
     #[test]
-    fn capability_boots_and_registers_sink() {
+    fn capability_boots_and_registers_mailbox() {
         let (registry, mailer) = fresh_substrate();
         let config = NetConfig {
             disabled: true,
             ..NetConfig::default()
         };
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(NetCapability::new(config))
+            .with_facade(NetCapability::new(NetAdapterBackend::new(
+                config,
+                Arc::clone(&mailer),
+            )))
             .build()
             .expect("net capability boots");
         assert!(
-            registry.lookup(NetCapability::NAMESPACE).is_some(),
-            "sink mailbox registered"
+            registry
+                .lookup(<NetCapability<NetAdapterBackend> as Actor>::NAMESPACE)
+                .is_some(),
+            "net mailbox registered"
         );
         chassis.shutdown();
     }
 
-    /// Builder rejects a duplicate claim. Same protection as the
-    /// other capabilities.
+    /// Builder rejects a duplicate claim.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink(NetCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+        registry.register_sink(
+            <NetCapability<NetAdapterBackend> as Actor>::NAMESPACE,
+            Arc::new(|_, _, _, _, _, _| {}),
+        );
         let config = NetConfig {
             disabled: true,
             ..NetConfig::default()
         };
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(NetCapability::new(config))
+            .with_facade(NetCapability::new(NetAdapterBackend::new(
+                config,
+                Arc::clone(&mailer),
+            )))
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,
-            BootError::MailboxAlreadyClaimed { ref name } if name == NetCapability::NAMESPACE
+            BootError::MailboxAlreadyClaimed { ref name }
+                if name == <NetCapability<NetAdapterBackend> as Actor>::NAMESPACE
         ));
     }
 
     #[test]
     fn disabled_adapter_replies_disabled() {
-        let adapter: Arc<dyn NetAdapter> = Arc::new(DisabledNetAdapter);
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Fetch {
-            url: "https://api.example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout_ms: None,
-        })
-        .unwrap();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            <Fetch as Kind>::ID,
-            session_sender(),
-            &req,
+        let mut backend = NetAdapterBackend::from_adapter(
+            Arc::new(DisabledNetAdapter),
+            mailer,
             NetConfig::default().default_timeout,
+        );
+        backend.on_fetch(
+            session_sender(),
+            Fetch {
+                url: "https://api.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: None,
+            },
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Err {
@@ -756,31 +659,30 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_fetch_ok_replies_with_response() {
-        let adapter = StubAdapter::with(Ok(FetchResponse {
+    fn backend_fetch_ok_replies_with_response() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let stub = StubAdapter::with(Ok(FetchResponse {
             status: 200,
             headers: vec![HttpHeader {
                 name: "content-type".to_string(),
                 value: "application/json".to_string(),
             }],
             body: b"{}".to_vec(),
-        })) as Arc<dyn NetAdapter>;
-        let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Fetch {
-            url: "https://api.example.com/v1".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout_ms: Some(5000),
-        })
-        .unwrap();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            <Fetch as Kind>::ID,
-            session_sender(),
-            &req,
+        }));
+        let mut backend = NetAdapterBackend::from_adapter(
+            stub as Arc<dyn NetAdapter>,
+            mailer,
             NetConfig::default().default_timeout,
+        );
+        backend.on_fetch(
+            session_sender(),
+            Fetch {
+                url: "https://api.example.com/v1".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: Some(5000),
+            },
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Ok {
@@ -799,24 +701,22 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_fetch_err_echoes_url_and_error() {
-        let adapter = StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>;
+    fn backend_fetch_err_echoes_url_and_error() {
         let (mailer, rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Fetch {
-            url: "https://slow.example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout_ms: None,
-        })
-        .unwrap();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            <Fetch as Kind>::ID,
-            session_sender(),
-            &req,
+        let mut backend = NetAdapterBackend::from_adapter(
+            StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>,
+            mailer,
             NetConfig::default().default_timeout,
+        );
+        backend.on_fetch(
+            session_sender(),
+            Fetch {
+                url: "https://slow.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: None,
+            },
         );
         match decode_reply::<FetchResult>(&rx) {
             FetchResult::Err { url, error } => {
@@ -828,73 +728,30 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_malformed_bytes_replies_adapter_error_with_empty_url() {
-        let adapter = StubAdapter::with(Ok(FetchResponse {
-            status: 200,
-            headers: vec![],
-            body: vec![],
-        })) as Arc<dyn NetAdapter>;
-        let (mailer, rx) = test_mailer_and_rx();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            <Fetch as Kind>::ID,
-            session_sender(),
-            &[0xffu8; 8],
-            NetConfig::default().default_timeout,
-        );
-        match decode_reply::<FetchResult>(&rx) {
-            FetchResult::Err {
-                url,
-                error: NetError::AdapterError(_),
-            } => {
-                assert_eq!(url, "");
-            }
-            other => panic!("expected Err AdapterError with empty url, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn dispatch_unknown_kind_does_not_reply() {
-        let adapter = StubAdapter::with(Err(NetError::Disabled)) as Arc<dyn NetAdapter>;
-        let (mailer, rx) = test_mailer_and_rx();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            KindId(0xdead_beef),
-            session_sender(),
-            &[],
-            NetConfig::default().default_timeout,
-        );
-        assert!(rx.try_recv().is_err(), "unexpected reply on unknown kind");
-    }
-
-    #[test]
-    fn dispatch_fetch_uses_default_timeout_when_none_provided() {
-        let adapter_stub = StubAdapter::with(Ok(FetchResponse {
+    fn backend_uses_default_timeout_when_none_provided() {
+        let (mailer, _rx) = test_mailer_and_rx();
+        let stub = StubAdapter::with(Ok(FetchResponse {
             status: 200,
             headers: vec![],
             body: vec![],
         }));
-        let adapter: Arc<dyn NetAdapter> = Arc::clone(&adapter_stub) as Arc<dyn NetAdapter>;
-        let (mailer, _rx) = test_mailer_and_rx();
-        let req = postcard::to_allocvec(&Fetch {
-            url: "https://api.example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout_ms: None,
-        })
-        .unwrap();
-        dispatch_net_mail(
-            adapter.as_ref(),
-            &mailer,
-            <Fetch as Kind>::ID,
-            session_sender(),
-            &req,
+        let stub_clone = Arc::clone(&stub);
+        let mut backend = NetAdapterBackend::from_adapter(
+            stub as Arc<dyn NetAdapter>,
+            mailer,
             NetConfig::default().default_timeout,
         );
-        let observed = adapter_stub
+        backend.on_fetch(
+            session_sender(),
+            Fetch {
+                url: "https://api.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: None,
+            },
+        );
+        let observed = stub_clone
             .last_request
             .lock()
             .unwrap()
@@ -919,4 +776,20 @@ mod tests {
         });
         assert!(matches!(resp, Err(NetError::Disabled)));
     }
+
+    /// Decode failure now goes through the macro's miss path —
+    /// reaching the backend's `on_fetch` is impossible without a
+    /// well-formed `Fetch`. The pre-PR-D2 dispatcher used to reply
+    /// `AdapterError("decode failed: ...")` with empty url; under
+    /// the facade pattern decode failure logs `tracing::warn!`
+    /// (chassis-side) and the sender's wait_reply times out.
+    /// Documented in PR D2's body; the Net cap inherits the same
+    /// behaviour.
+    #[allow(dead_code)]
+    fn _decode_failure_documentation_sentinel() {}
+
+    /// Silence `Kind` unused-import (handy for the test mod's
+    /// `decode_reply` bound).
+    #[allow(dead_code)]
+    fn _silence_kind<K: Kind>() {}
 }


### PR DESCRIPTION
## Summary

PR D3 of issue 533 / ADR-0075. Two more reply-bearing chassis caps onto the facade pattern. Validates that the PR D1 sender-arg + PR D2 facade shape carries cleanly to caps with multiple kinds.

> **Stacked on PR D2 (PR 542).** Base is `feat/handle-cap-facade`; the diff shows just the D3 changes. When D2 merges, GitHub auto-retargets the base to main.

## Scope adjustment from the original 4-PR plan

Original D3 was Audio + Io + Net. Audio's `cpal::Stream` is `!Send` on macOS, which means the existing inline-on-dispatcher-thread construction doesn't fit the chassis-owns-the-thread model without either a worker thread or a chassis init hook. That's a non-mechanical design beat, so I pulled it out:

- **PR D3** (this PR): Io + Net (both reply-bearing, mechanical).
- **PR D4**: Audio (with whichever init approach we pick — flagging now so you can weigh in).
- **PR D5**: Render (FRAME_BARRIER + driver-supplied state).

## Changes

- **`aether-kinds`**: new `io.rs` and `net.rs` with `IoBackend` / `NetBackend` traits, `ErasedIoBackend` / `ErasedNetBackend` ZSTs, `IoCapability<B>` / `NetCapability<B>` cap structs, and `#[actor]` impls. Every handler is 3-arg `(self, sender, mail)`.
- **`aether-substrate/capabilities/io.rs`** rewritten — `IoAdapterBackend` holds `Arc<AdapterRegistry>` + `Arc<Mailer>` and impls `IoBackend`. The `dispatch_io_mail` per-kind demux is gone; macro-emitted `Dispatch` does the kind matching.
- **`aether-substrate/capabilities/net.rs`** rewritten — `NetAdapterBackend` holds the resolved `Arc<dyn NetAdapter>`, `Arc<Mailer>`, and the default timeout. Adapter machinery (`UreqNetAdapter`, `DisabledNetAdapter`, `NetConfig`, env helpers) preserved verbatim.
- **`boot.rs`**: gains `add_facade<C>` parallel to `add_capability<C>` for caps booted post-build (TestBench uses this path).
- **Bundles** (`desktop`, `headless`, `test_bench` lib + bin) switch from `.with(IoCapability::new(roots))` / `.with(NetCapability::new(net))` to constructing the backend with `Arc::clone(&mailer)` then `.with_facade(...)`. Io's adapter init returns `Result`, propagated via `?` (or via `tracing::warn!` + skip in TestBench, matching pre-PR-D3 behavior on systems without writable default roots).

## Behaviour change carry-over from PR D2

Decode failure on malformed payload bytes used to reply synchronously with `IoError::AdapterError("decode failed: ...")` / `NetError::AdapterError("decode failed: ...")`. Under the facade pattern, decode failure is the macro's "miss" path — `tracing::warn!` (visible via engine_logs) and the sender's wait_reply times out instead. Same rationale as PR D2: schema mismatch at this layer indicates a substrate-side invariant violation, not user-recoverable input.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --workspace` all green (~1300 tests; rewritten io + net dispatcher tests now exercise backend methods directly)
- [x] `cargo check --target wasm32-unknown-unknown` for camera + mesh-viewer + test-fixture-probe components clean
- [x] TestBench integration tests (`io_*`, `frame_stats_broadcast_at_120_tick_cadence`, etc.) pass through the `add_facade` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)