### PR TITLE
docs: refresh three ReplyTo/RenderHandles doc comments to point at ADR-0076

### DIFF
--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -1,12 +1,13 @@
 //! Reply-routing types shared by every mail-bearing surface (ADR-0008,
-//! ADR-0037, ADR-0042). Lives in `aether-data` so chassis caps in
-//! `aether-kinds` can name the substrate's reply target type from
-//! their `#[handler]` signatures (ADR-0075 / issue 533 PR D).
+//! ADR-0037, ADR-0042). Lives in `aether-data` so the `Dispatch` trait
+//! in `aether-actor` (which references `ReplyTo` in its signature) can
+//! name them without depending on `aether-actor`-internal modules,
+//! AND to avoid a name clash with `aether-actor`'s wasm-side `ReplyTo`
+//! — that one is a `u32` FFI handle distinct in shape from this
+//! substrate-side dispatch type. ADR-0076 documents the split.
 //!
 //! `aether-substrate` re-exports these from `aether_substrate::mail`
-//! so existing call sites compile unchanged. Wasm components see a
-//! different `ReplyTo` (a u32 FFI handle in `aether-actor::mail`); the
-//! two types share a name but serve different sides of the boundary.
+//! so existing call sites compile unchanged.
 
 use crate::{EngineId, MailboxId, SessionToken};
 

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -708,9 +708,9 @@ pub struct DesktopDriverCapability {
     /// Cloned out of `RenderCapability::handles()` before the cap
     /// moves into the chassis builder. Pre-PR-E2 the driver's `boot`
     /// pulled `Arc<RenderCapability>` from `DriverCtx::expect`; post-
-    /// E2 the cap is owned by its dispatcher thread (facade pattern)
-    /// and only the Arc-shared handles bundle is reachable from the
-    /// driver side.
+    /// E2 the cap is owned by its dispatcher thread (ADR-0076's
+    /// unified `#[actor]` pattern) and only the Arc-shared handles
+    /// bundle is reachable from the driver side.
     pub render_handles: RenderHandles,
 }
 

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -6,11 +6,13 @@
 /// this remains re-exported under the `aether_substrate::mail::MailboxId`
 /// path so existing call sites compile unchanged.
 pub use aether_data::{KindId, MailboxId};
-/// Reply-routing types — ADR-0075 / issue 533 PR D1 hoisted these into
-/// `aether-data` so chassis caps in `aether-kinds` can name them from
-/// `#[handler]` signatures. This module re-exports them so existing
-/// `aether_substrate::mail::{ReplyTo, ReplyTarget}` call sites compile
-/// unchanged.
+/// Reply-routing types. Canonical home is `aether-data` (ADR-0076) —
+/// `aether-actor`'s `Dispatch` trait references them in its signature
+/// without taking an `aether-actor`-internal dep, and the location
+/// avoids a name clash with `aether-actor`'s wasm-side `ReplyTo` (a
+/// distinct `u32` FFI handle). This module re-exports them so
+/// existing `aether_substrate::mail::{ReplyTo, ReplyTarget}` call
+/// sites compile unchanged.
 pub use aether_data::{ReplyTarget, ReplyTo};
 /// Host/guest contract tag for the payload layout. The substrate and the
 /// components that talk to it agree on a specific layout per kind. The


### PR DESCRIPTION
## Summary

Sweeps three rustdoc blocks that still narrated the pre-ADR-0076-collapse reasoning:

- `aether-data/src/mail.rs` — said `ReplyTo` lives in aether-data so chassis caps in aether-kinds can name it. Post-ADR-0076 caps live in aether-substrate; the actual reason `ReplyTo` stays in aether-data is (a) `Dispatch` in aether-actor references it without taking an aether-actor-internal dep, (b) location avoids name clash with aether-actor's wasm-side `ReplyTo` (a u32 FFI handle).
- `aether-substrate/src/mail.rs` — same fix to the corresponding re-export comment.
- `aether-substrate-bundle/src/desktop/driver.rs` — the `render_handles` field doc said "facade pattern"; ADR-0076 retired the facade. Now points at ADR-0076's unified `#[actor]` pattern.

Pure rustdoc; no behavior changes.

## Test plan

- [x] `cargo check --workspace --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)