### PR TITLE
refactor(actor): migrate io+net+audio caps onto NativeActor (issue 552 stage 2c)

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -88,11 +88,10 @@ fn main() -> wasmtime::Result<()> {
         hub,
     } = TestBenchChassis::build_passive(env)?;
 
-    // Io cap on the `boot.add_capability` path — the binary fails fast on
+    // Io cap on the `boot.add_actor` path — the binary fails fast on
     // adapter init failure (the in-process API silent-skips for
     // systems without writable default roots).
-    let io_cap = IoCapability::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue))?;
-    boot.add_capability(io_cap)?;
+    boot.add_actor::<IoCapability>(boot.namespace_roots.clone())?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height, render_handles.clone());

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -354,14 +354,12 @@ impl DesktopChassis {
         // capabilities' boot tracing routes through the log capture;
         // render last so it claims its mailboxes after every other
         // chassis cap.
-        let io_cap = IoCapability::new(namespace_roots, Arc::clone(&mailer))
-            .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
             .with_actor::<LogCapability>(())
-            .with(io_cap)
-            .with(NetCapability::new(net, Arc::clone(&mailer)))
-            .with(AudioCapability::new(audio, Arc::clone(&mailer)))
+            .with_actor::<IoCapability>(namespace_roots)
+            .with_actor::<NetCapability>(net)
+            .with_actor::<AudioCapability>(audio)
             .with(render_cap)
             .driver(driver)
             .build()

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -228,13 +228,11 @@ impl HeadlessChassis {
         // chassis_builder `.with()` chain. Boot order is declaration
         // order — log first so other capabilities' boot tracing routes
         // through the log capture.
-        let io_cap = IoCapability::new(namespace_roots, Arc::clone(&mailer))
-            .map_err(|e| BootError::Other(Box::new(e)))?;
         Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
             .with_actor::<LogCapability>(())
-            .with(io_cap)
-            .with(NetCapability::new(net, Arc::clone(&mailer)))
+            .with_actor::<IoCapability>(namespace_roots)
+            .with_actor::<NetCapability>(net)
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -285,28 +285,17 @@ impl TestBench {
         boot.outbound
             .attach_backend(Arc::new(HubProtocolBackend::new(loopback_tx)));
 
-        // Io cap on the `boot.add_capability` path. Silent-skip on init
-        // failure preserves prior behavior so tests on systems without
-        // writable default roots don't fail at the harness layer;
-        // tests that care about io supply tempdir roots via the
+        // Io cap booted post-build via `SubstrateBoot::add_actor` so
+        // adapter init failures (no writable default roots, missing
+        // env, etc.) warn-and-skip rather than failing the harness.
+        // Tests that care about io supply tempdir roots through the
         // builder.
-        match IoCapability::new(boot.namespace_roots.clone(), Arc::clone(&boot.queue)) {
-            Ok(io_cap) => {
-                if let Err(e) = boot.add_capability(io_cap) {
-                    tracing::warn!(
-                        target: "aether_substrate::io",
-                        error = %e,
-                        "io cap boot failed in TestBench (expected on systems without writable default roots)",
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::io",
-                    error = %e,
-                    "io adapter init failed in TestBench (expected on systems without writable default roots)",
-                );
-            }
+        if let Err(e) = boot.add_actor::<IoCapability>(boot.namespace_roots.clone()) {
+            tracing::warn!(
+                target: "aether_substrate::io",
+                error = %e,
+                "io cap boot failed in TestBench (expected on systems without writable default roots)",
+            );
         }
 
         let gpu = Gpu::new(width, height, render_handles.clone());

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -180,6 +180,21 @@ impl SubstrateBoot {
             .add(&self.registry, &self.queue, cap)
             .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
     }
+
+    /// Issue 552 stage 2: post-build entry for a `NativeActor`.
+    /// Mirror of [`Self::add_capability`] for the new cap shape.
+    pub fn add_actor<A>(&mut self, config: A::Config) -> wasmtime::Result<()>
+    where
+        A: crate::NativeActor + crate::NativeDispatch,
+    {
+        let chassis = self
+            .chassis
+            .as_mut()
+            .expect("SubstrateBoot::build always installs a BootedChassis");
+        chassis
+            .add_actor::<A>(&self.registry, &self.queue, config)
+            .map_err(|e| wasmtime::Error::msg(format!("capability boot failed: {e}")))
+    }
 }
 
 impl<'a> SubstrateBootBuilder<'a> {

--- a/crates/aether-substrate/src/capabilities/audio.rs
+++ b/crates/aether-substrate/src/capabilities/audio.rs
@@ -55,11 +55,12 @@ use std::thread::{self, JoinHandle};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
-use aether_actor::{Actor, Singleton};
+use aether_actor::{MailCtx, Singleton};
 use aether_data::{MailboxId, ReplyTarget, ReplyTo};
 use aether_kinds::{NoteOff, NoteOn, SetMasterGain, SetMasterGainResult};
 
-use crate::mailer::Mailer;
+use crate::capability::BootError;
+use crate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// Capacity of the event queue between the cap's handlers and the
 /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -640,8 +641,7 @@ fn sender_mailbox_id(sender: ReplyTo) -> MailboxId {
     }
 }
 
-/// `aether.audio` mailbox cap. Holds the chassis [`Arc<Mailer>`] for
-/// `SetMasterGainResult` replies, the producer side of the synth
+/// `aether.audio` mailbox cap. Holds the producer side of the synth
 /// event queue ([`AudioEventSender`]), the audio worker thread that
 /// owns the [`cpal::Stream`] (see module-level "per-cap audio worker"
 /// docs for the `!Send` rationale), and a shutdown channel that
@@ -650,60 +650,36 @@ fn sender_mailbox_id(sender: ReplyTo) -> MailboxId {
 /// `audio_sender` is `None` when the cpal pipeline isn't running
 /// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In
 /// that mode `NoteOn` / `NoteOff` no-op and `SetMasterGain` replies
-/// `Err`.
+/// `Err`. The audio_thread / shutdown handles live behind a `Mutex`
+/// so the `Drop` impl can take ownership during teardown without
+/// requiring `&mut self` everywhere — handlers run with `&self`
+/// (Arc-shared) per the `NativeActor` contract.
+#[derive(Singleton)]
 pub struct AudioCapability {
-    mailer: Arc<Mailer>,
     audio_sender: Option<AudioEventSender>,
-    /// Worker thread holding the [`cpal::Stream`]. `None` in nop
-    /// mode (no pipeline to hold).
+    /// Worker thread holding the [`cpal::Stream`] + drop-on-shutdown
+    /// sender. Mutex-wrapped so `Drop` can `.take()` the JoinHandle
+    /// and Sender on `&mut self` while normal handlers (`&self`)
+    /// don't need to touch them.
+    teardown: std::sync::Mutex<AudioTeardown>,
+}
+
+/// Teardown state pulled aside so `Drop` can take ownership of the
+/// JoinHandle and shutdown sender without poisoning the rest of the
+/// cap struct.
+struct AudioTeardown {
     audio_thread: Option<JoinHandle<()>>,
-    /// Drop-on-shutdown sender; dropping it disconnects the channel
-    /// the worker is parked on, the worker exits, and the cpal
-    /// stream tears down on thread exit.
     audio_shutdown: Option<mpsc::Sender<()>>,
 }
 
 impl AudioCapability {
-    /// Construct from an [`AudioConfig`] (resolved by the chassis
-    /// main, typically via [`AudioConfig::from_env`]) and the
-    /// chassis [`Mailer`]. Always returns a cap instance — cpal init
-    /// failure logs a warning and falls back to nop mode (per
-    /// ADR-0039: audio is a peripheral, not infrastructure). The
-    /// cap always claims its mailbox so agents on chassis without
-    /// audio still get loud `Err` replies for `SetMasterGain` instead
-    /// of timing out.
-    pub fn new(config: AudioConfig, mailer: Arc<Mailer>) -> Self {
-        if config.disabled {
-            tracing::info!(
-                target: "aether_substrate::audio",
-                "AETHER_AUDIO_DISABLE=1 — skipping cpal init",
-            );
-            return Self::nop(mailer);
-        }
-        match spawn_audio_worker(config.requested_sample_rate) {
-            Ok((audio_sender, audio_thread, audio_shutdown)) => Self {
-                mailer,
-                audio_sender: Some(audio_sender),
-                audio_thread: Some(audio_thread),
-                audio_shutdown: Some(audio_shutdown),
-            },
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::audio",
-                    error = %e,
-                    "audio pipeline init failed — NoteOn/NoteOff will be nop, SetMasterGain will reply Err",
-                );
-                Self::nop(mailer)
-            }
-        }
-    }
-
-    fn nop(mailer: Arc<Mailer>) -> Self {
+    fn nop() -> Self {
         Self {
-            mailer,
             audio_sender: None,
-            audio_thread: None,
-            audio_shutdown: None,
+            teardown: std::sync::Mutex::new(AudioTeardown {
+                audio_thread: None,
+                audio_shutdown: None,
+            }),
         }
     }
 }
@@ -712,23 +688,58 @@ impl Drop for AudioCapability {
     fn drop(&mut self) {
         // Drop the shutdown sender first; the worker's `recv()`
         // returns, it drops the cpal::Stream on its own thread, and
-        // exits. Then we join.
-        self.audio_shutdown.take();
-        if let Some(t) = self.audio_thread.take() {
+        // exits. Then we join. Mutex contention is impossible here —
+        // Drop runs only when the last Arc is released.
+        let mut tear = self
+            .teardown
+            .lock()
+            .expect("AudioCapability teardown mutex poisoned");
+        tear.audio_shutdown.take();
+        if let Some(t) = tear.audio_thread.take() {
             let _ = t.join();
         }
     }
 }
 
-impl Actor for AudioCapability {
+#[aether_data::actor]
+impl NativeActor for AudioCapability {
+    type Config = AudioConfig;
+
     /// ADR-0039 + ADR-0074 Phase 5 chassis-owned mailbox.
     const NAMESPACE: &'static str = "aether.audio";
-}
 
-impl Singleton for AudioCapability {}
+    /// Boot the cap. Always succeeds — cpal init failure logs a
+    /// warning and falls back to nop mode (per ADR-0039: audio is a
+    /// peripheral, not infrastructure). The cap always claims its
+    /// mailbox so agents on chassis without audio still get loud
+    /// `Err` replies for `SetMasterGain` instead of timing out.
+    fn init(config: AudioConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        if config.disabled {
+            tracing::info!(
+                target: "aether_substrate::audio",
+                "AETHER_AUDIO_DISABLE=1 — skipping cpal init",
+            );
+            return Ok(Self::nop());
+        }
+        match spawn_audio_worker(config.requested_sample_rate) {
+            Ok((audio_sender, audio_thread, audio_shutdown)) => Ok(Self {
+                audio_sender: Some(audio_sender),
+                teardown: std::sync::Mutex::new(AudioTeardown {
+                    audio_thread: Some(audio_thread),
+                    audio_shutdown: Some(audio_shutdown),
+                }),
+            }),
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::audio",
+                    error = %e,
+                    "audio pipeline init failed — NoteOn/NoteOff will be nop, SetMasterGain will reply Err",
+                );
+                Ok(Self::nop())
+            }
+        }
+    }
 
-#[aether_data::actor]
-impl AudioCapability {
     /// Start a note.
     ///
     /// # Agent
@@ -736,12 +747,12 @@ impl AudioCapability {
     /// `(sender, instrument_id, pitch)`; sending two `NoteOn`s with
     /// the same triple is a no-op.
     #[aether_data::handler]
-    fn on_note_on(&mut self, sender: ReplyTo, mail: NoteOn) {
+    fn on_note_on(&self, ctx: &mut NativeCtx<'_>, mail: NoteOn) {
         let Some(s) = self.audio_sender.as_ref() else {
             return;
         };
         let ev = AudioEvent::NoteOn {
-            sender_mailbox: sender_mailbox_id(sender),
+            sender_mailbox: sender_mailbox_id(ctx.reply_target()),
             pitch: mail.pitch,
             velocity: mail.velocity,
             instrument_id: mail.instrument_id,
@@ -759,12 +770,12 @@ impl AudioCapability {
     /// # Agent
     /// Fire-and-forget.
     #[aether_data::handler]
-    fn on_note_off(&mut self, sender: ReplyTo, mail: NoteOff) {
+    fn on_note_off(&self, ctx: &mut NativeCtx<'_>, mail: NoteOff) {
         let Some(s) = self.audio_sender.as_ref() else {
             return;
         };
         let ev = AudioEvent::NoteOff {
-            sender_mailbox: sender_mailbox_id(sender),
+            sender_mailbox: sender_mailbox_id(ctx.reply_target()),
             pitch: mail.pitch,
             instrument_id: mail.instrument_id,
         };
@@ -782,17 +793,14 @@ impl AudioCapability {
     /// Reply: `SetMasterGainResult`. `Ok { applied_gain }` clamps to
     /// `0.0..=1.0`; `Err` on chassis without audio.
     #[aether_data::handler]
-    fn on_set_master_gain(&mut self, sender: ReplyTo, mail: SetMasterGain) {
+    fn on_set_master_gain(&self, ctx: &mut NativeCtx<'_>, mail: SetMasterGain) {
         let applied = mail.gain.clamp(0.0, 1.0);
         match self.audio_sender.as_ref() {
             Some(s) => {
                 let _ = s.push(AudioEvent::SetMasterGain { gain: applied });
-                self.mailer.send_reply(
-                    sender,
-                    &SetMasterGainResult::Ok {
-                        applied_gain: applied,
-                    },
-                );
+                ctx.reply(&SetMasterGainResult::Ok {
+                    applied_gain: applied,
+                });
                 tracing::info!(
                     target: "aether_substrate::audio",
                     requested = mail.gain,
@@ -801,13 +809,9 @@ impl AudioCapability {
                 );
             }
             None => {
-                self.mailer.send_reply(
-                    sender,
-                    &SetMasterGainResult::Err {
-                        error: "audio pipeline not initialised on this desktop substrate"
-                            .to_owned(),
-                    },
-                );
+                ctx.reply(&SetMasterGainResult::Err {
+                    error: "audio pipeline not initialised on this desktop substrate".to_owned(),
+                });
             }
         }
     }
@@ -868,7 +872,9 @@ fn spawn_audio_worker(
 mod tests {
     use super::*;
     use crate::capability::{BootError, ChassisBuilder};
+    use crate::mailer::Mailer;
     use crate::registry::Registry;
+    use aether_actor::Actor;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());
@@ -1013,15 +1019,11 @@ mod tests {
     #[test]
     fn capability_boots_and_registers_mailbox() {
         let (registry, mailer) = fresh_substrate();
-        let cap = AudioCapability::new(
-            AudioConfig {
+        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<AudioCapability>(AudioConfig {
                 disabled: true,
                 ..AudioConfig::default()
-            },
-            Arc::clone(&mailer),
-        );
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            })
             .build()
             .expect("audio capability boots");
         assert!(
@@ -1037,15 +1039,11 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         registry.register_sink(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-        let cap = AudioCapability::new(
-            AudioConfig {
+        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<AudioCapability>(AudioConfig {
                 disabled: true,
                 ..AudioConfig::default()
-            },
-            Arc::clone(&mailer),
-        );
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            })
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(

--- a/crates/aether-substrate/src/capabilities/io.rs
+++ b/crates/aether-substrate/src/capabilities/io.rs
@@ -1,38 +1,39 @@
-//! Issue 545 PR E1: collapsed `aether.io` cap. Pre-PR-E1 the cap
-//! lived split across `aether-kinds::io::IoCapability<B>` (facade
-//! generic) and this file (concrete `IoAdapterBackend`). The facade
-//! pattern (ADR-0075) is retired — caps are now regular `#[actor]`
-//! blocks, same shape as wasm components.
+//! Issue 552 stage 2: `aether.io` cap migrated onto `NativeActor`.
+//! Pre-stage-2 the cap was an `Actor + Singleton + Dispatch` shape
+//! taking `&mut self` handlers with `sender: ReplyTo` parameters and
+//! routing replies through `self.mailer.send_reply(sender, &result)`.
+//! Stage 2 collapses that into the symmetric authoring shape:
+//! `#[derive(Singleton)] struct + #[actor] impl NativeActor for X
+//! { type Config = NamespaceRoots; fn init; #[handler] fn (&self,
+//! ctx: &mut NativeCtx<'_>, mail) }`. Replies route via
+//! `ctx.reply(&result)`.
 //!
 //! Owns the full ADR-0041 stack — `FileAdapter` trait,
 //! `LocalFileAdapter`, `AdapterRegistry`, env-driven `NamespaceRoots`,
 //! and the [`IoCapability`] itself. Chassis mains resolve a
-//! [`NamespaceRoots`] (typically via [`NamespaceRoots::from_env`]),
-//! call [`IoCapability::new`], and hand the cap to the chassis
-//! builder.
+//! [`NamespaceRoots`] (typically via [`NamespaceRoots::from_env`])
+//! and pass it through `with_actor::<IoCapability>(roots)` —
+//! `init` builds the adapter registry and returns `BootError` on
+//! failure (per ADR-0063 fail-fast).
 //!
-//! Boot error policy: per ADR-0063 fail-fast, adapter init failure
-//! surfaces at [`IoCapability::new`] (returns `std::io::Result`) so
-//! chassis mains propagate via `?` to abort startup.
-//!
-//! Threading: chassis-side dispatcher thread (`spawn_actor_dispatcher`)
-//! pulls envelopes from the `aether.io` mailbox and routes them to
-//! the matching `#[handler]` method. Adapter calls run synchronously
-//! on the dispatcher thread; ADR-0041 flagged a future host-fn fast
-//! path for asset-sized streaming.
+//! Threading: the new actor dispatcher thread pulls envelopes from
+//! the `aether.io` mailbox and routes them through the macro-emitted
+//! `NativeDispatch::__aether_dispatch_envelope`. Adapter calls run
+//! synchronously on that thread; ADR-0041 flagged a future host-fn
+//! fast path for asset-sized streaming.
 
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use aether_actor::{Actor, Singleton};
-use aether_data::ReplyTo;
+use aether_actor::{MailCtx, Singleton};
 use aether_kinds::{
     Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
 };
 
-use crate::mailer::Mailer;
+use crate::capability::BootError;
+use crate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
@@ -309,23 +310,31 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
 }
 
 /// `aether.io` mailbox cap. Owns the resolved adapter registry +
-/// namespace roots and the chassis [`Arc<Mailer>`] for routing
-/// replies. The dispatcher thread owns this through the macro-emitted
-/// `Dispatch` impl.
+/// namespace roots. The dispatcher thread holds an `Arc<Self>` and
+/// routes envelopes through the macro-emitted `NativeDispatch` impl;
+/// replies route via `ctx.reply(&result)` through the substrate's
+/// `Mailer::send_reply`.
+#[derive(Singleton)]
 pub struct IoCapability {
     registry: Arc<AdapterRegistry>,
-    mailer: Arc<Mailer>,
 }
 
-impl IoCapability {
-    /// Construct from explicit [`NamespaceRoots`] (resolved by the
-    /// chassis main, typically via [`NamespaceRoots::from_env`]) and
-    /// the chassis's [`Mailer`]. Returns `Err(std::io::Error)` if the
-    /// adapter registry can't be built — chassis mains propagate via
-    /// `?` so misconfiguration aborts the chassis at startup
-    /// (ADR-0063 fail-fast).
-    pub fn new(roots: NamespaceRoots, mailer: Arc<Mailer>) -> std::io::Result<Self> {
-        let (registry, roots) = build_registry(roots)?;
+#[aether_data::actor]
+impl NativeActor for IoCapability {
+    /// Resolved namespace roots threaded through to `init`. Chassis
+    /// mains build this via [`NamespaceRoots::from_env`] (or hand-roll
+    /// for tests) and pass to `with_actor::<IoCapability>(roots)`.
+    type Config = NamespaceRoots;
+
+    /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.io";
+
+    /// Build the adapter registry from the resolved roots. Adapter
+    /// init failure surfaces as `BootError::Other(io::Error)` so
+    /// chassis mains propagate via `?` to abort startup (ADR-0063
+    /// fail-fast).
+    fn init(roots: NamespaceRoots, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        let (registry, roots) = build_registry(roots).map_err(|e| BootError::Other(Box::new(e)))?;
         tracing::info!(
             target: "aether_substrate::io",
             save = %roots.save.display(),
@@ -333,41 +342,21 @@ impl IoCapability {
             config = %roots.config.display(),
             "io adapters registered",
         );
-        Ok(Self { registry, mailer })
+        Ok(Self { registry })
     }
 
-    /// Construct from an explicit pre-built registry. Used by tests
-    /// that supply a save-only registry against a tempdir.
-    #[cfg(test)]
-    pub fn from_registry(registry: Arc<AdapterRegistry>, mailer: Arc<Mailer>) -> Self {
-        Self { registry, mailer }
-    }
-}
-
-impl Actor for IoCapability {
-    /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
-    const NAMESPACE: &'static str = "aether.io";
-}
-
-impl Singleton for IoCapability {}
-
-#[aether_data::actor]
-impl IoCapability {
     /// Read bytes from a logical namespace path.
     ///
     /// # Agent
     /// Reply: `ReadResult`. Echoes namespace + path on both arms.
     #[aether_data::handler]
-    fn on_read(&mut self, sender: ReplyTo, mail: Read) {
+    fn on_read(&self, ctx: &mut NativeCtx<'_>, mail: Read) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
-            self.mailer.send_reply(
-                sender,
-                &ReadResult::Err {
-                    namespace: mail.namespace,
-                    path: mail.path,
-                    error: IoError::UnknownNamespace,
-                },
-            );
+            ctx.reply(&ReadResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error: IoError::UnknownNamespace,
+            });
             return;
         };
         let reply = match adapter.read(&mail.path) {
@@ -382,7 +371,7 @@ impl IoCapability {
                 error,
             },
         };
-        self.mailer.send_reply(sender, &reply);
+        ctx.reply(&reply);
     }
 
     /// Write bytes to a logical namespace path. Atomic via tmp+rename
@@ -392,16 +381,13 @@ impl IoCapability {
     /// # Agent
     /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
     #[aether_data::handler]
-    fn on_write(&mut self, sender: ReplyTo, mail: Write) {
+    fn on_write(&self, ctx: &mut NativeCtx<'_>, mail: Write) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
-            self.mailer.send_reply(
-                sender,
-                &WriteResult::Err {
-                    namespace: mail.namespace,
-                    path: mail.path,
-                    error: IoError::UnknownNamespace,
-                },
-            );
+            ctx.reply(&WriteResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error: IoError::UnknownNamespace,
+            });
             return;
         };
         let reply = match adapter.write(&mail.path, &mail.bytes) {
@@ -415,7 +401,7 @@ impl IoCapability {
                 error,
             },
         };
-        self.mailer.send_reply(sender, &reply);
+        ctx.reply(&reply);
     }
 
     /// Delete a path under a namespace.
@@ -423,16 +409,13 @@ impl IoCapability {
     /// # Agent
     /// Reply: `DeleteResult`. Echoes namespace + path.
     #[aether_data::handler]
-    fn on_delete(&mut self, sender: ReplyTo, mail: Delete) {
+    fn on_delete(&self, ctx: &mut NativeCtx<'_>, mail: Delete) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
-            self.mailer.send_reply(
-                sender,
-                &DeleteResult::Err {
-                    namespace: mail.namespace,
-                    path: mail.path,
-                    error: IoError::UnknownNamespace,
-                },
-            );
+            ctx.reply(&DeleteResult::Err {
+                namespace: mail.namespace,
+                path: mail.path,
+                error: IoError::UnknownNamespace,
+            });
             return;
         };
         let reply = match adapter.delete(&mail.path) {
@@ -446,7 +429,7 @@ impl IoCapability {
                 error,
             },
         };
-        self.mailer.send_reply(sender, &reply);
+        ctx.reply(&reply);
     }
 
     /// List entries under a namespace prefix.
@@ -454,16 +437,13 @@ impl IoCapability {
     /// # Agent
     /// Reply: `ListResult`. Echoes namespace + prefix.
     #[aether_data::handler]
-    fn on_list(&mut self, sender: ReplyTo, mail: List) {
+    fn on_list(&self, ctx: &mut NativeCtx<'_>, mail: List) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
-            self.mailer.send_reply(
-                sender,
-                &ListResult::Err {
-                    namespace: mail.namespace,
-                    prefix: mail.prefix,
-                    error: IoError::UnknownNamespace,
-                },
-            );
+            ctx.reply(&ListResult::Err {
+                namespace: mail.namespace,
+                prefix: mail.prefix,
+                error: IoError::UnknownNamespace,
+            });
             return;
         };
         let reply = match adapter.list(&mail.prefix) {
@@ -478,7 +458,18 @@ impl IoCapability {
                 error,
             },
         };
-        self.mailer.send_reply(sender, &reply);
+        ctx.reply(&reply);
+    }
+}
+
+#[cfg(test)]
+impl IoCapability {
+    /// Test-only direct constructor. Production boots through
+    /// `Builder::with_actor::<IoCapability>(roots)` which calls `init`;
+    /// tests that want to drive handlers without spinning up a full
+    /// chassis hand a pre-built registry directly.
+    pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
+        Self { registry }
     }
 }
 
@@ -488,8 +479,41 @@ mod tests {
 
     use super::*;
     use crate::capability::{BootError, ChassisBuilder};
+    use crate::mail::ReplyTo;
+    use crate::mailer::Mailer;
+    use crate::native_actor::NativeCtx;
+    use crate::native_transport::NativeTransport;
     use crate::registry::Registry;
-    use aether_data::Kind;
+    use aether_actor::Actor;
+    use aether_data::{Kind, MailboxId};
+
+    /// Test fixture that bundles the cap, a fully-wired test mailer,
+    /// and a `NativeTransport` long enough for handlers to borrow.
+    /// Pre-stage-2 the tests called `cap.on_read(sender, mail)`
+    /// directly; the new shape requires a `NativeCtx` borrowed from a
+    /// transport, so the fixture owns the transport and hands out
+    /// fresh ctxs per invocation.
+    struct TestFixture {
+        cap: IoCapability,
+        rx: std::sync::mpsc::Receiver<EgressEvent>,
+        transport: NativeTransport,
+    }
+
+    impl TestFixture {
+        fn new(reg: Arc<AdapterRegistry>) -> Self {
+            let (mailer, rx) = test_mailer_and_rx();
+            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+            Self {
+                cap: IoCapability::from_registry(reg),
+                rx,
+                transport,
+            }
+        }
+
+        fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
+            NativeCtx::new(&self.transport, sender)
+        }
+    }
 
     /// Manual tempdir helper to avoid pulling in the `tempfile`
     /// crate. Caller cleans up via [`cleanup`] after the test asserts.
@@ -742,10 +766,8 @@ mod tests {
     fn capability_boots_and_registers_mailbox() {
         let root = scratch_root("boots");
         let (registry, mailer) = fresh_substrate();
-        let cap =
-            IoCapability::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_actor::<IoCapability>(roots_under(&root))
             .build()
             .expect("io capability boots");
         assert!(
@@ -758,8 +780,8 @@ mod tests {
 
     /// Cap init fails when the adapter registry can't be built —
     /// provoke `LocalFileAdapter::new` failure by pointing the save
-    /// root at a regular file rather than a directory. Constructor
-    /// returns `std::io::Result`, chassis main propagates via `?`.
+    /// root at a regular file rather than a directory. `init` returns
+    /// `BootError::Other(io::Error)`, the chassis builder propagates.
     #[test]
     fn cap_init_fails_when_adapter_init_fails() {
         let root = scratch_root("init-fails");
@@ -773,8 +795,10 @@ mod tests {
         std::fs::create_dir_all(&roots.assets).unwrap();
         std::fs::create_dir_all(&roots.config).unwrap();
 
-        let (_, mailer) = fresh_substrate();
-        let result = IoCapability::new(roots, mailer);
+        let (registry, mailer) = fresh_substrate();
+        let result = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<IoCapability>(roots)
+            .build();
         assert!(result.is_err(), "save root being a file must fail cap init");
         cleanup(&root);
     }
@@ -787,10 +811,8 @@ mod tests {
         let (registry, mailer) = fresh_substrate();
         registry.register_sink(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-        let cap =
-            IoCapability::new(roots_under(&root), Arc::clone(&mailer)).expect("adapters init");
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(cap)
+            .with_actor::<IoCapability>(roots_under(&root))
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
@@ -805,20 +827,20 @@ mod tests {
     fn cap_read_ok_replies_with_bytes() {
         let root = scratch_root("cap-read");
         let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
         reg.get("save")
             .unwrap()
             .write("slot.bin", &[9, 9, 9])
             .unwrap();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_read(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_read(
+            &mut ctx,
             Read {
                 namespace: "save".to_string(),
                 path: "slot.bin".to_string(),
             },
         );
-        match decode_reply::<ReadResult>(&rx) {
+        match decode_reply::<ReadResult>(&fix.rx) {
             ReadResult::Ok {
                 namespace,
                 path,
@@ -837,16 +859,16 @@ mod tests {
     fn cap_read_unknown_namespace_replies_err() {
         let root = scratch_root("cap-ns");
         let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_read(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_read(
+            &mut ctx,
             Read {
                 namespace: "nope".to_string(),
                 path: "x.bin".to_string(),
             },
         );
-        match decode_reply::<ReadResult>(&rx) {
+        match decode_reply::<ReadResult>(&fix.rx) {
             ReadResult::Err {
                 namespace,
                 path,
@@ -864,17 +886,17 @@ mod tests {
     fn cap_read_not_found_replies_err() {
         let root = scratch_root("cap-nf");
         let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_read(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_read(
+            &mut ctx,
             Read {
                 namespace: "save".to_string(),
                 path: "ghost.bin".to_string(),
             },
         );
         assert!(matches!(
-            decode_reply::<ReadResult>(&rx),
+            decode_reply::<ReadResult>(&fix.rx),
             ReadResult::Err {
                 error: IoError::NotFound,
                 ..
@@ -888,17 +910,17 @@ mod tests {
         let root = scratch_root("cap-write");
         let reg = build_save_only_registry(&root, true);
         let reg_clone = Arc::clone(&reg);
-        let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_write(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_write(
+            &mut ctx,
             Write {
                 namespace: "save".to_string(),
                 path: "slot.bin".to_string(),
                 bytes: vec![1, 2, 3],
             },
         );
-        match decode_reply::<WriteResult>(&rx) {
+        match decode_reply::<WriteResult>(&fix.rx) {
             WriteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
                 assert_eq!(path, "slot.bin");
@@ -916,10 +938,10 @@ mod tests {
     fn cap_write_read_only_namespace_replies_forbidden() {
         let root = scratch_root("cap-ro");
         let reg = build_save_only_registry(&root, false);
-        let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_write(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_write(
+            &mut ctx,
             Write {
                 namespace: "save".to_string(),
                 path: "slot.bin".to_string(),
@@ -927,7 +949,7 @@ mod tests {
             },
         );
         assert!(matches!(
-            decode_reply::<WriteResult>(&rx),
+            decode_reply::<WriteResult>(&fix.rx),
             WriteResult::Err {
                 error: IoError::Forbidden,
                 ..
@@ -941,17 +963,17 @@ mod tests {
         let root = scratch_root("cap-del");
         let reg = build_save_only_registry(&root, true);
         let reg_clone = Arc::clone(&reg);
-        let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("x.bin", b"x").unwrap();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_delete(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_delete(
+            &mut ctx,
             Delete {
                 namespace: "save".to_string(),
                 path: "x.bin".to_string(),
             },
         );
-        match decode_reply::<DeleteResult>(&rx) {
+        match decode_reply::<DeleteResult>(&fix.rx) {
             DeleteResult::Ok { namespace, path } => {
                 assert_eq!(namespace, "save");
                 assert_eq!(path, "x.bin");
@@ -969,18 +991,18 @@ mod tests {
     fn cap_list_returns_sorted_entries() {
         let root = scratch_root("cap-list");
         let reg = build_save_only_registry(&root, true);
-        let (mailer, rx) = test_mailer_and_rx();
         reg.get("save").unwrap().write("b.bin", b"").unwrap();
         reg.get("save").unwrap().write("a.bin", b"").unwrap();
-        let mut cap = IoCapability::from_registry(reg, mailer);
-        cap.on_list(
-            session_sender(),
+        let fix = TestFixture::new(reg);
+        let mut ctx = fix.ctx(session_sender());
+        fix.cap.on_list(
+            &mut ctx,
             List {
                 namespace: "save".to_string(),
                 prefix: "".to_string(),
             },
         );
-        match decode_reply::<ListResult>(&rx) {
+        match decode_reply::<ListResult>(&fix.rx) {
             ListResult::Ok {
                 namespace,
                 prefix,
@@ -1068,9 +1090,14 @@ mod tests {
             .unwrap()
             .insert(caller_mailbox, Arc::clone(&entry));
 
-        let mut cap = IoCapability::from_registry(reg, Arc::clone(&mailer));
-        cap.on_read(
+        let cap = IoCapability::from_registry(reg);
+        let transport = NativeTransport::new_for_test(Arc::clone(&mailer), MailboxId(0));
+        let mut ctx = NativeCtx::new(
+            &transport,
             ReplyTo::to(aether_data::ReplyTarget::Component(caller_mailbox)),
+        );
+        cap.on_read(
+            &mut ctx,
             Read {
                 namespace: "save".to_string(),
                 path: "slot.bin".to_string(),

--- a/crates/aether-substrate/src/capabilities/net.rs
+++ b/crates/aether-substrate/src/capabilities/net.rs
@@ -22,11 +22,11 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aether_actor::{Actor, Singleton};
-use aether_data::ReplyTo;
+use aether_actor::{MailCtx, Singleton};
 use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
 
-use crate::mailer::Mailer;
+use crate::capability::BootError;
+use crate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -352,62 +352,57 @@ fn parse_default_timeout_env() -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-/// `aether.net` mailbox cap. Owns the resolved adapter, the chassis
-/// [`Arc<Mailer>`] for routing replies, and the default per-request
-/// timeout applied when `Fetch.timeout_ms` is `None`. The dispatcher
-/// thread owns this through the macro-emitted `Dispatch` impl.
+/// `aether.net` mailbox cap. Owns the resolved adapter and the
+/// default per-request timeout applied when `Fetch.timeout_ms` is
+/// `None`. The dispatcher thread holds an `Arc<Self>` and routes
+/// envelopes through the macro-emitted `NativeDispatch` impl;
+/// replies route via `ctx.reply(&result)` through the substrate's
+/// `Mailer::send_reply`.
+#[derive(Singleton)]
 pub struct NetCapability {
     adapter: Arc<dyn NetAdapter>,
-    mailer: Arc<Mailer>,
     default_timeout: Duration,
 }
 
+#[cfg(test)]
 impl NetCapability {
-    /// Construct from a [`NetConfig`] (resolved by the chassis main
-    /// — typically via [`NetConfig::from_env`]) and the chassis's
-    /// [`Mailer`]. The adapter is built immediately so any
-    /// configuration error surfaces at chassis-builder time, not at
-    /// first fetch.
-    pub fn new(config: NetConfig, mailer: Arc<Mailer>) -> Self {
-        let default_timeout = config.default_timeout;
-        Self {
-            adapter: build_net_adapter(config),
-            mailer,
-            default_timeout,
-        }
-    }
-
-    /// Construct from an explicit adapter. Used by tests that supply
-    /// a stub.
-    pub fn from_adapter(
-        adapter: Arc<dyn NetAdapter>,
-        mailer: Arc<Mailer>,
-        default_timeout: Duration,
-    ) -> Self {
+    /// Test-only direct constructor. Production boots through
+    /// `Builder::with_actor::<NetCapability>(config)` which calls
+    /// `init`; tests that drive the cap with a stub adapter hand it
+    /// in directly.
+    pub(crate) fn from_adapter(adapter: Arc<dyn NetAdapter>, default_timeout: Duration) -> Self {
         Self {
             adapter,
-            mailer,
             default_timeout,
         }
     }
 }
 
-impl Actor for NetCapability {
+#[aether_data::actor]
+impl NativeActor for NetCapability {
+    type Config = NetConfig;
+
     /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
     const NAMESPACE: &'static str = "aether.net";
-}
 
-impl Singleton for NetCapability {}
+    /// Build the net adapter from the resolved config. The adapter is
+    /// built immediately so configuration errors surface at chassis-
+    /// builder time, not at first fetch.
+    fn init(config: NetConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        let default_timeout = config.default_timeout;
+        Ok(Self {
+            adapter: build_net_adapter(config),
+            default_timeout,
+        })
+    }
 
-#[aether_data::actor]
-impl NetCapability {
     /// Run a fetch request and reply with the response.
     ///
     /// # Agent
     /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
     /// long-running fetches block other net mail until they finish.
     #[aether_data::handler]
-    fn on_fetch(&mut self, sender: ReplyTo, mail: Fetch) {
+    fn on_fetch(&self, ctx: &mut NativeCtx<'_>, mail: Fetch) {
         let timeout = mail
             .timeout_ms
             .map(|ms| Duration::from_millis(ms as u64))
@@ -431,7 +426,7 @@ impl NetCapability {
             },
             Err(error) => FetchResult::Err { url, error },
         };
-        self.mailer.send_reply(sender, &reply);
+        ctx.reply(&reply);
     }
 }
 
@@ -439,8 +434,12 @@ impl NetCapability {
 mod tests {
     use super::*;
     use crate::capability::{BootError, ChassisBuilder};
+    use crate::mail::ReplyTo;
+    use crate::mailer::Mailer;
+    use crate::native_transport::NativeTransport;
     use crate::registry::Registry;
-    use aether_data::Kind;
+    use aether_actor::Actor;
+    use aether_data::{Kind, MailboxId};
     use std::sync::Mutex;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
@@ -528,7 +527,7 @@ mod tests {
             ..NetConfig::default()
         };
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(NetCapability::new(config, Arc::clone(&mailer)))
+            .with_actor::<NetCapability>(config)
             .build()
             .expect("net capability boots");
         assert!(
@@ -549,7 +548,7 @@ mod tests {
         };
 
         let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with(NetCapability::new(config, Arc::clone(&mailer)))
+            .with_actor::<NetCapability>(config)
             .build()
             .expect_err("collision must surface as BootError");
         assert!(matches!(
@@ -562,13 +561,14 @@ mod tests {
     #[test]
     fn disabled_adapter_replies_disabled() {
         let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = NetCapability::from_adapter(
+        let cap = NetCapability::from_adapter(
             Arc::new(DisabledNetAdapter),
-            mailer,
             NetConfig::default().default_timeout,
         );
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+        let mut ctx = NativeCtx::new(&transport, session_sender());
         cap.on_fetch(
-            session_sender(),
+            &mut ctx,
             Fetch {
                 url: "https://api.example.com/".to_string(),
                 method: HttpMethod::Get,
@@ -670,13 +670,14 @@ mod tests {
             }],
             body: b"{}".to_vec(),
         }));
-        let mut cap = NetCapability::from_adapter(
+        let cap = NetCapability::from_adapter(
             stub as Arc<dyn NetAdapter>,
-            mailer,
             NetConfig::default().default_timeout,
         );
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+        let mut ctx = NativeCtx::new(&transport, session_sender());
         cap.on_fetch(
-            session_sender(),
+            &mut ctx,
             Fetch {
                 url: "https://api.example.com/v1".to_string(),
                 method: HttpMethod::Get,
@@ -704,13 +705,14 @@ mod tests {
     #[test]
     fn cap_fetch_err_echoes_url_and_error() {
         let (mailer, rx) = test_mailer_and_rx();
-        let mut cap = NetCapability::from_adapter(
+        let cap = NetCapability::from_adapter(
             StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>,
-            mailer,
             NetConfig::default().default_timeout,
         );
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+        let mut ctx = NativeCtx::new(&transport, session_sender());
         cap.on_fetch(
-            session_sender(),
+            &mut ctx,
             Fetch {
                 url: "https://slow.example.com/".to_string(),
                 method: HttpMethod::Get,
@@ -737,13 +739,14 @@ mod tests {
             body: vec![],
         }));
         let stub_clone = Arc::clone(&stub);
-        let mut cap = NetCapability::from_adapter(
+        let cap = NetCapability::from_adapter(
             stub as Arc<dyn NetAdapter>,
-            mailer,
             NetConfig::default().default_timeout,
         );
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+        let mut ctx = NativeCtx::new(&transport, session_sender());
         cap.on_fetch(
-            session_sender(),
+            &mut ctx,
             Fetch {
                 url: "https://api.example.com/".to_string(),
                 method: HttpMethod::Get,

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -1111,6 +1111,34 @@ impl BootedChassis {
         Ok(())
     }
 
+    /// Issue 552 stage 2: post-build entry for booting a `NativeActor`.
+    /// Mirror of [`Self::add`] for the new cap shape; same boot
+    /// trampoline as [`ChassisBuilder::with_actor`] but addressed
+    /// through the post-build path that `SubstrateBoot::add_actor`
+    /// surfaces. Used for chassis-conditional caps (Io / Net / Audio
+    /// when the chassis carries them) booted after the initial build.
+    pub fn add_actor<A>(
+        &mut self,
+        registry: &Arc<Registry>,
+        mailer: &Arc<Mailer>,
+        config: A::Config,
+    ) -> Result<(), BootError>
+    where
+        A: crate::NativeActor + crate::NativeDispatch,
+    {
+        let mut ctx = ChassisCtx::new(
+            registry,
+            mailer,
+            &mut self._fallback,
+            &mut self.frame_bound_pending,
+            &self.frame_bound_set,
+            &self.aborter,
+        );
+        let erased = boot_native_actor::<A>(&mut ctx, config)?;
+        self.running.push(erased);
+        Ok(())
+    }
+
     /// Wait for every frame-bound capability's inbox to drain (the
     /// pending counter on each [`FrameBoundClaim`] hits zero) within
     /// `budget`. Returns `Ok(())` on clean drain, or


### PR DESCRIPTION
## Summary

Three caps with `type Config` adopt the NativeActor shape. Each handler moves from `(&mut self, sender: ReplyTo, mail: K)` to `(&self, ctx: &mut NativeCtx<'_>, mail: K)`; replies route through `ctx.reply(&result)`; `self.mailer` retires across all three.

- **IoCapability** (`Config = NamespaceRoots`): `init` builds the adapter registry and surfaces failure as `BootError::Other`. `from_registry` survives as a `#[cfg(test)]` direct constructor.
- **NetCapability** (`Config = NetConfig`): `init` builds the net adapter. `from_adapter` survives as a `#[cfg(test)]` constructor for stub adapters.
- **AudioCapability** (`Config = AudioConfig`): cpal init failure stays non-fatal per ADR-0039. Worker-thread teardown handles move behind a `Mutex<AudioTeardown>` so `&self` handlers don't conflict with `Drop`'s `&mut self` ownership of the JoinHandle. `sender_mailbox_id(...)` reads from `ctx.reply_target()` in place of the old `sender: ReplyTo` param.

Bundle chassis mains (desktop / headless / test_bench) + `aether-substrate-test-bench` bin switch to `with_actor::<X>(config)`. Adds `SubstrateBoot::add_actor::<A>(config)` and `BootedChassis::add_actor` for the post-build path (test_bench's optional Io cap goes through this).

## Why staged

Render still owns `FRAME_BARRIER` so the legacy `with(cap)` path stays for it; stage 2d wires frame-bound claims through `with_actor`. Stage 2e then extracts the lot to an `aether-capabilities` crate.

## Test plan

- [x] `cargo test --workspace --all-targets` green locally
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] All six wasm components build for `wasm32-unknown-unknown`
- [x] Each cap's existing test suite passes — `capability_routes_*`, duplicate-claim, dispatch round-trips
- [x] Test fixtures rewritten to use `NativeCtx::new(&transport, sender)` for direct-handler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)