### PR TITLE
refactor(actor): drop Capability trait + collapse with_facade into with (issue 545 PR E3)

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -88,11 +88,11 @@ fn main() -> wasmtime::Result<()> {
         hub,
     } = TestBenchChassis::build_passive(env)?;
 
-    // Io cap on the `boot.add_facade` path — the binary fails fast on
+    // Io cap on the `boot.add_capability` path — the binary fails fast on
     // adapter init failure (the in-process API silent-skips for
     // systems without writable default roots).
     let io_cap = IoCapability::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue))?;
-    boot.add_facade(io_cap)?;
+    boot.add_capability(io_cap)?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height, render_handles.clone());

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -358,11 +358,11 @@ impl DesktopChassis {
             .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
-            .with_facade(LogCapability::new())
-            .with_facade(io_cap)
-            .with_facade(NetCapability::new(net, Arc::clone(&mailer)))
-            .with_facade(AudioCapability::new(audio, Arc::clone(&mailer)))
-            .with_facade(render_cap)
+            .with(LogCapability::new())
+            .with(io_cap)
+            .with(NetCapability::new(net, Arc::clone(&mailer)))
+            .with(AudioCapability::new(audio, Arc::clone(&mailer)))
+            .with(render_cap)
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -232,9 +232,9 @@ impl HeadlessChassis {
             .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
-            .with_facade(LogCapability::new())
-            .with_facade(io_cap)
-            .with_facade(NetCapability::new(net, Arc::clone(&mailer)))
+            .with(LogCapability::new())
+            .with(io_cap)
+            .with(NetCapability::new(net, Arc::clone(&mailer)))
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -10,10 +10,10 @@
 //!   pushes it onto a writer channel.
 //! - [`HubClient`] — TCP dial + Hello/Welcome handshake + reader /
 //!   writer / heartbeat thread cluster.
-//! - [`HubClientCapability`] — passive `Capability` impl that wraps
-//!   [`HubClient::connect`] for chassis composition via
-//!   `Builder::with()`. Connects on boot when its URL is `Some`;
-//!   no-ops when `None` so chassis can opt out cleanly.
+//! - [`connect_hub_client`] — function-shaped wrapper around
+//!   [`HubClient::connect`] for chassis composition. Connects when
+//!   its URL is `Some`; no-ops when `None` so chassis can opt out
+//!   cleanly.
 //! - [`loopback_outbound`] — substitute for an in-process driver
 //!   (test-bench, hub-chassis loopback) that wants to drain
 //!   `EngineToHub` frames the substrate would otherwise serialise.
@@ -50,8 +50,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{KindDescriptor, KindId, MailboxId};
 use aether_substrate::{
-    BootError, Capability, ChassisCtx, EgressBackend, HubOutbound, LogEntry as SubstrateLogEntry,
-    LogLevel as SubstrateLogLevel, Mail, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
+    EgressBackend, HubOutbound, LogEntry as SubstrateLogEntry, LogLevel as SubstrateLogLevel, Mail,
+    Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
 };
 use tokio::net::TcpListener;
 
@@ -463,128 +463,15 @@ fn unix_now() -> u64 {
         .unwrap_or(0)
 }
 
-/// ADR-0071 phase 7 passive `Capability`: dials a hub at boot and
-/// retains the [`HubClient`]'s reader / writer / heartbeat threads for
-/// the chassis lifetime. `url == None` (or the empty string) is the
-/// no-op case — the capability boots successfully without dialing,
-/// retaining no threads. Boot failures (TCP dial, handshake, frame
-/// errors) propagate as [`BootError::Other`] so the chassis fail-fast
-/// path runs (ADR-0063).
-///
-/// The capability constructor takes the `Arc<HubOutbound>` from the
-/// chassis's [`aether_substrate::SubstrateBoot`] explicitly:
-/// substrate-core's `Builder` doesn't surface outbound through
-/// `ChassisCtx`, and the wiring relationship between the boot's
-/// outbound and a hub connection is naturally set at chassis-
-/// composition time. A successful connect calls
+/// Synchronous hub-client connect. Dials the hub if `url` is
+/// `Some(non-empty)` and returns the live [`HubClient`] handle;
+/// returns `Ok(None)` for `None` / empty. A successful connect calls
 /// `outbound.attach_backend(...)` which is what makes substrate-side
-/// egress flow upward through the TCP socket.
-/// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
-/// (`url`, `name`, `version`, `kinds`, `outbound`) is consumed by
-/// `boot` to produce the live `client`. The cap's [`Drop`] impl is a
-/// no-op — dropping the inner [`HubClient`] is enough; the writer
-/// thread observes the dropped channel and exits, the reader thread
-/// observes the closed socket and exits, and the heartbeat thread
-/// observes the closed channel and exits.
-pub struct HubClientCapability {
-    url: Option<String>,
-    name: Option<String>,
-    version: Option<String>,
-    kinds: Option<Vec<KindDescriptor>>,
-    outbound: Option<Arc<HubOutbound>>,
-    /// Live client populated by `boot` on a successful dial; `None`
-    /// when the constructor's `url` was `None` / empty.
-    pub client: Option<HubClient>,
-}
-
-impl HubClientCapability {
-    /// Construct a fresh capability. `url` is the engine-side hub URL
-    /// (typically `AETHER_HUB_URL`); `None` or empty boots cleanly
-    /// without dialing. `name` and `version` ride on the `Hello`
-    /// frame; `kinds` is the engine's full kind-descriptor list (the
-    /// same list the boot emits — clone from
-    /// `SubstrateBoot::boot_descriptors`). `outbound` is the boot's
-    /// `Arc<HubOutbound>`; the capability calls
-    /// [`HubOutbound::attach_backend`] on it after a successful
-    /// connect so substrate-side egress starts forwarding through the
-    /// TCP socket.
-    pub fn new(
-        url: Option<String>,
-        name: impl Into<String>,
-        version: impl Into<String>,
-        kinds: Vec<KindDescriptor>,
-        outbound: Arc<HubOutbound>,
-    ) -> Self {
-        Self {
-            url,
-            name: Some(name.into()),
-            version: Some(version.into()),
-            kinds: Some(kinds),
-            outbound: Some(outbound),
-            client: None,
-        }
-    }
-}
-
-impl aether_substrate::Actor for HubClientCapability {
-    /// The hub-client cap dials a TCP socket; it does not claim a
-    /// chassis mailbox. The `NAMESPACE` const is required by the
-    /// trait (issue 525 Phase 1) but never address-resolved, so the
-    /// value here is purely diagnostic.
-    const NAMESPACE: &'static str = "chassis.hub_client";
-}
-
-impl Capability for HubClientCapability {
-    fn boot(mut self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-        let url = match self.url.as_deref() {
-            Some(u) if !u.is_empty() => u.to_owned(),
-            _ => {
-                // No-op boot — preserves the pre-Phase-2 "boots cleanly
-                // without dialing" semantic. `client` stays `None`.
-                return Ok(self);
-            }
-        };
-        let registry = Arc::clone(ctx.registry());
-        let queue = Arc::clone(ctx.mailer());
-        let name = self.name.take().expect("HubClientCapability::boot twice");
-        let version = self
-            .version
-            .take()
-            .expect("HubClientCapability::boot twice");
-        let kinds = self.kinds.take().expect("HubClientCapability::boot twice");
-        let outbound = self
-            .outbound
-            .take()
-            .expect("HubClientCapability::boot twice");
-        let client = HubClient::connect(
-            url.as_str(),
-            name,
-            version,
-            kinds,
-            registry,
-            queue,
-            outbound,
-        )
-        .map_err(|e| {
-            BootError::Other(Box::new(io::Error::other(format!(
-                "hub connect to {url:?} failed: {e}"
-            ))))
-        })?;
-        self.client = Some(client);
-        Ok(self)
-    }
-}
-
-/// Drop-in replacement for the pre-refactor `boot.connect_hub(url)`.
-/// Dials the hub if `url` is `Some(non-empty)` and returns the live
-/// [`HubClient`] handle; returns `Ok(None)` for `None` / empty.
-/// Chassis crates that prefer explicit handle ownership over the
-/// [`HubClientCapability`] / `Builder::with()` adoption use this.
-///
-/// Equivalent to constructing a `HubClientCapability` and booting it
-/// against the boot's registry / mailer / outbound, but synchronous —
-/// returns the `HubClient` directly so the chassis can stash it next
-/// to its own state.
+/// egress flow upward through the TCP socket. Pre-PR-E3 there was
+/// also a `HubClientCapability` wrapper that fit the cap-builder
+/// chain via `Capability::boot`; that wrapper retired with
+/// `Capability` itself — every chassis now uses this function
+/// directly.
 pub fn connect_hub_client(
     boot: &SubstrateBoot,
     url: Option<&str>,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -285,14 +285,14 @@ impl TestBench {
         boot.outbound
             .attach_backend(Arc::new(HubProtocolBackend::new(loopback_tx)));
 
-        // Io cap on the `boot.add_facade` path. Silent-skip on init
+        // Io cap on the `boot.add_capability` path. Silent-skip on init
         // failure preserves prior behavior so tests on systems without
         // writable default roots don't fail at the harness layer;
         // tests that care about io supply tempdir roots via the
         // builder.
         match IoCapability::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue)) {
             Ok(io_cap) => {
-                if let Err(e) = boot.add_facade(io_cap) {
+                if let Err(e) = boot.add_capability(io_cap) {
                     tracing::warn!(
                         target: "aether_substrate::io",
                         error = %e,

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -282,8 +282,8 @@ impl TestBenchChassis {
 
         let passive =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
-                .with_facade(LogCapability::new())
-                .with_facade(render_cap)
+                .with(LogCapability::new())
+                .with(render_cap)
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
 

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -164,24 +164,11 @@ impl SubstrateBoot {
     /// same as build-time capabilities. The fallback-router slot is
     /// shared across build-time and post-build capabilities, so the
     /// single-claim invariant holds.
+    ///
+    /// Pre-PR-E3 there was a separate `add_facade` for actor caps
+    /// alongside `add_capability` for legacy `Capability` caps; the
+    /// legacy path retired alongside `Capability` itself.
     pub fn add_capability<C>(&mut self, cap: C) -> wasmtime::Result<()>
-    where
-        C: crate::Capability,
-    {
-        let chassis = self
-            .chassis
-            .as_mut()
-            .expect("SubstrateBoot::build always installs a BootedChassis");
-        chassis
-            .add(&self.registry, &self.queue, cap)
-            .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
-    }
-
-    /// Boot one more facade-style cap into the already-built chassis.
-    /// Counterpart to [`Self::add_capability`] for ADR-0075 facade
-    /// caps; the chassis owns the dispatcher thread and the cap moves
-    /// into it.
-    pub fn add_facade<C>(&mut self, cap: C) -> wasmtime::Result<()>
     where
         C: aether_actor::Actor + aether_data::Dispatch + Send + 'static,
     {
@@ -190,7 +177,7 @@ impl SubstrateBoot {
             .as_mut()
             .expect("SubstrateBoot::build always installs a BootedChassis");
         chassis
-            .add_facade(&self.registry, &self.queue, cap)
+            .add(&self.registry, &self.queue, cap)
             .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
     }
 }
@@ -347,7 +334,7 @@ impl<'a> SubstrateBootBuilder<'a> {
         // control-side code that wants to publish at load can reach
         // it.
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&queue))
-            .with_facade(HandleCapability::new(
+            .with(HandleCapability::new(
                 Arc::clone(&handle_store),
                 Arc::clone(&queue),
             ))

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -1020,7 +1020,7 @@ mod tests {
             Arc::clone(&mailer),
         );
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("audio capability boots");
         assert!(
@@ -1044,7 +1044,7 @@ mod tests {
             Arc::clone(&mailer),
         );
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -211,7 +211,7 @@ mod tests {
         let (store, mailer, registry, rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(HandleCapability::new(
+            .with(HandleCapability::new(
                 Arc::clone(&store),
                 Arc::clone(&mailer),
             ))
@@ -279,7 +279,7 @@ mod tests {
         let (store, mailer, registry, _rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(HandleCapability::new(
+            .with(HandleCapability::new(
                 Arc::clone(&store),
                 Arc::clone(&mailer),
             ))
@@ -303,7 +303,7 @@ mod tests {
         registry.register_sink(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(HandleCapability::new(
+            .with(HandleCapability::new(
                 Arc::clone(&store),
                 Arc::clone(&mailer),
             ))

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -744,7 +744,7 @@ mod tests {
         let cap =
             IoCapability::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("io capability boots");
         assert!(
@@ -789,7 +789,7 @@ mod tests {
         let cap =
             IoCapability::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -76,7 +76,7 @@ mod tests {
     fn capability_routes_log_event_through_dispatcher() {
         let (registry, mailer) = fresh_substrate();
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(LogCapability::new())
+            .with(LogCapability::new())
             .build()
             .expect("capability boots");
 
@@ -121,7 +121,7 @@ mod tests {
         registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(LogCapability::new())
+            .with(LogCapability::new())
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -527,7 +527,7 @@ mod tests {
             ..NetConfig::default()
         };
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(NetCapability::new(config, Arc::clone(&mailer)))
+            .with(NetCapability::new(config, Arc::clone(&mailer)))
             .build()
             .expect("net capability boots");
         assert!(
@@ -548,7 +548,7 @@ mod tests {
         };
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(NetCapability::new(config, Arc::clone(&mailer)))
+            .with(NetCapability::new(config, Arc::clone(&mailer)))
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capabilities/render.rs
+++ b/crates/aether-substrate/src/capabilities/render.rs
@@ -92,7 +92,7 @@ impl RenderCapability {
     }
 
     /// Cheap clone of the driver-facing handles bundle. Call this
-    /// **before** `chassis.with_facade(cap)` — once the cap moves into
+    /// **before** `chassis.with(cap)` — once the cap moves into
     /// the dispatcher thread, the only access to its accumulator
     /// state is through the cloned handles.
     pub fn handles(&self) -> RenderHandles {
@@ -408,7 +408,7 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         let cap = RenderCapability::new(RenderConfig::default());
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("build succeeds");
         assert_eq!(chassis.len(), 1);
@@ -424,7 +424,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("build succeeds");
 
@@ -462,7 +462,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("build succeeds");
 
@@ -499,7 +499,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("build succeeds");
 
@@ -533,7 +533,7 @@ mod tests {
         let handles = cap.handles();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_facade(cap)
+            .with(cap)
             .build()
             .expect("build succeeds");
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -229,49 +229,22 @@ impl From<wasmtime::Error> for BootError {
     }
 }
 
-/// A native actor: chassis-policy code that owns one or more
-/// mailboxes plus the state behind them. Each cap is `boot()`-ed
-/// once during chassis startup; teardown happens through the cap's
-/// own [`Drop`] impl when the chassis-owned `Box<Self>` drops
-/// (issue 525 Phase 2).
-///
-/// Renamed from `Capability` to `NativeActor` in issue 525 Phase 3:
-/// the cap is the chassis-side leaf of the unified [`Actor`] trait,
-/// the wasm-side leaf is `Component` (renaming to `WasmActor` in
-/// Phase 4). The [`Actor`] super-trait owns the symmetric bits
-/// (`NAMESPACE`, `FRAME_BARRIER`); `NativeActor` adds the
-/// chassis-side lifecycle method.
-///
-/// Implementors author one struct per cap. The struct typically holds
-/// `Option<JoinHandle<()>>`, an `Option<SinkSender>` (drives channel-
-/// drop shutdown), and the cap's `Arc<NativeTransport>` — `boot()`
-/// fills these from `None` to `Some` and returns the same `self`. The
-/// `Drop` impl drops the sender first to break the channel and then
-/// joins the thread.
-pub trait NativeActor: Actor {
-    /// Wire the cap into the chassis. The pre-boot `self` carries any
-    /// constructor config (read by `Self::new`-style builders); `boot`
-    /// claims mailboxes through `ctx`, spawns the dispatcher thread,
-    /// and returns the same `self` with its runtime-state fields
-    /// populated. On error the chassis aborts already-booted caps via
-    /// their [`Drop`] impls.
-    fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError>;
-}
-
-/// Backwards-compatibility alias for [`NativeActor`]. Lets the
-/// substrate's existing `crate::Capability` re-export keep resolving
-/// while consumers migrate to the new name. New code should prefer
-/// `NativeActor` directly; this alias is purely an ergonomic on-ramp
-/// during issue 525's phased rollout.
-pub use NativeActor as Capability;
-
-/// Marker trait for type-erased actor storage in [`BootedChassis`]
-/// and the [`crate::chassis_builder`] passive list. Implemented blanket
-/// for every [`NativeActor`]; carries no methods of its own —
-/// teardown runs through the cap's [`Drop`] impl when the
-/// `Box<dyn ActorErased>` drops (issue 525 Phase 2).
+/// Marker trait for type-erased chassis-stored entries. Pre-PR-E3
+/// the `BootedChassis` and `chassis_builder` passive lists held both
+/// owned caps (legacy `Capability` path) and `FacadeHandle` wrappers
+/// (facade caps). Post-E3 every cap is a facade; the only entries
+/// in those lists are `FacadeHandle<C>` instances plus the
+/// fallback-router marker. The trait survives so the boxed-dyn vec
+/// keeps a stable type.
 pub trait ActorErased: Send {}
-impl<C: NativeActor> ActorErased for C {}
+
+/// Zero-sized stand-in for `ChassisBuilder::with_fallback_router`.
+/// The fallback handler is owned by the chassis's `fallback` slot,
+/// not by anything held in the type-erased entries vec; we still
+/// push a marker so the boot order / shutdown drop semantics align
+/// with the cap entries.
+struct FallbackMarker;
+impl ActorErased for FallbackMarker {}
 
 /// Kernel-side handle bundle exposed to a capability during its
 /// `boot()` call. Shared (`&mut`) across every `boot()` in the
@@ -338,7 +311,7 @@ impl<'a> ChassisCtx<'a> {
     ///
     /// Tests that need a parameterized name (one fixture, many
     /// claims) reach for [`Self::claim_mailbox_with_override`].
-    pub fn claim_mailbox<C: Capability>(&mut self) -> Result<MailboxClaim, BootError> {
+    pub fn claim_mailbox<C: Actor>(&mut self) -> Result<MailboxClaim, BootError> {
         self.claim_mailbox_with_override(C::NAMESPACE)
     }
 
@@ -393,7 +366,7 @@ impl<'a> ChassisCtx<'a> {
     /// `C::NAMESPACE`. See
     /// [`Self::claim_mailbox_drop_on_shutdown_with_override`] for the
     /// arbitrary-name escape hatch.
-    pub fn claim_mailbox_drop_on_shutdown<C: Capability>(
+    pub fn claim_mailbox_drop_on_shutdown<C: Actor>(
         &mut self,
     ) -> Result<DropOnShutdownClaim, BootError> {
         self.claim_mailbox_drop_on_shutdown_with_override(C::NAMESPACE)
@@ -469,9 +442,7 @@ impl<'a> ChassisCtx<'a> {
     /// frame-bound capabilities. Claims under `C::NAMESPACE`. See
     /// [`Self::claim_frame_bound_mailbox_with_override`] for the
     /// arbitrary-name escape hatch.
-    pub fn claim_frame_bound_mailbox<C: Capability>(
-        &mut self,
-    ) -> Result<FrameBoundClaim, BootError> {
+    pub fn claim_frame_bound_mailbox<C: Actor>(&mut self) -> Result<FrameBoundClaim, BootError> {
         self.claim_frame_bound_mailbox_with_override(C::NAMESPACE)
     }
 
@@ -766,10 +737,11 @@ fn alloc_thread_name<C: Actor>() -> String {
 
 /// Type-erased boot trampoline so [`ChassisBuilder`] can collect
 /// heterogeneous capability types into one `Vec`. Each entry, when
-/// invoked, takes the ctx, calls the underlying `Capability::boot`,
-/// and boxes the resulting cap as [`ActorErased`] so the chassis can
-/// store every cap in one homogeneous `Vec`. Teardown runs through
-/// the cap's own [`Drop`] when the box drops (issue 525 Phase 2).
+/// invoked, takes the ctx, runs `spawn_actor_dispatcher` for the
+/// capability, and boxes the returned [`FacadeHandle`] as
+/// [`ActorErased`] so the chassis can store every cap in one
+/// homogeneous `Vec`. Teardown runs through the handle's `Drop`
+/// when the box drops.
 type BootFn =
     Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn ActorErased>, BootError> + Send>;
 
@@ -818,33 +790,32 @@ impl ChassisBuilder {
         self
     }
 
-    /// Append a capability. Boot order is declaration order.
+    /// Append a chassis cap. The chassis claims the cap's mailbox
+    /// and runs the dispatcher; the cap is an `Actor + Dispatch`
+    /// value (typically built by `#[actor]` on an inherent impl).
+    /// Boot order is declaration order. Pre-PR-E3 this method was
+    /// named `with_facade`; the legacy `with`-takes-Capability
+    /// variant retired alongside `Capability` itself.
     pub fn with<C>(mut self, cap: C) -> Self
-    where
-        C: Capability,
-    {
-        self.pending.push(Box::new(move |ctx| {
-            let booted = cap.boot(ctx)?;
-            Ok(Box::new(booted) as Box<dyn ActorErased>)
-        }));
-        self
-    }
-
-    /// Append a facade-style cap (ADR-0075 §Decision 3): the chassis
-    /// claims the mailbox and runs the dispatcher; the cap is purely
-    /// an `Actor + Dispatch` value carrying its backend. Boot order
-    /// is declaration order, same as [`Self::with`].
-    ///
-    /// PR C wires [`aether_kinds::LogCapability<LogTracingBackend>`]
-    /// through this; PR D migrates the rest of the chassis caps onto
-    /// it.
-    pub fn with_facade<C>(mut self, cap: C) -> Self
     where
         C: Actor + Dispatch + Send + 'static,
     {
         self.pending.push(Box::new(move |ctx| {
             let handle = ctx.spawn_actor_dispatcher(cap)?;
             Ok(Box::new(handle) as Box<dyn ActorErased>)
+        }));
+        self
+    }
+
+    /// Register a fallback router — a single-shot handler the
+    /// substrate consults for envelopes whose mailbox name doesn't
+    /// resolve. Useful for tests that want to observe routing of
+    /// unhandled mail; production chassis don't currently install
+    /// one. Multiple calls collapse to a `BootError` at `build()`.
+    pub fn with_fallback_router(mut self, handler: FallbackRouter) -> Self {
+        self.pending.push(Box::new(move |ctx| {
+            ctx.claim_fallback_router(handler)?;
+            Ok(Box::new(FallbackMarker) as Box<dyn ActorErased>)
         }));
         self
     }
@@ -951,46 +922,24 @@ impl BootedChassis {
     }
 
     /// Boot one more capability into an already-built chassis. The
-    /// capability sees the same `ChassisCtx` shape as those booted
-    /// through [`ChassisBuilder::with`] — the same registry, the
-    /// same mail-send handle, and (crucially) the same fallback-
-    /// router slot, so the single-claim invariant still holds across
-    /// the build-time and post-build sets.
+    /// cap sees the same `ChassisCtx` shape as those booted through
+    /// [`ChassisBuilder::with`] — the same registry, the same
+    /// mail-send handle, and (crucially) the same fallback-router
+    /// slot, so the single-claim invariant still holds across the
+    /// build-time and post-build sets.
     ///
     /// Used by chassis mains to compose chassis-conditional
-    /// capabilities (`LogCapability`, `IoCapability`, etc.) on top
-    /// of the universal capabilities `SubstrateBoot::build` already
-    /// installed. Boots run in call order; shutdown tears down in
-    /// reverse, exactly like the build-time path.
+    /// capabilities on top of the universal capabilities
+    /// `SubstrateBoot::build` already installed (today: the bundle
+    /// hooks `IoCapability` here in TestBench because adapter init
+    /// can fail silently on systems without writable default roots).
+    /// Boots run in call order; shutdown tears down in reverse,
+    /// exactly like the build-time path.
+    ///
+    /// Pre-PR-E3 there was a separate `add_facade` for actor caps
+    /// alongside `add` for legacy `Capability` caps; the legacy
+    /// path retired alongside `Capability` itself.
     pub fn add<C>(
-        &mut self,
-        registry: &Arc<Registry>,
-        mailer: &Arc<Mailer>,
-        cap: C,
-    ) -> Result<(), BootError>
-    where
-        C: Capability,
-    {
-        let mut ctx = ChassisCtx::new(
-            registry,
-            mailer,
-            &mut self._fallback,
-            &mut self.frame_bound_pending,
-            &self.frame_bound_set,
-            &self.aborter,
-        );
-        let booted = cap.boot(&mut ctx)?;
-        self.running.push(Box::new(booted));
-        Ok(())
-    }
-
-    /// Boot one more facade-style cap into an already-built chassis.
-    /// Counterpart to [`Self::add`] for [`ChassisBuilder::with_facade`]
-    /// caps. Used by chassis mains that compose chassis-conditional
-    /// caps (today: the bundle hooks `LogCapability`,
-    /// `IoCapability`, etc. on top of `SubstrateBoot::build`'s
-    /// universal set).
-    pub fn add_facade<C>(
         &mut self,
         registry: &Arc<Registry>,
         mailer: &Arc<Mailer>,
@@ -1085,226 +1034,91 @@ impl Drop for BootedChassis {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mail::ReplyTo;
-    use crate::registry::MailboxEntry;
-    use std::sync::Mutex;
-
-    /// Test-only capability that claims one mailbox and records
-    /// every envelope it receives plus whether shutdown ran.
-    /// Post-issue-525-Phase-2 the cap is one struct: pre-boot fields
-    /// (`name`, shared `log`/`shutdown_flag` handles) live alongside
-    /// the runtime `Option<Receiver>` populated in `boot`. `Drop`
-    /// runs the prior `shutdown` body.
-    struct EchoCapability {
-        name: &'static str,
-        log: Arc<Mutex<Vec<Envelope>>>,
-        shutdown_flag: Arc<Mutex<bool>>,
-        receiver: Mutex<Option<mpsc::Receiver<Envelope>>>,
-    }
-
-    impl EchoCapability {
-        fn new(
-            name: &'static str,
-            log: Arc<Mutex<Vec<Envelope>>>,
-            shutdown_flag: Arc<Mutex<bool>>,
-        ) -> Self {
-            Self {
-                name,
-                log,
-                shutdown_flag,
-                receiver: Mutex::new(None),
-            }
-        }
-    }
-
-    impl Actor for EchoCapability {
-        // Placeholder: parameterized fixtures bypass the type-level
-        // namespace via `claim_mailbox_with_override` below, so no
-        // production code observes this string.
-        const NAMESPACE: &'static str = "test.echo.placeholder";
-    }
-
-    impl Capability for EchoCapability {
-        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-            let claim = ctx.claim_mailbox_with_override(self.name)?;
-            *self.receiver.lock().unwrap() = Some(claim.receiver);
-            Ok(self)
-        }
-    }
-
-    impl Drop for EchoCapability {
-        fn drop(&mut self) {
-            // Drain any pending envelopes synchronously so tests can
-            // assert against `log` after the drop returns.
-            if let Some(rx) = self.receiver.lock().unwrap().take() {
-                while let Ok(env) = rx.try_recv() {
-                    self.log.lock().unwrap().push(env);
-                }
-            }
-            *self.shutdown_flag.lock().unwrap() = true;
-        }
-    }
+    use aether_data::ReplyTo;
+    use aether_kinds::LogEvent;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
-    fn deliver(registry: &Registry, name: &str, payload: &[u8]) {
-        let id = registry.lookup(name).expect("mailbox registered");
-        let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry exists") else {
-            panic!("expected sink entry for {name}");
-        };
-        handler(KindId(42), "test.kind", None, ReplyTo::NONE, payload, 1);
-    }
-
-    #[test]
-    fn capability_claims_mailbox_and_receives_mail() {
-        let (registry, mailer) = fresh_substrate();
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let flag = Arc::new(Mutex::new(false));
-
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability::new(
-                "test.echo",
-                Arc::clone(&log),
-                Arc::clone(&flag),
-            ))
-            .build()
-            .expect("build succeeds");
-        assert_eq!(chassis.len(), 1);
-
-        deliver(&registry, "test.echo", b"hello");
-        deliver(&registry, "test.echo", b"world");
-
-        chassis.shutdown();
-        let log = log.lock().unwrap();
-        assert_eq!(log.len(), 2);
-        assert_eq!(log[0].payload, b"hello");
-        assert_eq!(log[1].payload, b"world");
-        assert!(*flag.lock().unwrap());
-    }
-
-    #[test]
-    fn duplicate_mailbox_claim_fails_with_loud_error() {
-        let (registry, mailer) = fresh_substrate();
-        // Pre-register the name to simulate the side-by-side period
-        // where legacy `register_sink` and a new capability would
-        // both target the same mailbox.
-        registry.register_sink("test.collide", Arc::new(|_, _, _, _, _, _| {}));
-
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let flag = Arc::new(Mutex::new(false));
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability::new("test.collide", log, flag))
-            .build()
-            .expect_err("build must reject duplicate claim");
-        assert!(
-            matches!(err, BootError::MailboxAlreadyClaimed { ref name } if name == "test.collide")
-        );
-    }
-
+    /// Boot-time mailbox-claim collision aborts the build and runs
+    /// every already-booted cap's `Drop`. Two `LogCapability`
+    /// instances both claim `aether.log`; the second hits the
+    /// duplicate-claim guard and the chassis tears the first down.
+    /// Per-cap mailbox-claim and mail-receive coverage lives in
+    /// `crate::capabilities::log::tests` and the equivalents for
+    /// the other facade caps.
     #[test]
     fn boot_failure_shuts_down_already_booted_capabilities() {
+        use crate::capabilities::LogCapability;
+
         let (registry, mailer) = fresh_substrate();
-        // First capability claims a fresh name; the second is set up
-        // to fail by pre-registering its target name.
-        registry.register_sink("test.fail.second", Arc::new(|_, _, _, _, _, _| {}));
-
-        let first_flag = Arc::new(Mutex::new(false));
-        let second_flag = Arc::new(Mutex::new(false));
-        let log = Arc::new(Mutex::new(Vec::new()));
-
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(EchoCapability::new(
-                "test.fail.first",
-                Arc::clone(&log),
-                Arc::clone(&first_flag),
-            ))
-            .with(EchoCapability::new(
-                "test.fail.second",
-                Arc::clone(&log),
-                Arc::clone(&second_flag),
-            ))
+            .with(LogCapability::new())
+            .with(LogCapability::new())
             .build()
-            .expect_err("second capability must fail");
-        assert!(matches!(err, BootError::MailboxAlreadyClaimed { .. }));
+            .expect_err("second LogCapability must fail with duplicate claim");
         assert!(
-            *first_flag.lock().unwrap(),
-            "first capability dropped on boot abort"
+            matches!(err, BootError::MailboxAlreadyClaimed { ref name } if name == LogCapability::NAMESPACE)
         );
-        // Post-issue-525-Phase-2: `second_flag` is set to `true` here
-        // too — the second EchoCapability value drops on the failed
-        // boot path, running its `Drop` impl. Pre-Phase-2 the flag
-        // was a "ran shutdown" proxy on the post-boot Running, which
-        // never existed for the second cap. The new semantic is "Drop
-        // ran" (on every constructed value, regardless of boot
-        // success), so we don't assert against `second_flag` here —
-        // the boot-aborted-cleanly check is `first_flag` plus the
-        // typed `BootError`.
-        let _ = second_flag;
     }
 
+    /// Two `with_fallback_router` calls on one builder collapse to a
+    /// `FallbackRouterAlreadyClaimed` at `build()` — single-slot
+    /// invariant. Pre-PR-E3 a Capability::boot body called
+    /// `ctx.claim_fallback_router`; post-E3 the builder method
+    /// surfaces the same single-claim guard.
     #[test]
     fn fallback_router_slot_is_single_claim() {
         let (registry, mailer) = fresh_substrate();
-
-        struct FallbackCap {
-            should_succeed: bool,
-        }
-        impl Actor for FallbackCap {
-            const NAMESPACE: &'static str = "test.fallback.placeholder";
-        }
-        impl Capability for FallbackCap {
-            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-                let handler: FallbackRouter = Arc::new(|_env: &Envelope| true);
-                ctx.claim_fallback_router(handler)?;
-                if self.should_succeed {
-                    Ok(self)
-                } else {
-                    Err(BootError::Other("unreachable".into()))
-                }
-            }
-        }
-
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(FallbackCap {
-                should_succeed: true,
-            })
-            .with(FallbackCap {
-                should_succeed: true,
-            })
+            .with_fallback_router(Arc::new(|_env: &Envelope| true))
+            .with_fallback_router(Arc::new(|_env: &Envelope| true))
             .build()
             .expect_err("second fallback claim must fail");
         assert!(matches!(err, BootError::FallbackRouterAlreadyClaimed));
     }
 
+    /// Smoke test: one cap, one envelope, clean shutdown. Validates
+    /// the chassis builder boots through the facade path end-to-end.
+    /// Per-cap routing semantics live in their own test modules; this
+    /// test just exercises the chassis-level invariants
+    /// (`with(cap).build()` succeeds, `shutdown()` joins).
     #[test]
-    fn mail_send_handle_clones_to_same_mailer() {
+    fn chassis_builder_boots_one_cap_and_shuts_down_clean() {
+        use crate::capabilities::LogCapability;
+        use aether_data::Kind;
+
         let (registry, mailer) = fresh_substrate();
-
-        struct ProbeCap {
-            captured: Arc<Mutex<Option<Arc<Mailer>>>>,
-        }
-        impl Actor for ProbeCap {
-            const NAMESPACE: &'static str = "test.probe.placeholder";
-        }
-        impl Capability for ProbeCap {
-            fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-                *self.captured.lock().unwrap() = Some(ctx.mail_send_handle());
-                Ok(self)
-            }
-        }
-
-        let captured = Arc::new(Mutex::new(None));
-        ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(ProbeCap {
-                captured: Arc::clone(&captured),
-            })
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with(LogCapability::new())
             .build()
-            .expect("build succeeds")
-            .shutdown();
+            .expect("build succeeds");
+        assert_eq!(chassis.len(), 1);
 
-        let captured = captured.lock().unwrap().take().expect("handle captured");
-        assert!(Arc::ptr_eq(&captured, &mailer));
+        let id = registry
+            .lookup(LogCapability::NAMESPACE)
+            .expect("log mailbox registered");
+        let crate::registry::MailboxEntry::Sink(handler) =
+            registry.entry(id).expect("entry exists")
+        else {
+            panic!("expected sink entry");
+        };
+        let event = LogEvent {
+            level: 3,
+            target: "aether_test".into(),
+            message: "boot smoke".into(),
+        };
+        let bytes = postcard::to_allocvec(&event).expect("encode");
+        handler(
+            <LogEvent as Kind>::ID,
+            "aether.log",
+            None,
+            ReplyTo::NONE,
+            &bytes,
+            1,
+        );
+
+        chassis.shutdown();
     }
 }

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -21,17 +21,14 @@
 //!   alongside the first real driver extraction (phase 3) so every
 //!   chassis can nominate a real driver type rather than a stub.
 
-use std::any::{Any, TypeId};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
-use crate::capability::{
-    BootError, Capability, ChassisCtx, FacadeHandle, FallbackRouter, MailboxClaim,
-};
+use crate::capability::{BootError, ChassisCtx, FacadeHandle, FallbackRouter, MailboxClaim};
 use crate::chassis::Chassis;
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::MailboxId;
@@ -125,42 +122,13 @@ trait DynShutdown {
     fn shutdown_dyn(self: Box<Self>);
 }
 
-/// Concrete adapter: holds the booted cap as an [`Arc`] (so the same
-/// value can also live in the typed-running map for driver lookup)
-/// and on shutdown attempts to take exclusive ownership via
-/// [`Arc::try_unwrap`]. Post-issue-525-Phase-2 the cap's `Drop` impl
-/// replaces the prior `RunningCapability::shutdown`; whether teardown
-/// runs explicitly here or implicitly when the last `Arc` clone goes
-/// away, the same `Drop` body executes.
-struct ArcShutdown<C: Capability + Sync> {
-    arc: Arc<C>,
-    name: &'static str,
-}
-
-impl<C: Capability + Sync> DynShutdown for ArcShutdown<C> {
-    fn shutdown_dyn(self: Box<Self>) {
-        let ArcShutdown { arc, name } = *self;
-        match Arc::try_unwrap(arc) {
-            // Cap drops at end of arm, running its `Drop` impl
-            // (channel-drop + thread join) eagerly.
-            Ok(_cap) => {}
-            Err(_arc) => {
-                tracing::warn!(
-                    target: "aether_substrate::chassis_builder",
-                    capability = name,
-                    "skipped eager shutdown — outstanding Arc clones; relying on Drop"
-                );
-            }
-        }
-    }
-}
-
-/// Concrete adapter for an ADR-0075 facade cap. The chassis owns the
+/// Concrete adapter for a chassis cap. The chassis owns the
 /// [`FacadeHandle`]; the cap itself lives in the dispatcher thread.
-/// On shutdown the handle drops, severing the channel and joining the
-/// thread; the captured cap drops there. There's no `TypedRunnings`
-/// entry because the cap value isn't reachable from the chassis side
-/// (drivers that need to talk to the cap should use mail).
+/// On shutdown the handle drops, severing the channel and joining
+/// the thread; the captured cap drops there. Drivers that need to
+/// talk to the cap reach for it through mail or — for caps that
+/// expose driver-facing state, like render — through the cap's own
+/// pre-build accessor (e.g. `RenderCapability::handles`).
 struct FacadeShutdown<C: 'static> {
     handle: Option<FacadeHandle<C>>,
 }
@@ -175,59 +143,39 @@ impl<C: 'static> DynShutdown for FacadeShutdown<C> {
     }
 }
 
-/// Internal: typed running store keyed by [`TypeId::of::<R>`].
-/// Populated as each passive boots; queried by drivers via
-/// [`DriverCtx::expect`] / [`DriverCtx::try_get`] and by embedders
-/// via [`PassiveChassis::capability`].
-#[derive(Default)]
-struct TypedRunnings {
-    by_type: HashMap<TypeId, Arc<dyn Any + Send + Sync + 'static>>,
-}
+/// Concrete adapter for the fallback-router slot. The handler itself
+/// is owned by the chassis's `fallback` slot (claimed via
+/// `ctx.claim_fallback_router`); this entry exists purely to keep
+/// the boot-order / shutdown-order invariants aligned with cap
+/// entries when `with_fallback_router` is mixed into a builder.
+struct FallbackShutdown;
 
-impl TypedRunnings {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn insert<R: Send + Sync + 'static>(&mut self, running: Arc<R>) {
-        self.by_type.insert(TypeId::of::<R>(), running);
-    }
-
-    fn try_get<R: Send + Sync + 'static>(&self) -> Option<Arc<R>> {
-        self.by_type.get(&TypeId::of::<R>()).map(|arc| {
-            Arc::clone(arc)
-                .downcast::<R>()
-                .expect("TypeId match implies downcast success")
-        })
-    }
-
-    fn expect<R: Send + Sync + 'static>(&self) -> Arc<R> {
-        self.try_get::<R>().unwrap_or_else(|| {
-            panic!(
-                "DriverCtx::expect: running of type `{}` not booted",
-                std::any::type_name::<R>()
-            )
-        })
+impl DynShutdown for FallbackShutdown {
+    fn shutdown_dyn(self: Box<Self>) {
+        // The fallback router doesn't own any threads or channels —
+        // it's a single function pointer. Nothing to do here; the
+        // chassis's `fallback` slot drops the `Arc` when the
+        // `BootedPassives` drops.
     }
 }
 
 /// Boot-time context handed to a [`DriverCapability`]. Forwards the
-/// passive [`ChassisCtx`] surface plus typed access to passive
-/// runnings booted earlier in the same build.
+/// passive [`ChassisCtx`] surface; pre-PR-E3 it also exposed typed
+/// access to passive runnings via `expect` / `try_get`, but the
+/// typed-runnings map retired alongside `Capability` so drivers
+/// wanting cap state get it through pre-build accessors (today only
+/// render via `RenderHandles`).
 pub struct DriverCtx<'a> {
     inner: ChassisCtx<'a>,
-    runnings: &'a TypedRunnings,
 }
 
 impl<'a> DriverCtx<'a> {
-    fn new(inner: ChassisCtx<'a>, runnings: &'a TypedRunnings) -> Self {
-        Self { inner, runnings }
+    fn new(inner: ChassisCtx<'a>) -> Self {
+        Self { inner }
     }
 
-    /// Drivers don't impl `Capability`, so they have no `NAMESPACE`
-    /// const to delegate against — claim by explicit name. The
-    /// passive-side equivalent is [`ChassisCtx::claim_mailbox`] (typed)
-    /// or [`ChassisCtx::claim_mailbox_with_override`] (escape hatch).
+    /// Drivers have no `NAMESPACE` const to delegate against — claim
+    /// by explicit name.
     pub fn claim_mailbox(&mut self, name: &str) -> Result<MailboxClaim, BootError> {
         self.inner.claim_mailbox_with_override(name)
     }
@@ -238,17 +186,6 @@ impl<'a> DriverCtx<'a> {
 
     pub fn claim_fallback_router(&mut self, handler: FallbackRouter) -> Result<(), BootError> {
         self.inner.claim_fallback_router(handler)
-    }
-
-    /// Look up a previously-booted passive's [`Arc<R>`]. Panics if no
-    /// running of type `R` has been registered. Use [`Self::try_get`]
-    /// for soft lookup.
-    pub fn expect<R: Send + Sync + 'static>(&self) -> Arc<R> {
-        self.runnings.expect()
-    }
-
-    pub fn try_get<R: Send + Sync + 'static>(&self) -> Option<Arc<R>> {
-        self.runnings.try_get()
     }
 
     /// Snapshot of every frame-bound mailbox's pending counter
@@ -288,35 +225,25 @@ impl sealed::Sealed for HasDriver {}
 impl BuilderState for NoDriver {}
 impl BuilderState for HasDriver {}
 
-type PassiveBoot = Box<
-    dyn FnOnce(&mut ChassisCtx<'_>, &mut TypedRunnings) -> Result<Box<dyn DynShutdown>, BootError>,
->;
+type PassiveBoot = Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn DynShutdown>, BootError>>;
 type DriverBoot = Box<dyn FnOnce(&mut DriverCtx<'_>) -> Result<Box<dyn DriverRunning>, BootError>>;
 
-fn make_passive_boot<P>(cap: P) -> PassiveBoot
-where
-    P: Capability + Sync,
-{
-    Box::new(move |ctx, runnings| {
-        let booted = cap.boot(ctx)?;
-        let arc = Arc::new(booted);
-        runnings.insert(Arc::clone(&arc));
-        Ok(Box::new(ArcShutdown {
-            arc,
-            name: std::any::type_name::<P>(),
-        }) as Box<dyn DynShutdown>)
-    })
-}
-
-fn make_facade_passive_boot<C>(cap: C) -> PassiveBoot
+fn make_passive_boot<C>(cap: C) -> PassiveBoot
 where
     C: Actor + Dispatch + Send + 'static,
 {
-    Box::new(move |ctx, _runnings| {
+    Box::new(move |ctx| {
         let handle = ctx.spawn_actor_dispatcher(cap)?;
         Ok(Box::new(FacadeShutdown {
             handle: Some(handle),
         }) as Box<dyn DynShutdown>)
+    })
+}
+
+fn make_fallback_router_boot(handler: FallbackRouter) -> PassiveBoot {
+    Box::new(move |ctx| {
+        ctx.claim_fallback_router(handler)?;
+        Ok(Box::new(FallbackShutdown) as Box<dyn DynShutdown>)
     })
 }
 
@@ -373,25 +300,29 @@ impl<C: Chassis> Builder<C, NoDriver> {
         self
     }
 
-    /// Append a passive capability. Boot order is declaration order;
-    /// `.with` calls before and after `.driver(_)` boot together
-    /// before the driver.
+    /// Append a chassis cap. The chassis claims its mailbox and runs
+    /// the dispatcher; the cap is an `Actor + Dispatch` value
+    /// (typically built by `#[actor]` on an inherent impl). Boot
+    /// order is declaration order; `.with` calls before and after
+    /// `.driver(_)` boot together before the driver.
+    ///
+    /// Pre-PR-E3 this method was named `with_facade`; the legacy
+    /// `with`-takes-Capability variant retired alongside `Capability`
+    /// itself.
     pub fn with<P>(mut self, cap: P) -> Self
     where
-        P: Capability + Sync,
+        P: Actor + Dispatch + Send + 'static,
     {
         self.passives.push(make_passive_boot::<P>(cap));
         self
     }
 
-    /// Append an ADR-0075 facade-style cap (cap impls `Actor +
-    /// Dispatch`, chassis owns the dispatcher thread). Booted in
-    /// declaration order alongside [`Self::with`].
-    pub fn with_facade<P>(mut self, cap: P) -> Self
-    where
-        P: Actor + Dispatch + Send + 'static,
-    {
-        self.passives.push(make_facade_passive_boot::<P>(cap));
+    /// Register a fallback router — a single-shot handler the
+    /// substrate consults for envelopes whose mailbox name doesn't
+    /// resolve. Multiple calls collapse to a `BootError` at
+    /// `build()` (single-claim invariant).
+    pub fn with_fallback_router(mut self, handler: FallbackRouter) -> Self {
+        self.passives.push(make_fallback_router_boot(handler));
         self
     }
 
@@ -426,31 +357,27 @@ impl<C: Chassis> Builder<C, NoDriver> {
 }
 
 impl<C: Chassis> Builder<C, HasDriver> {
-    /// Append a passive capability after the driver was supplied.
-    /// Booted before the driver in declaration order.
+    /// Append a chassis cap after the driver was supplied. Booted
+    /// before the driver in declaration order.
     pub fn with<P>(mut self, cap: P) -> Self
     where
-        P: Capability + Sync,
+        P: Actor + Dispatch + Send + 'static,
     {
         self.passives.push(make_passive_boot::<P>(cap));
         self
     }
 
-    /// Append an ADR-0075 facade-style cap after the driver was
-    /// supplied. Booted before the driver in declaration order.
-    pub fn with_facade<P>(mut self, cap: P) -> Self
-    where
-        P: Actor + Dispatch + Send + 'static,
-    {
-        self.passives.push(make_facade_passive_boot::<P>(cap));
+    /// Register a fallback router after the driver was supplied.
+    /// Booted before the driver in declaration order.
+    pub fn with_fallback_router(mut self, handler: FallbackRouter) -> Self {
+        self.passives.push(make_fallback_router_boot(handler));
         self
     }
 
     /// Boot every passive in declaration order, then boot the driver
-    /// against a [`DriverCtx`] that exposes the passives' typed
-    /// runnings. Any failure aborts the build and shuts down the
-    /// passives that already booted (via [`BootedPassives::Drop`])
-    /// before propagating the error.
+    /// against a [`DriverCtx`]. Any failure aborts the build and
+    /// shuts down the passives that already booted (via
+    /// [`BootedPassives::Drop`]) before propagating the error.
     pub fn build(self) -> Result<BuiltChassis<C>, BootError> {
         let Builder {
             registry,
@@ -472,7 +399,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
                 &booted.frame_bound_set,
                 &booted.aborter,
             );
-            let mut driver_ctx = DriverCtx::new(chassis_ctx, &booted.runnings);
+            let mut driver_ctx = DriverCtx::new(chassis_ctx);
             driver_boot(&mut driver_ctx)?
         };
 
@@ -487,7 +414,6 @@ impl<C: Chassis> Builder<C, HasDriver> {
 /// Internal carrier for the result of booting every passive.
 struct BootedPassives {
     shutdowns: Vec<Box<dyn DynShutdown>>,
-    runnings: TypedRunnings,
     fallback: Option<FallbackRouter>,
     /// Per-mailbox pending counters from
     /// [`ChassisCtx::claim_frame_bound_mailbox`] calls — collected
@@ -510,14 +436,6 @@ struct BootedPassives {
 
 impl BootedPassives {
     fn shutdown_in_place(&mut self) {
-        // Clear the typed-runnings map before draining the shutdown
-        // queue: every passive's Arc lives in both stores, so leaving
-        // the map populated would force every `Arc::try_unwrap` in
-        // `ArcShutdown::shutdown_dyn` to fail (refcount ≥ 2). After
-        // this drain, the only remaining clone for each passive is
-        // the one inside its `ArcShutdown` wrapper, modulo any clones
-        // a driver or embedder retained via typed lookup.
-        self.runnings = TypedRunnings::new();
         while let Some(s) = self.shutdowns.pop() {
             s.shutdown_dyn();
         }
@@ -537,7 +455,6 @@ fn boot_passives(
     passives: Vec<PassiveBoot>,
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
-    let mut runnings = TypedRunnings::new();
     let mut fallback: Option<FallbackRouter> = None;
     let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
     let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
@@ -550,7 +467,7 @@ fn boot_passives(
             &frame_bound_set,
             aborter,
         );
-        match boot(&mut ctx, &mut runnings) {
+        match boot(&mut ctx) {
             Ok(shutdown) => shutdowns.push(shutdown),
             Err(e) => {
                 while let Some(s) = shutdowns.pop() {
@@ -562,7 +479,6 @@ fn boot_passives(
     }
     Ok(BootedPassives {
         shutdowns,
-        runnings,
         fallback,
         frame_bound_pending,
         frame_bound_set,
@@ -623,19 +539,6 @@ impl<C: Chassis> fmt::Debug for PassiveChassis<C> {
 }
 
 impl<C: Chassis> PassiveChassis<C> {
-    /// Look up a booted passive by type. Panics if no passive of type
-    /// `P` was registered. Post-issue-525-Phase-2 the type parameter
-    /// is the merged cap struct itself (the prior `Running` half no
-    /// longer exists as a distinct type).
-    pub fn capability<P: Capability + Sync>(&self) -> Arc<P> {
-        self.booted.runnings.expect()
-    }
-
-    /// Soft variant of [`Self::capability`].
-    pub fn try_capability<P: Capability + Sync>(&self) -> Option<Arc<P>> {
-        self.booted.runnings.try_get()
-    }
-
     /// Number of booted passives. Useful for tests; not expected to
     /// vary at runtime.
     pub fn len(&self) -> usize {
@@ -660,12 +563,9 @@ impl<C: Chassis> PassiveChassis<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capability::Envelope;
-    use aether_actor::Actor;
-    use std::sync::Mutex;
+    use crate::capabilities::LogCapability;
 
-    /// Fixture chassis for passive-build tests. `type Driver` is the
-    /// phantom [`NeverDriver`] since these tests use `build_passive`.
+    /// Fixture chassis for passive-build tests.
     struct TestChassis;
     impl Chassis for TestChassis {
         const PROFILE: &'static str = "test";
@@ -689,72 +589,23 @@ mod tests {
         }
     }
 
-    /// Test passive: claims one mailbox, records every envelope
-    /// received, exposes recorded envelopes via the typed lookup.
-    /// Post-issue-525-Phase-2 the cap is one struct: pre-boot config
-    /// (`name`) lives alongside the runtime fields populated in
-    /// `boot`. `Drop` runs the prior `shutdown` body.
-    struct EchoCap {
-        name: &'static str,
-        receiver: Mutex<Option<std::sync::mpsc::Receiver<Envelope>>>,
-        log: Mutex<Vec<Envelope>>,
-        shutdown_flag: std::sync::atomic::AtomicBool,
-    }
-
-    impl EchoCap {
-        fn new(name: &'static str) -> Self {
-            Self {
-                name,
-                receiver: Mutex::new(None),
-                log: Mutex::new(Vec::new()),
-                shutdown_flag: std::sync::atomic::AtomicBool::new(false),
-            }
-        }
-    }
-
-    impl Actor for EchoCap {
-        // Placeholder: parameterized fixtures bypass the type-level
-        // namespace via `claim_mailbox_with_override` below.
-        const NAMESPACE: &'static str = "test.echo.placeholder";
-    }
-
-    impl Capability for EchoCap {
-        fn boot(self, ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-            let claim = ctx.claim_mailbox_with_override(self.name)?;
-            *self.receiver.lock().unwrap() = Some(claim.receiver);
-            Ok(self)
-        }
-    }
-
-    impl Drop for EchoCap {
-        fn drop(&mut self) {
-            if let Some(rx) = self.receiver.lock().unwrap().take() {
-                while let Ok(env) = rx.try_recv() {
-                    self.log.lock().unwrap().push(env);
-                }
-            }
-            self.shutdown_flag
-                .store(true, std::sync::atomic::Ordering::SeqCst);
-        }
-    }
-
     /// Test driver: records that it ran, then exits.
-    struct EchoDriver {
+    struct RanDriver {
         ran: Arc<std::sync::atomic::AtomicBool>,
     }
 
-    struct EchoDriverRunning {
+    struct RanDriverRunning {
         ran: Arc<std::sync::atomic::AtomicBool>,
     }
 
-    impl DriverCapability for EchoDriver {
-        type Running = EchoDriverRunning;
+    impl DriverCapability for RanDriver {
+        type Running = RanDriverRunning;
         fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
-            Ok(EchoDriverRunning { ran: self.ran })
+            Ok(RanDriverRunning { ran: self.ran })
         }
     }
 
-    impl DriverRunning for EchoDriverRunning {
+    impl DriverRunning for RanDriverRunning {
         fn run(self: Box<Self>) -> Result<(), RunError> {
             self.ran.store(true, std::sync::atomic::Ordering::SeqCst);
             Ok(())
@@ -765,27 +616,18 @@ mod tests {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
-    #[test]
-    fn passive_build_exposes_capabilities_via_typed_lookup() {
-        let (registry, mailer) = fresh_substrate();
-        let passive = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap::new("test.echo"))
-            .build_passive()
-            .expect("build_passive succeeds");
-
-        assert_eq!(passive.len(), 1);
-        let echo: Arc<EchoCap> = passive.capability();
-        assert!(!echo.shutdown_flag.load(std::sync::atomic::Ordering::SeqCst));
-    }
-
+    /// Driver build path: passives boot, driver runs, passives tear
+    /// down on chassis drop. Per-cap dispatch coverage lives in the
+    /// individual cap modules; this test exercises the chassis-level
+    /// boot + run + teardown sequence.
     #[test]
     fn driver_build_runs_driver_and_tears_down_passives() {
         let (registry, mailer) = fresh_substrate();
         let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let chassis = Builder::<DrivenTestChassis<EchoDriver>>::new(registry, mailer)
-            .with(EchoCap::new("test.echo"))
-            .driver(EchoDriver {
+        let chassis = Builder::<DrivenTestChassis<RanDriver>>::new(registry, mailer)
+            .with(LogCapability::new())
+            .driver(RanDriver {
                 ran: Arc::clone(&ran),
             })
             .build()
@@ -795,113 +637,19 @@ mod tests {
         assert!(ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
+    /// Boot-time mailbox-claim collision aborts the build (and runs
+    /// the prior cap's drop). Two `LogCapability` instances both
+    /// claim `aether.log`; the second hits the duplicate-claim guard.
     #[test]
     fn duplicate_passive_mailbox_aborts_build_and_shuts_down_prior() {
         let (registry, mailer) = fresh_substrate();
-        registry.register_sink("test.collide", Arc::new(|_, _, _, _, _, _| {}));
 
         let err = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap::new("test.fresh"))
-            .with(EchoCap::new("test.collide"))
+            .with(LogCapability::new())
+            .with(LogCapability::new())
             .build_passive()
-            .expect_err("second passive must fail");
+            .expect_err("second passive must fail with duplicate claim");
 
         assert!(matches!(err, BootError::MailboxAlreadyClaimed { .. }));
-    }
-
-    #[test]
-    fn passive_chassis_drop_runs_shutdowns() {
-        let (registry, mailer) = fresh_substrate();
-        let passive = Builder::<TestChassis>::new(registry, mailer)
-            .with(EchoCap::new("test.echo"))
-            .build_passive()
-            .expect("build_passive succeeds");
-
-        let echo: Arc<EchoCap> = passive.capability();
-        // Drop the passive chassis. The internal Arc has refcount 2
-        // (chassis + our `echo` clone). The chassis-side shutdown
-        // call hits Arc::try_unwrap, sees an outstanding clone, and
-        // skips the explicit shutdown — the value drops when `echo`
-        // goes out of scope at end of test.
-        drop(passive);
-
-        assert!(!echo.shutdown_flag.load(std::sync::atomic::Ordering::SeqCst));
-        // The shared running survives until our clone drops.
-        drop(echo);
-    }
-
-    #[test]
-    fn passive_chassis_shutdown_calls_explicit_shutdown_when_arc_unique() {
-        // Capture the running's shutdown_flag externally so we can
-        // observe it after the chassis (and its Arc clone) drops.
-        let (registry, mailer) = fresh_substrate();
-
-        struct ProbeCap {
-            flag: Arc<std::sync::atomic::AtomicBool>,
-        }
-        impl Actor for ProbeCap {
-            const NAMESPACE: &'static str = "test.probe.placeholder";
-        }
-        impl Capability for ProbeCap {
-            fn boot(self, _ctx: &mut ChassisCtx<'_>) -> Result<Self, BootError> {
-                Ok(self)
-            }
-        }
-        impl Drop for ProbeCap {
-            fn drop(&mut self) {
-                self.flag.store(true, std::sync::atomic::Ordering::SeqCst);
-            }
-        }
-
-        let flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let passive = Builder::<TestChassis>::new(registry, mailer)
-            .with(ProbeCap {
-                flag: Arc::clone(&flag),
-            })
-            .build_passive()
-            .expect("build_passive succeeds");
-
-        // Don't take a typed clone; the chassis owns the only Arc.
-        drop(passive);
-
-        assert!(
-            flag.load(std::sync::atomic::Ordering::SeqCst),
-            "explicit shutdown must run when the chassis holds the only Arc",
-        );
-    }
-
-    #[test]
-    fn driver_ctx_expect_returns_passive_running() {
-        let (registry, mailer) = fresh_substrate();
-        let captured: Arc<Mutex<Option<Arc<EchoCap>>>> = Arc::new(Mutex::new(None));
-
-        struct CaptureDriver {
-            captured: Arc<Mutex<Option<Arc<EchoCap>>>>,
-        }
-        struct CaptureDriverRunning;
-        impl DriverCapability for CaptureDriver {
-            type Running = CaptureDriverRunning;
-            fn boot(self, ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
-                let echo: Arc<EchoCap> = ctx.expect();
-                *self.captured.lock().unwrap() = Some(echo);
-                Ok(CaptureDriverRunning)
-            }
-        }
-        impl DriverRunning for CaptureDriverRunning {
-            fn run(self: Box<Self>) -> Result<(), RunError> {
-                Ok(())
-            }
-        }
-
-        let chassis = Builder::<DrivenTestChassis<CaptureDriver>>::new(registry, mailer)
-            .with(EchoCap::new("test.echo"))
-            .driver(CaptureDriver {
-                captured: Arc::clone(&captured),
-            })
-            .build()
-            .expect("build succeeds");
-
-        chassis.run().expect("driver run succeeds");
-        assert!(captured.lock().unwrap().is_some());
     }
 }

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -56,9 +56,8 @@ pub mod scheduler;
 pub use aether_actor::Actor;
 pub use boot::{ChassisHandlerContext, SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
-    ActorErased, BootError, BootedChassis, Capability, ChassisBuilder, ChassisCtx,
-    DropOnShutdownClaim, Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, NativeActor,
-    SinkSender, WedgedFrameBound,
+    ActorErased, BootError, BootedChassis, ChassisBuilder, ChassisCtx, DropOnShutdownClaim,
+    Envelope, FallbackRouter, FrameBoundClaim, MailboxClaim, SinkSender, WedgedFrameBound,
 };
 pub use chassis::Chassis;
 pub use chassis_builder::{


### PR DESCRIPTION
## Summary

Stacked on PR 547 (E2). After E1+E2 every chassis cap is a facade — `Actor + Dispatch` built through `#[actor]`. The legacy `Capability` trait + `with(cap)` boot path no longer has any production users; the builders kept it alongside `with_facade` for a side-by-side period that's now over.

This PR collapses the duplication:

- `Capability` trait (alias for `NativeActor`) + `NativeActor` itself retire. Tests that exercised the boot path via inline `Capability` impls are rewritten against real cap types (`LogCapability`) so the invariants they covered (boot-failure abort, duplicate-claim guard, fallback-router single-slot) keep firing.
- `with_facade` renamed to `with`; `add_facade` renamed to `add_capability`. The legacy variants are gone. Every cap path now routes through `spawn_actor_dispatcher`.
- `claim_mailbox<C: Capability>` and friends rebind to `<C: Actor>` — `NAMESPACE` is on `Actor`, no behavior change.
- New builder method: `with_fallback_router(handler)`. The chassis's fallback-router slot was previously reachable only from inside a `Capability::boot` body; tests + future production callers go through this surfaced helper.
- `TypedRunnings` (the by-`TypeId` map populated from `Arc<Cap>` entries), `passive.capability::<R>()`, `try_capability::<R>()`, `DriverCtx::expect::<R>()`, `try_get::<R>()`, and `ArcShutdown` retire. Drivers that need cap state retrieve it through pre-build accessors (today only render, via `RenderHandles`).
- `HubClientCapability` (dead code — never instantiated) deleted from `aether-substrate-bundle::hub`. Every chassis already used `connect_hub_client()` directly.

Net diff: -820/+255 across 16 files.

## Out of scope

- Actor-marker move back to `aether-actor` — PR E4.
- ADR superseding ADR-0075 — PR E5.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` — all passing
- [x] `cargo check -p aether-camera-component -p aether-mesh-viewer-component --target wasm32-unknown-unknown` clean

Part of issue 545. Closes nothing yet — that issue closes on PR E5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)