### PR TITLE
refactor(actor): migrate log cap onto NativeActor (issue 552 stage 2a)

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -358,7 +358,7 @@ impl DesktopChassis {
             .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
-            .with(LogCapability::new())
+            .with_actor::<LogCapability>(())
             .with(io_cap)
             .with(NetCapability::new(net, Arc::clone(&mailer)))
             .with(AudioCapability::new(audio, Arc::clone(&mailer)))

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -232,7 +232,7 @@ impl HeadlessChassis {
             .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
-            .with(LogCapability::new())
+            .with_actor::<LogCapability>(())
             .with(io_cap)
             .with(NetCapability::new(net, Arc::clone(&mailer)))
             .driver(driver)

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -282,7 +282,7 @@ impl TestBenchChassis {
 
         let passive =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
-                .with(LogCapability::new())
+                .with_actor::<LogCapability>(())
                 .with(render_cap)
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;

--- a/crates/aether-substrate/src/capabilities/log.rs
+++ b/crates/aether-substrate/src/capabilities/log.rs
@@ -1,8 +1,13 @@
-//! Issue 545 PR E1: collapsed `aether.log` cap. Pre-PR-E1 the cap
-//! lived split across `aether-kinds::log::LogCapability<B>` (facade
-//! generic) and this file (concrete `LogTracingBackend`). The facade
-//! pattern (ADR-0075) is retired — caps are now regular `#[actor]`
-//! blocks, same shape as wasm components.
+//! Issue 552 stage 2: `aether.log` cap migrated onto `NativeActor`.
+//! Pre-stage-2 the cap was a unit struct with `impl Actor` +
+//! `impl Singleton` + an inherent `#[actor] impl LogCapability` block
+//! taking `&mut self` handlers. Stage 2 collapses that into the
+//! symmetric authoring shape: `#[capability] #[derive(Singleton)]
+//! struct + #[actor] impl NativeActor for X { type Config; fn init;
+//! #[handler] fn (&self, ctx: &mut NativeCtx<'_>, mail) }`. The Log
+//! cap is the smallest pilot — no fields, no `Config`, no reply, no
+//! sender param to drop — so it validates the macro + ctx + dispatch
+//! path before the larger caps follow in 2b/2c.
 //!
 //! Bridging via the `log` crate facade (rather than `tracing::event!`)
 //! is load-bearing — see [`crate::log_sink`] for the rationale.
@@ -11,35 +16,30 @@
 //! and let `tracing-subscriber`'s `tracing-log` integration lift each
 //! record back into the tracing pipeline.
 
-use aether_actor::{Actor, Singleton};
+use aether_actor::{Singleton, capability};
 use aether_kinds::LogEvent;
 
+use crate::capability::BootError;
 use crate::log_sink;
+use crate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// `aether.log` mailbox cap. Stateless beyond the process-wide
 /// `tracing` subscriber set up by [`crate::log_capture::init`] —
 /// every cap instance bridges decoded `LogEvent` mail through the
 /// `log` facade and `tracing-log` re-emits it.
-#[derive(Default)]
+#[capability]
+#[derive(Singleton)]
 pub struct LogCapability;
 
-impl LogCapability {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Actor for LogCapability {
-    /// Components mail `aether.log` (kind id) to this mailbox; the
-    /// `aether.<name>` form is the post-ADR-0074 Phase 5 convention
-    /// for chassis-owned mailboxes.
-    const NAMESPACE: &'static str = "aether.log";
-}
-
-impl Singleton for LogCapability {}
-
 #[aether_data::actor]
-impl LogCapability {
+impl NativeActor for LogCapability {
+    type Config = ();
+    const NAMESPACE: &'static str = "aether.log";
+
+    fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self)
+    }
+
     /// Emit a decoded log event through the host's `tracing` pipeline
     /// so `engine_logs` (ADR-0023) sees it.
     ///
@@ -47,7 +47,7 @@ impl LogCapability {
     /// Components mail `aether.log` `LogEvent { level, target, message }`
     /// to this mailbox. Fire-and-forget; no reply.
     #[aether_data::handler]
-    fn on_log_event(&mut self, event: LogEvent) {
+    fn on_log_event(&self, _ctx: &mut NativeCtx<'_>, event: LogEvent) {
         log_sink::handle_log_mail_decoded(event);
     }
 }
@@ -59,25 +59,41 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::*;
-    use crate::capability::ChassisBuilder;
+    use crate::chassis::Chassis;
+    use crate::chassis_builder::{Builder, BuiltChassis, NeverDriver};
     use crate::mailer::Mailer;
     use crate::registry::{MailboxEntry, Registry};
+    use aether_actor::Actor;
     use aether_data::Kind;
+
+    /// Stand-in chassis for the passive boot path. The Log cap doesn't
+    /// need a driver, so `build_passive()` is the natural test entry
+    /// — same shape as the `with_actor_*` smokes in
+    /// `chassis_builder::tests`.
+    struct TestChassis;
+    impl Chassis for TestChassis {
+        const PROFILE: &'static str = "test";
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        }
+    }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
-    /// End-to-end: boot the cap, push an `aether.log` mail at the
-    /// registered mailbox, the dispatcher thread runs the
-    /// macro-emitted `Dispatch::__dispatch` which calls
+    /// End-to-end: boot the cap through `with_actor`, push an
+    /// `aether.log` mail at the registered mailbox, the dispatcher
+    /// thread runs the macro-emitted `NativeDispatch` which calls
     /// `on_log_event`. Test asserts dispatch + clean shutdown.
     #[test]
     fn capability_routes_log_event_through_dispatcher() {
         let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
-            .build()
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<LogCapability>(())
+            .build_passive()
             .expect("capability boots");
 
         let id = registry
@@ -104,7 +120,7 @@ mod tests {
 
         thread::sleep(Duration::from_millis(50));
         let start = Instant::now();
-        chassis.shutdown();
+        drop(chassis);
         assert!(
             start.elapsed() < Duration::from_millis(500),
             "shutdown should complete promptly via channel-drop"
@@ -115,14 +131,12 @@ mod tests {
     /// was already registered.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
-        use crate::capability::BootError;
-
         let (registry, mailer) = fresh_substrate();
         registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
-            .build()
+        let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<LogCapability>(())
+            .build_passive()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
             err,

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -1035,31 +1035,45 @@ impl Drop for BootedChassis {
 mod tests {
     use super::*;
     use aether_data::ReplyTo;
-    use aether_kinds::LogEvent;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         (Arc::new(Registry::new()), Arc::new(Mailer::new()))
     }
 
+    /// Hand-rolled `Actor + Dispatch` fixture for the legacy
+    /// `ChassisBuilder.with(cap)` path. Pre-stage-2 the tests in this
+    /// module reached for `LogCapability::new()` as a representative
+    /// stand-in; stage 2 migrated `LogCapability` to `NativeActor`
+    /// (no longer `Actor + Dispatch`), so the legacy-path tests now
+    /// use this in-module fixture instead.
+    struct StubCap;
+    impl Actor for StubCap {
+        const NAMESPACE: &'static str = "test.legacy_chassis_builder.stub";
+    }
+    impl Dispatch for StubCap {
+        fn __dispatch(&mut self, _sender: ReplyTo, _kind: u64, _payload: &[u8]) -> Option<()> {
+            // Stub never dispatches anything substantive — these tests
+            // exercise boot/shutdown wiring, not handler routing.
+            None
+        }
+    }
+
     /// Boot-time mailbox-claim collision aborts the build and runs
-    /// every already-booted cap's `Drop`. Two `LogCapability`
-    /// instances both claim `aether.log`; the second hits the
+    /// every already-booted cap's `Drop`. Two `StubCap` instances both
+    /// claim `test.legacy_chassis_builder.stub`; the second hits the
     /// duplicate-claim guard and the chassis tears the first down.
-    /// Per-cap mailbox-claim and mail-receive coverage lives in
-    /// `crate::capabilities::log::tests` and the equivalents for
-    /// the other facade caps.
+    /// Per-cap mailbox-claim and mail-receive coverage lives in each
+    /// cap's own test module.
     #[test]
     fn boot_failure_shuts_down_already_booted_capabilities() {
-        use crate::capabilities::LogCapability;
-
         let (registry, mailer) = fresh_substrate();
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
-            .with(LogCapability::new())
+            .with(StubCap)
+            .with(StubCap)
             .build()
-            .expect_err("second LogCapability must fail with duplicate claim");
+            .expect_err("second cap must fail with duplicate claim");
         assert!(
-            matches!(err, BootError::MailboxAlreadyClaimed { ref name } if name == LogCapability::NAMESPACE)
+            matches!(err, BootError::MailboxAlreadyClaimed { ref name } if name == StubCap::NAMESPACE)
         );
     }
 
@@ -1086,36 +1100,31 @@ mod tests {
     /// (`with(cap).build()` succeeds, `shutdown()` joins).
     #[test]
     fn chassis_builder_boots_one_cap_and_shuts_down_clean() {
-        use crate::capabilities::LogCapability;
-        use aether_data::Kind;
-
         let (registry, mailer) = fresh_substrate();
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(LogCapability::new())
+            .with(StubCap)
             .build()
             .expect("build succeeds");
         assert_eq!(chassis.len(), 1);
 
         let id = registry
-            .lookup(LogCapability::NAMESPACE)
-            .expect("log mailbox registered");
+            .lookup(StubCap::NAMESPACE)
+            .expect("stub mailbox registered");
         let crate::registry::MailboxEntry::Sink(handler) =
             registry.entry(id).expect("entry exists")
         else {
             panic!("expected sink entry");
         };
-        let event = LogEvent {
-            level: 3,
-            target: "aether_test".into(),
-            message: "boot smoke".into(),
-        };
-        let bytes = postcard::to_allocvec(&event).expect("encode");
+        // Push an empty payload at an arbitrary kind id; StubCap's
+        // dispatch returns None unconditionally, but the test only
+        // cares that the sink handler exists and the chassis shuts
+        // down cleanly afterward.
         handler(
-            <LogEvent as Kind>::ID,
-            "aether.log",
+            aether_data::KindId(0xDEAD_BEEF_DEAD_BEEF),
+            StubCap::NAMESPACE,
             None,
             ReplyTo::NONE,
-            &bytes,
+            &[],
             1,
         );
 

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -840,7 +840,7 @@ mod tests {
         let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let chassis = Builder::<DrivenTestChassis<RanDriver>>::new(registry, mailer)
-            .with(LogCapability::new())
+            .with_actor::<LogCapability>(())
             .driver(RanDriver {
                 ran: Arc::clone(&ran),
             })
@@ -859,8 +859,8 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
 
         let err = Builder::<TestChassis>::new(registry, mailer)
-            .with(LogCapability::new())
-            .with(LogCapability::new())
+            .with_actor::<LogCapability>(())
+            .with_actor::<LogCapability>(())
             .build_passive()
             .expect_err("second passive must fail with duplicate claim");
 

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -25,6 +25,16 @@
 //! `decode_payload` and `resolve_bundle` are pub so chassis dispatch
 //! can validate mail bundles the same way core does.
 
+// Issue 552 stage 2: the `#[actor] impl NativeActor for X` macro
+// emits `impl ::aether_substrate::NativeDispatch for X` so external
+// callers (caps in user crates, `aether-capabilities` once the move
+// in stage 2c lands) resolve unambiguously. For caps written *inside*
+// aether-substrate (today: every cap under `capabilities/`) the
+// `::aether_substrate` prefix is in-crate; the self-alias makes
+// absolute paths resolve without a separate "internal vs external"
+// macro arm.
+extern crate self as aether_substrate;
+
 pub mod boot;
 pub mod capabilities;
 pub mod capability;


### PR DESCRIPTION
## Summary

- `LogCapability` adopts the post-stage-1 symmetric authoring shape: `#[capability] #[derive(Singleton)] struct` + `#[actor] impl NativeActor for X { type Config; const NAMESPACE; fn init; #[handler] fn (&self, ctx, mail) }`. Smallest cap (no fields, no Config, no reply, no sender param) so it pilots the macro + ctx + dispatch wiring before the larger caps migrate in 2b/2c.
- Bundle chassis mains (desktop / headless / test_bench) switch from `.with(LogCapability::new())` to `.with_actor::<LogCapability>(())`.
- `extern crate self as aether_substrate;` at the crate root so the macro's `::aether_substrate::NativeDispatch` emission resolves in-crate.

## Why staged

Issue 552 frames Stage 2 as one PR; in practice Stage 2 is large (six caps + crate extraction). Splitting into 2a (Log pilot) / 2b (caps with reply/Config) / 2c (extract to aether-capabilities) keeps each diff reviewable. Log validates the foundations; subsequent caps reuse the same pattern.

## Test plan

- [x] `cargo test --workspace --all-targets` green locally
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] All six wasm components build for `wasm32-unknown-unknown`
- [x] `capability_routes_log_event_through_dispatcher` passes — end-to-end mail through new boot path
- [x] `duplicate_passive_mailbox_aborts_build_and_shuts_down_prior` passes — duplicate-claim still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)