### PR TITLE
refactor(actor): probe wasm typed-send demo (issue 563)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ name = "aether-test-fixture-probe"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities",
  "aether-data",
  "aether-kinds",
  "bytemuck",

--- a/crates/aether-test-fixture-probe/Cargo.toml
+++ b/crates/aether-test-fixture-probe/Cargo.toml
@@ -10,5 +10,9 @@ crate-type = ["cdylib", "rlib"]
 aether-actor = { path = "../aether-actor" }
 aether-kinds = { path = "../aether-kinds" }
 aether-data = { path = "../aether-data", features = ["derive"] }
+# `default-features = false` exercises the issue 552 stage 4 wasm-header-only
+# build of aether-capabilities — the cap markers (Actor / Singleton /
+# HandlesKind) compile for wasm without dragging the native runtime in.
+aether-capabilities = { path = "../aether-capabilities", default-features = false }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -9,6 +9,12 @@
 //!   with a monotonic counter. Lets scenarios count tick deliveries
 //!   via `TestBench::count_observed` (broadcasts arrive on the
 //!   loopback and get recorded by kind name).
+//! - On the first tick, fires a typed `ctx.send_to::<LogCapability>`
+//!   call carrying a `LogEvent`. This is the issue 563 stage-5 demo:
+//!   the probe deps on `aether-capabilities` with
+//!   `default-features = false`, so the typed-sender path resolves
+//!   `LogCapability: Singleton + HandlesKind<LogEvent>` against the
+//!   wasm-header-only build with no native runtime in scope.
 //! - Receives `aether.test_fixture.set_render { r, g, b, visible }`
 //!   to update render state. When `visible` is non-zero, on_tick
 //!   emits a colored `DrawTriangle` to the chassis render sink, so
@@ -18,7 +24,8 @@
 use aether_actor::{
     BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor, wasm::resolve_mailbox,
 };
-use aether_kinds::{DrawTriangle, Tick, Vertex};
+use aether_capabilities::LogCapability;
+use aether_kinds::{DrawTriangle, LogEvent, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
 
 /// Broadcast payload emitted on each tick. Postcard-shaped — schema
@@ -87,6 +94,13 @@ impl WasmActor for Probe {
                 count: self.tick_count,
             },
         );
+        if self.tick_count == 1 {
+            ctx.send_to::<LogCapability, _>(&LogEvent {
+                level: 2,
+                target: "aether_test_fixture_probe".into(),
+                message: "typed_send_alive".into(),
+            });
+        }
         if self.render.visible != 0 {
             let r = self.render.r as f32 / 255.0;
             let g = self.render.g as f32 / 255.0;


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #563 is the intentional auto-close trigger -->
## Summary

End-to-end demo half of issue 563. The cargo-check side (PR 564) verified `aether-capabilities` builds for `wasm32-unknown-unknown --no-default-features`. This PR adds a real wasm consumer that resolves the typed cap markers and fires a typed send against `LogCapability`.

- `aether-test-fixture-probe/Cargo.toml` — adds `aether-capabilities = { ..., default-features = false }`. Wasm build does not drag in wasmtime / wgpu / cpal.
- `aether-test-fixture-probe/src/lib.rs` — on the first tick, `ctx.send_to::<LogCapability, _>(&LogEvent { ... })`. Compiles because `#[actor]` emits `Actor`, `Singleton`, and `HandlesKind<LogEvent>` always-on (only the `NativeActor` + `NativeDispatch` impls are cfg-gated to native).
- Every existing probe scenario (`tests/test_bench_scenario.rs`) already advances at least one tick, so the runtime dispatch into `LogCapability` is implicitly exercised by `cargo test`.

## Out of scope

- Explicit assertion that the dispatched `LogEvent` reaches the chassis `tracing` subscriber. Would require exposing log-capture probing through `TestBench` — meaningfully more API surface than the issue's "the cdylib builds" acceptance criterion. Easy to add in a follow-up if wanted.
- `ctx.send_to::<R, _>` ergonomics. Rust's turbofish-fill rule forces the `, _` even though `K` is inferable from the value arg. Tracked in issue 567 (Tier 1: add `Ctx::actor::<R: Singleton>() -> ActorMailbox<R, T>` so call sites collapse to `ctx.actor::<R>().send(&p)`).

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown -p aether-test-fixture-probe` (resolves header-only `aether-capabilities`)
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` (68 test result blocks, 0 failures)

Closes #563