### PR TITLE
refactor(actor): convert render to #[actor] shape + extract RenderHandles (issue 545 PR E2)

### DIFF
--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -1055,12 +1055,14 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                     ));
                 }
                 if let Some(idx) = handler_attr_idx {
-                    let (kind_ty, takes_sender) = extract_native_handler_kind_type(&f.sig)?;
+                    let (kind_ty, takes_sender, is_slice) =
+                        extract_native_handler_kind_type(&f.sig)?;
                     f.attrs.remove(idx);
                     handlers.push(NativeHandlerFn {
                         method: f,
                         kind_ty,
                         takes_sender,
+                        is_slice,
                     });
                 } else {
                     helpers.push(f);
@@ -1124,13 +1126,32 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
         } else {
             quote! { self.#method_ident(__decoded); }
         };
-        quote! {
-            if kind == <#kind_ty as ::aether_data::Kind>::ID.0 {
-                if let Some(__decoded) = <#kind_ty as ::aether_data::Kind>::decode_from_bytes(payload) {
-                    #call
-                    return Some(());
+        if h.is_slice {
+            // Slice handler — payload is `count * size_of::<K>()`
+            // contiguous bytes (ADR-0019 batch wire). Cast to
+            // `&[K]` for the handler. Only meaningful for cast-shape
+            // kinds; postcard kinds reject `&[K]` at the macro
+            // boundary because there's no batched postcard wire.
+            quote! {
+                if kind == <#kind_ty as ::aether_data::Kind>::ID.0 {
+                    if let Some(__decoded) =
+                        ::aether_data::__derive_runtime::decode_cast_slice::<#kind_ty>(payload)
+                    {
+                        #call
+                        return Some(());
+                    }
+                    return None;
                 }
-                return None;
+            }
+        } else {
+            quote! {
+                if kind == <#kind_ty as ::aether_data::Kind>::ID.0 {
+                    if let Some(__decoded) = <#kind_ty as ::aether_data::Kind>::decode_from_bytes(payload) {
+                        #call
+                        return Some(());
+                    }
+                    return None;
+                }
             }
         }
     });
@@ -1166,12 +1187,23 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
 
 struct NativeHandlerFn {
     method: syn::ImplItemFn,
+    /// The kind's inner type. For `mail: K` this is `K`; for slice
+    /// handlers `mail: &[K]` it's also `K` — the slice form just
+    /// changes how the dispatcher decodes from `payload` bytes.
     kind_ty: Type,
-    /// `true` for 3-arg `(&mut self, sender: ReplyTo, mail: K)` — the
+    /// `true` for 3-arg `(&mut self, sender: ReplyTo, mail: …)` — the
     /// dispatcher forwards the envelope's `sender` through to the
-    /// handler. `false` for 2-arg `(&mut self, mail: K)` — sender is
+    /// handler. `false` for 2-arg `(&mut self, mail: …)` — sender is
     /// ignored (fire-and-forget caps like Log).
     takes_sender: bool,
+    /// `true` when the `mail` parameter is `&[K]` rather than `K`.
+    /// The dispatch arm decodes the whole payload as a contiguous
+    /// slice via `bytemuck::cast_slice` so a single envelope with
+    /// `count > 1` (`Mailbox::send_many`, ADR-0019) reaches the
+    /// handler intact. Only valid for cast-shape kinds — postcard
+    /// has no batch wire (postcard slices would need length-prefix
+    /// framing per element).
+    is_slice: bool,
 }
 
 /// Extract `K` from a native handler's signature. Accepts two shapes:
@@ -1182,14 +1214,18 @@ struct NativeHandlerFn {
 ///     trusts the second arg's name/type and forwards the dispatcher's
 ///     `sender` through to it.
 ///
-/// Returns the kind type plus a `takes_sender` flag the caller uses
-/// to pick the right dispatch-arm shape.
-fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<(Type, bool)> {
+/// Returns the kind's inner type plus the `takes_sender` and
+/// `is_slice` flags the caller uses to pick the right dispatch-arm
+/// shape. `is_slice = true` when the parameter is `&[K]` (batched
+/// cast-shape decode); the inner `K` is what `HandlesKind` /
+/// `Kind::ID` reference.
+fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<(Type, bool, bool)> {
     if sig.inputs.len() != 2 && sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
             "native #[handler] method must have signature `(&mut self, arg: K)` \
-             or `(&mut self, sender: ::aether_data::ReplyTo, arg: K)`",
+             or `(&mut self, sender: ::aether_data::ReplyTo, arg: K)` \
+             (where K may also be `&[K]` for batched cast-shape kinds)",
         ));
     }
     let first = &sig.inputs[0];
@@ -1207,7 +1243,15 @@ fn extract_native_handler_kind_type(sig: &Signature) -> syn::Result<(Type, bool)
             "native #[handler] kind parameter must be a typed `arg: K`",
         ));
     };
-    Ok(((*pat_ty.ty).clone(), takes_sender))
+    // Detect `&[K]` slice handlers (any reference to a slice). Inner
+    // `K` is what `HandlesKind` / `Kind::ID` reference; the slice
+    // form just picks a different decode path in the dispatch arm.
+    if let Type::Reference(type_ref) = &*pat_ty.ty
+        && let Type::Slice(slice) = &*type_ref.elem
+    {
+        return Ok(((*slice.elem).clone(), takes_sender, true));
+    }
+    Ok(((*pat_ty.ty).clone(), takes_sender, false))
 }
 
 /// Extract `K` from a handler method's third parameter (`arg: K`).

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -504,6 +504,18 @@ pub mod __derive_runtime {
         Some(bytemuck::pod_read_unaligned(bytes))
     }
 
+    /// Slice-cast helper for batched cast-shape kinds. The native
+    /// `#[handler]` macro emits this when a handler's `mail`
+    /// parameter is `&[K]` rather than `K` — ADR-0019's `send_many`
+    /// wire shape lets one envelope carry `count` contiguous Ks, so
+    /// the handler sees the whole batch in one call. `bytes.len()`
+    /// must be a multiple of `size_of::<T>()` and the slice must be
+    /// suitably aligned; mis-shaped buffers return `None` and the
+    /// dispatcher's miss path warn-logs at the chassis side.
+    pub fn decode_cast_slice<T: bytemuck::AnyBitPattern>(bytes: &[u8]) -> Option<&[T]> {
+        bytemuck::try_cast_slice(bytes).ok()
+    }
+
     /// Postcard-shape decode helper. Sibling of `decode_cast` for
     /// schema-shaped kinds (anything carrying `Vec` / `String` /
     /// `Option` / a tagged enum). `T` satisfies `DeserializeOwned`

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -83,7 +83,6 @@ fn main() -> wasmtime::Result<()> {
         passive,
         mut boot,
         render_handles,
-        render_running,
         kind_tick,
         kind_frame_stats,
         hub,
@@ -96,7 +95,7 @@ fn main() -> wasmtime::Result<()> {
     boot.add_facade(io_cap)?;
 
     let (width, height) = parse_size_env();
-    let gpu = Gpu::new(width, height, render_running);
+    let gpu = Gpu::new(width, height, render_handles.clone());
     tracing::info!(
         target: "aether_substrate::boot",
         adapter = %gpu.adapter_info.name,

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -331,6 +331,13 @@ impl DesktopChassis {
             aether_substrate::lifecycle::OutboundFatalAborter::new(Arc::clone(&boot.outbound)),
         );
 
+        // PR E2: render is now a `#[actor]` cap. Extract the
+        // driver-facing accumulator + GPU bundle before the cap moves
+        // into the chassis builder; the dispatcher thread takes the
+        // cap by value and the driver retains the Arc-shared handles.
+        let render_cap = RenderCapability::new(RenderConfig::default());
+        let render_handles = render_cap.handles();
+
         let driver = DesktopDriverCapability {
             event_loop,
             boot,
@@ -340,13 +347,13 @@ impl DesktopChassis {
             boot_size,
             boot_title,
             hub,
+            render_handles,
         };
 
-        // ADR-0071 phase B: every native cap composes through the
-        // chassis_builder `.with()` chain. Boot order is declaration
-        // order — log first so other capabilities' boot tracing routes
-        // through the log capture; render last among passives so it
-        // claims its mailboxes after every other chassis cap.
+        // Boot order is declaration order — log first so other
+        // capabilities' boot tracing routes through the log capture;
+        // render last so it claims its mailboxes after every other
+        // chassis cap.
         let io_cap = IoCapability::new(namespace_roots, Arc::clone(&mailer))
             .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
@@ -355,7 +362,7 @@ impl DesktopChassis {
             .with_facade(io_cap)
             .with_facade(NetCapability::new(net, Arc::clone(&mailer)))
             .with_facade(AudioCapability::new(audio, Arc::clone(&mailer)))
-            .with(RenderCapability::new(RenderConfig::default()))
+            .with_facade(render_cap)
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -33,7 +33,7 @@ use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, SubstrateBoot,
-    capabilities::{RenderCapability, RenderHandles},
+    capabilities::RenderHandles,
     frame_loop,
     mail::{Mail, MailboxId},
     subscribers_for,
@@ -71,11 +71,11 @@ pub struct App {
     kind_mouse_move: aether_data::KindId,
     kind_window_size: aether_data::KindId,
     kind_frame_stats: aether_data::KindId,
-    /// Cloned out of `RenderCapability` at driver boot. Source-of-truth
-    /// lives in core's `RenderCapability`; the app holds a clone so
+    /// Cloned out of `RenderCapability::handles()` before the cap
+    /// moves into the chassis builder. The app holds a clone so
     /// `Gpu::new` can install wgpu state and the per-frame loop can
     /// call `record_frame` / `record_capture_copy` / `finish_capture`.
-    render_running: Arc<RenderCapability>,
+    render_handles: RenderHandles,
     triangles_rendered: Arc<AtomicU64>,
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
@@ -526,10 +526,7 @@ impl ApplicationHandler<UserEvent> for App {
             }
         }
         let window = Arc::new(event_loop.create_window(attrs).expect("create_window"));
-        self.gpu = Some(Gpu::new(
-            Arc::clone(&window),
-            Arc::clone(&self.render_running),
-        ));
+        self.gpu = Some(Gpu::new(Arc::clone(&window), self.render_handles.clone()));
         window.request_redraw();
         let initial_size = window.inner_size();
         self.window = Some(window);
@@ -708,6 +705,13 @@ pub struct DesktopDriverCapability {
     /// Held for the chassis lifetime so the hub reader + heartbeat
     /// threads stay spawned. `None` when `AETHER_HUB_URL` was unset.
     pub hub: Option<HubClient>,
+    /// Cloned out of `RenderCapability::handles()` before the cap
+    /// moves into the chassis builder. Pre-PR-E2 the driver's `boot`
+    /// pulled `Arc<RenderCapability>` from `DriverCtx::expect`; post-
+    /// E2 the cap is owned by its dispatcher thread (facade pattern)
+    /// and only the Arc-shared handles bundle is reachable from the
+    /// driver side.
+    pub render_handles: RenderHandles,
 }
 
 pub struct DesktopDriverRunning {
@@ -735,19 +739,17 @@ impl DriverCapability for DesktopDriverCapability {
             boot_size,
             boot_title,
             hub,
+            render_handles,
         } = self;
 
-        // Look up RenderCapability's running via the chassis_builder
-        // typed-store (ADR-0071). The render passive booted before
-        // this driver, so its `RenderCapability` is in the typed map;
-        // pull the accumulator handles for the per-frame loop to
-        // read.
-        let render_running: Arc<RenderCapability> = ctx.expect();
-        let RenderHandles {
-            frame_vertices: _,
-            camera_state: _,
-            triangles_rendered,
-        } = render_running.handles();
+        // Render is a facade cap (PR E2) so its dispatcher owns the
+        // cap; the Arc-shared accumulator state was extracted via
+        // `cap.handles()` before the cap moved into the chassis
+        // builder, and the chassis main passed the bundle through
+        // `DesktopDriverCapability.render_handles`. The frame-bound
+        // pending counter is registered separately in the chassis's
+        // `frame_bound_pending` list, queryable here via `ctx`.
+        let triangles_rendered = Arc::clone(&render_handles.triangles_rendered);
         let frame_bound_pending = ctx.frame_bound_pending();
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
@@ -784,7 +786,7 @@ impl DriverCapability for DesktopDriverCapability {
             kind_mouse_move,
             kind_window_size,
             kind_frame_stats,
-            render_running: Arc::clone(&render_running),
+            render_handles,
             triangles_rendered: Arc::clone(&triangles_rendered),
             capture_queue,
             outbound: Arc::clone(&boot.outbound),

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -2,7 +2,7 @@
 // into core's `RenderCapability` (via `RenderGpu` + `install_gpu`); this
 // file now owns only the desktop-specific surface + swapchain config
 // + optional wireframe overlay pipeline. Each frame creates an
-// encoder, asks `render_running.record_frame(...)` to record the
+// encoder, asks `render_handles.record_frame(...)` to record the
 // shared offscreen pass, optionally records a capture copy, copies
 // offscreen → swapchain, submits, and presents.
 //
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use aether_substrate::capabilities::{RenderCapability, RenderGpu};
+use aether_substrate::capabilities::{RenderGpu, RenderHandles};
 use aether_substrate::render::{self, RenderError, vertex_buffer_layout};
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
@@ -63,7 +63,7 @@ pub struct Gpu {
     /// is `1` / `overlay`. `record_frame` draws this after the main
     /// pipeline as an extra inside the same render pass.
     wire_pipeline: Option<wgpu::RenderPipeline>,
-    render_running: Arc<RenderCapability>,
+    render_handles: RenderHandles,
 }
 
 /// Wireframe rendering mode, set at boot via `AETHER_WIREFRAME`.
@@ -93,7 +93,7 @@ impl WireframeMode {
 }
 
 impl Gpu {
-    pub fn new(window: Arc<Window>, render_running: Arc<RenderCapability>) -> Self {
+    pub fn new(window: Arc<Window>, render_handles: RenderHandles) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let surface = instance
@@ -176,7 +176,7 @@ impl Gpu {
         } else {
             wgpu::PolygonMode::Fill
         };
-        render_running.install_gpu(RenderGpu::new(
+        render_handles.install_gpu(RenderGpu::new(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
@@ -191,7 +191,7 @@ impl Gpu {
         // install so it can borrow the bind group + pipeline layouts
         // from the installed RenderGpu's pipeline.
         let wire_pipeline = if wireframe_mode == WireframeMode::Overlay {
-            let installed = render_running.gpu().expect("install_gpu just succeeded");
+            let installed = render_handles.gpu().expect("install_gpu just succeeded");
             let pipeline_layout = &installed.pipeline.pipeline_layout;
             let wire_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("wireframe shader"),
@@ -253,7 +253,7 @@ impl Gpu {
             adapter_info,
             limits,
             wire_pipeline,
-            render_running,
+            render_handles,
         }
     }
 
@@ -264,8 +264,8 @@ impl Gpu {
         self.config.width = size.width;
         self.config.height = size.height;
         self.surface
-            .configure(&self.render_running.device(), &self.config);
-        self.render_running
+            .configure(&self.render_handles.device(), &self.config);
+        self.render_handles
             .resize(self.config.width, self.config.height);
     }
 
@@ -291,8 +291,8 @@ impl Gpu {
     /// couldn't allocate. Surface unavailability does *not* prevent
     /// capture — offscreen is the source of truth.
     fn render_impl(&mut self, capture: bool) -> Option<Result<Vec<u8>, String>> {
-        let device = self.render_running.device();
-        let queue = self.render_running.queue();
+        let device = self.render_handles.device();
+        let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
@@ -307,7 +307,7 @@ impl Gpu {
             None => &[],
         };
         match self
-            .render_running
+            .render_handles
             .record_frame(&mut encoder, extra_pipelines)
         {
             Ok(()) => {}
@@ -318,7 +318,7 @@ impl Gpu {
         // which is unaffected by whether a swapchain image is available
         // this frame. That decouples capture from window visibility.
         let capture_meta = if capture {
-            Some(self.render_running.record_capture_copy(&mut encoder))
+            Some(self.render_handles.record_capture_copy(&mut encoder))
         } else {
             None
         };
@@ -329,8 +329,8 @@ impl Gpu {
         // still resolve.
         let surface_tex = self.acquire_surface_texture();
         if let Some(tex) = surface_tex.as_ref() {
-            let (w, h) = self.render_running.color_size();
-            self.render_running.with_color_texture(|src| {
+            let (w, h) = self.render_handles.color_size();
+            self.render_handles.with_color_texture(|src| {
                 encoder.copy_texture_to_texture(
                     wgpu::TexelCopyTextureInfo {
                         texture: src,
@@ -358,7 +358,7 @@ impl Gpu {
             tex.present();
         }
 
-        capture_meta.map(|meta| self.render_running.finish_capture(&meta))
+        capture_meta.map(|meta| self.render_handles.finish_capture(&meta))
     }
 
     /// Try to get the current swapchain texture. Reconfigures the
@@ -370,12 +370,12 @@ impl Gpu {
             wgpu::CurrentSurfaceTexture::Success(t) => Some(t),
             wgpu::CurrentSurfaceTexture::Suboptimal(t) => {
                 self.surface
-                    .configure(&self.render_running.device(), &self.config);
+                    .configure(&self.render_handles.device(), &self.config);
                 Some(t)
             }
             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
                 self.surface
-                    .configure(&self.render_running.device(), &self.config);
+                    .configure(&self.render_handles.device(), &self.config);
                 None
             }
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => None,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -273,7 +273,6 @@ impl TestBench {
             passive,
             mut boot,
             render_handles,
-            render_running,
             kind_tick,
             kind_frame_stats,
             hub: _hub,
@@ -310,7 +309,7 @@ impl TestBench {
             }
         }
 
-        let gpu = Gpu::new(width, height, render_running);
+        let gpu = Gpu::new(width, height, render_handles.clone());
 
         let queue = Arc::clone(&boot.queue);
         let outbound = Arc::clone(&boot.outbound);

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -216,12 +216,12 @@ pub struct TestBenchEnv {
 pub struct TestBenchBuild {
     pub passive: PassiveChassis<TestBenchChassis>,
     pub boot: SubstrateBoot,
+    /// Driver-facing accumulator + GPU bundle. Pre-PR-E2 the embedder
+    /// also got `Arc<RenderCapability>` via `passive.capability()` to
+    /// call `install_gpu` / `record_frame` / etc. on it; post-E2
+    /// render is a facade cap (dispatcher owns the cap) and the
+    /// encoder-level methods live on [`RenderHandles`].
     pub render_handles: RenderHandles,
-    /// The [`RenderCapability`] handle the embedder calls
-    /// [`RenderCapability::install_gpu`] on once it has a wgpu device +
-    /// queue, plus encoder-level methods (`record_frame`, etc.)
-    /// thereafter. Cloned out of `passive` for ergonomic access.
-    pub render_running: Arc<RenderCapability>,
     pub kind_tick: KindId,
     pub kind_frame_stats: KindId,
     pub hub: Option<HubClient>,
@@ -283,11 +283,10 @@ impl TestBenchChassis {
         let passive =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
                 .with_facade(LogCapability::new())
-                .with(render_cap)
+                .with_facade(render_cap)
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
 
-        let render_running: Arc<RenderCapability> = passive.capability();
         let hub = crate::hub::connect_hub_client(&boot, hub_url.as_deref())?;
 
         // The chassis-control closure already cloned `events_tx`;
@@ -302,7 +301,6 @@ impl TestBenchChassis {
             passive,
             boot,
             render_handles,
-            render_running,
             kind_tick,
             kind_frame_stats,
             hub,

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use aether_substrate::capabilities::{RenderCapability, RenderGpu};
+use aether_substrate::capabilities::{RenderGpu, RenderHandles};
 use aether_substrate::render::RenderError;
 
 pub use aether_substrate::render::VERTEX_BUFFER_BYTES;
@@ -24,7 +24,7 @@ pub struct Gpu {
     /// `Err` to.
     #[allow(dead_code)]
     pub limits: wgpu::Limits,
-    render_running: Arc<RenderCapability>,
+    render_handles: RenderHandles,
 }
 
 impl Gpu {
@@ -33,7 +33,7 @@ impl Gpu {
     /// `render_running` so encoder methods on the running can read
     /// them. `width` and `height` size the offscreen color + depth
     /// targets — the dimensions every captured frame will report.
-    pub fn new(width: u32, height: u32, render_running: Arc<RenderCapability>) -> Self {
+    pub fn new(width: u32, height: u32, render_handles: RenderHandles) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -55,7 +55,7 @@ impl Gpu {
         }))
         .expect("request_device");
 
-        render_running.install_gpu(RenderGpu::new(
+        render_handles.install_gpu(RenderGpu::new(
             Arc::new(device),
             Arc::new(queue),
             COLOR_FORMAT,
@@ -67,7 +67,7 @@ impl Gpu {
         Self {
             adapter_info,
             limits,
-            render_running,
+            render_handles,
         }
     }
 
@@ -76,7 +76,7 @@ impl Gpu {
     /// and invalidates the readback buffer.
     #[allow(dead_code)] // wired in PR2 alongside test_bench.advance kinds
     pub fn resize(&mut self, width: u32, height: u32) {
-        self.render_running.resize(width, height);
+        self.render_handles.resize(width, height);
     }
 
     /// Draw the current accumulator's vertices into the offscreen
@@ -84,12 +84,12 @@ impl Gpu {
     /// — desktop's swapchain blit is omitted because there's no
     /// surface.
     pub fn render(&mut self) {
-        let device = self.render_running.device();
-        let queue = self.render_running.queue();
+        let device = self.render_handles.device();
+        let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
-        match self.render_running.record_frame(&mut encoder, &[]) {
+        match self.render_handles.record_frame(&mut encoder, &[]) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return,
         }
@@ -101,19 +101,19 @@ impl Gpu {
     /// On any capture-path failure, returns `Err(reason)`; the frame
     /// still rendered to the offscreen — capture is a side channel.
     pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
-        let device = self.render_running.device();
-        let queue = self.render_running.queue();
+        let device = self.render_handles.device();
+        let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
-        match self.render_running.record_frame(&mut encoder, &[]) {
+        match self.render_handles.record_frame(&mut encoder, &[]) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => {
                 return Err("vertex buffer overflow — capture skipped".to_owned());
             }
         }
-        let meta = self.render_running.record_capture_copy(&mut encoder);
+        let meta = self.render_handles.record_capture_copy(&mut encoder);
         queue.submit(std::iter::once(encoder.finish()));
-        self.render_running.finish_capture(&meta)
+        self.render_handles.finish_capture(&meta)
     }
 }

--- a/crates/aether-substrate/src/capabilities/render.rs
+++ b/crates/aether-substrate/src/capabilities/render.rs
@@ -1,49 +1,37 @@
-//! ADR-0070 phase 3 (Option B per ADR-0071 phase 4) + ADR-0074
-//! §Decision 7: render is one native [`Capability`] with one mailbox
-//! and one dispatcher thread. The pre-Phase-3 `aether.sink.camera`
-//! mailbox folded into `aether.render`; the camera kind
-//! (`aether.camera`) keeps its name but its recipient is now the
-//! render mailbox.
+//! Issue 545 PR E2: render cap converted onto the unified `#[actor]`
+//! shape. Pre-PR-E2 render was the one cap still on the legacy
+//! `Capability + boot()` path with hand-rolled thread spawn — every
+//! other cap moved to `#[actor]` in PR E1. This PR closes the drift.
 //!
-//! The dispatcher pulls envelopes off a [`crate::FrameBoundClaim`]
-//! inbox and routes by kind id:
+//! `RenderCapability` is now a regular `#[actor]` block. Two
+//! `#[handler]` methods (`on_draw_triangle`, `on_camera`) replace the
+//! manual `dispatch_envelope` / `Capability::boot` machinery. The
+//! chassis builder spawns the dispatcher thread via
+//! `spawn_actor_dispatcher`, which detects `FRAME_BARRIER = true` and
+//! claims through the frame-bound path so the chassis frame loop's
+//! `drain_frame_bound_or_abort` can wait on the cap's `pending`
+//! counter as before (ADR-0074 §Decision 5).
 //!
-//! - `aether.draw_triangle` → append vertex bytes to `frame_vertices`,
-//!   bump `triangles_rendered` (with the same fixed-buffer truncation
-//!   semantics as before).
-//! - `aether.camera` → overwrite the cached `view_proj` (latest-value-
-//!   wins; init'd to [`crate::render::IDENTITY_VIEW_PROJ`]).
-//!
-//! Frame-bound (`Capability::FRAME_BARRIER = true`): the chassis frame
-//! loop calls [`crate::frame_loop::drain_frame_bound_or_abort`] each
-//! frame so render's inbox quiesces before the chassis driver records
-//! the GPU pass. The pending counter rides on `FrameBoundClaim` —
-//! incremented by the sink registration handler, decremented by the
-//! dispatcher after each `dispatch_envelope` call.
+//! Driver-side state (wgpu device, queue, pipeline, offscreen
+//! targets, accumulator buffers) lives on [`RenderHandles`], which
+//! the cap exposes via [`RenderCapability::handles`] **before** the
+//! cap moves into the chassis builder. The driver retains an
+//! `RenderHandles` clone (cheap — every field is Arc-shared) and
+//! calls encoder-level methods on it. Pre-PR-E2 the driver retrieved
+//! `Arc<RenderCapability>` via `DriverCtx::expect`; that path retires
+//! for render — facade caps don't go through the typed runnings map.
 //!
 //! Phase 4 keeps the GPU lifecycle, encoder creation, and presentation
 //! in the chassis driver — this capability owns only the mail surface
-//! and accumulator state. Encoder-level primitives + GPU bring-up are
-//! deferred to a future phase once a second consumer (test-bench
-//! `PassiveChassis` build with no winit) makes the right shape obvious.
-//!
-//! The capability builder exposes [`RenderCapability::handles`] so a
-//! chassis adding it via the legacy `boot.add_capability` path can
-//! pull the accumulator `Arc`s before the capability's `boot()` moves
-//! `self`. Once chassis composition migrates to the chassis_builder
-//! `Builder` (ADR-0071), drivers will read the same `Arc`s through
-//! `DriverCtx::expect::<RenderCapability>()` instead.
+//! and accumulator state.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
-use std::thread::{self, JoinHandle};
 
-use aether_actor::Actor;
-use aether_data::Kind;
+use aether_data::{Actor, Kind, Singleton};
 use aether_kinds::{Camera, DRAW_TRIANGLE_BYTES, DrawTriangle};
 
-use crate::capability::{BootError, Capability, ChassisCtx, Envelope, SinkSender};
 use crate::render::{
     CaptureMeta, IDENTITY_VIEW_PROJ, Pipeline, RenderError, Targets, build_main_pipeline,
     finish_capture, prepare_capture_copy, record_main_pass,
@@ -54,10 +42,16 @@ use crate::render::{
 /// truncating with a warn — desktop and test-bench both pass
 /// [`crate::render::VERTEX_BUFFER_BYTES`].
 ///
-/// `observed_kinds`, when set, has every inbound mail's kind name
-/// pushed to it from the unified render dispatcher — used by the
-/// in-process test-bench to assert what kinds the sink has seen.
-/// Production chassis leave it `None` (zero overhead).
+/// `observed_kinds`, when set, has every successfully-dispatched
+/// inbound mail's kind name pushed to it from the cap's `#[handler]`
+/// methods — used by the in-process test-bench to assert what kinds
+/// the cap has seen. Production chassis leave it `None` (zero
+/// overhead). Decode failures and unknown kinds don't push (the
+/// macro miss path warn-logs at the chassis-side dispatcher and
+/// short-circuits before any handler runs); pre-PR-E2 the legacy
+/// path pushed the raw `kind_name` regardless of dispatch outcome,
+/// but tests only use the list as a diagnostic in failure messages
+/// so the narrower semantic is fine.
 #[derive(Clone)]
 pub struct RenderConfig {
     pub vertex_buffer_bytes: usize,
@@ -73,42 +67,15 @@ impl Default for RenderConfig {
     }
 }
 
-/// Render sink capability. Constructed before [`Capability::boot`];
-/// the accumulator `Arc`s are pre-allocated so the chassis frame
-/// loop and the dispatcher thread share the same backing storage.
-///
-/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
-/// (`config`, `handles`) lives alongside the runtime fields populated
-/// in `boot` (`thread`, `sink_sender`, `gpu`). The encoder-level
-/// methods (`install_gpu`, `record_frame`, `record_capture_copy`,
-/// etc.) live as inherent methods directly on `RenderCapability` —
-/// drivers retrieve the cap via `DriverCtx::expect::<RenderCapability>()`
-/// and call those methods on the returned `Arc<RenderCapability>`.
+/// `aether.render` mailbox cap. Holds [`RenderHandles`] (the
+/// driver-facing accumulator state plus GPU bundle) and the
+/// per-instance config. Pre-extract the handles via [`Self::handles`]
+/// before moving the cap into the chassis builder; the dispatcher
+/// thread then owns the cap and routes `aether.draw_triangle` /
+/// `aether.camera` mail through the macro-emitted `Dispatch` impl.
 pub struct RenderCapability {
-    config: RenderConfig,
     handles: RenderHandles,
-    thread: Option<JoinHandle<()>>,
-    sink_sender: Option<SinkSender>,
-    /// wgpu state, installed post-boot by the driver via
-    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
-    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
-    /// after [`Capability::boot`] has returned. Test-bench (no
-    /// surface) installs immediately after `build_passive`; desktop
-    /// installs in its `resumed` handler. Encoder-level methods
-    /// panic if called before install — in practice every code path
-    /// that calls them runs after the install site.
-    gpu: OnceLock<RenderGpu>,
-}
-
-/// Bundle of accumulator state shared between the capability's
-/// dispatcher thread (write side) and the chassis frame loop (read
-/// side). All fields are `Arc`s so cloning is cheap and shutdown
-/// drops are independent.
-#[derive(Clone)]
-pub struct RenderHandles {
-    pub frame_vertices: Arc<Mutex<Vec<u8>>>,
-    pub triangles_rendered: Arc<AtomicU64>,
-    pub camera_state: Arc<Mutex<[f32; 16]>>,
+    config: RenderConfig,
 }
 
 impl RenderCapability {
@@ -119,70 +86,131 @@ impl RenderCapability {
             ))),
             triangles_rendered: Arc::new(AtomicU64::new(0)),
             camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
+            gpu: Arc::new(OnceLock::new()),
         };
-        Self {
-            config,
-            handles,
-            thread: None,
-            sink_sender: None,
-            gpu: OnceLock::new(),
-        }
+        Self { handles, config }
     }
 
-    /// Pre-boot accessor for the accumulator state. Cloned references
-    /// survive the move into [`Capability::boot`] so the chassis frame
-    /// loop reads the same buffers the dispatcher thread writes.
+    /// Cheap clone of the driver-facing handles bundle. Call this
+    /// **before** `chassis.with_facade(cap)` — once the cap moves into
+    /// the dispatcher thread, the only access to its accumulator
+    /// state is through the cloned handles.
     pub fn handles(&self) -> RenderHandles {
         self.handles.clone()
     }
 }
 
-/// Bundle of wgpu resources `RenderCapability` owns post-install.
-/// Constructed by the driver from a wgpu device + queue obtained via
-/// `Adapter::request_device` (desktop: with surface compatibility;
-/// test-bench: offscreen-only). Holds the pipeline + offscreen
-/// targets so encoder-level methods can record draws and capture
-/// copies without the driver threading these through every call.
-pub struct RenderGpu {
-    pub device: Arc<wgpu::Device>,
-    pub queue: Arc<wgpu::Queue>,
-    pub pipeline: Pipeline,
-    pub targets: Mutex<Targets>,
-    pub color_format: wgpu::TextureFormat,
+impl Actor for RenderCapability {
+    /// Components mail `aether.draw_triangle` and `aether.camera`
+    /// (kind ids) to this mailbox; the GPU recorder pulls from here.
+    /// The `aether.<name>` form is the post-ADR-0074 Phase 5
+    /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
+    /// folded the camera mailbox into render under this name.
+    const NAMESPACE: &'static str = "aether.render";
+
+    /// Render is the one chassis-owned actor that participates in the
+    /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
+    /// a `DrawTriangle` mail in flight when the chassis driver records
+    /// the frame would land in the *next* frame's `frame_vertices`,
+    /// dropping a triangle the component meant for this frame. The
+    /// chassis builder's `spawn_actor_dispatcher` checks this const
+    /// and claims through the frame-bound path so the cap's `pending`
+    /// counter registers in the chassis's `frame_bound_pending` Vec.
+    const FRAME_BARRIER: bool = true;
 }
 
-impl RenderGpu {
-    /// Build the standard render pipeline + offscreen targets at the
-    /// given size and pass [`Self`] to [`RenderCapability::install_gpu`].
-    /// `polygon_mode` is `Fill` for the normal case; desktop's
-    /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
-    /// pipeline draws as wireframe instead of building a separate
-    /// overlay pipeline.
-    pub fn new(
-        device: Arc<wgpu::Device>,
-        queue: Arc<wgpu::Queue>,
-        color_format: wgpu::TextureFormat,
-        width: u32,
-        height: u32,
-        polygon_mode: wgpu::PolygonMode,
-    ) -> Self {
-        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
-        let targets = Targets::new(&device, color_format, width, height);
-        Self {
-            device,
-            queue,
-            pipeline,
-            targets: Mutex::new(targets),
-            color_format,
+impl Singleton for RenderCapability {}
+
+#[aether_data::actor]
+impl RenderCapability {
+    /// `DrawTriangle` handler. Slice-typed because `Mailbox::send_many`
+    /// (ADR-0019) packs `count` triangles into one envelope — the
+    /// macro decodes the whole payload as `&[DrawTriangle]` so a
+    /// batched mesh reaches the cap intact. Truncates at the cap
+    /// boundary so a single oversized mesh degrades gracefully
+    /// instead of collapsing the whole frame downstream; rounds to
+    /// whole triangles so the GPU vertex buffer never sees a half-
+    /// triangle.
+    ///
+    /// # Agent
+    /// Components mail one or more `DrawTriangle`s (cast-shape,
+    /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
+    /// per tick. Fire-and-forget; the cap accumulates into
+    /// `frame_vertices` until the chassis driver records the frame.
+    #[aether_data::handler]
+    fn on_draw_triangle(&mut self, mails: &[DrawTriangle]) {
+        if let Some(obs) = &self.config.observed_kinds {
+            obs.lock()
+                .unwrap()
+                .push(<DrawTriangle as Kind>::NAME.into());
         }
+        let bytes: &[u8] = bytemuck::cast_slice(mails);
+        let cap_bytes = self.config.vertex_buffer_bytes;
+        let mut verts = self.handles.frame_vertices.lock().unwrap();
+        let available = cap_bytes.saturating_sub(verts.len());
+        let write_len = bytes.len().min(available);
+        let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+        if write_len > 0 {
+            verts.extend_from_slice(&bytes[..write_len]);
+            self.handles
+                .triangles_rendered
+                .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+        }
+        if write_len < bytes.len() {
+            tracing::warn!(
+                target: "aether_substrate::render",
+                accepted_bytes = write_len,
+                dropped_bytes = bytes.len() - write_len,
+                cap = cap_bytes,
+                "render cap dropped triangles beyond fixed vertex buffer",
+            );
+        }
+    }
+
+    /// `Camera` handler. Latest-value-wins semantics: each successful
+    /// mail overwrites; the prior value is replaced wholesale.
+    /// Initialised in [`RenderCapability::new`] to
+    /// [`IDENTITY_VIEW_PROJ`] so the first frame draws unchanged
+    /// until a camera component starts publishing.
+    ///
+    /// # Agent
+    /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
+    /// to this mailbox. Fire-and-forget; latest value wins.
+    #[aether_data::handler]
+    fn on_camera(&mut self, mail: Camera) {
+        if let Some(obs) = &self.config.observed_kinds {
+            obs.lock().unwrap().push(<Camera as Kind>::NAME.into());
+        }
+        *self.handles.camera_state.lock().unwrap() = mail.view_proj;
     }
 }
 
-impl RenderCapability {
-    /// Install the wgpu resources the encoder-level methods read. The
-    /// driver constructs [`RenderGpu`] once it has a device + queue —
-    /// for desktop that's inside `resumed` after winit hands back a
-    /// window and surface; for test-bench it's right after
+/// Bundle of accumulator state plus GPU resources, shared between
+/// the cap's dispatcher thread (write side for accumulators) and the
+/// chassis driver (read side for accumulators, install + read for
+/// GPU). All fields are `Arc`s so cloning is cheap and shutdown
+/// drops are independent.
+#[derive(Clone)]
+pub struct RenderHandles {
+    pub frame_vertices: Arc<Mutex<Vec<u8>>>,
+    pub triangles_rendered: Arc<AtomicU64>,
+    pub camera_state: Arc<Mutex<[f32; 16]>>,
+    /// wgpu state, installed post-cap-construction by the driver via
+    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
+    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
+    /// after `Builder::build` has returned. Test-bench (no surface)
+    /// installs immediately after `build_passive`; desktop installs
+    /// in its `resumed` handler. Encoder-level methods panic if
+    /// called before install — in practice every code path that
+    /// calls them runs after the install site.
+    gpu: Arc<OnceLock<RenderGpu>>,
+}
+
+impl RenderHandles {
+    /// Install the wgpu resources the encoder-level methods read.
+    /// The driver constructs [`RenderGpu`] once it has a device +
+    /// queue — for desktop that's inside `resumed` after winit hands
+    /// back a window and surface; for test-bench it's right after
     /// `build_passive` returns. Calling twice panics: install is the
     /// chassis's promise that wgpu state is now ready and stable for
     /// the chassis lifetime.
@@ -190,7 +218,7 @@ impl RenderCapability {
         self.gpu
             .set(gpu)
             .ok()
-            .expect("RenderCapability::install_gpu called twice");
+            .expect("RenderHandles::install_gpu called twice");
     }
 
     /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
@@ -203,7 +231,7 @@ impl RenderCapability {
 
     fn expect_gpu(&self) -> &RenderGpu {
         self.gpu.get().expect(
-            "RenderCapability::install_gpu must be called before encoder-level methods. \
+            "RenderHandles::install_gpu must be called before encoder-level methods. \
              Desktop installs in winit's resumed; test-bench installs after build_passive.",
         )
     }
@@ -221,12 +249,12 @@ impl RenderCapability {
         extra_pipelines: &[&wgpu::RenderPipeline],
     ) -> Result<(), RenderError> {
         let gpu = self.expect_gpu();
-        let cap = self.handles.frame_vertices.lock().unwrap().capacity();
+        let cap = self.frame_vertices.lock().unwrap().capacity();
         let vertices = std::mem::replace(
-            &mut *self.handles.frame_vertices.lock().unwrap(),
+            &mut *self.frame_vertices.lock().unwrap(),
             Vec::with_capacity(cap),
         );
-        let view_proj = *self.handles.camera_state.lock().unwrap();
+        let view_proj = *self.camera_state.lock().unwrap();
         let targets = gpu.targets.lock().unwrap();
         record_main_pass(
             &gpu.queue,
@@ -312,155 +340,44 @@ impl RenderCapability {
     }
 }
 
-impl Actor for RenderCapability {
-    /// Components mail `aether.draw_triangle` and `aether.camera`
-    /// (kind ids) to this mailbox; the GPU recorder pulls from here.
-    /// The `aether.<name>` form is the post-ADR-0074 Phase 5
-    /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
-    /// folded the camera mailbox into render under this name.
-    const NAMESPACE: &'static str = "aether.render";
-
-    /// Render is the one chassis-owned actor that participates in the
-    /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
-    /// a `DrawTriangle` mail in flight when the chassis driver records
-    /// the frame would land in the *next* frame's `frame_vertices`,
-    /// dropping a triangle the component meant for this frame.
-    const FRAME_BARRIER: bool = true;
+/// Bundle of wgpu resources `RenderHandles` exposes post-install.
+/// Constructed by the driver from a wgpu device + queue obtained via
+/// `Adapter::request_device` (desktop: with surface compatibility;
+/// test-bench: offscreen-only). Holds the pipeline + offscreen
+/// targets so encoder-level methods can record draws and capture
+/// copies without the driver threading these through every call.
+pub struct RenderGpu {
+    pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
+    pub pipeline: Pipeline,
+    pub targets: Mutex<Targets>,
+    pub color_format: wgpu::TextureFormat,
 }
 
-impl Capability for RenderCapability {
-    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-        let claim = ctx.claim_frame_bound_mailbox::<Self>()?;
-
-        let frame_vertices = Arc::clone(&self.handles.frame_vertices);
-        let triangles_rendered = Arc::clone(&self.handles.triangles_rendered);
-        let camera_state = Arc::clone(&self.handles.camera_state);
-        let cap_bytes = self.config.vertex_buffer_bytes;
-        let observed = self.config.observed_kinds.clone();
-        let pending = Arc::clone(&claim.pending);
-        let receiver = claim.receiver;
-
-        let thread = thread::Builder::new()
-            .name("aether-render-sink".into())
-            .spawn(move || {
-                // Channel-drop + join: the sender lives on
-                // `RenderCapability.sink_sender`; shutdown drops it,
-                // disconnecting the channel so `recv()` returns
-                // `Err(Disconnected)` and the loop exits.
-                while let Ok(env) = receiver.recv() {
-                    if let Some(obs) = &observed {
-                        obs.lock().unwrap().push(env.kind_name.clone());
-                    }
-                    dispatch_envelope(
-                        &frame_vertices,
-                        &triangles_rendered,
-                        &camera_state,
-                        cap_bytes,
-                        &env,
-                    );
-                    // Decrement matches the sink-handler's increment —
-                    // the chassis frame-bound drain barrier
-                    // (`drain_frame_bound_or_abort`) reads this counter
-                    // to know when the dispatcher is caught up.
-                    pending.fetch_sub(1, Ordering::AcqRel);
-                }
-            })
-            .map_err(|e| BootError::Other(Box::new(e)))?;
-
-        self.thread = Some(thread);
-        self.sink_sender = Some(claim.sink_sender);
-        Ok(self)
-    }
-}
-
-impl Drop for RenderCapability {
-    fn drop(&mut self) {
-        // Drop the strong sender to break the channel.
-        self.sink_sender.take();
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
+impl RenderGpu {
+    /// Build the standard render pipeline + offscreen targets at the
+    /// given size and pass [`Self`] to [`RenderHandles::install_gpu`].
+    /// `polygon_mode` is `Fill` for the normal case; desktop's
+    /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
+    /// pipeline draws as wireframe instead of building a separate
+    /// overlay pipeline.
+    pub fn new(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        color_format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+        polygon_mode: wgpu::PolygonMode,
+    ) -> Self {
+        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
+        let targets = Targets::new(&device, color_format, width, height);
+        Self {
+            device,
+            queue,
+            pipeline,
+            targets: Mutex::new(targets),
+            color_format,
         }
-        // gpu drops here; wgpu device/queue/pipeline/targets clean up
-        // via their own Drop impls.
-    }
-}
-
-/// Dispatch one envelope to the right per-kind handler. Routes by
-/// kind id — `aether.draw_triangle` builds the frame vertex buffer,
-/// `aether.camera` updates the cached `view_proj`. Unknown kinds
-/// warn-drop without affecting either accumulator.
-fn dispatch_envelope(
-    frame_vertices: &Mutex<Vec<u8>>,
-    triangles_rendered: &AtomicU64,
-    camera_state: &Mutex<[f32; 16]>,
-    cap_bytes: usize,
-    env: &Envelope,
-) {
-    if env.kind == <DrawTriangle as Kind>::ID {
-        dispatch_draw_triangle(frame_vertices, triangles_rendered, cap_bytes, env);
-    } else if env.kind == <Camera as Kind>::ID {
-        dispatch_camera(camera_state, env);
-    } else {
-        tracing::warn!(
-            target: "aether_substrate::render",
-            kind = %env.kind,
-            kind_name = %env.kind_name,
-            "render sink received unknown kind — dropping",
-        );
-    }
-}
-
-/// DrawTriangle handler. Truncates the inbound vertex bytes at the
-/// sink boundary so a single oversized mesh degrades gracefully
-/// instead of collapsing the whole frame downstream. Rounds to whole
-/// triangles so the GPU vertex buffer never sees a half-triangle.
-fn dispatch_draw_triangle(
-    frame_vertices: &Mutex<Vec<u8>>,
-    triangles_rendered: &AtomicU64,
-    cap_bytes: usize,
-    env: &Envelope,
-) {
-    let mut verts = frame_vertices.lock().unwrap();
-    let available = cap_bytes.saturating_sub(verts.len());
-    let write_len = env.payload.len().min(available);
-    let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-    if write_len > 0 {
-        verts.extend_from_slice(&env.payload[..write_len]);
-        triangles_rendered.fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-    }
-    if write_len < env.payload.len() {
-        tracing::warn!(
-            target: "aether_substrate::render",
-            accepted_bytes = write_len,
-            dropped_bytes = env.payload.len() - write_len,
-            cap = cap_bytes,
-            "render sink dropped triangles beyond fixed vertex buffer",
-        );
-    }
-}
-
-/// Camera handler. Latest-value-wins semantics: each successful mail
-/// overwrites; on length mismatch or cast failure the prior value
-/// stays. Initialised in [`RenderCapability::new`] to
-/// [`IDENTITY_VIEW_PROJ`] so the first frame draws unchanged until a
-/// camera component starts publishing.
-fn dispatch_camera(camera_state: &Mutex<[f32; 16]>, env: &Envelope) {
-    if env.payload.len() != 64 {
-        tracing::warn!(
-            target: "aether_substrate::camera",
-            got = env.payload.len(),
-            expected = 64,
-            "camera mail: payload length mismatch, dropping",
-        );
-        return;
-    }
-    match bytemuck::try_pod_read_unaligned::<[f32; 16]>(&env.payload) {
-        Ok(mat) => *camera_state.lock().unwrap() = mat,
-        Err(e) => tracing::warn!(
-            target: "aether_substrate::camera",
-            error = %e,
-            "camera mail: cast failed, dropping",
-        ),
     }
 }
 
@@ -491,7 +408,7 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         let cap = RenderCapability::new(RenderConfig::default());
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_facade(cap)
             .build()
             .expect("build succeeds");
         assert_eq!(chassis.len(), 1);
@@ -507,7 +424,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_facade(cap)
             .build()
             .expect("build succeeds");
 
@@ -545,11 +462,13 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_facade(cap)
             .build()
             .expect("build succeeds");
 
-        // Send 5 triangles; only 2 fit.
+        // Send 5 triangles' worth of bytes in one batched mail; only
+        // 2 fit. The slice-typed handler reads the whole batch and
+        // truncates at the cap boundary.
         let payload = vec![0u8; DRAW_TRIANGLE_BYTES * 5];
         deliver(
             &registry,
@@ -580,7 +499,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_facade(cap)
             .build()
             .expect("build succeeds");
 
@@ -614,11 +533,12 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_facade(cap)
             .build()
             .expect("build succeeds");
 
-        // 16 bytes — wrong length, should be 64.
+        // 16 bytes — wrong length, decode fails, macro miss path
+        // logs warn at chassis-side dispatcher; identity unchanged.
         deliver(
             &registry,
             RenderCapability::NAMESPACE,
@@ -627,7 +547,6 @@ mod tests {
         );
 
         std::thread::sleep(Duration::from_millis(50));
-        // Identity unchanged.
         assert_eq!(*handles.camera_state.lock().unwrap(), IDENTITY_VIEW_PROJ);
 
         chassis.shutdown();

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -685,12 +685,30 @@ impl<'a> ChassisCtx<'a> {
     where
         C: Actor + Dispatch + Send + 'static,
     {
-        let claim = self.claim_mailbox_drop_on_shutdown_with_override(C::NAMESPACE)?;
-        let DropOnShutdownClaim {
-            id: _,
-            receiver,
-            sink_sender,
-        } = claim;
+        // FRAME_BARRIER caps (today: render) need the pending counter
+        // the chassis frame loop drains against — claim through the
+        // frame-bound path so the `pending` counter registers in the
+        // chassis's `frame_bound_pending` Vec. Free-running caps go
+        // through the regular drop-on-shutdown claim. The dispatch
+        // loop is identical apart from the post-dispatch decrement.
+        let (receiver, sink_sender, pending) = if C::FRAME_BARRIER {
+            let claim = self.claim_frame_bound_mailbox_with_override(C::NAMESPACE)?;
+            let FrameBoundClaim {
+                id: _,
+                receiver,
+                sink_sender,
+                pending,
+            } = claim;
+            (receiver, sink_sender, Some(pending))
+        } else {
+            let claim = self.claim_mailbox_drop_on_shutdown_with_override(C::NAMESPACE)?;
+            let DropOnShutdownClaim {
+                id: _,
+                receiver,
+                sink_sender,
+            } = claim;
+            (receiver, sink_sender, None)
+        };
 
         let mut owned = cap;
         let thread = thread::Builder::new()
@@ -713,6 +731,13 @@ impl<'a> ChassisCtx<'a> {
                             kind = env.kind_name.as_str(),
                             "facade cap dispatch missed: kind not handled or decode failed"
                         );
+                    }
+                    // Decrement matches the sink-handler's increment —
+                    // the chassis frame-bound drain barrier
+                    // (`drain_frame_bound_or_abort`) reads this counter
+                    // to know when the dispatcher is caught up.
+                    if let Some(p) = &pending {
+                        p.fetch_sub(1, Ordering::AcqRel);
                     }
                 }
                 // `owned` drops here on thread exit, running the cap's


### PR DESCRIPTION
## Summary

Stacked on PR 546 (E1). Render — the one chassis cap still on the legacy `Capability + boot()` path with a hand-rolled thread spawn — converts to a regular `#[actor]` block. Two `#[handler]` methods replace the manual `dispatch_envelope` / `boot()` machinery. The chassis builder's `spawn_actor_dispatcher` grows a one-line branch on `Actor::FRAME_BARRIER` so render claims through the frame-bound path (the chassis frame loop's drain barrier still works exactly as before, ADR-0074 §Decision 5).

Driver-side state (wgpu, accumulator buffers) moves to a new `RenderHandles` bundle, exposed via `cap.handles()` before the cap moves into the chassis builder. The driver retains a cheap clone and calls encoder-level methods (`record_frame`, `record_capture_copy`, `finish_capture`, `device`, `queue`, `resize`, `install_gpu`, …) on the bundle. `DriverCtx::expect::<RenderCapability>()` retires for render — facade caps don't go through the typed runnings map.

## Macro extension

Native `#[handler]` methods now accept `mail: &[K]` in addition to `mail: K`. The dispatch arm decodes via `bytemuck::cast_slice` so a batched `send_many` envelope (ADR-0019) reaches the handler intact. Only valid for cast-shape kinds; postcard rejects `&[K]` (no batched postcard wire). Added `decode_cast_slice` helper to aether-data's `__derive_runtime`.

Render's `on_draw_triangle` uses the slice form because the mesh viewer component sends batched triangles via `Mailbox::send_many`. Without this, only the first triangle in each batch would dispatch.

## Out of scope

- `with_facade` / `add_facade` collapse into `with` / `add_capability` — PR E3.
- Actor-marker move back to `aether-actor` — PR E4.
- ADR superseding ADR-0075 — PR E5.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` — all passing (including the in-process `TestBench` scenarios that exercise render's frame-bound drain end-to-end)
- [x] `cargo check -p aether-camera-component -p aether-mesh-viewer-component --target wasm32-unknown-unknown` clean

Part of issue 545. Closes nothing yet — that issue closes on PR E5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)