### PR TITLE
refactor(actor): wasm-header-only build for aether-capabilities (issue 552 stage 4)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -840,6 +840,11 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into();
     }
     let mut item = parse_macro_input!(item as syn::ItemStruct);
+    // Issue 552 stage 4: gate fields on `not(target_arch = "wasm32")`
+    // to match the macro-emitted `NativeActor` / `NativeDispatch`
+    // impls. Wasm builds see the cap struct with no fields (a pure
+    // marker), which is what typed `ctx.send_to::<R>(...)` needs;
+    // host builds see the full struct.
     match &mut item.fields {
         syn::Fields::Named(fields) => {
             for field in fields.named.iter_mut() {
@@ -847,7 +852,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
                 if !already_cfg {
                     field
                         .attrs
-                        .push(syn::parse_quote!(#[cfg(feature = "native")]));
+                        .push(syn::parse_quote!(#[cfg(not(target_arch = "wasm32"))]));
                 }
             }
         }
@@ -857,7 +862,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
                 if !already_cfg {
                     field
                         .attrs
-                        .push(syn::parse_quote!(#[cfg(feature = "native")]));
+                        .push(syn::parse_quote!(#[cfg(not(target_arch = "wasm32"))]));
                 }
             }
         }
@@ -1465,16 +1470,32 @@ fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
     let handler_methods = handlers.iter().map(|h| &h.method);
     let helper_methods = helpers.iter();
 
+    // Issue 552 stage 4: NativeActor + NativeDispatch + the inherent
+    // handler-method impl all reach for `::aether_substrate::*` paths
+    // and native-only types in their bodies. They're emitted under
+    // `#[cfg(not(target_arch = "wasm32"))]` so `aether-capabilities`
+    // can compile for `wasm32-unknown-unknown` without the substrate
+    // dep — wasm consumers see only the always-on Actor +
+    // HandlesKind markers, which is enough for typed
+    // `ctx.send_to::<R>` against cap markers.
+    //
+    // Gate is `target_arch` not `feature = "native"` because
+    // NativeActor/NativeDispatch are wasm-incompatible by definition;
+    // there's no realistic case where a host build wants to skip
+    // them. Pinning the cfg in the macro means consumer crates never
+    // have to define matching feature flags.
     Ok(quote! {
         #actor_impl
 
         #(#handles_kind_impls)*
 
+        #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics #trait_path for #self_ty #where_clause {
             #config_type
             #init_method
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics ::aether_substrate::NativeDispatch for #self_ty #where_clause {
             fn __aether_dispatch_envelope(
                 &self,
@@ -1487,6 +1508,7 @@ fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
             }
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics #self_ty #where_clause {
             #(#handler_methods)*
             #(#helper_methods)*

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -13,31 +13,61 @@ edition.workspace = true
 # resolved through `R::NAMESPACE` — without pulling in
 # `aether-substrate`'s wasmtime / wgpu / cpal stack. Splitting the
 # cap structs and their `Actor` markers off `aether-substrate`
-# keeps the wasm-component compile graph small. Today the crate
-# always pulls `aether-substrate` (the `NativeActor` impls live
-# alongside the structs); the wasm-side header-only build is a
-# follow-up that will cfg-gate the native impls.
+# keeps the wasm-component compile graph small.
+#
+# Stage 4 (this PR, issue 563) feature-gates everything substrate-
+# adjacent under `native` so wasm components can dep with
+# `default-features = false` and pick up only the target-agnostic
+# Actor / Singleton / HandlesKind markers. The `#[actor]` macro
+# emits `NativeActor` + `NativeDispatch` + handler-method impls
+# under `#[cfg(not(target_arch = "wasm32"))]`, so the feature gate
+# here matches: cfg cleanly elides on wasm regardless of how the
+# consumer flips features.
 
 [features]
-# Mirrors `aether-substrate`'s feature shape: chassis that draw
-# enable `render`, chassis with an audio device enable `audio`.
-# Headless and hub leave both off.
-render = ["aether-substrate/render", "dep:wgpu", "dep:png"]
-audio = ["aether-substrate/audio", "dep:cpal", "dep:crossbeam-queue"]
+# Default-on: chassis-target builds get the full cap set with their
+# substrate-side runtime impls. Wasm consumers do
+# `default-features = false`.
+default = ["native"]
+
+# Pulls every wasm-incompatible dep + the `aether-substrate` runtime
+# the `NativeActor` macro arm references. Always on for chassis.
+native = [
+    "dep:aether-substrate",
+    "dep:bytemuck",
+    "dep:dirs",
+    "dep:log",
+    "dep:postcard",
+    "dep:tracing",
+    "dep:ureq",
+    "dep:url",
+]
+
+# Per-cap toggles for the GPU / audio backends. Each implies
+# `native` because the cap modules these gate are themselves
+# substrate-bound.
+render = ["native", "aether-substrate/render", "dep:wgpu", "dep:png"]
+audio = ["native", "aether-substrate/audio", "dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
+# Always-on: target-agnostic SDK + data layer + kind types. These
+# compile fine for `wasm32-unknown-unknown` and carry the markers
+# wasm components rely on.
 aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
-aether-substrate = { path = "../aether-substrate" }
-bytemuck = "1.19"
-dirs = "5"
-log = "0.4"
-postcard = { version = "1.1", features = ["alloc"] }
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-ureq = { version = "3", features = ["rustls"] }
-url = "2"
+serde = { version = "1", default-features = false, features = ["derive"] }
+
+# Native-only: gated behind the `native` feature so wasm builds
+# don't drag in wasmtime / cpal / wgpu transitively.
+aether-substrate = { path = "../aether-substrate", optional = true }
+bytemuck = { version = "1.19", optional = true }
+dirs = { version = "5", optional = true }
+log = { version = "0.4", optional = true }
+postcard = { version = "1.1", optional = true, features = ["alloc"] }
+tracing = { version = "0.1", optional = true }
+ureq = { version = "3", optional = true, features = ["rustls"] }
+url = { version = "2", optional = true }
 wgpu = { version = "29.0.1", optional = true }
 png = { version = "0.17", optional = true }
 cpal = { version = "0.15", optional = true }

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -18,17 +18,27 @@
 //! constructor; the chassis builder's `with_actor::<HandleCapability>(())`
 //! is the boot site.
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
-use aether_actor::Singleton;
+use aether_actor::{Singleton, capability};
+// Kind imports split: handler-signature kinds stay always-on so the
+// macro-emitted `HandlesKind<K>` impls can reference them; reply-side
+// `*Result` + `HandleError` types are referenced only inside handler
+// bodies (gated by the macro emission), so their imports gate too.
+#[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::{
-    HandleError, HandlePin, HandlePinResult, HandlePublish, HandlePublishResult, HandleRelease,
-    HandleReleaseResult, HandleUnpin, HandleUnpinResult,
+    HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult, HandleUnpinResult,
 };
+use aether_kinds::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
 
+#[cfg(not(target_arch = "wasm32"))]
 use aether_actor::MailCtx;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::capability::BootError;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::handle_store::{HandleStore, PutError};
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`
@@ -37,6 +47,7 @@ use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 /// through the macro miss path (warn-log, no reply, sender's
 /// `wait_reply` times out) — substrate-level invariant violation, not
 /// user-recoverable input.
+#[capability]
 #[derive(Singleton)]
 pub struct HandleCapability {
     store: Arc<HandleStore>,
@@ -146,6 +157,7 @@ impl NativeActor for HandleCapability {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn put_error_to_handle_error(e: PutError) -> HandleError {
     match e {
         PutError::EvictionFailed { .. } => HandleError::EvictionFailed,

--- a/crates/aether-capabilities/src/io.rs
+++ b/crates/aether-capabilities/src/io.rs
@@ -27,12 +27,19 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use aether_actor::{MailCtx, Singleton};
-use aether_kinds::{
-    Delete, DeleteResult, IoError, List, ListResult, Read, ReadResult, Write, WriteResult,
-};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_actor::MailCtx;
+use aether_actor::{Singleton, capability};
+// Kind imports split: handler-signature kinds stay always-on so the
+// macro-emitted `HandlesKind<K>` impls can reference them; reply-side
+// `*Result` types are body-only and gate with the rest.
+use aether_kinds::{Delete, IoError, List, Read, Write};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
 
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::capability::BootError;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// Result shape used throughout the adapter layer. The variants of
@@ -228,6 +235,7 @@ pub struct NamespaceRoots {
     pub config: PathBuf,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl NamespaceRoots {
     /// Resolve each root from its env-var override, falling back to
     /// the `dirs`-crate platform default. v1 ships the env layer;
@@ -277,6 +285,7 @@ impl NamespaceRoots {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
     match std::env::var(var) {
         Ok(s) if !s.is_empty() => PathBuf::from(s),
@@ -305,6 +314,7 @@ pub fn build_registry(
 
 /// Env-driven wrapper around [`build_registry`]. Resolves
 /// [`NamespaceRoots::from_env`] then delegates.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
     build_registry(NamespaceRoots::from_env())
 }
@@ -314,6 +324,7 @@ pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, Namesp
 /// routes envelopes through the macro-emitted `NativeDispatch` impl;
 /// replies route via `ctx.reply(&result)` through the substrate's
 /// `Mailer::send_reply`.
+#[capability]
 #[derive(Singleton)]
 pub struct IoCapability {
     registry: Arc<AdapterRegistry>,

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -19,8 +19,11 @@
 use aether_actor::{Singleton, capability};
 use aether_kinds::LogEvent;
 
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::capability::BootError;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::log_sink;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// `aether.log` mailbox cap. Stateless beyond the process-wide

--- a/crates/aether-capabilities/src/net.rs
+++ b/crates/aether-capabilities/src/net.rs
@@ -19,13 +19,22 @@
 //!   `Fetch.timeout_ms`.
 
 use std::collections::HashSet;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 use std::time::Duration;
 
-use aether_actor::{MailCtx, Singleton};
-use aether_kinds::{Fetch, FetchResult, HttpHeader, HttpMethod, NetError};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_actor::MailCtx;
+use aether_actor::{Singleton, capability};
+// Handler-signature kind stays always-on; reply-side `FetchResult`
+// + ureq error types are body-only.
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::FetchResult;
+use aether_kinds::{Fetch, HttpHeader, HttpMethod, NetError};
 
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::capability::BootError;
+#[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
@@ -82,6 +91,7 @@ impl NetAdapter for DisabledNetAdapter {
 /// internally synchronised, so the same adapter drives the cap from
 /// one dispatch thread today and would parallelise cleanly behind a
 /// multi-thread dispatcher later.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct UreqNetAdapter {
     agent: ureq::Agent,
     allowlist: HashSet<String>,
@@ -89,6 +99,7 @@ pub struct UreqNetAdapter {
     max_body_bytes: usize,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl UreqNetAdapter {
     /// Construct an adapter with explicit knobs. Chassis code uses
     /// [`build_default_adapter`] for env-derived construction;
@@ -115,6 +126,7 @@ impl UreqNetAdapter {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl NetAdapter for UreqNetAdapter {
     fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError> {
         let parsed = url::Url::parse(&req.url).map_err(|e| NetError::InvalidUrl(format!("{e}")))?;
@@ -209,6 +221,7 @@ impl NetAdapter for UreqNetAdapter {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn http_method_to_http_crate(m: HttpMethod) -> ureq::http::Method {
     match m {
         HttpMethod::Get => ureq::http::Method::GET,
@@ -221,6 +234,7 @@ fn http_method_to_http_crate(m: HttpMethod) -> ureq::http::Method {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
     match e {
         ureq::Error::Timeout(_) => NetError::Timeout,
@@ -283,6 +297,7 @@ impl NetConfig {
 }
 
 /// Build a net adapter from explicit configuration.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
     if config.disabled {
         tracing::info!(
@@ -308,6 +323,7 @@ pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
 }
 
 /// Env-driven wrapper around [`build_net_adapter`].
+#[cfg(not(target_arch = "wasm32"))]
 pub fn build_default_adapter() -> Arc<dyn NetAdapter> {
     build_net_adapter(NetConfig::from_env())
 }
@@ -358,6 +374,7 @@ fn parse_default_timeout_env() -> Duration {
 /// envelopes through the macro-emitted `NativeDispatch` impl;
 /// replies route via `ctx.reply(&result)` through the substrate's
 /// `Mailer::send_reply`.
+#[capability]
 #[derive(Singleton)]
 pub struct NetCapability {
     adapter: Arc<dyn NetAdapter>,


### PR DESCRIPTION
## Summary

Closes issue 563. Stage 4 of issue 552 makes aether-capabilities compile cleanly for wasm32-unknown-unknown with --no-default-features. Wasm components can now dep on it as a header-only crate to reach cap markers for typed ctx.send_to::<R>(&kind) sends, without dragging wasmtime / wgpu / cpal through the cdylib build.

Three coupled changes (chosen path A from the eyeball — target_arch gates, structural rather than feature-flagged):

1. aether-actor-derive — the #[actor] impl NativeActor for X expander wraps the emitted NativeActor + NativeDispatch + handler-method inherent impl with cfg(not(target_arch = "wasm32")). Actor + HandlesKind impls stay always-on. Same gate applied to #[capability] struct-field cfg. Gate is target_arch (not feature) because the gated impls reference aether_substrate paths that are inherently wasm-incompatible.

2. aether-capabilities Cargo.toml — default = ["native"]. aether-substrate, bytemuck, dirs, log, postcard, tracing, ureq, url are optional = true and gated behind native. render and audio per-cap features imply native.

3. Per-cap files — use aether_substrate::* and other native-only imports gain cfg(not(target_arch = "wasm32")). Cap structs with native fields use #[capability] for auto-gating. Reply-side *Result kind imports also gate; handler-signature kinds (e.g. HandlePublish) stay always-on so the macro-emitted HandlesKind<K> impls compile on wasm.

## Verification

- [x] cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features
- [x] cargo check --workspace --all-targets (native, default features)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace

## Out of scope

audio + render caps stay native-only via the existing per-cap features (gated wholesale at the module declaration in lib.rs). Their markers ARE wasm-visible when a consumer opts in, but the substrate-bound impls require the native runtime regardless. A wasm component that wants to typed-send to render or audio enables those features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)