### PR TITLE
refactor(actor): collapse send_to to actor().send (issue 567)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -786,7 +786,7 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
 /// (loading the cap crate via `aether-capabilities` with
 /// `default-features = false`) must still see the always-on `Actor`
 /// and `HandlesKind<K>` markers so typed sends like
-/// `ctx.send_to::<X, _>(&kind)` compile-check, but the substrate-side
+/// `ctx.actor::<X>().send(&kind)` compile-check, but the substrate-side
 /// trait impls and helpers can't be in scope on wasm32.
 ///
 /// `#[bridge]`'s expansion splits across that boundary:
@@ -949,7 +949,7 @@ fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
     //   a unit-struct stub takes its place at file root so the marker
     //   impls below have a type to reference. Wasm consumers never
     //   construct caps — they only address them by type via
-    //   `ctx.send_to::<X, _>(&kind)` — so the stub being uninhabited
+    //   `ctx.actor::<X>().send(&kind)` — so the stub being uninhabited
     //   is fine.
     // - On native, the `pub use` re-exports the real struct from `mod
     //   native` to file root, so callers writing `crate::log::LogCapability`
@@ -1110,7 +1110,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Issue 552 stage 4: gate fields on `not(target_arch = "wasm32")`
     // to match the macro-emitted `NativeActor` / `NativeDispatch`
     // impls. Wasm builds see the cap struct with no fields (a pure
-    // marker), which is what typed `ctx.send_to::<R>(...)` needs;
+    // marker), which is what typed `ctx.actor::<R>().send(...)` needs;
     // host builds see the full struct.
     match &mut item.fields {
         syn::Fields::Named(fields) => {
@@ -1369,11 +1369,12 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     };
 
     // ADR-0075: emit one `impl HandlesKind<K> for Self {}` per handler
-    // kind. Auto-generated marker impls gate `Ctx::send_to::<R>(&K)` and
-    // `ActorMailbox<R, T>::send::<K>` so wrong-kind sends are compile
-    // errors at the call site. The handler list above is the single
-    // source of truth — adding a `#[handler]` automatically updates
-    // senders' compile-time checks.
+    // kind. Auto-generated marker impls gate
+    // `ActorMailbox<'_, R, T>::send::<K>` (constructed via
+    // `ctx.actor::<R>()` / `ctx.resolve_actor::<R>(name)`) so wrong-kind
+    // sends are compile errors at the call site. The handler list above
+    // is the single source of truth — adding a `#[handler]` automatically
+    // updates senders' compile-time checks.
     let handles_kind_impls = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         quote! {
@@ -1774,7 +1775,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // can compile for `wasm32-unknown-unknown` without the substrate
     // dep — wasm consumers see only the always-on Actor +
     // HandlesKind markers, which is enough for typed
-    // `ctx.send_to::<R>` against cap markers.
+    // `ctx.actor::<R>().send(...)` against cap markers.
     //
     // Gate is `target_arch` not `feature = "native"` because
     // NativeActor/NativeDispatch are wasm-incompatible by definition;

--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -42,7 +42,7 @@ pub trait Actor: Sized + Send + 'static {
 }
 
 /// Marker: only one instance of this actor can be live per substrate.
-/// Required by `Ctx::send_to::<R>` so the type → mailbox lookup is
+/// Required by `Ctx::actor::<R>()` so the type → mailbox lookup is
 /// unambiguous — the substrate enforces "at most one Singleton actor
 /// per `R::NAMESPACE`" at registration time, and senders address by
 /// type rather than by name.
@@ -59,8 +59,9 @@ pub trait Singleton: Actor {}
 /// `#[actor]` proc-macro alongside the dispatch table — one impl per
 /// handler kind. Authors never write these by hand.
 ///
-/// Gates `Ctx::send_to::<R>(&K)` and `ActorMailbox<R, T>::send::<K>` so
-/// the compiler rejects sends to a kind the receiver doesn't handle.
+/// Gates `ActorMailbox<'_, R, T>::send::<K>` (constructed via
+/// `ctx.actor::<R>()` / `ctx.resolve_actor::<R>(name)`) so the compiler
+/// rejects sends to a kind the receiver doesn't handle.
 /// The single source of truth is the handler list on the actor's
 /// `impl` block; adding a `#[handler]` updates senders' compile-time
 /// checks automatically. ADR-0075 §Decision 1.

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -16,15 +16,13 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use aether_data::{Kind, Schema};
+use aether_data::{Kind, Schema, mailbox_id_from_name};
 
 use crate::actor::{Actor, HandlesKind, Singleton};
 use crate::handle::{self, Handle, SyncHandleError};
 use crate::mail::ReplyTo;
 use crate::sender::{MailCtx, Sender};
-use crate::sink::{
-    ActorMailbox, KindId, Mailbox, resolve, resolve_actor, resolve_actor_named, resolve_mailbox,
-};
+use crate::sink::{ActorMailbox, KindId, Mailbox, resolve, resolve_mailbox};
 use crate::transport::MailTransport;
 
 /// Init-only capability handle. The type split between `InitCtx` and
@@ -108,6 +106,27 @@ impl<'a, T: MailTransport> InitCtx<'a, T> {
             mailbox: ::aether_data::MailboxId(self.mailbox),
         };
         resolve_mailbox::<SubscribeInput, T>("aether.control").send(self.transport, &payload);
+    }
+
+    /// Singleton sender shortcut: returns a typed [`ActorMailbox`] that
+    /// addresses the unique instance of receiver actor `R`. The returned
+    /// handle borrows this ctx's transport for the duration of the call,
+    /// so subsequent `send` / `send_many` are `&self`-receiver and need
+    /// no transport thread-through.
+    ///
+    /// `R: Singleton` gates this call to actors loaded under their
+    /// `R::NAMESPACE` default name; multi-instance receivers go through
+    /// [`Self::resolve_actor`] with an explicit runtime name.
+    pub fn actor<R: Singleton>(&self) -> ActorMailbox<'_, R, T> {
+        ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+    }
+
+    /// Multi-instance sender: resolve a typed [`ActorMailbox`] from a
+    /// runtime instance name. The string surfaces ONCE per handle;
+    /// subsequent sends are string-free and compile-checked against
+    /// `R: HandlesKind<K>`.
+    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, T> {
+        ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
     }
 }
 
@@ -210,34 +229,36 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
             .reply_mail(sender.raw(), kind.raw(), &bytes, 1);
     }
 
-    /// ADR-0075 singleton path: send `payload` to the unique instance of
-    /// actor `R`, addressed by `R::NAMESPACE`. Compile-checked against
-    /// `R: Singleton + HandlesKind<K>` so wrong-receiver and wrong-kind
-    /// sends are caught at the call site instead of silent runtime
-    /// warn-drops.
+    /// Singleton sender shortcut: returns a typed [`ActorMailbox`] that
+    /// addresses the unique instance of receiver actor `R`. The
+    /// returned handle borrows this ctx's transport, so subsequent
+    /// `send` / `send_many` calls are `&self`-receiver and need no
+    /// explicit transport argument.
     ///
-    /// During the migration (Phases 1–3) this lives alongside the
-    /// kind-typed `Ctx::send(&sink, &payload)`. Phase 4 retires the old
-    /// form and renames `send_to` → `send`.
-    pub fn send_to<R, K>(&self, payload: &K)
-    where
-        R: Singleton + HandlesKind<K>,
-        K: Kind,
-    {
-        resolve_actor::<R, T>().send(self.transport, payload);
+    /// ```ignore
+    /// ctx.actor::<LogCapability>().send(&LogEvent { ... });
+    /// ```
+    ///
+    /// `R: Singleton` gates the shortcut to actors loaded under their
+    /// `R::NAMESPACE` default name; multi-instance receivers go through
+    /// [`Self::resolve_actor`] with an explicit runtime name. Wrong-
+    /// kind sends are compile errors via `R: HandlesKind<K>` on
+    /// [`ActorMailbox::send`].
+    pub fn actor<R: Singleton>(&self) -> ActorMailbox<'_, R, T> {
+        ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
     }
 
-    /// ADR-0075 multi-instance path: resolve a typed `ActorMailbox<R, T>`
-    /// from a runtime instance name. The string surfaces ONCE per
-    /// handle; subsequent sends through the returned handle are
-    /// string-free and compile-checked against `R: HandlesKind<K>`.
+    /// Multi-instance sender: resolve a typed [`ActorMailbox`] from a
+    /// runtime instance name. The string surfaces ONCE per handle;
+    /// subsequent sends through the returned handle are string-free
+    /// and compile-checked against `R: HandlesKind<K>`.
     ///
     /// Use this when addressing one of several live instances of the
     /// same actor type (e.g. `"player_1"` vs `"player_2"`). For
     /// singletons (chassis caps, uniquely-loaded user components),
-    /// `send_to::<R>(&payload)` skips the explicit handle entirely.
-    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<R, T> {
-        resolve_actor_named::<R, T>(name)
+    /// [`Self::actor`] skips the explicit name.
+    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, T> {
+        ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
     }
 }
 
@@ -351,9 +372,9 @@ impl<'a, T: MailTransport> DropCtx<'a, T> {
 }
 
 /// Issue 552 stage 1: cross-transport [`Sender`] impl. Routes through
-/// the actor-typed sink (`resolve_actor::<R, T>`) for typed sends and
-/// through the kind-typed sink (`resolve_mailbox::<K, T>`) for the
-/// string-keyed escape hatch. The wasm path's `Ctx<'a, WasmTransport>`
+/// the actor-typed sink (`ActorMailbox::__new` bound to `self.transport`)
+/// for typed sends and through the kind-typed sink (`resolve_mailbox::<K, T>`)
+/// for the string-keyed escape hatch. The wasm path's `Ctx<'a, WasmTransport>`
 /// inherits this impl through the [`crate::WasmCtx`] alias; the native
 /// `NativeCtx<'a>` (in `aether-substrate`) writes its own `Sender`
 /// impl since it doesn't go through `Ctx<'a, T>` (extra per-mail state
@@ -365,7 +386,8 @@ impl<'a, T: MailTransport> Sender for Ctx<'a, T> {
         R: Actor + HandlesKind<K>,
         K: aether_data::Kind,
     {
-        resolve_actor::<R, T>().send(self.transport, payload);
+        ActorMailbox::<R, T>::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+            .send(payload);
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -373,7 +395,8 @@ impl<'a, T: MailTransport> Sender for Ctx<'a, T> {
         R: Actor + HandlesKind<K>,
         K: aether_data::Kind + bytemuck::NoUninit,
     {
-        resolve_actor::<R, T>().send_many(self.transport, payloads);
+        ActorMailbox::<R, T>::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+            .send_many(payloads);
     }
 
     fn send_to_named<K: aether_data::Kind>(&mut self, name: &str, payload: &K) {
@@ -405,7 +428,8 @@ impl<'a, T: MailTransport> Sender for InitCtx<'a, T> {
         R: Actor + HandlesKind<K>,
         K: aether_data::Kind,
     {
-        resolve_actor::<R, T>().send(self.transport, payload);
+        ActorMailbox::<R, T>::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+            .send(payload);
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -413,7 +437,8 @@ impl<'a, T: MailTransport> Sender for InitCtx<'a, T> {
         R: Actor + HandlesKind<K>,
         K: aether_data::Kind + bytemuck::NoUninit,
     {
-        resolve_actor::<R, T>().send_many(self.transport, payloads);
+        ActorMailbox::<R, T>::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+            .send_many(payloads);
     }
 
     fn send_to_named<K: aether_data::Kind>(&mut self, name: &str, payload: &K) {

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -72,9 +72,7 @@ pub use sender::{MailCtx, Sender};
 // `wasm`) under the same `Mailbox` / `Handle` names so existing
 // `aether_component::Mailbox<K>` consumers keep their call shape
 // when migrating to `aether_actor::*`.
-pub use sink::{
-    ActorMailbox, KindId, resolve, resolve_actor, resolve_actor_named, resolve_mailbox,
-};
+pub use sink::{ActorMailbox, KindId, resolve, resolve_mailbox};
 pub use slot::Slot;
 pub use sync::{WaitError, decode_wait_reply, wait_reply};
 pub use transport::MailTransport;

--- a/crates/aether-actor/src/sink.rs
+++ b/crates/aether-actor/src/sink.rs
@@ -167,58 +167,52 @@ pub const fn resolve_mailbox<K: Kind, T: MailTransport>(mailbox_name: &str) -> M
 }
 
 /// Phantom-typed receiver-actor handle. ADR-0075's actor-typed sender
-/// API: `ActorMailbox<R, T>` addresses the mailbox of receiver actor `R`,
-/// not a single kind. Lives alongside [`Mailbox<K, T>`] during the
-/// migration — Phase 4 retires the kind-typed form and renames this
-/// to `Mailbox`.
+/// API: `ActorMailbox<'a, R, T>` addresses the mailbox of receiver
+/// actor `R`, not a single kind. Carries a borrow of the sender's
+/// transport so `send` / `send_many` are `&self`-receiver and don't
+/// require threading a transport reference at every call site.
 ///
 /// Multi-kind by construction: `send::<K>` is gated on `R: HandlesKind<K>`,
-/// so the same `ActorMailbox<RenderCapability, T>` accepts both
-/// `&DrawTriangle` and `&Camera` (instead of needing two `Mailbox<K>`
-/// declarations as today). Wrong-kind sends are compile errors.
+/// so the same `ActorMailbox<'_, RenderCapability, T>` accepts both
+/// `&DrawTriangle` and `&Camera`. Wrong-kind sends are compile errors.
 ///
-/// Built two ways:
-///
-/// - Singleton path: senders never construct one explicitly. Inside
-///   `Ctx::send_to::<R>(&kind)` the SDK resolves the singleton mailbox
-///   from `R::NAMESPACE` and dispatches in one call.
-/// - Multi-instance path: `Ctx::resolve_actor::<R>(name)` returns an
-///   `ActorMailbox<R, T>` value that the caller stores; subsequent sends
-///   go through `actor_mailbox.send(transport, &kind)` and are
-///   string-free.
-pub struct ActorMailbox<R, T: MailTransport> {
+/// Constructed by [`crate::Ctx::actor`] (singleton shortcut) or
+/// [`crate::Ctx::resolve_actor`] (multi-instance, by name) — there is
+/// no public free-fn constructor because the lifetime ties the handle
+/// to the borrowed transport, which only exists inside a ctx.
+pub struct ActorMailbox<'a, R, T: MailTransport> {
     mailbox: u64,
+    transport: &'a T,
     _r: PhantomData<fn() -> R>,
-    _t: PhantomData<fn() -> T>,
 }
 
-impl<R, T: MailTransport> Copy for ActorMailbox<R, T> {}
-impl<R, T: MailTransport> Clone for ActorMailbox<R, T> {
+impl<'a, R, T: MailTransport> Copy for ActorMailbox<'a, R, T> {}
+impl<'a, R, T: MailTransport> Clone for ActorMailbox<'a, R, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<R, T: MailTransport> ActorMailbox<R, T> {
-    /// Not part of the public API; the const builders go through here
-    /// so the field stays private.
+impl<'a, R, T: MailTransport> ActorMailbox<'a, R, T> {
+    /// Not part of the public API; the ctx-level constructors go
+    /// through here so the field stays private.
     #[doc(hidden)]
-    pub const fn __new(mailbox: u64) -> Self {
+    pub fn __new(mailbox: u64, transport: &'a T) -> Self {
         ActorMailbox {
             mailbox,
+            transport,
             _r: PhantomData,
-            _t: PhantomData,
         }
     }
 
-    /// Raw mailbox id. Exposed for callers that need it for a
-    /// host fn the SDK doesn't yet wrap.
-    pub fn mailbox(self) -> u64 {
-        self.mailbox
+    /// The receiver's typed mailbox id. Exposed for callers that need
+    /// it for diagnostics or a host fn the SDK doesn't yet wrap.
+    pub fn mailbox_id(&self) -> ::aether_data::MailboxId {
+        ::aether_data::MailboxId(self.mailbox)
     }
 }
 
-impl<R: crate::Actor, T: MailTransport> ActorMailbox<R, T> {
+impl<'a, R: crate::Actor, T: MailTransport> ActorMailbox<'a, R, T> {
     /// Send a single payload of kind `K` to actor `R`. Compile-checked
     /// against `R: HandlesKind<K>` — wrong-kind sends are rejected at
     /// the call site.
@@ -228,7 +222,8 @@ impl<R: crate::Actor, T: MailTransport> ActorMailbox<R, T> {
     /// per issue #240.
     ///
     /// ```compile_fail
-    /// use aether_actor::{Actor, ActorMailbox, HandlesKind, Singleton, MailTransport};
+    /// use aether_actor::{Actor, HandlesKind, Singleton, MailTransport};
+    /// use aether_actor::wasm::WASM_TRANSPORT;
     /// use aether_data::Kind;
     ///
     /// // Two kinds; the receiver only handles the first.
@@ -247,56 +242,30 @@ impl<R: crate::Actor, T: MailTransport> ActorMailbox<R, T> {
     /// impl Singleton for R {}
     /// impl HandlesKind<KindOk> for R {}     // R handles KindOk only
     ///
-    /// struct T;
-    /// impl MailTransport for T {
-    ///     fn send_mail(&self, _: u64, _: u64, _: &[u8], _: u32) -> u32 { 0 }
-    ///     fn reply_mail(&self, _: u32, _: u64, _: &[u8], _: u32) -> u32 { 0 }
-    ///     fn save_state(&self, _: u32, _: &[u8]) -> u32 { 0 }
-    ///     fn wait_reply(&self, _: u64, _: &mut [u8], _: u32, _: u64) -> i32 { -1 }
-    ///     fn prev_correlation(&self) -> u64 { 0 }
-    /// }
-    ///
-    /// let h: ActorMailbox<R, T> = aether_actor::resolve_actor::<R, T>();
-    /// let t = T;
-    /// h.send(&t, &KindWrong);   // ← compile error: R does not impl HandlesKind<KindWrong>
+    /// // Build a ctx, then take the mailbox via ctx.actor::<R>().
+    /// let ctx = aether_actor::Ctx::__new(&WASM_TRANSPORT);
+    /// ctx.actor::<R>().send(&KindWrong);   // ← compile error: R does not impl HandlesKind<KindWrong>
     /// ```
-    pub fn send<K>(self, transport: &T, payload: &K)
+    pub fn send<K>(&self, payload: &K)
     where
         R: crate::HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        transport.send_mail(self.mailbox, K::ID.0, &bytes, 1);
+        self.transport.send_mail(self.mailbox, K::ID.0, &bytes, 1);
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —
     /// see [`Mailbox::send_many`] for the wire-shape rationale.
-    pub fn send_many<K>(self, transport: &T, payloads: &[K])
+    pub fn send_many<K>(&self, payloads: &[K])
     where
         R: crate::HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        transport.send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32);
+        self.transport
+            .send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32);
     }
-}
-
-/// Resolve an actor by its `Actor::NAMESPACE`, producing a typed
-/// `ActorMailbox<R, T>` for the singleton instance. Pure compile-time
-/// construction — the mailbox id is `mailbox_id_from_name(R::NAMESPACE)`.
-///
-/// For multi-instance actors loaded under a non-default name, use
-/// [`resolve_actor_named`] (or `Ctx::resolve_actor`) instead.
-pub const fn resolve_actor<R: crate::Actor, T: MailTransport>() -> ActorMailbox<R, T> {
-    ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0)
-}
-
-/// Resolve a multi-instance actor by runtime name, producing a typed
-/// `ActorMailbox<R, T>`. The string surfaces ONCE per handle; subsequent
-/// sends through the returned handle are string-free and compile-checked
-/// against `R: HandlesKind<K>`.
-pub fn resolve_actor_named<R: crate::Actor, T: MailTransport>(name: &str) -> ActorMailbox<R, T> {
-    ActorMailbox::__new(mailbox_id_from_name(name).0)
 }
 
 #[cfg(test)]
@@ -352,14 +321,15 @@ mod tests {
         assert_eq!(s.kind(), 11);
     }
 
-    /// ADR-0075 actor-typed sender API. `ActorMailbox<R, T>` is keyed on
-    /// the receiver actor `R`; `send::<K>` is gated on `R: HandlesKind<K>`
-    /// so wrong-kind sends are rejected at the call site.
+    /// ADR-0075 actor-typed sender API. `ActorMailbox<'a, R, T>` is keyed
+    /// on the receiver actor `R` and carries a borrow of the sender's
+    /// transport; `send::<K>` is gated on `R: HandlesKind<K>` so
+    /// wrong-kind sends are rejected at the call site.
     mod actor_typed_send {
-        use super::super::{ActorMailbox, resolve_actor, resolve_actor_named};
+        use super::super::ActorMailbox;
         use crate::actor::{Actor, HandlesKind, Singleton};
         use crate::transport::MailTransport;
-        use ::aether_data::{Kind, mailbox_id_from_name};
+        use ::aether_data::{Kind, MailboxId, mailbox_id_from_name};
         use alloc::vec::Vec;
         use core::cell::RefCell;
 
@@ -442,24 +412,34 @@ mod tests {
         unsafe impl Sync for RecordingTransport {}
 
         #[test]
-        fn resolve_actor_addresses_namespace() {
-            let h: ActorMailbox<PingActor, RecordingTransport> = resolve_actor::<PingActor, _>();
-            assert_eq!(h.mailbox(), mailbox_id_from_name(PingActor::NAMESPACE).0);
+        fn singleton_mailbox_addresses_namespace() {
+            let transport = RecordingTransport::new();
+            let h: ActorMailbox<'_, PingActor, RecordingTransport> =
+                ActorMailbox::__new(mailbox_id_from_name(PingActor::NAMESPACE).0, &transport);
+            assert_eq!(
+                h.mailbox_id(),
+                MailboxId(mailbox_id_from_name(PingActor::NAMESPACE).0)
+            );
         }
 
         #[test]
-        fn resolve_actor_named_addresses_runtime_name() {
-            let h: ActorMailbox<PingActor, RecordingTransport> =
-                resolve_actor_named::<PingActor, _>("instance_42");
-            assert_eq!(h.mailbox(), mailbox_id_from_name("instance_42").0);
+        fn named_mailbox_addresses_runtime_name() {
+            let transport = RecordingTransport::new();
+            let h: ActorMailbox<'_, PingActor, RecordingTransport> =
+                ActorMailbox::__new(mailbox_id_from_name("instance_42").0, &transport);
+            assert_eq!(
+                h.mailbox_id(),
+                MailboxId(mailbox_id_from_name("instance_42").0)
+            );
         }
 
         #[test]
         fn actor_mailbox_send_records_recipient_and_kind() {
             let transport = RecordingTransport::new();
-            let h: ActorMailbox<PingActor, RecordingTransport> = resolve_actor::<PingActor, _>();
+            let h: ActorMailbox<'_, PingActor, RecordingTransport> =
+                ActorMailbox::__new(mailbox_id_from_name(PingActor::NAMESPACE).0, &transport);
             let payload = PingKind { tag: 0xCAFE_BABE };
-            h.send(&transport, &payload);
+            h.send(&payload);
 
             let snap = transport.snapshot();
             assert_eq!(snap.len(), 1);

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -9,8 +9,9 @@
 //! Pre-stage-2e these modules lived under
 //! `aether_substrate::capabilities`. The split decouples the
 //! cap-marker layer from the substrate runtime so wasm components
-//! can address caps via `ctx.send_to::<R>` (resolved through
-//! `R::NAMESPACE`) without dragging in wasmtime / wgpu / cpal. Today
+//! can address caps via `ctx.actor::<R>().send(&kind)` (resolved
+//! through `R::NAMESPACE`) without dragging in wasmtime / wgpu /
+//! cpal. Today
 //! the crate always pulls `aether-substrate` (the `NativeActor`
 //! impls live alongside the structs); the header-only wasm build is
 //! a follow-up.

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -49,8 +49,8 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use aether_actor::{Actor, HandlesKind, MailCtx, Sender};
-use aether_data::Kind;
+use aether_actor::{Actor, ActorMailbox, HandlesKind, MailCtx, Sender, Singleton};
+use aether_data::{Kind, mailbox_id_from_name};
 
 use crate::mail::KindId;
 
@@ -156,6 +156,20 @@ impl<'a> NativeCtx<'a> {
     pub fn reply_target(&self) -> ReplyTo {
         self.sender
     }
+
+    /// Singleton sender shortcut: returns a typed [`ActorMailbox`]
+    /// addressing the unique instance of receiver actor `R`. Mirrors
+    /// [`aether_actor::Ctx::actor`]; same `&self`-receiver `send` /
+    /// `send_many` ergonomics.
+    pub fn actor<R: Singleton>(&self) -> ActorMailbox<'_, R, NativeTransport> {
+        ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+    }
+
+    /// Multi-instance sender: resolve a typed [`ActorMailbox`] from a
+    /// runtime instance name. Mirrors [`aether_actor::Ctx::resolve_actor`].
+    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, NativeTransport> {
+        ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
+    }
 }
 
 impl<'a> Sender for NativeCtx<'a> {
@@ -164,7 +178,11 @@ impl<'a> Sender for NativeCtx<'a> {
         R: Actor + HandlesKind<K>,
         K: Kind,
     {
-        aether_actor::resolve_actor::<R, NativeTransport>().send(self.transport, payload);
+        ActorMailbox::<R, NativeTransport>::__new(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            self.transport,
+        )
+        .send(payload);
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -172,7 +190,11 @@ impl<'a> Sender for NativeCtx<'a> {
         R: Actor + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
-        aether_actor::resolve_actor::<R, NativeTransport>().send_many(self.transport, payloads);
+        ActorMailbox::<R, NativeTransport>::__new(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            self.transport,
+        )
+        .send_many(payloads);
     }
 
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
@@ -202,15 +224,17 @@ impl<'a> MailCtx for NativeCtx<'a> {
 /// Boot-time context for [`NativeActor::init`]. Carries a borrow of
 /// the actor's transport (for init-time mail), a borrow of the
 /// actors-so-far [`Actors`] map (so init can peer at caps booted
-/// earlier in the chain via [`Self::actor`]), and a clone of the
+/// earlier in the chain via [`Self::peer`]), and a clone of the
 /// substrate's mailer for caps that need to register an outbound
 /// hook at boot.
 ///
-/// Stage-1 doesn't expose the handle store directly — caps that
-/// migrate in stage 2 retrieve it through
-/// `ctx.actor::<HandleCapability>()` once `HandleCapability` itself
-/// has migrated and surfaces an `Arc<HandleStore>` field. Boot order
-/// (chain order) ensures the lookup succeeds.
+/// `peer::<HandleCapability>()` (the type-keyed `Arc` lookup) is
+/// distinct from `actor::<R>()` (the typed sender shortcut, mirror of
+/// [`aether_actor::Ctx::actor`]) — peer is for boot-time setup that
+/// genuinely needs to inspect a sibling cap's `Arc`-shared state;
+/// actor is for sending mail. Memory: "actor::<A>() lookup is
+/// bootstrap-only" stays in force for `peer`; messaging is the
+/// runtime shape.
 pub struct NativeInitCtx<'a> {
     transport: &'a NativeTransport,
     actors: &'a Actors,
@@ -250,11 +274,25 @@ impl<'a> NativeInitCtx<'a> {
     /// Look up an earlier-booted cap by type and clone its `Arc`.
     /// `None` if the cap hasn't booted yet (chain order matters —
     /// `with::<A>(…)` → `with::<B>(…)` lets B's `init` see A but
-    /// not vice versa). Stage-1 use cases are limited to the boot
-    /// trampoline itself; stage-2 migrations may use this for
-    /// driver pre-build.
-    pub fn actor<A: NativeActor>(&self) -> Option<Arc<A>> {
+    /// not vice versa). Use cases are limited to boot-time wiring
+    /// (driver pre-build, capability chains that genuinely need a
+    /// sibling's `Arc`-shared state); for sending mail to a sibling,
+    /// reach for [`Self::actor`] / [`Self::resolve_actor`] instead.
+    pub fn peer<A: NativeActor>(&self) -> Option<Arc<A>> {
         self.actors.get::<A>()
+    }
+
+    /// Singleton sender shortcut: returns a typed [`ActorMailbox`]
+    /// addressing the unique instance of receiver actor `R`. Mirrors
+    /// [`aether_actor::Ctx::actor`].
+    pub fn actor<R: Singleton>(&self) -> ActorMailbox<'_, R, NativeTransport> {
+        ActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.transport)
+    }
+
+    /// Multi-instance sender: resolve a typed [`ActorMailbox`] from a
+    /// runtime instance name. Mirrors [`aether_actor::Ctx::resolve_actor`].
+    pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, NativeTransport> {
+        ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
     }
 }
 
@@ -264,7 +302,11 @@ impl<'a> Sender for NativeInitCtx<'a> {
         R: Actor + HandlesKind<K>,
         K: Kind,
     {
-        aether_actor::resolve_actor::<R, NativeTransport>().send(self.transport, payload);
+        ActorMailbox::<R, NativeTransport>::__new(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            self.transport,
+        )
+        .send(payload);
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -272,7 +314,11 @@ impl<'a> Sender for NativeInitCtx<'a> {
         R: Actor + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
-        aether_actor::resolve_actor::<R, NativeTransport>().send_many(self.transport, payloads);
+        ActorMailbox::<R, NativeTransport>::__new(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            self.transport,
+        )
+        .send_many(payloads);
     }
 
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -9,12 +9,14 @@
 //!   with a monotonic counter. Lets scenarios count tick deliveries
 //!   via `TestBench::count_observed` (broadcasts arrive on the
 //!   loopback and get recorded by kind name).
-//! - On the first tick, fires a typed `ctx.send_to::<LogCapability>`
+//! - On the first tick, fires a typed `ctx.actor::<LogCapability>().send`
 //!   call carrying a `LogEvent`. This is the issue 563 stage-5 demo:
 //!   the probe deps on `aether-capabilities` with
 //!   `default-features = false`, so the typed-sender path resolves
 //!   `LogCapability: Singleton + HandlesKind<LogEvent>` against the
-//!   wasm-header-only build with no native runtime in scope.
+//!   wasm-header-only build with no native runtime in scope. Issue 567
+//!   collapsed the call site from `ctx.send_to::<R, _>(&p)` to
+//!   `ctx.actor::<R>().send(&p)`.
 //! - Receives `aether.test_fixture.set_render { r, g, b, visible }`
 //!   to update render state. When `visible` is non-zero, on_tick
 //!   emits a colored `DrawTriangle` to the chassis render sink, so
@@ -95,7 +97,7 @@ impl WasmActor for Probe {
             },
         );
         if self.tick_count == 1 {
-            ctx.send_to::<LogCapability, _>(&LogEvent {
+            ctx.actor::<LogCapability>().send(&LogEvent {
                 level: 2,
                 target: "aether_test_fixture_probe".into(),
                 message: "typed_send_alive".into(),


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #567 is the intentional auto-close trigger -->

## Summary

- ActorMailbox gains an 'a lifetime carrying the transport reference, so send / send_many are &self-receiver with no explicit transport arg. Issue 567's ergonomic goal: `ctx.actor::<LogCapability>().send(&LogEvent { ... })` collapses the prior `ctx.send_to::<LogCapability, _>(&LogEvent { ... })` two-slot turbofish.
- Ctx, InitCtx, NativeCtx, and NativeInitCtx grow actor::<R: Singleton>() and resolve_actor::<R: Actor>(name) returning the bound mailbox. Free fns resolve_actor / resolve_actor_named retire (no transport ref to bind).
- NativeInitCtx::actor (the boot-time Arc-lookup form, currently zero callers) renames to peer, freeing the actor name for the typed-sender shortcut. Memory entry "actor::<A>() lookup is bootstrap-only" stays in force for peer.
- Ctx::send_to retires; the lone call site in aether-test-fixture-probe migrates to `ctx.actor::<LogCapability>().send`.
- Sender trait surface unchanged; only impl bodies bind through self.transport. Tier 2 (request/reply, forward) and Tier 3 (kinds enumeration) remain parked per the issue.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo test -p aether-actor --doc` — compile_fail doctest still rejects wrong-kind sends through the new ctx.actor() path
- [x] `cargo check -p aether-test-fixture-probe --target wasm32-unknown-unknown`

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)