### PR TITLE
refactor(actor): unify actor-macro imports + compress cfg attrs (issue 552 stage 4 cleanup)

### DIFF
--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -155,3 +155,27 @@ pub use aether_data::{Kind, KindId as DataKindId, Schema, actor, capability, fal
 // rather than under a synthetic re-export shim.
 #[doc(inline)]
 pub use aether_data::Singleton;
+
+/// Wrap one-or-more items in `#[cfg(not(target_arch = "wasm32"))]`.
+/// Issue 552 stage 4's wasm-header-only build of `aether-capabilities`
+/// gates per-cap native imports + helpers + impls behind that cfg;
+/// this macro compresses what would otherwise be 5-7 sprinkled
+/// attributes per cap file into one block per native-only chunk.
+///
+/// ```ignore
+/// aether_actor::native_only! {
+///     use aether_substrate::capability::BootError;
+///     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+///
+///     fn put_error_to_handle_error(e: PutError) -> HandleError { ... }
+/// }
+/// ```
+///
+/// expands to each `$item` annotated with `#[cfg(not(target_arch = "wasm32"))]`.
+/// Pure mechanical wrap — no clever cfg, no feature flags.
+#[macro_export]
+macro_rules! native_only {
+    ($($item:item)*) => {
+        $( #[cfg(not(target_arch = "wasm32"))] $item )*
+    };
+}

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -55,7 +55,7 @@ use std::thread::{self, JoinHandle};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
-use aether_actor::{MailCtx, Singleton};
+use aether_actor::{MailCtx, Singleton, actor};
 use aether_data::{MailboxId, ReplyTarget, ReplyTo};
 use aether_kinds::{NoteOff, NoteOn, SetMasterGain, SetMasterGainResult};
 
@@ -701,7 +701,7 @@ impl Drop for AudioCapability {
     }
 }
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for AudioCapability {
     type Config = AudioConfig;
 
@@ -746,7 +746,7 @@ impl NativeActor for AudioCapability {
     /// Fire-and-forget. The synth keys voices on
     /// `(sender, instrument_id, pitch)`; sending two `NoteOn`s with
     /// the same triple is a no-op.
-    #[aether_data::handler]
+    #[handler]
     fn on_note_on(&self, ctx: &mut NativeCtx<'_>, mail: NoteOn) {
         let Some(s) = self.audio_sender.as_ref() else {
             return;
@@ -769,7 +769,7 @@ impl NativeActor for AudioCapability {
     ///
     /// # Agent
     /// Fire-and-forget.
-    #[aether_data::handler]
+    #[handler]
     fn on_note_off(&self, ctx: &mut NativeCtx<'_>, mail: NoteOff) {
         let Some(s) = self.audio_sender.as_ref() else {
             return;
@@ -792,7 +792,7 @@ impl NativeActor for AudioCapability {
     /// # Agent
     /// Reply: `SetMasterGainResult`. `Ok { applied_gain }` clamps to
     /// `0.0..=1.0`; `Err` on chassis without audio.
-    #[aether_data::handler]
+    #[handler]
     fn on_set_master_gain(&self, ctx: &mut NativeCtx<'_>, mail: SetMasterGain) {
         let applied = mail.gain.clamp(0.0, 1.0);
         match self.audio_sender.as_ref() {

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -18,28 +18,26 @@
 //! constructor; the chassis builder's `with_actor::<HandleCapability>(())`
 //! is the boot site.
 
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::Arc;
-
-use aether_actor::{Singleton, capability};
+use aether_actor::{Singleton, actor, capability};
 // Kind imports split: handler-signature kinds stay always-on so the
 // macro-emitted `HandlesKind<K>` impls can reference them; reply-side
 // `*Result` + `HandleError` types are referenced only inside handler
-// bodies (gated by the macro emission), so their imports gate too.
-#[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::{
-    HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult, HandleUnpinResult,
-};
+// bodies (gated by the macro emission), so they live in the
+// `native_only!` block below.
 use aether_kinds::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_actor::MailCtx;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::capability::BootError;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::handle_store::{HandleStore, PutError};
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+aether_actor::native_only! {
+    use std::sync::Arc;
+
+    use aether_actor::MailCtx;
+    use aether_kinds::{
+        HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult,
+        HandleUnpinResult,
+    };
+    use aether_substrate::capability::BootError;
+    use aether_substrate::handle_store::{HandleStore, PutError};
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+}
 
 /// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`
 /// and routes ADR-0045 publish/release/pin/unpin requests via
@@ -53,7 +51,7 @@ pub struct HandleCapability {
     store: Arc<HandleStore>,
 }
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for HandleCapability {
     type Config = ();
     /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
@@ -83,7 +81,7 @@ impl NativeActor for HandleCapability {
     ///
     /// # Agent
     /// Reply: `HandlePublishResult`.
-    #[aether_data::handler]
+    #[handler]
     fn on_publish(&self, ctx: &mut NativeCtx<'_>, mail: HandlePublish) {
         let id = self.store.next_ephemeral();
         match self.store.put(id, mail.kind_id, mail.bytes) {
@@ -112,7 +110,7 @@ impl NativeActor for HandleCapability {
     ///
     /// # Agent
     /// Reply: `HandleReleaseResult`.
-    #[aether_data::handler]
+    #[handler]
     fn on_release(&self, ctx: &mut NativeCtx<'_>, mail: HandleRelease) {
         if self.store.dec_ref(mail.id) {
             ctx.reply(&HandleReleaseResult::Ok { id: mail.id });
@@ -128,7 +126,7 @@ impl NativeActor for HandleCapability {
     ///
     /// # Agent
     /// Reply: `HandlePinResult`.
-    #[aether_data::handler]
+    #[handler]
     fn on_pin(&self, ctx: &mut NativeCtx<'_>, mail: HandlePin) {
         if self.store.pin(mail.id) {
             ctx.reply(&HandlePinResult::Ok { id: mail.id });
@@ -144,7 +142,7 @@ impl NativeActor for HandleCapability {
     ///
     /// # Agent
     /// Reply: `HandleUnpinResult`.
-    #[aether_data::handler]
+    #[handler]
     fn on_unpin(&self, ctx: &mut NativeCtx<'_>, mail: HandleUnpin) {
         if self.store.unpin(mail.id) {
             ctx.reply(&HandleUnpinResult::Ok { id: mail.id });
@@ -157,16 +155,17 @@ impl NativeActor for HandleCapability {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-fn put_error_to_handle_error(e: PutError) -> HandleError {
-    match e {
-        PutError::EvictionFailed { .. } => HandleError::EvictionFailed,
-        PutError::KindMismatch {
-            existing_kind,
-            requested_kind,
-        } => HandleError::AdapterError(format!(
-            "kind id mismatch: existing={existing_kind} requested={requested_kind}"
-        )),
+aether_actor::native_only! {
+    fn put_error_to_handle_error(e: PutError) -> HandleError {
+        match e {
+            PutError::EvictionFailed { .. } => HandleError::EvictionFailed,
+            PutError::KindMismatch {
+                existing_kind,
+                requested_kind,
+            } => HandleError::AdapterError(format!(
+                "kind id mismatch: existing={existing_kind} requested={requested_kind}"
+            )),
+        }
     }
 }
 

--- a/crates/aether-capabilities/src/io.rs
+++ b/crates/aether-capabilities/src/io.rs
@@ -27,20 +27,18 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_actor::MailCtx;
-use aether_actor::{Singleton, capability};
+use aether_actor::{Singleton, actor, capability};
 // Kind imports split: handler-signature kinds stay always-on so the
 // macro-emitted `HandlesKind<K>` impls can reference them; reply-side
-// `*Result` types are body-only and gate with the rest.
+// `*Result` types are body-only and live in the `native_only!` block.
 use aether_kinds::{Delete, IoError, List, Read, Write};
-#[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::capability::BootError;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+aether_actor::native_only! {
+    use aether_actor::MailCtx;
+    use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+}
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
@@ -330,7 +328,7 @@ pub struct IoCapability {
     registry: Arc<AdapterRegistry>,
 }
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for IoCapability {
     /// Resolved namespace roots threaded through to `init`. Chassis
     /// mains build this via [`NamespaceRoots::from_env`] (or hand-roll
@@ -360,7 +358,7 @@ impl NativeActor for IoCapability {
     ///
     /// # Agent
     /// Reply: `ReadResult`. Echoes namespace + path on both arms.
-    #[aether_data::handler]
+    #[handler]
     fn on_read(&self, ctx: &mut NativeCtx<'_>, mail: Read) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
             ctx.reply(&ReadResult::Err {
@@ -391,7 +389,7 @@ impl NativeActor for IoCapability {
     ///
     /// # Agent
     /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
-    #[aether_data::handler]
+    #[handler]
     fn on_write(&self, ctx: &mut NativeCtx<'_>, mail: Write) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
             ctx.reply(&WriteResult::Err {
@@ -419,7 +417,7 @@ impl NativeActor for IoCapability {
     ///
     /// # Agent
     /// Reply: `DeleteResult`. Echoes namespace + path.
-    #[aether_data::handler]
+    #[handler]
     fn on_delete(&self, ctx: &mut NativeCtx<'_>, mail: Delete) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
             ctx.reply(&DeleteResult::Err {
@@ -447,7 +445,7 @@ impl NativeActor for IoCapability {
     ///
     /// # Agent
     /// Reply: `ListResult`. Echoes namespace + prefix.
-    #[aether_data::handler]
+    #[handler]
     fn on_list(&self, ctx: &mut NativeCtx<'_>, mail: List) {
         let Some(adapter) = self.registry.get(&mail.namespace) else {
             ctx.reply(&ListResult::Err {

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -16,15 +16,14 @@
 //! and let `tracing-subscriber`'s `tracing-log` integration lift each
 //! record back into the tracing pipeline.
 
-use aether_actor::{Singleton, capability};
+use aether_actor::{Singleton, actor, capability};
 use aether_kinds::LogEvent;
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::capability::BootError;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::log_sink;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+aether_actor::native_only! {
+    use aether_substrate::capability::BootError;
+    use aether_substrate::log_sink;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+}
 
 /// `aether.log` mailbox cap. Stateless beyond the process-wide
 /// `tracing` subscriber set up by [`aether_substrate::log_capture::init`] —
@@ -34,7 +33,7 @@ use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 #[derive(Singleton)]
 pub struct LogCapability;
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for LogCapability {
     type Config = ();
     const NAMESPACE: &'static str = "aether.log";
@@ -49,7 +48,7 @@ impl NativeActor for LogCapability {
     /// # Agent
     /// Components mail `aether.log` `LogEvent { level, target, message }`
     /// to this mailbox. Fire-and-forget; no reply.
-    #[aether_data::handler]
+    #[handler]
     fn on_log_event(&self, _ctx: &mut NativeCtx<'_>, event: LogEvent) {
         log_sink::handle_log_mail_decoded(event);
     }

--- a/crates/aether-capabilities/src/net.rs
+++ b/crates/aether-capabilities/src/net.rs
@@ -19,23 +19,21 @@
 //!   `Fetch.timeout_ms`.
 
 use std::collections::HashSet;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_actor::MailCtx;
-use aether_actor::{Singleton, capability};
+use aether_actor::{Singleton, actor, capability};
 // Handler-signature kind stays always-on; reply-side `FetchResult`
-// + ureq error types are body-only.
-#[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::FetchResult;
+// + ureq error types live in the `native_only!` block.
 use aether_kinds::{Fetch, HttpHeader, HttpMethod, NetError};
 
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::capability::BootError;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+aether_actor::native_only! {
+    use std::sync::Arc;
+
+    use aether_actor::MailCtx;
+    use aether_kinds::FetchResult;
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+}
 
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -395,7 +393,7 @@ impl NetCapability {
     }
 }
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for NetCapability {
     type Config = NetConfig;
 
@@ -418,7 +416,7 @@ impl NativeActor for NetCapability {
     /// # Agent
     /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
     /// long-running fetches block other net mail until they finish.
-    #[aether_data::handler]
+    #[handler]
     fn on_fetch(&self, ctx: &mut NativeCtx<'_>, mail: Fetch) {
         let timeout = mail
             .timeout_ms

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
-use aether_actor::Singleton;
+use aether_actor::{Singleton, actor};
 use aether_data::Kind;
 use aether_kinds::{Camera, DRAW_TRIANGLE_BYTES, DrawTriangle};
 
@@ -90,7 +90,7 @@ impl RenderCapability {
     }
 }
 
-#[aether_data::actor]
+#[actor]
 impl NativeActor for RenderCapability {
     type Config = RenderConfig;
 
@@ -142,7 +142,7 @@ impl NativeActor for RenderCapability {
     /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
     /// per tick. Fire-and-forget; the cap accumulates into
     /// `frame_vertices` until the chassis driver records the frame.
-    #[aether_data::handler]
+    #[handler]
     fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
         if let Some(obs) = &self.config.observed_kinds {
             obs.lock()
@@ -181,7 +181,7 @@ impl NativeActor for RenderCapability {
     /// # Agent
     /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
     /// to this mailbox. Fire-and-forget; latest value wins.
-    #[aether_data::handler]
+    #[handler]
     fn on_camera(&self, _ctx: &mut NativeCtx<'_>, mail: Camera) {
         if let Some(obs) = &self.config.observed_kinds {
             obs.lock().unwrap().push(<Camera as Kind>::NAME.into());


### PR DESCRIPTION
## Summary

Two cosmetic cleanups on stage 4:

- Cap files reach for `#[actor]` / `#[handler]` / `#[capability]` through `aether_actor::*` (the SDK home), matching how `Singleton` is imported. Pre-cleanup the same files mixed `aether_actor::{Singleton, capability}` with bare-path `#[aether_data::actor]` / `#[aether_data::handler]` — both spellings resolve through the same re-exports but the asymmetry was noise.
- New `aether_actor::native_only! { … }` declarative macro wraps one-or-more items in `#[cfg(not(target_arch = "wasm32"))]`. Native-only import + helper blocks compress from 5-7 sprinkled attributes per cap file to one cfg attribute per chunk. Single cfg-gated items keep their bare attribute.

A heavier shape (split each cap into always-on cap struct + a single `#[cfg(not(target_arch = "wasm32"))] mod native_impl`) is captured in issue 565 for separate discussion — the macro change there is more invasive and decision-bearing.

## Test plan

- [x] cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features
- [x] cargo check --workspace --all-targets
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [x] cargo test --workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)