### PR TITLE
refactor(actor): add NativeActor + NativeCtx + Sender/MailCtx + Arc-shared storage (issue 552 stage 1)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -880,9 +880,34 @@ struct FallbackFn {
 }
 
 fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
-    if item.trait_.is_some() {
-        expand_wasm_actor(item)
+    if let Some((_, trait_path, _)) = item.trait_.as_ref() {
+        // Pattern-match the trait path's last identifier so the macro
+        // works regardless of the user's import style — bare
+        // `WasmActor` / `NativeActor`, `aether_actor::WasmActor`,
+        // `aether_substrate::NativeActor`, etc. all resolve here.
+        let last = trait_path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        match last.as_str() {
+            "NativeActor" => expand_native_actor_trait(item),
+            // `WasmActor` is the post-552 trait name; `Component` is
+            // the back-compat alias retained until stage 4.
+            "WasmActor" | "Component" => expand_wasm_actor(item),
+            other => Err(syn::Error::new_spanned(
+                trait_path,
+                format!(
+                    "#[actor] expects `impl WasmActor for X`, `impl NativeActor for X`, or \
+                     `impl Component for X` (back-compat alias) — got `{other}`",
+                ),
+            )),
+        }
     } else {
+        // Inherent `impl X { … }` is the legacy native-cap shape used
+        // by post-545 capabilities (LogCapability et al.). Stays
+        // available through stage 1; stage 2 migrates caps onto the
+        // `impl NativeActor for X` shape so this arm retires.
         expand_native_actor(item)
     }
 }
@@ -1268,6 +1293,225 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             #(#helper_methods_tokens)*
         }
     })
+}
+
+/// Issue 552 stage 1: expansion for `#[actor] impl NativeActor for X`
+/// — the new native chassis-cap shape. Per-handler ctx + `&self`
+/// (Arc-shared) + typed `init`. Mirrors `expand_wasm_actor`'s shape
+/// across the wasm/native split.
+///
+/// Emits, all rooted in the consumer crate's namespace:
+///   - `impl Actor for X` carrying the user-declared `const NAMESPACE`
+///     / `const FRAME_BARRIER` (extracted from the impl block so the
+///     `NativeActor: Actor` supertrait bound is satisfied).
+///   - `impl HandlesKind<K> for X` per `#[handler]` method — the
+///     compile-time gate `Sender::send::<R, K>` consults.
+///   - `impl NativeActor for X { type Config; fn init }` (the user's
+///     bodies, attribute-stripped).
+///   - `impl ::aether_substrate::NativeDispatch for X` whose body is
+///     a kind-id if-chain that decodes payload via
+///     `Kind::decode_from_bytes` and dispatches to the matching
+///     handler method.
+///   - The handler methods themselves (and any helper fns) on a
+///     sibling inherent `impl X { … }`.
+///
+/// `#[fallback]` is rejected — native actors are typed receivers;
+/// unknown kinds are programming errors, not fallback paths.
+fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
+    let self_ty = &item.self_ty;
+    let generics = &item.generics;
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let trait_path = item
+        .trait_
+        .as_ref()
+        .map(|(_, p, _)| p)
+        .expect("trait_ checked above");
+
+    let mut init_method: Option<syn::ImplItemFn> = None;
+    let mut config_type: Option<syn::ImplItemType> = None;
+    let mut handlers: Vec<NativeActorHandlerFn> = Vec::new();
+    let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
+    let mut consts: Vec<syn::ImplItemConst> = Vec::new();
+
+    for impl_item in item.items {
+        match impl_item {
+            ImplItem::Type(it) if it.ident == "Config" => {
+                config_type = Some(it);
+            }
+            ImplItem::Type(it) => {
+                return Err(syn::Error::new_spanned(
+                    it,
+                    "#[actor] impl NativeActor for X accepts only `type Config = …` — \
+                     other associated types aren't part of the trait",
+                ));
+            }
+            ImplItem::Const(c) => {
+                consts.push(c);
+            }
+            ImplItem::Fn(mut f) => {
+                if f.attrs.iter().any(attr_is_fallback) {
+                    return Err(syn::Error::new_spanned(
+                        &f,
+                        "#[fallback] is not supported on `impl NativeActor for X` blocks — \
+                         every kind a native actor accepts is declared via #[handler]",
+                    ));
+                }
+                let handler_idx = f.attrs.iter().position(attr_is_handler);
+                if let Some(idx) = handler_idx {
+                    let kind_ty = extract_native_actor_handler_kind(&f.sig)?;
+                    f.attrs.remove(idx);
+                    handlers.push(NativeActorHandlerFn { method: f, kind_ty });
+                } else if f.sig.ident == "init" {
+                    init_method = Some(f);
+                } else {
+                    helpers.push(f);
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unexpected item in #[actor] impl NativeActor for X (only fns, \
+                     `type Config = …`, and `const` items are accepted)",
+                ));
+            }
+        }
+    }
+
+    let init_method = init_method.ok_or_else(|| {
+        syn::Error::new_spanned(
+            self_ty,
+            "#[actor] impl NativeActor requires \
+             `fn init(config: Self::Config, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError>`",
+        )
+    })?;
+
+    let config_type = config_type.ok_or_else(|| {
+        syn::Error::new_spanned(
+            self_ty,
+            "#[actor] impl NativeActor requires `type Config = …` — \
+             use `()` for caps without configuration",
+        )
+    })?;
+
+    if handlers.is_empty() {
+        return Err(syn::Error::new_spanned(
+            self_ty,
+            "#[actor] impl NativeActor requires at least one #[handler] method",
+        ));
+    }
+
+    // `NAMESPACE` / `FRAME_BARRIER` are declared on the supertrait
+    // `Actor`, but the user wrote them inside `impl NativeActor for X`
+    // for the symmetric authoring shape. Route the consts onto a
+    // sibling `impl Actor for X` block so satisfying the supertrait
+    // bound works without making the user split the impl.
+    let const_tokens = consts.iter();
+    let actor_impl = if consts.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
+                #(#const_tokens)*
+            }
+        }
+    };
+
+    let handles_kind_impls = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        quote! {
+            impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+                for #self_ty #where_clause {}
+        }
+    });
+
+    let dispatch_arms = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        let method_ident = &h.method.sig.ident;
+        quote! {
+            if __aether_kind.0 == <#kind_ty as ::aether_data::Kind>::ID.0 {
+                if let Some(__aether_decoded) =
+                    <#kind_ty as ::aether_data::Kind>::decode_from_bytes(__aether_payload)
+                {
+                    self.#method_ident(__aether_ctx, __aether_decoded);
+                    return ::core::option::Option::Some(());
+                }
+                return ::core::option::Option::None;
+            }
+        }
+    });
+
+    let handler_methods = handlers.iter().map(|h| &h.method);
+    let helper_methods = helpers.iter();
+
+    Ok(quote! {
+        #actor_impl
+
+        #(#handles_kind_impls)*
+
+        impl #impl_generics #trait_path for #self_ty #where_clause {
+            #config_type
+            #init_method
+        }
+
+        impl #impl_generics ::aether_substrate::NativeDispatch for #self_ty #where_clause {
+            fn __aether_dispatch_envelope(
+                &self,
+                __aether_ctx: &mut ::aether_substrate::NativeCtx<'_>,
+                __aether_kind: ::aether_substrate::mail::KindId,
+                __aether_payload: &[u8],
+            ) -> ::core::option::Option<()> {
+                #(#dispatch_arms)*
+                ::core::option::Option::None
+            }
+        }
+
+        impl #impl_generics #self_ty #where_clause {
+            #(#handler_methods)*
+            #(#helper_methods)*
+        }
+    })
+}
+
+struct NativeActorHandlerFn {
+    method: syn::ImplItemFn,
+    kind_ty: Type,
+}
+
+/// Extract `K` from a `#[actor] impl NativeActor` handler method's
+/// third parameter. Required signature: `(&self, ctx: &mut NativeCtx<'_>, mail: K)`.
+/// The `&self` (vs `&mut self`) is load-bearing — the actor lives
+/// behind `Arc<Self>` and shares the ref across dispatcher / lookup
+/// consumers.
+fn extract_native_actor_handler_kind(sig: &Signature) -> syn::Result<Type> {
+    if sig.inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "#[actor] impl NativeActor #[handler] method must have signature \
+             `(&self, ctx: &mut NativeCtx<'_>, arg: K)`",
+        ));
+    }
+    let first = &sig.inputs[0];
+    let FnArg::Receiver(recv) = first else {
+        return Err(syn::Error::new_spanned(
+            first,
+            "#[handler] first parameter must be `&self` (NativeActor caps share state via Arc)",
+        ));
+    };
+    if recv.mutability.is_some() {
+        return Err(syn::Error::new_spanned(
+            recv,
+            "#[actor] impl NativeActor #[handler] receiver must be `&self`, not `&mut self` — \
+             native caps share state across threads via interior mutability behind `Arc<Self>`",
+        ));
+    }
+    let third = &sig.inputs[2];
+    let FnArg::Typed(pt) = third else {
+        return Err(syn::Error::new_spanned(
+            third,
+            "#[handler] third parameter must be a typed `arg: K`",
+        ));
+    };
+    Ok((*pt.ty).clone())
 }
 
 struct NativeHandlerFn {

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -21,6 +21,7 @@ use aether_data::{Kind, Schema};
 use crate::actor::{Actor, HandlesKind, Singleton};
 use crate::handle::{self, Handle, SyncHandleError};
 use crate::mail::ReplyTo;
+use crate::sender::{MailCtx, Sender};
 use crate::sink::{
     ActorMailbox, KindId, Mailbox, resolve, resolve_actor, resolve_actor_named, resolve_mailbox,
 };
@@ -346,6 +347,77 @@ impl<'a, T: MailTransport> DropCtx<'a, T> {
         let payload = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
         out.extend_from_slice(&payload);
         self.save_state(version, &out);
+    }
+}
+
+/// Issue 552 stage 1: cross-transport [`Sender`] impl. Routes through
+/// the actor-typed sink (`resolve_actor::<R, T>`) for typed sends and
+/// through the kind-typed sink (`resolve_mailbox::<K, T>`) for the
+/// string-keyed escape hatch. The wasm path's `Ctx<'a, WasmTransport>`
+/// inherits this impl through the [`crate::WasmCtx`] alias; the native
+/// `NativeCtx<'a>` (in `aether-substrate`) writes its own `Sender`
+/// impl since it doesn't go through `Ctx<'a, T>` (extra per-mail state
+/// — origin mailbox + reply target — that the universal ctx doesn't
+/// carry).
+impl<'a, T: MailTransport> Sender for Ctx<'a, T> {
+    fn send<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: aether_data::Kind,
+    {
+        resolve_actor::<R, T>().send(self.transport, payload);
+    }
+
+    fn send_many<R, K>(&mut self, payloads: &[K])
+    where
+        R: Actor + HandlesKind<K>,
+        K: aether_data::Kind + bytemuck::NoUninit,
+    {
+        resolve_actor::<R, T>().send_many(self.transport, payloads);
+    }
+
+    fn send_to_named<K: aether_data::Kind>(&mut self, name: &str, payload: &K) {
+        resolve_mailbox::<K, T>(name).send(self.transport, payload);
+    }
+}
+
+/// Issue 552 stage 1: per-handler reply surface on top of [`Sender`].
+/// `reply::<K>(...)` re-encodes through `Kind::encode_into_bytes` and
+/// dispatches via `T::reply_mail`. No-op when the inbound has no
+/// reply target (component-origin / broadcast mail).
+impl<'a, T: MailTransport> MailCtx for Ctx<'a, T> {
+    fn reply<K: aether_data::Kind>(&mut self, payload: &K) {
+        if let Some(raw) = self.sender {
+            let bytes = payload.encode_into_bytes();
+            self.transport.reply_mail(raw, K::ID.0, &bytes, 1);
+        }
+        // No-op on no-sender mail (broadcast or peer-component).
+    }
+}
+
+/// Issue 552 stage 1: init-time [`Sender`] impl. Same routing as
+/// per-handler `Sender`. Init contexts deliberately don't implement
+/// [`MailCtx`] — there is no inbound mail at boot, so no sender or
+/// reply target is defined.
+impl<'a, T: MailTransport> Sender for InitCtx<'a, T> {
+    fn send<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: aether_data::Kind,
+    {
+        resolve_actor::<R, T>().send(self.transport, payload);
+    }
+
+    fn send_many<R, K>(&mut self, payloads: &[K])
+    where
+        R: Actor + HandlesKind<K>,
+        K: aether_data::Kind + bytemuck::NoUninit,
+    {
+        resolve_actor::<R, T>().send_many(self.transport, payloads);
+    }
+
+    fn send_to_named<K: aether_data::Kind>(&mut self, name: &str, payload: &K) {
+        resolve_mailbox::<K, T>(name).send(self.transport, payload);
     }
 }
 

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -55,6 +55,7 @@ mod actor;
 mod ctx;
 pub mod handle;
 mod mail;
+mod sender;
 mod sink;
 mod slot;
 mod sync;
@@ -64,6 +65,7 @@ pub mod wasm;
 pub use actor::{Actor, Dispatch, HandlesKind, Singleton};
 pub use ctx::{Ctx, DropCtx, InitCtx};
 pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
+pub use sender::{MailCtx, Sender};
 // Generic 2-arg `Mailbox<K, T>` and `Handle<K, T>` stay accessible
 // as `aether_actor::sink::Mailbox` / `aether_actor::handle::Handle`.
 // At the crate root we re-export the 1-arg wasm aliases (defined in

--- a/crates/aether-actor/src/sender.rs
+++ b/crates/aether-actor/src/sender.rs
@@ -1,0 +1,103 @@
+//! Issue 552 stage 1: cross-transport actor-typed sender surface.
+//!
+//! Both the wasm-guest [`Ctx<'a, WasmTransport>`] and the native
+//! [`aether_substrate::NativeCtx<'a>`] implement [`Sender`] and
+//! [`MailCtx`]. The traits are the language stage-3 senders walk
+//! against once `resolve_mailbox::<K>(name)` retires — `ctx.send::<R>(&kind)`
+//! is the same call shape everywhere, with the trait body picking
+//! the per-transport routing.
+//!
+//! [`Sender`] is the addressing minimum every per-handler ctx and
+//! every init-time ctx exposes — single-payload `send`, batched
+//! `send_many` (cast-only, see [`crate::sink::Mailbox::send_many`]
+//! for the wire-shape rationale), plus `send_to_named` as the
+//! string-keyed escape hatch for cases where the caller genuinely
+//! has no Rust type at compile site.
+//!
+//! [`MailCtx`] adds the per-mail surface that only makes sense
+//! while a handler is running: read the inbound's `sender` (so
+//! a reply can route back to the originator) and `reply` to it
+//! without rethreading the handle. Init contexts implement
+//! [`Sender`] but NOT [`MailCtx`] — there's no active inbound mail
+//! at boot time, so neither a sender nor a reply target is defined.
+//!
+//! The two-trait split mirrors the existing `InitCtx` / `Ctx` /
+//! `DropCtx` typestate fence (init can resolve, receive can send /
+//! reply): `Sender` is "you can send mail," `MailCtx` is "and you
+//! also have an active inbound to reply to." Stage 2 caps and
+//! stage 3 components will program against [`Sender`] / [`MailCtx`]
+//! generic over the ctx type when they need to be ctx-agnostic.
+
+use aether_data::Kind;
+
+use crate::actor::{Actor, HandlesKind};
+
+/// Outbound-mail surface every actor ctx exposes. Implementations
+/// route through their owning transport — the wasm impl on
+/// [`crate::Ctx<'a, WasmTransport>`] dispatches through host fns;
+/// the native impl on `NativeCtx<'_>` (in `aether-substrate`)
+/// pushes onto the cross-actor `Arc<Mailer>` queue.
+///
+/// `R` is the receiving actor type. `R::NAMESPACE` resolves to the
+/// receiver's mailbox id at compile time (ADR-0029 stable hash).
+/// The `R: Actor + HandlesKind<K>` bound is the compile-time gate:
+/// trying to send a kind the receiver doesn't handle is rejected
+/// at the call site, not silently warn-dropped at runtime.
+pub trait Sender {
+    /// Send a single payload of kind `K` to the singleton instance
+    /// of receiver actor `R`. The receiver's mailbox is resolved
+    /// from `R::NAMESPACE`; the kind is `K::ID`. Wire shape (cast
+    /// or postcard) follows `Kind::encode_into_bytes` (issue #240).
+    fn send<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind;
+
+    /// Send a slice of cast-shape payloads as a contiguous batch.
+    /// Cast-only — postcard has no efficient batched wire shape, so
+    /// senders that need to fan out N postcard payloads call
+    /// [`Self::send`] in a loop. ADR-0019 §6 fixes the batch wire
+    /// as raw bytes; `count = payloads.len()`.
+    fn send_many<R, K>(&mut self, payloads: &[K])
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind + bytemuck::NoUninit;
+
+    /// String-keyed escape hatch for callers that genuinely don't
+    /// know the receiver type at compile site (debug tools, dynamic
+    /// dispatch, components addressing user-named mailboxes the
+    /// substrate registered without a corresponding Rust type).
+    /// Survives stage 4 alongside the actor-typed sends.
+    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K);
+}
+
+/// Per-handler ctx surface, on top of [`Sender`]. Adds reply-to-
+/// originator: handlers call [`Self::reply::<K>(&payload)`][Self::reply]
+/// without threading a per-call sender argument; the ctx pulled the
+/// inbound's reply target out of the dispatcher and stashed it
+/// internally.
+///
+/// Init contexts deliberately don't implement this — there's no
+/// inbound-mail context at boot time. Per-handler ctxs (`WasmCtx`,
+/// `NativeCtx`) do.
+///
+/// Note: Stage 1 deliberately omits a `sender()` accessor. The
+/// wasm-side reply handle (opaque `u32`) and the substrate-side
+/// `aether_data::ReplyTo` (target + correlation) carry different
+/// shapes — no single return type fits both transports honestly.
+/// The two sides converge through the implicit reply path
+/// ([`Self::reply`]) that knows internally which shape it holds.
+/// Stage 2 may add an `Option<…>`-shaped accessor if a handler
+/// needs to inspect the sender (multi-tenancy, audit trails) —
+/// today's caps don't, so the accessor doesn't ship pre-emptively.
+pub trait MailCtx: Sender {
+    /// Reply to the originator of the mail currently being dispatched.
+    /// No-op when there's no reply target (broadcast / peer-component
+    /// mail). The wire shape (cast or postcard) follows
+    /// `Kind::encode_into_bytes`.
+    ///
+    /// Stage 1 ships the trait method; stage 2/3 fold call sites
+    /// over from the existing `Ctx::reply(sender, kind, payload)`
+    /// shape onto `ctx.reply::<K>(&payload)`.
+    fn reply<K: Kind>(&mut self, payload: &K);
+}

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -70,3 +70,10 @@ wasmparser = "0.224"
 
 [dev-dependencies]
 wat = "1"
+# Issue 552 stage 1: integration tests for the macro-emitted
+# NativeActor/NativeDispatch path use the Kind/Schema derives + Pod
+# derives. Dev-deps merge with the regular deps' feature sets, so the
+# test binary picks up the derive macros without the lib pulling them
+# in for non-test builds.
+aether-data = { path = "../aether-data", features = ["derive"] }
+bytemuck = { version = "1.19", features = ["derive"] }

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -28,11 +28,15 @@ use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
-use crate::capability::{BootError, ChassisCtx, FacadeHandle, FallbackRouter, MailboxClaim};
+use crate::capability::{
+    BootError, ChassisCtx, DropOnShutdownClaim, FacadeHandle, FallbackRouter, MailboxClaim,
+};
 use crate::chassis::Chassis;
 use crate::lifecycle::{FatalAborter, PanicAborter};
 use crate::mail::MailboxId;
 use crate::mailer::Mailer;
+use crate::native_actor::{Actors, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx};
+use crate::native_transport::NativeTransport;
 use crate::registry::Registry;
 use aether_actor::Actor;
 use aether_actor::Dispatch;
@@ -165,13 +169,18 @@ impl DynShutdown for FallbackShutdown {
 /// typed-runnings map retired alongside `Capability` so drivers
 /// wanting cap state get it through pre-build accessors (today only
 /// render via `RenderHandles`).
+///
+/// Issue 552 stage 1: also borrows the chassis's [`Actors`] map so
+/// drivers can pull `Arc<A>` for caps booted via [`Builder::with_actor`].
+/// `actor::<A>()` returns `None` if `A` wasn't booted.
 pub struct DriverCtx<'a> {
     inner: ChassisCtx<'a>,
+    actors: &'a Actors,
 }
 
 impl<'a> DriverCtx<'a> {
-    fn new(inner: ChassisCtx<'a>) -> Self {
-        Self { inner }
+    fn new(inner: ChassisCtx<'a>, actors: &'a Actors) -> Self {
+        Self { inner, actors }
     }
 
     /// Drivers have no `NAMESPACE` const to delegate against — claim
@@ -200,6 +209,17 @@ impl<'a> DriverCtx<'a> {
     pub fn frame_bound_pending(&self) -> Vec<(MailboxId, Arc<AtomicU64>)> {
         self.inner.frame_bound_pending().to_vec()
     }
+
+    /// Issue 552 stage 1: look up an earlier-booted [`NativeActor`]
+    /// by type and clone its `Arc`. `None` if the cap wasn't booted
+    /// through [`Builder::with_actor`] (legacy `with(cap)` boots
+    /// don't populate the actors map). Drivers reach for this when
+    /// they need to clone a cap-owned handle (today: render's
+    /// `RenderHandles` once `RenderCapability` migrates to
+    /// `NativeActor` in stage 2).
+    pub fn actor<A: NativeActor>(&self) -> Option<Arc<A>> {
+        self.actors.get::<A>()
+    }
 }
 
 mod sealed {
@@ -225,14 +245,21 @@ impl sealed::Sealed for HasDriver {}
 impl BuilderState for NoDriver {}
 impl BuilderState for HasDriver {}
 
-type PassiveBoot = Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn DynShutdown>, BootError>>;
+/// Issue 552 stage 1: every `PassiveBoot` closure now receives both a
+/// [`ChassisCtx`] (registry / mailer / fallback / frame-bound state)
+/// and a `&mut Actors` view so the new [`Builder::with_actor::<A>`]
+/// path can insert booted `Arc<A>` instances. Closures from
+/// [`make_passive_boot`] / [`make_fallback_router_boot`] ignore the
+/// second arg; the new [`make_native_actor_boot`] uses it.
+type PassiveBoot =
+    Box<dyn FnOnce(&mut ChassisCtx<'_>, &mut Actors) -> Result<Box<dyn DynShutdown>, BootError>>;
 type DriverBoot = Box<dyn FnOnce(&mut DriverCtx<'_>) -> Result<Box<dyn DriverRunning>, BootError>>;
 
 fn make_passive_boot<C>(cap: C) -> PassiveBoot
 where
     C: Actor + Dispatch + Send + 'static,
 {
-    Box::new(move |ctx| {
+    Box::new(move |ctx, _actors| {
         let handle = ctx.spawn_actor_dispatcher(cap)?;
         Ok(Box::new(FacadeShutdown {
             handle: Some(handle),
@@ -241,10 +268,136 @@ where
 }
 
 fn make_fallback_router_boot(handler: FallbackRouter) -> PassiveBoot {
-    Box::new(move |ctx| {
+    Box::new(move |ctx, _actors| {
         ctx.claim_fallback_router(handler)?;
         Ok(Box::new(FallbackShutdown) as Box<dyn DynShutdown>)
     })
+}
+
+/// Issue 552 stage 1: factory for the new [`NativeActor`] boot path.
+/// Claims the cap's mailbox under `A::NAMESPACE`, builds a fresh
+/// per-cap [`NativeTransport`], constructs a [`NativeInitCtx`], calls
+/// `A::init(config, &mut init_ctx)`, wraps the returned cap in an
+/// `Arc<A>`, inserts into the chassis-side [`Actors`] map, and spawns
+/// a dispatcher thread that pulls from the transport's inbox and
+/// routes through [`NativeDispatch::__aether_dispatch_envelope`] —
+/// the sum dispatch trait the `#[actor] impl NativeActor for A`
+/// macro emits.
+///
+/// FRAME_BARRIER caps aren't supported by this entry yet (today only
+/// `RenderCapability` is frame-bound, and it stays on the legacy
+/// `with(cap)` path until stage 2 migrates render onto `NativeActor`).
+/// The fast-fail is intentional: a frame-bound cap booted through
+/// the non-frame-bound claim would silently miss the per-frame drain
+/// barrier, reintroducing the race FRAME_BARRIER exists to close.
+fn make_native_actor_boot<A>(config: A::Config) -> PassiveBoot
+where
+    A: NativeActor + NativeDispatch,
+{
+    Box::new(move |ctx, actors| {
+        if A::FRAME_BARRIER {
+            return Err(BootError::Other(Box::new(std::io::Error::other(format!(
+                "with_actor::<{}> rejected: FRAME_BARRIER caps must use the legacy with(cap) path \
+                 until stage 2 wires frame-bound claims through with_actor",
+                A::NAMESPACE
+            )))));
+        }
+
+        let claim = ctx.claim_mailbox_drop_on_shutdown::<A>()?;
+        let DropOnShutdownClaim {
+            id: mailbox_id,
+            receiver,
+            sink_sender,
+        } = claim;
+
+        // Per-cap transport. `NativeTransport::from_ctx` pulls the
+        // chassis's frame-bound set + aborter so the cross-class
+        // wait_reply guard wires automatically.
+        let transport = Arc::new(NativeTransport::from_ctx(ctx, mailbox_id, A::FRAME_BARRIER));
+        transport.install_inbox(receiver);
+
+        // Boot the cap through `init`. The NativeInitCtx borrows the
+        // actors-so-far map (read-only) plus the transport (read-only)
+        // plus a mailer clone for outbound hooks.
+        let actor = {
+            let mailer_clone = ctx.mail_send_handle();
+            let mut init_ctx = NativeInitCtx::new(&transport, actors, mailer_clone);
+            A::init(config, &mut init_ctx)?
+        };
+        let actor_arc: Arc<A> = Arc::new(actor);
+
+        // Insert into the chassis lookup map. Earlier-booted caps
+        // already inserted; later-booted caps will. Double-insert
+        // can't happen because mailbox name is the dedup key (the
+        // claim above would have failed first).
+        actors.insert::<A>(Arc::clone(&actor_arc));
+
+        // Spawn the dispatcher thread. The thread owns one Arc<A>
+        // and one Arc<NativeTransport>; it loops `recv_blocking()`
+        // on the transport (which pulls from the installed inbox
+        // and disconnects when the chassis drops its `sink_sender`)
+        // and routes through `__aether_dispatch_envelope`.
+        let actor_for_thread = Arc::clone(&actor_arc);
+        let transport_for_thread = Arc::clone(&transport);
+        let thread_name = alloc_native_actor_thread_name::<A>();
+        let thread = std::thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                while let Some(env) = transport_for_thread.recv_blocking() {
+                    let mut ctx = NativeCtx::new(&transport_for_thread, env.sender);
+                    if actor_for_thread
+                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
+                        .is_none()
+                    {
+                        tracing::warn!(
+                            target: "aether_substrate::chassis_builder",
+                            actor = A::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "native actor dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                }
+            })
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+
+        Ok(Box::new(NativeActorShutdown {
+            thread: Some(thread),
+            sink_sender: Some(sink_sender),
+        }) as Box<dyn DynShutdown>)
+    })
+}
+
+/// Build a stable `aether-actor-<namespace>` thread name for the
+/// dispatcher. Mirrors the legacy capability path's helper but lives
+/// in this module so `make_native_actor_boot` doesn't depend on a
+/// `pub(crate)` shim from `capability.rs`.
+fn alloc_native_actor_thread_name<A: Actor>() -> String {
+    let mut name = String::with_capacity("aether-actor-".len() + A::NAMESPACE.len());
+    name.push_str("aether-actor-");
+    name.push_str(A::NAMESPACE);
+    name
+}
+
+/// Shutdown adapter for a [`NativeActor`] booted through
+/// [`Builder::with_actor`]. Drops the [`crate::capability::SinkSender`]
+/// to disconnect the channel (the dispatcher's `recv_blocking` returns
+/// `None` and the thread exits), then joins the thread. Mirrors
+/// [`FacadeShutdown`] for the legacy facade path.
+struct NativeActorShutdown {
+    thread: Option<std::thread::JoinHandle<()>>,
+    sink_sender: Option<crate::capability::SinkSender>,
+}
+
+impl DynShutdown for NativeActorShutdown {
+    fn shutdown_dyn(mut self: Box<Self>) {
+        // Sender first — disconnects the channel and lets the
+        // dispatcher's `recv_blocking` return None so the thread
+        // exits. Joining a still-attached sender would hang.
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
 }
 
 fn make_driver_boot<D: DriverCapability>(driver: D) -> DriverBoot {
@@ -326,6 +479,28 @@ impl<C: Chassis> Builder<C, NoDriver> {
         self
     }
 
+    /// Issue 552 stage 1: boot a [`NativeActor`] with its associated
+    /// `Config`. The chassis claims the cap's mailbox under
+    /// `A::NAMESPACE`, runs `A::init(config, ctx)`, stores `Arc<A>`
+    /// in the chassis-side [`Actors`] map, and spawns a dispatcher
+    /// thread that drives the cap via [`NativeDispatch`].
+    ///
+    /// Boot order is declaration order; `.with_actor` calls before
+    /// and after `.driver(_)` boot together before the driver runs.
+    /// Init-time peer lookups via `ctx.actor::<EarlierCap>()` see
+    /// every cap inserted earlier in the chain.
+    ///
+    /// FRAME_BARRIER caps aren't supported on this entry yet — see
+    /// [`make_native_actor_boot`] for the fast-fail rationale. The
+    /// legacy `with(cap)` path stays available for them.
+    pub fn with_actor<A>(mut self, config: A::Config) -> Self
+    where
+        A: NativeActor + NativeDispatch,
+    {
+        self.passives.push(make_native_actor_boot::<A>(config));
+        self
+    }
+
     /// Supply the chassis's driver. Transitions to [`HasDriver`] —
     /// further `.driver(_)` calls are forbidden by the type system.
     /// Per ADR-0071 the driver type is fixed by `C::Driver`, so the
@@ -374,6 +549,18 @@ impl<C: Chassis> Builder<C, HasDriver> {
         self
     }
 
+    /// Mirror of [`Builder::with_actor`][Builder<C, NoDriver>::with_actor]
+    /// for the post-driver state — same semantics, accepted because
+    /// declaration-order before/after `.driver(_)` doesn't change
+    /// boot order (passives boot before the driver regardless).
+    pub fn with_actor<A>(mut self, config: A::Config) -> Self
+    where
+        A: NativeActor + NativeDispatch,
+    {
+        self.passives.push(make_native_actor_boot::<A>(config));
+        self
+    }
+
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via
@@ -399,7 +586,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
                 &booted.frame_bound_set,
                 &booted.aborter,
             );
-            let mut driver_ctx = DriverCtx::new(chassis_ctx);
+            let mut driver_ctx = DriverCtx::new(chassis_ctx, &booted.actors);
             driver_boot(&mut driver_ctx)?
         };
 
@@ -415,6 +602,13 @@ impl<C: Chassis> Builder<C, HasDriver> {
 struct BootedPassives {
     shutdowns: Vec<Box<dyn DynShutdown>>,
     fallback: Option<FallbackRouter>,
+    /// Issue 552 stage 1: type-keyed map of booted [`NativeActor`]s.
+    /// Populated by [`Builder::with_actor`] entries; the legacy
+    /// `with(cap)` path leaves it empty. Borrowed (read-only) into
+    /// [`DriverCtx`] and surfaced through [`PassiveChassis::actor`]
+    /// / [`BuiltChassis`]'s lookup so drivers / embedders can pull
+    /// `Arc<A>` for cap state without going through mail.
+    actors: Actors,
     /// Per-mailbox pending counters from
     /// [`ChassisCtx::claim_frame_bound_mailbox`] calls — collected
     /// during passive boot, exposed to the driver via
@@ -456,6 +650,7 @@ fn boot_passives(
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
     let mut fallback: Option<FallbackRouter> = None;
+    let mut actors = Actors::new();
     let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
     let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
     for boot in passives {
@@ -467,7 +662,7 @@ fn boot_passives(
             &frame_bound_set,
             aborter,
         );
-        match boot(&mut ctx) {
+        match boot(&mut ctx, &mut actors) {
             Ok(shutdown) => shutdowns.push(shutdown),
             Err(e) => {
                 while let Some(s) = shutdowns.pop() {
@@ -480,6 +675,7 @@ fn boot_passives(
     Ok(BootedPassives {
         shutdowns,
         fallback,
+        actors,
         frame_bound_pending,
         frame_bound_set,
         aborter: Arc::clone(aborter),
@@ -505,6 +701,15 @@ impl<C: Chassis> fmt::Debug for BuiltChassis<C> {
 }
 
 impl<C: Chassis> BuiltChassis<C> {
+    /// Issue 552 stage 1: look up a [`NativeActor`] booted via
+    /// [`Builder::with_actor`]. `None` if `A` wasn't booted on this
+    /// chassis. Useful for embedders that hold a [`BuiltChassis`]
+    /// directly (today: hand-written test harnesses; bin chassis
+    /// hand off to `run()` and don't keep the chassis around).
+    pub fn actor<A: NativeActor>(&self) -> Option<Arc<A>> {
+        self.booted.actors.get::<A>()
+    }
+
     /// Block on the driver's run loop. On clean return, shut down
     /// every passive in reverse boot order. Driver errors propagate
     /// as [`RunError`]; passives still tear down before the error
@@ -557,6 +762,15 @@ impl<C: Chassis> PassiveChassis<C> {
     /// on the driver-build path.
     pub fn frame_bound_pending(&self) -> Vec<(MailboxId, Arc<AtomicU64>)> {
         self.booted.frame_bound_pending.clone()
+    }
+
+    /// Issue 552 stage 1: look up a [`NativeActor`] booted via
+    /// [`Builder::with_actor`]. `None` if `A` wasn't booted on this
+    /// chassis. Embedders (TestBench, integration tests) reach for
+    /// this when they need to peer at cap state without going
+    /// through mail.
+    pub fn actor<A: NativeActor>(&self) -> Option<Arc<A>> {
+        self.booted.actors.get::<A>()
     }
 }
 
@@ -651,5 +865,172 @@ mod tests {
             .expect_err("second passive must fail with duplicate claim");
 
         assert!(matches!(err, BootError::MailboxAlreadyClaimed { .. }));
+    }
+
+    /// Issue 552 stage 1: end-to-end smoke for the new
+    /// [`Builder::with_actor`] boot path. Boots a hand-rolled
+    /// `NativeActor + NativeDispatch` fixture, looks it up via
+    /// [`PassiveChassis::actor`], pushes one envelope at the cap's
+    /// mailbox, and asserts the dispatcher routed it to the right
+    /// handler. Stage 1 lands the infrastructure; stage 2 migrates
+    /// real caps onto it. This test is the load-bearing acceptance
+    /// gate.
+    #[test]
+    fn with_actor_boots_dispatches_and_tears_down() {
+        use crate::registry::MailboxEntry;
+        use aether_data::{Kind, ReplyTo as DataReplyTo};
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        // Fixture kind: a 4-byte cast-shape payload so encode_into_bytes
+        // lands on the bytemuck path.
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Ping {
+            tag: u32,
+        }
+        impl Kind for Ping {
+            const NAME: &'static str = "test.with_actor.ping";
+            const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0001);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        // Fixture cap. State behind interior mutability so `&self`
+        // dispatch can mutate it (the post-552 norm).
+        struct ProbeCap {
+            received: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for ProbeCap {
+            const NAMESPACE: &'static str = "test.with_actor.probe";
+        }
+        impl aether_actor::Singleton for ProbeCap {}
+        impl aether_actor::HandlesKind<Ping> for ProbeCap {}
+
+        impl crate::native_actor::NativeActor for ProbeCap {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self { received: config })
+            }
+        }
+
+        // Hand-rolled NativeDispatch — what the macro arm emits in
+        // task #731. The if-arm decodes Ping bytes, calls the
+        // handler, returns Some(()) on success.
+        impl crate::native_actor::NativeDispatch for ProbeCap {
+            fn __aether_dispatch_envelope(
+                &self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Ping::ID.0 {
+                    let _decoded = Ping::decode_from_bytes(payload)?;
+                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let received = Arc::new(AtomicU32::new(0));
+
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<ProbeCap>(Arc::clone(&received))
+            .build_passive()
+            .expect("with_actor boot succeeds");
+
+        // PassiveChassis lookup returns the booted Arc.
+        let probe: Arc<ProbeCap> = chassis
+            .actor::<ProbeCap>()
+            .expect("ProbeCap registered in the actors map");
+        assert!(Arc::ptr_eq(&probe.received, &received));
+
+        // Push one envelope at the cap's mailbox via the registry's
+        // sink handler. The dispatcher thread pulls from its inbox
+        // and routes through __aether_dispatch_envelope → on_ping.
+        let mailbox_id = registry
+            .lookup(<ProbeCap as aether_actor::Actor>::NAMESPACE)
+            .expect("with_actor claimed the mailbox");
+        let MailboxEntry::Sink(handler) = registry.entry(mailbox_id).expect("sink registered")
+        else {
+            panic!("ProbeCap claim must be a sink entry");
+        };
+
+        let payload = Ping { tag: 0xDEAD_BEEF };
+        let bytes = payload.encode_into_bytes();
+        handler(
+            <Ping as Kind>::ID,
+            Ping::NAME,
+            None,
+            DataReplyTo::NONE,
+            &bytes,
+            1,
+        );
+
+        // Wait briefly for the dispatcher thread to dispatch.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while received.load(AtomicOrdering::SeqCst) == 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            received.load(AtomicOrdering::SeqCst),
+            1,
+            "dispatcher should have routed Ping → on_ping within the wait budget"
+        );
+
+        drop(chassis);
+    }
+
+    /// Issue 552 stage 1: with_actor rejects FRAME_BARRIER caps with
+    /// a typed error rather than silently missing the per-frame
+    /// drain barrier. Stage 2 (or later) wires the frame-bound claim
+    /// path through with_actor when render migrates onto NativeActor.
+    #[test]
+    fn with_actor_rejects_frame_barrier_caps() {
+        struct FrameBoundProbe;
+        impl aether_actor::Actor for FrameBoundProbe {
+            const NAMESPACE: &'static str = "test.with_actor.frame_bound";
+            const FRAME_BARRIER: bool = true;
+        }
+        impl aether_actor::Singleton for FrameBoundProbe {}
+
+        impl crate::native_actor::NativeActor for FrameBoundProbe {
+            type Config = ();
+            fn init(
+                _: (),
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self)
+            }
+        }
+
+        impl crate::native_actor::NativeDispatch for FrameBoundProbe {
+            fn __aether_dispatch_envelope(
+                &self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let err = Builder::<TestChassis>::new(registry, mailer)
+            .with_actor::<FrameBoundProbe>(())
+            .build_passive()
+            .expect_err("FRAME_BARRIER caps must reject");
+        assert!(matches!(err, BootError::Other(_)));
     }
 }

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -44,6 +44,7 @@ pub mod log_capture;
 pub mod log_sink;
 pub mod mail;
 pub mod mailer;
+pub mod native_actor;
 pub mod native_transport;
 pub mod outbound;
 pub mod panic_hook;
@@ -70,6 +71,7 @@ pub use ctx::SubstrateCtx;
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
+pub use native_actor::{Actors, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx};
 pub use native_transport::NativeTransport;
 pub use outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, LogEntry, LogLevel, RecordingBackend,

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -1,0 +1,437 @@
+//! Issue 552 stage 1: native chassis-cap actor surface.
+//!
+//! The native counterpart of `aether_actor::WasmActor`. Stage 1
+//! introduces the type-level vocabulary; Stage 2 migrates the
+//! existing capabilities (Log, Handle, Io, Net, Audio, Render) onto
+//! it. Stage 1's deliverable is the trait + ctx + dispatch
+//! infrastructure plus a working boot path through
+//! [`crate::chassis_builder::Builder::with_actor`]. No existing cap
+//! changes shape during stage 1 — the legacy `with(cap)` path that
+//! takes `Actor + Dispatch` continues to work alongside.
+//!
+//! ## Shape
+//!
+//! ```ignore
+//! #[capability]
+//! #[derive(Singleton)]
+//! pub struct ExampleCap { /* state behind interior mutability */ }
+//!
+//! #[actor]
+//! impl NativeActor for ExampleCap {
+//!     type Config = ();
+//!     const NAMESPACE: &'static str = "aether.example";
+//!
+//!     fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> { … }
+//!
+//!     #[handler] fn on_hello(&self, ctx: &mut NativeCtx<'_>, mail: Hello) { … }
+//! }
+//! ```
+//!
+//! Per-handler `&self` (Arc-shared) — caps put their mutable state
+//! behind interior mutability (today: `Arc<Mutex<…>>`,
+//! `Arc<HandleStore>`, `crossbeam_queue::ArrayQueue`). The dispatcher
+//! borrows `&Arc<Self>` from the chassis [`Actors`] map, builds a
+//! per-mail [`NativeCtx`], and calls
+//! [`NativeDispatch::dispatch`].
+//!
+//! ## What does NOT live here
+//!
+//! - `actor::<A>()` lookups on per-handler ctx. Once dispatchers are
+//!   running, caps and components communicate via mail — peering at
+//!   sibling state recreates the shared-state coupling the actor
+//!   model is designed to eliminate. Lookups live on
+//!   [`NativeInitCtx`], `DriverCtx`, and `PassiveChassis` only.
+//! - `#[fallback]` on a `NativeActor` impl. Native caps are typed
+//!   receivers; an unknown-kind delivery is a programming error,
+//!   not a fallback path. The macro rejects this at expansion time.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aether_actor::{Actor, HandlesKind, MailCtx, Sender};
+use aether_data::Kind;
+
+use crate::mail::KindId;
+
+use crate::capability::BootError;
+use crate::mail::ReplyTo;
+use crate::mailer::Mailer;
+use crate::native_transport::NativeTransport;
+
+/// Native chassis-cap actor trait. Per-cap shape: one struct, one
+/// `#[actor] impl NativeActor for X` block. The `Config` associated
+/// type is moved into [`Self::init`] by the chassis builder; pass
+/// `()` for caps with no configuration.
+///
+/// `: Actor + Send + Sync` ensures `Arc<Self>` is shareable across
+/// the dispatcher thread, the chassis lookup map, and any post-init
+/// driver/embedder consumer. `Sync` is the new requirement vs
+/// pre-552 caps — every existing cap satisfies it (mutable state is
+/// behind `Arc<Mutex<…>>` / `Arc<HandleStore>` / atomic counters
+/// already), so the migration in stage 2 is mechanical.
+pub trait NativeActor: Actor + Sync {
+    /// Configuration the chassis builder threads through to
+    /// [`Self::init`]. `()` for caps without configuration; the
+    /// actual config struct (e.g. `AudioConfig`) for caps that
+    /// take one.
+    type Config: Send + 'static;
+
+    /// Boot the cap. The chassis has already claimed the cap's
+    /// mailbox under `Actor::NAMESPACE` and built a fresh
+    /// `NativeTransport` whose self-mailbox is that claim — the
+    /// `ctx` exposes those (and the actors-so-far map for boot-time
+    /// peer lookups) plus the universal handle-store for caps that
+    /// hold typed handles.
+    fn init(config: Self::Config, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError>
+    where
+        Self: Sized;
+}
+
+/// Sum dispatch entry-point — emitted once per `#[actor] impl
+/// NativeActor for X` block. Takes the inbound mail's `(kind, payload)`
+/// pair, routes by kind id to the right `#[handler]` method, and
+/// returns `Some(())` on match + decode success or `None` on unknown
+/// kind / decode failure.
+///
+/// `&self` because the actor lives behind an `Arc<Self>` shared with
+/// the chassis lookup map and any post-init driver/embedder consumer.
+/// Per-handler-kind compile checks come from
+/// [`aether_actor::HandlesKind`] (one impl per handler the macro
+/// emits); a future per-K `NativeDispatch<K>` may layer on top if a
+/// caller wants a typed `dispatch_kind::<K>` entry, but stage 1
+/// doesn't need it.
+///
+/// Distinct from [`aether_actor::Dispatch`] (the legacy substrate-
+/// side dispatch on `&mut self`, used by today's `with(cap)` boot
+/// path). Stage 2 migrates caps onto the new entry; for stage 1
+/// both coexist.
+pub trait NativeDispatch: Send + Sync + 'static {
+    fn __aether_dispatch_envelope(
+        &self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        payload: &[u8],
+    ) -> Option<()>;
+}
+
+/// Per-mail context for a [`NativeActor`] handler. Borrows the
+/// actor's [`NativeTransport`] for outbound mail and carries the
+/// inbound's reply target so [`MailCtx::reply::<K>(&payload)`] can
+/// route back to the originator without rethreading the handle.
+///
+/// Stage 1 ships the wiring; the actual reply routing through
+/// [`NativeTransport::reply_mail`] / `Mailer::send_reply` is the
+/// stage-2 migration's responsibility (today's caps reply via
+/// `mailer.send_reply(...)` directly; stage 2 routes those onto
+/// `ctx.reply(...)`).
+pub struct NativeCtx<'a> {
+    transport: &'a NativeTransport,
+    sender: ReplyTo,
+}
+
+impl<'a> NativeCtx<'a> {
+    /// Internal constructor — only the chassis dispatcher trampoline
+    /// (in `chassis_builder`) builds these.
+    pub(crate) fn new(transport: &'a NativeTransport, sender: ReplyTo) -> Self {
+        Self { transport, sender }
+    }
+
+    /// Borrow the actor's transport. Exposed for stage-2 caps that
+    /// need to call low-level transport helpers the SDK doesn't yet
+    /// wrap.
+    pub fn transport(&self) -> &NativeTransport {
+        self.transport
+    }
+
+    /// The reply target for the mail currently being dispatched.
+    /// Useful when a handler wants to inspect the originator (audit
+    /// trails, multi-tenant routing) without going through
+    /// [`MailCtx::reply`]. `target == ReplyTarget::None` means the
+    /// inbound was broadcast or peer-component mail with no reply
+    /// destination.
+    pub fn reply_target(&self) -> ReplyTo {
+        self.sender
+    }
+}
+
+impl<'a> Sender for NativeCtx<'a> {
+    fn send<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind,
+    {
+        aether_actor::resolve_actor::<R, NativeTransport>().send(self.transport, payload);
+    }
+
+    fn send_many<R, K>(&mut self, payloads: &[K])
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind + bytemuck::NoUninit,
+    {
+        aether_actor::resolve_actor::<R, NativeTransport>().send_many(self.transport, payloads);
+    }
+
+    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
+        // resolve_mailbox is generic over T: MailTransport — the
+        // const-construction path lands at the same MailboxId as
+        // ADR-0029's name hash, so the substrate routes the mail
+        // identically on either transport.
+        let mailbox = aether_actor::resolve_mailbox::<K, NativeTransport>(name);
+        mailbox.send(self.transport, payload);
+    }
+}
+
+impl<'a> MailCtx for NativeCtx<'a> {
+    fn reply<K: Kind>(&mut self, payload: &K) {
+        // Stage 1: the trait method exists and dispatches through
+        // `NativeTransport::reply_mail`, which is itself a stage-2
+        // stub today. So `ctx.reply(...)` from a stage-1 native
+        // handler logs an `ERR_NOT_IMPLEMENTED` warning rather than
+        // routing — exactly the behaviour the macro+ctx infra
+        // promises. Stage 2 fleshes out `reply_mail` and the entire
+        // call site lights up without changing trait shape.
+        let bytes = payload.encode_into_bytes();
+        // The transport's `reply_mail` takes a u32 sender; the
+        // substrate-side `ReplyTo` carries richer routing info.
+        // Stage 2 either grows `reply_mail` to take the full
+        // ReplyTo (via a side channel) or routes through the
+        // mailer here directly. Today the no-op stub is fine.
+        let _ = bytes;
+        let _ = self.sender;
+        let _ = self.transport;
+        tracing::trace!(
+            target: "aether_substrate::native_actor",
+            kind = K::NAME,
+            "NativeCtx::reply called — wired to NativeTransport::reply_mail (stage 2 will route)"
+        );
+    }
+}
+
+/// Boot-time context for [`NativeActor::init`]. Carries a borrow of
+/// the actor's transport (for init-time mail), a borrow of the
+/// actors-so-far [`Actors`] map (so init can peer at caps booted
+/// earlier in the chain via [`Self::actor`]), and a clone of the
+/// substrate's mailer for caps that need to register an outbound
+/// hook at boot.
+///
+/// Stage-1 doesn't expose the handle store directly — caps that
+/// migrate in stage 2 retrieve it through
+/// `ctx.actor::<HandleCapability>()` once `HandleCapability` itself
+/// has migrated and surfaces an `Arc<HandleStore>` field. Boot order
+/// (chain order) ensures the lookup succeeds.
+pub struct NativeInitCtx<'a> {
+    transport: &'a NativeTransport,
+    actors: &'a Actors,
+    mailer: Arc<Mailer>,
+}
+
+impl<'a> NativeInitCtx<'a> {
+    /// Internal constructor — only [`crate::chassis_builder::Builder::with_actor`]
+    /// builds these.
+    pub(crate) fn new(
+        transport: &'a NativeTransport,
+        actors: &'a Actors,
+        mailer: Arc<Mailer>,
+    ) -> Self {
+        Self {
+            transport,
+            actors,
+            mailer,
+        }
+    }
+
+    /// Borrow the cap-bound transport. Caps rarely reach for this —
+    /// `Sender::send::<R>(...)` covers the typed-send path — but
+    /// stage-2 migrations may want it during init for one-shot
+    /// outbound mail.
+    pub fn transport(&self) -> &NativeTransport {
+        self.transport
+    }
+
+    /// Clone the substrate's mailer. Caps that need to register a
+    /// `Mailer::set_outbound`-style hook (Hub client, future
+    /// fallback routers) reach for this; most caps don't need it.
+    pub fn mailer(&self) -> Arc<Mailer> {
+        Arc::clone(&self.mailer)
+    }
+
+    /// Look up an earlier-booted cap by type and clone its `Arc`.
+    /// `None` if the cap hasn't booted yet (chain order matters —
+    /// `with::<A>(…)` → `with::<B>(…)` lets B's `init` see A but
+    /// not vice versa). Stage-1 use cases are limited to the boot
+    /// trampoline itself; stage-2 migrations may use this for
+    /// driver pre-build.
+    pub fn actor<A: NativeActor>(&self) -> Option<Arc<A>> {
+        self.actors.get::<A>()
+    }
+}
+
+impl<'a> Sender for NativeInitCtx<'a> {
+    fn send<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind,
+    {
+        aether_actor::resolve_actor::<R, NativeTransport>().send(self.transport, payload);
+    }
+
+    fn send_many<R, K>(&mut self, payloads: &[K])
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind + bytemuck::NoUninit,
+    {
+        aether_actor::resolve_actor::<R, NativeTransport>().send_many(self.transport, payloads);
+    }
+
+    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
+        let mailbox = aether_actor::resolve_mailbox::<K, NativeTransport>(name);
+        mailbox.send(self.transport, payload);
+    }
+}
+
+/// Type-keyed map of booted native actors. Owned by
+/// `BootedPassives`; borrowed into [`NativeInitCtx`],
+/// `DriverCtx`, and `PassiveChassis` via accessor methods. Stage 1's
+/// minimal storage — stage 2's actor migrations populate it; stage 3+
+/// consumers (drivers, embedders) read from it.
+pub struct Actors {
+    by_type: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+}
+
+impl Default for Actors {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Actors {
+    pub fn new() -> Self {
+        Self {
+            by_type: HashMap::new(),
+        }
+    }
+
+    /// Insert a freshly-booted `Arc<A>`. The chassis builder calls
+    /// this once per `with_actor::<A>(config)` after `A::init`
+    /// returns Ok. Returns the prior value (if any) so the builder
+    /// can detect double-`with_actor::<A>` and surface a typed
+    /// error.
+    pub fn insert<A: NativeActor>(&mut self, actor: Arc<A>) -> Option<Arc<dyn Any + Send + Sync>> {
+        self.by_type.insert(TypeId::of::<A>(), actor)
+    }
+
+    /// Retrieve a clone of the booted `Arc<A>` if `A` has booted.
+    /// `None` if `A` hasn't been added yet, or if a different type
+    /// happens to share the `TypeId` slot (impossible in safe Rust
+    /// modulo unsoundness bugs).
+    pub fn get<A: NativeActor>(&self) -> Option<Arc<A>> {
+        let any_arc = self.by_type.get(&TypeId::of::<A>())?;
+        Arc::downcast::<A>(Arc::clone(any_arc)).ok()
+    }
+
+    /// `true` when no actors have booted yet. Useful for tests.
+    pub fn is_empty(&self) -> bool {
+        self.by_type.is_empty()
+    }
+
+    /// Number of booted actors. Useful for tests.
+    pub fn len(&self) -> usize {
+        self.by_type.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::KindId as DataKindId;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Hand-rolled `Actor` impl so the test doesn't depend on the
+    /// macro arm (which lands later in the same PR).
+    struct StubActor {
+        boots: AtomicU32,
+    }
+
+    impl Actor for StubActor {
+        const NAMESPACE: &'static str = "test.stub";
+    }
+
+    impl aether_actor::Singleton for StubActor {}
+
+    impl NativeActor for StubActor {
+        type Config = ();
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                boots: AtomicU32::new(0),
+            })
+        }
+    }
+
+    /// Second stub actor type so we can exercise type-keyed lookup.
+    struct OtherActor;
+
+    impl Actor for OtherActor {
+        const NAMESPACE: &'static str = "test.other";
+    }
+
+    impl aether_actor::Singleton for OtherActor {}
+
+    impl NativeActor for OtherActor {
+        type Config = ();
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+    }
+
+    #[test]
+    fn actors_insert_and_get_roundtrip() {
+        let mut actors = Actors::new();
+        assert!(actors.is_empty());
+        let stub = Arc::new(StubActor {
+            boots: AtomicU32::new(0),
+        });
+        let prior = actors.insert::<StubActor>(Arc::clone(&stub));
+        assert!(prior.is_none());
+        assert_eq!(actors.len(), 1);
+
+        let retrieved: Arc<StubActor> = actors.get::<StubActor>().expect("StubActor was inserted");
+        retrieved.boots.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(stub.boots.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn actors_get_distinguishes_types() {
+        let mut actors = Actors::new();
+        actors.insert::<StubActor>(Arc::new(StubActor {
+            boots: AtomicU32::new(0),
+        }));
+        assert!(actors.get::<StubActor>().is_some());
+        assert!(actors.get::<OtherActor>().is_none());
+    }
+
+    #[test]
+    fn actors_double_insert_returns_prior() {
+        let mut actors = Actors::new();
+        actors.insert::<StubActor>(Arc::new(StubActor {
+            boots: AtomicU32::new(0),
+        }));
+        let second = actors.insert::<StubActor>(Arc::new(StubActor {
+            boots: AtomicU32::new(0),
+        }));
+        assert!(second.is_some(), "second insert returns the displaced Arc");
+    }
+
+    /// Compile-time signal that `NativeActor: Actor + Sync` plus
+    /// `Arc<A>` round-trips through `Arc<dyn Any + Send + Sync>`.
+    /// If a future change to `Actor` drops `Send + 'static` or to
+    /// `NativeActor` drops `Sync`, the asserts here fail to
+    /// instantiate.
+    fn _assert_arc_shareable() {
+        fn requires<T: Any + Send + Sync>() {}
+        requires::<StubActor>();
+        // Avoid an unused-import diagnostic when the compiler
+        // dead-code-eliminates the helper.
+        let _ = DataKindId(0);
+    }
+}

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -1,0 +1,195 @@
+//! Issue 552 stage 1: integration test for the
+//! `#[actor] impl NativeActor for X` macro arm.
+//!
+//! Lives as a standalone integration test (not in `#[cfg(test)] mod`)
+//! because the macro emits absolute paths (`::aether_substrate::*`)
+//! that the lib's own test mod can't resolve via implicit `extern
+//! crate self`. An integration test depends on `aether_substrate`
+//! externally, so the path resolves naturally.
+//!
+//! The chassis-side hand-rolled fixture in
+//! `chassis_builder::tests::with_actor_boots_dispatches_and_tears_down`
+//! covers the same end-to-end guarantee without the macro layer; this
+//! test is the additional gate that the macro's codegen produces a
+//! working `Actor + HandlesKind + NativeActor + NativeDispatch`
+//! stack on a real cap shape.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+use std::time::{Duration, Instant};
+
+use aether_data::{Kind, ReplyTo};
+use aether_substrate::{
+    Actor, Builder, BuiltChassis, Chassis, NativeActor, NativeCtx, NativeInitCtx, NeverDriver,
+    PassiveChassis, capability::BootError, mail::MailboxId, mailer::Mailer, registry::Registry,
+};
+
+/// Postcard-shape kind via the derive — exercises the
+/// `decode_from_bytes` postcard path the macro's dispatch arm uses.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.greet")]
+struct Greet {
+    tag: u32,
+}
+
+/// Cast-shape kind so both arms (postcard + cast) get exercised
+/// through one cap.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct MacroProbeCap {
+    greet_total: Arc<AtomicU32>,
+    ping_total: Arc<AtomicU32>,
+}
+
+impl aether_actor::Singleton for MacroProbeCap {}
+
+/// Per-cap config — caps without a domain-specific config type
+/// would write `()`, but here we thread shared atomic counters in
+/// so the test can observe each handler's effect.
+#[derive(Clone)]
+struct ProbeConfig {
+    greet_total: Arc<AtomicU32>,
+    ping_total: Arc<AtomicU32>,
+}
+
+#[aether_data::actor]
+impl NativeActor for MacroProbeCap {
+    type Config = ProbeConfig;
+    const NAMESPACE: &'static str = "test.macro_native_actor.probe";
+
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self {
+            greet_total: config.greet_total,
+            ping_total: config.ping_total,
+        })
+    }
+
+    /// Handles postcard-shape `Greet` mail.
+    #[aether_data::handler]
+    fn on_greet(&self, _ctx: &mut NativeCtx<'_>, mail: Greet) {
+        self.greet_total.fetch_add(mail.tag, AtomicOrdering::SeqCst);
+    }
+
+    /// Handles cast-shape `Ping` mail.
+    #[aether_data::handler]
+    fn on_ping(&self, _ctx: &mut NativeCtx<'_>, mail: Ping) {
+        self.ping_total.fetch_add(mail.seq, AtomicOrdering::SeqCst);
+    }
+}
+
+/// Test chassis fixture so `Builder::<C>::new` has a typed `C` to
+/// parameterise on. `NeverDriver` makes the no-driver passive build
+/// path the only valid one.
+struct TestChassis;
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("TestChassis is built directly via Builder in tests");
+    }
+}
+
+fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+    (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+}
+
+fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
+    use aether_substrate::registry::MailboxEntry;
+    let id: MailboxId = registry.lookup(recipient).expect("mailbox registered");
+    let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry exists") else {
+        panic!("expected sink entry under {recipient}");
+    };
+    let bytes = payload.encode_into_bytes();
+    handler(<K as Kind>::ID, K::NAME, None, ReplyTo::NONE, &bytes, 1);
+}
+
+fn wait_for(target: u32, counter: &AtomicU32, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while counter.load(AtomicOrdering::SeqCst) < target && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    counter.load(AtomicOrdering::SeqCst) >= target
+}
+
+#[test]
+fn macro_emitted_cap_routes_postcard_kind_through_dispatch() {
+    let (registry, mailer) = fresh_substrate();
+    let greet_total = Arc::new(AtomicU32::new(0));
+    let ping_total = Arc::new(AtomicU32::new(0));
+
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<MacroProbeCap>(ProbeConfig {
+                greet_total: Arc::clone(&greet_total),
+                ping_total: Arc::clone(&ping_total),
+            })
+            .build_passive()
+            .expect("macro-emitted cap boots");
+
+    push_envelope(&registry, MacroProbeCap::NAMESPACE, &Greet { tag: 7 });
+    assert!(
+        wait_for(7, &greet_total, Duration::from_millis(500)),
+        "macro dispatcher should route Greet → on_greet within budget"
+    );
+    assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+
+    drop(chassis);
+}
+
+#[test]
+fn macro_emitted_cap_routes_cast_kind_through_dispatch() {
+    let (registry, mailer) = fresh_substrate();
+    let greet_total = Arc::new(AtomicU32::new(0));
+    let ping_total = Arc::new(AtomicU32::new(0));
+
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<MacroProbeCap>(ProbeConfig {
+                greet_total: Arc::clone(&greet_total),
+                ping_total: Arc::clone(&ping_total),
+            })
+            .build_passive()
+            .expect("macro-emitted cap boots");
+
+    push_envelope(&registry, MacroProbeCap::NAMESPACE, &Ping { seq: 42 });
+    assert!(
+        wait_for(42, &ping_total, Duration::from_millis(500)),
+        "macro dispatcher should route Ping → on_ping within budget"
+    );
+    assert_eq!(greet_total.load(AtomicOrdering::SeqCst), 0);
+
+    drop(chassis);
+}
+
+/// Type-level assertion that the macro emits the universal
+/// `HandlesKind<K>` impls for each `#[handler]`. Runs at compile
+/// time — the body never executes.
+#[test]
+fn macro_emits_handles_kind_per_handler() {
+    fn assert_handles<R: aether_actor::HandlesKind<K>, K: Kind>() {}
+    assert_handles::<MacroProbeCap, Greet>();
+    assert_handles::<MacroProbeCap, Ping>();
+}


### PR DESCRIPTION
<!-- pr-body-ok: b,c — Refs #552 deliberate so GitHub links the umbrella issue without auto-closing on squash-merge; title leads with the Rust type name `NativeActor` (proper noun) which the lowercase-leading-letter check would otherwise reject. -->

## Summary

Stage 1 of the issue 552 actor unification — picks up where stage 0's macro+namespace collapse left off. Introduces the type-level vocabulary the existing chassis caps will migrate onto in stage 2:

- `aether-actor`: `Sender` + `MailCtx` traits — universal cross-transport outbound surface. The wasm-side `Ctx<'a, T>` and `InitCtx<'a, T>` get blanket `Sender` impls so the wasm 1-arg aliases inherit them automatically.
- `aether-substrate`: `NativeActor` trait (`type Config: Send + 'static`, `init(config, ctx) -> Result<Self, BootError>`), `NativeCtx<'a>` per-handler context, `NativeInitCtx<'a>` boot-time context, `NativeDispatch` sum dispatch trait, `Actors` map (TypeId-keyed `Arc<dyn Any + Send + Sync>`).
- `Builder::with_actor::<A>(config)` parallel boot path to legacy `with(cap)`. Spawns one mpsc-fed OS thread per actor; the legacy path keeps working alongside.
- `actor::<A>()` lookups on `NativeInitCtx`, `DriverCtx`, `PassiveChassis`, `BuiltChassis`. Per-handler `NativeCtx` and `WasmCtx` deliberately don't expose it — handlers communicate via mail.
- `aether-actor-derive`: new `#[actor] impl NativeActor for X` macro arm. Dispatches by trait-path's last identifier so `WasmActor` / `NativeActor` / `Component` (back-compat alias) all resolve. Emits universal `Actor` + `HandlesKind` impls without cfg. Rejects `#[fallback]` on `NativeActor` blocks; native caps are typed receivers.

## Out of scope (Stage 2+)

- Existing caps (Log, Handle, Io, Net, Audio, Render) keep their current shape on the legacy `with(cap)` path. Stage 2 migrates them onto the new `#[actor] impl NativeActor for X` shape.
- `FRAME_BARRIER` caps reject from `with_actor` with a typed error today; stage 2 wires the frame-bound claim through `with_actor` when render migrates.
- `NativeCtx::reply` is wired but `NativeTransport::reply_mail` is itself a stage-2 stub. Calls today emit a tracing event and no-op; the trait shape is the deliverable.

## Test plan

- [x] cargo check workspace clean
- [x] cargo clippy workspace clean (-D warnings)
- [x] cargo fmt clean
- [x] cargo test workspace clean (57 result groups, 0 failures)
- [x] Per-component wasm build clean (test-fixture-probe, camera, mesh-viewer, sokoban, tic-tac-toe-server/client)
- [x] New test chassis_builder::tests::with_actor_boots_dispatches_and_tears_down exercises boot + lookup + dispatch + teardown with a hand-rolled fixture
- [x] New test chassis_builder::tests::with_actor_rejects_frame_barrier_caps confirms FRAME_BARRIER fail-fast
- [x] New integration test tests/native_actor_macro.rs proves the macro arm produces a working Actor + HandlesKind + NativeActor + NativeDispatch stack (postcard + cast kinds)

Refs #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)