### PR TITLE
refactor(actor): migrate kind-typed Mailbox sends to ctx.actor::<R>() (issue 575)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "aether-actor"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-capabilities",
  "aether-data",
  "aether-kinds",
  "bytemuck",
@@ -65,6 +66,7 @@ name = "aether-camera"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities",
  "aether-data",
  "aether-kinds",
  "aether-math",
@@ -128,6 +130,7 @@ version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
  "aether-camera",
+ "aether-capabilities",
  "aether-data",
  "aether-kinds",
  "aether-scenario",
@@ -152,6 +155,7 @@ name = "aether-demo-tic-tac-toe-client"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities",
  "aether-demo-tic-tac-toe",
  "aether-kinds",
  "aether-scenario",
@@ -166,6 +170,7 @@ name = "aether-demo-tic-tac-toe-server"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities",
  "aether-data",
  "aether-demo-tic-tac-toe",
  "aether-scenario",
@@ -210,6 +215,7 @@ name = "aether-mesh-viewer"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-capabilities",
  "aether-data",
  "aether-kinds",
  "aether-math",

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -800,24 +800,61 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
 ///
 /// Naming follows the `cxx::bridge` precedent — an attribute on a
 /// mod that splits emission across a boundary.
+///
+/// ## `#[bridge(feature = "name")]`
+///
+/// Caps whose native impl pulls heavy native-only deps (`render` →
+/// wgpu+png, `audio` → cpal) live behind a cargo feature. Without the
+/// feature, the inner `#[actor]` block can't compile (its imports are
+/// gone). The optional `feature = "name"` argument adds the feature
+/// to the cfg keying both the wasm stub vs. native re-export and the
+/// inner `mod native` itself: stub when wasm32 OR the feature is off;
+/// re-export when native AND the feature is on. This keeps the
+/// always-on markers reachable for wasm components (so they can write
+/// `ctx.actor::<RenderCapability>().send(&triangle)`) without the
+/// feature pulling its native dep set in.
 #[proc_macro_attribute]
 pub fn bridge(attr: TokenStream, item: TokenStream) -> TokenStream {
-    if !attr.is_empty() {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "#[bridge] takes no arguments",
-        )
-        .to_compile_error()
-        .into();
-    }
+    let feature = match parse_bridge_attr(attr) {
+        Ok(f) => f,
+        Err(e) => return e.to_compile_error().into(),
+    };
     let item = parse_macro_input!(item as ItemMod);
-    match expand_bridge(item) {
+    match expand_bridge(item, feature) {
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }
 }
 
-fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
+/// Parse the optional `feature = "name"` argument on `#[bridge]`.
+/// Empty attr returns `None` (the default no-feature mode); anything
+/// else parses as a `syn::MetaNameValue` whose path must be `feature`
+/// and value must be a string literal.
+fn parse_bridge_attr(attr: TokenStream) -> syn::Result<Option<String>> {
+    if attr.is_empty() {
+        return Ok(None);
+    }
+    let meta: syn::MetaNameValue = syn::parse(attr)?;
+    if !meta.path.is_ident("feature") {
+        return Err(syn::Error::new_spanned(
+            &meta.path,
+            "#[bridge] only accepts `feature = \"name\"`",
+        ));
+    }
+    let syn::Expr::Lit(syn::ExprLit {
+        lit: syn::Lit::Str(s),
+        ..
+    }) = meta.value
+    else {
+        return Err(syn::Error::new_spanned(
+            &meta.path,
+            "#[bridge(feature = ...)] expects a string literal",
+        ));
+    };
+    Ok(Some(s.value()))
+}
+
+fn expand_bridge(mut item_mod: ItemMod, feature: Option<String>) -> syn::Result<TokenStream2> {
     let Some((brace, items)) = item_mod.content.take() else {
         return Err(syn::Error::new_spanned(
             &item_mod,
@@ -987,11 +1024,26 @@ fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
     let frame_barrier_const = frame_barrier_expr.map(|expr| {
         quote! { const FRAME_BARRIER: bool = #expr; }
     });
+    // When the bridge declares `feature = "X"`, the wasm stub also
+    // covers "native target without the feature" so consumers that
+    // build with `default-features = false` keep a reachable type for
+    // the always-on markers below. The native re-export and the inner
+    // `mod native` then key on `feature = "X"` too.
+    let (stub_cfg, native_cfg) = match feature.as_deref() {
+        None => (
+            quote! { #[cfg(target_arch = "wasm32")] },
+            quote! { #[cfg(not(target_arch = "wasm32"))] },
+        ),
+        Some(feat) => (
+            quote! { #[cfg(any(target_arch = "wasm32", not(feature = #feat)))] },
+            quote! { #[cfg(all(not(target_arch = "wasm32"), feature = #feat))] },
+        ),
+    };
     let stub_and_reexport = quote! {
-        #[cfg(target_arch = "wasm32")]
+        #stub_cfg
         pub struct #type_ident;
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #native_cfg
         pub use #mod_ident::#type_ident;
     };
     let singleton_marker = quote! {
@@ -1047,7 +1099,10 @@ fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
     }
 
     // Reassemble the mod with the rewritten contents and prepend the
-    // cfg gate.
+    // cfg gate. `native_cfg` keys on the optional feature too — without
+    // a feature it's the original `not(target_arch = "wasm32")`; with
+    // one it adds `feature = "X"` so the inner `mod native` only
+    // compiles when both the target and the feature say to.
     item_mod.content = Some((brace, items));
     let mod_attrs = std::mem::take(&mut item_mod.attrs);
     Ok(quote! {
@@ -1057,7 +1112,7 @@ fn expand_bridge(mut item_mod: ItemMod) -> syn::Result<TokenStream2> {
         #(#handles_kind_markers)*
 
         #(#mod_attrs)*
-        #[cfg(not(target_arch = "wasm32"))]
+        #native_cfg
         #item_mod
     })
 }

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -35,6 +35,12 @@ serde = { version = "1", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
+# Examples migrate from kind-typed `Mailbox` resolutions to actor-
+# typed `ctx.actor::<R>()` calls (issue 575) — needs the cap markers
+# in scope. `default-features = false, features = ["render"]` pulls
+# the marker layer only (cycle-safe via dev-dep, no cargo build of
+# `aether-substrate` from this crate's build graph).
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 bytemuck = { version = "1", features = ["derive"] }
 postcard = { version = "1.1", features = ["alloc"] }

--- a/crates/aether-actor/examples/caller.rs
+++ b/crates/aether-actor/examples/caller.rs
@@ -7,10 +7,16 @@
 //! trip is visible to the driving Claude session.
 //!
 //! ADR-0033 phase 3: each kind gets its own `#[handler]` method on
-//! the `#[actor]`-decorated impl; `Mailbox<K>` still carries the
-//! send-side mailbox name (data, not type).
+//! the `#[actor]`-decorated impl. ADR-0075 actor-typed sender API:
+//! the broadcast send goes through `ctx.actor::<BroadcastCapability>()`
+//! (typed receiver, gates `HandlesKind<K>` at the call site), and
+//! the peer-component send to `"echoer"` rides the `Sender::send_to_named`
+//! string-keyed escape hatch — the echoer's actor type lives in a
+//! sibling cdylib this crate can't import without colliding FFI
+//! exports.
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, Sender, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::BroadcastCapability;
 use aether_data::{Kind, Schema};
 use aether_kinds::Tick;
 use bytemuck::{Pod, Zeroable};
@@ -37,8 +43,6 @@ pub struct Observation {
 }
 
 pub struct Caller {
-    request: Mailbox<Request>,
-    observe: Mailbox<Observation>,
     next_seq: u32,
 }
 
@@ -46,24 +50,21 @@ pub struct Caller {
 impl WasmActor for Caller {
     const NAMESPACE: &'static str = "caller";
 
-    fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(Caller {
-            request: ctx.resolve_mailbox::<Request>("echoer"),
-            observe: ctx.resolve_mailbox::<Observation>("hub.claude.broadcast"),
-            next_seq: 0,
-        })
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Caller { next_seq: 0 })
     }
 
     #[handler]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _tick: Tick) {
         let seq = self.next_seq;
         self.next_seq = self.next_seq.wrapping_add(1);
-        ctx.send(&self.request, &Request { seq });
+        ctx.send_to_named("echoer", &Request { seq });
     }
 
     #[handler]
     fn on_response(&mut self, ctx: &mut WasmCtx<'_>, resp: Response) {
-        ctx.send(&self.observe, &Observation { seq: resp.seq });
+        ctx.actor::<BroadcastCapability>()
+            .send(&Observation { seq: resp.seq });
     }
 }
 

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -16,7 +16,8 @@
 //! MCP via the same section so the harness sees typed capabilities
 //! plus author-written intent for each inbox.
 
-use aether_actor::{BootError, KindId, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, KindId, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::RenderCapability;
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
@@ -51,7 +52,6 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
 /// Per-instance state for the hello component.
 pub struct Hello {
     pong: KindId<Pong>,
-    render: Mailbox<DrawTriangle>,
 }
 
 /// Minimal end-to-end smoke component: draws a static triangle every
@@ -69,7 +69,6 @@ impl WasmActor for Hello {
     fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
         Ok(Hello {
             pong: ctx.resolve::<Pong>(),
-            render: ctx.resolve_mailbox::<DrawTriangle>("aether.render"),
         })
     }
 
@@ -81,7 +80,7 @@ impl WasmActor for Hello {
     /// output.
     #[handler]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _tick: Tick) {
-        ctx.send(&self.render, &TRIANGLE);
+        ctx.actor::<RenderCapability>().send(&TRIANGLE);
     }
 
     /// Replies to a ping with a pong carrying the same sequence

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -14,7 +14,8 @@
 //! kind at init, so the test harness just loads the component and
 //! starts driving input — no manual `subscribe_input` needed.
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::BroadcastCapability;
 use aether_data::{Kind, Schema};
 use aether_kinds::{Key, MouseButton, MouseMove, Tick};
 use bytemuck::{Pod, Zeroable};
@@ -27,50 +28,42 @@ pub struct InputObserved {
     pub code: u32,
 }
 
-pub struct InputLogger {
-    observe: Mailbox<InputObserved>,
-}
+pub struct InputLogger;
 
 #[actor]
 impl WasmActor for InputLogger {
     const NAMESPACE: &'static str = "input_logger";
 
-    fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(InputLogger {
-            observe: ctx.resolve_mailbox::<InputObserved>("hub.claude.broadcast"),
-        })
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(InputLogger)
     }
 
     #[handler]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _tick: Tick) {
-        ctx.send(&self.observe, &InputObserved { stream: 0, code: 0 });
+        ctx.actor::<BroadcastCapability>()
+            .send(&InputObserved { stream: 0, code: 0 });
     }
 
     #[handler]
     fn on_key(&mut self, ctx: &mut WasmCtx<'_>, key: Key) {
-        ctx.send(
-            &self.observe,
-            &InputObserved {
-                stream: 1,
-                code: key.code,
-            },
-        );
+        ctx.actor::<BroadcastCapability>().send(&InputObserved {
+            stream: 1,
+            code: key.code,
+        });
     }
 
     #[handler]
     fn on_mouse_button(&mut self, ctx: &mut WasmCtx<'_>, _mb: MouseButton) {
-        ctx.send(&self.observe, &InputObserved { stream: 2, code: 0 });
+        ctx.actor::<BroadcastCapability>()
+            .send(&InputObserved { stream: 2, code: 0 });
     }
 
     #[handler]
     fn on_mouse_move(&mut self, ctx: &mut WasmCtx<'_>, m: MouseMove) {
-        ctx.send(
-            &self.observe,
-            &InputObserved {
-                stream: 3,
-                code: m.x as u32,
-            },
-        );
+        ctx.actor::<BroadcastCapability>().send(&InputObserved {
+            stream: 3,
+            code: m.x as u32,
+        });
     }
 }
 

--- a/crates/aether-actor/examples/postcard_echoer.rs
+++ b/crates/aether-actor/examples/postcard_echoer.rs
@@ -13,7 +13,8 @@
 //! to wasm; load via `mcp__aether-hub__load_component` and send
 //! `demo.postcard_request` to verify the dispatch.
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::BroadcastCapability;
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
@@ -39,18 +40,14 @@ pub struct PostcardObserved {
     pub payload_len: u32,
 }
 
-pub struct PostcardEchoer {
-    broadcast: Mailbox<PostcardObserved>,
-}
+pub struct PostcardEchoer;
 
 #[actor]
 impl WasmActor for PostcardEchoer {
     const NAMESPACE: &'static str = "postcard_echoer";
 
-    fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(PostcardEchoer {
-            broadcast: ctx.resolve_mailbox::<PostcardObserved>("hub.claude.broadcast"),
-        })
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(PostcardEchoer)
     }
 
     /// Decoded postcard payload arrives as the third parameter. No
@@ -59,13 +56,10 @@ impl WasmActor for PostcardEchoer {
     /// the absence of `#[repr(C)]`) already knows the wire shape.
     #[handler]
     fn on_request(&mut self, ctx: &mut WasmCtx<'_>, req: PostcardRequest) {
-        ctx.send(
-            &self.broadcast,
-            &PostcardObserved {
-                tag_len: req.tag.len() as u32,
-                payload_len: req.payload.len() as u32,
-            },
-        );
+        ctx.actor::<BroadcastCapability>().send(&PostcardObserved {
+            tag_len: req.tag.len() as u32,
+            payload_len: req.payload.len() as u32,
+        });
     }
 }
 

--- a/crates/aether-actor/examples/save_counter.rs
+++ b/crates/aether-actor/examples/save_counter.rs
@@ -21,9 +21,8 @@
 //! 3. `terminate_substrate`, spawn another, observe the count
 //!    bumped by one.
 
-use aether_actor::{
-    BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor, io, wasm::resolve_mailbox,
-};
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor, io};
+use aether_capabilities::BroadcastCapability;
 use aether_kinds::{IoError, Tick};
 
 /// Broadcast payload the Claude session (or any component listening
@@ -45,11 +44,6 @@ const SAVE_PATH: &str = "counter.bin";
 /// should complete in sub-ms; larger backends (future cloud adapter)
 /// would want a bigger budget.
 const IO_TIMEOUT_MS: u32 = 1_000;
-/// Broadcast sink — `hub.claude.broadcast` fans out to every
-/// attached Claude session. `Count` is postcard-shaped; the unified
-/// `Mailbox::send` routes through `Kind::encode_into_bytes`, which the
-/// derive specializes to postcard here (issue #240).
-const BROADCAST: Mailbox<Count> = resolve_mailbox::<Count>("hub.claude.broadcast");
 
 pub struct SaveCounter {
     initialized: bool,
@@ -90,7 +84,8 @@ impl WasmActor for SaveCounter {
             &next.to_le_bytes(),
             IO_TIMEOUT_MS,
         );
-        BROADCAST.send(ctx.transport(), &Count { count: next });
+        ctx.actor::<BroadcastCapability>()
+            .send(&Count { count: next });
     }
 }
 

--- a/crates/aether-actor/src/ctx.rs
+++ b/crates/aether-actor/src/ctx.rs
@@ -123,8 +123,8 @@ impl<'a, T: MailTransport> InitCtx<'a, T> {
 /// Resolution is intentionally absent — runtime resolution after init
 /// is not a supported shape.
 ///
-/// Holds the transport borrow so `ctx.send(&sink, &payload)` is the
-/// natural call shape inside a handler — no need for the user to
+/// Holds the transport borrow so `ctx.actor::<R>().send(&payload)` is
+/// the natural call shape inside a handler — no need for the user to
 /// thread a transport reference through every send. ADR-0033: typed
 /// handlers receive `K` by value, so they no longer hold a `Mail<'_>`
 /// to call `mail.reply_to()` on. The synthesized dispatcher threads
@@ -158,10 +158,10 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
         self.sender = sender.map(|s| s.raw());
     }
 
-    /// Borrow the actor's transport. Exposed for callers that want to
-    /// call `Sink::send` or one of the `handle::publish` family
-    /// helpers directly with the transport ref instead of going
-    /// through `Ctx::send` / `Ctx::publish`.
+    /// Borrow the actor's transport. Exposed for the few SDK helper
+    /// modules (`aether-actor::wasm::{io,net,log}`) that resolve a
+    /// kind-typed `Mailbox<K, T>` internally and call its `send`
+    /// directly with the transport ref.
     pub fn transport(&self) -> &T {
         self.transport
     }
@@ -173,21 +173,6 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
     /// session (ADR-0013).
     pub fn reply_to(&self) -> Option<ReplyTo> {
         self.sender.map(ReplyTo::__from_raw)
-    }
-
-    /// Send a single payload to `sink`. Typed wrapper around
-    /// `Sink::send` — having the same entry point through both
-    /// `Ctx` and `Sink` is deliberate: `Ctx` is the receive-time
-    /// vocabulary, `Sink::send` is the universal one. Wire shape
-    /// (cast or postcard) is the kind's, not the call's (issue #240).
-    pub fn send<K: Kind>(&self, sink: &Mailbox<K, T>, payload: &K) {
-        sink.send(self.transport, payload);
-    }
-
-    /// Send a slice of payloads as a contiguous batch. Cast-only —
-    /// see [`Sink::send_many`] for the wire-shape rationale.
-    pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Mailbox<K, T>, payloads: &[K]) {
-        sink.send_many(self.transport, payloads);
     }
 
     /// Reply to the Claude session that originated the inbound mail
@@ -243,9 +228,10 @@ impl<'a, T: MailTransport> Ctx<'a, T> {
 /// Narrowed capability handle for shutdown hooks (`on_replace`,
 /// `on_drop`). Like `Ctx`, but deliberately smaller:
 ///
-/// - `send` / `send_many` still work — outbound mail during shutdown
-///   is a valid and useful pattern ("I'm going away, here's the last
-///   thing I observed").
+/// - Outbound mail still works through the [`Sender`] trait
+///   (`ctx.send::<R, _>(&kind)` / `ctx.send_to_named(name, &kind)`)
+///   — outbound mail during shutdown is a valid pattern ("I'm going
+///   away, here's the last thing I observed").
 /// - `save_state` is only meaningful in `on_replace` — it deposits a
 ///   version-tagged byte bundle the substrate hands to the new
 ///   instance via `on_rehydrate`. Calling it from `on_drop` is
@@ -274,18 +260,6 @@ impl<'a, T: MailTransport> DropCtx<'a, T> {
     /// [`Ctx::transport`].
     pub fn transport(&self) -> &T {
         self.transport
-    }
-
-    /// Send a single payload during a shutdown hook. Wire shape (cast
-    /// or postcard) follows `Kind::encode_into_bytes`.
-    pub fn send<K: Kind>(&self, sink: &Mailbox<K, T>, payload: &K) {
-        sink.send(self.transport, payload);
-    }
-
-    /// Send a slice of payloads during a shutdown hook. Cast-only —
-    /// see [`Sink::send_many`] for the wire-shape rationale.
-    pub fn send_many<K: Kind + bytemuck::NoUninit>(&self, sink: &Mailbox<K, T>, payloads: &[K]) {
-        sink.send_many(self.transport, payloads);
     }
 
     /// Deposit a migration bundle for the substrate to hand to the

--- a/crates/aether-camera/Cargo.toml
+++ b/crates/aether-camera/Cargo.toml
@@ -36,6 +36,7 @@ runtime = []
 
 [dependencies]
 aether-actor = { path = "../aether-actor" }
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render"] }
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -35,7 +35,8 @@
 
 use std::collections::HashMap;
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::RenderCapability;
 use aether_kinds::{Camera, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
 
@@ -224,7 +225,6 @@ pub struct CameraComponent {
     cameras: HashMap<String, CameraState>,
     active: Option<String>,
     aspect: f32,
-    camera: Mailbox<Camera>,
 }
 
 /// Multi-camera component. Hosts N named cameras, ticks all, publishes
@@ -249,7 +249,7 @@ pub struct CameraComponent {
 impl WasmActor for CameraComponent {
     const NAMESPACE: &'static str = "camera";
 
-    fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
         let mut cameras = HashMap::new();
         cameras.insert(
             "main".to_owned(),
@@ -261,7 +261,6 @@ impl WasmActor for CameraComponent {
             cameras,
             active: Some("main".to_owned()),
             aspect: DEFAULT_ASPECT,
-            camera: ctx.resolve_mailbox::<Camera>("aether.render"),
         })
     }
 
@@ -281,7 +280,7 @@ impl WasmActor for CameraComponent {
             && let Some(cam) = self.cameras.get(name)
         {
             let view_proj = cam.mode.view_proj(self.aspect);
-            ctx.send(&self.camera, &Camera { view_proj });
+            ctx.actor::<RenderCapability>().send(&Camera { view_proj });
         }
     }
 

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -27,7 +27,8 @@ edition.workspace = true
 [features]
 # Default-on: chassis-target builds get the full cap set with their
 # substrate-side runtime impls. Wasm consumers do
-# `default-features = false`.
+# `default-features = false` and opt into per-cap marker features
+# (`render` / `audio`) for the caps they typed-send to.
 default = ["native"]
 
 # Pulls every wasm-incompatible dep + the `aether-substrate` runtime
@@ -43,11 +44,21 @@ native = [
     "dep:url",
 ]
 
-# Per-cap toggles for the GPU / audio backends. Each implies
-# `native` because the cap modules these gate are themselves
-# substrate-bound.
-render = ["native", "aether-substrate/render", "dep:wgpu", "dep:png"]
-audio = ["native", "aether-substrate/audio", "dep:cpal", "dep:crossbeam-queue"]
+# Wasm-safe marker layers. Activate from a wasm component that wants to
+# address the cap via `ctx.actor::<RenderCapability>().send(&kind)` —
+# the feature gates the cap module so its always-on `Actor` /
+# `Singleton` / `HandlesKind` impls + wasm-stub `pub struct` are
+# reachable, without dragging the GPU / audio native deps in.
+# Empty bodies on purpose: the markers compile from pure-Rust sources
+# already pulled in unconditionally (`aether-actor`, `aether-kinds`).
+render = []
+audio = []
+
+# Native impl layers — adds the substrate-side runtime + heavy deps
+# atop the marker layer. Chassis bins activate these. Each implies its
+# marker layer + `native` so chassis builds still see the full cap.
+render-native = ["render", "native", "aether-substrate/render", "dep:wgpu", "dep:png"]
+audio-native = ["audio", "native", "aether-substrate/audio", "dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
 # Always-on: target-agnostic SDK + data layer + kind types. These

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -52,51 +52,16 @@
 // of the mod (always-on, outside the cfg gate).
 use aether_kinds::{NoteOff, NoteOn, SetMasterGain};
 
-/// Capacity of the event queue between the cap's handlers and the
-/// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
-/// 100-note-per-second stream; overflow is warn-dropped, which the
-/// ADR-0039 timing-quantization section already documents as a v1
-/// limitation (tight-burst percussion may drop notes under load).
-pub const EVENT_QUEUE_CAPACITY: usize = 1024;
+// `AudioConfig` rides through file root for chassis-bin consumers
+// that build it from env (`from_env`) and pass it to
+// `with_actor::<AudioCapability>(cfg)`. Native-only re-export — wasm
+// components opting into the marker-only `audio` feature don't need
+// the config struct (sends are typed; config is the chassis's
+// concern).
+#[cfg(all(not(target_arch = "wasm32"), feature = "audio-native"))]
+pub use native::AudioConfig;
 
-/// Maximum concurrent voices before voice-stealing kicks in. Chosen
-/// as "more than a string section fits in one component" — if we
-/// exceed it regularly the symptom is oldest-note cut-off, not audio
-/// glitches.
-pub const MAX_VOICES: usize = 64;
-
-/// Resolved configuration for the audio synth. Chassis mains read
-/// env vars (`AETHER_AUDIO_DISABLE`, `AETHER_AUDIO_SAMPLE_RATE`)
-/// into an `AudioConfig` and pass it to [`AudioCapability::new`]
-/// (issue 464). Tests build an `AudioConfig` directly.
-#[derive(Clone, Debug, Default)]
-pub struct AudioConfig {
-    /// `AETHER_AUDIO_DISABLE=1` skips cpal init entirely. The cap
-    /// still claims its mailbox and replies `Err` to `SetMasterGain`
-    /// so agents fail fast instead of hanging.
-    pub disabled: bool,
-    /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. If
-    /// the device doesn't support it, boot falls back to nop
-    /// (ADR-0039 — non-fatal).
-    pub requested_sample_rate: Option<u32>,
-}
-
-impl AudioConfig {
-    pub fn from_env() -> Self {
-        let disabled = std::env::var("AETHER_AUDIO_DISABLE")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        let requested_sample_rate = std::env::var("AETHER_AUDIO_SAMPLE_RATE")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok());
-        Self {
-            disabled,
-            requested_sample_rate,
-        }
-    }
-}
-
-#[aether_actor::bridge]
+#[aether_actor::bridge(feature = "audio-native")]
 mod native {
     use std::f32::consts::TAU;
     use std::sync::Arc;
@@ -113,7 +78,51 @@ mod native {
     use aether_substrate::capability::BootError;
     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
 
-    use super::{AudioConfig, EVENT_QUEUE_CAPACITY, MAX_VOICES, NoteOff, NoteOn, SetMasterGain};
+    use super::{NoteOff, NoteOn, SetMasterGain};
+
+    /// Capacity of the event queue between the cap's handlers and the
+    /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
+    /// 100-note-per-second stream; overflow is warn-dropped, which the
+    /// ADR-0039 timing-quantization section already documents as a v1
+    /// limitation (tight-burst percussion may drop notes under load).
+    const EVENT_QUEUE_CAPACITY: usize = 1024;
+
+    /// Maximum concurrent voices before voice-stealing kicks in. Chosen
+    /// as "more than a string section fits in one component" — if we
+    /// exceed it regularly the symptom is oldest-note cut-off, not audio
+    /// glitches.
+    const MAX_VOICES: usize = 64;
+
+    /// Resolved configuration for the audio synth. Chassis mains read
+    /// env vars (`AETHER_AUDIO_DISABLE`, `AETHER_AUDIO_SAMPLE_RATE`)
+    /// into an `AudioConfig` and pass it to `with_actor::<AudioCapability>(cfg)`
+    /// (issue 464). Tests build an `AudioConfig` directly.
+    #[derive(Clone, Debug, Default)]
+    pub struct AudioConfig {
+        /// `AETHER_AUDIO_DISABLE=1` skips cpal init entirely. The cap
+        /// still claims its mailbox and replies `Err` to `SetMasterGain`
+        /// so agents fail fast instead of hanging.
+        pub disabled: bool,
+        /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. If
+        /// the device doesn't support it, boot falls back to nop
+        /// (ADR-0039 — non-fatal).
+        pub requested_sample_rate: Option<u32>,
+    }
+
+    impl AudioConfig {
+        pub fn from_env() -> Self {
+            let disabled = std::env::var("AETHER_AUDIO_DISABLE")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+            let requested_sample_rate = std::env::var("AETHER_AUDIO_SAMPLE_RATE")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok());
+            Self {
+                disabled,
+                requested_sample_rate,
+            }
+        }
+    }
 
     /// Event a handler pushes into the audio callback's queue. The
     /// `sender_mailbox` is baked in here (not re-derived on the callback

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -36,11 +36,15 @@ pub mod net;
 pub mod render;
 
 #[cfg(feature = "audio")]
-pub use audio::{AudioCapability, AudioConfig};
+pub use audio::AudioCapability;
+#[cfg(feature = "audio-native")]
+pub use audio::AudioConfig;
 pub use broadcast::BroadcastCapability;
 pub use handle::HandleCapability;
 pub use io::IoCapability;
 pub use log::LogCapability;
 pub use net::{NetCapability, NetConfig};
 #[cfg(feature = "render")]
-pub use render::{RenderCapability, RenderConfig, RenderGpu, RenderHandles};
+pub use render::RenderCapability;
+#[cfg(feature = "render-native")]
+pub use render::{RenderConfig, RenderGpu, RenderHandles};

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -19,11 +19,14 @@ use aether_kinds::{Camera, DrawTriangle};
 
 // Auxiliary native-only types the chassis driver consumes alongside
 // `RenderCapability`. `#[bridge]` only re-exports the actor type
-// itself; these need explicit re-exports.
-#[cfg(not(target_arch = "wasm32"))]
+// itself; these need explicit re-exports. Keyed on the `render-native`
+// feature so wasm components that opt into the marker-only `render`
+// feature see only the cap stub + Actor / HandlesKind impls, not
+// these heavy GPU-bound types.
+#[cfg(all(not(target_arch = "wasm32"), feature = "render-native"))]
 pub use native::{RenderConfig, RenderGpu, RenderHandles};
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(feature = "render-native")]
 mod native {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -36,6 +36,7 @@ runtime = []
 [dependencies]
 aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data", features = ["derive"] }
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-mesh = { path = "../aether-mesh" }
 aether-math = { path = "../aether-math" }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -31,7 +31,8 @@
 //! 4. Every `aether.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor, io};
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor, io};
+use aether_capabilities::RenderCapability;
 use aether_kinds::{DrawTriangle, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
@@ -57,7 +58,6 @@ const OBJ_DEFAULT_COLOR: (f32, f32, f32) = PALETTE[0];
 
 pub struct MeshViewer {
     triangles: Vec<DrawTriangle>,
-    render: Mailbox<DrawTriangle>,
 }
 
 /// Mesh viewer component.
@@ -74,10 +74,9 @@ pub struct MeshViewer {
 impl WasmActor for MeshViewer {
     const NAMESPACE: &'static str = "mesh_viewer";
 
-    fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
         Ok(MeshViewer {
             triangles: Vec::new(),
-            render: ctx.resolve_mailbox::<DrawTriangle>("aether.render"),
         })
     }
 
@@ -90,7 +89,7 @@ impl WasmActor for MeshViewer {
     #[handler]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _tick: Tick) {
         if !self.triangles.is_empty() {
-            ctx.send_many(&self.render, &self.triangles);
+            ctx.actor::<RenderCapability>().send_many(&self.triangles);
         }
     }
 

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/bin/test-bench.rs"
 
 [dependencies]
 aether-substrate = { path = "../aether-substrate", features = ["render", "audio"] }
-aether-capabilities = { path = "../aether-capabilities", features = ["render", "audio"] }
+aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native"] }
 aether-data = { path = "../aether-data" }
 aether-codec = { path = "../aether-codec" }
 aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-test-fixture-probe/Cargo.toml
+++ b/crates/aether-test-fixture-probe/Cargo.toml
@@ -13,6 +13,8 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # `default-features = false` exercises the issue 552 stage 4 wasm-header-only
 # build of aether-capabilities — the cap markers (Actor / Singleton /
 # HandlesKind) compile for wasm without dragging the native runtime in.
-aether-capabilities = { path = "../aether-capabilities", default-features = false }
+# `render` opts into the marker layer for `RenderCapability`; `audio`
+# is unused here, omitted on purpose.
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render"] }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -23,10 +23,8 @@
 //!   `capture_frame` scenarios can observe pre-mail effects in the
 //!   captured PNG.
 
-use aether_actor::{
-    BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor, wasm::resolve_mailbox,
-};
-use aether_capabilities::LogCapability;
+use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::{BroadcastCapability, LogCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, LogEvent, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
 
@@ -56,9 +54,6 @@ pub struct SetRender {
     pub b: u8,
     pub visible: u8,
 }
-
-const BROADCAST: Mailbox<TickObserved> = resolve_mailbox::<TickObserved>("hub.claude.broadcast");
-const RENDER: Mailbox<DrawTriangle> = resolve_mailbox::<DrawTriangle>("aether.render");
 
 pub struct Probe {
     tick_count: u64,
@@ -90,12 +85,9 @@ impl WasmActor for Probe {
     #[handler]
     fn on_tick(&mut self, ctx: &mut WasmCtx<'_>, _: Tick) {
         self.tick_count += 1;
-        BROADCAST.send(
-            ctx.transport(),
-            &TickObserved {
-                count: self.tick_count,
-            },
-        );
+        ctx.actor::<BroadcastCapability>().send(&TickObserved {
+            count: self.tick_count,
+        });
         if self.tick_count == 1 {
             ctx.actor::<LogCapability>().send(&LogEvent {
                 level: 2,
@@ -115,12 +107,9 @@ impl WasmActor for Probe {
                 g,
                 b,
             };
-            RENDER.send(
-                ctx.transport(),
-                &DrawTriangle {
-                    verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
-                },
-            );
+            ctx.actor::<RenderCapability>().send(&DrawTriangle {
+                verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
+            });
         }
     }
 

--- a/demos/sokoban/Cargo.toml
+++ b/demos/sokoban/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-actor = { path = "../../crates/aether-actor" }
+# Marker-only opt-in so `ctx.actor::<RenderCapability>()` resolves
+# without dragging wgpu/png into sokoban's wasm graph.
+aether-capabilities = { path = "../../crates/aether-capabilities", default-features = false, features = ["render"] }
 # `default-features = false` keeps the camera trunk's `runtime` module
 # (and its `aether_actor::export!()` FFI exports) out of sokoban's
 # wasm build. Without this, both crates' `init` / `receive_p32`

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -11,8 +11,9 @@
 //!
 //! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
-use aether_actor::{BootError, KindId, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, KindId, Sender, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_camera::{CameraTopdownSet, TopdownParams};
+use aether_capabilities::RenderCapability;
 use aether_data::{Kind, Schema};
 use aether_kinds::{DrawTriangle, Key, Tick, Vertex, keycode};
 use bytemuck::{Pod, Zeroable};
@@ -117,8 +118,6 @@ const LEVELS: &[&[&str]] = &[
 pub struct Sokoban {
     state: SokobanState,
     state_kind: KindId<SokobanState>,
-    render: Mailbox<DrawTriangle>,
-    camera_follow: Mailbox<CameraTopdownSet>,
     /// Cached camera-follow envelope. The `name` field is set once at
     /// init and reused every tick to avoid re-allocating the String;
     /// only `params.center` is mutated per frame.
@@ -145,8 +144,6 @@ impl WasmActor for Sokoban {
         let mut me = Sokoban {
             state: SokobanState::default(),
             state_kind: ctx.resolve::<SokobanState>(),
-            render: ctx.resolve_mailbox::<DrawTriangle>("aether.render"),
-            camera_follow: ctx.resolve_mailbox::<CameraTopdownSet>("camera"),
             follow_msg: CameraTopdownSet {
                 name: "main".to_owned(),
                 params: TopdownParams {
@@ -165,7 +162,11 @@ impl WasmActor for Sokoban {
         let (px, py) = self.player_world_pos();
         self.render_player(ctx, px, py);
         self.follow_msg.params.center = Some([px, py]);
-        ctx.send(&self.camera_follow, &self.follow_msg);
+        // Camera component lives in a sibling cdylib whose runtime
+        // type isn't reachable here (enabling its `runtime` feature
+        // would emit duplicate FFI exports), so we stay on the
+        // string-keyed escape hatch for this peer-component send.
+        ctx.send_to_named("camera", &self.follow_msg);
     }
 
     /// Movement key. Tile-step on press; release is ignored.
@@ -346,7 +347,7 @@ impl Sokoban {
                 },
             ],
         };
-        ctx.send(&self.render, &body);
+        ctx.actor::<RenderCapability>().send(&body);
     }
 
     fn reply_state(&self, ctx: &mut WasmCtx<'_>) {
@@ -436,7 +437,7 @@ impl Sokoban {
                 n += 2;
             }
         }
-        ctx.send_many(&self.render, &tris[..n]);
+        ctx.actor::<RenderCapability>().send_many(&tris[..n]);
     }
 }
 

--- a/demos/tic-tac-toe-client/Cargo.toml
+++ b/demos/tic-tac-toe-client/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-actor = { path = "../../crates/aether-actor" }
+aether-capabilities = { path = "../../crates/aether-capabilities", default-features = false, features = ["render"] }
 # Trunk rlib for the demo (ADR-0066) — wire types + well-known names.
 # The server's runtime `Component` impl + FFI exports live in the
 # sibling `aether-demo-tic-tac-toe-server` cdylib, which this crate

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -45,7 +45,8 @@
 //! That's as shape-y as this first pass gets; proper X / O glyphs
 //! are a rendering-polish pass for later.
 
-use aether_actor::{BootError, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, Sender, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::RenderCapability;
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, GameState, LAST_MOVE_NONE, MoveResult, PLAYER_X, PlayMove, SERVER,
 };
@@ -89,8 +90,6 @@ pub struct TicTacToeClient {
     /// mapped to a cell, so they're dropped until the first publish
     /// lands (happens within one tick of subscribing).
     window: Option<(u32, u32)>,
-    render: Mailbox<DrawTriangle>,
-    server: Mailbox<PlayMove>,
 }
 
 impl Default for TicTacToeClient {
@@ -105,8 +104,6 @@ impl Default for TicTacToeClient {
             state: GameState::new_game(),
             mouse: None,
             window: None,
-            render: aether_actor::wasm::resolve_mailbox::<DrawTriangle>("aether.render"),
-            server: aether_actor::wasm::resolve_mailbox::<PlayMove>(SERVER),
         }
     }
 }
@@ -203,8 +200,8 @@ impl WasmActor for TicTacToeClient {
         let Some((mx, my)) = self.mouse else { return };
         let Some((w, h)) = self.window else { return };
         if let Some((row, col)) = hit_test(mx, my, w, h) {
-            ctx.send(
-                &self.server,
+            ctx.send_to_named(
+                SERVER,
                 &PlayMove {
                     row,
                     col,
@@ -272,7 +269,7 @@ impl TicTacToeClient {
             }
         }
 
-        ctx.send_many(&self.render, &tris[..n]);
+        ctx.actor::<RenderCapability>().send_many(&tris[..n]);
     }
 }
 

--- a/demos/tic-tac-toe-server/Cargo.toml
+++ b/demos/tic-tac-toe-server/Cargo.toml
@@ -14,6 +14,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aether-actor = { path = "../../crates/aether-actor" }
+# Server uses `BroadcastCapability` (always-on, no feature) — no
+# marker features needed.
+aether-capabilities = { path = "../../crates/aether-capabilities", default-features = false }
 aether-demo-tic-tac-toe = { path = "../tic-tac-toe" }
 aether-data = { path = "../../crates/aether-data" }
 

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -22,21 +22,22 @@
 //! on the trunk for those without pulling in this crate's
 //! `Component` impl. Per ADR-0066.
 
-use aether_actor::{BootError, KindId, Mailbox, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{BootError, KindId, Sender, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_capabilities::BroadcastCapability;
 use aether_demo_tic_tac_toe::{
     CELL_EMPTY, CLIENT_OBSERVER, GAME_DRAW, GAME_PLAYING, GAME_WON_O, GAME_WON_X, GameState,
     MOVE_CELL_OCCUPIED, MOVE_GAME_OVER, MOVE_OK, MOVE_OUT_OF_BOUNDS, MoveResult, PLAYER_NONE,
     PLAYER_O, PLAYER_X, PlayMove, Reset,
 };
 
-/// Per-instance component state. Holds the live game board plus cached
-/// kind / sink handles — resolved once in `init` and reused across
-/// every move.
+/// Per-instance component state. Holds the live game board plus the
+/// cached kind id used for replies. Receivers are addressed via
+/// `ctx.actor::<R>()` (broadcast) or `ctx.send_to_named` (the
+/// observer client, whose Rust type is in a sibling cdylib the server
+/// can't import).
 pub struct TicTacToe {
     state: GameState,
     move_result_kind: KindId<MoveResult>,
-    broadcast: Mailbox<GameState>,
-    client_observer: Mailbox<GameState>,
 }
 
 /// Authoritative tic-tac-toe server. Accepts `PlayMove` and `Reset`
@@ -63,8 +64,6 @@ impl WasmActor for TicTacToe {
         Ok(TicTacToe {
             state: GameState::new_game(),
             move_result_kind: ctx.resolve::<MoveResult>(),
-            broadcast: ctx.resolve_mailbox::<GameState>("hub.claude.broadcast"),
-            client_observer: ctx.resolve_mailbox::<GameState>(CLIENT_OBSERVER),
         })
     }
 
@@ -84,8 +83,8 @@ impl WasmActor for TicTacToe {
         let status = self.apply_move(mv.row, mv.col);
         self.reply(ctx, status);
         if status == MOVE_OK {
-            ctx.send(&self.broadcast, &self.state);
-            ctx.send(&self.client_observer, &self.state);
+            ctx.actor::<BroadcastCapability>().send(&self.state);
+            ctx.send_to_named(CLIENT_OBSERVER, &self.state);
         }
     }
 
@@ -100,8 +99,8 @@ impl WasmActor for TicTacToe {
     fn on_reset(&mut self, ctx: &mut WasmCtx<'_>, _r: Reset) {
         self.state = GameState::new_game();
         self.reply(ctx, MOVE_OK);
-        ctx.send(&self.broadcast, &self.state);
-        ctx.send(&self.client_observer, &self.state);
+        ctx.actor::<BroadcastCapability>().send(&self.state);
+        ctx.send_to_named(CLIENT_OBSERVER, &self.state);
     }
 }
 
@@ -194,13 +193,11 @@ mod tests {
     fn new_component() -> TicTacToe {
         // Host-side unit tests can't route through the SDK's
         // `InitCtx`, so fabricate a minimal instance with the same
-        // starting state the runtime would build. The kind / sink
-        // handles are dummies — `apply_move` never touches them.
+        // starting state the runtime would build. `apply_move` only
+        // touches `state`; the kind handle is a placeholder.
         TicTacToe {
             state: GameState::new_game(),
             move_result_kind: aether_actor::resolve::<MoveResult>(),
-            broadcast: aether_actor::wasm::resolve_mailbox::<GameState>("hub.claude.broadcast"),
-            client_observer: aether_actor::wasm::resolve_mailbox::<GameState>(CLIENT_OBSERVER),
         }
     }
 


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes keyword + GitHub URL fragment are legitimate -->
## Summary

- Migrate every `Ctx::send(&mailbox, &payload)` / `send_many` callsite (23 audited sites across mesh-viewer, camera, probe, tic-tac-toe demos, sokoban, and 5 examples) onto the actor-typed `ctx.actor::<R>().send(&payload)` shape from issue 567.
- Retire `Ctx::send` / `Ctx::send_many` / `DropCtx::send` / `DropCtx::send_many`. `Sender::send_to_named` survives as the genuine no-type escape hatch (used where the peer component's actor type lives in a sibling cdylib).
- Split the render/audio cap features into marker-only (`render` / `audio`, wasm-safe, empty deps) and native-impl (`render-native` / `audio-native`, heavy, chassis-only). Bridge macro grew an optional `feature = "X"` argument so the inner `mod native` cfg keys on both target and feature.

The feature split is needed because wasm components addressing `ctx.actor::<RenderCapability>()` need the marker stub reachable, but the previous `render` feature pulled wgpu / png / aether-substrate-render — none of which build for `wasm32-unknown-unknown`. Renaming made the boundary literal: `render` is now "I want the cap markers," `render-native` is "I want the GPU runtime."

Audio caught a small leak as a side effect — `AudioConfig` + queue capacity constants were at file root, so once `pub mod audio;` went always-on they'd have been visible to wasm consumers. Moved inside the bridge mod.

Discussion + audit-vs-shipped delta posted on the issue: https://github.com/iamacoffeepot/aether/issues/575#issuecomment-4383063733

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — 199 + integration suites green
- [x] All 6 wasm components build for `wasm32-unknown-unknown`
- [x] Per-component integration tests (`aether-mesh-viewer`, `aether-camera`, demos) pass

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)