### PR TITLE
feat(actor): actor-local storage primitive symmetric across wasm and native

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1153,6 +1153,55 @@ pub fn fallback(_attr: TokenStream, _item: TokenStream) -> TokenStream {
     .into()
 }
 
+/// `#[local]` — attribute macro that declares a struct as
+/// per-actor scratch storage (issue 582). Passes the struct
+/// through unchanged and emits `impl ::aether_actor::Local for T
+/// {}` underneath.
+///
+/// The trait requires `Default + Send + 'static` (native) /
+/// `Default + 'static` (wasm) — the user supplies `Default` either
+/// via `#[derive(Default)]` or a hand-rolled impl, depending on
+/// whether the struct's fields default trivially. The macro
+/// deliberately does *not* auto-derive `Default` so types that
+/// need a custom default (e.g. a counter that starts at 1, a Vec
+/// with reserved capacity) aren't fighting the derive.
+///
+/// ```ignore
+/// #[derive(Default)]
+/// #[local]
+/// struct LogBuffer(Vec<LogEvent>);
+///
+/// #[derive(Default)]
+/// #[local]
+/// struct AppState {
+///     pending: u32,
+///     events: Vec<Event>,
+/// }
+///
+/// // Custom Default:
+/// #[local]
+/// struct Retries { count: u32 }
+/// impl Default for Retries {
+///     fn default() -> Self { Self { count: 3 } }
+/// }
+/// ```
+///
+/// Generics are forwarded — `#[local] struct Foo<T>(T);` emits
+/// `impl<T: Default + Send + 'static> Local for Foo<T>`. In
+/// practice Local types are concrete; the generics support is
+/// mostly for completeness.
+#[proc_macro_attribute]
+pub fn local(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as syn::ItemStruct);
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    quote! {
+        #input
+        impl #impl_generics ::aether_actor::Local for #name #ty_generics #where_clause {}
+    }
+    .into()
+}
+
 /// `#[derive(Singleton)]` — emits `impl ::aether_actor::Singleton for T {}`.
 ///
 /// Issue 552 stage 0: explicit opt-in marker that an actor type is

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -48,8 +48,16 @@
 
 extern crate alloc;
 
+// Self-alias so proc-macros (today: `#[local]` in
+// `aether-actor-derive`) that emit absolute paths like
+// `::aether_actor::Local` resolve when used inside this crate
+// itself — e.g., the `local` test module's probe newtypes.
+// Outside callers don't need this; it's a no-op for them.
+extern crate self as aether_actor;
+
 mod actor;
 mod ctx;
+pub mod local;
 mod mail;
 mod sender;
 mod sink;
@@ -60,6 +68,7 @@ pub mod wasm;
 
 pub use actor::{Actor, Dispatch, HandlesKind, Singleton};
 pub use ctx::{Ctx, DropCtx, InitCtx};
+pub use local::Local;
 pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
 pub use sender::{MailCtx, Sender};
 // Generic 2-arg `Mailbox<K, T>` stays accessible as
@@ -132,7 +141,7 @@ pub mod __macro_internals {
 /// alongside the existing actor derives so component / capability
 /// authors only need `aether-actor` in their dep list.
 pub use aether_data::{
-    Kind, KindId as DataKindId, Schema, actor, bridge, capability, fallback, handler,
+    Kind, KindId as DataKindId, Schema, actor, bridge, capability, fallback, handler, local,
 };
 // `Singleton` lives in two namespaces:
 //   - the type namespace for the marker trait (`Actor` super-trait),

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -1,0 +1,476 @@
+//! `Local` — per-actor scratch storage, type-keyed.
+//! Issue 582.
+//!
+//! Storage is *semantically mailbox-keyed*: the chassis dispatcher
+//! trampoline stamps a `*const ActorSlots` into TLS via
+//! [`with_stamped`] before each handler call (and around `init`),
+//! and `with` / `with_mut` read the stamped pointer to find the
+//! current actor's storage. Within an actor's storage the lookup
+//! is keyed on `TypeId<Self>` — distinct logical storages map to
+//! distinct types. This is the convention: `struct AppLog(Vec<u8>);
+//! struct AuditLog(Vec<u8>);` get independent slots because their
+//! `TypeId`s differ. The type system makes "I want distinct
+//! storage" a structural fact rather than a runtime convention.
+//!
+//! TLS is a per-handler-call routing pointer, not the data:
+//! `ActorSlots` lives in a `Box` owned by the actor's dispatcher
+//! closure for the actor's lifetime. If the scheduler shape ever
+//! changed and an actor migrated between threads, the `Box` would
+//! transfer with the actor, the new thread would `with_stamped`
+//! the same heap pointer, and `with_mut` callers would see the
+//! same data — the binding is to the actor, not to the thread.
+//! See `native_slots_follow_box_across_threads`.
+//!
+//! Single-threaded-per-actor (ADR-0038) is what makes `RefCell`
+//! safe on both targets:
+//!
+//! - Concurrent borrows of the same `Self` panic via
+//!   `RefCell::borrow_mut` ("already borrowed"). Free runtime
+//!   check covering cross-actor leak, dispatcher bug, and
+//!   recursive-from-the-same-handler.
+//! - Native panics with `debug_assert!` if `with` / `with_mut`
+//!   is called outside an active stamp (substrate boot code,
+//!   init-before-stamp, etc.).
+//!
+//! First consumer: issue 581's per-actor log buffer (a named
+//! `LogBuffer` newtype around `Vec<LogEvent>`), drained to
+//! `LogCapability` at handler exit by an actor-aware composite
+//! tracing subscriber.
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    extern crate alloc;
+
+    use alloc::boxed::Box;
+    use alloc::collections::BTreeMap;
+    use core::any::{Any, TypeId};
+    use core::cell::{RefCell, UnsafeCell};
+
+    /// Single-actor type-keyed storage in wasm linear memory. The
+    /// `unsafe impl Sync` is justified by the structural single-
+    /// thread of the wasm linear memory: every component runs on
+    /// one logical thread inside its own linear memory, so the
+    /// static can never be racily aliased across threads. Same
+    /// loophole `WASM_TRANSPORT` uses.
+    ///
+    /// `BTreeMap` instead of `HashMap` because `BTreeMap::new()`
+    /// is `const fn` and `aether-actor` is `no_std + alloc` — we
+    /// don't pull in `hashbrown`. The map holds at most a handful
+    /// of entries per actor in practice (one per `Local`-
+    /// implementing type), so the log-N lookup cost is irrelevant.
+    pub(super) struct WasmActorSlots {
+        inner: UnsafeCell<RefCell<BTreeMap<TypeId, Box<dyn Any>>>>,
+    }
+
+    unsafe impl Sync for WasmActorSlots {}
+
+    impl WasmActorSlots {
+        const fn new() -> Self {
+            Self {
+                inner: UnsafeCell::new(RefCell::new(BTreeMap::new())),
+            }
+        }
+
+        pub(super) fn with_mut<T, R>(&self, f: impl FnOnce(&mut T) -> R) -> R
+        where
+            T: Default + 'static,
+        {
+            // SAFETY: the wasm linear memory is single-threaded;
+            // the static is reachable only from this actor's code.
+            let map_cell = unsafe { &*self.inner.get() };
+            let cell_ptr: *const RefCell<T> = {
+                let mut map = map_cell.borrow_mut();
+                let entry = map
+                    .entry(TypeId::of::<T>())
+                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);
+                entry
+                    .downcast_ref::<RefCell<T>>()
+                    .expect("TypeId<T> ⇒ RefCell<T>") as *const RefCell<T>
+            };
+            // SAFETY: stable heap pointer (Box never moves the
+            // pointed-to RefCell when the BTreeMap rebalances);
+            // we never remove entries; the outer borrow released
+            // at end of the inner block so nested with_mut on a
+            // different T re-enters the map fine.
+            let cell = unsafe { &*cell_ptr };
+            let mut borrow = cell.borrow_mut();
+            f(&mut *borrow)
+        }
+
+        pub(super) fn with<T, R>(&self, f: impl FnOnce(&T) -> R) -> R
+        where
+            T: Default + 'static,
+        {
+            let map_cell = unsafe { &*self.inner.get() };
+            let cell_ptr: *const RefCell<T> = {
+                let mut map = map_cell.borrow_mut();
+                let entry = map
+                    .entry(TypeId::of::<T>())
+                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);
+                entry
+                    .downcast_ref::<RefCell<T>>()
+                    .expect("TypeId<T> ⇒ RefCell<T>") as *const RefCell<T>
+            };
+            let cell = unsafe { &*cell_ptr };
+            let borrow = cell.borrow();
+            f(&*borrow)
+        }
+    }
+
+    pub(super) static WASM_SLOTS: WasmActorSlots = WasmActorSlots::new();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_impl {
+    extern crate std;
+
+    use core::any::{Any, TypeId};
+    use core::cell::{Cell, RefCell};
+    use std::boxed::Box;
+    use std::collections::HashMap;
+
+    /// Per-actor slot map. Owned as a `Box<ActorSlots>` by the
+    /// chassis dispatcher closure for the actor's lifetime; the
+    /// dispatcher stamps a `*const ActorSlots` into TLS via
+    /// [`with_stamped`] for the duration of `init` and each
+    /// handler call.
+    ///
+    /// `RefCell<HashMap>` is deliberate: the single-thread-per-
+    /// actor invariant (ADR-0038) means no concurrent access can
+    /// reach this, so `RefCell` suffices instead of `Mutex`. Each
+    /// slot stores `Box<RefCell<T>>` erased as
+    /// `Box<dyn Any + Send>` so concurrent borrows of the same
+    /// slot panic via the inner cell while concurrent borrows of
+    /// different slots succeed.
+    ///
+    /// Keyed on `TypeId<T>`. Two `struct AppLog(Vec<u8>);` and
+    /// `struct AuditLog(Vec<u8>);` impls of `Local` get
+    /// independent slots because their `TypeId`s differ.
+    pub struct ActorSlots {
+        by_type: RefCell<HashMap<TypeId, Box<dyn Any + Send>>>,
+    }
+
+    impl ActorSlots {
+        /// Construct an empty slot map. The substrate's
+        /// dispatcher trampoline calls this once per booted
+        /// native actor.
+        pub fn new() -> Self {
+            Self {
+                by_type: RefCell::new(HashMap::new()),
+            }
+        }
+
+        pub(super) fn with_mut<T, R>(&self, f: impl FnOnce(&mut T) -> R) -> R
+        where
+            T: Default + Send + 'static,
+        {
+            let cell_ptr: *const RefCell<T> = {
+                let mut map = self.by_type.borrow_mut();
+                let entry = map
+                    .entry(TypeId::of::<T>())
+                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);
+                entry
+                    .downcast_ref::<RefCell<T>>()
+                    .expect("TypeId<T> ⇒ RefCell<T>") as *const RefCell<T>
+            };
+            // SAFETY: the pointer is into a heap-allocated
+            // `Box<RefCell<T>>` owned by `self.by_type`. The
+            // outer borrow released at end of `cell_ptr` so a
+            // nested `with_mut::<U>` can re-enter the map; the
+            // box's heap address is stable (HashMap rehashes
+            // move the `Box` header in the bucket, not the
+            // pointed-to `RefCell<T>`); we never remove entries.
+            let cell = unsafe { &*cell_ptr };
+            let mut borrow = cell.borrow_mut();
+            f(&mut *borrow)
+        }
+
+        pub(super) fn with<T, R>(&self, f: impl FnOnce(&T) -> R) -> R
+        where
+            T: Default + Send + 'static,
+        {
+            let cell_ptr: *const RefCell<T> = {
+                let mut map = self.by_type.borrow_mut();
+                let entry = map
+                    .entry(TypeId::of::<T>())
+                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);
+                entry
+                    .downcast_ref::<RefCell<T>>()
+                    .expect("TypeId<T> ⇒ RefCell<T>") as *const RefCell<T>
+            };
+            let cell = unsafe { &*cell_ptr };
+            let borrow = cell.borrow();
+            f(&*borrow)
+        }
+    }
+
+    impl Default for ActorSlots {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    std::thread_local! {
+        static CURRENT_SLOTS: Cell<*const ActorSlots> = const { Cell::new(core::ptr::null()) };
+    }
+
+    /// RAII guard restoring the prior `CURRENT_SLOTS` value on
+    /// drop. Built by [`with_stamped`]; covers panics from the
+    /// wrapped closure so the TLS slot doesn't leak a dangling
+    /// pointer past a panicking handler.
+    struct StampGuard {
+        prev: *const ActorSlots,
+    }
+
+    impl Drop for StampGuard {
+        fn drop(&mut self) {
+            CURRENT_SLOTS.with(|slot| slot.set(self.prev));
+        }
+    }
+
+    /// Stamp `slots` as the current actor's slot map for the
+    /// duration of `f`. The chassis dispatcher trampoline calls
+    /// this around each handler dispatch (and around `init`); the
+    /// pointer is restored to its prior value (almost always
+    /// null) before this returns. Panics propagate out — the TLS
+    /// slot is restored via the [`StampGuard`] drop, not via
+    /// explicit unwind handling.
+    pub fn with_stamped<R>(slots: &ActorSlots, f: impl FnOnce() -> R) -> R {
+        let _guard = CURRENT_SLOTS.with(|slot| {
+            let prev = slot.get();
+            slot.set(slots as *const ActorSlots);
+            StampGuard { prev }
+        });
+        f()
+    }
+
+    pub(super) fn with_current<R>(f: impl FnOnce(&ActorSlots) -> R) -> R {
+        CURRENT_SLOTS.with(|slot| {
+            let ptr = slot.get();
+            debug_assert!(!ptr.is_null(), "Local accessed outside actor dispatch");
+            // SAFETY: `with_stamped` only stamps a live
+            // `&ActorSlots`; the StampGuard restores the prior
+            // value before returning. Reading the pointer here
+            // happens within the `with_stamped` call's stack
+            // frame, so the slot pointee is still alive.
+            let slots = unsafe { &*ptr };
+            f(slots)
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native_impl::{ActorSlots, with_stamped};
+
+/// Per-actor scratch storage, type-keyed.
+///
+/// Implement `Local` on a named newtype to claim a slot:
+/// `TypeId<Self>` is the storage key. `struct AppLog(Vec<u8>);`
+/// and `struct AuditLog(Vec<u8>);` get independent slots because
+/// their `TypeId`s differ — distinct logical storage = distinct
+/// type, structurally.
+///
+/// ```ignore
+/// use aether_actor::Local;
+///
+/// #[derive(Default)]
+/// struct AppLog(Vec<u8>);
+/// impl Local for AppLog {}
+///
+/// fn append(byte: u8) {
+///     AppLog::with_mut(|log| log.0.push(byte));
+/// }
+/// ```
+///
+/// Lazy-initialized via `Default::default()` on first access.
+/// Concurrent borrows of the same `Self` panic via the inner
+/// `RefCell`. Concurrent borrows of *different* `Local`
+/// types succeed (each type is its own slot).
+///
+/// Native: outside an active [`with_stamped`] guard, `with` /
+/// `with_mut` trip `debug_assert!` ("Local accessed outside
+/// actor dispatch"). The chassis dispatcher trampoline opens that
+/// guard around every handler call and around `init`.
+///
+/// `Send` (native only) so slot maps can move between the chassis
+/// builder thread (during `init`) and the dispatcher thread
+/// (during handler dispatch).
+#[cfg(not(target_arch = "wasm32"))]
+pub trait Local: Default + Send + 'static {
+    /// Borrow this actor's instance of `Self` immutably.
+    fn with<R>(f: impl FnOnce(&Self) -> R) -> R {
+        native_impl::with_current(|slots| slots.with::<Self, R>(f))
+    }
+
+    /// Borrow this actor's instance of `Self` mutably. Lazily
+    /// initialized via `Default::default()` on first access.
+    fn with_mut<R>(f: impl FnOnce(&mut Self) -> R) -> R {
+        native_impl::with_current(|slots| slots.with_mut::<Self, R>(f))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub trait Local: Default + 'static {
+    /// Borrow this actor's instance of `Self` immutably.
+    fn with<R>(f: impl FnOnce(&Self) -> R) -> R {
+        wasm::WASM_SLOTS.with::<Self, R>(f)
+    }
+
+    /// Borrow this actor's instance of `Self` mutably. Lazily
+    /// initialized via `Default::default()` on first access.
+    fn with_mut<R>(f: impl FnOnce(&mut Self) -> R) -> R {
+        wasm::WASM_SLOTS.with_mut::<Self, R>(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use crate::local;
+    use alloc::boxed::Box;
+    use alloc::string::String;
+
+    // Probe newtypes via the `#[local]` attribute — exercises
+    // the macro and keeps the test bodies focused on the storage
+    // semantics rather than boilerplate.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[derive(Default)]
+    #[local]
+    struct Probe(u64);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[derive(Default)]
+    #[local]
+    struct OtherProbe(u64);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[derive(Default)]
+    #[local]
+    struct ProbeStr(String);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_per_actor_isolation() {
+        // Two ActorSlots, one user type — each "actor" sees its
+        // own value. The TLS stamp routes the lookup into the
+        // current actor's slots.
+        let slots_a = ActorSlots::new();
+        let slots_b = ActorSlots::new();
+
+        with_stamped(&slots_a, || Probe::with_mut(|p| p.0 = 7));
+        with_stamped(&slots_b, || Probe::with_mut(|p| p.0 = 11));
+
+        with_stamped(&slots_a, || Probe::with(|p| assert_eq!(p.0, 7)));
+        with_stamped(&slots_b, || Probe::with(|p| assert_eq!(p.0, 11)));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_distinct_types_independent() {
+        // Two distinct user types, same ActorSlots, independent
+        // slots keyed by TypeId.
+        let slots = ActorSlots::new();
+        with_stamped(&slots, || {
+            Probe::with_mut(|p| p.0 = 42);
+            ProbeStr::with_mut(|p| p.0.push_str("hello"));
+            Probe::with(|p| assert_eq!(p.0, 42));
+            ProbeStr::with(|p| assert_eq!(p.0, "hello"));
+        });
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_nested_with_mut_disjoint_types_succeeds() {
+        // Different types ⇒ different TypeId slots ⇒ nested
+        // borrow succeeds.
+        let slots = ActorSlots::new();
+        with_stamped(&slots, || {
+            Probe::with_mut(|a| {
+                a.0 = 1;
+                OtherProbe::with_mut(|b| b.0 = 2);
+                assert_eq!(a.0, 1);
+            });
+            OtherProbe::with(|b| assert_eq!(b.0, 2));
+        });
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_nested_with_mut_same_type_panics() {
+        // Two re-entrant borrows of the *same* Local type
+        // trip the inner RefCell — this is the recursion-guard
+        // for hazards like a logging buffer that loops back into
+        // itself.
+        let slots = ActorSlots::new();
+        with_stamped(&slots, || {
+            Probe::with_mut(|outer| {
+                outer.0 = 1;
+                let inner = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    Probe::with_mut(|p| p.0 = 2)
+                }));
+                assert!(inner.is_err(), "nested same-type with_mut must panic");
+            });
+        });
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    #[should_panic(expected = "Local accessed outside actor dispatch")]
+    fn native_outside_stamp_panics_in_debug() {
+        // No `with_stamped` wrapping — debug_assert! trips.
+        Probe::with_mut(|p| p.0 += 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_stamp_restores_prior_on_panic() {
+        // If a handler panics, the StampGuard drop must still
+        // restore CURRENT_SLOTS so a subsequent stamped call
+        // doesn't see a stale pointer. Verify by checking that
+        // an out-of-stamp access *after* a panicking stamp still
+        // trips debug_assert.
+        let slots = ActorSlots::new();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_stamped(&slots, || panic!("handler trapped"));
+        }));
+        assert!(outcome.is_err(), "inner panic propagates");
+
+        let outside = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Probe::with_mut(|p| p.0 = 1);
+        }));
+        assert!(
+            outside.is_err(),
+            "post-panic access must still panic via debug_assert"
+        );
+    }
+
+    /// Issue 582: the binding is to the actor (via `Box<ActorSlots>`
+    /// ownership), not to the thread. If a future scheduler
+    /// migrated an actor between threads, the `Box` would transfer
+    /// with it and the same data would still be reachable. Today's
+    /// chassis pins one thread per actor (ADR-0038), but the API
+    /// must not bake that in — this test asserts the design
+    /// property explicitly so a future regression that ties data to
+    /// thread identity (e.g., switching to true `thread_local!`)
+    /// would fail loudly.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_slots_follow_box_across_threads() {
+        let slots = Box::new(ActorSlots::new());
+
+        // Thread A (this test thread): write 42 through the
+        // stamped slots.
+        with_stamped(&slots, || Probe::with_mut(|p| p.0 = 42));
+
+        // Move the Box into a freshly-spawned thread and read
+        // back — same slots, same data, despite the thread
+        // boundary.
+        let observed = std::thread::spawn(move || with_stamped(&slots, || Probe::with(|p| p.0)))
+            .join()
+            .expect("worker thread joined cleanly");
+
+        assert_eq!(observed, 42, "Local data follows the Box, not the thread");
+    }
+}

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -72,7 +72,7 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 /// SDK and the derive share a home.
 #[cfg(feature = "derive")]
 pub use aether_actor_derive::{
-    Kind, Schema, Singleton, actor, bridge, capability, fallback, handler,
+    Kind, Schema, Singleton, actor, bridge, capability, fallback, handler, local,
 };
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -793,11 +793,18 @@ where
     // a real map for caps that DO need peer lookups; both end up using
     // the same NativeInitCtx + dispatcher trampoline shape.
     let empty_actors = crate::Actors::new();
+
+    // Per-actor scratch storage (issue 582). Stamped into TLS via
+    // `local::with_stamped` for the duration of `init` and
+    // each handler dispatch. Mirrors the non-legacy path in
+    // `chassis_builder::make_native_actor_boot`.
+    let slots = Box::new(aether_actor::local::ActorSlots::new());
+
     let actor = {
         let mailer_clone = ctx.mail_send_handle();
         let mut init_ctx =
             crate::native_actor::NativeInitCtx::new(&transport, &empty_actors, mailer_clone);
-        A::init(config, &mut init_ctx)?
+        aether_actor::local::with_stamped(&slots, || A::init(config, &mut init_ctx))?
     };
     drop(empty_actors); // explicit shape — no shared state outlives init
 
@@ -810,19 +817,21 @@ where
         .name(thread_name)
         .spawn(move || {
             while let Some(env) = transport_for_thread.recv_blocking() {
-                let mut native_ctx =
-                    crate::native_actor::NativeCtx::new(&transport_for_thread, env.sender);
-                if actor_for_thread
-                    .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
-                    .is_none()
-                {
-                    tracing::warn!(
-                        target: "aether_substrate::capability",
-                        actor = A::NAMESPACE,
-                        kind = env.kind_name.as_str(),
-                        "native actor dispatch missed: kind not handled or decode failed"
-                    );
-                }
+                aether_actor::local::with_stamped(&slots, || {
+                    let mut native_ctx =
+                        crate::native_actor::NativeCtx::new(&transport_for_thread, env.sender);
+                    if actor_for_thread
+                        .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
+                        .is_none()
+                    {
+                        tracing::warn!(
+                            target: "aether_substrate::capability",
+                            actor = A::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "native actor dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                });
                 // Decrement matches the sink-handler's increment —
                 // the chassis frame-bound drain barrier reads this
                 // counter to know when the dispatcher is caught up.

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -318,13 +318,20 @@ where
         let transport = Arc::new(NativeTransport::from_ctx(ctx, mailbox_id, A::FRAME_BARRIER));
         transport.install_inbox(receiver);
 
+        // Per-actor scratch storage (issue 582 / ADR-0074). Stamped
+        // into TLS via `local::with_stamped` for the duration
+        // of `init` and each handler dispatch so library code inside
+        // the actor (e.g., the issue-581 log buffer) can reach
+        // `Local::with_mut` without threading a ctx through.
+        let slots = Box::new(aether_actor::local::ActorSlots::new());
+
         // Boot the cap through `init`. The NativeInitCtx borrows the
         // actors-so-far map (read-only) plus the transport (read-only)
         // plus a mailer clone for outbound hooks.
         let actor = {
             let mailer_clone = ctx.mail_send_handle();
             let mut init_ctx = NativeInitCtx::new(&transport, actors, mailer_clone);
-            A::init(config, &mut init_ctx)?
+            aether_actor::local::with_stamped(&slots, || A::init(config, &mut init_ctx))?
         };
         let actor_arc: Arc<A> = Arc::new(actor);
 
@@ -334,11 +341,14 @@ where
         // claim above would have failed first).
         actors.insert::<A>(Arc::clone(&actor_arc));
 
-        // Spawn the dispatcher thread. The thread owns one Arc<A>
-        // and one Arc<NativeTransport>; it loops `recv_blocking()`
-        // on the transport (which pulls from the installed inbox
-        // and disconnects when the chassis drops its `sink_sender`)
-        // and routes through `__aether_dispatch_envelope`.
+        // Spawn the dispatcher thread. The thread owns one Arc<A>,
+        // one Arc<NativeTransport>, and the per-actor `ActorSlots`
+        // (moved in by value); it loops `recv_blocking()` on the
+        // transport (which pulls from the installed inbox and
+        // disconnects when the chassis drops its `sink_sender`) and
+        // routes each envelope through `__aether_dispatch_envelope`,
+        // wrapped in `local::with_stamped` so handler bodies
+        // see the per-actor storage.
         let actor_for_thread = Arc::clone(&actor_arc);
         let transport_for_thread = Arc::clone(&transport);
         let thread_name = alloc_native_actor_thread_name::<A>();
@@ -346,24 +356,27 @@ where
             .name(thread_name)
             .spawn(move || {
                 while let Some(env) = transport_for_thread.recv_blocking() {
-                    let mut ctx = NativeCtx::new(&transport_for_thread, env.sender);
-                    if actor_for_thread
-                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
-                        .is_none()
-                        && !actor_for_thread.__aether_dispatch_fallback(&mut ctx, &env)
-                    {
-                        // Issue 576: catch-all caps override
-                        // `__aether_dispatch_fallback` and return
-                        // `true` after their fallback runs, suppressing
-                        // this warn. Strict receivers keep the default
-                        // (returns `false`) and surface the miss.
-                        tracing::warn!(
-                            target: "aether_substrate::chassis_builder",
-                            actor = A::NAMESPACE,
-                            kind = env.kind_name.as_str(),
-                            "native actor dispatch missed: kind not handled or decode failed"
-                        );
-                    }
+                    aether_actor::local::with_stamped(&slots, || {
+                        let mut ctx = NativeCtx::new(&transport_for_thread, env.sender);
+                        if actor_for_thread
+                            .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
+                            .is_none()
+                            && !actor_for_thread.__aether_dispatch_fallback(&mut ctx, &env)
+                        {
+                            // Issue 576: catch-all caps override
+                            // `__aether_dispatch_fallback` and return
+                            // `true` after their fallback runs,
+                            // suppressing this warn. Strict receivers
+                            // keep the default (returns `false`) and
+                            // surface the miss.
+                            tracing::warn!(
+                                target: "aether_substrate::chassis_builder",
+                                actor = A::NAMESPACE,
+                                kind = env.kind_name.as_str(),
+                                "native actor dispatch missed: kind not handled or decode failed"
+                            );
+                        }
+                    });
                     // Decrement matches the sink-handler's increment —
                     // the chassis frame-bound drain barrier
                     // (`drain_frame_bound_or_abort`) reads this counter
@@ -1086,6 +1099,138 @@ mod tests {
             1,
             "FRAME_BARRIER cap registered its pending counter for the drain barrier"
         );
+        drop(chassis);
+    }
+
+    /// Issue 582: the chassis dispatcher trampoline stamps the
+    /// per-actor [`aether_actor::local::ActorSlots`] into TLS
+    /// for the duration of `init` and each handler call. A cap that
+    /// reaches for `Local::with_mut` from inside both lifecycle
+    /// stages must see its own state — verified end-to-end here so
+    /// the stamping wiring can't silently regress.
+    #[test]
+    fn with_actor_stamps_local_for_init_and_handler() {
+        use crate::registry::MailboxEntry;
+        use aether_actor::Local;
+        use aether_data::{Kind, ReplyTo as DataReplyTo};
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Tick {
+            seq: u32,
+        }
+        impl Kind for Tick {
+            const NAME: &'static str = "test.local.tick";
+            const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0002);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        // The cap holds an Arc<AtomicU32> the test reads after each
+        // dispatch. The actor-local counter is keyed by `TypeId<Counter>`
+        // — the chassis stamp is what makes `with_mut` resolve at
+        // all (outside a stamp it would `debug_assert!` panic).
+        struct LocalProbe {
+            observed: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for LocalProbe {
+            const NAMESPACE: &'static str = "test.local.probe";
+        }
+        impl aether_actor::Singleton for LocalProbe {}
+        impl aether_actor::HandlesKind<Tick> for LocalProbe {}
+
+        // Newtype-per-slot is the Local convention: each
+        // logical storage gets its own type, so two probes that
+        // both want a u32 don't alias under TypeId. The
+        // `#[local]` attribute is the shorthand for the
+        // marker impl.
+        #[derive(Default)]
+        #[aether_actor::local]
+        struct Counter(u32);
+
+        impl crate::native_actor::NativeActor for LocalProbe {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                // Init runs inside the chassis builder's stamp guard
+                // — write a sentinel so the handler test below proves
+                // the same slots are reused across init→dispatch.
+                Counter::with_mut(|c| c.0 = 100);
+                Ok(Self { observed: config })
+            }
+        }
+
+        impl crate::native_actor::NativeDispatch for LocalProbe {
+            fn __aether_dispatch_envelope(
+                &self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Tick::ID.0 {
+                    let _decoded = Tick::decode_from_bytes(payload)?;
+                    Counter::with_mut(|c| c.0 += 1);
+                    let snapshot = Counter::with(|c| c.0);
+                    self.observed.store(snapshot, AtomicOrdering::SeqCst);
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let observed = Arc::new(AtomicU32::new(0));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<LocalProbe>(Arc::clone(&observed))
+            .build_passive()
+            .expect("LocalProbe boots");
+
+        let mailbox_id = registry
+            .lookup(<LocalProbe as aether_actor::Actor>::NAMESPACE)
+            .expect("with_actor claimed the mailbox");
+        let MailboxEntry::Sink(handler) = registry.entry(mailbox_id).expect("sink registered")
+        else {
+            panic!("LocalProbe claim must be a sink entry");
+        };
+
+        // Three dispatches. Init seeded 100; the handler bumps once
+        // per dispatch and snapshots — so observed should walk
+        // 101, 102, 103 in order. We assert the final 103 with a
+        // wait budget to cover dispatcher-thread scheduling.
+        for seq in 0..3 {
+            let payload = Tick { seq };
+            let bytes = payload.encode_into_bytes();
+            handler(
+                <Tick as Kind>::ID,
+                Tick::NAME,
+                None,
+                DataReplyTo::NONE,
+                &bytes,
+                1,
+            );
+        }
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while observed.load(AtomicOrdering::SeqCst) != 103 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            observed.load(AtomicOrdering::SeqCst),
+            103,
+            "init seeded 100 + 3 handler bumps ⇒ Local at 103 (proves the same \
+             ActorSlots is stamped across init and dispatch)"
+        );
+
         drop(chassis);
     }
 }


### PR DESCRIPTION
<!-- pr-body-ok: b — closes-keyword needs bare #NNN to trigger GitHub auto-close -->

## Summary

- Adds `aether_actor::Local` — per-actor scratch storage, type-keyed. `TypeId<Self>` is the lookup; newtype-per-slot makes "distinct storage = distinct type" structural.
- `#[local]` proc-macro attribute (sibling of `#[actor]` / `#[bridge]`) emits the trait marker. `Default` stays user-supplied.
- Wasm: per-linear-memory `BTreeMap<TypeId, Box<RefCell<T>>>` static. Native: per-actor `Box<ActorSlots>` (`RefCell<HashMap<TypeId, Box<RefCell<T>>>>`). Both lockless — `RefCell` instead of `Mutex` because each storage is owned by one actor's dispatcher thread (ADR-0038).
- Native chassis dispatcher trampolines wrap `init` and each handler in `local::with_stamped(&slots, ...)`, threading the per-actor `ActorSlots` into TLS. Outside an active stamp, `with` / `with_mut` trip `debug_assert!`.

## Use

```rust
use aether_actor::Local;

#[derive(Default)]
#[aether_actor::local]
struct LogBuffer(Vec<LogEvent>);

#[derive(Default)]
#[aether_actor::local]
struct AuditLog(Vec<LogEvent>);  // distinct type ⇒ distinct slot

LogBuffer::with_mut(|b| b.0.push(ev));
AuditLog::with_mut(|b| b.0.push(audit));
```

## Why type-keyed (vs address or counter)

Earlier sketches keyed on the static's address (with a `_addr_anchor: u8` to dodge ZST address sharing) or on a `OnceLock<u32>` slot id from a global `AtomicU32` counter. Both worked; both had aesthetic costs (the anchor byte was a fragile workaround; the counter introduced atomics for what's structurally a single-threaded operation). Type-keyed lookup needs no address tricks, no atomics, and no counter — the type *is* the identity, and the type system enforces "I want distinct storage" structurally.

## Wiring

Stamps land in both native dispatcher trampolines:
- `chassis_builder::make_native_actor_boot` — the `with_actor` path.
- `capability::spawn_legacy_native_actor_dispatcher` — the `with(cap)` path migrating onto `NativeActor`.

Both wrap `init` and each `__aether_dispatch_envelope` call in `with_stamped(&slots, || ...)`. The `Box<ActorSlots>` is heap-allocated per actor and moves into the dispatcher thread's closure once `init` returns — the data follows the actor's lifetime, not the thread.

The wasm hook is structurally a no-op (each linear memory's static IS the actor's storage), so the `export!` macro is unchanged.

## Test plan

- [x] `cargo test -p aether-actor --lib local::` — 7 unit tests cover per-actor isolation, type-keyed independence, nested-same-type panic via RefCell, nested-disjoint-types succeed, outside-stamp `debug_assert!`, panic-safe TLS restore, and a focused **thread-migration test** (`native_slots_follow_box_across_threads`) that locks in "the data follows the `Box`, not the thread" — so a future regression that ties data to thread identity fails loudly.
- [x] `cargo test --workspace --lib` — including the substrate integration test (`with_actor_stamps_local_for_init_and_handler`) that boots a `NativeActor` using `Local::with_mut` from both `init` and a handler and asserts the same slots round-trip across the chassis-builder→dispatcher thread move.
- [x] `cargo test --workspace` — including bins + integration tests.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt -- --check`.

Closes #582