### PR TITLE
feat(hub): process capability — register adr-0078 phase 1 cap (issue 595)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
 name = "aether-substrate-bundle"
 version = "0.2.0-alpha"
 dependencies = [
+ "aether-actor",
  "aether-capabilities",
  "aether-codec",
  "aether-data",

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -52,9 +52,9 @@ mod tests {
     use crate::{
         Delete, DeleteResult, DrawTriangle, DropComponent, DropResult, Fetch, FetchResult,
         FrameStats, Key, List, ListResult, LoadComponent, LoadResult, MouseButton, MouseMove,
-        NoteOff, NoteOn, Ping, Pong, Read, ReadResult, ReplaceComponent, ReplaceResult,
-        SetMasterGain, SubscribeInput, SubscribeInputResult, Tick, UnsubscribeInput, Write,
-        WriteResult,
+        NoteOff, NoteOn, Ping, Pong, ProcessExited, Read, ReadResult, ReplaceComponent,
+        ReplaceResult, SetMasterGain, Spawn, SpawnResult, SubscribeInput, SubscribeInputResult,
+        Terminate, TerminateResult, Tick, UnsubscribeInput, Write, WriteResult,
     };
 
     #[test]
@@ -120,6 +120,11 @@ mod tests {
         assert!(names.contains(&ListResult::NAME));
         assert!(names.contains(&Fetch::NAME));
         assert!(names.contains(&FetchResult::NAME));
+        assert!(names.contains(&Spawn::NAME));
+        assert!(names.contains(&SpawnResult::NAME));
+        assert!(names.contains(&Terminate::NAME));
+        assert!(names.contains(&TerminateResult::NAME));
+        assert!(names.contains(&ProcessExited::NAME));
     }
 
     #[test]

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1378,6 +1378,100 @@ mod control_plane {
         Ok { ticks_completed: u32 },
         Err { error: String },
     }
+
+    /// One environment variable pair carried in [`Spawn::env`]. Pairs
+    /// rather than a `HashMap` because postcard-shaped wire kinds
+    /// don't have a `Schema` impl for tuple element types and a
+    /// keyed-collection schema isn't load-bearing here — duplicate
+    /// keys aren't expected and last-write-wins matches the env
+    /// `HashMap` the hub builds anyway.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct EnvVar {
+        pub key: String,
+        pub value: String,
+    }
+
+    /// `aether.process.spawn` — request the hub chassis launch a
+    /// substrate binary as a child process and return the assigned
+    /// engine id once the child completes its `Hello` handshake
+    /// (ADR-0078 Phase 1, supersedes ADR-0009 §3 for the post-actor
+    /// model spawn path). `binary_path` is the absolute filesystem
+    /// path to the substrate binary. `args` and `env` are forwarded
+    /// to the child verbatim; the hub also injects `AETHER_HUB_URL`
+    /// pointing at its engine listener so the child dials back.
+    /// `handshake_timeout_ms` caps how long the hub waits for the
+    /// child's `Hello` before declaring the spawn failed (default
+    /// 5000 ms when `None`). Reply: `SpawnResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.process.spawn")]
+    pub struct Spawn {
+        pub binary_path: String,
+        pub args: Vec<String>,
+        pub env: Vec<EnvVar>,
+        pub handshake_timeout_ms: Option<u32>,
+    }
+
+    /// Reply to `Spawn`. `Ok` carries the freshly minted engine id
+    /// in tagged-string form (`eng-...` per ADR-0064 — `EngineId`
+    /// doesn't implement `Schema`, so the wire carries the
+    /// authoritative string the substrate registry already uses
+    /// at the MCP boundary). The hub adopted the child into its
+    /// registry; lifetime is tied to the connection until `Terminate`
+    /// or external exit. `Err` carries a free-form reason — io
+    /// failure, missing pid, handshake timeout.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.process.spawn_result")]
+    pub enum SpawnResult {
+        Ok { engine_id: String, pid: u32 },
+        Err { error: String },
+    }
+
+    /// `aether.process.terminate` — request the hub chassis shut down
+    /// a previously-spawned substrate. Sends SIGTERM, waits up to
+    /// `grace_ms` (default 2000 ms when `None`), then escalates to
+    /// SIGKILL if the child is still running. `engine_id` is the
+    /// Uuid string form the hub returned from `Spawn`. Reply:
+    /// `TerminateResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.process.terminate")]
+    pub struct Terminate {
+        pub engine_id: String,
+        pub grace_ms: Option<u32>,
+    }
+
+    /// Reply to `Terminate`. `Ok` reports the child's exit code (if
+    /// the kernel returned one) and whether escalation to SIGKILL
+    /// was needed. `Err` is for unknown engine ids, externally-
+    /// connected engines the hub didn't spawn, or os-level signal
+    /// failure.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.process.terminate_result")]
+    pub enum TerminateResult {
+        Ok {
+            exit_code: Option<i32>,
+            sigkilled: bool,
+        },
+        Err {
+            error: String,
+        },
+    }
+
+    /// `aether.process.exited` — broadcast emitted by the hub's
+    /// reaper when a spawned child terminates (whether via
+    /// `Terminate` mail or external exit). Fire-and-forget; lands
+    /// on every attached MCP session via `egress_broadcast`. The
+    /// reaper task converts `Child::wait` completion into this kind
+    /// so any cap or operator that wants to react to "engine X
+    /// exited" subscribes to broadcast rather than threading a
+    /// callback through `EngineRegistry`. `engine_id` is the
+    /// Uuid string form the hub used while the child was alive.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.process.exited")]
+    pub struct ProcessExited {
+        pub engine_id: String,
+        pub exit_code: Option<i32>,
+        pub reason: String,
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -37,6 +37,7 @@ path = "src/bin/test-bench.rs"
 [dependencies]
 aether-substrate = { path = "../aether-substrate", features = ["render", "audio"] }
 aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native"] }
+aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-codec = { path = "../aether-codec" }
 aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -34,6 +34,8 @@ use aether_substrate::chassis_builder::{
 };
 use tokio::runtime::Runtime;
 
+use crate::hub::process_capability::{ProcessCapability, ProcessCapabilityConfig};
+
 use crate::hub::loopback::{
     LoopbackEngine, LoopbackHandle, run_inbound_drainer, spawn_outbound_drainer,
 };
@@ -122,6 +124,20 @@ impl HubChassis {
             engine_addr,
         );
 
+        // ADR-0078 Phase 1: ProcessCapability needs a tokio runtime
+        // handle at cap-init time to drive its async spawn / wait /
+        // terminate work from the dispatcher-thread sync handlers.
+        // Build the runtime here (instead of in
+        // `DriverCapability::boot`) so the Handle is available before
+        // `Builder::with_actor::<ProcessCapability>(...)` runs `init`.
+        // The driver later runs `block_on(coordinator)` against this
+        // same runtime — no second runtime is constructed.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let rt_handle = rt.handle().clone();
+
         // The chassis_builder's `Builder::new` takes the substrate's
         // registry + mailer so passives have somewhere to claim
         // mailboxes against. The hub-chassis substrate lives inside
@@ -133,16 +149,23 @@ impl HubChassis {
         let driver = HubServerDriverCapability {
             engine_addr,
             mcp_addr,
-            registry,
+            registry: registry.clone(),
             sessions,
-            pending,
+            pending: pending.clone(),
             logs,
             state,
             loopback,
+            rt,
         };
 
         Builder::<HubChassis>::new(registry_arc, mailer_arc)
             .with_actor::<BroadcastCapability>(())
+            .with_actor::<ProcessCapability>(ProcessCapabilityConfig {
+                engines: registry,
+                pending,
+                hub_engine_addr: engine_addr,
+                runtime: rt_handle,
+            })
             .driver(driver)
             .build()
     }
@@ -164,6 +187,11 @@ pub struct HubServerDriverCapability {
     logs: LogStore,
     state: Arc<HubState>,
     loopback: LoopbackEngine,
+    /// Tokio runtime constructed in `HubChassis::build_inner` so
+    /// `ProcessCapability::init` could grab a `Handle` at cap boot.
+    /// `boot` moves this into [`HubServerDriverRunning`]; `run`
+    /// blocks on `block_on(coordinator)` against it.
+    rt: Runtime,
 }
 
 /// Post-boot handle for [`HubServerDriverCapability`]. Holds the constructed
@@ -185,10 +213,6 @@ impl DriverCapability for HubServerDriverCapability {
     type Running = HubServerDriverRunning;
 
     fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| BootError::Other(Box::new(e)))?;
         let HubServerDriverCapability {
             engine_addr,
             mcp_addr,
@@ -198,6 +222,7 @@ impl DriverCapability for HubServerDriverCapability {
             logs,
             state,
             loopback,
+            rt,
         } = self;
         Ok(HubServerDriverRunning {
             rt,

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -66,6 +66,7 @@ mod engine;
 mod log_store;
 mod loopback;
 mod mcp;
+mod process_capability;
 mod registry;
 mod session;
 mod spawn;
@@ -78,13 +79,14 @@ pub use engine::READ_TIMEOUT;
 pub use log_store::{LogStore, ReadResult as LogReadResult};
 pub use loopback::{HUB_SELF_ENGINE_ID, LoopbackEngine, LoopbackHandle};
 pub use mcp::{DEFAULT_MCP_PORT, HubState, run_mcp_server};
+pub use process_capability::{ProcessCapability, ProcessCapabilityConfig};
 pub use registry::{EngineRecord, EngineRegistry};
 pub use session::{
     QueuedMail, SESSION_CHANNEL_CAPACITY, SessionHandle, SessionRecord, SessionRegistry,
 };
 pub use spawn::{
     DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnError, SpawnOpts,
-    TerminateOutcome, spawn_substrate, terminate_substrate,
+    TerminateOutcome, spawn_substrate, spawn_substrate_no_adopt, terminate_substrate,
 };
 
 /// Default port the hub binds for engine TCP clients. ADR-0006 V0

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -1,0 +1,514 @@
+//! `aether.process` cap (ADR-0078 Phase 1). Wraps the hub chassis's
+//! bespoke `spawn_substrate` / `terminate_substrate` plumbing in a
+//! `#[bridge] mod native` cap so process supervision shares the same
+//! shape, testability, and composition as every other chassis cap.
+//!
+//! Hub-only — desktop / headless / test-bench chassis don't load this
+//! cap (they don't supervise child processes).
+//!
+//! In PR 1 the cap is registered but the MCP coordinator still calls
+//! the bespoke async functions in `hub::spawn`. PR 2 routes the
+//! `spawn_substrate` / `terminate_substrate` MCP tools through this
+//! cap and retires the registry-side child storage. PR 3 tacks an
+//! editorial note onto ADR-0009.
+
+use aether_kinds::{ProcessExited, Spawn, SpawnResult, Terminate, TerminateResult};
+
+use crate::hub::registry::EngineRegistry;
+use crate::hub::spawn::PendingSpawns;
+
+#[aether_actor::bridge]
+mod native {
+    use super::{
+        EngineRegistry, PendingSpawns, ProcessExited, Spawn, SpawnResult, Terminate,
+        TerminateResult,
+    };
+    use aether_actor::{MailCtx, actor};
+    use aether_data::Kind;
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::outbound::HubOutbound;
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tokio::process::Child;
+    use tokio::runtime::Handle;
+    use tokio::task::JoinHandle as TokioJoinHandle;
+
+    use crate::hub::spawn::{
+        DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, SpawnOpts, spawn_substrate_no_adopt,
+        terminate_substrate,
+    };
+    use crate::hub::wire::{EngineId, Uuid};
+
+    /// Per-engine slot for a spawned child. The reaper task and the
+    /// terminate handler race to take ownership; whoever wins runs
+    /// the wait/signal sequence and the loser bows out.
+    type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+    /// Resolved configuration `ProcessCapability::init` consumes. Every
+    /// piece of hub state the cap needs to drive child lifecycle:
+    /// the engine registry (for record lookup on terminate), the
+    /// shared pending-handshake table (so the engine handshake path
+    /// resolves PIDs the cap spawned), the listener address to inject
+    /// as `AETHER_HUB_URL`, and a `tokio::runtime::Handle` so the
+    /// dispatcher-thread sync handlers can drive async spawn / wait /
+    /// terminate work on the hub's existing tokio runtime.
+    pub struct ProcessCapabilityConfig {
+        pub engines: EngineRegistry,
+        pub pending: PendingSpawns,
+        pub hub_engine_addr: SocketAddr,
+        pub runtime: Handle,
+    }
+
+    /// `aether.process` mailbox cap. Owns the spawned children
+    /// directly (not via the registry side-map) so the reaper task
+    /// can take ownership of `Child` and `wait()` on it without
+    /// racing the bespoke `terminate_substrate` MCP path that PR 1
+    /// still leaves wired. PR 2 retires the registry-side storage
+    /// once the MCP coordinator routes through this cap.
+    pub struct ProcessCapability {
+        engines: EngineRegistry,
+        pending: PendingSpawns,
+        hub_engine_addr: SocketAddr,
+        runtime: Handle,
+        outbound: Option<Arc<HubOutbound>>,
+        /// Cap-local child handles. Per-spawn entry holds a
+        /// [`ChildSlot`] so the reaper task can take the `Child`
+        /// for `wait()` while the terminate handler can take it
+        /// for the SIGTERM/SIGKILL escalation. Whoever wins the
+        /// take leaves `None`; the loser sees `None` and bows out
+        /// gracefully.
+        children: Arc<Mutex<HashMap<EngineId, ChildSlot>>>,
+        /// Per-child reaper task handles. Tracked so terminate can
+        /// abort the reaper if it's still waiting (it shouldn't be,
+        /// but a stuck reaper leaves a tokio task pinned).
+        reapers: Arc<Mutex<HashMap<EngineId, TokioJoinHandle<()>>>>,
+    }
+
+    #[actor]
+    impl NativeActor for ProcessCapability {
+        type Config = ProcessCapabilityConfig;
+        const NAMESPACE: &'static str = "aether.process";
+
+        fn init(
+            cfg: ProcessCapabilityConfig,
+            ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self {
+                engines: cfg.engines,
+                pending: cfg.pending,
+                hub_engine_addr: cfg.hub_engine_addr,
+                runtime: cfg.runtime,
+                outbound: ctx.mailer().outbound().cloned(),
+                children: Arc::new(Mutex::new(HashMap::new())),
+                reapers: Arc::new(Mutex::new(HashMap::new())),
+            })
+        }
+
+        /// Spawn a substrate binary as a hub child and wait for its
+        /// `Hello` handshake.
+        ///
+        /// # Agent
+        /// Reply: `SpawnResult`. On `Ok`, a per-child reaper task is
+        /// spawned that emits an `aether.process.exited` broadcast
+        /// when the child terminates (whether via `Terminate` mail
+        /// or external exit).
+        #[handler]
+        fn on_spawn(&self, ctx: &mut NativeCtx<'_>, mail: Spawn) {
+            let opts = SpawnOpts {
+                binary_path: PathBuf::from(mail.binary_path),
+                args: mail.args,
+                env: mail.env.into_iter().map(|v| (v.key, v.value)).collect(),
+                handshake_timeout: mail
+                    .handshake_timeout_ms
+                    .map(|ms| Duration::from_millis(ms as u64))
+                    .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT),
+            };
+
+            let result = self.runtime.block_on(spawn_substrate_no_adopt(
+                opts,
+                self.hub_engine_addr,
+                &self.pending,
+            ));
+
+            match result {
+                Ok((engine_id, child)) => {
+                    let pid = self.engines.get(&engine_id).map(|r| r.pid).unwrap_or(0);
+                    self.adopt_and_reap(engine_id, child);
+                    ctx.reply(&SpawnResult::Ok {
+                        engine_id: engine_id.0.to_string(),
+                        pid,
+                    });
+                }
+                Err(e) => ctx.reply(&SpawnResult::Err {
+                    error: format!("spawn failed: {e}"),
+                }),
+            }
+        }
+
+        /// Terminate a hub-spawned substrate.
+        ///
+        /// # Agent
+        /// Reply: `TerminateResult`. SIGTERM → `grace_ms` window →
+        /// SIGKILL escalation. Errors on unknown engine id, or an
+        /// engine the cap didn't spawn (externally connected).
+        #[handler]
+        fn on_terminate(&self, ctx: &mut NativeCtx<'_>, mail: Terminate) {
+            let engine_id = match parse_engine_id(&mail.engine_id) {
+                Ok(id) => id,
+                Err(e) => {
+                    ctx.reply(&TerminateResult::Err { error: e });
+                    return;
+                }
+            };
+
+            let slot = self.children.lock().unwrap().remove(&engine_id);
+            let Some(slot) = slot else {
+                ctx.reply(&TerminateResult::Err {
+                    error: format!(
+                        "engine {} is not hub-spawned by ProcessCapability; \
+                         no child handle in cap",
+                        mail.engine_id
+                    ),
+                });
+                return;
+            };
+
+            // Reaper might already have taken the Child (race: external
+            // exit fired the same moment as the terminate request).
+            // Take what's there; if None, the reaper already broadcast
+            // ProcessExited and we report Ok with no exit info.
+            let Some(child) = slot.lock().unwrap().take() else {
+                ctx.reply(&TerminateResult::Ok {
+                    exit_code: None,
+                    sigkilled: false,
+                });
+                return;
+            };
+
+            let grace = mail
+                .grace_ms
+                .map(|ms| Duration::from_millis(ms as u64))
+                .unwrap_or(DEFAULT_TERMINATE_GRACE);
+
+            let outcome = self.runtime.block_on(terminate_substrate(child, grace));
+            // Once we've reaped, the reaper task's `wait()` will
+            // resolve too — but its slot's Child is gone, so it
+            // exits without broadcasting. Drop the join handle.
+            self.reapers.lock().unwrap().remove(&engine_id);
+
+            match outcome {
+                Ok(o) => {
+                    self.broadcast_exited(engine_id, o.exit_code, "terminate".to_owned());
+                    ctx.reply(&TerminateResult::Ok {
+                        exit_code: o.exit_code,
+                        sigkilled: o.sigkilled,
+                    })
+                }
+                Err(e) => ctx.reply(&TerminateResult::Err {
+                    error: format!("terminate failed: {e}"),
+                }),
+            }
+        }
+    }
+
+    impl ProcessCapability {
+        /// Park the freshly-spawned child in the cap-local map and
+        /// kick off a reaper task on the tokio runtime that takes
+        /// the `Child` back out, awaits its exit, and broadcasts
+        /// `ProcessExited`. The reaper exits silently if the slot's
+        /// child is already gone — the terminate handler races for
+        /// the same `Child` and the loser bows out.
+        fn adopt_and_reap(&self, engine_id: EngineId, child: Child) {
+            let slot = Arc::new(Mutex::new(Some(child)));
+            self.children
+                .lock()
+                .unwrap()
+                .insert(engine_id, Arc::clone(&slot));
+
+            let outbound = self.outbound.clone();
+            let children = Arc::clone(&self.children);
+            let reapers = Arc::clone(&self.reapers);
+            let task = self.runtime.spawn(async move {
+                let Some(mut child) = slot.lock().unwrap().take() else {
+                    // Terminate handler already took it.
+                    return;
+                };
+                let exit_code = match child.wait().await {
+                    Ok(status) => status.code(),
+                    Err(_) => None,
+                };
+                children.lock().unwrap().remove(&engine_id);
+                reapers.lock().unwrap().remove(&engine_id);
+                if let Some(out) = outbound {
+                    broadcast_exited_via(&out, engine_id, exit_code, "exited".to_owned());
+                }
+            });
+            self.reapers.lock().unwrap().insert(engine_id, task);
+        }
+
+        fn broadcast_exited(&self, engine_id: EngineId, exit_code: Option<i32>, reason: String) {
+            if let Some(out) = self.outbound.as_ref() {
+                broadcast_exited_via(out, engine_id, exit_code, reason);
+            }
+        }
+    }
+
+    fn broadcast_exited_via(
+        outbound: &HubOutbound,
+        engine_id: EngineId,
+        exit_code: Option<i32>,
+        reason: String,
+    ) {
+        let payload = ProcessExited {
+            engine_id: engine_id.0.to_string(),
+            exit_code,
+            reason,
+        };
+        let bytes = match postcard::to_allocvec(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::process",
+                    error = %e,
+                    "failed to encode ProcessExited",
+                );
+                return;
+            }
+        };
+        outbound.egress_broadcast(<ProcessExited as Kind>::NAME, bytes, None, 0);
+    }
+
+    fn parse_engine_id(s: &str) -> Result<EngineId, String> {
+        Uuid::parse_str(s)
+            .map(EngineId)
+            .map_err(|e| format!("engine_id is not a valid UUID: {e}"))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::super::EngineRegistry;
+        use super::{Arc, PendingSpawns, ProcessCapability, ProcessCapabilityConfig};
+        use aether_actor::Actor;
+        use aether_data::Kind;
+        use aether_kinds::{EnvVar, ProcessExited, Spawn, SpawnResult};
+        use aether_substrate::capability::ChassisBuilder;
+        use aether_substrate::mail::ReplyTo;
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::native_actor::NativeCtx;
+        use aether_substrate::native_transport::NativeTransport;
+        use aether_substrate::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::registry::Registry;
+        use std::net::SocketAddr;
+        use std::sync::mpsc;
+        use std::time::Duration;
+        use tokio::runtime::Runtime;
+
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            (registry, Arc::new(Mailer::new()))
+        }
+
+        fn cfg(rt: &Runtime, addr: SocketAddr) -> ProcessCapabilityConfig {
+            ProcessCapabilityConfig {
+                engines: EngineRegistry::new(),
+                pending: PendingSpawns::new(),
+                hub_engine_addr: addr,
+                runtime: rt.handle().clone(),
+            }
+        }
+
+        fn unreachable_addr() -> SocketAddr {
+            "127.0.0.1:1".parse().unwrap()
+        }
+
+        /// Boot the cap through `with_actor` and verify the mailbox is
+        /// claimed under `aether.process`. No spawn happens — this is
+        /// the registration smoke test that PR 2 will build on.
+        #[test]
+        fn capability_boots_and_registers_mailbox() {
+            let rt = Runtime::new().expect("tokio runtime");
+            let (registry, mailer) = fresh_substrate();
+            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<ProcessCapability>(cfg(&rt, unreachable_addr()))
+                .build()
+                .expect("process capability boots");
+            assert!(
+                registry.lookup(ProcessCapability::NAMESPACE).is_some(),
+                "aether.process mailbox registered",
+            );
+            chassis.shutdown();
+        }
+
+        /// Manually constructed cap + a fully-wired test mailer so we
+        /// can drive `on_spawn` / `on_terminate` without going through
+        /// the dispatcher (much cheaper than the chassis path and
+        /// produces deterministic egress for assertions).
+        struct TestFixture {
+            cap: ProcessCapability,
+            rx: mpsc::Receiver<EgressEvent>,
+            transport: NativeTransport,
+            _rt: Runtime,
+        }
+
+        impl TestFixture {
+            fn new() -> Self {
+                let rt = Runtime::new().expect("tokio runtime");
+                let (mailer, outbound, rx) = test_mailer_and_rx();
+                let transport = NativeTransport::new_for_test(mailer, aether_data::MailboxId(0));
+                let cap = ProcessCapability {
+                    engines: EngineRegistry::new(),
+                    pending: PendingSpawns::new(),
+                    hub_engine_addr: unreachable_addr(),
+                    runtime: rt.handle().clone(),
+                    outbound: Some(outbound),
+                    children: Arc::new(super::Mutex::new(super::HashMap::new())),
+                    reapers: Arc::new(super::Mutex::new(super::HashMap::new())),
+                };
+                Self {
+                    cap,
+                    rx,
+                    transport,
+                    _rt: rt,
+                }
+            }
+
+            fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
+                NativeCtx::new(&self.transport, sender)
+            }
+        }
+
+        fn test_mailer_and_rx() -> (Arc<Mailer>, Arc<HubOutbound>, mpsc::Receiver<EgressEvent>) {
+            use std::collections::HashMap;
+            use std::sync::RwLock;
+
+            let (outbound, rx) = HubOutbound::attached_loopback();
+            let mailer = Arc::new(Mailer::new());
+            mailer.wire(
+                Arc::new(Registry::new()),
+                Arc::new(RwLock::new(HashMap::new())),
+            );
+            mailer.wire_outbound(Arc::clone(&outbound));
+            (mailer, outbound, rx)
+        }
+
+        fn session_sender() -> ReplyTo {
+            ReplyTo::to(aether_substrate::mail::ReplyTarget::Session(
+                aether_data::SessionToken(aether_data::Uuid::nil()),
+            ))
+        }
+
+        fn decode_reply<K: Kind + serde::de::DeserializeOwned>(
+            rx: &mpsc::Receiver<EgressEvent>,
+        ) -> K {
+            let event = rx.recv_timeout(Duration::from_secs(2)).expect("egress");
+            let EgressEvent::ToSession {
+                kind_name, payload, ..
+            } = event
+            else {
+                panic!("expected ToSession egress, got {event:?}");
+            };
+            assert_eq!(kind_name, K::NAME);
+            postcard::from_bytes(&payload).unwrap()
+        }
+
+        fn drain_for<K: Kind>(
+            rx: &mpsc::Receiver<EgressEvent>,
+            timeout: Duration,
+        ) -> Option<EgressEvent> {
+            let deadline = std::time::Instant::now() + timeout;
+            loop {
+                let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+                let event = rx.recv_timeout(remaining).ok()?;
+                let kind = match &event {
+                    EgressEvent::ToSession { kind_name, .. } => kind_name.as_str(),
+                    EgressEvent::Broadcast { kind_name, .. } => kind_name.as_str(),
+                    _ => continue,
+                };
+                if kind == K::NAME {
+                    return Some(event);
+                }
+            }
+        }
+
+        /// `Spawn` against a child that never handshakes resolves as
+        /// `SpawnResult::Err` (handshake timeout) within the configured
+        /// window. Validates the sync handler can drive an async spawn
+        /// + handshake-timeout via the runtime handle.
+        #[test]
+        #[cfg(unix)]
+        fn spawn_handshake_timeout_replies_err() {
+            let fix = TestFixture::new();
+            let mut ctx = fix.ctx(session_sender());
+            fix.cap.on_spawn(
+                &mut ctx,
+                Spawn {
+                    binary_path: "/bin/sh".to_owned(),
+                    args: vec!["-c".to_owned(), "sleep 60".to_owned()],
+                    env: Vec::<EnvVar>::new(),
+                    handshake_timeout_ms: Some(150),
+                },
+            );
+            match decode_reply::<SpawnResult>(&fix.rx) {
+                SpawnResult::Err { error } => {
+                    assert!(
+                        error.contains("handshake") || error.contains("Handshake"),
+                        "expected handshake-timeout reason, got {error}",
+                    );
+                }
+                SpawnResult::Ok { .. } => panic!("expected Err, got Ok"),
+            }
+        }
+
+        /// Reaper integration test: spawn a `/bin/sh` child that exits
+        /// shortly via the no-adopt helper directly, hand it to the
+        /// cap's adopt-and-reap path, and assert
+        /// `aether.process.exited` fires on broadcast within a
+        /// reasonable window. Bypasses the spawn handshake — what
+        /// we're exercising here is the reaper task plumbing itself.
+        #[test]
+        #[cfg(unix)]
+        fn reaper_emits_process_exited_when_child_exits() {
+            let fix = TestFixture::new();
+            let pid = std::process::id();
+            let engine_id = super::EngineId(aether_data::Uuid::from_u128(0xC0FFEE_u128));
+
+            // Hand-spawn a short-lived child (no handshake — cap's
+            // reaper machinery doesn't depend on the engine record).
+            let child = fix
+                ._rt
+                .block_on(async {
+                    tokio::process::Command::new("/bin/sh")
+                        .arg("-c")
+                        .arg("exit 7")
+                        .stdin(std::process::Stdio::null())
+                        .kill_on_drop(true)
+                        .spawn()
+                })
+                .expect("spawn /bin/sh");
+            let _ = pid;
+
+            fix.cap.adopt_and_reap(engine_id, child);
+
+            let event = drain_for::<ProcessExited>(&fix.rx, Duration::from_secs(3))
+                .expect("ProcessExited within 3s");
+            let payload = match event {
+                EgressEvent::Broadcast { payload, .. } => payload,
+                EgressEvent::ToSession { payload, .. } => payload,
+                _ => panic!("unexpected event"),
+            };
+            let exited: ProcessExited = postcard::from_bytes(&payload).unwrap();
+            assert_eq!(exited.engine_id, engine_id.0.to_string());
+            assert_eq!(exited.exit_code, Some(7));
+            assert_eq!(exited.reason, "exited");
+        }
+    }
+}
+
+pub use native::ProcessCapabilityConfig;

--- a/crates/aether-substrate-bundle/src/hub/spawn.rs
+++ b/crates/aether-substrate-bundle/src/hub/spawn.rs
@@ -150,20 +150,24 @@ impl PendingSpawns {
     }
 }
 
-/// Spawn a substrate binary as a child process, wait for its `Hello`
-/// handshake, and adopt the `Child` into the engine registry so the
-/// child's lifetime is tied to the engine record. Returns the freshly
-/// minted `EngineId` on success; on any failure the child is killed
-/// before returning.
+/// Spawn a substrate binary as a child process and wait for its
+/// `Hello` handshake. Returns both the freshly minted `EngineId` and
+/// the live `Child` so the caller decides where the handle lives.
 ///
-/// `hub_engine_addr` is the address the child should dial to reach the
-/// hub — it's injected as `AETHER_HUB_URL` in the child's environment.
-pub async fn spawn_substrate(
+/// On any failure the child is killed before returning. `pending`
+/// must already be wired into the engine handshake path so the
+/// substrate's `Hello` frame can fulfil the registered slot keyed
+/// on the child's PID.
+///
+/// Callers pick between this and [`spawn_substrate`]: this returns
+/// the `Child` for the cap to own (ADR-0078); [`spawn_substrate`]
+/// adopts it into the registry side-map for the bespoke pre-cap
+/// MCP coordinator path. Both share this body up to the handshake.
+pub async fn spawn_substrate_no_adopt(
     opts: SpawnOpts,
     hub_engine_addr: SocketAddr,
     pending: &PendingSpawns,
-    engines: &EngineRegistry,
-) -> Result<EngineId, SpawnError> {
+) -> Result<(EngineId, Child), SpawnError> {
     let mut cmd = Command::new(&opts.binary_path);
     cmd.args(&opts.args);
     for (k, v) in &opts.env {
@@ -185,10 +189,7 @@ pub async fn spawn_substrate(
     let rx = pending.register(pid);
 
     match tokio::time::timeout(opts.handshake_timeout, rx).await {
-        Ok(Ok(engine_id)) => {
-            engines.adopt_child(engine_id, child);
-            Ok(engine_id)
-        }
+        Ok(Ok(engine_id)) => Ok((engine_id, child)),
         Ok(Err(_)) => {
             pending.cancel(pid);
             // Child drops here; kill_on_drop reaps it.
@@ -199,6 +200,25 @@ pub async fn spawn_substrate(
             Err(SpawnError::HandshakeTimeout(opts.handshake_timeout))
         }
     }
+}
+
+/// Spawn a substrate binary as a child process, wait for its `Hello`
+/// handshake, and adopt the `Child` into the engine registry so the
+/// child's lifetime is tied to the engine record. Returns the freshly
+/// minted `EngineId` on success; on any failure the child is killed
+/// before returning.
+///
+/// `hub_engine_addr` is the address the child should dial to reach the
+/// hub — it's injected as `AETHER_HUB_URL` in the child's environment.
+pub async fn spawn_substrate(
+    opts: SpawnOpts,
+    hub_engine_addr: SocketAddr,
+    pending: &PendingSpawns,
+    engines: &EngineRegistry,
+) -> Result<EngineId, SpawnError> {
+    let (engine_id, child) = spawn_substrate_no_adopt(opts, hub_engine_addr, pending).await?;
+    engines.adopt_child(engine_id, child);
+    Ok(engine_id)
 }
 
 /// Outcome of `terminate_substrate`. `sigkilled` is `true` if the


### PR DESCRIPTION
<!-- pr-body-ok: b — ADR refs + bare issue refs intentional -->

## Summary

- Registers `ProcessCapability` as the first chassis-internal cap under ADR-0078, claiming the `aether.process` mailbox in the hub chassis. Reaper task converts `Child::wait` completion into `aether.process.exited` broadcast mail so future caps and operators react via mail subscription rather than threading callbacks through `EngineRegistry`.
- Cap is registered but dormant in production — the MCP coordinator still calls bespoke `spawn_substrate` / `terminate_substrate` in `hub::spawn`. PR 2 routes the MCP tools through this cap and retires the registry-side child storage. PR 3 lands the ADR-0009 editorial note.
- New `aether.process.{spawn, spawn_result, terminate, terminate_result, exited}` postcard wire kinds in `aether-kinds`.

## Implementation notes

- `spawn_substrate` is split into a no-adopt helper that returns `(EngineId, Child)` and the existing function that wraps it. The cap consumes the no-adopt helper so it owns the child slot directly.
- `tokio::runtime::Builder::new_multi_thread()` moves from `DriverCapability::boot` up into `HubChassis::build_inner` so `Builder::with_actor::<ProcessCapability>(cfg)` has a `Handle` at cap-init time. The driver inherits the constructed runtime and `block_on(coordinator)`s against it — no second runtime is spawned.
- `engine_id` rides the wire as a Uuid string (`EngineId` has no `Schema` impl). Env pairs ride as a small `EnvVar { key, value }` struct because `(String, String)` doesn't implement `Schema`.
- Terminate handler races the reaper for the `Child` slot; whoever wins runs the SIGTERM → grace → SIGKILL sequence and the loser bows out gracefully.

## Test plan

- [x] `cargo test -p aether-kinds` — 38 passing
- [x] `cargo test -p aether-substrate-bundle --lib` — 91 passing including 3 new cap tests:
  - `capability_boots_and_registers_mailbox`
  - `spawn_handshake_timeout_replies_err`
  - `reaper_emits_process_exited_when_child_exits` (`/bin/sh -c "exit 7"` → broadcast in <3s)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Smoke test: hub binary boots clean with cap registered; existing MCP `spawn_substrate` → `load_component` → `capture_frame` → `terminate_substrate` flow round-trips end-to-end against a desktop substrate.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)