### PR TITLE
refactor(actor): wire NativeCtx::reply + migrate handle cap (issue 552 stage 2b)

### DIFF
--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -386,7 +386,7 @@ impl<'a, T: MailTransport> Sender for Ctx<'a, T> {
 /// dispatches via `T::reply_mail`. No-op when the inbound has no
 /// reply target (component-origin / broadcast mail).
 impl<'a, T: MailTransport> MailCtx for Ctx<'a, T> {
-    fn reply<K: aether_data::Kind>(&mut self, payload: &K) {
+    fn reply<K: aether_data::Kind + serde::Serialize>(&mut self, payload: &K) {
         if let Some(raw) = self.sender {
             let bytes = payload.encode_into_bytes();
             self.transport.reply_mail(raw, K::ID.0, &bytes, 1);

--- a/crates/aether-actor/src/sender.rs
+++ b/crates/aether-actor/src/sender.rs
@@ -96,8 +96,20 @@ pub trait MailCtx: Sender {
     /// mail). The wire shape (cast or postcard) follows
     /// `Kind::encode_into_bytes`.
     ///
-    /// Stage 1 ships the trait method; stage 2/3 fold call sites
-    /// over from the existing `Ctx::reply(sender, kind, payload)`
-    /// shape onto `ctx.reply::<K>(&payload)`.
-    fn reply<K: Kind>(&mut self, payload: &K);
+    /// The `serde::Serialize` bound matches the substrate-side
+    /// `Mailer::send_reply` /`HubOutbound::send_reply` requirement —
+    /// reply kinds route through postcard when the target is a Claude
+    /// session or remote engine mailbox, so they must serialize. In
+    /// practice every reply kind in the workspace already derives
+    /// `Serialize` (they all derive `aether_data::Kind` +
+    /// `aether_data::Schema` + `serde::{Serialize, Deserialize}`
+    /// together), so the bound is a documentation move rather than a
+    /// breaking change. The wasm `Ctx::reply` body still encodes via
+    /// `Kind::encode_into_bytes` (cast-or-postcard); the bound is
+    /// satisfied transparently.
+    ///
+    /// Stage 1 shipped the trait method; stage 2 wires native
+    /// dispatch onto it (NativeCtx routes through the substrate
+    /// `Mailer::send_reply` / outbound bridge).
+    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K);
 }

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -333,11 +333,15 @@ impl<'a> SubstrateBootBuilder<'a> {
         // dispatcher thread before the control plane is wired so any
         // control-side code that wants to publish at load can reach
         // it.
+        // HandleCapability pulls its `Arc<HandleStore>` from the
+        // `Mailer::handle_store()` accessor at init — the store is
+        // wired above before chassis build, so the lookup succeeds.
+        // The Arc<HandleStore> we hold locally stays so subsequent
+        // wires / control-plane resolution paths can read it; the cap
+        // and the local reference share the same backing store.
+        let _ = &handle_store;
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&queue))
-            .with(HandleCapability::new(
-                Arc::clone(&handle_store),
-                Arc::clone(&queue),
-            ))
+            .with_actor::<HandleCapability>(())
             .build()
             .map_err(|e| wasmtime::Error::msg(format!("chassis capability boot: {e}")))?;
 

--- a/crates/aether-substrate/src/capabilities/handle.rs
+++ b/crates/aether-substrate/src/capabilities/handle.rs
@@ -1,65 +1,79 @@
-//! Issue 545 PR E1: collapsed `aether.handle` cap. Pre-PR-E1 the cap
-//! lived split across `aether-kinds::handle::HandleCapability<B>`
-//! (facade generic) and this file (concrete `HandleStoreBackend`).
-//! The facade pattern (ADR-0075) is retired — caps are now regular
-//! `#[actor]` blocks, same shape as wasm components.
+//! Issue 552 stage 2: `aether.handle` cap migrated onto `NativeActor`.
+//! Pre-stage-2 the cap was an `Actor + Singleton + Dispatch` shape
+//! taking `&mut self` handlers with `sender: ReplyTo` parameters and
+//! routing replies through `self.mailer.send_reply(sender, &result)`.
+//! Stage 2 collapses that into the symmetric authoring shape:
+//! `#[capability] #[derive(Singleton)] struct + #[actor] impl
+//! NativeActor for X { type Config; fn init; #[handler] fn (&self,
+//! ctx: &mut NativeCtx<'_>, mail) }` — the same source shape wasm
+//! components write. Replies route through `ctx.reply(&result)`,
+//! which the per-mail `NativeCtx` walks back through the substrate's
+//! `Mailer::send_reply` to the originator (Component / Session /
+//! EngineMailbox / silent drop).
 //!
 //! Owns the shared [`HandleStore`] (the same instance the substrate's
-//! `Mailer::wire_handle_store` references for `Ref<Handle>` resolution)
-//! and an [`Arc<Mailer>`] for routing reply mail. The dispatcher
-//! thread owns the cap through the macro-emitted `Dispatch` impl;
-//! channel-drop on shutdown disconnects the inbox and the cap drops
-//! on the dispatcher thread.
+//! `Mailer::wire_handle_store` references for `Ref<Handle>` resolution).
+//! The store now flows in through `NativeInitCtx::mailer().handle_store()`
+//! at boot — caps no longer need their own `new(store, mailer)`
+//! constructor; the chassis builder's `with_actor::<HandleCapability>(())`
+//! is the boot site.
 
 use std::sync::Arc;
 
-use aether_actor::{Actor, Singleton};
-use aether_data::ReplyTo;
+use aether_actor::Singleton;
 use aether_kinds::{
     HandleError, HandlePin, HandlePinResult, HandlePublish, HandlePublishResult, HandleRelease,
     HandleReleaseResult, HandleUnpin, HandleUnpinResult,
 };
 
+use crate::capability::BootError;
 use crate::handle_store::{HandleStore, PutError};
-use crate::mailer::Mailer;
+use crate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+use aether_actor::MailCtx;
 
 /// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`
-/// and routes ADR-0045 publish/release/pin/unpin requests, replying
-/// via `Mailer::send_reply`. Decode failure on a malformed payload
-/// goes through the macro miss path (warn-log, no reply, sender's
+/// and routes ADR-0045 publish/release/pin/unpin requests via
+/// `ctx.reply(&result)`. Decode failure on a malformed payload goes
+/// through the macro miss path (warn-log, no reply, sender's
 /// `wait_reply` times out) — substrate-level invariant violation, not
 /// user-recoverable input.
+#[derive(Singleton)]
 pub struct HandleCapability {
     store: Arc<HandleStore>,
-    mailer: Arc<Mailer>,
 }
 
-impl HandleCapability {
-    /// Construct against the substrate's [`HandleStore`] and
-    /// [`Mailer`]. The store is shared with `Mailer::wire_handle_store`
-    /// so dispatch-time `Ref<Handle>` resolution and capability-handled
-    /// publish/release/pin/unpin observe the same entries.
-    pub fn new(store: Arc<HandleStore>, mailer: Arc<Mailer>) -> Self {
-        Self { store, mailer }
-    }
-}
-
-impl Actor for HandleCapability {
+#[aether_data::actor]
+impl NativeActor for HandleCapability {
+    type Config = ();
     /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
     /// `aether.<name>` namespace.
     const NAMESPACE: &'static str = "aether.handle";
-}
 
-impl Singleton for HandleCapability {}
+    /// Pull the shared [`HandleStore`] off the substrate's wired
+    /// [`crate::Mailer`]. The store is wired by `SubstrateBoot::build`
+    /// before the chassis builder runs, so a `None` here is a
+    /// substrate-level boot ordering bug rather than user input —
+    /// surface it as a `BootError`.
+    fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        let store = ctx
+            .mailer()
+            .handle_store()
+            .ok_or_else(|| {
+                BootError::Other(Box::new(std::io::Error::other(
+                    "HandleCapability::init: substrate Mailer has no HandleStore wired \
+                     (call wire_handle_store before chassis build)",
+                )))
+            })?
+            .clone();
+        Ok(Self { store })
+    }
 
-#[aether_data::actor]
-impl HandleCapability {
     /// Publish bytes under a fresh handle id.
     ///
     /// # Agent
     /// Reply: `HandlePublishResult`.
     #[aether_data::handler]
-    fn on_publish(&mut self, sender: ReplyTo, mail: HandlePublish) {
+    fn on_publish(&self, ctx: &mut NativeCtx<'_>, mail: HandlePublish) {
         let id = self.store.next_ephemeral();
         match self.store.put(id, mail.kind_id, mail.bytes) {
             Ok(()) => {
@@ -68,22 +82,16 @@ impl HandleCapability {
                 // zero the entry stays in the store (subject to LRU
                 // eviction under pressure).
                 self.store.inc_ref(id);
-                self.mailer.send_reply(
-                    sender,
-                    &HandlePublishResult::Ok {
-                        kind_id: mail.kind_id,
-                        id,
-                    },
-                );
+                ctx.reply(&HandlePublishResult::Ok {
+                    kind_id: mail.kind_id,
+                    id,
+                });
             }
             Err(e) => {
-                self.mailer.send_reply(
-                    sender,
-                    &HandlePublishResult::Err {
-                        kind_id: mail.kind_id,
-                        error: put_error_to_handle_error(e),
-                    },
-                );
+                ctx.reply(&HandlePublishResult::Err {
+                    kind_id: mail.kind_id,
+                    error: put_error_to_handle_error(e),
+                });
             }
         }
     }
@@ -94,18 +102,14 @@ impl HandleCapability {
     /// # Agent
     /// Reply: `HandleReleaseResult`.
     #[aether_data::handler]
-    fn on_release(&mut self, sender: ReplyTo, mail: HandleRelease) {
+    fn on_release(&self, ctx: &mut NativeCtx<'_>, mail: HandleRelease) {
         if self.store.dec_ref(mail.id) {
-            self.mailer
-                .send_reply(sender, &HandleReleaseResult::Ok { id: mail.id });
+            ctx.reply(&HandleReleaseResult::Ok { id: mail.id });
         } else {
-            self.mailer.send_reply(
-                sender,
-                &HandleReleaseResult::Err {
-                    id: mail.id,
-                    error: HandleError::UnknownHandle,
-                },
-            );
+            ctx.reply(&HandleReleaseResult::Err {
+                id: mail.id,
+                error: HandleError::UnknownHandle,
+            });
         }
     }
 
@@ -114,18 +118,14 @@ impl HandleCapability {
     /// # Agent
     /// Reply: `HandlePinResult`.
     #[aether_data::handler]
-    fn on_pin(&mut self, sender: ReplyTo, mail: HandlePin) {
+    fn on_pin(&self, ctx: &mut NativeCtx<'_>, mail: HandlePin) {
         if self.store.pin(mail.id) {
-            self.mailer
-                .send_reply(sender, &HandlePinResult::Ok { id: mail.id });
+            ctx.reply(&HandlePinResult::Ok { id: mail.id });
         } else {
-            self.mailer.send_reply(
-                sender,
-                &HandlePinResult::Err {
-                    id: mail.id,
-                    error: HandleError::UnknownHandle,
-                },
-            );
+            ctx.reply(&HandlePinResult::Err {
+                id: mail.id,
+                error: HandleError::UnknownHandle,
+            });
         }
     }
 
@@ -134,18 +134,14 @@ impl HandleCapability {
     /// # Agent
     /// Reply: `HandleUnpinResult`.
     #[aether_data::handler]
-    fn on_unpin(&mut self, sender: ReplyTo, mail: HandleUnpin) {
+    fn on_unpin(&self, ctx: &mut NativeCtx<'_>, mail: HandleUnpin) {
         if self.store.unpin(mail.id) {
-            self.mailer
-                .send_reply(sender, &HandleUnpinResult::Ok { id: mail.id });
+            ctx.reply(&HandleUnpinResult::Ok { id: mail.id });
         } else {
-            self.mailer.send_reply(
-                sender,
-                &HandleUnpinResult::Err {
-                    id: mail.id,
-                    error: HandleError::UnknownHandle,
-                },
-            );
+            ctx.reply(&HandleUnpinResult::Err {
+                id: mail.id,
+                error: HandleError::UnknownHandle,
+            });
         }
     }
 }
@@ -170,6 +166,7 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
+    use aether_actor::Actor;
     use aether_data::{HandleId, Kind, KindId};
     use aether_data::{SessionToken, Uuid};
 
@@ -203,19 +200,18 @@ mod tests {
         ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
     }
 
-    /// End-to-end through the cap: boot it, push a `HandlePublish`
-    /// mail at the registered mailbox, the dispatcher thread runs the
-    /// macro-emitted `Dispatch::__dispatch` which calls `on_publish`,
-    /// the reply lands on the hub-outbound channel.
+    /// End-to-end through the cap: boot it via `with_actor`, push a
+    /// `HandlePublish` mail at the registered mailbox, the dispatcher
+    /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
+    /// which calls `on_publish`, the reply lands on the hub-outbound
+    /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
+    /// `Mailer::send_reply` → `outbound.send_reply`.
     #[test]
     fn capability_routes_publish_through_dispatcher_thread() {
         let (store, mailer, registry, rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(HandleCapability::new(
-                Arc::clone(&store),
-                Arc::clone(&mailer),
-            ))
+            .with_actor::<HandleCapability>(())
             .build()
             .expect("capability boots");
 
@@ -277,13 +273,10 @@ mod tests {
     /// thread exits within a generous deadline.
     #[test]
     fn shutdown_joins_dispatcher_thread() {
-        let (store, mailer, registry, _rx) = fresh_substrate();
+        let (_store, mailer, registry, _rx) = fresh_substrate();
 
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(HandleCapability::new(
-                Arc::clone(&store),
-                Arc::clone(&mailer),
-            ))
+            .with_actor::<HandleCapability>(())
             .build()
             .expect("capability boots");
 
@@ -300,14 +293,11 @@ mod tests {
     /// name was already registered.
     #[test]
     fn duplicate_claim_rejects_with_typed_error() {
-        let (store, mailer, registry, _rx) = fresh_substrate();
+        let (_store, mailer, registry, _rx) = fresh_substrate();
         registry.register_sink(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(HandleCapability::new(
-                Arc::clone(&store),
-                Arc::clone(&mailer),
-            ))
+            .with_actor::<HandleCapability>(())
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -745,6 +745,125 @@ fn alloc_thread_name<C: Actor>() -> String {
 type BootFn =
     Box<dyn FnOnce(&mut ChassisCtx<'_>) -> Result<Box<dyn ActorErased>, BootError> + Send>;
 
+/// Issue 552 stage 2: boot a `NativeActor` through the legacy
+/// `ChassisBuilder` path. Mirrors
+/// `chassis_builder::make_native_actor_boot` but uses the legacy
+/// boot machinery (no chassis-side Actors map; init-time peer lookups
+/// via `NativeInitCtx::actor::<A>()` always return `None`). The cap's
+/// dispatcher thread, transport, and inbox lifecycle match the new
+/// `Builder::with_actor` path verbatim — only the chassis-level
+/// bookkeeping differs, so cross-cap mail flow (the substrate's
+/// universal communication primitive) is unchanged.
+fn boot_native_actor<A>(
+    ctx: &mut ChassisCtx<'_>,
+    config: A::Config,
+) -> Result<Box<dyn ActorErased>, BootError>
+where
+    A: crate::NativeActor + crate::NativeDispatch,
+{
+    if A::FRAME_BARRIER {
+        return Err(BootError::Other(Box::new(std::io::Error::other(format!(
+            "with_actor::<{}> rejected: FRAME_BARRIER caps must use the legacy with(cap) path \
+             until stage 2 wires frame-bound claims through with_actor",
+            A::NAMESPACE
+        )))));
+    }
+
+    let claim = ctx.claim_mailbox_drop_on_shutdown::<A>()?;
+    let DropOnShutdownClaim {
+        id: mailbox_id,
+        receiver,
+        sink_sender,
+    } = claim;
+
+    let transport = Arc::new(crate::NativeTransport::from_ctx(
+        ctx,
+        mailbox_id,
+        A::FRAME_BARRIER,
+    ));
+    transport.install_inbox(receiver);
+
+    // The legacy path doesn't carry a chassis-side `Actors` map; init
+    // contexts that don't need peer lookups (today: every cap migrating
+    // through this path — Handle, Audio, Io, Net) work fine against an
+    // empty map. The new `Builder::with_actor` path threads a real map
+    // for caps that DO need peer lookups; both end up using the same
+    // NativeInitCtx + dispatcher trampoline shape.
+    let empty_actors = crate::Actors::new();
+    let actor = {
+        let mailer_clone = ctx.mail_send_handle();
+        let mut init_ctx =
+            crate::native_actor::NativeInitCtx::new(&transport, &empty_actors, mailer_clone);
+        A::init(config, &mut init_ctx)?
+    };
+    drop(empty_actors); // explicit shape — no shared state outlives init
+
+    let actor_arc: Arc<A> = Arc::new(actor);
+
+    let actor_for_thread = Arc::clone(&actor_arc);
+    let transport_for_thread = Arc::clone(&transport);
+    let thread_name = alloc_legacy_native_actor_thread_name::<A>();
+    let thread = std::thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            while let Some(env) = transport_for_thread.recv_blocking() {
+                let mut native_ctx =
+                    crate::native_actor::NativeCtx::new(&transport_for_thread, env.sender);
+                if actor_for_thread
+                    .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
+                    .is_none()
+                {
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        actor = A::NAMESPACE,
+                        kind = env.kind_name.as_str(),
+                        "native actor dispatch missed: kind not handled or decode failed"
+                    );
+                }
+            }
+        })
+        .map_err(|e| BootError::Other(Box::new(e)))?;
+
+    Ok(Box::new(LegacyNativeActorErased {
+        thread: Some(thread),
+        sink_sender: Some(sink_sender),
+        // Hold the Arc<A> to keep the actor alive for the dispatcher
+        // thread's lifetime; on drop the dispatcher's recv exits and
+        // the Arc reaches refcount zero, dropping the actor itself.
+        _actor: actor_arc as Arc<dyn std::any::Any + Send + Sync>,
+    }) as Box<dyn ActorErased>)
+}
+
+fn alloc_legacy_native_actor_thread_name<A: aether_actor::Actor>() -> String {
+    let mut name = String::with_capacity("aether-actor-".len() + A::NAMESPACE.len());
+    name.push_str("aether-actor-");
+    name.push_str(A::NAMESPACE);
+    name
+}
+
+/// Erased shutdown for a `NativeActor` booted through the legacy
+/// `ChassisBuilder.with_actor` path. Drops the [`SinkSender`] to
+/// disconnect the inbox channel (the dispatcher's `recv` returns
+/// `None` and the thread exits), then joins.
+struct LegacyNativeActorErased {
+    thread: Option<std::thread::JoinHandle<()>>,
+    sink_sender: Option<SinkSender>,
+    _actor: Arc<dyn std::any::Any + Send + Sync>,
+}
+
+impl ActorErased for LegacyNativeActorErased {}
+
+impl Drop for LegacyNativeActorErased {
+    fn drop(&mut self) {
+        // Sender first — disconnects the channel and lets the
+        // dispatcher's recv return None so the thread exits.
+        self.sink_sender.take();
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
 /// Declarative chassis composition. Capabilities are added in
 /// declaration order (ADR-0070 resolved decision 3); `build()` boots
 /// them in the same order. The first failure aborts the build and
@@ -816,6 +935,37 @@ impl ChassisBuilder {
         self.pending.push(Box::new(move |ctx| {
             ctx.claim_fallback_router(handler)?;
             Ok(Box::new(FallbackMarker) as Box<dyn ActorErased>)
+        }));
+        self
+    }
+
+    /// Issue 552 stage 2: boot a [`crate::NativeActor`] with its
+    /// associated `Config`. Mirrors
+    /// [`crate::chassis_builder::Builder::with_actor`] for the legacy
+    /// `ChassisBuilder` boot path used by [`crate::SubstrateBoot::build`].
+    /// Both paths exist side-by-side until stage 2c retires the legacy
+    /// builder; this method lets caps migrate onto `NativeActor` without
+    /// blocking on that retirement.
+    ///
+    /// FRAME_BARRIER caps aren't supported here yet — same fast-fail
+    /// rationale as the new builder: a frame-bound cap booted through
+    /// the non-frame-bound claim would silently miss the per-frame
+    /// drain barrier.
+    pub fn with_actor<A>(mut self, config: A::Config) -> Self
+    where
+        A: crate::NativeActor + crate::NativeDispatch,
+    {
+        // Use a `Cell<Option<Config>>` so the closure can take ownership
+        // on the single firing without making the whole closure FnOnce
+        // (the boot trampoline is FnOnce already, but `Box<dyn ...>`
+        // demands the right erasure). Move the config through a
+        // single-shot Option pulled out at boot time.
+        let mut config_cell = Some(config);
+        self.pending.push(Box::new(move |ctx| {
+            let config = config_cell
+                .take()
+                .expect("with_actor closure fired exactly once");
+            boot_native_actor::<A>(ctx, config)
         }));
         self
     }

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -183,28 +183,16 @@ impl<'a> Sender for NativeCtx<'a> {
 }
 
 impl<'a> MailCtx for NativeCtx<'a> {
-    fn reply<K: Kind>(&mut self, payload: &K) {
-        // Stage 1: the trait method exists and dispatches through
-        // `NativeTransport::reply_mail`, which is itself a stage-2
-        // stub today. So `ctx.reply(...)` from a stage-1 native
-        // handler logs an `ERR_NOT_IMPLEMENTED` warning rather than
-        // routing — exactly the behaviour the macro+ctx infra
-        // promises. Stage 2 fleshes out `reply_mail` and the entire
-        // call site lights up without changing trait shape.
-        let bytes = payload.encode_into_bytes();
-        // The transport's `reply_mail` takes a u32 sender; the
-        // substrate-side `ReplyTo` carries richer routing info.
-        // Stage 2 either grows `reply_mail` to take the full
-        // ReplyTo (via a side channel) or routes through the
-        // mailer here directly. Today the no-op stub is fine.
-        let _ = bytes;
-        let _ = self.sender;
-        let _ = self.transport;
-        tracing::trace!(
-            target: "aether_substrate::native_actor",
-            kind = K::NAME,
-            "NativeCtx::reply called — wired to NativeTransport::reply_mail (stage 2 will route)"
-        );
+    /// Stage 2: route the reply through the substrate's `Mailer::send_reply`
+    /// (Component recipient → push as Mail with the originator's
+    /// correlation echoed and reply-to None; Session / EngineMailbox
+    /// → outbound bridge; None → silent drop). This is the same path
+    /// pre-stage-2 caps walked manually via `self.mailer.send_reply(sender, &result)`
+    /// — caps now reach for `ctx.reply(&result)` and the per-mail
+    /// ctx already holds both the mailer reference (via the transport)
+    /// and the inbound's reply target.
+    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
+        self.transport.send_reply_for_handler(self.sender, payload);
     }
 }
 

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -246,6 +246,21 @@ impl NativeTransport {
         let inbox = self.inbox.get()?;
         inbox.lock().unwrap().try_recv().ok()
     }
+
+    /// Stage 2 reply path for native actors. Routes through the
+    /// substrate's `Mailer::send_reply` so a handler's `ctx.reply(&result)`
+    /// reaches the originator the same way a pre-stage-2 cap's
+    /// `self.mailer.send_reply(sender, &result)` did. The wasm-flavoured
+    /// `MailTransport::reply_mail` still returns `ERR_NOT_IMPLEMENTED`
+    /// because its `sender: u32` is a wasm-handle shape that doesn't
+    /// fit the native `ReplyTo` — the typed entry below is the actual
+    /// reply API native actors use.
+    pub fn send_reply_for_handler<K>(&self, sender: ReplyTo, payload: &K)
+    where
+        K: aether_data::Kind + serde::Serialize,
+    {
+        self.mailer.send_reply(sender, payload);
+    }
 }
 
 /// Return code surfaced from `send_mail` / `reply_mail` /


### PR DESCRIPTION
## Summary

- `NativeCtx::reply<K>(&payload)` now routes through `Mailer::send_reply`. Caps no longer hold `Arc<Mailer>` for replies — the per-handler ctx already carries the transport, and the transport already holds the mailer.
- `MailCtx::reply<K>` widens to `K: Kind + serde::Serialize` to match the substrate-side reply path. Wasm-side body unchanged (still uses `Kind::encode_into_bytes`); every reply kind in-tree already derives Serialize.
- Legacy `ChassisBuilder` gets `with_actor::<A>(config)` so caps booted through `SubstrateBoot::build` can adopt the `NativeActor` shape. Mirrors `chassis_builder::Builder::with_actor`.
- `HandleCapability` migrates to `NativeActor` (second cap after Log). Drops `self.mailer`, pulls `HandleStore` from `NativeInitCtx::mailer().handle_store()`, replies via `ctx.reply(&result)`.

## Why staged

Stage 2 in issue 552 was framed as one PR; in practice the cap migrations are a wide sweep. 2a (Log pilot) shipped via PR 557. 2b is foundations + Handle (uses reply, no Config) — validates the reply path before Audio/Io/Net (Config + reply, larger diff each) and Render (FRAME_BARRIER plumbing).

Next sub-stages: 2c migrates Audio, Io, Net in-place; 2d migrates Render with FRAME_BARRIER through `with_actor`; 2e extracts to `aether-capabilities` crate.

## Test plan

- [x] `cargo test --workspace --all-targets` green locally
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] All six wasm components build for `wasm32-unknown-unknown`
- [x] `capability_routes_publish_through_dispatcher_thread` passes — `ctx.reply` round-trips a `HandlePublishResult` through outbound to a session-flavoured `ReplyTo`
- [x] `shutdown_joins_dispatcher_thread` passes — channel-drop teardown still works
- [x] `duplicate_claim_rejects_with_typed_error` passes — duplicate-claim guard preserved on the new boot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)