### PR TITLE
refactor(actor): #[bridge] mod attribute (issue 565)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -39,7 +39,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
     Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
-    GenericArgument, ImplItem, ItemImpl, Lit, Meta, PathArguments, Signature, Type,
+    GenericArgument, ImplItem, Item, ItemImpl, ItemMod, Lit, Meta, PathArguments, Signature, Type,
     parse_macro_input, spanned::Spanned,
 };
 
@@ -741,19 +741,286 @@ fn to_screaming_snake_case(s: &str) -> String {
 /// a follow-up).
 #[proc_macro_attribute]
 pub fn actor(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let opts = match parse_actor_opts(attr.into()) {
+        Ok(opts) => opts,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let item = parse_macro_input!(item as ItemImpl);
+    match expand_handlers(item, opts) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Parsed `#[actor(...)]` attribute arguments. Only `skip_markers` is
+/// recognised today (issue 565: tells the expander not to emit
+/// `Actor` + `HandlesKind` impls because a wrapping `#[bridge]`
+/// already emitted them as siblings of a cfg-gated module).
+#[derive(Default, Clone, Copy)]
+struct ActorOpts {
+    skip_markers: bool,
+}
+
+fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
+    let mut opts = ActorOpts::default();
+    if attr.is_empty() {
+        return Ok(opts);
+    }
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("skip_markers") {
+            opts.skip_markers = true;
+            Ok(())
+        } else {
+            Err(meta.error("unrecognised #[actor] argument; only `skip_markers` is supported"))
+        }
+    });
+    syn::parse::Parser::parse2(parser, attr)?;
+    Ok(opts)
+}
+
+/// `#[bridge]` — attribute on a `mod foo { ... }` block holding the
+/// native-side implementation of an actor (issue 565).
+///
+/// The mod hosts substrate-side imports, helpers, and a single
+/// `#[actor] impl NativeActor for X { ... }` block. Wasm consumers
+/// (loading the cap crate via `aether-capabilities` with
+/// `default-features = false`) must still see the always-on `Actor`
+/// and `HandlesKind<K>` markers so typed sends like
+/// `ctx.send_to::<X, _>(&kind)` compile-check, but the substrate-side
+/// trait impls and helpers can't be in scope on wasm32.
+///
+/// `#[bridge]`'s expansion splits across that boundary:
+///
+/// 1. The marker impls (`Actor` + `HandlesKind<K>` per handler kind)
+///    are emitted at sibling level to the mod, **outside** any cfg
+///    gate — wasm consumers see them.
+/// 2. The original mod is emitted with `#[cfg(not(target_arch =
+///    "wasm32"))]` injected, with the inner `#[actor]` rewritten to
+///    `#[actor(skip_markers)]` so it doesn't duplicate the markers.
+///
+/// Naming follows the `cxx::bridge` precedent — an attribute on a
+/// mod that splits emission across a boundary.
+#[proc_macro_attribute]
+pub fn bridge(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
         return syn::Error::new(
             proc_macro2::Span::call_site(),
-            "#[actor] takes no arguments",
+            "#[bridge] takes no arguments",
         )
         .to_compile_error()
         .into();
     }
-    let item = parse_macro_input!(item as ItemImpl);
-    match expand_handlers(item) {
+    let item = parse_macro_input!(item as ItemMod);
+    match expand_bridge(item) {
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
+    let Some((brace, items)) = item_mod.content.take() else {
+        return Err(syn::Error::new_spanned(
+            &item_mod,
+            "#[bridge] must be applied to an inline `mod foo { ... }` block, not a file-backed mod",
+        ));
+    };
+    let mod_ident = item_mod.ident.clone();
+
+    // Find the `#[actor] impl NativeActor for X { ... }` block.
+    // Collect its index (so we can rewrite the attribute in place) and
+    // walk its items to extract X, NAMESPACE, and handler kinds.
+    let mut actor_idx: Option<usize> = None;
+    for (idx, it) in items.iter().enumerate() {
+        if let Item::Impl(impl_block) = it
+            && impl_block.attrs.iter().any(attr_is_actor)
+        {
+            actor_idx = Some(idx);
+            break;
+        }
+    }
+    let Some(actor_idx) = actor_idx else {
+        return Err(syn::Error::new_spanned(
+            &item_mod,
+            "#[bridge] expects exactly one `#[actor] impl NativeActor for X { ... }` block \
+             inside the wrapped mod",
+        ));
+    };
+
+    // Collect everything we need from the inner actor impl into owned
+    // values so the borrow on `items` ends before we mutate it below.
+    let (self_ty, type_ident, generics, namespace_expr, frame_barrier_expr, handler_kinds) = {
+        let Item::Impl(actor_impl) = &items[actor_idx] else {
+            unreachable!("actor_idx points to an Item::Impl by construction");
+        };
+
+        // Reject `impl Trait for X` shapes that aren't `NativeActor`.
+        let trait_path = actor_impl.trait_.as_ref().ok_or_else(|| {
+            syn::Error::new_spanned(
+                actor_impl,
+                "#[bridge]'s inner #[actor] block must be `impl NativeActor for X`, \
+                 not an inherent `impl X { ... }`",
+            )
+        })?;
+        let last_seg = trait_path
+            .1
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        if last_seg != "NativeActor" {
+            return Err(syn::Error::new_spanned(
+                &trait_path.1,
+                format!(
+                    "#[bridge]'s inner #[actor] block must be `impl NativeActor for X` — got `{last_seg}`",
+                ),
+            ));
+        }
+
+        // Pull the bare struct ident out of `self_ty`. Required for the
+        // wasm-stub + re-export emission, where we need to write
+        // `pub struct X;` and `pub use <mod>::X;` referencing X by name.
+        let type_ident = match &*actor_impl.self_ty {
+            Type::Path(tp) if tp.qself.is_none() && tp.path.segments.len() == 1 => {
+                tp.path.segments[0].ident.clone()
+            }
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    &actor_impl.self_ty,
+                    "#[bridge]'s actor type must be a bare ident (`HandleCapability`), not a \
+                     path or generic — the macro emits a wasm-stub `pub struct X;` and a \
+                     `pub use <mod>::X;` re-export referencing it by name",
+                ));
+            }
+        };
+
+        // Walk the impl items to collect handler kind types and the
+        // `NAMESPACE` const expression. The const lives on the supertrait
+        // `Actor`, but the user wrote it inside `impl NativeActor for X`
+        // — same source-of-truth contract `expand_native_actor_trait`
+        // uses.
+        let mut handler_kinds: Vec<Type> = Vec::new();
+        let mut namespace_expr: Option<Expr> = None;
+        let mut frame_barrier_expr: Option<Expr> = None;
+        for impl_item in &actor_impl.items {
+            match impl_item {
+                ImplItem::Fn(f) if f.attrs.iter().any(attr_is_handler) => {
+                    let (kind_ty, _is_slice) = extract_native_actor_handler_kind(&f.sig)?;
+                    handler_kinds.push(kind_ty);
+                }
+                ImplItem::Const(c) => {
+                    if c.ident == "NAMESPACE" {
+                        namespace_expr = Some(c.expr.clone());
+                    } else if c.ident == "FRAME_BARRIER" {
+                        frame_barrier_expr = Some(c.expr.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let namespace_expr = namespace_expr.ok_or_else(|| {
+            syn::Error::new_spanned(
+                actor_impl,
+                "#[bridge]'s inner #[actor] block must declare \
+                 `const NAMESPACE: &'static str = ...` so the marker `impl Actor` can carry it",
+            )
+        })?;
+        if handler_kinds.is_empty() {
+            return Err(syn::Error::new_spanned(
+                actor_impl,
+                "#[bridge]'s inner #[actor] block must declare at least one #[handler] method",
+            ));
+        }
+        (
+            (*actor_impl.self_ty).clone(),
+            type_ident,
+            actor_impl.generics.clone(),
+            namespace_expr,
+            frame_barrier_expr,
+            handler_kinds,
+        )
+    };
+
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+
+    // Always-on marker surface, emitted as siblings of the mod.
+    //
+    // - On wasm, the real struct (inside `mod native`) is cfg-stripped;
+    //   a unit-struct stub takes its place at file root so the marker
+    //   impls below have a type to reference. Wasm consumers never
+    //   construct caps — they only address them by type via
+    //   `ctx.send_to::<X, _>(&kind)` — so the stub being uninhabited
+    //   is fine.
+    // - On native, the `pub use` re-exports the real struct from `mod
+    //   native` to file root, so callers writing `crate::log::LogCapability`
+    //   (chassis builders, tests in sibling mods) keep working.
+    // - Singleton, Actor, and HandlesKind impls are always-on so wasm
+    //   consumers compile typed sends without the substrate runtime.
+    let frame_barrier_const = frame_barrier_expr.map(|expr| {
+        quote! { const FRAME_BARRIER: bool = #expr; }
+    });
+    let stub_and_reexport = quote! {
+        #[cfg(target_arch = "wasm32")]
+        pub struct #type_ident;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        pub use #mod_ident::#type_ident;
+    };
+    let singleton_marker = quote! {
+        impl #impl_generics ::aether_actor::Singleton for #self_ty #where_clause {}
+    };
+    let actor_marker = quote! {
+        impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
+            const NAMESPACE: &'static str = #namespace_expr;
+            #frame_barrier_const
+        }
+    };
+    let handles_kind_markers = handler_kinds.iter().map(|kind_ty| {
+        quote! {
+            impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+                for #self_ty #where_clause {}
+        }
+    });
+
+    // Rewrite the inner `#[actor]` to `#[actor(skip_markers)]` so the
+    // expander inside the cfg-gated mod doesn't duplicate the markers
+    // we just emitted. Preserve the user's original path token so a
+    // `use aether_actor::actor;` line remains "used" — replacing with
+    // an absolute path would silently produce unused-import warnings
+    // in caller code.
+    let mut items = items;
+    if let Item::Impl(actor_impl_mut) = &mut items[actor_idx] {
+        for attr in actor_impl_mut.attrs.iter_mut() {
+            if attr_is_actor(attr) {
+                let path = attr.path().clone();
+                *attr = syn::parse_quote!(#[#path(skip_markers)]);
+            }
+        }
+    }
+
+    // Reassemble the mod with the rewritten contents and prepend the
+    // cfg gate.
+    item_mod.content = Some((brace, items));
+    let mod_attrs = std::mem::take(&mut item_mod.attrs);
+    Ok(quote! {
+        #stub_and_reexport
+        #singleton_marker
+        #actor_marker
+        #(#handles_kind_markers)*
+
+        #(#mod_attrs)*
+        #[cfg(not(target_arch = "wasm32"))]
+        #item_mod
+    })
+}
+
+/// Match `#[actor]` or `#[crate::actor]` or `#[aether_actor::actor]` —
+/// any path whose last segment is `actor`.
+fn attr_is_actor(attr: &Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == "actor")
 }
 
 #[proc_macro_attribute]
@@ -884,7 +1151,7 @@ struct FallbackFn {
     agent_doc: Option<String>,
 }
 
-fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
+fn expand_handlers(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2> {
     if let Some((_, trait_path, _)) = item.trait_.as_ref() {
         // Pattern-match the trait path's last identifier so the macro
         // works regardless of the user's import style — bare
@@ -896,10 +1163,19 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         match last.as_str() {
-            "NativeActor" => expand_native_actor_trait(item),
+            "NativeActor" => expand_native_actor_trait(item, opts),
             // `WasmActor` is the post-552 trait name; `Component` is
             // the back-compat alias retained until stage 4.
-            "WasmActor" | "Component" => expand_wasm_actor(item),
+            "WasmActor" | "Component" => {
+                if opts.skip_markers {
+                    return Err(syn::Error::new_spanned(
+                        trait_path,
+                        "#[actor(skip_markers)] is only meaningful on \
+                         `impl NativeActor for X` blocks wrapped by `#[bridge]`",
+                    ));
+                }
+                expand_wasm_actor(item)
+            }
             other => Err(syn::Error::new_spanned(
                 trait_path,
                 format!(
@@ -909,6 +1185,13 @@ fn expand_handlers(item: ItemImpl) -> syn::Result<TokenStream2> {
             )),
         }
     } else {
+        if opts.skip_markers {
+            return Err(syn::Error::new_spanned(
+                &item.self_ty,
+                "#[actor(skip_markers)] is only meaningful on \
+                 `impl NativeActor for X` blocks wrapped by `#[bridge]`",
+            ));
+        }
         // Inherent `impl X { … }` is the legacy native-cap shape used
         // by post-545 capabilities (LogCapability et al.). Stays
         // available through stage 1; stage 2 migrates caps onto the
@@ -1322,7 +1605,7 @@ fn expand_native_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
 ///
 /// `#[fallback]` is rejected — native actors are typed receivers;
 /// unknown kinds are programming errors, not fallback paths.
-fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
+fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -1414,8 +1697,15 @@ fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
     // for the symmetric authoring shape. Route the consts onto a
     // sibling `impl Actor for X` block so satisfying the supertrait
     // bound works without making the user split the impl.
+    //
+    // `skip_markers` (issue 565): when `#[bridge]` wraps a cfg-gated
+    // `mod native` containing the actor block, it emits the always-on
+    // `Actor` + `HandlesKind` impls itself as siblings of the mod and
+    // rewrites this `#[actor]` to `#[actor(skip_markers)]` so this
+    // expansion does not duplicate them. The native-only impls below
+    // still emit unchanged.
     let const_tokens = consts.iter();
-    let actor_impl = if consts.is_empty() {
+    let actor_impl = if opts.skip_markers || consts.is_empty() {
         quote! {}
     } else {
         quote! {
@@ -1425,13 +1715,20 @@ fn expand_native_actor_trait(item: ItemImpl) -> syn::Result<TokenStream2> {
         }
     };
 
-    let handles_kind_impls = handlers.iter().map(|h| {
-        let kind_ty = &h.kind_ty;
-        quote! {
-            impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
-                for #self_ty #where_clause {}
-        }
-    });
+    let handles_kind_impls: Vec<TokenStream2> = if opts.skip_markers {
+        Vec::new()
+    } else {
+        handlers
+            .iter()
+            .map(|h| {
+                let kind_ty = &h.kind_ty;
+                quote! {
+                    impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+                        for #self_ty #where_clause {}
+                }
+            })
+            .collect()
+    };
 
     let dispatch_arms = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -139,7 +139,9 @@ pub mod __macro_internals {
 /// and `#[derive(Singleton)]` (emits the `Singleton` marker) sit
 /// alongside the existing actor derives so component / capability
 /// authors only need `aether-actor` in their dep list.
-pub use aether_data::{Kind, KindId as DataKindId, Schema, actor, capability, fallback, handler};
+pub use aether_data::{
+    Kind, KindId as DataKindId, Schema, actor, bridge, capability, fallback, handler,
+};
 // `Singleton` lives in two namespaces:
 //   - the type namespace for the marker trait (`Actor` super-trait),
 //     re-exported above as part of `actor::*`.

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -47,20 +47,10 @@
 //! `NoteOn` / `NoteOff` are dropped silently and `SetMasterGain`
 //! replies `Err` so agents fail fast instead of hanging.
 
-use std::f32::consts::TAU;
-use std::sync::Arc;
-use std::sync::mpsc;
-use std::thread::{self, JoinHandle};
-
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use crossbeam_queue::ArrayQueue;
-
-use aether_actor::{MailCtx, Singleton, actor};
-use aether_data::{MailboxId, ReplyTarget, ReplyTo};
-use aether_kinds::{NoteOff, NoteOn, SetMasterGain, SetMasterGainResult};
-
-use aether_substrate::capability::BootError;
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
+use aether_kinds::{NoteOff, NoteOn, SetMasterGain};
 
 /// Capacity of the event queue between the cap's handlers and the
 /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -106,826 +96,816 @@ impl AudioConfig {
     }
 }
 
-/// Event a handler pushes into the audio callback's queue. The
-/// `sender_mailbox` is baked in here (not re-derived on the callback
-/// side) so the callback stays branch-minimal.
-#[derive(Copy, Clone, Debug)]
-enum AudioEvent {
-    NoteOn {
-        sender_mailbox: MailboxId,
-        pitch: u8,
-        velocity: u8,
-        instrument_id: u8,
-    },
-    NoteOff {
-        sender_mailbox: MailboxId,
-        pitch: u8,
-        instrument_id: u8,
-    },
-    SetMasterGain {
-        gain: f32,
-    },
-}
+#[aether_actor::bridge]
+mod native {
+    use std::f32::consts::TAU;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::thread::{self, JoinHandle};
 
-/// Producer side of the audio event queue. The cap holds one (after
-/// building the pipeline) and pushes events on every inbound `NoteOn`
-/// / `NoteOff` / `SetMasterGain`.
-#[derive(Clone)]
-struct AudioEventSender {
-    queue: Arc<ArrayQueue<AudioEvent>>,
-}
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use crossbeam_queue::ArrayQueue;
 
-impl AudioEventSender {
-    fn push(&self, event: AudioEvent) -> Result<(), AudioEvent> {
-        self.queue.push(event)
+    use aether_actor::{MailCtx, actor};
+    use aether_data::{MailboxId, ReplyTarget, ReplyTo};
+    use aether_kinds::SetMasterGainResult;
+
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+
+    use super::{AudioConfig, EVENT_QUEUE_CAPACITY, MAX_VOICES, NoteOff, NoteOn, SetMasterGain};
+
+    /// Event a handler pushes into the audio callback's queue. The
+    /// `sender_mailbox` is baked in here (not re-derived on the callback
+    /// side) so the callback stays branch-minimal.
+    #[derive(Copy, Clone, Debug)]
+    enum AudioEvent {
+        NoteOn {
+            sender_mailbox: MailboxId,
+            pitch: u8,
+            velocity: u8,
+            instrument_id: u8,
+        },
+        NoteOff {
+            sender_mailbox: MailboxId,
+            pitch: u8,
+            instrument_id: u8,
+        },
+        SetMasterGain {
+            gain: f32,
+        },
     }
-}
 
-fn new_event_channel() -> (AudioEventSender, Arc<ArrayQueue<AudioEvent>>) {
-    let queue = Arc::new(ArrayQueue::new(EVENT_QUEUE_CAPACITY));
-    (
-        AudioEventSender {
-            queue: Arc::clone(&queue),
+    /// Producer side of the audio event queue. The cap holds one (after
+    /// building the pipeline) and pushes events on every inbound `NoteOn`
+    /// / `NoteOff` / `SetMasterGain`.
+    #[derive(Clone)]
+    struct AudioEventSender {
+        queue: Arc<ArrayQueue<AudioEvent>>,
+    }
+
+    impl AudioEventSender {
+        fn push(&self, event: AudioEvent) -> Result<(), AudioEvent> {
+            self.queue.push(event)
+        }
+    }
+
+    fn new_event_channel() -> (AudioEventSender, Arc<ArrayQueue<AudioEvent>>) {
+        let queue = Arc::new(ArrayQueue::new(EVENT_QUEUE_CAPACITY));
+        (
+            AudioEventSender {
+                queue: Arc::clone(&queue),
+            },
+            queue,
+        )
+    }
+
+    /// Primitive waveform the oscillator shapes. `Saw` is a downward ramp
+    /// scaled to ±1; `Pluck` reuses `Saw` geometry but pairs with a
+    /// fast-decay envelope — kept implicit by the patch table.
+    #[derive(Copy, Clone, Debug)]
+    enum Wave {
+        Sine,
+        Square,
+        Triangle,
+        Saw,
+    }
+
+    /// Envelope shape — linear segments at sample-rate resolution. Values
+    /// are held in seconds; the voice converts to per-sample step on
+    /// instantiation so the hot loop is add-only.
+    #[derive(Copy, Clone, Debug)]
+    struct Adsr {
+        attack_s: f32,
+        decay_s: f32,
+        sustain: f32,
+        release_s: f32,
+    }
+
+    /// Full instrument patch. Agents address instruments by numeric id
+    /// into the built-in registry; the registry hands the voice a copy of
+    /// this struct at `note_on` time so each voice is self-contained.
+    #[derive(Copy, Clone, Debug)]
+    struct InstrumentDef {
+        name: &'static str,
+        wave: Wave,
+        adsr: Adsr,
+        base_amp: f32,
+    }
+
+    /// The v1 instrument registry. Index matches `NoteOn.instrument_id`.
+    /// Reordering these is a breaking change on the wire — adds go at
+    /// the end. Future follow-up: mailed patch definitions fill in past
+    /// the built-ins (ADR-0039 "runtime-defined patches" parked item).
+    const BUILTINS: &[InstrumentDef] = &[
+        InstrumentDef {
+            name: "sine_lead",
+            wave: Wave::Sine,
+            adsr: Adsr {
+                attack_s: 0.01,
+                decay_s: 0.08,
+                sustain: 0.7,
+                release_s: 0.18,
+            },
+            base_amp: 0.35,
         },
-        queue,
-    )
-}
-
-/// Primitive waveform the oscillator shapes. `Saw` is a downward ramp
-/// scaled to ±1; `Pluck` reuses `Saw` geometry but pairs with a
-/// fast-decay envelope — kept implicit by the patch table.
-#[derive(Copy, Clone, Debug)]
-enum Wave {
-    Sine,
-    Square,
-    Triangle,
-    Saw,
-}
-
-/// Envelope shape — linear segments at sample-rate resolution. Values
-/// are held in seconds; the voice converts to per-sample step on
-/// instantiation so the hot loop is add-only.
-#[derive(Copy, Clone, Debug)]
-struct Adsr {
-    attack_s: f32,
-    decay_s: f32,
-    sustain: f32,
-    release_s: f32,
-}
-
-/// Full instrument patch. Agents address instruments by numeric id
-/// into the built-in registry; the registry hands the voice a copy of
-/// this struct at `note_on` time so each voice is self-contained.
-#[derive(Copy, Clone, Debug)]
-struct InstrumentDef {
-    name: &'static str,
-    wave: Wave,
-    adsr: Adsr,
-    base_amp: f32,
-}
-
-/// The v1 instrument registry. Index matches `NoteOn.instrument_id`.
-/// Reordering these is a breaking change on the wire — adds go at
-/// the end. Future follow-up: mailed patch definitions fill in past
-/// the built-ins (ADR-0039 "runtime-defined patches" parked item).
-const BUILTINS: &[InstrumentDef] = &[
-    InstrumentDef {
-        name: "sine_lead",
-        wave: Wave::Sine,
-        adsr: Adsr {
-            attack_s: 0.01,
-            decay_s: 0.08,
-            sustain: 0.7,
-            release_s: 0.18,
+        InstrumentDef {
+            name: "square_bass",
+            wave: Wave::Square,
+            adsr: Adsr {
+                attack_s: 0.005,
+                decay_s: 0.12,
+                sustain: 0.6,
+                release_s: 0.12,
+            },
+            base_amp: 0.22,
         },
-        base_amp: 0.35,
-    },
-    InstrumentDef {
-        name: "square_bass",
-        wave: Wave::Square,
-        adsr: Adsr {
-            attack_s: 0.005,
-            decay_s: 0.12,
-            sustain: 0.6,
-            release_s: 0.12,
+        InstrumentDef {
+            name: "triangle",
+            wave: Wave::Triangle,
+            adsr: Adsr {
+                attack_s: 0.02,
+                decay_s: 0.1,
+                sustain: 0.7,
+                release_s: 0.2,
+            },
+            base_amp: 0.32,
         },
-        base_amp: 0.22,
-    },
-    InstrumentDef {
-        name: "triangle",
-        wave: Wave::Triangle,
-        adsr: Adsr {
-            attack_s: 0.02,
-            decay_s: 0.1,
-            sustain: 0.7,
-            release_s: 0.2,
+        InstrumentDef {
+            name: "saw_lead",
+            wave: Wave::Saw,
+            adsr: Adsr {
+                attack_s: 0.01,
+                decay_s: 0.15,
+                sustain: 0.55,
+                release_s: 0.15,
+            },
+            base_amp: 0.2,
         },
-        base_amp: 0.32,
-    },
-    InstrumentDef {
-        name: "saw_lead",
-        wave: Wave::Saw,
-        adsr: Adsr {
-            attack_s: 0.01,
-            decay_s: 0.15,
-            sustain: 0.55,
-            release_s: 0.15,
+        InstrumentDef {
+            name: "pluck",
+            wave: Wave::Saw,
+            adsr: Adsr {
+                attack_s: 0.002,
+                decay_s: 0.35,
+                sustain: 0.0,
+                release_s: 0.05,
+            },
+            base_amp: 0.3,
         },
-        base_amp: 0.2,
-    },
-    InstrumentDef {
-        name: "pluck",
-        wave: Wave::Saw,
-        adsr: Adsr {
-            attack_s: 0.002,
-            decay_s: 0.35,
-            sustain: 0.0,
-            release_s: 0.05,
-        },
-        base_amp: 0.3,
-    },
-];
+    ];
 
-fn instrument_by_id(id: u8) -> Option<&'static InstrumentDef> {
-    BUILTINS.get(id as usize)
-}
+    fn instrument_by_id(id: u8) -> Option<&'static InstrumentDef> {
+        BUILTINS.get(id as usize)
+    }
 
-/// Number of built-in instruments. Used by the boot log so MCP
-/// agents can cross-reference.
-pub fn builtin_count() -> usize {
-    BUILTINS.len()
-}
+    /// Number of built-in instruments. Used by the boot log so MCP
+    /// agents can cross-reference.
+    pub fn builtin_count() -> usize {
+        BUILTINS.len()
+    }
 
-/// Names of the built-in instruments, in id order.
-pub fn builtin_names() -> Vec<&'static str> {
-    BUILTINS.iter().map(|d| d.name).collect()
-}
+    /// Names of the built-in instruments, in id order.
+    pub fn builtin_names() -> Vec<&'static str> {
+        BUILTINS.iter().map(|d| d.name).collect()
+    }
 
-/// Envelope state machine. `Release` captures the level it was at
-/// when the note was released, since a note can be released mid-attack
-/// or mid-decay — the release ramp starts from that value, not from
-/// the sustain level.
-#[derive(Copy, Clone, Debug)]
-enum EnvelopeStage {
-    Attack { t: f32 },
-    Decay { t: f32 },
-    Sustain,
-    Release { t: f32, from_level: f32 },
-    Done,
-}
+    /// Envelope state machine. `Release` captures the level it was at
+    /// when the note was released, since a note can be released mid-attack
+    /// or mid-decay — the release ramp starts from that value, not from
+    /// the sustain level.
+    #[derive(Copy, Clone, Debug)]
+    enum EnvelopeStage {
+        Attack { t: f32 },
+        Decay { t: f32 },
+        Sustain,
+        Release { t: f32, from_level: f32 },
+        Done,
+    }
 
-/// A single sounding voice. Sized for stack allocation in the voice
-/// pool — the hot loop iterates `&mut [Voice]` and every field is
-/// touched per sample, so keeping the struct compact helps cache.
-#[derive(Copy, Clone, Debug)]
-struct Voice {
-    sender_mailbox: MailboxId,
-    instrument_id: u8,
-    pitch: u8,
-    /// Oscillator phase in turns (`[0.0, 1.0)`), incremented by
-    /// `freq / sample_rate` per sample.
-    phase: f32,
-    /// Turns-per-sample step — precomputed so the per-sample path is
-    /// add-only.
-    phase_step: f32,
-    /// Base amplitude after velocity scaling; envelope multiplies this.
-    amplitude: f32,
-    wave: Wave,
-    adsr: Adsr,
-    envelope: EnvelopeStage,
-}
-
-impl Voice {
-    fn new(
+    /// A single sounding voice. Sized for stack allocation in the voice
+    /// pool — the hot loop iterates `&mut [Voice]` and every field is
+    /// touched per sample, so keeping the struct compact helps cache.
+    #[derive(Copy, Clone, Debug)]
+    struct Voice {
         sender_mailbox: MailboxId,
         instrument_id: u8,
         pitch: u8,
-        velocity: u8,
-        def: &InstrumentDef,
+        /// Oscillator phase in turns (`[0.0, 1.0)`), incremented by
+        /// `freq / sample_rate` per sample.
+        phase: f32,
+        /// Turns-per-sample step — precomputed so the per-sample path is
+        /// add-only.
+        phase_step: f32,
+        /// Base amplitude after velocity scaling; envelope multiplies this.
+        amplitude: f32,
+        wave: Wave,
+        adsr: Adsr,
+        envelope: EnvelopeStage,
+    }
+
+    impl Voice {
+        fn new(
+            sender_mailbox: MailboxId,
+            instrument_id: u8,
+            pitch: u8,
+            velocity: u8,
+            def: &InstrumentDef,
+            sample_rate: f32,
+        ) -> Self {
+            let freq = 440.0 * 2f32.powf((f32::from(pitch) - 69.0) / 12.0);
+            let phase_step = freq / sample_rate;
+            let v = f32::from(velocity) / 127.0;
+            let amplitude = def.base_amp * v * v;
+            Self {
+                sender_mailbox,
+                instrument_id,
+                pitch,
+                phase: 0.0,
+                phase_step,
+                amplitude,
+                wave: def.wave,
+                adsr: def.adsr,
+                envelope: EnvelopeStage::Attack { t: 0.0 },
+            }
+        }
+
+        fn note_off(&mut self) {
+            let from_level = match self.envelope {
+                EnvelopeStage::Attack { t } => {
+                    if self.adsr.attack_s > 0.0 {
+                        (t / self.adsr.attack_s).clamp(0.0, 1.0)
+                    } else {
+                        1.0
+                    }
+                }
+                EnvelopeStage::Decay { t } => {
+                    if self.adsr.decay_s > 0.0 {
+                        let fall = 1.0 - (1.0 - self.adsr.sustain) * (t / self.adsr.decay_s);
+                        fall.clamp(self.adsr.sustain.min(1.0), 1.0)
+                    } else {
+                        self.adsr.sustain
+                    }
+                }
+                EnvelopeStage::Sustain => self.adsr.sustain,
+                EnvelopeStage::Release { .. } | EnvelopeStage::Done => return,
+            };
+            self.envelope = EnvelopeStage::Release { t: 0.0, from_level };
+        }
+
+        fn done(&self) -> bool {
+            matches!(self.envelope, EnvelopeStage::Done)
+        }
+
+        fn advance_envelope(&mut self, dt: f32) -> f32 {
+            match &mut self.envelope {
+                EnvelopeStage::Attack { t } => {
+                    *t += dt;
+                    if self.adsr.attack_s <= 0.0 || *t >= self.adsr.attack_s {
+                        self.envelope = EnvelopeStage::Decay { t: 0.0 };
+                        1.0
+                    } else {
+                        *t / self.adsr.attack_s
+                    }
+                }
+                EnvelopeStage::Decay { t } => {
+                    *t += dt;
+                    if self.adsr.decay_s <= 0.0 || *t >= self.adsr.decay_s {
+                        self.envelope = EnvelopeStage::Sustain;
+                        self.adsr.sustain
+                    } else {
+                        1.0 - (1.0 - self.adsr.sustain) * (*t / self.adsr.decay_s)
+                    }
+                }
+                EnvelopeStage::Sustain => self.adsr.sustain,
+                EnvelopeStage::Release { t, from_level } => {
+                    *t += dt;
+                    if self.adsr.release_s <= 0.0 || *t >= self.adsr.release_s {
+                        self.envelope = EnvelopeStage::Done;
+                        0.0
+                    } else {
+                        *from_level * (1.0 - (*t / self.adsr.release_s))
+                    }
+                }
+                EnvelopeStage::Done => 0.0,
+            }
+        }
+
+        fn oscillator(&self) -> f32 {
+            match self.wave {
+                Wave::Sine => (self.phase * TAU).sin(),
+                Wave::Square => {
+                    if self.phase < 0.5 {
+                        1.0
+                    } else {
+                        -1.0
+                    }
+                }
+                Wave::Triangle => {
+                    if self.phase < 0.5 {
+                        -1.0 + 4.0 * self.phase
+                    } else {
+                        3.0 - 4.0 * self.phase
+                    }
+                }
+                Wave::Saw => 1.0 - 2.0 * self.phase,
+            }
+        }
+
+        fn next_sample(&mut self, dt: f32) -> f32 {
+            let env = self.advance_envelope(dt);
+            let s = self.oscillator() * self.amplitude * env;
+            self.phase += self.phase_step;
+            if self.phase >= 1.0 {
+                self.phase -= 1.0;
+            }
+            s
+        }
+    }
+
+    /// Whole-process synth state. Lives on the cpal callback thread;
+    /// the cap communicates via the event queue.
+    struct Synth {
+        events: Arc<ArrayQueue<AudioEvent>>,
+        voices: Vec<Voice>,
         sample_rate: f32,
-    ) -> Self {
-        let freq = 440.0 * 2f32.powf((f32::from(pitch) - 69.0) / 12.0);
-        let phase_step = freq / sample_rate;
-        let v = f32::from(velocity) / 127.0;
-        let amplitude = def.base_amp * v * v;
-        Self {
-            sender_mailbox,
-            instrument_id,
-            pitch,
-            phase: 0.0,
-            phase_step,
-            amplitude,
-            wave: def.wave,
-            adsr: def.adsr,
-            envelope: EnvelopeStage::Attack { t: 0.0 },
+        master_gain: f32,
+    }
+
+    impl Synth {
+        fn new(events: Arc<ArrayQueue<AudioEvent>>, sample_rate: f32) -> Self {
+            Self {
+                events,
+                voices: Vec::with_capacity(MAX_VOICES),
+                sample_rate,
+                master_gain: 1.0,
+            }
         }
-    }
 
-    fn note_off(&mut self) {
-        let from_level = match self.envelope {
-            EnvelopeStage::Attack { t } => {
-                if self.adsr.attack_s > 0.0 {
-                    (t / self.adsr.attack_s).clamp(0.0, 1.0)
-                } else {
-                    1.0
-                }
-            }
-            EnvelopeStage::Decay { t } => {
-                if self.adsr.decay_s > 0.0 {
-                    let fall = 1.0 - (1.0 - self.adsr.sustain) * (t / self.adsr.decay_s);
-                    fall.clamp(self.adsr.sustain.min(1.0), 1.0)
-                } else {
-                    self.adsr.sustain
-                }
-            }
-            EnvelopeStage::Sustain => self.adsr.sustain,
-            EnvelopeStage::Release { .. } | EnvelopeStage::Done => return,
-        };
-        self.envelope = EnvelopeStage::Release { t: 0.0, from_level };
-    }
-
-    fn done(&self) -> bool {
-        matches!(self.envelope, EnvelopeStage::Done)
-    }
-
-    fn advance_envelope(&mut self, dt: f32) -> f32 {
-        match &mut self.envelope {
-            EnvelopeStage::Attack { t } => {
-                *t += dt;
-                if self.adsr.attack_s <= 0.0 || *t >= self.adsr.attack_s {
-                    self.envelope = EnvelopeStage::Decay { t: 0.0 };
-                    1.0
-                } else {
-                    *t / self.adsr.attack_s
-                }
-            }
-            EnvelopeStage::Decay { t } => {
-                *t += dt;
-                if self.adsr.decay_s <= 0.0 || *t >= self.adsr.decay_s {
-                    self.envelope = EnvelopeStage::Sustain;
-                    self.adsr.sustain
-                } else {
-                    1.0 - (1.0 - self.adsr.sustain) * (*t / self.adsr.decay_s)
-                }
-            }
-            EnvelopeStage::Sustain => self.adsr.sustain,
-            EnvelopeStage::Release { t, from_level } => {
-                *t += dt;
-                if self.adsr.release_s <= 0.0 || *t >= self.adsr.release_s {
-                    self.envelope = EnvelopeStage::Done;
-                    0.0
-                } else {
-                    *from_level * (1.0 - (*t / self.adsr.release_s))
-                }
-            }
-            EnvelopeStage::Done => 0.0,
-        }
-    }
-
-    fn oscillator(&self) -> f32 {
-        match self.wave {
-            Wave::Sine => (self.phase * TAU).sin(),
-            Wave::Square => {
-                if self.phase < 0.5 {
-                    1.0
-                } else {
-                    -1.0
-                }
-            }
-            Wave::Triangle => {
-                if self.phase < 0.5 {
-                    -1.0 + 4.0 * self.phase
-                } else {
-                    3.0 - 4.0 * self.phase
-                }
-            }
-            Wave::Saw => 1.0 - 2.0 * self.phase,
-        }
-    }
-
-    fn next_sample(&mut self, dt: f32) -> f32 {
-        let env = self.advance_envelope(dt);
-        let s = self.oscillator() * self.amplitude * env;
-        self.phase += self.phase_step;
-        if self.phase >= 1.0 {
-            self.phase -= 1.0;
-        }
-        s
-    }
-}
-
-/// Whole-process synth state. Lives on the cpal callback thread;
-/// the cap communicates via the event queue.
-struct Synth {
-    events: Arc<ArrayQueue<AudioEvent>>,
-    voices: Vec<Voice>,
-    sample_rate: f32,
-    master_gain: f32,
-}
-
-impl Synth {
-    fn new(events: Arc<ArrayQueue<AudioEvent>>, sample_rate: f32) -> Self {
-        Self {
-            events,
-            voices: Vec::with_capacity(MAX_VOICES),
-            sample_rate,
-            master_gain: 1.0,
-        }
-    }
-
-    fn drain_events(&mut self) {
-        while let Some(ev) = self.events.pop() {
-            match ev {
-                AudioEvent::NoteOn {
-                    sender_mailbox,
-                    pitch,
-                    velocity,
-                    instrument_id,
-                } => {
-                    let Some(def) = instrument_by_id(instrument_id) else {
-                        tracing::warn!(
-                            target: "aether_substrate::audio",
-                            instrument_id,
-                            "note_on: unknown instrument_id, dropping",
-                        );
-                        continue;
-                    };
-                    if self.voices.len() >= MAX_VOICES {
-                        self.voices.remove(0);
-                    }
-                    if let Some(existing) = self.voices.iter().position(|v| {
-                        v.sender_mailbox == sender_mailbox
-                            && v.instrument_id == instrument_id
-                            && v.pitch == pitch
-                    }) {
-                        self.voices.swap_remove(existing);
-                    }
-                    self.voices.push(Voice::new(
+        fn drain_events(&mut self) {
+            while let Some(ev) = self.events.pop() {
+                match ev {
+                    AudioEvent::NoteOn {
                         sender_mailbox,
-                        instrument_id,
                         pitch,
                         velocity,
-                        def,
-                        self.sample_rate,
-                    ));
-                }
-                AudioEvent::NoteOff {
-                    sender_mailbox,
-                    pitch,
-                    instrument_id,
-                } => {
-                    if let Some(v) = self.voices.iter_mut().find(|v| {
-                        v.sender_mailbox == sender_mailbox
-                            && v.instrument_id == instrument_id
-                            && v.pitch == pitch
-                    }) {
-                        v.note_off();
+                        instrument_id,
+                    } => {
+                        let Some(def) = instrument_by_id(instrument_id) else {
+                            tracing::warn!(
+                                target: "aether_substrate::audio",
+                                instrument_id,
+                                "note_on: unknown instrument_id, dropping",
+                            );
+                            continue;
+                        };
+                        if self.voices.len() >= MAX_VOICES {
+                            self.voices.remove(0);
+                        }
+                        if let Some(existing) = self.voices.iter().position(|v| {
+                            v.sender_mailbox == sender_mailbox
+                                && v.instrument_id == instrument_id
+                                && v.pitch == pitch
+                        }) {
+                            self.voices.swap_remove(existing);
+                        }
+                        self.voices.push(Voice::new(
+                            sender_mailbox,
+                            instrument_id,
+                            pitch,
+                            velocity,
+                            def,
+                            self.sample_rate,
+                        ));
+                    }
+                    AudioEvent::NoteOff {
+                        sender_mailbox,
+                        pitch,
+                        instrument_id,
+                    } => {
+                        if let Some(v) = self.voices.iter_mut().find(|v| {
+                            v.sender_mailbox == sender_mailbox
+                                && v.instrument_id == instrument_id
+                                && v.pitch == pitch
+                        }) {
+                            v.note_off();
+                        }
+                    }
+                    AudioEvent::SetMasterGain { gain } => {
+                        self.master_gain = gain.clamp(0.0, 1.0);
                     }
                 }
-                AudioEvent::SetMasterGain { gain } => {
-                    self.master_gain = gain.clamp(0.0, 1.0);
+            }
+        }
+
+        fn fill(&mut self, buffer: &mut [f32], channels: usize) {
+            self.drain_events();
+            let dt = 1.0 / self.sample_rate;
+            let frames = buffer.len() / channels.max(1);
+            for frame in 0..frames {
+                let mut sample = 0.0f32;
+                for voice in &mut self.voices {
+                    sample += voice.next_sample(dt);
+                }
+                sample *= self.master_gain;
+                sample = sample.tanh();
+                let start = frame * channels;
+                for ch in 0..channels {
+                    buffer[start + ch] = sample;
+                }
+            }
+            let mut i = 0;
+            while i < self.voices.len() {
+                if self.voices[i].done() {
+                    self.voices.swap_remove(i);
+                } else {
+                    i += 1;
                 }
             }
         }
+
+        #[cfg(test)]
+        fn voice_count(&self) -> usize {
+            self.voices.len()
+        }
+
+        #[cfg(test)]
+        fn master_gain_value(&self) -> f32 {
+            self.master_gain
+        }
     }
 
-    fn fill(&mut self, buffer: &mut [f32], channels: usize) {
-        self.drain_events();
-        let dt = 1.0 / self.sample_rate;
-        let frames = buffer.len() / channels.max(1);
-        for frame in 0..frames {
-            let mut sample = 0.0f32;
-            for voice in &mut self.voices {
-                sample += voice.next_sample(dt);
+    /// Handle to a running cpal pipeline. Lives on the audio worker
+    /// thread for the entire run — `cpal::Stream` is `!Send` on macOS,
+    /// so the stream is constructed on, owned by, and dropped from the
+    /// same thread. Dropping the pipeline silences every voice and tears
+    /// down the cpal stream.
+    struct AudioPipeline {
+        sender: AudioEventSender,
+        _stream: cpal::Stream,
+    }
+
+    #[derive(Debug)]
+    enum AudioBuildError {
+        NoDevice,
+        RateUnsupported(u32),
+        ConfigQuery(String),
+        StreamBuild(String),
+        StreamPlay(String),
+    }
+
+    impl core::fmt::Display for AudioBuildError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Self::NoDevice => write!(f, "no default audio output device"),
+                Self::RateUnsupported(r) => write!(f, "requested sample rate {r} Hz unsupported"),
+                Self::ConfigQuery(e) => write!(f, "config query failed: {e}"),
+                Self::StreamBuild(e) => write!(f, "stream build failed: {e}"),
+                Self::StreamPlay(e) => write!(f, "stream play failed: {e}"),
             }
-            sample *= self.master_gain;
-            sample = sample.tanh();
-            let start = frame * channels;
-            for ch in 0..channels {
-                buffer[start + ch] = sample;
+        }
+    }
+
+    fn try_build_pipeline(
+        requested_sample_rate: Option<u32>,
+    ) -> Result<AudioPipeline, AudioBuildError> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or(AudioBuildError::NoDevice)?;
+
+        let config = match requested_sample_rate {
+            Some(rate) => {
+                find_config_for_rate(&device, rate).ok_or(AudioBuildError::RateUnsupported(rate))?
+            }
+            None => device
+                .default_output_config()
+                .map_err(|e| AudioBuildError::ConfigQuery(e.to_string()))?
+                .config(),
+        };
+
+        let sample_rate = config.sample_rate.0;
+        let channels = config.channels;
+
+        let (sender, queue) = new_event_channel();
+        let mut synth = Synth::new(queue, sample_rate as f32);
+
+        let stream = device
+            .build_output_stream(
+                &config,
+                move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                    synth.fill(data, channels as usize);
+                },
+                |err| {
+                    tracing::warn!(
+                        target: "aether_substrate::audio",
+                        error = %err,
+                        "cpal stream error",
+                    );
+                },
+                None,
+            )
+            .map_err(|e| AudioBuildError::StreamBuild(e.to_string()))?;
+
+        stream
+            .play()
+            .map_err(|e| AudioBuildError::StreamPlay(e.to_string()))?;
+
+        tracing::info!(
+            target: "aether_substrate::audio",
+            sample_rate,
+            channels,
+            instruments = builtin_count(),
+            builtin_names = ?builtin_names(),
+            "audio pipeline started",
+        );
+
+        Ok(AudioPipeline {
+            sender,
+            _stream: stream,
+        })
+    }
+
+    fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
+        let configs = device.supported_output_configs().ok()?;
+        for cfg in configs {
+            let min = cfg.min_sample_rate().0;
+            let max = cfg.max_sample_rate().0;
+            if rate >= min && rate <= max {
+                return Some(cfg.with_sample_rate(cpal::SampleRate(rate)).config());
             }
         }
-        let mut i = 0;
-        while i < self.voices.len() {
-            if self.voices[i].done() {
-                self.voices.swap_remove(i);
-            } else {
-                i += 1;
-            }
+        None
+    }
+
+    /// Extract the sender's mailbox id for voice-table keying. Component
+    /// senders come through as `EngineMailbox { mailbox_id }`; Claude
+    /// sessions and substrate-internal pushes (which shouldn't reach the
+    /// audio cap in practice) collapse to id `0`, sharing one voice
+    /// slot per (instrument, pitch).
+    fn sender_mailbox_id(sender: ReplyTo) -> MailboxId {
+        match sender.target {
+            ReplyTarget::EngineMailbox { mailbox_id, .. } => mailbox_id,
+            _ => MailboxId(0),
         }
     }
 
-    #[cfg(test)]
-    fn voice_count(&self) -> usize {
-        self.voices.len()
+    /// `aether.audio` mailbox cap. Holds the producer side of the synth
+    /// event queue ([`AudioEventSender`]), the audio worker thread that
+    /// owns the [`cpal::Stream`] (see module-level "per-cap audio worker"
+    /// docs for the `!Send` rationale), and a shutdown channel that
+    /// signals the worker to exit on drop.
+    ///
+    /// `audio_sender` is `None` when the cpal pipeline isn't running
+    /// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In
+    /// that mode `NoteOn` / `NoteOff` no-op and `SetMasterGain` replies
+    /// `Err`. The audio_thread / shutdown handles live behind a `Mutex`
+    /// so the `Drop` impl can take ownership during teardown without
+    /// requiring `&mut self` everywhere — handlers run with `&self`
+    /// (Arc-shared) per the `NativeActor` contract.
+    pub struct AudioCapability {
+        audio_sender: Option<AudioEventSender>,
+        /// Worker thread holding the [`cpal::Stream`] + drop-on-shutdown
+        /// sender. Mutex-wrapped so `Drop` can `.take()` the JoinHandle
+        /// and Sender on `&mut self` while normal handlers (`&self`)
+        /// don't need to touch them.
+        teardown: std::sync::Mutex<AudioTeardown>,
     }
 
-    #[cfg(test)]
-    fn master_gain_value(&self) -> f32 {
-        self.master_gain
+    /// Teardown state pulled aside so `Drop` can take ownership of the
+    /// JoinHandle and shutdown sender without poisoning the rest of the
+    /// cap struct.
+    struct AudioTeardown {
+        audio_thread: Option<JoinHandle<()>>,
+        audio_shutdown: Option<mpsc::Sender<()>>,
     }
-}
 
-/// Handle to a running cpal pipeline. Lives on the audio worker
-/// thread for the entire run — `cpal::Stream` is `!Send` on macOS,
-/// so the stream is constructed on, owned by, and dropped from the
-/// same thread. Dropping the pipeline silences every voice and tears
-/// down the cpal stream.
-struct AudioPipeline {
-    sender: AudioEventSender,
-    _stream: cpal::Stream,
-}
-
-#[derive(Debug)]
-enum AudioBuildError {
-    NoDevice,
-    RateUnsupported(u32),
-    ConfigQuery(String),
-    StreamBuild(String),
-    StreamPlay(String),
-}
-
-impl core::fmt::Display for AudioBuildError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::NoDevice => write!(f, "no default audio output device"),
-            Self::RateUnsupported(r) => write!(f, "requested sample rate {r} Hz unsupported"),
-            Self::ConfigQuery(e) => write!(f, "config query failed: {e}"),
-            Self::StreamBuild(e) => write!(f, "stream build failed: {e}"),
-            Self::StreamPlay(e) => write!(f, "stream play failed: {e}"),
-        }
-    }
-}
-
-fn try_build_pipeline(
-    requested_sample_rate: Option<u32>,
-) -> Result<AudioPipeline, AudioBuildError> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or(AudioBuildError::NoDevice)?;
-
-    let config = match requested_sample_rate {
-        Some(rate) => {
-            find_config_for_rate(&device, rate).ok_or(AudioBuildError::RateUnsupported(rate))?
-        }
-        None => device
-            .default_output_config()
-            .map_err(|e| AudioBuildError::ConfigQuery(e.to_string()))?
-            .config(),
-    };
-
-    let sample_rate = config.sample_rate.0;
-    let channels = config.channels;
-
-    let (sender, queue) = new_event_channel();
-    let mut synth = Synth::new(queue, sample_rate as f32);
-
-    let stream = device
-        .build_output_stream(
-            &config,
-            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                synth.fill(data, channels as usize);
-            },
-            |err| {
-                tracing::warn!(
-                    target: "aether_substrate::audio",
-                    error = %err,
-                    "cpal stream error",
-                );
-            },
-            None,
-        )
-        .map_err(|e| AudioBuildError::StreamBuild(e.to_string()))?;
-
-    stream
-        .play()
-        .map_err(|e| AudioBuildError::StreamPlay(e.to_string()))?;
-
-    tracing::info!(
-        target: "aether_substrate::audio",
-        sample_rate,
-        channels,
-        instruments = builtin_count(),
-        builtin_names = ?builtin_names(),
-        "audio pipeline started",
-    );
-
-    Ok(AudioPipeline {
-        sender,
-        _stream: stream,
-    })
-}
-
-fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
-    let configs = device.supported_output_configs().ok()?;
-    for cfg in configs {
-        let min = cfg.min_sample_rate().0;
-        let max = cfg.max_sample_rate().0;
-        if rate >= min && rate <= max {
-            return Some(cfg.with_sample_rate(cpal::SampleRate(rate)).config());
-        }
-    }
-    None
-}
-
-/// Extract the sender's mailbox id for voice-table keying. Component
-/// senders come through as `EngineMailbox { mailbox_id }`; Claude
-/// sessions and substrate-internal pushes (which shouldn't reach the
-/// audio cap in practice) collapse to id `0`, sharing one voice
-/// slot per (instrument, pitch).
-fn sender_mailbox_id(sender: ReplyTo) -> MailboxId {
-    match sender.target {
-        ReplyTarget::EngineMailbox { mailbox_id, .. } => mailbox_id,
-        _ => MailboxId(0),
-    }
-}
-
-/// `aether.audio` mailbox cap. Holds the producer side of the synth
-/// event queue ([`AudioEventSender`]), the audio worker thread that
-/// owns the [`cpal::Stream`] (see module-level "per-cap audio worker"
-/// docs for the `!Send` rationale), and a shutdown channel that
-/// signals the worker to exit on drop.
-///
-/// `audio_sender` is `None` when the cpal pipeline isn't running
-/// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In
-/// that mode `NoteOn` / `NoteOff` no-op and `SetMasterGain` replies
-/// `Err`. The audio_thread / shutdown handles live behind a `Mutex`
-/// so the `Drop` impl can take ownership during teardown without
-/// requiring `&mut self` everywhere — handlers run with `&self`
-/// (Arc-shared) per the `NativeActor` contract.
-#[derive(Singleton)]
-pub struct AudioCapability {
-    audio_sender: Option<AudioEventSender>,
-    /// Worker thread holding the [`cpal::Stream`] + drop-on-shutdown
-    /// sender. Mutex-wrapped so `Drop` can `.take()` the JoinHandle
-    /// and Sender on `&mut self` while normal handlers (`&self`)
-    /// don't need to touch them.
-    teardown: std::sync::Mutex<AudioTeardown>,
-}
-
-/// Teardown state pulled aside so `Drop` can take ownership of the
-/// JoinHandle and shutdown sender without poisoning the rest of the
-/// cap struct.
-struct AudioTeardown {
-    audio_thread: Option<JoinHandle<()>>,
-    audio_shutdown: Option<mpsc::Sender<()>>,
-}
-
-impl AudioCapability {
-    fn nop() -> Self {
-        Self {
-            audio_sender: None,
-            teardown: std::sync::Mutex::new(AudioTeardown {
-                audio_thread: None,
-                audio_shutdown: None,
-            }),
-        }
-    }
-}
-
-impl Drop for AudioCapability {
-    fn drop(&mut self) {
-        // Drop the shutdown sender first; the worker's `recv()`
-        // returns, it drops the cpal::Stream on its own thread, and
-        // exits. Then we join. Mutex contention is impossible here —
-        // Drop runs only when the last Arc is released.
-        let mut tear = self
-            .teardown
-            .lock()
-            .expect("AudioCapability teardown mutex poisoned");
-        tear.audio_shutdown.take();
-        if let Some(t) = tear.audio_thread.take() {
-            let _ = t.join();
-        }
-    }
-}
-
-#[actor]
-impl NativeActor for AudioCapability {
-    type Config = AudioConfig;
-
-    /// ADR-0039 + ADR-0074 Phase 5 chassis-owned mailbox.
-    const NAMESPACE: &'static str = "aether.audio";
-
-    /// Boot the cap. Always succeeds — cpal init failure logs a
-    /// warning and falls back to nop mode (per ADR-0039: audio is a
-    /// peripheral, not infrastructure). The cap always claims its
-    /// mailbox so agents on chassis without audio still get loud
-    /// `Err` replies for `SetMasterGain` instead of timing out.
-    fn init(config: AudioConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        if config.disabled {
-            tracing::info!(
-                target: "aether_substrate::audio",
-                "AETHER_AUDIO_DISABLE=1 — skipping cpal init",
-            );
-            return Ok(Self::nop());
-        }
-        match spawn_audio_worker(config.requested_sample_rate) {
-            Ok((audio_sender, audio_thread, audio_shutdown)) => Ok(Self {
-                audio_sender: Some(audio_sender),
+    impl AudioCapability {
+        fn nop() -> Self {
+            Self {
+                audio_sender: None,
                 teardown: std::sync::Mutex::new(AudioTeardown {
-                    audio_thread: Some(audio_thread),
-                    audio_shutdown: Some(audio_shutdown),
+                    audio_thread: None,
+                    audio_shutdown: None,
                 }),
-            }),
-            Err(e) => {
-                tracing::warn!(
-                    target: "aether_substrate::audio",
-                    error = %e,
-                    "audio pipeline init failed — NoteOn/NoteOff will be nop, SetMasterGain will reply Err",
-                );
-                Ok(Self::nop())
             }
         }
     }
 
-    /// Start a note.
-    ///
-    /// # Agent
-    /// Fire-and-forget. The synth keys voices on
-    /// `(sender, instrument_id, pitch)`; sending two `NoteOn`s with
-    /// the same triple is a no-op.
-    #[handler]
-    fn on_note_on(&self, ctx: &mut NativeCtx<'_>, mail: NoteOn) {
-        let Some(s) = self.audio_sender.as_ref() else {
-            return;
-        };
-        let ev = AudioEvent::NoteOn {
-            sender_mailbox: sender_mailbox_id(ctx.reply_target()),
-            pitch: mail.pitch,
-            velocity: mail.velocity,
-            instrument_id: mail.instrument_id,
-        };
-        if s.push(ev).is_err() {
-            tracing::warn!(
-                target: "aether_substrate::audio",
-                "event queue full — dropping note_on",
-            );
+    impl Drop for AudioCapability {
+        fn drop(&mut self) {
+            // Drop the shutdown sender first; the worker's `recv()`
+            // returns, it drops the cpal::Stream on its own thread, and
+            // exits. Then we join. Mutex contention is impossible here —
+            // Drop runs only when the last Arc is released.
+            let mut tear = self
+                .teardown
+                .lock()
+                .expect("AudioCapability teardown mutex poisoned");
+            tear.audio_shutdown.take();
+            if let Some(t) = tear.audio_thread.take() {
+                let _ = t.join();
+            }
         }
     }
 
-    /// Stop a note. Pairs with `on_note_on` by voice key.
-    ///
-    /// # Agent
-    /// Fire-and-forget.
-    #[handler]
-    fn on_note_off(&self, ctx: &mut NativeCtx<'_>, mail: NoteOff) {
-        let Some(s) = self.audio_sender.as_ref() else {
-            return;
-        };
-        let ev = AudioEvent::NoteOff {
-            sender_mailbox: sender_mailbox_id(ctx.reply_target()),
-            pitch: mail.pitch,
-            instrument_id: mail.instrument_id,
-        };
-        if s.push(ev).is_err() {
-            tracing::warn!(
-                target: "aether_substrate::audio",
-                "event queue full — dropping note_off",
-            );
-        }
-    }
+    #[actor]
+    impl NativeActor for AudioCapability {
+        type Config = AudioConfig;
 
-    /// Set the master gain.
-    ///
-    /// # Agent
-    /// Reply: `SetMasterGainResult`. `Ok { applied_gain }` clamps to
-    /// `0.0..=1.0`; `Err` on chassis without audio.
-    #[handler]
-    fn on_set_master_gain(&self, ctx: &mut NativeCtx<'_>, mail: SetMasterGain) {
-        let applied = mail.gain.clamp(0.0, 1.0);
-        match self.audio_sender.as_ref() {
-            Some(s) => {
-                let _ = s.push(AudioEvent::SetMasterGain { gain: applied });
-                ctx.reply(&SetMasterGainResult::Ok {
-                    applied_gain: applied,
-                });
+        /// ADR-0039 + ADR-0074 Phase 5 chassis-owned mailbox.
+        const NAMESPACE: &'static str = "aether.audio";
+
+        /// Boot the cap. Always succeeds — cpal init failure logs a
+        /// warning and falls back to nop mode (per ADR-0039: audio is a
+        /// peripheral, not infrastructure). The cap always claims its
+        /// mailbox so agents on chassis without audio still get loud
+        /// `Err` replies for `SetMasterGain` instead of timing out.
+        fn init(config: AudioConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            if config.disabled {
                 tracing::info!(
                     target: "aether_substrate::audio",
-                    requested = mail.gain,
-                    applied,
-                    "master gain set",
+                    "AETHER_AUDIO_DISABLE=1 — skipping cpal init",
+                );
+                return Ok(Self::nop());
+            }
+            match spawn_audio_worker(config.requested_sample_rate) {
+                Ok((audio_sender, audio_thread, audio_shutdown)) => Ok(Self {
+                    audio_sender: Some(audio_sender),
+                    teardown: std::sync::Mutex::new(AudioTeardown {
+                        audio_thread: Some(audio_thread),
+                        audio_shutdown: Some(audio_shutdown),
+                    }),
+                }),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::audio",
+                        error = %e,
+                        "audio pipeline init failed — NoteOn/NoteOff will be nop, SetMasterGain will reply Err",
+                    );
+                    Ok(Self::nop())
+                }
+            }
+        }
+
+        /// Start a note.
+        ///
+        /// # Agent
+        /// Fire-and-forget. The synth keys voices on
+        /// `(sender, instrument_id, pitch)`; sending two `NoteOn`s with
+        /// the same triple is a no-op.
+        #[handler]
+        fn on_note_on(&self, ctx: &mut NativeCtx<'_>, mail: NoteOn) {
+            let Some(s) = self.audio_sender.as_ref() else {
+                return;
+            };
+            let ev = AudioEvent::NoteOn {
+                sender_mailbox: sender_mailbox_id(ctx.reply_target()),
+                pitch: mail.pitch,
+                velocity: mail.velocity,
+                instrument_id: mail.instrument_id,
+            };
+            if s.push(ev).is_err() {
+                tracing::warn!(
+                    target: "aether_substrate::audio",
+                    "event queue full — dropping note_on",
                 );
             }
-            None => {
-                ctx.reply(&SetMasterGainResult::Err {
-                    error: "audio pipeline not initialised on this desktop substrate".to_owned(),
-                });
+        }
+
+        /// Stop a note. Pairs with `on_note_on` by voice key.
+        ///
+        /// # Agent
+        /// Fire-and-forget.
+        #[handler]
+        fn on_note_off(&self, ctx: &mut NativeCtx<'_>, mail: NoteOff) {
+            let Some(s) = self.audio_sender.as_ref() else {
+                return;
+            };
+            let ev = AudioEvent::NoteOff {
+                sender_mailbox: sender_mailbox_id(ctx.reply_target()),
+                pitch: mail.pitch,
+                instrument_id: mail.instrument_id,
+            };
+            if s.push(ev).is_err() {
+                tracing::warn!(
+                    target: "aether_substrate::audio",
+                    "event queue full — dropping note_off",
+                );
+            }
+        }
+
+        /// Set the master gain.
+        ///
+        /// # Agent
+        /// Reply: `SetMasterGainResult`. `Ok { applied_gain }` clamps to
+        /// `0.0..=1.0`; `Err` on chassis without audio.
+        #[handler]
+        fn on_set_master_gain(&self, ctx: &mut NativeCtx<'_>, mail: SetMasterGain) {
+            let applied = mail.gain.clamp(0.0, 1.0);
+            match self.audio_sender.as_ref() {
+                Some(s) => {
+                    let _ = s.push(AudioEvent::SetMasterGain { gain: applied });
+                    ctx.reply(&SetMasterGainResult::Ok {
+                        applied_gain: applied,
+                    });
+                    tracing::info!(
+                        target: "aether_substrate::audio",
+                        requested = mail.gain,
+                        applied,
+                        "master gain set",
+                    );
+                }
+                None => {
+                    ctx.reply(&SetMasterGainResult::Err {
+                        error: "audio pipeline not initialised on this desktop substrate"
+                            .to_owned(),
+                    });
+                }
             }
         }
     }
-}
 
-/// Spawn the audio worker thread that owns `cpal::Stream` for the
-/// cap's lifetime. The worker:
-///   1. Builds the cpal pipeline on its own thread (`!Send`
-///      constraint).
-///   2. Sends the [`AudioEventSender`] back over the init channel.
-///   3. Parks on the shutdown channel, holding the stream alive.
-///   4. On shutdown sender drop, `recv()` returns and the stream
-///      drops on this thread.
-///
-/// Returns the producer side of the synth event queue plus the
-/// worker thread + shutdown sender for the cap to manage. On
-/// pipeline build failure, the worker thread exits cleanly and the
-/// caller sees the error.
-fn spawn_audio_worker(
-    requested_sample_rate: Option<u32>,
-) -> Result<(AudioEventSender, JoinHandle<()>, mpsc::Sender<()>), AudioBuildError> {
-    let (init_tx, init_rx) = mpsc::channel::<Result<AudioEventSender, AudioBuildError>>();
-    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+    /// Spawn the audio worker thread that owns `cpal::Stream` for the
+    /// cap's lifetime. The worker:
+    ///   1. Builds the cpal pipeline on its own thread (`!Send`
+    ///      constraint).
+    ///   2. Sends the [`AudioEventSender`] back over the init channel.
+    ///   3. Parks on the shutdown channel, holding the stream alive.
+    ///   4. On shutdown sender drop, `recv()` returns and the stream
+    ///      drops on this thread.
+    ///
+    /// Returns the producer side of the synth event queue plus the
+    /// worker thread + shutdown sender for the cap to manage. On
+    /// pipeline build failure, the worker thread exits cleanly and the
+    /// caller sees the error.
+    fn spawn_audio_worker(
+        requested_sample_rate: Option<u32>,
+    ) -> Result<(AudioEventSender, JoinHandle<()>, mpsc::Sender<()>), AudioBuildError> {
+        let (init_tx, init_rx) = mpsc::channel::<Result<AudioEventSender, AudioBuildError>>();
+        let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
 
-    let thread = thread::Builder::new()
-        .name("aether-audio-cpal".into())
-        .spawn(move || {
-            match try_build_pipeline(requested_sample_rate) {
-                Ok(pipeline) => {
-                    let _ = init_tx.send(Ok(pipeline.sender.clone()));
-                    drop(init_tx);
-                    let _ = shutdown_rx.recv();
-                    drop(pipeline); // cpal::Stream tears down here
+        let thread = thread::Builder::new()
+            .name("aether-audio-cpal".into())
+            .spawn(move || {
+                match try_build_pipeline(requested_sample_rate) {
+                    Ok(pipeline) => {
+                        let _ = init_tx.send(Ok(pipeline.sender.clone()));
+                        drop(init_tx);
+                        let _ = shutdown_rx.recv();
+                        drop(pipeline); // cpal::Stream tears down here
+                    }
+                    Err(e) => {
+                        let _ = init_tx.send(Err(e));
+                    }
                 }
-                Err(e) => {
-                    let _ = init_tx.send(Err(e));
-                }
+            })
+            .map_err(|e| {
+                AudioBuildError::StreamBuild(format!("worker thread spawn failed: {e}"))
+            })?;
+
+        match init_rx.recv() {
+            Ok(Ok(sender)) => Ok((sender, thread, shutdown_tx)),
+            Ok(Err(e)) => {
+                let _ = thread.join();
+                Err(e)
             }
-        })
-        .map_err(|e| AudioBuildError::StreamBuild(format!("worker thread spawn failed: {e}")))?;
-
-    match init_rx.recv() {
-        Ok(Ok(sender)) => Ok((sender, thread, shutdown_tx)),
-        Ok(Err(e)) => {
-            let _ = thread.join();
-            Err(e)
-        }
-        Err(_) => {
-            let _ = thread.join();
-            Err(AudioBuildError::StreamBuild(
-                "audio worker closed channel before init".to_string(),
-            ))
+            Err(_) => {
+                let _ = thread.join();
+                Err(AudioBuildError::StreamBuild(
+                    "audio worker closed channel before init".to_string(),
+                ))
+            }
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use aether_actor::Actor;
-    use aether_substrate::capability::{BootError, ChassisBuilder};
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::registry::Registry;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use aether_actor::Actor;
+        use aether_substrate::capability::{BootError, ChassisBuilder};
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::registry::Registry;
 
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            (registry, Arc::new(Mailer::new()))
         }
-        (registry, Arc::new(Mailer::new()))
-    }
 
-    #[test]
-    fn builtin_registry_covers_five_patches() {
-        assert_eq!(builtin_count(), 5);
-        assert_eq!(BUILTINS[0].name, "sine_lead");
-        assert_eq!(BUILTINS[4].name, "pluck");
-    }
+        #[test]
+        fn builtin_registry_covers_five_patches() {
+            assert_eq!(builtin_count(), 5);
+            assert_eq!(BUILTINS[0].name, "sine_lead");
+            assert_eq!(BUILTINS[4].name, "pluck");
+        }
 
-    #[test]
-    fn note_on_off_lifecycle() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        sender
-            .push(AudioEvent::NoteOn {
-                sender_mailbox: MailboxId(1),
-                pitch: 60,
-                velocity: 100,
-                instrument_id: 0,
-            })
-            .unwrap();
-        let mut buf = vec![0.0f32; 480];
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), 1);
-        assert!(buf.iter().any(|s| s.abs() > 0.0));
-
-        sender
-            .push(AudioEvent::NoteOff {
-                sender_mailbox: MailboxId(1),
-                pitch: 60,
-                instrument_id: 0,
-            })
-            .unwrap();
-        let release_samples = (0.5 * 48_000.0) as usize;
-        let mut tail = vec![0.0f32; release_samples];
-        synth.fill(&mut tail, 1);
-        assert_eq!(synth.voice_count(), 0);
-    }
-
-    #[test]
-    fn retrigger_same_key_replaces_voice() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        for _ in 0..3 {
+        #[test]
+        fn note_on_off_lifecycle() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
             sender
                 .push(AudioEvent::NoteOn {
                     sender_mailbox: MailboxId(1),
@@ -934,122 +914,154 @@ mod tests {
                     instrument_id: 0,
                 })
                 .unwrap();
-        }
-        let mut buf = vec![0.0f32; 128];
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), 1);
-    }
+            let mut buf = vec![0.0f32; 480];
+            synth.fill(&mut buf, 1);
+            assert_eq!(synth.voice_count(), 1);
+            assert!(buf.iter().any(|s| s.abs() > 0.0));
 
-    #[test]
-    fn different_senders_get_independent_voices() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        for mailbox in 1..=3 {
             sender
-                .push(AudioEvent::NoteOn {
-                    sender_mailbox: MailboxId(mailbox),
+                .push(AudioEvent::NoteOff {
+                    sender_mailbox: MailboxId(1),
                     pitch: 60,
-                    velocity: 100,
                     instrument_id: 0,
                 })
                 .unwrap();
+            let release_samples = (0.5 * 48_000.0) as usize;
+            let mut tail = vec![0.0f32; release_samples];
+            synth.fill(&mut tail, 1);
+            assert_eq!(synth.voice_count(), 0);
         }
-        let mut buf = vec![0.0f32; 128];
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), 3);
-    }
 
-    #[test]
-    fn set_master_gain_clamps_above_unity() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        sender
-            .push(AudioEvent::SetMasterGain { gain: 1.5 })
-            .unwrap();
-        let mut buf = vec![0.0f32; 64];
-        synth.fill(&mut buf, 1);
-        assert!((synth.master_gain_value() - 1.0).abs() < f32::EPSILON);
+        #[test]
+        fn retrigger_same_key_replaces_voice() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
+            for _ in 0..3 {
+                sender
+                    .push(AudioEvent::NoteOn {
+                        sender_mailbox: MailboxId(1),
+                        pitch: 60,
+                        velocity: 100,
+                        instrument_id: 0,
+                    })
+                    .unwrap();
+            }
+            let mut buf = vec![0.0f32; 128];
+            synth.fill(&mut buf, 1);
+            assert_eq!(synth.voice_count(), 1);
+        }
 
-        sender
-            .push(AudioEvent::SetMasterGain { gain: -0.2 })
-            .unwrap();
-        synth.fill(&mut buf, 1);
-        assert!(synth.master_gain_value().abs() < f32::EPSILON);
-    }
+        #[test]
+        fn different_senders_get_independent_voices() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
+            for mailbox in 1..=3 {
+                sender
+                    .push(AudioEvent::NoteOn {
+                        sender_mailbox: MailboxId(mailbox),
+                        pitch: 60,
+                        velocity: 100,
+                        instrument_id: 0,
+                    })
+                    .unwrap();
+            }
+            let mut buf = vec![0.0f32; 128];
+            synth.fill(&mut buf, 1);
+            assert_eq!(synth.voice_count(), 3);
+        }
 
-    #[test]
-    fn unknown_instrument_id_drops_note() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        sender
-            .push(AudioEvent::NoteOn {
-                sender_mailbox: MailboxId(1),
-                pitch: 60,
-                velocity: 100,
-                instrument_id: 99,
-            })
-            .unwrap();
-        let mut buf = vec![0.0f32; 64];
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), 0);
-    }
+        #[test]
+        fn set_master_gain_clamps_above_unity() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
+            sender
+                .push(AudioEvent::SetMasterGain { gain: 1.5 })
+                .unwrap();
+            let mut buf = vec![0.0f32; 64];
+            synth.fill(&mut buf, 1);
+            assert!((synth.master_gain_value() - 1.0).abs() < f32::EPSILON);
 
-    #[test]
-    fn voice_steal_caps_at_max_voices() {
-        let (sender, queue) = new_event_channel();
-        let mut synth = Synth::new(queue, 48_000.0);
-        for i in 0..(MAX_VOICES as u64 + 10) {
+            sender
+                .push(AudioEvent::SetMasterGain { gain: -0.2 })
+                .unwrap();
+            synth.fill(&mut buf, 1);
+            assert!(synth.master_gain_value().abs() < f32::EPSILON);
+        }
+
+        #[test]
+        fn unknown_instrument_id_drops_note() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
             sender
                 .push(AudioEvent::NoteOn {
-                    sender_mailbox: MailboxId(i + 1),
+                    sender_mailbox: MailboxId(1),
                     pitch: 60,
                     velocity: 100,
-                    instrument_id: 0,
+                    instrument_id: 99,
                 })
                 .unwrap();
+            let mut buf = vec![0.0f32; 64];
+            synth.fill(&mut buf, 1);
+            assert_eq!(synth.voice_count(), 0);
         }
-        let mut buf = vec![0.0f32; 64];
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), MAX_VOICES);
-    }
 
-    /// Boot the cap against a disabled config and confirm the
-    /// mailbox is registered. The dispatch path itself is exercised
-    /// by the synth tests above; this validates wiring.
-    #[test]
-    fn capability_boots_and_registers_mailbox() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<AudioCapability>(AudioConfig {
-                disabled: true,
-                ..AudioConfig::default()
-            })
-            .build()
-            .expect("audio capability boots");
-        assert!(
-            registry.lookup(AudioCapability::NAMESPACE).is_some(),
-            "audio mailbox registered"
-        );
-        chassis.shutdown();
-    }
+        #[test]
+        fn voice_steal_caps_at_max_voices() {
+            let (sender, queue) = new_event_channel();
+            let mut synth = Synth::new(queue, 48_000.0);
+            for i in 0..(MAX_VOICES as u64 + 10) {
+                sender
+                    .push(AudioEvent::NoteOn {
+                        sender_mailbox: MailboxId(i + 1),
+                        pitch: 60,
+                        velocity: 100,
+                        instrument_id: 0,
+                    })
+                    .unwrap();
+            }
+            let mut buf = vec![0.0f32; 64];
+            synth.fill(&mut buf, 1);
+            assert_eq!(synth.voice_count(), MAX_VOICES);
+        }
 
-    /// Builder rejects a duplicate claim.
-    #[test]
-    fn duplicate_claim_rejects_with_typed_error() {
-        let (registry, mailer) = fresh_substrate();
-        registry.register_sink(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+        /// Boot the cap against a disabled config and confirm the
+        /// mailbox is registered. The dispatch path itself is exercised
+        /// by the synth tests above; this validates wiring.
+        #[test]
+        fn capability_boots_and_registers_mailbox() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<AudioCapability>(AudioConfig {
+                    disabled: true,
+                    ..AudioConfig::default()
+                })
+                .build()
+                .expect("audio capability boots");
+            assert!(
+                registry.lookup(AudioCapability::NAMESPACE).is_some(),
+                "audio mailbox registered"
+            );
+            chassis.shutdown();
+        }
 
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<AudioCapability>(AudioConfig {
-                disabled: true,
-                ..AudioConfig::default()
-            })
-            .build()
-            .expect_err("collision must surface as BootError");
-        assert!(matches!(
-            err,
-            BootError::MailboxAlreadyClaimed { ref name }
-                if name == AudioCapability::NAMESPACE
-        ));
+        /// Builder rejects a duplicate claim.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            let (registry, mailer) = fresh_substrate();
+            registry.register_sink(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+
+            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<AudioCapability>(AudioConfig {
+                    disabled: true,
+                    ..AudioConfig::default()
+                })
+                .build()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == AudioCapability::NAMESPACE
+            ));
+        }
     }
 }

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -1,161 +1,140 @@
-//! Issue 552 stage 2: `aether.handle` cap migrated onto `NativeActor`.
-//! Pre-stage-2 the cap was an `Actor + Singleton + Dispatch` shape
-//! taking `&mut self` handlers with `sender: ReplyTo` parameters and
-//! routing replies through `self.mailer.send_reply(sender, &result)`.
-//! Stage 2 collapses that into the symmetric authoring shape:
-//! `#[capability] #[derive(Singleton)] struct + #[actor] impl
-//! NativeActor for X { type Config; fn init; #[handler] fn (&self,
-//! ctx: &mut NativeCtx<'_>, mail) }` — the same source shape wasm
-//! components write. Replies route through `ctx.reply(&result)`,
-//! which the per-mail `NativeCtx` walks back through the substrate's
-//! `Mailer::send_reply` to the originator (Component / Session /
-//! EngineMailbox / silent drop).
+//! `aether.handle` cap. Owns the substrate's `HandleStore` and routes
+//! ADR-0045 publish/release/pin/unpin requests via `ctx.reply(&result)`.
+//! Decode failure on a malformed payload goes through the macro miss
+//! path (warn-log, no reply, sender's `wait_reply` times out) —
+//! substrate-level invariant violation, not user-recoverable input.
 //!
-//! Owns the shared [`HandleStore`] (the same instance the substrate's
-//! `Mailer::wire_handle_store` references for `Ref<Handle>` resolution).
-//! The store now flows in through `NativeInitCtx::mailer().handle_store()`
-//! at boot — caps no longer need their own `new(store, mailer)`
-//! constructor; the chassis builder's `with_actor::<HandleCapability>(())`
+//! The handle store flows in through `NativeInitCtx::mailer().handle_store()`
+//! at boot; the chassis builder's `with_actor::<HandleCapability>(())`
 //! is the boot site.
 
-use aether_actor::{Singleton, actor, capability};
-// Kind imports split: handler-signature kinds stay always-on so the
-// macro-emitted `HandlesKind<K>` impls can reference them; reply-side
-// `*Result` + `HandleError` types are referenced only inside handler
-// bodies (gated by the macro emission), so they live in the
-// `native_only!` block below.
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
 use aether_kinds::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
 
-aether_actor::native_only! {
+#[aether_actor::bridge]
+mod native {
     use std::sync::Arc;
 
-    use aether_actor::MailCtx;
+    use super::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
+    use aether_actor::{MailCtx, actor};
     use aether_kinds::{
-        HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult,
-        HandleUnpinResult,
+        HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult, HandleUnpinResult,
     };
     use aether_substrate::capability::BootError;
     use aether_substrate::handle_store::{HandleStore, PutError};
     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-}
 
-/// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`
-/// and routes ADR-0045 publish/release/pin/unpin requests via
-/// `ctx.reply(&result)`. Decode failure on a malformed payload goes
-/// through the macro miss path (warn-log, no reply, sender's
-/// `wait_reply` times out) — substrate-level invariant violation, not
-/// user-recoverable input.
-#[capability]
-#[derive(Singleton)]
-pub struct HandleCapability {
-    store: Arc<HandleStore>,
-}
-
-#[actor]
-impl NativeActor for HandleCapability {
-    type Config = ();
-    /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
-    /// `aether.<name>` namespace.
-    const NAMESPACE: &'static str = "aether.handle";
-
-    /// Pull the shared [`HandleStore`] off the substrate's wired
-    /// [`aether_substrate::Mailer`]. The store is wired by `SubstrateBoot::build`
-    /// before the chassis builder runs, so a `None` here is a
-    /// substrate-level boot ordering bug rather than user input —
-    /// surface it as a `BootError`.
-    fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        let store = ctx
-            .mailer()
-            .handle_store()
-            .ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
-                    "HandleCapability::init: substrate Mailer has no HandleStore wired \
-                     (call wire_handle_store before chassis build)",
-                )))
-            })?
-            .clone();
-        Ok(Self { store })
+    /// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`.
+    pub struct HandleCapability {
+        store: Arc<HandleStore>,
     }
 
-    /// Publish bytes under a fresh handle id.
-    ///
-    /// # Agent
-    /// Reply: `HandlePublishResult`.
-    #[handler]
-    fn on_publish(&self, ctx: &mut NativeCtx<'_>, mail: HandlePublish) {
-        let id = self.store.next_ephemeral();
-        match self.store.put(id, mail.kind_id, mail.bytes) {
-            Ok(()) => {
-                // Hold a reference on behalf of the publishing
-                // component. Drop / explicit release decrements; on
-                // zero the entry stays in the store (subject to LRU
-                // eviction under pressure).
-                self.store.inc_ref(id);
-                ctx.reply(&HandlePublishResult::Ok {
-                    kind_id: mail.kind_id,
-                    id,
-                });
-            }
-            Err(e) => {
-                ctx.reply(&HandlePublishResult::Err {
-                    kind_id: mail.kind_id,
-                    error: put_error_to_handle_error(e),
-                });
+    #[actor]
+    impl NativeActor for HandleCapability {
+        type Config = ();
+        /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
+        /// `aether.<name>` namespace.
+        const NAMESPACE: &'static str = "aether.handle";
+
+        /// Pull the shared [`HandleStore`] off the substrate's wired
+        /// [`aether_substrate::Mailer`]. The store is wired by `SubstrateBoot::build`
+        /// before the chassis builder runs, so a `None` here is a
+        /// substrate-level boot ordering bug rather than user input —
+        /// surface it as a `BootError`.
+        fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let store = ctx
+                .mailer()
+                .handle_store()
+                .ok_or_else(|| {
+                    BootError::Other(Box::new(std::io::Error::other(
+                        "HandleCapability::init: substrate Mailer has no HandleStore wired \
+                         (call wire_handle_store before chassis build)",
+                    )))
+                })?
+                .clone();
+            Ok(Self { store })
+        }
+
+        /// Publish bytes under a fresh handle id.
+        ///
+        /// # Agent
+        /// Reply: `HandlePublishResult`.
+        #[handler]
+        fn on_publish(&self, ctx: &mut NativeCtx<'_>, mail: HandlePublish) {
+            let id = self.store.next_ephemeral();
+            match self.store.put(id, mail.kind_id, mail.bytes) {
+                Ok(()) => {
+                    // Hold a reference on behalf of the publishing
+                    // component. Drop / explicit release decrements;
+                    // on zero the entry stays in the store (subject
+                    // to LRU eviction under pressure).
+                    self.store.inc_ref(id);
+                    ctx.reply(&HandlePublishResult::Ok {
+                        kind_id: mail.kind_id,
+                        id,
+                    });
+                }
+                Err(e) => {
+                    ctx.reply(&HandlePublishResult::Err {
+                        kind_id: mail.kind_id,
+                        error: put_error_to_handle_error(e),
+                    });
+                }
             }
         }
-    }
 
-    /// Decrement a handle's refcount. SDK-side `Handle<K>::Drop`
-    /// fires this; explicit `Ctx::release` paths also use it.
-    ///
-    /// # Agent
-    /// Reply: `HandleReleaseResult`.
-    #[handler]
-    fn on_release(&self, ctx: &mut NativeCtx<'_>, mail: HandleRelease) {
-        if self.store.dec_ref(mail.id) {
-            ctx.reply(&HandleReleaseResult::Ok { id: mail.id });
-        } else {
-            ctx.reply(&HandleReleaseResult::Err {
-                id: mail.id,
-                error: HandleError::UnknownHandle,
-            });
+        /// Decrement a handle's refcount. SDK-side `Handle<K>::Drop`
+        /// fires this; explicit `Ctx::release` paths also use it.
+        ///
+        /// # Agent
+        /// Reply: `HandleReleaseResult`.
+        #[handler]
+        fn on_release(&self, ctx: &mut NativeCtx<'_>, mail: HandleRelease) {
+            if self.store.dec_ref(mail.id) {
+                ctx.reply(&HandleReleaseResult::Ok { id: mail.id });
+            } else {
+                ctx.reply(&HandleReleaseResult::Err {
+                    id: mail.id,
+                    error: HandleError::UnknownHandle,
+                });
+            }
+        }
+
+        /// Pin a handle so the LRU evictor skips it.
+        ///
+        /// # Agent
+        /// Reply: `HandlePinResult`.
+        #[handler]
+        fn on_pin(&self, ctx: &mut NativeCtx<'_>, mail: HandlePin) {
+            if self.store.pin(mail.id) {
+                ctx.reply(&HandlePinResult::Ok { id: mail.id });
+            } else {
+                ctx.reply(&HandlePinResult::Err {
+                    id: mail.id,
+                    error: HandleError::UnknownHandle,
+                });
+            }
+        }
+
+        /// Clear the pinned flag on a handle.
+        ///
+        /// # Agent
+        /// Reply: `HandleUnpinResult`.
+        #[handler]
+        fn on_unpin(&self, ctx: &mut NativeCtx<'_>, mail: HandleUnpin) {
+            if self.store.unpin(mail.id) {
+                ctx.reply(&HandleUnpinResult::Ok { id: mail.id });
+            } else {
+                ctx.reply(&HandleUnpinResult::Err {
+                    id: mail.id,
+                    error: HandleError::UnknownHandle,
+                });
+            }
         }
     }
 
-    /// Pin a handle so the LRU evictor skips it.
-    ///
-    /// # Agent
-    /// Reply: `HandlePinResult`.
-    #[handler]
-    fn on_pin(&self, ctx: &mut NativeCtx<'_>, mail: HandlePin) {
-        if self.store.pin(mail.id) {
-            ctx.reply(&HandlePinResult::Ok { id: mail.id });
-        } else {
-            ctx.reply(&HandlePinResult::Err {
-                id: mail.id,
-                error: HandleError::UnknownHandle,
-            });
-        }
-    }
-
-    /// Clear the pinned flag on a handle.
-    ///
-    /// # Agent
-    /// Reply: `HandleUnpinResult`.
-    #[handler]
-    fn on_unpin(&self, ctx: &mut NativeCtx<'_>, mail: HandleUnpin) {
-        if self.store.unpin(mail.id) {
-            ctx.reply(&HandleUnpinResult::Ok { id: mail.id });
-        } else {
-            ctx.reply(&HandleUnpinResult::Err {
-                id: mail.id,
-                error: HandleError::UnknownHandle,
-            });
-        }
-    }
-}
-
-aether_actor::native_only! {
     fn put_error_to_handle_error(e: PutError) -> HandleError {
         match e {
             PutError::EvictionFailed { .. } => HandleError::EvictionFailed,
@@ -167,154 +146,156 @@ aether_actor::native_only! {
             )),
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::sync::RwLock;
-    use std::sync::mpsc;
-    use std::thread;
-    use std::time::{Duration, Instant};
+    #[cfg(test)]
+    mod tests {
+        use std::collections::HashMap;
+        use std::sync::RwLock;
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::{Duration, Instant};
 
-    use aether_actor::Actor;
-    use aether_data::{HandleId, Kind, KindId};
-    use aether_data::{SessionToken, Uuid};
+        use aether_actor::Actor;
+        use aether_data::{HandleId, Kind, KindId};
+        use aether_data::{SessionToken, Uuid};
 
-    use super::*;
-    use aether_substrate::capability::{BootError, ChassisBuilder};
-    use aether_substrate::mail::{ReplyTarget, ReplyTo};
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::outbound::EgressEvent;
-    use aether_substrate::registry::{MailboxEntry, Registry};
+        use super::{
+            Arc, BootError, HandleCapability, HandlePublish, HandlePublishResult, HandleStore,
+        };
+        use aether_substrate::capability::ChassisBuilder;
+        use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::outbound::EgressEvent;
+        use aether_substrate::registry::{MailboxEntry, Registry};
 
-    fn fresh_substrate() -> (
-        Arc<HandleStore>,
-        Arc<Mailer>,
-        Arc<Registry>,
-        mpsc::Receiver<EgressEvent>,
-    ) {
-        let store = Arc::new(HandleStore::new(64 * 1024));
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
+        fn fresh_substrate() -> (
+            Arc<HandleStore>,
+            Arc<Mailer>,
+            Arc<Registry>,
+            mpsc::Receiver<EgressEvent>,
+        ) {
+            let store = Arc::new(HandleStore::new(64 * 1024));
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
+            let mailer = Arc::new(Mailer::new());
+            mailer.wire(Arc::clone(&registry), Arc::new(RwLock::new(HashMap::new())));
+            mailer.wire_outbound(outbound);
+            mailer.wire_handle_store(Arc::clone(&store));
+            (store, mailer, registry, rx)
         }
-        let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry), Arc::new(RwLock::new(HashMap::new())));
-        mailer.wire_outbound(outbound);
-        mailer.wire_handle_store(Arc::clone(&store));
-        (store, mailer, registry, rx)
-    }
 
-    fn session_reply_to() -> ReplyTo {
-        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
-    }
+        fn session_reply_to() -> ReplyTo {
+            ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
+        }
 
-    /// End-to-end through the cap: boot it via `with_actor`, push a
-    /// `HandlePublish` mail at the registered mailbox, the dispatcher
-    /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
-    /// which calls `on_publish`, the reply lands on the hub-outbound
-    /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
-    /// `Mailer::send_reply` → `outbound.send_reply`.
-    #[test]
-    fn capability_routes_publish_through_dispatcher_thread() {
-        let (store, mailer, registry, rx) = fresh_substrate();
+        /// End-to-end through the cap: boot it via `with_actor`, push a
+        /// `HandlePublish` mail at the registered mailbox, the dispatcher
+        /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
+        /// which calls `on_publish`, the reply lands on the hub-outbound
+        /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
+        /// `Mailer::send_reply` → `outbound.send_reply`.
+        #[test]
+        fn capability_routes_publish_through_dispatcher_thread() {
+            let (store, mailer, registry, rx) = fresh_substrate();
 
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<HandleCapability>(())
-            .build()
-            .expect("capability boots");
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<HandleCapability>(())
+                .build()
+                .expect("capability boots");
 
-        let id = registry
-            .lookup(HandleCapability::NAMESPACE)
-            .expect("mailbox registered");
-        let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
-            panic!("expected sink entry");
-        };
+            let id = registry
+                .lookup(HandleCapability::NAMESPACE)
+                .expect("mailbox registered");
+            let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
+                panic!("expected sink entry");
+            };
 
-        let req = HandlePublish {
-            kind_id: KindId(0xCAFE),
-            bytes: vec![1, 2, 3, 4, 5],
-        };
-        let bytes = postcard::to_allocvec(&req).unwrap();
-        handler(
-            <HandlePublish as Kind>::ID,
-            "aether.handle.publish",
-            None,
-            session_reply_to(),
-            &bytes,
-            1,
-        );
+            let req = HandlePublish {
+                kind_id: KindId(0xCAFE),
+                bytes: vec![1, 2, 3, 4, 5],
+            };
+            let bytes = postcard::to_allocvec(&req).unwrap();
+            handler(
+                <HandlePublish as Kind>::ID,
+                "aether.handle.publish",
+                None,
+                session_reply_to(),
+                &bytes,
+                1,
+            );
 
-        let deadline = Instant::now() + Duration::from_secs(2);
-        let frame = loop {
-            if let Ok(f) = rx.try_recv() {
-                break f;
-            }
-            if Instant::now() >= deadline {
-                panic!("publish reply did not arrive within deadline");
-            }
-            thread::sleep(Duration::from_millis(5));
-        };
-        let payload = match frame {
-            EgressEvent::ToSession { payload, .. } | EgressEvent::Broadcast { payload, .. } => {
-                payload
-            }
-            other => panic!("expected ToSession/Broadcast egress, got {other:?}"),
-        };
-        let result: HandlePublishResult = postcard::from_bytes(&payload).unwrap();
-        let HandlePublishResult::Ok {
-            kind_id,
-            id: handle_id,
-        } = result
-        else {
-            panic!("expected Ok, got {result:?}");
-        };
-        assert_eq!(kind_id, KindId(0xCAFE));
-        assert_ne!(handle_id, HandleId(0));
-        let (stored_kind, stored_bytes) = store.get(handle_id).unwrap();
-        assert_eq!(stored_kind, KindId(0xCAFE));
-        assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let frame = loop {
+                if let Ok(f) = rx.try_recv() {
+                    break f;
+                }
+                if Instant::now() >= deadline {
+                    panic!("publish reply did not arrive within deadline");
+                }
+                thread::sleep(Duration::from_millis(5));
+            };
+            let payload = match frame {
+                EgressEvent::ToSession { payload, .. } | EgressEvent::Broadcast { payload, .. } => {
+                    payload
+                }
+                other => panic!("expected ToSession/Broadcast egress, got {other:?}"),
+            };
+            let result: HandlePublishResult = postcard::from_bytes(&payload).unwrap();
+            let HandlePublishResult::Ok {
+                kind_id,
+                id: handle_id,
+            } = result
+            else {
+                panic!("expected Ok, got {result:?}");
+            };
+            assert_eq!(kind_id, KindId(0xCAFE));
+            assert_ne!(handle_id, HandleId(0));
+            let (stored_kind, stored_bytes) = store.get(handle_id).unwrap();
+            assert_eq!(stored_kind, KindId(0xCAFE));
+            assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
 
-        chassis.shutdown();
-    }
+            chassis.shutdown();
+        }
 
-    /// Channel-drop shutdown: drop the chassis, the cap's dispatcher
-    /// thread exits within a generous deadline.
-    #[test]
-    fn shutdown_joins_dispatcher_thread() {
-        let (_store, mailer, registry, _rx) = fresh_substrate();
+        /// Channel-drop shutdown: drop the chassis, the cap's dispatcher
+        /// thread exits within a generous deadline.
+        #[test]
+        fn shutdown_joins_dispatcher_thread() {
+            let (_store, mailer, registry, _rx) = fresh_substrate();
 
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<HandleCapability>(())
-            .build()
-            .expect("capability boots");
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<HandleCapability>(())
+                .build()
+                .expect("capability boots");
 
-        let start = Instant::now();
-        chassis.shutdown();
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_millis(500),
-            "shutdown should complete promptly via channel-drop (took {elapsed:?})"
-        );
-    }
+            let start = Instant::now();
+            chassis.shutdown();
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed < Duration::from_millis(500),
+                "shutdown should complete promptly via channel-drop (took {elapsed:?})"
+            );
+        }
 
-    /// Builder rejects a duplicate claim if the well-known mailbox
-    /// name was already registered.
-    #[test]
-    fn duplicate_claim_rejects_with_typed_error() {
-        let (_store, mailer, registry, _rx) = fresh_substrate();
-        registry.register_sink(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+        /// Builder rejects a duplicate claim if the well-known mailbox
+        /// name was already registered.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            let (_store, mailer, registry, _rx) = fresh_substrate();
+            registry.register_sink(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<HandleCapability>(())
-            .build()
-            .expect_err("collision must surface as BootError");
-        assert!(matches!(
-            err,
-            BootError::MailboxAlreadyClaimed { ref name }
-                if name == HandleCapability::NAMESPACE
-        ));
+            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<HandleCapability>(())
+                .build()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == HandleCapability::NAMESPACE
+            ));
+        }
     }
 }

--- a/crates/aether-capabilities/src/io.rs
+++ b/crates/aether-capabilities/src/io.rs
@@ -1,23 +1,13 @@
-//! Issue 552 stage 2: `aether.io` cap migrated onto `NativeActor`.
-//! Pre-stage-2 the cap was an `Actor + Singleton + Dispatch` shape
-//! taking `&mut self` handlers with `sender: ReplyTo` parameters and
-//! routing replies through `self.mailer.send_reply(sender, &result)`.
-//! Stage 2 collapses that into the symmetric authoring shape:
-//! `#[derive(Singleton)] struct + #[actor] impl NativeActor for X
-//! { type Config = NamespaceRoots; fn init; #[handler] fn (&self,
-//! ctx: &mut NativeCtx<'_>, mail) }`. Replies route via
-//! `ctx.reply(&result)`.
-//!
-//! Owns the full ADR-0041 stack — `FileAdapter` trait,
+//! `aether.io` cap. Owns the full ADR-0041 stack — `FileAdapter` trait,
 //! `LocalFileAdapter`, `AdapterRegistry`, env-driven `NamespaceRoots`,
 //! and the [`IoCapability`] itself. Chassis mains resolve a
-//! [`NamespaceRoots`] (typically via [`NamespaceRoots::from_env`])
-//! and pass it through `with_actor::<IoCapability>(roots)` —
-//! `init` builds the adapter registry and returns `BootError` on
-//! failure (per ADR-0063 fail-fast).
+//! [`NamespaceRoots`] (typically via [`NamespaceRoots::from_env`]) and
+//! pass it through `with_actor::<IoCapability>(roots)` — `init` builds
+//! the adapter registry and returns `BootError` on failure (per
+//! ADR-0063 fail-fast).
 //!
-//! Threading: the new actor dispatcher thread pulls envelopes from
-//! the `aether.io` mailbox and routes them through the macro-emitted
+//! Threading: the actor dispatcher thread pulls envelopes from the
+//! `aether.io` mailbox and routes them through the macro-emitted
 //! `NativeDispatch::__aether_dispatch_envelope`. Adapter calls run
 //! synchronously on that thread; ADR-0041 flagged a future host-fn
 //! fast path for asset-sized streaming.
@@ -27,18 +17,10 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use aether_actor::{Singleton, actor, capability};
-// Kind imports split: handler-signature kinds stay always-on so the
-// macro-emitted `HandlesKind<K>` impls can reference them; reply-side
-// `*Result` types are body-only and live in the `native_only!` block.
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
 use aether_kinds::{Delete, IoError, List, Read, Write};
-
-aether_actor::native_only! {
-    use aether_actor::MailCtx;
-    use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
-    use aether_substrate::capability::BootError;
-    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-}
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `IoError` map directly onto ADR-0041 §1's reply enums, so the
@@ -233,64 +215,6 @@ pub struct NamespaceRoots {
     pub config: PathBuf,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl NamespaceRoots {
-    /// Resolve each root from its env-var override, falling back to
-    /// the `dirs`-crate platform default. v1 ships the env layer;
-    /// ADR-0041's precedence order (CLI > env > TOML > defaults)
-    /// leaves room for TOML and CLI to sit in front of this without
-    /// changing the cap or adapter code.
-    ///
-    /// Defaults:
-    /// - `save` → `data_dir()/aether/save`
-    /// - `assets` → `{current_exe}/../assets`
-    /// - `config` → `config_dir()/aether`
-    ///
-    /// If a platform directory lookup fails (e.g. no HOME) or
-    /// `current_exe()` can't resolve, the fallback is `temp_dir()/aether/...`
-    /// so a boot always finishes even on headless CI.
-    ///
-    /// Per issue 464, this is the chassis-main edge — substrate-core
-    /// itself never reads env. The builder
-    /// (`SubstrateBootBuilder::namespace_roots`) accepts a resolved
-    /// `NamespaceRoots` directly so tests and chassis-as-library
-    /// embedders can supply their own roots without process-env
-    /// mutation.
-    pub fn from_env() -> Self {
-        let save = env_or_default("AETHER_SAVE_DIR", || {
-            dirs::data_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join("aether")
-                .join("save")
-        });
-        let assets = env_or_default("AETHER_ASSETS_DIR", || {
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(Path::to_path_buf))
-                .map(|p| p.join("assets"))
-                .unwrap_or_else(|| std::env::temp_dir().join("aether").join("assets"))
-        });
-        let config = env_or_default("AETHER_CONFIG_DIR", || {
-            dirs::config_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join("aether")
-        });
-        Self {
-            save,
-            assets,
-            config,
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
-    match std::env::var(var) {
-        Ok(s) if !s.is_empty() => PathBuf::from(s),
-        _ => default(),
-    }
-}
-
 /// Populate a fresh `AdapterRegistry` with `LocalFileAdapter`s for
 /// each of the three ADR-0041 namespaces using the supplied
 /// [`NamespaceRoots`]. `save` and `config` are writable; `assets` is
@@ -310,735 +234,798 @@ pub fn build_registry(
     Ok((Arc::new(registry), roots))
 }
 
-/// Env-driven wrapper around [`build_registry`]. Resolves
-/// [`NamespaceRoots::from_env`] then delegates.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn build_default_registry() -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
-    build_registry(NamespaceRoots::from_env())
-}
+#[aether_actor::bridge]
+mod native {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
-/// `aether.io` mailbox cap. Owns the resolved adapter registry +
-/// namespace roots. The dispatcher thread holds an `Arc<Self>` and
-/// routes envelopes through the macro-emitted `NativeDispatch` impl;
-/// replies route via `ctx.reply(&result)` through the substrate's
-/// `Mailer::send_reply`.
-#[capability]
-#[derive(Singleton)]
-pub struct IoCapability {
-    registry: Arc<AdapterRegistry>,
-}
+    use super::{
+        AdapterRegistry, Delete, IoError, List, NamespaceRoots, Read, Write, build_registry,
+    };
+    use aether_actor::{MailCtx, actor};
+    use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
-#[actor]
-impl NativeActor for IoCapability {
-    /// Resolved namespace roots threaded through to `init`. Chassis
-    /// mains build this via [`NamespaceRoots::from_env`] (or hand-roll
-    /// for tests) and pass to `with_actor::<IoCapability>(roots)`.
-    type Config = NamespaceRoots;
-
-    /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
-    const NAMESPACE: &'static str = "aether.io";
-
-    /// Build the adapter registry from the resolved roots. Adapter
-    /// init failure surfaces as `BootError::Other(io::Error)` so
-    /// chassis mains propagate via `?` to abort startup (ADR-0063
-    /// fail-fast).
-    fn init(roots: NamespaceRoots, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        let (registry, roots) = build_registry(roots).map_err(|e| BootError::Other(Box::new(e)))?;
-        tracing::info!(
-            target: "aether_substrate::io",
-            save = %roots.save.display(),
-            assets = %roots.assets.display(),
-            config = %roots.config.display(),
-            "io adapters registered",
-        );
-        Ok(Self { registry })
-    }
-
-    /// Read bytes from a logical namespace path.
-    ///
-    /// # Agent
-    /// Reply: `ReadResult`. Echoes namespace + path on both arms.
-    #[handler]
-    fn on_read(&self, ctx: &mut NativeCtx<'_>, mail: Read) {
-        let Some(adapter) = self.registry.get(&mail.namespace) else {
-            ctx.reply(&ReadResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error: IoError::UnknownNamespace,
+    impl NamespaceRoots {
+        /// Resolve each root from its env-var override, falling back to
+        /// the `dirs`-crate platform default. v1 ships the env layer;
+        /// ADR-0041's precedence order (CLI > env > TOML > defaults)
+        /// leaves room for TOML and CLI to sit in front of this without
+        /// changing the cap or adapter code.
+        ///
+        /// Defaults:
+        /// - `save` → `data_dir()/aether/save`
+        /// - `assets` → `{current_exe}/../assets`
+        /// - `config` → `config_dir()/aether`
+        ///
+        /// If a platform directory lookup fails (e.g. no HOME) or
+        /// `current_exe()` can't resolve, the fallback is `temp_dir()/aether/...`
+        /// so a boot always finishes even on headless CI.
+        ///
+        /// Per issue 464, this is the chassis-main edge — substrate-core
+        /// itself never reads env. The builder
+        /// (`SubstrateBootBuilder::namespace_roots`) accepts a resolved
+        /// `NamespaceRoots` directly so tests and chassis-as-library
+        /// embedders can supply their own roots without process-env
+        /// mutation.
+        pub fn from_env() -> Self {
+            let save = env_or_default("AETHER_SAVE_DIR", || {
+                dirs::data_dir()
+                    .unwrap_or_else(std::env::temp_dir)
+                    .join("aether")
+                    .join("save")
             });
-            return;
-        };
-        let reply = match adapter.read(&mail.path) {
-            Ok(bytes) => ReadResult::Ok {
-                namespace: mail.namespace,
-                path: mail.path,
-                bytes,
-            },
-            Err(error) => ReadResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error,
-            },
-        };
-        ctx.reply(&reply);
-    }
-
-    /// Write bytes to a logical namespace path. Atomic via tmp+rename
-    /// in the local file adapter; semantics may differ in future
-    /// adapters (cloud, in-memory).
-    ///
-    /// # Agent
-    /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
-    #[handler]
-    fn on_write(&self, ctx: &mut NativeCtx<'_>, mail: Write) {
-        let Some(adapter) = self.registry.get(&mail.namespace) else {
-            ctx.reply(&WriteResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error: IoError::UnknownNamespace,
+            let assets = env_or_default("AETHER_ASSETS_DIR", || {
+                std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.parent().map(Path::to_path_buf))
+                    .map(|p| p.join("assets"))
+                    .unwrap_or_else(|| std::env::temp_dir().join("aether").join("assets"))
             });
-            return;
-        };
-        let reply = match adapter.write(&mail.path, &mail.bytes) {
-            Ok(()) => WriteResult::Ok {
-                namespace: mail.namespace,
-                path: mail.path,
-            },
-            Err(error) => WriteResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error,
-            },
-        };
-        ctx.reply(&reply);
-    }
-
-    /// Delete a path under a namespace.
-    ///
-    /// # Agent
-    /// Reply: `DeleteResult`. Echoes namespace + path.
-    #[handler]
-    fn on_delete(&self, ctx: &mut NativeCtx<'_>, mail: Delete) {
-        let Some(adapter) = self.registry.get(&mail.namespace) else {
-            ctx.reply(&DeleteResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error: IoError::UnknownNamespace,
+            let config = env_or_default("AETHER_CONFIG_DIR", || {
+                dirs::config_dir()
+                    .unwrap_or_else(std::env::temp_dir)
+                    .join("aether")
             });
-            return;
-        };
-        let reply = match adapter.delete(&mail.path) {
-            Ok(()) => DeleteResult::Ok {
-                namespace: mail.namespace,
-                path: mail.path,
-            },
-            Err(error) => DeleteResult::Err {
-                namespace: mail.namespace,
-                path: mail.path,
-                error,
-            },
-        };
-        ctx.reply(&reply);
-    }
-
-    /// List entries under a namespace prefix.
-    ///
-    /// # Agent
-    /// Reply: `ListResult`. Echoes namespace + prefix.
-    #[handler]
-    fn on_list(&self, ctx: &mut NativeCtx<'_>, mail: List) {
-        let Some(adapter) = self.registry.get(&mail.namespace) else {
-            ctx.reply(&ListResult::Err {
-                namespace: mail.namespace,
-                prefix: mail.prefix,
-                error: IoError::UnknownNamespace,
-            });
-            return;
-        };
-        let reply = match adapter.list(&mail.prefix) {
-            Ok(entries) => ListResult::Ok {
-                namespace: mail.namespace,
-                prefix: mail.prefix,
-                entries,
-            },
-            Err(error) => ListResult::Err {
-                namespace: mail.namespace,
-                prefix: mail.prefix,
-                error,
-            },
-        };
-        ctx.reply(&reply);
-    }
-}
-
-#[cfg(test)]
-impl IoCapability {
-    /// Test-only direct constructor. Production boots through
-    /// `Builder::with_actor::<IoCapability>(roots)` which calls `init`;
-    /// tests that want to drive handlers without spinning up a full
-    /// chassis hand a pre-built registry directly.
-    pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
-        Self { registry }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::env::temp_dir;
-
-    use super::*;
-    use aether_actor::Actor;
-    use aether_data::MailboxId;
-    use aether_substrate::capability::{BootError, ChassisBuilder};
-    use aether_substrate::mail::ReplyTo;
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::native_actor::NativeCtx;
-    use aether_substrate::native_transport::NativeTransport;
-    use aether_substrate::registry::Registry;
-
-    /// Test fixture that bundles the cap, a fully-wired test mailer,
-    /// and a `NativeTransport` long enough for handlers to borrow.
-    /// Pre-stage-2 the tests called `cap.on_read(sender, mail)`
-    /// directly; the new shape requires a `NativeCtx` borrowed from a
-    /// transport, so the fixture owns the transport and hands out
-    /// fresh ctxs per invocation.
-    struct TestFixture {
-        cap: IoCapability,
-        rx: std::sync::mpsc::Receiver<EgressEvent>,
-        transport: NativeTransport,
-    }
-
-    impl TestFixture {
-        fn new(reg: Arc<AdapterRegistry>) -> Self {
-            let (mailer, rx) = test_mailer_and_rx();
-            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
             Self {
-                cap: IoCapability::from_registry(reg),
-                rx,
-                transport,
+                save,
+                assets,
+                config,
             }
         }
+    }
 
-        fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
-            NativeCtx::new(&self.transport, sender)
+    fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
+        match std::env::var(var) {
+            Ok(s) if !s.is_empty() => PathBuf::from(s),
+            _ => default(),
         }
     }
 
-    /// Manual tempdir helper to avoid pulling in the `tempfile`
-    /// crate. Caller cleans up via [`cleanup`] after the test asserts.
-    fn scratch_root(tag: &str) -> PathBuf {
-        let pid = std::process::id();
-        let nonce: u64 = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0);
-        let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
-        std::fs::create_dir_all(&path).unwrap();
-        path
+    /// `aether.io` mailbox cap. Owns the resolved adapter registry +
+    /// namespace roots. The dispatcher thread holds an `Arc<Self>` and
+    /// routes envelopes through the macro-emitted `NativeDispatch` impl;
+    /// replies route via `ctx.reply(&result)` through the substrate's
+    /// `Mailer::send_reply`.
+    pub struct IoCapability {
+        registry: Arc<AdapterRegistry>,
     }
 
-    fn cleanup(path: &Path) {
-        let _ = std::fs::remove_dir_all(path);
-    }
+    #[actor]
+    impl NativeActor for IoCapability {
+        /// Resolved namespace roots threaded through to `init`. Chassis
+        /// mains build this via [`NamespaceRoots::from_env`] (or hand-roll
+        /// for tests) and pass to `with_actor::<IoCapability>(roots)`.
+        type Config = NamespaceRoots;
 
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
+        /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
+        const NAMESPACE: &'static str = "aether.io";
+
+        /// Build the adapter registry from the resolved roots. Adapter
+        /// init failure surfaces as `BootError::Other(io::Error)` so
+        /// chassis mains propagate via `?` to abort startup (ADR-0063
+        /// fail-fast).
+        fn init(roots: NamespaceRoots, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let (registry, roots) =
+                build_registry(roots).map_err(|e| BootError::Other(Box::new(e)))?;
+            tracing::info!(
+                target: "aether_substrate::io",
+                save = %roots.save.display(),
+                assets = %roots.assets.display(),
+                config = %roots.config.display(),
+                "io adapters registered",
+            );
+            Ok(Self { registry })
         }
-        (registry, Arc::new(Mailer::new()))
+
+        /// Read bytes from a logical namespace path.
+        ///
+        /// # Agent
+        /// Reply: `ReadResult`. Echoes namespace + path on both arms.
+        #[handler]
+        fn on_read(&self, ctx: &mut NativeCtx<'_>, mail: Read) {
+            let Some(adapter) = self.registry.get(&mail.namespace) else {
+                ctx.reply(&ReadResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                });
+                return;
+            };
+            let reply = match adapter.read(&mail.path) {
+                Ok(bytes) => ReadResult::Ok {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    bytes,
+                },
+                Err(error) => ReadResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error,
+                },
+            };
+            ctx.reply(&reply);
+        }
+
+        /// Write bytes to a logical namespace path. Atomic via tmp+rename
+        /// in the local file adapter; semantics may differ in future
+        /// adapters (cloud, in-memory).
+        ///
+        /// # Agent
+        /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
+        #[handler]
+        fn on_write(&self, ctx: &mut NativeCtx<'_>, mail: Write) {
+            let Some(adapter) = self.registry.get(&mail.namespace) else {
+                ctx.reply(&WriteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                });
+                return;
+            };
+            let reply = match adapter.write(&mail.path, &mail.bytes) {
+                Ok(()) => WriteResult::Ok {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                },
+                Err(error) => WriteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error,
+                },
+            };
+            ctx.reply(&reply);
+        }
+
+        /// Delete a path under a namespace.
+        ///
+        /// # Agent
+        /// Reply: `DeleteResult`. Echoes namespace + path.
+        #[handler]
+        fn on_delete(&self, ctx: &mut NativeCtx<'_>, mail: Delete) {
+            let Some(adapter) = self.registry.get(&mail.namespace) else {
+                ctx.reply(&DeleteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error: IoError::UnknownNamespace,
+                });
+                return;
+            };
+            let reply = match adapter.delete(&mail.path) {
+                Ok(()) => DeleteResult::Ok {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                },
+                Err(error) => DeleteResult::Err {
+                    namespace: mail.namespace,
+                    path: mail.path,
+                    error,
+                },
+            };
+            ctx.reply(&reply);
+        }
+
+        /// List entries under a namespace prefix.
+        ///
+        /// # Agent
+        /// Reply: `ListResult`. Echoes namespace + prefix.
+        #[handler]
+        fn on_list(&self, ctx: &mut NativeCtx<'_>, mail: List) {
+            let Some(adapter) = self.registry.get(&mail.namespace) else {
+                ctx.reply(&ListResult::Err {
+                    namespace: mail.namespace,
+                    prefix: mail.prefix,
+                    error: IoError::UnknownNamespace,
+                });
+                return;
+            };
+            let reply = match adapter.list(&mail.prefix) {
+                Ok(entries) => ListResult::Ok {
+                    namespace: mail.namespace,
+                    prefix: mail.prefix,
+                    entries,
+                },
+                Err(error) => ListResult::Err {
+                    namespace: mail.namespace,
+                    prefix: mail.prefix,
+                    error,
+                },
+            };
+            ctx.reply(&reply);
+        }
     }
 
-    fn roots_under(root: &Path) -> NamespaceRoots {
-        let r = NamespaceRoots {
-            save: root.join("save"),
-            assets: root.join("assets"),
-            config: root.join("config"),
+    #[cfg(test)]
+    impl IoCapability {
+        /// Test-only direct constructor. Production boots through
+        /// `Builder::with_actor::<IoCapability>(roots)` which calls `init`;
+        /// tests that want to drive handlers without spinning up a full
+        /// chassis hand a pre-built registry directly.
+        pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
+            Self { registry }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::env::temp_dir;
+
+        use super::super::{
+            AdapterRegistry, Delete, FileAdapter, IoError, List, LocalFileAdapter, NamespaceRoots,
+            Read, Write,
         };
-        std::fs::create_dir_all(&r.save).unwrap();
-        std::fs::create_dir_all(&r.assets).unwrap();
-        std::fs::create_dir_all(&r.config).unwrap();
-        r
-    }
+        use super::{Arc, IoCapability, Path, PathBuf};
+        use aether_actor::Actor;
+        use aether_data::MailboxId;
+        use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
+        use aether_substrate::capability::{BootError, ChassisBuilder};
+        use aether_substrate::mail::ReplyTo;
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::native_actor::NativeCtx;
+        use aether_substrate::native_transport::NativeTransport;
+        use aether_substrate::registry::Registry;
 
-    #[test]
-    fn resolve_rejects_parent_traversal() {
-        let root = scratch_root("resolve-parent");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.read("../etc/passwd"), Err(IoError::Forbidden)));
-        assert!(matches!(
-            a.read("sub/../../escape"),
-            Err(IoError::Forbidden)
-        ));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn resolve_rejects_absolute() {
-        let root = scratch_root("resolve-abs");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.read("/etc/passwd"), Err(IoError::Forbidden)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn resolve_permits_dot_segments() {
-        let root = scratch_root("resolve-dot");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.read("./nonexistent"), Err(IoError::NotFound)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn read_missing_file_returns_not_found() {
-        let root = scratch_root("read-missing");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.read("slot.bin"), Err(IoError::NotFound)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn write_then_read_roundtrip() {
-        let root = scratch_root("write-read");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("slot.bin", &[1, 2, 3, 4]).unwrap();
-        assert_eq!(a.read("slot.bin").unwrap(), vec![1, 2, 3, 4]);
-        cleanup(&root);
-    }
-
-    #[test]
-    fn write_creates_parent_directories() {
-        let root = scratch_root("write-parents");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("deep/sub/dir/slot.bin", b"hi").unwrap();
-        assert_eq!(a.read("deep/sub/dir/slot.bin").unwrap(), b"hi");
-        cleanup(&root);
-    }
-
-    #[test]
-    fn write_is_atomic_no_tmp_left_behind() {
-        let root = scratch_root("write-atomic");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("slot.bin", &[0u8; 16]).unwrap();
-        let siblings: Vec<String> = std::fs::read_dir(a.root())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
-            .collect();
-        assert!(
-            !siblings.iter().any(|s| s.contains(".tmp-")),
-            "unexpected tmp file left behind: {siblings:?}",
-        );
-        cleanup(&root);
-    }
-
-    #[test]
-    fn write_on_read_only_returns_forbidden() {
-        let root = scratch_root("write-readonly");
-        let a = LocalFileAdapter::new(root.clone(), false).unwrap();
-        assert!(matches!(a.write("x.bin", &[]), Err(IoError::Forbidden)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn delete_missing_returns_not_found() {
-        let root = scratch_root("delete-missing");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.delete("ghost.bin"), Err(IoError::NotFound)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn delete_removes_file() {
-        let root = scratch_root("delete-works");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("slot.bin", b"x").unwrap();
-        a.delete("slot.bin").unwrap();
-        assert!(matches!(a.read("slot.bin"), Err(IoError::NotFound)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn delete_on_read_only_returns_forbidden() {
-        let root = scratch_root("delete-readonly");
-        let a = LocalFileAdapter::new(root.clone(), false).unwrap();
-        assert!(matches!(a.delete("x.bin"), Err(IoError::Forbidden)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn list_empty_root_returns_empty_vec() {
-        let root = scratch_root("list-empty");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert_eq!(a.list("").unwrap(), Vec::<String>::new());
-        cleanup(&root);
-    }
-
-    #[test]
-    fn list_returns_sorted_names_at_root() {
-        let root = scratch_root("list-root");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("c.bin", b"").unwrap();
-        a.write("a.bin", b"").unwrap();
-        a.write("b.bin", b"").unwrap();
-        assert_eq!(a.list("").unwrap(), vec!["a.bin", "b.bin", "c.bin"]);
-        cleanup(&root);
-    }
-
-    #[test]
-    fn list_under_subdirectory() {
-        let root = scratch_root("list-sub");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        a.write("saves/slot1.bin", b"").unwrap();
-        a.write("saves/slot2.bin", b"").unwrap();
-        a.write("cfg/keys.toml", b"").unwrap();
-        let saves = a.list("saves").unwrap();
-        assert_eq!(saves, vec!["slot1.bin", "slot2.bin"]);
-        cleanup(&root);
-    }
-
-    #[test]
-    fn list_missing_directory_returns_not_found() {
-        let root = scratch_root("list-missing");
-        let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-        assert!(matches!(a.list("nope"), Err(IoError::NotFound)));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn registry_returns_none_for_unknown_namespace() {
-        let reg = AdapterRegistry::new();
-        assert!(reg.get("save").is_none());
-        assert!(!reg.has("save"));
-    }
-
-    #[test]
-    fn registry_registers_and_retrieves_adapter() {
-        let root = scratch_root("reg-basic");
-        let adapter: Arc<dyn FileAdapter> =
-            Arc::new(LocalFileAdapter::new(root.clone(), true).unwrap());
-        let mut reg = AdapterRegistry::new();
-        reg.register("save", adapter);
-        assert!(reg.has("save"));
-        assert!(reg.get("save").is_some());
-        cleanup(&root);
-    }
-
-    use aether_data::{SessionToken, Uuid};
-    use aether_substrate::outbound::EgressEvent;
-
-    fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
-        let adapter: Arc<dyn FileAdapter> =
-            Arc::new(LocalFileAdapter::new(root.to_path_buf(), writable).unwrap());
-        let mut r = AdapterRegistry::new();
-        r.register("save", adapter);
-        Arc::new(r)
-    }
-
-    fn session_sender() -> ReplyTo {
-        ReplyTo::to(aether_substrate::mail::ReplyTarget::Session(SessionToken(
-            Uuid::nil(),
-        )))
-    }
-
-    /// Build a fully-wired `Mailer` connected to a fresh test
-    /// outbound channel.
-    fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
-        use std::collections::HashMap;
-        use std::sync::RwLock;
-
-        let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(
-            Arc::new(Registry::new()),
-            Arc::new(RwLock::new(HashMap::new())),
-        );
-        mailer.wire_outbound(outbound);
-        (mailer, rx)
-    }
-
-    fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
-        rx: &std::sync::mpsc::Receiver<EgressEvent>,
-    ) -> K {
-        let event = rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap();
-        let EgressEvent::ToSession {
-            kind_name, payload, ..
-        } = event
-        else {
-            panic!("expected ToSession egress, got {event:?}");
-        };
-        assert_eq!(kind_name, K::NAME);
-        postcard::from_bytes(&payload).unwrap()
-    }
-
-    /// Boot the cap against a fresh tempdir; assert the mailbox
-    /// is registered.
-    #[test]
-    fn capability_boots_and_registers_mailbox() {
-        let root = scratch_root("boots");
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<IoCapability>(roots_under(&root))
-            .build()
-            .expect("io capability boots");
-        assert!(
-            registry.lookup(IoCapability::NAMESPACE).is_some(),
-            "io mailbox registered"
-        );
-        chassis.shutdown();
-        cleanup(&root);
-    }
-
-    /// Cap init fails when the adapter registry can't be built —
-    /// provoke `LocalFileAdapter::new` failure by pointing the save
-    /// root at a regular file rather than a directory. `init` returns
-    /// `BootError::Other(io::Error)`, the chassis builder propagates.
-    #[test]
-    fn cap_init_fails_when_adapter_init_fails() {
-        let root = scratch_root("init-fails");
-        let save_path = root.join("save_is_actually_a_file");
-        std::fs::write(&save_path, b"not a dir").unwrap();
-        let roots = NamespaceRoots {
-            save: save_path,
-            assets: root.join("assets"),
-            config: root.join("config"),
-        };
-        std::fs::create_dir_all(&roots.assets).unwrap();
-        std::fs::create_dir_all(&roots.config).unwrap();
-
-        let (registry, mailer) = fresh_substrate();
-        let result = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<IoCapability>(roots)
-            .build();
-        assert!(result.is_err(), "save root being a file must fail cap init");
-        cleanup(&root);
-    }
-
-    /// Builder rejects a duplicate claim. Same protection as the
-    /// other capabilities.
-    #[test]
-    fn duplicate_claim_rejects_with_typed_error() {
-        let root = scratch_root("collide");
-        let (registry, mailer) = fresh_substrate();
-        registry.register_sink(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
-
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<IoCapability>(roots_under(&root))
-            .build()
-            .expect_err("collision must surface as BootError");
-        assert!(matches!(
-            err,
-            BootError::MailboxAlreadyClaimed { ref name }
-                if name == IoCapability::NAMESPACE
-        ));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn cap_read_ok_replies_with_bytes() {
-        let root = scratch_root("cap-read");
-        let reg = build_save_only_registry(&root, true);
-        reg.get("save")
-            .unwrap()
-            .write("slot.bin", &[9, 9, 9])
-            .unwrap();
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_read(
-            &mut ctx,
-            Read {
-                namespace: "save".to_string(),
-                path: "slot.bin".to_string(),
-            },
-        );
-        match decode_reply::<ReadResult>(&fix.rx) {
-            ReadResult::Ok {
-                namespace,
-                path,
-                bytes,
-            } => {
-                assert_eq!(namespace, "save");
-                assert_eq!(path, "slot.bin");
-                assert_eq!(bytes, vec![9, 9, 9]);
-            }
-            ReadResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+        /// Test fixture that bundles the cap, a fully-wired test mailer,
+        /// and a `NativeTransport` long enough for handlers to borrow.
+        struct TestFixture {
+            cap: IoCapability,
+            rx: std::sync::mpsc::Receiver<EgressEvent>,
+            transport: NativeTransport,
         }
-        cleanup(&root);
-    }
 
-    #[test]
-    fn cap_read_unknown_namespace_replies_err() {
-        let root = scratch_root("cap-ns");
-        let reg = build_save_only_registry(&root, true);
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_read(
-            &mut ctx,
-            Read {
-                namespace: "nope".to_string(),
-                path: "x.bin".to_string(),
-            },
-        );
-        match decode_reply::<ReadResult>(&fix.rx) {
-            ReadResult::Err {
-                namespace,
-                path,
-                error: IoError::UnknownNamespace,
-            } => {
-                assert_eq!(namespace, "nope");
-                assert_eq!(path, "x.bin");
+        impl TestFixture {
+            fn new(reg: Arc<AdapterRegistry>) -> Self {
+                let (mailer, rx) = test_mailer_and_rx();
+                let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+                Self {
+                    cap: IoCapability::from_registry(reg),
+                    rx,
+                    transport,
+                }
             }
-            other => panic!("expected Err UnknownNamespace echoing request, got {other:?}"),
+
+            fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
+                NativeCtx::new(&self.transport, sender)
+            }
         }
-        cleanup(&root);
-    }
 
-    #[test]
-    fn cap_read_not_found_replies_err() {
-        let root = scratch_root("cap-nf");
-        let reg = build_save_only_registry(&root, true);
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_read(
-            &mut ctx,
-            Read {
-                namespace: "save".to_string(),
-                path: "ghost.bin".to_string(),
-            },
-        );
-        assert!(matches!(
-            decode_reply::<ReadResult>(&fix.rx),
-            ReadResult::Err {
-                error: IoError::NotFound,
-                ..
-            }
-        ));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn cap_write_ok_persists_bytes() {
-        let root = scratch_root("cap-write");
-        let reg = build_save_only_registry(&root, true);
-        let reg_clone = Arc::clone(&reg);
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_write(
-            &mut ctx,
-            Write {
-                namespace: "save".to_string(),
-                path: "slot.bin".to_string(),
-                bytes: vec![1, 2, 3],
-            },
-        );
-        match decode_reply::<WriteResult>(&fix.rx) {
-            WriteResult::Ok { namespace, path } => {
-                assert_eq!(namespace, "save");
-                assert_eq!(path, "slot.bin");
-            }
-            WriteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+        /// Manual tempdir helper to avoid pulling in the `tempfile`
+        /// crate. Caller cleans up via [`cleanup`] after the test asserts.
+        fn scratch_root(tag: &str) -> PathBuf {
+            let pid = std::process::id();
+            let nonce: u64 = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0);
+            let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
+            std::fs::create_dir_all(&path).unwrap();
+            path
         }
-        assert_eq!(
-            reg_clone.get("save").unwrap().read("slot.bin").unwrap(),
-            vec![1, 2, 3]
-        );
-        cleanup(&root);
-    }
 
-    #[test]
-    fn cap_write_read_only_namespace_replies_forbidden() {
-        let root = scratch_root("cap-ro");
-        let reg = build_save_only_registry(&root, false);
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_write(
-            &mut ctx,
-            Write {
-                namespace: "save".to_string(),
-                path: "slot.bin".to_string(),
-                bytes: vec![],
-            },
-        );
-        assert!(matches!(
-            decode_reply::<WriteResult>(&fix.rx),
-            WriteResult::Err {
-                error: IoError::Forbidden,
-                ..
-            }
-        ));
-        cleanup(&root);
-    }
-
-    #[test]
-    fn cap_delete_then_read_surfaces_not_found() {
-        let root = scratch_root("cap-del");
-        let reg = build_save_only_registry(&root, true);
-        let reg_clone = Arc::clone(&reg);
-        reg.get("save").unwrap().write("x.bin", b"x").unwrap();
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_delete(
-            &mut ctx,
-            Delete {
-                namespace: "save".to_string(),
-                path: "x.bin".to_string(),
-            },
-        );
-        match decode_reply::<DeleteResult>(&fix.rx) {
-            DeleteResult::Ok { namespace, path } => {
-                assert_eq!(namespace, "save");
-                assert_eq!(path, "x.bin");
-            }
-            DeleteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+        fn cleanup(path: &Path) {
+            let _ = std::fs::remove_dir_all(path);
         }
-        assert!(matches!(
-            reg_clone.get("save").unwrap().read("x.bin"),
-            Err(IoError::NotFound)
-        ));
-        cleanup(&root);
-    }
 
-    #[test]
-    fn cap_list_returns_sorted_entries() {
-        let root = scratch_root("cap-list");
-        let reg = build_save_only_registry(&root, true);
-        reg.get("save").unwrap().write("b.bin", b"").unwrap();
-        reg.get("save").unwrap().write("a.bin", b"").unwrap();
-        let fix = TestFixture::new(reg);
-        let mut ctx = fix.ctx(session_sender());
-        fix.cap.on_list(
-            &mut ctx,
-            List {
-                namespace: "save".to_string(),
-                prefix: "".to_string(),
-            },
-        );
-        match decode_reply::<ListResult>(&fix.rx) {
-            ListResult::Ok {
-                namespace,
-                prefix,
-                entries,
-            } => {
-                assert_eq!(namespace, "save");
-                assert_eq!(prefix, "");
-                assert_eq!(entries, vec!["a.bin".to_string(), "b.bin".to_string()]);
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
             }
-            ListResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            (registry, Arc::new(Mailer::new()))
         }
-        cleanup(&root);
-    }
 
-    // The end-to-end "component pushes Read, dispatcher delivers
-    // ReadResult to the component's receive_p32" test that lived here
-    // pre-stage-2e (issue 552) reached deep into `aether_substrate`
-    // privates (`Component::read_u32`, `ComponentEntry`, `host_fns`)
-    // plus wasmtime + wat. With the cap extracted to its own crate
-    // those internals are no longer reachable as crate-locals. The
-    // path it exercised is now covered by:
-    //   - `aether-scenario` declarative scenarios (they go through
-    //     the same Mailer + dispatch reply machinery), and
-    //   - the substrate's own `mailer` / `scheduler` unit tests for
-    //     `Mailer::send_reply` → component delivery.
-    // Reach for the in-bundle integration suite if a future change
-    // wants the full WAT roundtrip back as targeted coverage.
+        fn roots_under(root: &Path) -> NamespaceRoots {
+            let r = NamespaceRoots {
+                save: root.join("save"),
+                assets: root.join("assets"),
+                config: root.join("config"),
+            };
+            std::fs::create_dir_all(&r.save).unwrap();
+            std::fs::create_dir_all(&r.assets).unwrap();
+            std::fs::create_dir_all(&r.config).unwrap();
+            r
+        }
+
+        #[test]
+        fn resolve_rejects_parent_traversal() {
+            let root = scratch_root("resolve-parent");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.read("../etc/passwd"), Err(IoError::Forbidden)));
+            assert!(matches!(
+                a.read("sub/../../escape"),
+                Err(IoError::Forbidden)
+            ));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn resolve_rejects_absolute() {
+            let root = scratch_root("resolve-abs");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.read("/etc/passwd"), Err(IoError::Forbidden)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn resolve_permits_dot_segments() {
+            let root = scratch_root("resolve-dot");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.read("./nonexistent"), Err(IoError::NotFound)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn read_missing_file_returns_not_found() {
+            let root = scratch_root("read-missing");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.read("slot.bin"), Err(IoError::NotFound)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn write_then_read_roundtrip() {
+            let root = scratch_root("write-read");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("slot.bin", &[1, 2, 3, 4]).unwrap();
+            assert_eq!(a.read("slot.bin").unwrap(), vec![1, 2, 3, 4]);
+            cleanup(&root);
+        }
+
+        #[test]
+        fn write_creates_parent_directories() {
+            let root = scratch_root("write-parents");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("deep/sub/dir/slot.bin", b"hi").unwrap();
+            assert_eq!(a.read("deep/sub/dir/slot.bin").unwrap(), b"hi");
+            cleanup(&root);
+        }
+
+        #[test]
+        fn write_is_atomic_no_tmp_left_behind() {
+            let root = scratch_root("write-atomic");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("slot.bin", &[0u8; 16]).unwrap();
+            let siblings: Vec<String> = std::fs::read_dir(a.root())
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+                .collect();
+            assert!(
+                !siblings.iter().any(|s| s.contains(".tmp-")),
+                "unexpected tmp file left behind: {siblings:?}",
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn write_on_read_only_returns_forbidden() {
+            let root = scratch_root("write-readonly");
+            let a = LocalFileAdapter::new(root.clone(), false).unwrap();
+            assert!(matches!(a.write("x.bin", &[]), Err(IoError::Forbidden)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn delete_missing_returns_not_found() {
+            let root = scratch_root("delete-missing");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.delete("ghost.bin"), Err(IoError::NotFound)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn delete_removes_file() {
+            let root = scratch_root("delete-works");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("slot.bin", b"x").unwrap();
+            a.delete("slot.bin").unwrap();
+            assert!(matches!(a.read("slot.bin"), Err(IoError::NotFound)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn delete_on_read_only_returns_forbidden() {
+            let root = scratch_root("delete-readonly");
+            let a = LocalFileAdapter::new(root.clone(), false).unwrap();
+            assert!(matches!(a.delete("x.bin"), Err(IoError::Forbidden)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn list_empty_root_returns_empty_vec() {
+            let root = scratch_root("list-empty");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert_eq!(a.list("").unwrap(), Vec::<String>::new());
+            cleanup(&root);
+        }
+
+        #[test]
+        fn list_returns_sorted_names_at_root() {
+            let root = scratch_root("list-root");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("c.bin", b"").unwrap();
+            a.write("a.bin", b"").unwrap();
+            a.write("b.bin", b"").unwrap();
+            assert_eq!(a.list("").unwrap(), vec!["a.bin", "b.bin", "c.bin"]);
+            cleanup(&root);
+        }
+
+        #[test]
+        fn list_under_subdirectory() {
+            let root = scratch_root("list-sub");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            a.write("saves/slot1.bin", b"").unwrap();
+            a.write("saves/slot2.bin", b"").unwrap();
+            a.write("cfg/keys.toml", b"").unwrap();
+            let saves = a.list("saves").unwrap();
+            assert_eq!(saves, vec!["slot1.bin", "slot2.bin"]);
+            cleanup(&root);
+        }
+
+        #[test]
+        fn list_missing_directory_returns_not_found() {
+            let root = scratch_root("list-missing");
+            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            assert!(matches!(a.list("nope"), Err(IoError::NotFound)));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn registry_returns_none_for_unknown_namespace() {
+            let reg = AdapterRegistry::new();
+            assert!(reg.get("save").is_none());
+            assert!(!reg.has("save"));
+        }
+
+        #[test]
+        fn registry_registers_and_retrieves_adapter() {
+            let root = scratch_root("reg-basic");
+            let adapter: Arc<dyn FileAdapter> =
+                Arc::new(LocalFileAdapter::new(root.clone(), true).unwrap());
+            let mut reg = AdapterRegistry::new();
+            reg.register("save", adapter);
+            assert!(reg.has("save"));
+            assert!(reg.get("save").is_some());
+            cleanup(&root);
+        }
+
+        use aether_data::{SessionToken, Uuid};
+        use aether_substrate::outbound::EgressEvent;
+
+        fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
+            let adapter: Arc<dyn FileAdapter> =
+                Arc::new(LocalFileAdapter::new(root.to_path_buf(), writable).unwrap());
+            let mut r = AdapterRegistry::new();
+            r.register("save", adapter);
+            Arc::new(r)
+        }
+
+        fn session_sender() -> ReplyTo {
+            ReplyTo::to(aether_substrate::mail::ReplyTarget::Session(SessionToken(
+                Uuid::nil(),
+            )))
+        }
+
+        /// Build a fully-wired `Mailer` connected to a fresh test
+        /// outbound channel.
+        fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
+            use std::collections::HashMap;
+            use std::sync::RwLock;
+
+            let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
+            let mailer = Arc::new(Mailer::new());
+            mailer.wire(
+                Arc::new(Registry::new()),
+                Arc::new(RwLock::new(HashMap::new())),
+            );
+            mailer.wire_outbound(outbound);
+            (mailer, rx)
+        }
+
+        fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
+            rx: &std::sync::mpsc::Receiver<EgressEvent>,
+        ) -> K {
+            let event = rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap();
+            let EgressEvent::ToSession {
+                kind_name, payload, ..
+            } = event
+            else {
+                panic!("expected ToSession egress, got {event:?}");
+            };
+            assert_eq!(kind_name, K::NAME);
+            postcard::from_bytes(&payload).unwrap()
+        }
+
+        /// Boot the cap against a fresh tempdir; assert the mailbox
+        /// is registered.
+        #[test]
+        fn capability_boots_and_registers_mailbox() {
+            let root = scratch_root("boots");
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<IoCapability>(roots_under(&root))
+                .build()
+                .expect("io capability boots");
+            assert!(
+                registry.lookup(IoCapability::NAMESPACE).is_some(),
+                "io mailbox registered"
+            );
+            chassis.shutdown();
+            cleanup(&root);
+        }
+
+        /// Cap init fails when the adapter registry can't be built —
+        /// provoke `LocalFileAdapter::new` failure by pointing the save
+        /// root at a regular file rather than a directory. `init` returns
+        /// `BootError::Other(io::Error)`, the chassis builder propagates.
+        #[test]
+        fn cap_init_fails_when_adapter_init_fails() {
+            let root = scratch_root("init-fails");
+            let save_path = root.join("save_is_actually_a_file");
+            std::fs::write(&save_path, b"not a dir").unwrap();
+            let roots = NamespaceRoots {
+                save: save_path,
+                assets: root.join("assets"),
+                config: root.join("config"),
+            };
+            std::fs::create_dir_all(&roots.assets).unwrap();
+            std::fs::create_dir_all(&roots.config).unwrap();
+
+            let (registry, mailer) = fresh_substrate();
+            let result = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<IoCapability>(roots)
+                .build();
+            assert!(result.is_err(), "save root being a file must fail cap init");
+            cleanup(&root);
+        }
+
+        /// Builder rejects a duplicate claim. Same protection as the
+        /// other capabilities.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            let root = scratch_root("collide");
+            let (registry, mailer) = fresh_substrate();
+            registry.register_sink(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+
+            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<IoCapability>(roots_under(&root))
+                .build()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == IoCapability::NAMESPACE
+            ));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_read_ok_replies_with_bytes() {
+            let root = scratch_root("cap-read");
+            let reg = build_save_only_registry(&root, true);
+            reg.get("save")
+                .unwrap()
+                .write("slot.bin", &[9, 9, 9])
+                .unwrap();
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_read(
+                &mut ctx,
+                Read {
+                    namespace: "save".to_string(),
+                    path: "slot.bin".to_string(),
+                },
+            );
+            match decode_reply::<ReadResult>(&fix.rx) {
+                ReadResult::Ok {
+                    namespace,
+                    path,
+                    bytes,
+                } => {
+                    assert_eq!(namespace, "save");
+                    assert_eq!(path, "slot.bin");
+                    assert_eq!(bytes, vec![9, 9, 9]);
+                }
+                ReadResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_read_unknown_namespace_replies_err() {
+            let root = scratch_root("cap-ns");
+            let reg = build_save_only_registry(&root, true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_read(
+                &mut ctx,
+                Read {
+                    namespace: "nope".to_string(),
+                    path: "x.bin".to_string(),
+                },
+            );
+            match decode_reply::<ReadResult>(&fix.rx) {
+                ReadResult::Err {
+                    namespace,
+                    path,
+                    error: IoError::UnknownNamespace,
+                } => {
+                    assert_eq!(namespace, "nope");
+                    assert_eq!(path, "x.bin");
+                }
+                other => panic!("expected Err UnknownNamespace echoing request, got {other:?}"),
+            }
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_read_not_found_replies_err() {
+            let root = scratch_root("cap-nf");
+            let reg = build_save_only_registry(&root, true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_read(
+                &mut ctx,
+                Read {
+                    namespace: "save".to_string(),
+                    path: "ghost.bin".to_string(),
+                },
+            );
+            assert!(matches!(
+                decode_reply::<ReadResult>(&fix.rx),
+                ReadResult::Err {
+                    error: IoError::NotFound,
+                    ..
+                }
+            ));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_write_ok_persists_bytes() {
+            let root = scratch_root("cap-write");
+            let reg = build_save_only_registry(&root, true);
+            let reg_clone = Arc::clone(&reg);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_write(
+                &mut ctx,
+                Write {
+                    namespace: "save".to_string(),
+                    path: "slot.bin".to_string(),
+                    bytes: vec![1, 2, 3],
+                },
+            );
+            match decode_reply::<WriteResult>(&fix.rx) {
+                WriteResult::Ok { namespace, path } => {
+                    assert_eq!(namespace, "save");
+                    assert_eq!(path, "slot.bin");
+                }
+                WriteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+            assert_eq!(
+                reg_clone.get("save").unwrap().read("slot.bin").unwrap(),
+                vec![1, 2, 3]
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_write_read_only_namespace_replies_forbidden() {
+            let root = scratch_root("cap-ro");
+            let reg = build_save_only_registry(&root, false);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_write(
+                &mut ctx,
+                Write {
+                    namespace: "save".to_string(),
+                    path: "slot.bin".to_string(),
+                    bytes: vec![],
+                },
+            );
+            assert!(matches!(
+                decode_reply::<WriteResult>(&fix.rx),
+                WriteResult::Err {
+                    error: IoError::Forbidden,
+                    ..
+                }
+            ));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_delete_then_read_surfaces_not_found() {
+            let root = scratch_root("cap-del");
+            let reg = build_save_only_registry(&root, true);
+            let reg_clone = Arc::clone(&reg);
+            reg.get("save").unwrap().write("x.bin", b"x").unwrap();
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_delete(
+                &mut ctx,
+                Delete {
+                    namespace: "save".to_string(),
+                    path: "x.bin".to_string(),
+                },
+            );
+            match decode_reply::<DeleteResult>(&fix.rx) {
+                DeleteResult::Ok { namespace, path } => {
+                    assert_eq!(namespace, "save");
+                    assert_eq!(path, "x.bin");
+                }
+                DeleteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+            assert!(matches!(
+                reg_clone.get("save").unwrap().read("x.bin"),
+                Err(IoError::NotFound)
+            ));
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_list_returns_sorted_entries() {
+            let root = scratch_root("cap-list");
+            let reg = build_save_only_registry(&root, true);
+            reg.get("save").unwrap().write("b.bin", b"").unwrap();
+            reg.get("save").unwrap().write("a.bin", b"").unwrap();
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_list(
+                &mut ctx,
+                List {
+                    namespace: "save".to_string(),
+                    prefix: "".to_string(),
+                },
+            );
+            match decode_reply::<ListResult>(&fix.rx) {
+                ListResult::Ok {
+                    namespace,
+                    prefix,
+                    entries,
+                } => {
+                    assert_eq!(namespace, "save");
+                    assert_eq!(prefix, "");
+                    assert_eq!(entries, vec!["a.bin".to_string(), "b.bin".to_string()]);
+                }
+                ListResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+            cleanup(&root);
+        }
+
+        // The end-to-end "component pushes Read, dispatcher delivers
+        // ReadResult to the component's receive_p32" test that lived here
+        // pre-stage-2e (issue 552) reached deep into `aether_substrate`
+        // privates (`Component::read_u32`, `ComponentEntry`, `host_fns`)
+        // plus wasmtime + wat. With the cap extracted to its own crate
+        // those internals are no longer reachable as crate-locals. The
+        // path it exercised is now covered by:
+        //   - `aether-scenario` declarative scenarios (they go through
+        //     the same Mailer + dispatch reply machinery), and
+        //   - the substrate's own `mailer` / `scheduler` unit tests for
+        //     `Mailer::send_reply` → component delivery.
+        // Reach for the in-bundle integration suite if a future change
+        // wants the full WAT roundtrip back as targeted coverage.
+    }
 }

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -1,13 +1,9 @@
-//! Issue 552 stage 2: `aether.log` cap migrated onto `NativeActor`.
-//! Pre-stage-2 the cap was a unit struct with `impl Actor` +
-//! `impl Singleton` + an inherent `#[actor] impl LogCapability` block
-//! taking `&mut self` handlers. Stage 2 collapses that into the
-//! symmetric authoring shape: `#[capability] #[derive(Singleton)]
-//! struct + #[actor] impl NativeActor for X { type Config; fn init;
-//! #[handler] fn (&self, ctx: &mut NativeCtx<'_>, mail) }`. The Log
-//! cap is the smallest pilot — no fields, no `Config`, no reply, no
-//! sender param to drop — so it validates the macro + ctx + dispatch
-//! path before the larger caps follow in 2b/2c.
+//! `aether.log` cap. Issue 565 pilot for the `#[bridge]` mod pattern:
+//! the struct + actor impl + tests live inside `mod native`, which
+//! `#[bridge]` cfg-gates. The macro emits a wasm-stub `pub struct
+//! LogCapability;` at file root plus always-on Singleton + Actor +
+//! HandlesKind markers, and re-exports the real struct from inside
+//! the mod on native.
 //!
 //! Bridging via the `log` crate facade (rather than `tracing::event!`)
 //! is load-bearing — see [`aether_substrate::log_sink`] for the rationale.
@@ -16,134 +12,138 @@
 //! and let `tracing-subscriber`'s `tracing-log` integration lift each
 //! record back into the tracing pipeline.
 
-use aether_actor::{Singleton, actor, capability};
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate). Aether-kinds is
+// wasm-compatible so the import doesn't need cfg gating.
 use aether_kinds::LogEvent;
 
-aether_actor::native_only! {
+#[aether_actor::bridge]
+mod native {
+    use super::LogEvent;
+    use aether_actor::actor;
     use aether_substrate::capability::BootError;
     use aether_substrate::log_sink;
     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-}
 
-/// `aether.log` mailbox cap. Stateless beyond the process-wide
-/// `tracing` subscriber set up by [`aether_substrate::log_capture::init`] —
-/// every cap instance bridges decoded `LogEvent` mail through the
-/// `log` facade and `tracing-log` re-emits it.
-#[capability]
-#[derive(Singleton)]
-pub struct LogCapability;
+    /// `aether.log` mailbox cap. Stateless beyond the process-wide
+    /// `tracing` subscriber set up by [`aether_substrate::log_capture::init`] —
+    /// every cap instance bridges decoded `LogEvent` mail through the
+    /// `log` facade and `tracing-log` re-emits it.
+    pub struct LogCapability;
 
-#[actor]
-impl NativeActor for LogCapability {
-    type Config = ();
-    const NAMESPACE: &'static str = "aether.log";
+    #[actor]
+    impl NativeActor for LogCapability {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.log";
 
-    fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(Self)
-    }
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
 
-    /// Emit a decoded log event through the host's `tracing` pipeline
-    /// so `engine_logs` (ADR-0023) sees it.
-    ///
-    /// # Agent
-    /// Components mail `aether.log` `LogEvent { level, target, message }`
-    /// to this mailbox. Fire-and-forget; no reply.
-    #[handler]
-    fn on_log_event(&self, _ctx: &mut NativeCtx<'_>, event: LogEvent) {
-        log_sink::handle_log_mail_decoded(event);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::thread;
-    use std::time::{Duration, Instant};
-
-    use super::*;
-    use aether_actor::Actor;
-    use aether_data::Kind;
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis_builder::{Builder, BuiltChassis, NeverDriver};
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::registry::{MailboxEntry, Registry};
-
-    /// Stand-in chassis for the passive boot path. The Log cap doesn't
-    /// need a driver, so `build_passive()` is the natural test entry
-    /// — same shape as the `with_actor_*` smokes in
-    /// `chassis_builder::tests`.
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        /// Emit a decoded log event through the host's `tracing` pipeline
+        /// so `engine_logs` (ADR-0023) sees it.
+        ///
+        /// # Agent
+        /// Components mail `aether.log` `LogEvent { level, target, message }`
+        /// to this mailbox. Fire-and-forget; no reply.
+        #[handler]
+        fn on_log_event(&self, _ctx: &mut NativeCtx<'_>, event: LogEvent) {
+            log_sink::handle_log_mail_decoded(event);
         }
     }
 
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        (Arc::new(Registry::new()), Arc::new(Mailer::new()))
-    }
+    #[cfg(test)]
+    mod tests {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
 
-    /// End-to-end: boot the cap through `with_actor`, push an
-    /// `aether.log` mail at the registered mailbox, the dispatcher
-    /// thread runs the macro-emitted `NativeDispatch` which calls
-    /// `on_log_event`. Test asserts dispatch + clean shutdown.
-    #[test]
-    fn capability_routes_log_event_through_dispatcher() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<LogCapability>(())
-            .build_passive()
-            .expect("capability boots");
+        use super::{BootError, LogCapability, LogEvent};
+        use aether_actor::Actor;
+        use aether_data::Kind;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis_builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::registry::{MailboxEntry, Registry};
 
-        let id = registry
-            .lookup(LogCapability::NAMESPACE)
-            .expect("mailbox registered");
-        let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
-            panic!("expected sink entry");
-        };
+        /// Stand-in chassis for the passive boot path. The Log cap doesn't
+        /// need a driver, so `build_passive()` is the natural test entry
+        /// — same shape as the `with_actor_*` smokes in
+        /// `chassis_builder::tests`.
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
-        let event = LogEvent {
-            level: 3,
-            target: "aether_test_guest".into(),
-            message: "parse failed: missing close paren".into(),
-        };
-        let bytes = postcard::to_allocvec(&event).expect("encode");
-        handler(
-            <LogEvent as Kind>::ID,
-            "aether.log",
-            None,
-            aether_substrate::mail::ReplyTo::NONE,
-            &bytes,
-            1,
-        );
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+        }
 
-        thread::sleep(Duration::from_millis(50));
-        let start = Instant::now();
-        drop(chassis);
-        assert!(
-            start.elapsed() < Duration::from_millis(500),
-            "shutdown should complete promptly via channel-drop"
-        );
-    }
+        /// End-to-end: boot the cap through `with_actor`, push an
+        /// `aether.log` mail at the registered mailbox, the dispatcher
+        /// thread runs the macro-emitted `NativeDispatch` which calls
+        /// `on_log_event`. Test asserts dispatch + clean shutdown.
+        #[test]
+        fn capability_routes_log_event_through_dispatcher() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<LogCapability>(())
+                .build_passive()
+                .expect("capability boots");
 
-    /// Builder rejects a duplicate claim if the well-known mailbox name
-    /// was already registered.
-    #[test]
-    fn duplicate_claim_rejects_with_typed_error() {
-        let (registry, mailer) = fresh_substrate();
-        registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            let id = registry
+                .lookup(LogCapability::NAMESPACE)
+                .expect("mailbox registered");
+            let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry") else {
+                panic!("expected sink entry");
+            };
 
-        let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<LogCapability>(())
-            .build_passive()
-            .expect_err("collision must surface as BootError");
-        assert!(matches!(
-            err,
-            BootError::MailboxAlreadyClaimed { ref name }
-                if name == LogCapability::NAMESPACE
-        ));
+            let event = LogEvent {
+                level: 3,
+                target: "aether_test_guest".into(),
+                message: "parse failed: missing close paren".into(),
+            };
+            let bytes = postcard::to_allocvec(&event).expect("encode");
+            handler(
+                <LogEvent as Kind>::ID,
+                "aether.log",
+                None,
+                aether_substrate::mail::ReplyTo::NONE,
+                &bytes,
+                1,
+            );
+
+            thread::sleep(Duration::from_millis(50));
+            let start = Instant::now();
+            drop(chassis);
+            assert!(
+                start.elapsed() < Duration::from_millis(500),
+                "shutdown should complete promptly via channel-drop"
+            );
+        }
+
+        /// Builder rejects a duplicate claim if the well-known mailbox name
+        /// was already registered.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            let (registry, mailer) = fresh_substrate();
+            registry.register_sink(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<LogCapability>(())
+                .build_passive()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == LogCapability::NAMESPACE
+            ));
+        }
     }
 }

--- a/crates/aether-capabilities/src/net.rs
+++ b/crates/aether-capabilities/src/net.rs
@@ -1,14 +1,8 @@
-//! Issue 545 PR E1: collapsed `aether.net` cap. Pre-PR-E1 the cap
-//! lived split across `aether-kinds::net::NetCapability<B>` (facade
-//! generic) and this file (concrete `NetAdapterBackend`). The facade
-//! pattern (ADR-0075) is retired — caps are now regular `#[actor]`
-//! blocks, same shape as wasm components.
-//!
-//! Owns the full HTTP egress stack — `NetAdapter` trait, the `ureq`-
-//! backed `UreqNetAdapter`, env-driven `NetConfig`, and the
-//! [`NetCapability`] itself. Chassis mains resolve a [`NetConfig`]
-//! (typically via [`NetConfig::from_env`]), call
-//! [`NetCapability::new`], and hand the cap to the chassis builder.
+//! `aether.net` cap. Owns the full HTTP egress stack — `NetAdapter`
+//! trait, the `ureq`-backed `UreqNetAdapter`, env-driven `NetConfig`,
+//! and the [`NetCapability`] itself. Chassis mains resolve a
+//! [`NetConfig`] (typically via [`NetConfig::from_env`]) and pass it
+//! to `with_actor::<NetCapability>(config)`.
 //!
 //! v1 semantics (ADR-0043):
 //! - Blocking on the dispatcher thread (one request at a time).
@@ -21,19 +15,10 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use aether_actor::{Singleton, actor, capability};
-// Handler-signature kind stays always-on; reply-side `FetchResult`
-// + ureq error types live in the `native_only!` block.
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
 use aether_kinds::{Fetch, HttpHeader, HttpMethod, NetError};
-
-aether_actor::native_only! {
-    use std::sync::Arc;
-
-    use aether_actor::MailCtx;
-    use aether_kinds::FetchResult;
-    use aether_substrate::capability::BootError;
-    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-}
 
 /// Default response-body cap when `AETHER_NET_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -80,164 +65,6 @@ pub struct DisabledNetAdapter;
 impl NetAdapter for DisabledNetAdapter {
     fn fetch(&self, _req: FetchRequest) -> Result<FetchResponse, NetError> {
         Err(NetError::Disabled)
-    }
-}
-
-/// `ureq`-backed adapter. Holds the shared agent, the allowlist
-/// (empty = deny all), the response cap, and the `require_https`
-/// flag. Thread-safe: `ureq::Agent` is cheaply cloneable and
-/// internally synchronised, so the same adapter drives the cap from
-/// one dispatch thread today and would parallelise cleanly behind a
-/// multi-thread dispatcher later.
-#[cfg(not(target_arch = "wasm32"))]
-pub struct UreqNetAdapter {
-    agent: ureq::Agent,
-    allowlist: HashSet<String>,
-    require_https: bool,
-    max_body_bytes: usize,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl UreqNetAdapter {
-    /// Construct an adapter with explicit knobs. Chassis code uses
-    /// [`build_default_adapter`] for env-derived construction;
-    /// tests build adapters directly to avoid env contamination.
-    pub fn new(allowlist: HashSet<String>, require_https: bool, max_body_bytes: usize) -> Self {
-        let config = ureq::Agent::config_builder()
-            .http_status_as_error(false)
-            .build();
-        let agent = ureq::Agent::new_with_config(config);
-        Self {
-            agent,
-            allowlist,
-            require_https,
-            max_body_bytes,
-        }
-    }
-
-    fn check_allowlist(&self, host: &str) -> Result<(), NetError> {
-        if self.allowlist.contains(host) {
-            Ok(())
-        } else {
-            Err(NetError::AllowlistDenied)
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl NetAdapter for UreqNetAdapter {
-    fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError> {
-        let parsed = url::Url::parse(&req.url).map_err(|e| NetError::InvalidUrl(format!("{e}")))?;
-
-        if self.require_https && parsed.scheme() != "https" {
-            return Err(NetError::InvalidUrl(
-                "http scheme not allowed (AETHER_NET_REQUIRE_HTTPS=1)".to_string(),
-            ));
-        }
-
-        let host = parsed
-            .host_str()
-            .ok_or_else(|| NetError::InvalidUrl("no host in url".to_string()))?;
-        self.check_allowlist(host)?;
-
-        if req.body.len() > self.max_body_bytes {
-            return Err(NetError::BodyTooLarge);
-        }
-
-        let mut builder = ureq::http::Request::builder()
-            .method(http_method_to_http_crate(req.method))
-            .uri(&req.url);
-
-        // Host header is derived from the URL by ureq; reject any
-        // caller-set Host so it can't be used to bypass the
-        // allowlist (component requests allowlisted A, TLS SNI is A,
-        // but `Host: B` routes the vhost to B server-side). User-
-        // Agent defaults to `aether/<version>` if not set.
-        let mut saw_user_agent = false;
-        for h in &req.headers {
-            if h.name.eq_ignore_ascii_case("host") {
-                tracing::warn!(
-                    target: "aether_substrate::net",
-                    value = %h.value,
-                    "stripping caller-set Host header",
-                );
-                continue;
-            }
-            if h.name.eq_ignore_ascii_case("user-agent") {
-                saw_user_agent = true;
-            }
-            builder = builder.header(&h.name, &h.value);
-        }
-        if !saw_user_agent {
-            builder = builder.header("User-Agent", concat!("aether/", env!("CARGO_PKG_VERSION")));
-        }
-
-        let http_req = builder
-            .body(req.body)
-            .map_err(|e| NetError::InvalidUrl(format!("{e}")))?;
-
-        use ureq::RequestExt;
-        let mut response = http_req
-            .with_agent(&self.agent)
-            .configure()
-            .timeout_global(Some(req.timeout))
-            .build()
-            .run()
-            .map_err(ureq_error_to_net_error)?;
-
-        let status = response.status().as_u16();
-
-        let mut headers = Vec::with_capacity(response.headers().len());
-        for (name, value) in response.headers() {
-            // Non-UTF8 header values are rare but real (binary
-            // cookies, broken servers). Skip rather than fail the
-            // whole fetch.
-            if let Ok(value_str) = value.to_str() {
-                headers.push(HttpHeader {
-                    name: name.as_str().to_string(),
-                    value: value_str.to_string(),
-                });
-            }
-        }
-
-        let body = match response
-            .body_mut()
-            .with_config()
-            .limit(self.max_body_bytes as u64)
-            .read_to_vec()
-        {
-            Ok(b) => b,
-            Err(ureq::Error::BodyExceedsLimit(_)) => return Err(NetError::BodyTooLarge),
-            Err(e) => return Err(NetError::AdapterError(format!("body read: {e}"))),
-        };
-
-        Ok(FetchResponse {
-            status,
-            headers,
-            body,
-        })
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn http_method_to_http_crate(m: HttpMethod) -> ureq::http::Method {
-    match m {
-        HttpMethod::Get => ureq::http::Method::GET,
-        HttpMethod::Post => ureq::http::Method::POST,
-        HttpMethod::Put => ureq::http::Method::PUT,
-        HttpMethod::Delete => ureq::http::Method::DELETE,
-        HttpMethod::Patch => ureq::http::Method::PATCH,
-        HttpMethod::Head => ureq::http::Method::HEAD,
-        HttpMethod::Options => ureq::http::Method::OPTIONS,
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
-    match e {
-        ureq::Error::Timeout(_) => NetError::Timeout,
-        ureq::Error::BodyExceedsLimit(_) => NetError::BodyTooLarge,
-        other => NetError::AdapterError(format!("{other}")),
     }
 }
 
@@ -294,38 +121,6 @@ impl NetConfig {
     }
 }
 
-/// Build a net adapter from explicit configuration.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
-    if config.disabled {
-        tracing::info!(
-            target: "aether_substrate::net",
-            "net adapter disabled — every fetch replies Disabled",
-        );
-        return Arc::new(DisabledNetAdapter);
-    }
-
-    tracing::info!(
-        target: "aether_substrate::net",
-        allowlist_size = config.allowlist.len(),
-        require_https = config.require_https,
-        max_body_bytes = config.max_body_bytes,
-        "net adapter configured",
-    );
-
-    Arc::new(UreqNetAdapter::new(
-        config.allowlist,
-        config.require_https,
-        config.max_body_bytes,
-    ))
-}
-
-/// Env-driven wrapper around [`build_net_adapter`].
-#[cfg(not(target_arch = "wasm32"))]
-pub fn build_default_adapter() -> Arc<dyn NetAdapter> {
-    build_net_adapter(NetConfig::from_env())
-}
-
 fn disable_flag_env() -> bool {
     std::env::var("AETHER_NET_DISABLE")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -366,438 +161,644 @@ fn parse_default_timeout_env() -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-/// `aether.net` mailbox cap. Owns the resolved adapter and the
-/// default per-request timeout applied when `Fetch.timeout_ms` is
-/// `None`. The dispatcher thread holds an `Arc<Self>` and routes
-/// envelopes through the macro-emitted `NativeDispatch` impl;
-/// replies route via `ctx.reply(&result)` through the substrate's
-/// `Mailer::send_reply`.
-#[capability]
-#[derive(Singleton)]
-pub struct NetCapability {
-    adapter: Arc<dyn NetAdapter>,
-    default_timeout: Duration,
-}
+#[aether_actor::bridge]
+mod native {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::Duration;
 
-#[cfg(test)]
-impl NetCapability {
-    /// Test-only direct constructor. Production boots through
-    /// `Builder::with_actor::<NetCapability>(config)` which calls
-    /// `init`; tests that drive the cap with a stub adapter hand it
-    /// in directly.
-    pub(crate) fn from_adapter(adapter: Arc<dyn NetAdapter>, default_timeout: Duration) -> Self {
-        Self {
-            adapter,
-            default_timeout,
+    use super::{
+        DisabledNetAdapter, Fetch, FetchRequest, FetchResponse, HttpHeader, HttpMethod, NetAdapter,
+        NetConfig, NetError,
+    };
+    use aether_actor::{MailCtx, actor};
+    use aether_kinds::FetchResult;
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+
+    /// `ureq`-backed adapter. Holds the shared agent, the allowlist
+    /// (empty = deny all), the response cap, and the `require_https`
+    /// flag. Thread-safe: `ureq::Agent` is cheaply cloneable and
+    /// internally synchronised, so the same adapter drives the cap from
+    /// one dispatch thread today and would parallelise cleanly behind a
+    /// multi-thread dispatcher later.
+    pub struct UreqNetAdapter {
+        agent: ureq::Agent,
+        allowlist: HashSet<String>,
+        require_https: bool,
+        max_body_bytes: usize,
+    }
+
+    impl UreqNetAdapter {
+        /// Construct an adapter with explicit knobs. Chassis code uses
+        /// [`build_net_adapter`] for env-derived construction;
+        /// tests build adapters directly to avoid env contamination.
+        pub fn new(allowlist: HashSet<String>, require_https: bool, max_body_bytes: usize) -> Self {
+            let config = ureq::Agent::config_builder()
+                .http_status_as_error(false)
+                .build();
+            let agent = ureq::Agent::new_with_config(config);
+            Self {
+                agent,
+                allowlist,
+                require_https,
+                max_body_bytes,
+            }
+        }
+
+        fn check_allowlist(&self, host: &str) -> Result<(), NetError> {
+            if self.allowlist.contains(host) {
+                Ok(())
+            } else {
+                Err(NetError::AllowlistDenied)
+            }
         }
     }
-}
 
-#[actor]
-impl NativeActor for NetCapability {
-    type Config = NetConfig;
+    impl NetAdapter for UreqNetAdapter {
+        fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError> {
+            let parsed =
+                url::Url::parse(&req.url).map_err(|e| NetError::InvalidUrl(format!("{e}")))?;
 
-    /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
-    const NAMESPACE: &'static str = "aether.net";
+            if self.require_https && parsed.scheme() != "https" {
+                return Err(NetError::InvalidUrl(
+                    "http scheme not allowed (AETHER_NET_REQUIRE_HTTPS=1)".to_string(),
+                ));
+            }
 
-    /// Build the net adapter from the resolved config. The adapter is
-    /// built immediately so configuration errors surface at chassis-
-    /// builder time, not at first fetch.
-    fn init(config: NetConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        let default_timeout = config.default_timeout;
-        Ok(Self {
-            adapter: build_net_adapter(config),
-            default_timeout,
-        })
-    }
+            let host = parsed
+                .host_str()
+                .ok_or_else(|| NetError::InvalidUrl("no host in url".to_string()))?;
+            self.check_allowlist(host)?;
 
-    /// Run a fetch request and reply with the response.
-    ///
-    /// # Agent
-    /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
-    /// long-running fetches block other net mail until they finish.
-    #[handler]
-    fn on_fetch(&self, ctx: &mut NativeCtx<'_>, mail: Fetch) {
-        let timeout = mail
-            .timeout_ms
-            .map(|ms| Duration::from_millis(ms as u64))
-            .unwrap_or(self.default_timeout);
+            if req.body.len() > self.max_body_bytes {
+                return Err(NetError::BodyTooLarge);
+            }
 
-        let url = mail.url.clone();
-        let adapter_req = FetchRequest {
-            url: mail.url,
-            method: mail.method,
-            headers: mail.headers,
-            body: mail.body,
-            timeout,
-        };
+            let mut builder = ureq::http::Request::builder()
+                .method(http_method_to_http_crate(req.method))
+                .uri(&req.url);
 
-        let reply = match self.adapter.fetch(adapter_req) {
-            Ok(r) => FetchResult::Ok {
-                url,
-                status: r.status,
-                headers: r.headers,
-                body: r.body,
-            },
-            Err(error) => FetchResult::Err { url, error },
-        };
-        ctx.reply(&reply);
-    }
-}
+            // Host header is derived from the URL by ureq; reject any
+            // caller-set Host so it can't be used to bypass the
+            // allowlist (component requests allowlisted A, TLS SNI is A,
+            // but `Host: B` routes the vhost to B server-side). User-
+            // Agent defaults to `aether/<version>` if not set.
+            let mut saw_user_agent = false;
+            for h in &req.headers {
+                if h.name.eq_ignore_ascii_case("host") {
+                    tracing::warn!(
+                        target: "aether_substrate::net",
+                        value = %h.value,
+                        "stripping caller-set Host header",
+                    );
+                    continue;
+                }
+                if h.name.eq_ignore_ascii_case("user-agent") {
+                    saw_user_agent = true;
+                }
+                builder = builder.header(&h.name, &h.value);
+            }
+            if !saw_user_agent {
+                builder =
+                    builder.header("User-Agent", concat!("aether/", env!("CARGO_PKG_VERSION")));
+            }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use aether_actor::Actor;
-    use aether_data::{Kind, MailboxId};
-    use aether_substrate::capability::{BootError, ChassisBuilder};
-    use aether_substrate::mail::ReplyTo;
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::native_transport::NativeTransport;
-    use aether_substrate::registry::Registry;
-    use std::sync::Mutex;
+            let http_req = builder
+                .body(req.body)
+                .map_err(|e| NetError::InvalidUrl(format!("{e}")))?;
 
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
-        }
-        (registry, Arc::new(Mailer::new()))
-    }
+            use ureq::RequestExt;
+            let mut response = http_req
+                .with_agent(&self.agent)
+                .configure()
+                .timeout_global(Some(req.timeout))
+                .build()
+                .run()
+                .map_err(ureq_error_to_net_error)?;
 
-    struct StubAdapter {
-        response: Mutex<Option<Result<FetchResponse, NetError>>>,
-        last_request: Mutex<Option<FetchRequest>>,
-    }
+            let status = response.status().as_u16();
 
-    impl StubAdapter {
-        fn with(response: Result<FetchResponse, NetError>) -> Arc<Self> {
-            Arc::new(Self {
-                response: Mutex::new(Some(response)),
-                last_request: Mutex::new(None),
+            let mut headers = Vec::with_capacity(response.headers().len());
+            for (name, value) in response.headers() {
+                // Non-UTF8 header values are rare but real (binary
+                // cookies, broken servers). Skip rather than fail the
+                // whole fetch.
+                if let Ok(value_str) = value.to_str() {
+                    headers.push(HttpHeader {
+                        name: name.as_str().to_string(),
+                        value: value_str.to_string(),
+                    });
+                }
+            }
+
+            let body = match response
+                .body_mut()
+                .with_config()
+                .limit(self.max_body_bytes as u64)
+                .read_to_vec()
+            {
+                Ok(b) => b,
+                Err(ureq::Error::BodyExceedsLimit(_)) => return Err(NetError::BodyTooLarge),
+                Err(e) => return Err(NetError::AdapterError(format!("body read: {e}"))),
+            };
+
+            Ok(FetchResponse {
+                status,
+                headers,
+                body,
             })
         }
     }
 
-    impl NetAdapter for StubAdapter {
-        fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError> {
-            *self.last_request.lock().unwrap() = Some(FetchRequest {
-                url: req.url.clone(),
-                method: req.method,
-                headers: req.headers.clone(),
-                body: req.body.clone(),
-                timeout: req.timeout,
+    fn http_method_to_http_crate(m: HttpMethod) -> ureq::http::Method {
+        match m {
+            HttpMethod::Get => ureq::http::Method::GET,
+            HttpMethod::Post => ureq::http::Method::POST,
+            HttpMethod::Put => ureq::http::Method::PUT,
+            HttpMethod::Delete => ureq::http::Method::DELETE,
+            HttpMethod::Patch => ureq::http::Method::PATCH,
+            HttpMethod::Head => ureq::http::Method::HEAD,
+            HttpMethod::Options => ureq::http::Method::OPTIONS,
+        }
+    }
+
+    fn ureq_error_to_net_error(e: ureq::Error) -> NetError {
+        match e {
+            ureq::Error::Timeout(_) => NetError::Timeout,
+            ureq::Error::BodyExceedsLimit(_) => NetError::BodyTooLarge,
+            other => NetError::AdapterError(format!("{other}")),
+        }
+    }
+
+    /// Build a net adapter from explicit configuration.
+    pub fn build_net_adapter(config: NetConfig) -> Arc<dyn NetAdapter> {
+        if config.disabled {
+            tracing::info!(
+                target: "aether_substrate::net",
+                "net adapter disabled — every fetch replies Disabled",
+            );
+            return Arc::new(DisabledNetAdapter);
+        }
+
+        tracing::info!(
+            target: "aether_substrate::net",
+            allowlist_size = config.allowlist.len(),
+            require_https = config.require_https,
+            max_body_bytes = config.max_body_bytes,
+            "net adapter configured",
+        );
+
+        Arc::new(UreqNetAdapter::new(
+            config.allowlist,
+            config.require_https,
+            config.max_body_bytes,
+        ))
+    }
+
+    /// `aether.net` mailbox cap. Owns the resolved adapter and the
+    /// default per-request timeout applied when `Fetch.timeout_ms` is
+    /// `None`. The dispatcher thread holds an `Arc<Self>` and routes
+    /// envelopes through the macro-emitted `NativeDispatch` impl;
+    /// replies route via `ctx.reply(&result)` through the substrate's
+    /// `Mailer::send_reply`.
+    pub struct NetCapability {
+        adapter: Arc<dyn NetAdapter>,
+        default_timeout: Duration,
+    }
+
+    #[cfg(test)]
+    impl NetCapability {
+        /// Test-only direct constructor. Production boots through
+        /// `Builder::with_actor::<NetCapability>(config)` which calls
+        /// `init`; tests that drive the cap with a stub adapter hand it
+        /// in directly.
+        pub(crate) fn from_adapter(
+            adapter: Arc<dyn NetAdapter>,
+            default_timeout: Duration,
+        ) -> Self {
+            Self {
+                adapter,
+                default_timeout,
+            }
+        }
+    }
+
+    #[actor]
+    impl NativeActor for NetCapability {
+        type Config = NetConfig;
+
+        /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
+        const NAMESPACE: &'static str = "aether.net";
+
+        /// Build the net adapter from the resolved config. The adapter is
+        /// built immediately so configuration errors surface at chassis-
+        /// builder time, not at first fetch.
+        fn init(config: NetConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let default_timeout = config.default_timeout;
+            Ok(Self {
+                adapter: build_net_adapter(config),
+                default_timeout,
+            })
+        }
+
+        /// Run a fetch request and reply with the response.
+        ///
+        /// # Agent
+        /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
+        /// long-running fetches block other net mail until they finish.
+        #[handler]
+        fn on_fetch(&self, ctx: &mut NativeCtx<'_>, mail: Fetch) {
+            let timeout = mail
+                .timeout_ms
+                .map(|ms| Duration::from_millis(ms as u64))
+                .unwrap_or(self.default_timeout);
+
+            let url = mail.url.clone();
+            let adapter_req = FetchRequest {
+                url: mail.url,
+                method: mail.method,
+                headers: mail.headers,
+                body: mail.body,
+                timeout,
+            };
+
+            let reply = match self.adapter.fetch(adapter_req) {
+                Ok(r) => FetchResult::Ok {
+                    url,
+                    status: r.status,
+                    headers: r.headers,
+                    body: r.body,
+                },
+                Err(error) => FetchResult::Err { url, error },
+            };
+            ctx.reply(&reply);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::sync::Mutex;
+
+        use super::super::{
+            DEFAULT_MAX_BODY_BYTES, DisabledNetAdapter, FetchRequest, FetchResponse, HttpHeader,
+            HttpMethod, NetAdapter, NetConfig, NetError,
+        };
+        use super::{
+            Arc, Duration, Fetch, FetchResult, HashSet, NetCapability, UreqNetAdapter,
+            build_net_adapter,
+        };
+        use aether_actor::Actor;
+        use aether_data::{Kind, MailboxId};
+        use aether_substrate::capability::{BootError, ChassisBuilder};
+        use aether_substrate::mail::ReplyTo;
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::native_actor::NativeCtx;
+        use aether_substrate::native_transport::NativeTransport;
+        use aether_substrate::registry::Registry;
+
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            (registry, Arc::new(Mailer::new()))
+        }
+
+        struct StubAdapter {
+            response: Mutex<Option<Result<FetchResponse, NetError>>>,
+            last_request: Mutex<Option<FetchRequest>>,
+        }
+
+        impl StubAdapter {
+            fn with(response: Result<FetchResponse, NetError>) -> Arc<Self> {
+                Arc::new(Self {
+                    response: Mutex::new(Some(response)),
+                    last_request: Mutex::new(None),
+                })
+            }
+        }
+
+        impl NetAdapter for StubAdapter {
+            fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, NetError> {
+                *self.last_request.lock().unwrap() = Some(FetchRequest {
+                    url: req.url.clone(),
+                    method: req.method,
+                    headers: req.headers.clone(),
+                    body: req.body.clone(),
+                    timeout: req.timeout,
+                });
+                self.response
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("stub response already consumed")
+            }
+        }
+
+        use aether_data::{ReplyTarget, SessionToken, Uuid};
+
+        use aether_substrate::outbound::EgressEvent;
+
+        fn session_sender() -> ReplyTo {
+            ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
+        }
+
+        fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
+            use std::collections::HashMap;
+            use std::sync::RwLock;
+
+            let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
+            let mailer = Arc::new(Mailer::new());
+            mailer.wire(
+                Arc::new(aether_substrate::registry::Registry::new()),
+                Arc::new(RwLock::new(HashMap::new())),
+            );
+            mailer.wire_outbound(outbound);
+            (mailer, rx)
+        }
+
+        fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
+            rx: &std::sync::mpsc::Receiver<EgressEvent>,
+        ) -> K {
+            let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            let EgressEvent::ToSession {
+                kind_name, payload, ..
+            } = event
+            else {
+                panic!("expected ToSession egress, got {event:?}");
+            };
+            assert_eq!(kind_name, K::NAME);
+            postcard::from_bytes(&payload).unwrap()
+        }
+
+        /// Boot the cap against a default disabled NetConfig and confirm
+        /// the mailbox is registered.
+        #[test]
+        fn capability_boots_and_registers_mailbox() {
+            let (registry, mailer) = fresh_substrate();
+            let config = NetConfig {
+                disabled: true,
+                ..NetConfig::default()
+            };
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<NetCapability>(config)
+                .build()
+                .expect("net capability boots");
+            assert!(
+                registry.lookup(NetCapability::NAMESPACE).is_some(),
+                "net mailbox registered"
+            );
+            chassis.shutdown();
+        }
+
+        /// Builder rejects a duplicate claim.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            let (registry, mailer) = fresh_substrate();
+            registry.register_sink(NetCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            let config = NetConfig {
+                disabled: true,
+                ..NetConfig::default()
+            };
+
+            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<NetCapability>(config)
+                .build()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == NetCapability::NAMESPACE
+            ));
+        }
+
+        #[test]
+        fn disabled_adapter_replies_disabled() {
+            let (mailer, rx) = test_mailer_and_rx();
+            let cap = NetCapability::from_adapter(
+                Arc::new(DisabledNetAdapter),
+                NetConfig::default().default_timeout,
+            );
+            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+            let mut ctx = NativeCtx::new(&transport, session_sender());
+            cap.on_fetch(
+                &mut ctx,
+                Fetch {
+                    url: "https://api.example.com/".to_string(),
+                    method: HttpMethod::Get,
+                    headers: vec![],
+                    body: vec![],
+                    timeout_ms: None,
+                },
+            );
+            match decode_reply::<FetchResult>(&rx) {
+                FetchResult::Err {
+                    url,
+                    error: NetError::Disabled,
+                } => {
+                    assert_eq!(url, "https://api.example.com/");
+                }
+                other => panic!("expected Err Disabled, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn allowlist_empty_rejects_every_host() {
+            let adapter = UreqNetAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
+            let resp = adapter.fetch(FetchRequest {
+                url: "https://api.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout: Duration::from_secs(30),
             });
-            self.response
+            assert!(matches!(resp, Err(NetError::AllowlistDenied)));
+        }
+
+        #[test]
+        fn allowlist_miss_returns_denied_without_making_request() {
+            let mut allowlist = HashSet::new();
+            allowlist.insert("allowed.example.com".to_string());
+            let adapter = UreqNetAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES);
+            let resp = adapter.fetch(FetchRequest {
+                url: "https://denied.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout: Duration::from_secs(30),
+            });
+            assert!(matches!(resp, Err(NetError::AllowlistDenied)));
+        }
+
+        #[test]
+        fn invalid_url_returns_invalid_url_variant() {
+            let adapter = UreqNetAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
+            let resp = adapter.fetch(FetchRequest {
+                url: "not-a-url".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout: Duration::from_secs(30),
+            });
+            assert!(matches!(resp, Err(NetError::InvalidUrl(_))));
+        }
+
+        #[test]
+        fn require_https_rejects_http_scheme() {
+            let mut allowlist = HashSet::new();
+            allowlist.insert("example.com".to_string());
+            let adapter = UreqNetAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES);
+            let resp = adapter.fetch(FetchRequest {
+                url: "http://example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout: Duration::from_secs(30),
+            });
+            assert!(matches!(resp, Err(NetError::InvalidUrl(_))));
+        }
+
+        #[test]
+        fn oversize_request_body_returns_body_too_large() {
+            let mut allowlist = HashSet::new();
+            allowlist.insert("example.com".to_string());
+            let adapter = UreqNetAdapter::new(allowlist, false, 10);
+            let resp = adapter.fetch(FetchRequest {
+                url: "https://example.com/".to_string(),
+                method: HttpMethod::Post,
+                headers: vec![],
+                body: vec![0u8; 20],
+                timeout: Duration::from_secs(30),
+            });
+            assert!(matches!(resp, Err(NetError::BodyTooLarge)));
+        }
+
+        #[test]
+        fn cap_fetch_ok_replies_with_response() {
+            let (mailer, rx) = test_mailer_and_rx();
+            let stub = StubAdapter::with(Ok(FetchResponse {
+                status: 200,
+                headers: vec![HttpHeader {
+                    name: "content-type".to_string(),
+                    value: "application/json".to_string(),
+                }],
+                body: b"{}".to_vec(),
+            }));
+            let cap = NetCapability::from_adapter(
+                stub as Arc<dyn NetAdapter>,
+                NetConfig::default().default_timeout,
+            );
+            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+            let mut ctx = NativeCtx::new(&transport, session_sender());
+            cap.on_fetch(
+                &mut ctx,
+                Fetch {
+                    url: "https://api.example.com/v1".to_string(),
+                    method: HttpMethod::Get,
+                    headers: vec![],
+                    body: vec![],
+                    timeout_ms: Some(5000),
+                },
+            );
+            match decode_reply::<FetchResult>(&rx) {
+                FetchResult::Ok {
+                    url,
+                    status,
+                    headers,
+                    body,
+                } => {
+                    assert_eq!(url, "https://api.example.com/v1");
+                    assert_eq!(status, 200);
+                    assert_eq!(headers.len(), 1);
+                    assert_eq!(body, b"{}".to_vec());
+                }
+                FetchResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+        }
+
+        #[test]
+        fn cap_fetch_err_echoes_url_and_error() {
+            let (mailer, rx) = test_mailer_and_rx();
+            let cap = NetCapability::from_adapter(
+                StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>,
+                NetConfig::default().default_timeout,
+            );
+            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+            let mut ctx = NativeCtx::new(&transport, session_sender());
+            cap.on_fetch(
+                &mut ctx,
+                Fetch {
+                    url: "https://slow.example.com/".to_string(),
+                    method: HttpMethod::Get,
+                    headers: vec![],
+                    body: vec![],
+                    timeout_ms: None,
+                },
+            );
+            match decode_reply::<FetchResult>(&rx) {
+                FetchResult::Err { url, error } => {
+                    assert_eq!(url, "https://slow.example.com/");
+                    assert_eq!(error, NetError::Timeout);
+                }
+                FetchResult::Ok { .. } => panic!("expected Err"),
+            }
+        }
+
+        #[test]
+        fn cap_uses_default_timeout_when_none_provided() {
+            let (mailer, _rx) = test_mailer_and_rx();
+            let stub = StubAdapter::with(Ok(FetchResponse {
+                status: 200,
+                headers: vec![],
+                body: vec![],
+            }));
+            let stub_clone = Arc::clone(&stub);
+            let cap = NetCapability::from_adapter(
+                stub as Arc<dyn NetAdapter>,
+                NetConfig::default().default_timeout,
+            );
+            let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
+            let mut ctx = NativeCtx::new(&transport, session_sender());
+            cap.on_fetch(
+                &mut ctx,
+                Fetch {
+                    url: "https://api.example.com/".to_string(),
+                    method: HttpMethod::Get,
+                    headers: vec![],
+                    body: vec![],
+                    timeout_ms: None,
+                },
+            );
+            let observed = stub_clone
+                .last_request
                 .lock()
                 .unwrap()
                 .take()
-                .expect("stub response already consumed")
+                .expect("adapter was not called");
+            assert!(observed.timeout > Duration::ZERO);
         }
-    }
 
-    use aether_data::{ReplyTarget, SessionToken, Uuid};
-
-    use aether_substrate::outbound::EgressEvent;
-
-    fn session_sender() -> ReplyTo {
-        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
-    }
-
-    fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
-        use std::collections::HashMap;
-        use std::sync::RwLock;
-
-        let (outbound, rx) = aether_substrate::outbound::HubOutbound::attached_loopback();
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(
-            Arc::new(aether_substrate::registry::Registry::new()),
-            Arc::new(RwLock::new(HashMap::new())),
-        );
-        mailer.wire_outbound(outbound);
-        (mailer, rx)
-    }
-
-    fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
-        rx: &std::sync::mpsc::Receiver<EgressEvent>,
-    ) -> K {
-        let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        let EgressEvent::ToSession {
-            kind_name, payload, ..
-        } = event
-        else {
-            panic!("expected ToSession egress, got {event:?}");
-        };
-        assert_eq!(kind_name, K::NAME);
-        postcard::from_bytes(&payload).unwrap()
-    }
-
-    /// Boot the cap against a default disabled NetConfig and confirm
-    /// the mailbox is registered.
-    #[test]
-    fn capability_boots_and_registers_mailbox() {
-        let (registry, mailer) = fresh_substrate();
-        let config = NetConfig {
-            disabled: true,
-            ..NetConfig::default()
-        };
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<NetCapability>(config)
-            .build()
-            .expect("net capability boots");
-        assert!(
-            registry.lookup(NetCapability::NAMESPACE).is_some(),
-            "net mailbox registered"
-        );
-        chassis.shutdown();
-    }
-
-    /// Builder rejects a duplicate claim.
-    #[test]
-    fn duplicate_claim_rejects_with_typed_error() {
-        let (registry, mailer) = fresh_substrate();
-        registry.register_sink(NetCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
-        let config = NetConfig {
-            disabled: true,
-            ..NetConfig::default()
-        };
-
-        let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<NetCapability>(config)
-            .build()
-            .expect_err("collision must surface as BootError");
-        assert!(matches!(
-            err,
-            BootError::MailboxAlreadyClaimed { ref name }
-                if name == NetCapability::NAMESPACE
-        ));
-    }
-
-    #[test]
-    fn disabled_adapter_replies_disabled() {
-        let (mailer, rx) = test_mailer_and_rx();
-        let cap = NetCapability::from_adapter(
-            Arc::new(DisabledNetAdapter),
-            NetConfig::default().default_timeout,
-        );
-        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
-        let mut ctx = NativeCtx::new(&transport, session_sender());
-        cap.on_fetch(
-            &mut ctx,
-            Fetch {
-                url: "https://api.example.com/".to_string(),
+        #[test]
+        fn build_net_adapter_with_disable_returns_disabled() {
+            let cfg = NetConfig {
+                disabled: true,
+                ..NetConfig::default()
+            };
+            let a = build_net_adapter(cfg);
+            let resp = a.fetch(FetchRequest {
+                url: "https://example.com/".to_string(),
                 method: HttpMethod::Get,
                 headers: vec![],
                 body: vec![],
-                timeout_ms: None,
-            },
-        );
-        match decode_reply::<FetchResult>(&rx) {
-            FetchResult::Err {
-                url,
-                error: NetError::Disabled,
-            } => {
-                assert_eq!(url, "https://api.example.com/");
-            }
-            other => panic!("expected Err Disabled, got {other:?}"),
+                timeout: Duration::from_secs(30),
+            });
+            assert!(matches!(resp, Err(NetError::Disabled)));
         }
-    }
 
-    #[test]
-    fn allowlist_empty_rejects_every_host() {
-        let adapter = UreqNetAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
-            url: "https://api.example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::AllowlistDenied)));
+        /// Silence `Kind` unused-import (handy for the test mod's
+        /// `decode_reply` bound).
+        #[allow(dead_code)]
+        fn _silence_kind<K: Kind>() {}
     }
-
-    #[test]
-    fn allowlist_miss_returns_denied_without_making_request() {
-        let mut allowlist = HashSet::new();
-        allowlist.insert("allowed.example.com".to_string());
-        let adapter = UreqNetAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
-            url: "https://denied.example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::AllowlistDenied)));
-    }
-
-    #[test]
-    fn invalid_url_returns_invalid_url_variant() {
-        let adapter = UreqNetAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
-            url: "not-a-url".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::InvalidUrl(_))));
-    }
-
-    #[test]
-    fn require_https_rejects_http_scheme() {
-        let mut allowlist = HashSet::new();
-        allowlist.insert("example.com".to_string());
-        let adapter = UreqNetAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES);
-        let resp = adapter.fetch(FetchRequest {
-            url: "http://example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::InvalidUrl(_))));
-    }
-
-    #[test]
-    fn oversize_request_body_returns_body_too_large() {
-        let mut allowlist = HashSet::new();
-        allowlist.insert("example.com".to_string());
-        let adapter = UreqNetAdapter::new(allowlist, false, 10);
-        let resp = adapter.fetch(FetchRequest {
-            url: "https://example.com/".to_string(),
-            method: HttpMethod::Post,
-            headers: vec![],
-            body: vec![0u8; 20],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::BodyTooLarge)));
-    }
-
-    #[test]
-    fn cap_fetch_ok_replies_with_response() {
-        let (mailer, rx) = test_mailer_and_rx();
-        let stub = StubAdapter::with(Ok(FetchResponse {
-            status: 200,
-            headers: vec![HttpHeader {
-                name: "content-type".to_string(),
-                value: "application/json".to_string(),
-            }],
-            body: b"{}".to_vec(),
-        }));
-        let cap = NetCapability::from_adapter(
-            stub as Arc<dyn NetAdapter>,
-            NetConfig::default().default_timeout,
-        );
-        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
-        let mut ctx = NativeCtx::new(&transport, session_sender());
-        cap.on_fetch(
-            &mut ctx,
-            Fetch {
-                url: "https://api.example.com/v1".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout_ms: Some(5000),
-            },
-        );
-        match decode_reply::<FetchResult>(&rx) {
-            FetchResult::Ok {
-                url,
-                status,
-                headers,
-                body,
-            } => {
-                assert_eq!(url, "https://api.example.com/v1");
-                assert_eq!(status, 200);
-                assert_eq!(headers.len(), 1);
-                assert_eq!(body, b"{}".to_vec());
-            }
-            FetchResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
-        }
-    }
-
-    #[test]
-    fn cap_fetch_err_echoes_url_and_error() {
-        let (mailer, rx) = test_mailer_and_rx();
-        let cap = NetCapability::from_adapter(
-            StubAdapter::with(Err(NetError::Timeout)) as Arc<dyn NetAdapter>,
-            NetConfig::default().default_timeout,
-        );
-        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
-        let mut ctx = NativeCtx::new(&transport, session_sender());
-        cap.on_fetch(
-            &mut ctx,
-            Fetch {
-                url: "https://slow.example.com/".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout_ms: None,
-            },
-        );
-        match decode_reply::<FetchResult>(&rx) {
-            FetchResult::Err { url, error } => {
-                assert_eq!(url, "https://slow.example.com/");
-                assert_eq!(error, NetError::Timeout);
-            }
-            FetchResult::Ok { .. } => panic!("expected Err"),
-        }
-    }
-
-    #[test]
-    fn cap_uses_default_timeout_when_none_provided() {
-        let (mailer, _rx) = test_mailer_and_rx();
-        let stub = StubAdapter::with(Ok(FetchResponse {
-            status: 200,
-            headers: vec![],
-            body: vec![],
-        }));
-        let stub_clone = Arc::clone(&stub);
-        let cap = NetCapability::from_adapter(
-            stub as Arc<dyn NetAdapter>,
-            NetConfig::default().default_timeout,
-        );
-        let transport = NativeTransport::new_for_test(mailer, MailboxId(0));
-        let mut ctx = NativeCtx::new(&transport, session_sender());
-        cap.on_fetch(
-            &mut ctx,
-            Fetch {
-                url: "https://api.example.com/".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout_ms: None,
-            },
-        );
-        let observed = stub_clone
-            .last_request
-            .lock()
-            .unwrap()
-            .take()
-            .expect("adapter was not called");
-        assert!(observed.timeout > Duration::ZERO);
-    }
-
-    #[test]
-    fn build_net_adapter_with_disable_returns_disabled() {
-        let cfg = NetConfig {
-            disabled: true,
-            ..NetConfig::default()
-        };
-        let a = build_net_adapter(cfg);
-        let resp = a.fetch(FetchRequest {
-            url: "https://example.com/".to_string(),
-            method: HttpMethod::Get,
-            headers: vec![],
-            body: vec![],
-            timeout: Duration::from_secs(30),
-        });
-        assert!(matches!(resp, Err(NetError::Disabled)));
-    }
-
-    /// Silence `Kind` unused-import (handy for the test mod's
-    /// `decode_reply` bound).
-    #[allow(dead_code)]
-    fn _silence_kind<K: Kind>() {}
 }

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -1,522 +1,527 @@
-//! Issue 552 stage 2d: render cap migrated onto `NativeActor`. The
-//! cap is now `#[capability] #[derive(Singleton)]` plus `#[actor] impl
-//! NativeActor` — the symmetric authoring shape every other cap
-//! adopted in 2a/2b/2c. FRAME_BARRIER = true and the new
-//! `Builder::with_actor` boot path claims through the frame-bound
-//! mailbox machinery (the chassis frame loop's
-//! `drain_frame_bound_or_abort` reads the per-mailbox `pending`
-//! counter the dispatcher decrements after each handler — ADR-0074
-//! §Decision 5).
+//! `aether.render` cap. Owns the render mailbox surface plus the
+//! driver-facing accumulator state ([`RenderHandles`]) and GPU bundle
+//! ([`RenderGpu`]). FRAME_BARRIER = true so the chassis frame loop's
+//! drain-or-abort sees the per-mailbox pending counter before recording
+//! a frame (ADR-0074 §Decision 5).
 //!
 //! Driver-side state (wgpu device, queue, pipeline, offscreen
-//! targets, accumulator buffers) lives on [`RenderHandles`]. Pre-2d
-//! the chassis main pulled `cap.handles()` BEFORE moving the cap
-//! into the chassis builder; with `with_actor::<RenderCapability>(...)`
-//! the cap is constructed inside `init`, so the driver fetches the
-//! booted cap via `DriverCtx::actor::<RenderCapability>()` and clones
-//! `.handles()` from there. Both desktop and test_bench follow that
-//! pattern; the legacy `with(cap)` path retires for render.
-//!
-//! Phase 4 keeps the GPU lifecycle, encoder creation, and presentation
-//! in the chassis driver — this capability owns only the mail surface
-//! and accumulator state.
+//! targets, accumulator buffers) lives on [`RenderHandles`]. The
+//! driver fetches the booted cap via
+//! `DriverCtx::actor::<RenderCapability>()` and clones `.handles()`
+//! from there. Phase 4 keeps the GPU lifecycle, encoder creation, and
+//! presentation in the chassis driver — this capability owns only the
+//! mail surface and accumulator state.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
+use aether_kinds::{Camera, DrawTriangle};
 
-use aether_actor::{Singleton, actor};
-use aether_data::Kind;
-use aether_kinds::{Camera, DRAW_TRIANGLE_BYTES, DrawTriangle};
+// Auxiliary native-only types the chassis driver consumes alongside
+// `RenderCapability`. `#[bridge]` only re-exports the actor type
+// itself; these need explicit re-exports.
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::{RenderConfig, RenderGpu, RenderHandles};
 
-use aether_substrate::capability::BootError;
-use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-use aether_substrate::render::{
-    CaptureMeta, IDENTITY_VIEW_PROJ, Pipeline, RenderError, Targets, build_main_pipeline,
-    finish_capture, prepare_capture_copy, record_main_pass,
-};
+#[aether_actor::bridge]
+mod native {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, OnceLock};
 
-/// Configuration for [`RenderCapability`]. `vertex_buffer_bytes` is
-/// the maximum bytes the render accumulator will hold before
-/// truncating with a warn — desktop and test-bench both pass
-/// [`aether_substrate::render::VERTEX_BUFFER_BYTES`].
-///
-/// `observed_kinds`, when set, has every successfully-dispatched
-/// inbound mail's kind name pushed to it from the cap's `#[handler]`
-/// methods — used by the in-process test-bench to assert what kinds
-/// the cap has seen. Production chassis leave it `None` (zero
-/// overhead). Decode failures and unknown kinds don't push (the
-/// macro miss path warn-logs at the chassis-side dispatcher and
-/// short-circuits before any handler runs); pre-PR-E2 the legacy
-/// path pushed the raw `kind_name` regardless of dispatch outcome,
-/// but tests only use the list as a diagnostic in failure messages
-/// so the narrower semantic is fine.
-#[derive(Clone)]
-pub struct RenderConfig {
-    pub vertex_buffer_bytes: usize,
-    pub observed_kinds: Option<Arc<Mutex<Vec<String>>>>,
-}
+    use aether_actor::actor;
+    use aether_data::Kind;
+    use aether_kinds::DRAW_TRIANGLE_BYTES;
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::render::{
+        CaptureMeta, IDENTITY_VIEW_PROJ, Pipeline, RenderError, Targets, build_main_pipeline,
+        finish_capture, prepare_capture_copy, record_main_pass,
+    };
 
-impl Default for RenderConfig {
-    fn default() -> Self {
-        Self {
-            vertex_buffer_bytes: aether_substrate::render::VERTEX_BUFFER_BYTES,
-            observed_kinds: None,
-        }
-    }
-}
+    use super::{Camera, DrawTriangle};
 
-/// `aether.render` mailbox cap. Holds [`RenderHandles`] (the
-/// driver-facing accumulator state plus GPU bundle) and the
-/// per-instance config. The dispatcher thread holds an
-/// `Arc<Self>` and routes `aether.draw_triangle` / `aether.camera`
-/// mail through the macro-emitted `NativeDispatch` impl. Driver
-/// glue fetches handles via
-/// `DriverCtx::actor::<RenderCapability>()` (post-init) and clones
-/// the cheap Arc-shared bundle.
-#[derive(Singleton)]
-pub struct RenderCapability {
-    handles: RenderHandles,
-    config: RenderConfig,
-}
-
-impl RenderCapability {
-    /// Cheap clone of the driver-facing handles bundle. Call this on
-    /// the booted `Arc<RenderCapability>` (fetched via
-    /// `DriverCtx::actor`) — every field is Arc-shared, so the clone
-    /// is just refcount bumps.
-    pub fn handles(&self) -> RenderHandles {
-        self.handles.clone()
-    }
-}
-
-#[actor]
-impl NativeActor for RenderCapability {
-    type Config = RenderConfig;
-
-    /// Components mail `aether.draw_triangle` and `aether.camera`
-    /// (kind ids) to this mailbox; the GPU recorder pulls from here.
-    /// The `aether.<name>` form is the post-ADR-0074 Phase 5
-    /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
-    /// folded the camera mailbox into render under this name.
-    const NAMESPACE: &'static str = "aether.render";
-
-    /// Render is the one chassis-owned actor that participates in the
-    /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
-    /// a `DrawTriangle` mail in flight when the chassis driver records
-    /// the frame would land in the *next* frame's `frame_vertices`,
-    /// dropping a triangle the component meant for this frame. The
-    /// `Builder::with_actor` boot path checks this const and claims
-    /// through the frame-bound path so the cap's `pending` counter
-    /// registers in the chassis's `frame_bound_pending` Vec.
-    const FRAME_BARRIER: bool = true;
-
-    /// Allocate the accumulator state up front. Idempotent on the
-    /// driver-facing side: every chassis main passes a fresh
-    /// `RenderConfig`; init only sets up the in-process buffers and
-    /// the wgpu `OnceLock` (the driver fills it in `resumed` /
-    /// post-`build_passive`).
-    fn init(config: RenderConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        let handles = RenderHandles {
-            frame_vertices: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
-                config.vertex_buffer_bytes,
-            ))),
-            triangles_rendered: Arc::new(AtomicU64::new(0)),
-            camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
-            gpu: Arc::new(OnceLock::new()),
-        };
-        Ok(Self { handles, config })
-    }
-
-    /// `DrawTriangle` handler. Slice-typed because `Mailbox::send_many`
-    /// (ADR-0019) packs `count` triangles into one envelope — the
-    /// macro decodes the whole payload as `&[DrawTriangle]` so a
-    /// batched mesh reaches the cap intact. Truncates at the cap
-    /// boundary so a single oversized mesh degrades gracefully
-    /// instead of collapsing the whole frame downstream; rounds to
-    /// whole triangles so the GPU vertex buffer never sees a half-
-    /// triangle.
+    /// Configuration for [`RenderCapability`]. `vertex_buffer_bytes` is
+    /// the maximum bytes the render accumulator will hold before
+    /// truncating with a warn — desktop and test-bench both pass
+    /// [`aether_substrate::render::VERTEX_BUFFER_BYTES`].
     ///
-    /// # Agent
-    /// Components mail one or more `DrawTriangle`s (cast-shape,
-    /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
-    /// per tick. Fire-and-forget; the cap accumulates into
-    /// `frame_vertices` until the chassis driver records the frame.
-    #[handler]
-    fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
-        if let Some(obs) = &self.config.observed_kinds {
-            obs.lock()
-                .unwrap()
-                .push(<DrawTriangle as Kind>::NAME.into());
-        }
-        let bytes: &[u8] = bytemuck::cast_slice(mails);
-        let cap_bytes = self.config.vertex_buffer_bytes;
-        let mut verts = self.handles.frame_vertices.lock().unwrap();
-        let available = cap_bytes.saturating_sub(verts.len());
-        let write_len = bytes.len().min(available);
-        let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-        if write_len > 0 {
-            verts.extend_from_slice(&bytes[..write_len]);
-            self.handles
-                .triangles_rendered
-                .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-        }
-        if write_len < bytes.len() {
-            tracing::warn!(
-                target: "aether_substrate::render",
-                accepted_bytes = write_len,
-                dropped_bytes = bytes.len() - write_len,
-                cap = cap_bytes,
-                "render cap dropped triangles beyond fixed vertex buffer",
-            );
-        }
+    /// `observed_kinds`, when set, has every successfully-dispatched
+    /// inbound mail's kind name pushed to it from the cap's `#[handler]`
+    /// methods — used by the in-process test-bench to assert what kinds
+    /// the cap has seen. Production chassis leave it `None` (zero
+    /// overhead). Decode failures and unknown kinds don't push (the
+    /// macro miss path warn-logs at the chassis-side dispatcher and
+    /// short-circuits before any handler runs); pre-PR-E2 the legacy
+    /// path pushed the raw `kind_name` regardless of dispatch outcome,
+    /// but tests only use the list as a diagnostic in failure messages
+    /// so the narrower semantic is fine.
+    #[derive(Clone)]
+    pub struct RenderConfig {
+        pub vertex_buffer_bytes: usize,
+        pub observed_kinds: Option<Arc<Mutex<Vec<String>>>>,
     }
 
-    /// `Camera` handler. Latest-value-wins semantics: each successful
-    /// mail overwrites; the prior value is replaced wholesale.
-    /// Initialised in `init` to [`IDENTITY_VIEW_PROJ`] so the first
-    /// frame draws unchanged until a camera component starts
-    /// publishing.
-    ///
-    /// # Agent
-    /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
-    /// to this mailbox. Fire-and-forget; latest value wins.
-    #[handler]
-    fn on_camera(&self, _ctx: &mut NativeCtx<'_>, mail: Camera) {
-        if let Some(obs) = &self.config.observed_kinds {
-            obs.lock().unwrap().push(<Camera as Kind>::NAME.into());
-        }
-        *self.handles.camera_state.lock().unwrap() = mail.view_proj;
-    }
-}
-
-/// Bundle of accumulator state plus GPU resources, shared between
-/// the cap's dispatcher thread (write side for accumulators) and the
-/// chassis driver (read side for accumulators, install + read for
-/// GPU). All fields are `Arc`s so cloning is cheap and shutdown
-/// drops are independent.
-#[derive(Clone)]
-pub struct RenderHandles {
-    pub frame_vertices: Arc<Mutex<Vec<u8>>>,
-    pub triangles_rendered: Arc<AtomicU64>,
-    pub camera_state: Arc<Mutex<[f32; 16]>>,
-    /// wgpu state, installed post-cap-construction by the driver via
-    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
-    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
-    /// after `Builder::build` has returned. Test-bench (no surface)
-    /// installs immediately after `build_passive`; desktop installs
-    /// in its `resumed` handler. Encoder-level methods panic if
-    /// called before install — in practice every code path that
-    /// calls them runs after the install site.
-    gpu: Arc<OnceLock<RenderGpu>>,
-}
-
-impl RenderHandles {
-    /// Install the wgpu resources the encoder-level methods read.
-    /// The driver constructs [`RenderGpu`] once it has a device +
-    /// queue — for desktop that's inside `resumed` after winit hands
-    /// back a window and surface; for test-bench it's right after
-    /// `build_passive` returns. Calling twice panics: install is the
-    /// chassis's promise that wgpu state is now ready and stable for
-    /// the chassis lifetime.
-    pub fn install_gpu(&self, gpu: RenderGpu) {
-        self.gpu
-            .set(gpu)
-            .ok()
-            .expect("RenderHandles::install_gpu called twice");
-    }
-
-    /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
-    /// hasn't been called yet. Chassis-side glue that needs raw
-    /// access to the pipeline's bind group layouts (e.g. desktop's
-    /// wireframe overlay pipeline construction) reaches in here.
-    pub fn gpu(&self) -> Option<&RenderGpu> {
-        self.gpu.get()
-    }
-
-    fn expect_gpu(&self) -> &RenderGpu {
-        self.gpu.get().expect(
-            "RenderHandles::install_gpu must be called before encoder-level methods. \
-             Desktop installs in winit's resumed; test-bench installs after build_passive.",
-        )
-    }
-
-    /// Drain the current frame's accumulated vertices, read the
-    /// latest camera view-proj, and record the main render pass into
-    /// `encoder`. Each call consumes the accumulator (subsequent
-    /// inbound mail builds the next frame). `extra_pipelines` are
-    /// drawn after the main pipeline inside the same render pass —
-    /// desktop passes a wireframe overlay pipeline here when
-    /// `AETHER_WIREFRAME=overlay`; test-bench passes `&[]`.
-    pub fn record_frame(
-        &self,
-        encoder: &mut wgpu::CommandEncoder,
-        extra_pipelines: &[&wgpu::RenderPipeline],
-    ) -> Result<(), RenderError> {
-        let gpu = self.expect_gpu();
-        let cap = self.frame_vertices.lock().unwrap().capacity();
-        let vertices = std::mem::replace(
-            &mut *self.frame_vertices.lock().unwrap(),
-            Vec::with_capacity(cap),
-        );
-        let view_proj = *self.camera_state.lock().unwrap();
-        let targets = gpu.targets.lock().unwrap();
-        record_main_pass(
-            &gpu.queue,
-            encoder,
-            &gpu.pipeline,
-            &targets,
-            &vertices,
-            &view_proj,
-            extra_pipelines,
-        )
-    }
-
-    /// Encode a copy of the offscreen color target into a readback
-    /// buffer. Pair with [`Self::finish_capture`] after submit. The
-    /// readback buffer is reallocated on size mismatch with the
-    /// current offscreen, so any sequence of resize → record_frame →
-    /// record_capture_copy → submit → finish_capture works.
-    pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
-        let gpu = self.expect_gpu();
-        let mut targets = gpu.targets.lock().unwrap();
-        prepare_capture_copy(&gpu.device, &mut targets, encoder)
-    }
-
-    /// Map the readback buffer prepared by [`Self::record_capture_copy`]
-    /// and return the encoded PNG. Call after the encoder containing
-    /// the matching `record_capture_copy` has been submitted.
-    pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
-        let gpu = self.expect_gpu();
-        let targets = gpu.targets.lock().unwrap();
-        finish_capture(&gpu.device, &targets, meta)
-    }
-
-    /// Resize the offscreen color + depth targets. Idempotent on
-    /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
-    pub fn resize(&self, width: u32, height: u32) {
-        let gpu = self.expect_gpu();
-        let mut targets = gpu.targets.lock().unwrap();
-        targets.resize(&gpu.device, width, height);
-    }
-
-    /// Cloned `Arc<wgpu::Device>`. Drivers that need the device for
-    /// their own pipelines (e.g. desktop's wireframe overlay pipeline,
-    /// swapchain blit) clone here.
-    pub fn device(&self) -> Arc<wgpu::Device> {
-        Arc::clone(&self.expect_gpu().device)
-    }
-
-    /// Cloned `Arc<wgpu::Queue>`. Drivers submit through this; the
-    /// shared queue means render's `record_frame` writes and the
-    /// driver's swapchain submit go through the same submission
-    /// order.
-    pub fn queue(&self) -> Arc<wgpu::Queue> {
-        Arc::clone(&self.expect_gpu().queue)
-    }
-
-    /// Format the offscreen color target was created with. Capture's
-    /// BGRA-vs-RGBA decision keys on this; desktop's swapchain blit
-    /// matches its surface format against this to pick a direct copy
-    /// vs a manual swizzle.
-    pub fn color_format(&self) -> wgpu::TextureFormat {
-        self.expect_gpu().color_format
-    }
-
-    /// Current offscreen color target dimensions. Drivers reading
-    /// after a `resize` see the new dimensions immediately.
-    pub fn color_size(&self) -> (u32, u32) {
-        let targets = self.expect_gpu().targets.lock().unwrap();
-        (targets.width(), targets.height())
-    }
-
-    /// Run `f` with a borrow of the offscreen color texture. Used by
-    /// desktop's swapchain blit: the closure body holds the targets
-    /// mutex, so any encoder commands recorded inside are sequenced
-    /// against any concurrent resize. Test-bench reaches the
-    /// offscreen via the capture path and doesn't need this.
-    pub fn with_color_texture<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(&wgpu::Texture) -> R,
-    {
-        let gpu = self.expect_gpu();
-        let targets = gpu.targets.lock().unwrap();
-        f(targets.color_texture())
-    }
-}
-
-/// Bundle of wgpu resources `RenderHandles` exposes post-install.
-/// Constructed by the driver from a wgpu device + queue obtained via
-/// `Adapter::request_device` (desktop: with surface compatibility;
-/// test-bench: offscreen-only). Holds the pipeline + offscreen
-/// targets so encoder-level methods can record draws and capture
-/// copies without the driver threading these through every call.
-pub struct RenderGpu {
-    pub device: Arc<wgpu::Device>,
-    pub queue: Arc<wgpu::Queue>,
-    pub pipeline: Pipeline,
-    pub targets: Mutex<Targets>,
-    pub color_format: wgpu::TextureFormat,
-}
-
-impl RenderGpu {
-    /// Build the standard render pipeline + offscreen targets at the
-    /// given size and pass [`Self`] to [`RenderHandles::install_gpu`].
-    /// `polygon_mode` is `Fill` for the normal case; desktop's
-    /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
-    /// pipeline draws as wireframe instead of building a separate
-    /// overlay pipeline.
-    pub fn new(
-        device: Arc<wgpu::Device>,
-        queue: Arc<wgpu::Queue>,
-        color_format: wgpu::TextureFormat,
-        width: u32,
-        height: u32,
-        polygon_mode: wgpu::PolygonMode,
-    ) -> Self {
-        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
-        let targets = Targets::new(&device, color_format, width, height);
-        Self {
-            device,
-            queue,
-            pipeline,
-            targets: Mutex::new(targets),
-            color_format,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use super::*;
-    use aether_actor::Actor;
-    use aether_substrate::capability::ChassisBuilder;
-    use aether_substrate::mail::{KindId, ReplyTo};
-    use aether_substrate::mailer::Mailer;
-    use aether_substrate::registry::{MailboxEntry, Registry};
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        (Arc::new(Registry::new()), Arc::new(Mailer::new()))
-    }
-
-    fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
-        let id = registry.lookup(name).expect("mailbox registered");
-        let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry exists") else {
-            panic!("expected sink entry for {name}");
-        };
-        handler(kind, "test.kind", None, ReplyTo::NONE, payload, 1);
-    }
-
-    #[test]
-    fn capability_claims_render_mailbox_only() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build()
-            .expect("build succeeds");
-        assert_eq!(chassis.len(), 1);
-        assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
-        // Camera mailbox retired (ADR-0074 §Decision 7).
-        assert!(registry.lookup("aether.sink.camera").is_none());
-    }
-
-    /// Boots render through the legacy `ChassisBuilder.with_actor`
-    /// path and asserts a `DrawTriangle` mail accumulates into the
-    /// frame_vertices buffer. The `RenderHandles` here is reached
-    /// via the chassis post-build (legacy ChassisBuilder doesn't
-    /// expose an actors map; the test asserts via the registry sink
-    /// the dispatcher drains rather than reading the cap state
-    /// directly). Coverage of `handles` accessor is in the desktop
-    /// chassis path post-2d.
-    #[test]
-    fn render_dispatcher_appends_triangles_to_frame_vertices() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build()
-            .expect("build succeeds");
-
-        let one_triangle = vec![0u8; DRAW_TRIANGLE_BYTES];
-        deliver(
-            &registry,
-            RenderCapability::NAMESPACE,
-            <DrawTriangle as Kind>::ID,
-            &one_triangle,
-        );
-
-        // Wait briefly for the dispatcher thread to drain. The legacy
-        // `ChassisBuilder` boot path doesn't expose an Actors map for
-        // direct lookup, so the test waits on the per-mailbox pending
-        // counter the FRAME_BARRIER claim populates and treats a
-        // drain-to-zero as the dispatch happening. Pre-2d the test
-        // peeked at `cap.handles()` directly; the new shape doesn't
-        // expose that without a chassis-side actors map.
-        for _ in 0..50 {
-            if chassis.frame_bound_pending().is_empty()
-                || chassis.frame_bound_pending()[0].1.load(Ordering::Acquire) == 0
-            {
-                break;
+    impl Default for RenderConfig {
+        fn default() -> Self {
+            Self {
+                vertex_buffer_bytes: aether_substrate::render::VERTEX_BUFFER_BYTES,
+                observed_kinds: None,
             }
-            std::thread::sleep(Duration::from_millis(5));
         }
-        // The pending counter must have hit zero — the dispatcher
-        // ran the handler.
-        assert_eq!(chassis.frame_bound_pending().len(), 1);
-        assert_eq!(
-            chassis.frame_bound_pending()[0].1.load(Ordering::Acquire),
-            0,
-            "dispatcher should have processed the DrawTriangle"
-        );
-
-        chassis.shutdown();
     }
 
-    /// Frame-bound claim populates the chassis's `frame_bound_pending`
-    /// Vec. Direct render-internal-state assertions live on the
-    /// `with_actor`-via-`Builder` path (chassis_builder tests +
-    /// integration tests in the bundle), where the chassis-side
-    /// actors map exposes `Arc<RenderCapability>` for `handles()`
-    /// access.
-    #[test]
-    fn render_registers_frame_bound_pending_counter() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build()
-            .expect("build succeeds");
-        assert_eq!(
-            chassis.frame_bound_pending().len(),
-            1,
-            "render claimed through frame-bound path"
-        );
-        chassis.shutdown();
+    /// `aether.render` mailbox cap. Holds [`RenderHandles`] (the
+    /// driver-facing accumulator state plus GPU bundle) and the
+    /// per-instance config. The dispatcher thread holds an
+    /// `Arc<Self>` and routes `aether.draw_triangle` / `aether.camera`
+    /// mail through the macro-emitted `NativeDispatch` impl. Driver
+    /// glue fetches handles via
+    /// `DriverCtx::actor::<RenderCapability>()` (post-init) and clones
+    /// the cheap Arc-shared bundle.
+    pub struct RenderCapability {
+        handles: RenderHandles,
+        config: RenderConfig,
     }
 
-    #[test]
-    fn camera_kind_drops_wrong_length_payload() {
-        let (registry, mailer) = fresh_substrate();
-        let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<RenderCapability>(RenderConfig::default())
-            .build()
-            .expect("build succeeds");
+    impl RenderCapability {
+        /// Cheap clone of the driver-facing handles bundle. Call this on
+        /// the booted `Arc<RenderCapability>` (fetched via
+        /// `DriverCtx::actor`) — every field is Arc-shared, so the clone
+        /// is just refcount bumps.
+        pub fn handles(&self) -> RenderHandles {
+            self.handles.clone()
+        }
+    }
 
-        // 16 bytes — wrong length, decode fails, macro miss path
-        // logs warn at chassis-side dispatcher; identity unchanged.
-        deliver(
-            &registry,
-            RenderCapability::NAMESPACE,
-            <Camera as Kind>::ID,
-            &[1u8; 16],
-        );
+    #[actor]
+    impl NativeActor for RenderCapability {
+        type Config = RenderConfig;
 
-        std::thread::sleep(Duration::from_millis(50));
-        // No further assertion on internal state — the legacy
-        // `ChassisBuilder` boot path doesn't expose `Arc<RenderCapability>`.
-        // Decode failure is observable via the macro miss path's
-        // warn-log; this test asserts shutdown still proceeds cleanly
-        // (no dispatcher panic on malformed input).
-        chassis.shutdown();
+        /// Components mail `aether.draw_triangle` and `aether.camera`
+        /// (kind ids) to this mailbox; the GPU recorder pulls from here.
+        /// The `aether.<name>` form is the post-ADR-0074 Phase 5
+        /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
+        /// folded the camera mailbox into render under this name.
+        const NAMESPACE: &'static str = "aether.render";
+
+        /// Render is the one chassis-owned actor that participates in the
+        /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
+        /// a `DrawTriangle` mail in flight when the chassis driver records
+        /// the frame would land in the *next* frame's `frame_vertices`,
+        /// dropping a triangle the component meant for this frame. The
+        /// `Builder::with_actor` boot path checks this const and claims
+        /// through the frame-bound path so the cap's `pending` counter
+        /// registers in the chassis's `frame_bound_pending` Vec.
+        const FRAME_BARRIER: bool = true;
+
+        /// Allocate the accumulator state up front. Idempotent on the
+        /// driver-facing side: every chassis main passes a fresh
+        /// `RenderConfig`; init only sets up the in-process buffers and
+        /// the wgpu `OnceLock` (the driver fills it in `resumed` /
+        /// post-`build_passive`).
+        fn init(config: RenderConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let handles = RenderHandles {
+                frame_vertices: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
+                    config.vertex_buffer_bytes,
+                ))),
+                triangles_rendered: Arc::new(AtomicU64::new(0)),
+                camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
+                gpu: Arc::new(OnceLock::new()),
+            };
+            Ok(Self { handles, config })
+        }
+
+        /// `DrawTriangle` handler. Slice-typed because `Mailbox::send_many`
+        /// (ADR-0019) packs `count` triangles into one envelope — the
+        /// macro decodes the whole payload as `&[DrawTriangle]` so a
+        /// batched mesh reaches the cap intact. Truncates at the cap
+        /// boundary so a single oversized mesh degrades gracefully
+        /// instead of collapsing the whole frame downstream; rounds to
+        /// whole triangles so the GPU vertex buffer never sees a half-
+        /// triangle.
+        ///
+        /// # Agent
+        /// Components mail one or more `DrawTriangle`s (cast-shape,
+        /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
+        /// per tick. Fire-and-forget; the cap accumulates into
+        /// `frame_vertices` until the chassis driver records the frame.
+        #[handler]
+        fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
+            if let Some(obs) = &self.config.observed_kinds {
+                obs.lock()
+                    .unwrap()
+                    .push(<DrawTriangle as Kind>::NAME.into());
+            }
+            let bytes: &[u8] = bytemuck::cast_slice(mails);
+            let cap_bytes = self.config.vertex_buffer_bytes;
+            let mut verts = self.handles.frame_vertices.lock().unwrap();
+            let available = cap_bytes.saturating_sub(verts.len());
+            let write_len = bytes.len().min(available);
+            let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+            if write_len > 0 {
+                verts.extend_from_slice(&bytes[..write_len]);
+                self.handles
+                    .triangles_rendered
+                    .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+            }
+            if write_len < bytes.len() {
+                tracing::warn!(
+                    target: "aether_substrate::render",
+                    accepted_bytes = write_len,
+                    dropped_bytes = bytes.len() - write_len,
+                    cap = cap_bytes,
+                    "render cap dropped triangles beyond fixed vertex buffer",
+                );
+            }
+        }
+
+        /// `Camera` handler. Latest-value-wins semantics: each successful
+        /// mail overwrites; the prior value is replaced wholesale.
+        /// Initialised in `init` to [`IDENTITY_VIEW_PROJ`] so the first
+        /// frame draws unchanged until a camera component starts
+        /// publishing.
+        ///
+        /// # Agent
+        /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
+        /// to this mailbox. Fire-and-forget; latest value wins.
+        #[handler]
+        fn on_camera(&self, _ctx: &mut NativeCtx<'_>, mail: Camera) {
+            if let Some(obs) = &self.config.observed_kinds {
+                obs.lock().unwrap().push(<Camera as Kind>::NAME.into());
+            }
+            *self.handles.camera_state.lock().unwrap() = mail.view_proj;
+        }
+    }
+
+    /// Bundle of accumulator state plus GPU resources, shared between
+    /// the cap's dispatcher thread (write side for accumulators) and the
+    /// chassis driver (read side for accumulators, install + read for
+    /// GPU). All fields are `Arc`s so cloning is cheap and shutdown
+    /// drops are independent.
+    #[derive(Clone)]
+    pub struct RenderHandles {
+        pub frame_vertices: Arc<Mutex<Vec<u8>>>,
+        pub triangles_rendered: Arc<AtomicU64>,
+        pub camera_state: Arc<Mutex<[f32; 16]>>,
+        /// wgpu state, installed post-cap-construction by the driver via
+        /// [`Self::install_gpu`]. Boots empty because winit 0.30's
+        /// `ActiveEventLoop::create_window` only fires inside `resumed`,
+        /// after `Builder::build` has returned. Test-bench (no surface)
+        /// installs immediately after `build_passive`; desktop installs
+        /// in its `resumed` handler. Encoder-level methods panic if
+        /// called before install — in practice every code path that
+        /// calls them runs after the install site.
+        gpu: Arc<OnceLock<RenderGpu>>,
+    }
+
+    impl RenderHandles {
+        /// Install the wgpu resources the encoder-level methods read.
+        /// The driver constructs [`RenderGpu`] once it has a device +
+        /// queue — for desktop that's inside `resumed` after winit hands
+        /// back a window and surface; for test-bench it's right after
+        /// `build_passive` returns. Calling twice panics: install is the
+        /// chassis's promise that wgpu state is now ready and stable for
+        /// the chassis lifetime.
+        pub fn install_gpu(&self, gpu: RenderGpu) {
+            self.gpu
+                .set(gpu)
+                .ok()
+                .expect("RenderHandles::install_gpu called twice");
+        }
+
+        /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
+        /// hasn't been called yet. Chassis-side glue that needs raw
+        /// access to the pipeline's bind group layouts (e.g. desktop's
+        /// wireframe overlay pipeline construction) reaches in here.
+        pub fn gpu(&self) -> Option<&RenderGpu> {
+            self.gpu.get()
+        }
+
+        fn expect_gpu(&self) -> &RenderGpu {
+            self.gpu.get().expect(
+                "RenderHandles::install_gpu must be called before encoder-level methods. \
+             Desktop installs in winit's resumed; test-bench installs after build_passive.",
+            )
+        }
+
+        /// Drain the current frame's accumulated vertices, read the
+        /// latest camera view-proj, and record the main render pass into
+        /// `encoder`. Each call consumes the accumulator (subsequent
+        /// inbound mail builds the next frame). `extra_pipelines` are
+        /// drawn after the main pipeline inside the same render pass —
+        /// desktop passes a wireframe overlay pipeline here when
+        /// `AETHER_WIREFRAME=overlay`; test-bench passes `&[]`.
+        pub fn record_frame(
+            &self,
+            encoder: &mut wgpu::CommandEncoder,
+            extra_pipelines: &[&wgpu::RenderPipeline],
+        ) -> Result<(), RenderError> {
+            let gpu = self.expect_gpu();
+            let cap = self.frame_vertices.lock().unwrap().capacity();
+            let vertices = std::mem::replace(
+                &mut *self.frame_vertices.lock().unwrap(),
+                Vec::with_capacity(cap),
+            );
+            let view_proj = *self.camera_state.lock().unwrap();
+            let targets = gpu.targets.lock().unwrap();
+            record_main_pass(
+                &gpu.queue,
+                encoder,
+                &gpu.pipeline,
+                &targets,
+                &vertices,
+                &view_proj,
+                extra_pipelines,
+            )
+        }
+
+        /// Encode a copy of the offscreen color target into a readback
+        /// buffer. Pair with [`Self::finish_capture`] after submit. The
+        /// readback buffer is reallocated on size mismatch with the
+        /// current offscreen, so any sequence of resize → record_frame →
+        /// record_capture_copy → submit → finish_capture works.
+        pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
+            let gpu = self.expect_gpu();
+            let mut targets = gpu.targets.lock().unwrap();
+            prepare_capture_copy(&gpu.device, &mut targets, encoder)
+        }
+
+        /// Map the readback buffer prepared by [`Self::record_capture_copy`]
+        /// and return the encoded PNG. Call after the encoder containing
+        /// the matching `record_capture_copy` has been submitted.
+        pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
+            let gpu = self.expect_gpu();
+            let targets = gpu.targets.lock().unwrap();
+            finish_capture(&gpu.device, &targets, meta)
+        }
+
+        /// Resize the offscreen color + depth targets. Idempotent on
+        /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
+        pub fn resize(&self, width: u32, height: u32) {
+            let gpu = self.expect_gpu();
+            let mut targets = gpu.targets.lock().unwrap();
+            targets.resize(&gpu.device, width, height);
+        }
+
+        /// Cloned `Arc<wgpu::Device>`. Drivers that need the device for
+        /// their own pipelines (e.g. desktop's wireframe overlay pipeline,
+        /// swapchain blit) clone here.
+        pub fn device(&self) -> Arc<wgpu::Device> {
+            Arc::clone(&self.expect_gpu().device)
+        }
+
+        /// Cloned `Arc<wgpu::Queue>`. Drivers submit through this; the
+        /// shared queue means render's `record_frame` writes and the
+        /// driver's swapchain submit go through the same submission
+        /// order.
+        pub fn queue(&self) -> Arc<wgpu::Queue> {
+            Arc::clone(&self.expect_gpu().queue)
+        }
+
+        /// Format the offscreen color target was created with. Capture's
+        /// BGRA-vs-RGBA decision keys on this; desktop's swapchain blit
+        /// matches its surface format against this to pick a direct copy
+        /// vs a manual swizzle.
+        pub fn color_format(&self) -> wgpu::TextureFormat {
+            self.expect_gpu().color_format
+        }
+
+        /// Current offscreen color target dimensions. Drivers reading
+        /// after a `resize` see the new dimensions immediately.
+        pub fn color_size(&self) -> (u32, u32) {
+            let targets = self.expect_gpu().targets.lock().unwrap();
+            (targets.width(), targets.height())
+        }
+
+        /// Run `f` with a borrow of the offscreen color texture. Used by
+        /// desktop's swapchain blit: the closure body holds the targets
+        /// mutex, so any encoder commands recorded inside are sequenced
+        /// against any concurrent resize. Test-bench reaches the
+        /// offscreen via the capture path and doesn't need this.
+        pub fn with_color_texture<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(&wgpu::Texture) -> R,
+        {
+            let gpu = self.expect_gpu();
+            let targets = gpu.targets.lock().unwrap();
+            f(targets.color_texture())
+        }
+    }
+
+    /// Bundle of wgpu resources `RenderHandles` exposes post-install.
+    /// Constructed by the driver from a wgpu device + queue obtained via
+    /// `Adapter::request_device` (desktop: with surface compatibility;
+    /// test-bench: offscreen-only). Holds the pipeline + offscreen
+    /// targets so encoder-level methods can record draws and capture
+    /// copies without the driver threading these through every call.
+    pub struct RenderGpu {
+        pub device: Arc<wgpu::Device>,
+        pub queue: Arc<wgpu::Queue>,
+        pub pipeline: Pipeline,
+        pub targets: Mutex<Targets>,
+        pub color_format: wgpu::TextureFormat,
+    }
+
+    impl RenderGpu {
+        /// Build the standard render pipeline + offscreen targets at the
+        /// given size and pass [`Self`] to [`RenderHandles::install_gpu`].
+        /// `polygon_mode` is `Fill` for the normal case; desktop's
+        /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
+        /// pipeline draws as wireframe instead of building a separate
+        /// overlay pipeline.
+        pub fn new(
+            device: Arc<wgpu::Device>,
+            queue: Arc<wgpu::Queue>,
+            color_format: wgpu::TextureFormat,
+            width: u32,
+            height: u32,
+            polygon_mode: wgpu::PolygonMode,
+        ) -> Self {
+            let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
+            let targets = Targets::new(&device, color_format, width, height);
+            Self {
+                device,
+                queue,
+                pipeline,
+                targets: Mutex::new(targets),
+                color_format,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::time::Duration;
+
+        use super::*;
+        use aether_actor::Actor;
+        use aether_substrate::capability::ChassisBuilder;
+        use aether_substrate::mail::{KindId, ReplyTo};
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::registry::{MailboxEntry, Registry};
+
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+        }
+
+        fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
+            let id = registry.lookup(name).expect("mailbox registered");
+            let MailboxEntry::Sink(handler) = registry.entry(id).expect("entry exists") else {
+                panic!("expected sink entry for {name}");
+            };
+            handler(kind, "test.kind", None, ReplyTo::NONE, payload, 1);
+        }
+
+        #[test]
+        fn capability_claims_render_mailbox_only() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<RenderCapability>(RenderConfig::default())
+                .build()
+                .expect("build succeeds");
+            assert_eq!(chassis.len(), 1);
+            assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
+            // Camera mailbox retired (ADR-0074 §Decision 7).
+            assert!(registry.lookup("aether.sink.camera").is_none());
+        }
+
+        /// Boots render through the legacy `ChassisBuilder.with_actor`
+        /// path and asserts a `DrawTriangle` mail accumulates into the
+        /// frame_vertices buffer. The `RenderHandles` here is reached
+        /// via the chassis post-build (legacy ChassisBuilder doesn't
+        /// expose an actors map; the test asserts via the registry sink
+        /// the dispatcher drains rather than reading the cap state
+        /// directly). Coverage of `handles` accessor is in the desktop
+        /// chassis path post-2d.
+        #[test]
+        fn render_dispatcher_appends_triangles_to_frame_vertices() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<RenderCapability>(RenderConfig::default())
+                .build()
+                .expect("build succeeds");
+
+            let one_triangle = vec![0u8; DRAW_TRIANGLE_BYTES];
+            deliver(
+                &registry,
+                RenderCapability::NAMESPACE,
+                <DrawTriangle as Kind>::ID,
+                &one_triangle,
+            );
+
+            // Wait briefly for the dispatcher thread to drain. The legacy
+            // `ChassisBuilder` boot path doesn't expose an Actors map for
+            // direct lookup, so the test waits on the per-mailbox pending
+            // counter the FRAME_BARRIER claim populates and treats a
+            // drain-to-zero as the dispatch happening. Pre-2d the test
+            // peeked at `cap.handles()` directly; the new shape doesn't
+            // expose that without a chassis-side actors map.
+            for _ in 0..50 {
+                if chassis.frame_bound_pending().is_empty()
+                    || chassis.frame_bound_pending()[0].1.load(Ordering::Acquire) == 0
+                {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            // The pending counter must have hit zero — the dispatcher
+            // ran the handler.
+            assert_eq!(chassis.frame_bound_pending().len(), 1);
+            assert_eq!(
+                chassis.frame_bound_pending()[0].1.load(Ordering::Acquire),
+                0,
+                "dispatcher should have processed the DrawTriangle"
+            );
+
+            chassis.shutdown();
+        }
+
+        /// Frame-bound claim populates the chassis's `frame_bound_pending`
+        /// Vec. Direct render-internal-state assertions live on the
+        /// `with_actor`-via-`Builder` path (chassis_builder tests +
+        /// integration tests in the bundle), where the chassis-side
+        /// actors map exposes `Arc<RenderCapability>` for `handles()`
+        /// access.
+        #[test]
+        fn render_registers_frame_bound_pending_counter() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<RenderCapability>(RenderConfig::default())
+                .build()
+                .expect("build succeeds");
+            assert_eq!(
+                chassis.frame_bound_pending().len(),
+                1,
+                "render claimed through frame-bound path"
+            );
+            chassis.shutdown();
+        }
+
+        #[test]
+        fn camera_kind_drops_wrong_length_payload() {
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<RenderCapability>(RenderConfig::default())
+                .build()
+                .expect("build succeeds");
+
+            // 16 bytes — wrong length, decode fails, macro miss path
+            // logs warn at chassis-side dispatcher; identity unchanged.
+            deliver(
+                &registry,
+                RenderCapability::NAMESPACE,
+                <Camera as Kind>::ID,
+                &[1u8; 16],
+            );
+
+            std::thread::sleep(Duration::from_millis(50));
+            // No further assertion on internal state — the legacy
+            // `ChassisBuilder` boot path doesn't expose `Arc<RenderCapability>`.
+            // Decode failure is observable via the macro miss path's
+            // warn-log; this test asserts shutdown still proceeds cleanly
+            // (no dispatcher panic on malformed input).
+            chassis.shutdown();
+        }
     }
 }

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -71,7 +71,9 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 /// split into a single `aether-actor-derive` proc-macro crate so the
 /// SDK and the derive share a home.
 #[cfg(feature = "derive")]
-pub use aether_actor_derive::{Kind, Schema, Singleton, actor, capability, fallback, handler};
+pub use aether_actor_derive::{
+    Kind, Schema, Singleton, actor, bridge, capability, fallback, handler,
+};
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`) and a `u64` id derived from


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #565 is the intentional auto-close trigger; PR/issue numbers are cross-references -->
## Summary

Each chassis cap collapses to a single `#[bridge] mod native { ... }` block. The struct, substrate imports, helpers, and `#[actor] impl NativeActor` all live inside the module. The bridge macro emits a wasm-stub struct + native re-export at file root and lifts the always-on `Actor` / `HandlesKind` / `Singleton` markers out of the cfg gate, so wasm consumers compile typed sends like `ctx.send_to::<R, _>(&kind)` against the cap without dragging in the substrate runtime.

`#[actor]` gains a `skip_markers` flag — when `#[bridge]` rewrites the inner `#[actor]` to `#[actor(skip_markers)]`, the inner expansion elides marker emission to avoid duplicate-impl errors with the markers `#[bridge]` already emitted as siblings of the mod.

## What retires from cap files

- `#[capability]` decoration — struct fields are naturally cfg-gated by living inside the cfg-gated mod.
- `#[derive(Singleton)]` on the struct — bridge auto-emits Singleton alongside Actor + HandlesKind.
- `aether_actor::native_only! { ... }` preamble blocks at file root for substrate imports — those imports now live inside `mod native` next to the code that uses them.

## What the bridge expansion looks like

```rust
// User writes:
use aether_kinds::LogEvent;

#[aether_actor::bridge]
mod native {
    use super::LogEvent;
    use aether_actor::actor;
    use aether_substrate::capability::BootError;
    use aether_substrate::log_sink;
    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};

    pub struct LogCapability;

    #[actor]
    impl NativeActor for LogCapability {
        type Config = ();
        const NAMESPACE: &'static str = "aether.log";
        fn init(_: (), _: &mut NativeInitCtx<'_>) -> Result<Self, BootError> { Ok(Self) }

        #[handler]
        fn on_log_event(&self, _: &mut NativeCtx<'_>, event: LogEvent) { ... }
    }
}

// Bridge expands to:
#[cfg(target_arch = "wasm32")]
pub struct LogCapability;
#[cfg(not(target_arch = "wasm32"))]
pub use native::LogCapability;

impl ::aether_actor::Singleton for LogCapability {}
impl ::aether_actor::Actor for LogCapability {
    const NAMESPACE: &'static str = "aether.log";
}
impl ::aether_actor::HandlesKind<LogEvent> for LogCapability {}

#[cfg(not(target_arch = "wasm32"))]
mod native {
    /* user's body, with #[actor] rewritten to #[actor(skip_markers)] */
}
```

## Test plan

- [x] `cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features` succeeds (header-only build)
- [x] `cargo build --target wasm32-unknown-unknown -p aether-test-fixture-probe` succeeds (typed-send `ctx.send_to::<LogCapability, _>` resolves through the wasm-stub + always-on markers)
- [x] `cargo test --workspace` — 68 test blocks, 0 failures
- [x] `cargo test -p aether-capabilities --features audio,render` — 57 cap tests including 9 audio + 4 render gated tests
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #565