### PR TITLE
feat(hub): mcp coordinator routes process supervision through cap (issue 595)

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -39,7 +39,6 @@ use crate::hub::process_capability::{ProcessCapability, ProcessCapabilityConfig}
 use crate::hub::loopback::{
     LoopbackEngine, LoopbackHandle, run_inbound_drainer, spawn_outbound_drainer,
 };
-use crate::hub::spawn::terminate_substrate;
 use crate::hub::{
     DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, LogStore, PendingSpawns,
     SessionRegistry, run_engine_listener, run_mcp_server,
@@ -116,13 +115,7 @@ impl HubChassis {
         let pending = PendingSpawns::new();
         let logs = LogStore::new();
         let loopback = LoopbackEngine::boot(&registry)?;
-        let state = HubState::new(
-            registry.clone(),
-            sessions.clone(),
-            pending.clone(),
-            logs.clone(),
-            engine_addr,
-        );
+        let state = HubState::new(registry.clone(), sessions.clone(), logs.clone());
 
         // ADR-0078 Phase 1: ProcessCapability needs a tokio runtime
         // handle at cap-init time to drive its async spawn / wait /
@@ -207,12 +200,19 @@ pub struct HubServerDriverRunning {
     logs: LogStore,
     state: Arc<HubState>,
     loopback: LoopbackEngine,
+    /// Handle to the booted [`ProcessCapability`]. The shutdown
+    /// coordinator calls [`ProcessCapability::shutdown_all`] on this
+    /// to terminate every spawned child before dropping the loopback
+    /// substrate. `None` is unreachable in production (the cap is
+    /// always booted on the hub chassis); kept Optional only because
+    /// `DriverCtx::actor` returns Option for type-system purity.
+    process_cap: Option<Arc<ProcessCapability>>,
 }
 
 impl DriverCapability for HubServerDriverCapability {
     type Running = HubServerDriverRunning;
 
-    fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
+    fn boot(self, ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
         let HubServerDriverCapability {
             engine_addr,
             mcp_addr,
@@ -224,6 +224,7 @@ impl DriverCapability for HubServerDriverCapability {
             loopback,
             rt,
         } = self;
+        let process_cap = ctx.actor::<ProcessCapability>();
         Ok(HubServerDriverRunning {
             rt,
             engine_addr,
@@ -234,6 +235,7 @@ impl DriverCapability for HubServerDriverCapability {
             logs,
             state,
             loopback,
+            process_cap,
         })
     }
 }
@@ -250,6 +252,7 @@ impl DriverRunning for HubServerDriverRunning {
             logs,
             state,
             loopback,
+            process_cap,
         } = *self;
 
         rt.block_on(coordinator(
@@ -261,6 +264,7 @@ impl DriverRunning for HubServerDriverRunning {
             logs,
             state,
             loopback,
+            process_cap,
         ));
 
         Ok(())
@@ -270,8 +274,9 @@ impl DriverRunning for HubServerDriverRunning {
 /// The body that pre-Builder lived inside `HubChassis::run_async`.
 /// Spawns the inbound + outbound loopback drainers, the engine
 /// listener, and the MCP server; `tokio::select!`s on all four +
-/// the shutdown-signal future; then runs `terminate_all_children` and
-/// drops the substrate boot in deterministic order.
+/// the shutdown-signal future; then asks `ProcessCapability` to
+/// terminate every spawned child and drops the substrate boot in
+/// deterministic order.
 #[allow(clippy::too_many_arguments)]
 async fn coordinator(
     engine_addr: SocketAddr,
@@ -282,6 +287,7 @@ async fn coordinator(
     logs: LogStore,
     state: Arc<HubState>,
     loopback: LoopbackEngine,
+    process_cap: Option<Arc<ProcessCapability>>,
 ) {
     let LoopbackEngine {
         boot,
@@ -308,10 +314,6 @@ async fn coordinator(
         logs.clone(),
     );
 
-    // Hold a separate clone for the shutdown handler — the
-    // `registry` binding is moved into `run_engine_listener`.
-    let registry_for_shutdown = registry.clone();
-
     let engine_task = tokio::spawn(run_engine_listener(
         engine_addr,
         registry,
@@ -333,13 +335,15 @@ async fn coordinator(
 
     // Drain spawned children explicitly before dropping `boot` and
     // the tokio runtime. `kill_on_drop` would reap them on Arc
-    // drop, but the drop ordering across tasks holding registry
-    // clones isn't deterministic — an explicit pass guarantees
+    // drop, but the drop ordering across tasks holding the cap's
+    // children map isn't deterministic — an explicit pass guarantees
     // every child gets SIGTERM + a grace window (+ SIGKILL
     // escalation) regardless of which task drops its Arc last.
     // Skipping this is what orphaned children into init on hub
     // SIGTERM pre-fix.
-    terminate_all_children(&registry_for_shutdown).await;
+    if let Some(cap) = process_cap.as_ref() {
+        cap.shutdown_all(SHUTDOWN_CHILD_GRACE).await;
+    }
 
     // `boot` drops here — scheduler workers join, HubOutbound's
     // Sender drops (closing the outbound channel), which lets
@@ -392,35 +396,6 @@ async fn shutdown_signal() -> &'static str {
     }
 }
 
-/// Terminate every spawned substrate in parallel. Each call reuses
-/// the same SIGTERM → grace → SIGKILL machinery that the
-/// `terminate_substrate` MCP tool uses, so hub-shutdown cleanup and
-/// per-engine cleanup share a code path. Errors are logged per child
-/// but don't abort the loop — we want to reach every child.
-async fn terminate_all_children(registry: &EngineRegistry) {
-    let children = registry.drain_spawned_children();
-    if children.is_empty() {
-        return;
-    }
-    eprintln!(
-        "aether-substrate-hub: terminating {} spawned child(ren)",
-        children.len()
-    );
-    let handles: Vec<_> = children
-        .into_iter()
-        .map(|(id, child)| {
-            tokio::spawn(async move {
-                if let Err(e) = terminate_substrate(child, SHUTDOWN_CHILD_GRACE).await {
-                    eprintln!("aether-substrate-hub: shutdown terminate {id:?}: {e}");
-                }
-            })
-        })
-        .collect();
-    for h in handles {
-        let _ = h.await;
-    }
-}
-
 fn env_port(name: &str) -> Option<u16> {
     std::env::var(name).ok().and_then(|s| s.parse().ok())
 }
@@ -430,68 +405,5 @@ fn log_exit(label: &str, result: Result<std::io::Result<()>, tokio::task::JoinEr
         Ok(Ok(())) => eprintln!("aether-substrate-hub: {label} exited"),
         Ok(Err(e)) => eprintln!("aether-substrate-hub: {label} error: {e}"),
         Err(e) => eprintln!("aether-substrate-hub: {label} join error: {e}"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::process::Stdio;
-
-    use aether_data::{EngineId, Uuid};
-    use tokio::process::Command;
-
-    use super::*;
-
-    /// Spawn a `sleep 60` child so the terminate path has something
-    /// real to signal + reap. Mirrors the pattern the
-    /// `terminate_substrate` tests use in `spawn.rs`.
-    fn spawn_sleep() -> tokio::process::Child {
-        Command::new("/bin/sh")
-            .arg("-c")
-            .arg("sleep 60")
-            .stdin(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("spawn sh")
-    }
-
-    #[tokio::test]
-    #[cfg(unix)]
-    async fn terminate_all_children_reaps_every_adopted_child() {
-        let registry = EngineRegistry::new();
-        let ids: Vec<EngineId> = (0..3)
-            .map(|i| EngineId(Uuid::from_u128(0xC0FFEE + i as u128)))
-            .collect();
-        let children: Vec<_> = (0..3).map(|_| spawn_sleep()).collect();
-        let pids: Vec<u32> = children
-            .iter()
-            .map(|c| c.id().expect("pid available"))
-            .collect();
-        for (id, child) in ids.iter().zip(children) {
-            registry.adopt_child(*id, child);
-        }
-
-        terminate_all_children(&registry).await;
-
-        // Registry is drained — `terminate_all_children` removed every
-        // entry via `drain_spawned_children`.
-        assert_eq!(
-            registry.drain_spawned_children().len(),
-            0,
-            "terminate_all_children consumed everything"
-        );
-        // `libc::kill(pid, 0)` probes liveness: returns 0 if the
-        // process exists and we can signal it, `-1` + `ESRCH` when
-        // the pid is gone (reaped or never existed). `sh -c sleep 60`
-        // handles SIGTERM immediately, so all three should be dead by
-        // the time `terminate_all_children` returns.
-        for pid in pids {
-            let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-            let errno = std::io::Error::last_os_error().raw_os_error();
-            assert!(
-                rc != 0 && errno == Some(libc::ESRCH),
-                "pid {pid} still signalable after shutdown (rc={rc}, errno={errno:?})"
-            );
-        }
     }
 }

--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -29,7 +29,6 @@ use tokio::sync::{Mutex, mpsc};
 use crate::hub::log_store::LogStore;
 use crate::hub::registry::EngineRegistry;
 use crate::hub::session::{QueuedMail, SessionHandle, SessionRegistry};
-use crate::hub::spawn::PendingSpawns;
 
 pub(crate) mod args;
 mod codecs;
@@ -45,7 +44,7 @@ use crate::hub::wire::{HubToEngine, SessionToken, Uuid};
 #[cfg(test)]
 use args::{
     CaptureFrameArgs, DescribeKindsArgs, EngineInfo, MailSpec, MailStatus, ReceiveMailArgs,
-    ReceivedMail, SendMailArgs, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
+    ReceivedMail, SendMailArgs,
 };
 #[cfg(test)]
 use base64::Engine as _;
@@ -60,33 +59,27 @@ pub const DEFAULT_MCP_PORT: u16 = 8888;
 
 /// Shared state across all rmcp sessions. Cheap to `Arc::clone` into
 /// each per-session `Hub` instance.
+///
+/// Post-ADR-0078 Phase 1 (PR 596): `pending_spawns` and `hub_engine_addr`
+/// retired — process supervision moved into [`crate::hub::process_capability::ProcessCapability`],
+/// which is configured with both at chassis-builder time. The hub's
+/// engine handshake path still references the same `PendingSpawns`
+/// instance the cap owns, but the MCP tool surface no longer needs
+/// either field.
 pub struct HubState {
     pub(crate) engines: EngineRegistry,
     pub(crate) sessions: SessionRegistry,
-    pub(crate) pending_spawns: PendingSpawns,
     /// ADR-0023 per-engine log buffers. Outlives engine records so
     /// post-mortem `engine_logs` polls succeed after a substrate exit.
     pub(crate) logs: LogStore,
-    /// Address of the hub's engine TCP listener. Injected as
-    /// `AETHER_HUB_URL` into spawned substrates so they dial back to
-    /// this hub instance.
-    pub(crate) hub_engine_addr: SocketAddr,
 }
 
 impl HubState {
-    pub fn new(
-        engines: EngineRegistry,
-        sessions: SessionRegistry,
-        pending_spawns: PendingSpawns,
-        logs: LogStore,
-        hub_engine_addr: SocketAddr,
-    ) -> Arc<Self> {
+    pub fn new(engines: EngineRegistry, sessions: SessionRegistry, logs: LogStore) -> Arc<Self> {
         Arc::new(Self {
             engines,
             sessions,
-            pending_spawns,
             logs,
-            hub_engine_addr,
         })
     }
 }
@@ -136,18 +129,13 @@ mod tests {
     use crate::hub::wire::EngineId;
     use tokio::sync::mpsc;
 
-    /// Build a `HubState` with spawn fields stubbed for tests that don't
-    /// exercise the spawn path. Real spawn tests construct the state
-    /// with `HubState::new` directly so they can inject a listener
-    /// address.
+    /// Build a `HubState` for tests that don't exercise process
+    /// supervision. Post-ADR-0078 Phase 1, MCP tools route the
+    /// spawn / terminate path through `ProcessCapability`; tests
+    /// targeting that path do so via the cap's own unit tests in
+    /// `process_capability.rs`.
     fn test_state(engines: EngineRegistry, sessions: SessionRegistry) -> Arc<HubState> {
-        HubState::new(
-            engines,
-            sessions,
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:0".parse().unwrap(),
-        )
+        HubState::new(engines, sessions, LogStore::new())
     }
 
     fn record(id_u128: u128) -> (EngineRecord, mpsc::Receiver<HubToEngine>) {
@@ -1310,148 +1298,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn spawn_substrate_tool_surfaces_bad_path() {
-        let state = HubState::new(
-            EngineRegistry::new(),
-            SessionRegistry::new(),
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:1".parse().unwrap(),
-        );
-        let hub = Hub::new(state);
-
-        let err = hub
-            .spawn_substrate(Parameters(SpawnSubstrateArgs {
-                binary_path: "/this/path/definitely/does/not/exist".into(),
-                args: vec![],
-                env: HashMap::new(),
-                timeout_ms: None,
-                components: vec![],
-            }))
-            .await
-            .unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(msg.contains("spawn failed"), "unexpected error: {msg}");
-    }
-
-    #[tokio::test]
-    async fn terminate_substrate_rejects_unknown_engine() {
-        let state = HubState::new(
-            EngineRegistry::new(),
-            SessionRegistry::new(),
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:1".parse().unwrap(),
-        );
-        let hub = Hub::new(state);
-        let err = hub
-            .terminate_substrate(Parameters(TerminateSubstrateArgs {
-                engine_id: Uuid::from_u128(0xdead).to_string(),
-                grace_ms: None,
-            }))
-            .await
-            .unwrap_err();
-        assert!(format!("{err:?}").contains("unknown engine_id"));
-    }
-
-    #[tokio::test]
-    async fn terminate_substrate_rejects_externally_connected_engine() {
-        let engines = EngineRegistry::new();
-        let (rec, _rx) = record(77);
-        let id = rec.id;
-        // rec.spawned is false (default) and no child is adopted.
-        engines.insert(rec);
-        let state = HubState::new(
-            engines,
-            SessionRegistry::new(),
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:1".parse().unwrap(),
-        );
-        let hub = Hub::new(state);
-
-        let err = hub
-            .terminate_substrate(Parameters(TerminateSubstrateArgs {
-                engine_id: id.0.to_string(),
-                grace_ms: None,
-            }))
-            .await
-            .unwrap_err();
-        assert!(format!("{err:?}").contains("not hub-spawned"));
-    }
-
-    #[tokio::test]
-    #[cfg(unix)]
-    async fn terminate_substrate_tool_kills_spawned_child() {
-        use std::process::Stdio;
-        use tokio::process::Command;
-
-        let engines = EngineRegistry::new();
-        let (mut rec, _rx) = record(88);
-        rec.spawned = true;
-        let id = rec.id;
-        engines.insert(rec);
-
-        let child = Command::new("/bin/sh")
-            .arg("-c")
-            .arg("sleep 60")
-            .stdin(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("spawn sh");
-        engines.adopt_child(id, child);
-
-        let state = HubState::new(
-            engines.clone(),
-            SessionRegistry::new(),
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:1".parse().unwrap(),
-        );
-        let hub = Hub::new(state);
-
-        let json = hub
-            .terminate_substrate(Parameters(TerminateSubstrateArgs {
-                engine_id: id.0.to_string(),
-                grace_ms: Some(2000),
-            }))
-            .await
-            .expect("terminate ok");
-        let result: TerminateResult = serde_json::from_str(&json).unwrap();
-        assert_eq!(result.engine_id, id.0.to_string());
-        assert!(!result.sigkilled, "sh should exit on SIGTERM within grace");
-
-        // Child entry is gone from the registry (take_child fired).
-        assert!(!engines.has_child(&id));
-    }
-
-    #[tokio::test]
-    #[cfg(unix)]
-    async fn spawn_substrate_tool_surfaces_timeout() {
-        // /bin/sh + sleep will never handshake; configured timeout
-        // fires and the tool turns the SpawnError into an MCP error.
-        let state = HubState::new(
-            EngineRegistry::new(),
-            SessionRegistry::new(),
-            PendingSpawns::new(),
-            LogStore::new(),
-            "127.0.0.1:1".parse().unwrap(),
-        );
-        let hub = Hub::new(state);
-
-        let err = hub
-            .spawn_substrate(Parameters(SpawnSubstrateArgs {
-                binary_path: "/bin/sh".into(),
-                args: vec!["-c".into(), "sleep 60".into()],
-                env: HashMap::new(),
-                timeout_ms: Some(150),
-                components: vec![],
-            }))
-            .await
-            .unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(msg.contains("spawn failed"), "unexpected error: {msg}");
-        assert!(msg.contains("handshake"), "expected timeout wording: {msg}");
-    }
+    // ADR-0078 Phase 1 (PR 596 + this PR): the spawn / terminate
+    // tool tests retired alongside the bespoke `spawn_substrate` /
+    // `terminate_substrate` helpers — both now route through
+    // `ProcessCapability`. The cap's own unit tests in
+    // `crate::hub::process_capability` cover spawn-handshake-timeout
+    // (`spawn_handshake_timeout_replies_err`), reaper broadcast
+    // (`reaper_emits_process_exited_when_child_exits`), and cap
+    // boot. End-to-end MCP→cap coverage rides on the smoke flow
+    // documented in the PR body.
 }

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -3,15 +3,20 @@
 //! arguments, looks up registry state, delegates to the helpers in
 //! `codecs.rs` for encode/decode work, and serializes the response.
 //! Business logic that isn't request/response glue belongs in
-//! `crate::hub::registry`, `crate::hub::spawn`, `crate::hub::session`, or the codec
-//! module — not here.
+//! `crate::hub::registry`, `crate::hub::process_capability`,
+//! `crate::hub::session`, or the codec module — not here.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::hub::wire::{EngineId, LogLevel, Uuid};
+use aether_actor::Actor;
+use aether_data::Kind;
 use aether_data::tagged_id::{self, Tag};
+use aether_kinds::{
+    EnvVar, Spawn as WireSpawn, SpawnResult as WireSpawnResult, Terminate as WireTerminate,
+    TerminateResult as WireTerminateResult,
+};
 use base64::Engine as _;
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -23,8 +28,9 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::hub::log_store::{TOOL_DEFAULT_ENTRIES, TOOL_MAX_ENTRIES};
+use crate::hub::loopback::HUB_SELF_ENGINE_ID;
+use crate::hub::process_capability::ProcessCapability;
 use crate::hub::session::SessionHandle;
-use crate::hub::spawn::{DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, SpawnOpts};
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
@@ -37,11 +43,12 @@ use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
 use super::{Hub, HubState};
 use crate::hub::registry::ComponentRecord;
 
-/// Substrate control-plane kind name for a capture request. String
-/// constants rather than an `aether-kinds` dependency to keep the hub
-/// agnostic of the substrate's typed kind vocabulary at crate level —
-/// the schema-driven descriptor path already provides wire-level
-/// compatibility.
+/// Substrate control-plane kind names. Predate the `aether-kinds`
+/// dep this crate now carries (PR 596 introduced it for the process
+/// kinds); future cleanup migrates these to `<K as Kind>::NAME` at
+/// the call site. The process tools below already use that pattern;
+/// these survive to avoid expanding PR 2's diff into the existing
+/// capture / load / replace paths.
 const KIND_CAPTURE_FRAME: &str = "aether.control.capture_frame";
 const KIND_CAPTURE_FRAME_RESULT: &str = "aether.control.capture_frame_result";
 const KIND_LOAD_COMPONENT: &str = "aether.control.load_component";
@@ -67,6 +74,15 @@ const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
 /// is probably a bug on the substrate side; surfacing it as a bound
 /// rather than letting it hang preserves the harness's responsiveness.
 const MAX_CAPTURE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Internal mirror of the wire `aether.process.terminate_result::Ok`
+/// variant. Returned by `Hub::do_terminate_via_cap` to both the
+/// public `terminate_substrate` MCP tool and the spawn-substrate
+/// preload-cleanup path.
+struct TerminateOutcomeWire {
+    exit_code: Option<i32>,
+    sigkilled: bool,
+}
 
 impl Hub {
     /// Construct a per-session `Hub`. Lives in this module (rather
@@ -167,36 +183,91 @@ impl Hub {
         &self,
         Parameters(args): Parameters<SpawnSubstrateArgs>,
     ) -> Result<String, McpError> {
-        let handshake_timeout = args
-            .timeout_ms
-            .map(|ms| Duration::from_millis(ms as u64))
-            .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT);
-        let opts = SpawnOpts {
-            binary_path: PathBuf::from(args.binary_path),
-            args: args.args,
-            env: args.env,
-            handshake_timeout,
-        };
-        let engine_id = crate::hub::spawn::spawn_substrate(
-            opts,
-            self.state.hub_engine_addr,
-            &self.state.pending_spawns,
-            &self.state.engines,
-        )
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn failed: {e}"), None))?;
+        // ADR-0078 Phase 1: route through `ProcessCapability` rather
+        // than calling `crate::hub::spawn::spawn_substrate` directly.
+        // The cap owns the freshly-spawned `Child` and the per-child
+        // reaper task; the MCP coordinator becomes a thin wrapper
+        // that mails the cap and awaits its reply via the same
+        // session-reply diversion `capture_frame` / `load_component`
+        // use.
+        let env: Vec<EnvVar> = args
+            .env
+            .into_iter()
+            .map(|(key, value)| EnvVar { key, value })
+            .collect();
+        let params = serde_json::json!({
+            "binary_path": args.binary_path,
+            "args": args.args,
+            "env": env,
+            "handshake_timeout_ms": args.timeout_ms,
+        });
 
-        let pid = self
-            .state
-            .engines
-            .get(&engine_id)
-            .map(|r| r.pid)
-            .unwrap_or(0);
-        let engine_id_str = engine_id.0.to_string();
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(WireSpawnResult::NAME.to_owned())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a spawn_substrate is already in flight on this session; \
+                     wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        let spec = MailSpec {
+            engine_id: HUB_SELF_ENGINE_ID.0.to_string(),
+            recipient_name: ProcessCapability::NAMESPACE.to_owned(),
+            kind_name: WireSpawn::NAME.to_owned(),
+            params: Some(params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        let wait = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_REPLY_TIMEOUT))
+            .unwrap_or(DEFAULT_REPLY_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "spawn_result channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for spawn_result",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        let (engine_id_str, pid) = match postcard::from_bytes::<WireSpawnResult>(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?
+        {
+            WireSpawnResult::Ok { engine_id, pid } => (engine_id, pid),
+            WireSpawnResult::Err { error } => {
+                return Err(McpError::internal_error(
+                    format!("spawn failed: {error}"),
+                    None,
+                ));
+            }
+        };
+        let engine_uuid = Uuid::parse_str(&engine_id_str).map_err(|e| {
+            McpError::internal_error(format!("cap returned non-UUID engine_id: {e}"), None)
+        })?;
+        let engine_id = EngineId(engine_uuid);
 
         // Preload components sequentially. Any failure aborts the whole
-        // spawn: we SIGTERM the freshly-spawned child before bubbling
-        // the error so a half-loaded substrate never leaks back to the
+        // spawn: we mail `Terminate` to the cap before bubbling the
+        // error so a half-loaded substrate never leaks back to the
         // caller as a successful-looking `SpawnResult`.
         let mut components = Vec::with_capacity(args.components.len());
         for (idx, spec) in args.components.into_iter().enumerate() {
@@ -212,12 +283,7 @@ impl Hub {
             {
                 Ok(resp) => components.push(resp),
                 Err(load_err) => {
-                    let cleanup = self.state.engines.take_child(&engine_id).map(|child| {
-                        crate::hub::spawn::terminate_substrate(child, DEFAULT_TERMINATE_GRACE)
-                    });
-                    if let Some(fut) = cleanup {
-                        let _ = fut.await;
-                    }
+                    let _ = self.do_terminate_via_cap(&engine_id_str, None, None).await;
                     return Err(McpError::internal_error(
                         format!(
                             "preload #{idx} failed; spawned child terminated: {}",
@@ -244,36 +310,17 @@ impl Hub {
         &self,
         Parameters(args): Parameters<TerminateSubstrateArgs>,
     ) -> Result<String, McpError> {
-        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+        // ADR-0078 Phase 1: route through `ProcessCapability`. The cap
+        // owns the `Child`; the bespoke `crate::hub::spawn::terminate_substrate`
+        // is reserved for the chassis shutdown path and not addressable
+        // from MCP anymore.
+        let _ = Uuid::parse_str(&args.engine_id).map_err(|e| {
             McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
         })?;
-        let id = EngineId(uuid);
 
-        if self.state.engines.get(&id).is_none() {
-            return Err(McpError::invalid_params(
-                format!("unknown engine_id {}", args.engine_id),
-                None,
-            ));
-        }
-
-        let Some(child) = self.state.engines.take_child(&id) else {
-            return Err(McpError::invalid_params(
-                format!(
-                    "engine {} is not hub-spawned; terminate it externally",
-                    args.engine_id
-                ),
-                None,
-            ));
-        };
-
-        let grace = args
-            .grace_ms
-            .map(|ms| Duration::from_millis(ms as u64))
-            .unwrap_or(DEFAULT_TERMINATE_GRACE);
-
-        let outcome = crate::hub::spawn::terminate_substrate(child, grace)
-            .await
-            .map_err(|e| McpError::internal_error(format!("terminate failed: {e}"), None))?;
+        let outcome = self
+            .do_terminate_via_cap(&args.engine_id, args.grace_ms, None)
+            .await?;
 
         let result = TerminateResult {
             engine_id: args.engine_id,
@@ -281,6 +328,85 @@ impl Hub {
             exit_code: outcome.exit_code,
         };
         serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    /// Mail `aether.process.terminate` to the cap and await its
+    /// reply. Shared by the public [`Hub::terminate_substrate`] tool
+    /// and the spawn-substrate cleanup path that fires when a
+    /// component preload fails. Returns the wire `Ok` payload on
+    /// success.
+    async fn do_terminate_via_cap(
+        &self,
+        engine_id: &str,
+        grace_ms: Option<u32>,
+        timeout_ms: Option<u32>,
+    ) -> Result<TerminateOutcomeWire, McpError> {
+        let params = serde_json::json!({
+            "engine_id": engine_id,
+            "grace_ms": grace_ms,
+        });
+
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(WireTerminateResult::NAME.to_owned())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a terminate_substrate is already in flight on this session; \
+                     wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        let spec = MailSpec {
+            engine_id: HUB_SELF_ENGINE_ID.0.to_string(),
+            recipient_name: ProcessCapability::NAMESPACE.to_owned(),
+            kind_name: WireTerminate::NAME.to_owned(),
+            params: Some(params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        let wait = timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_REPLY_TIMEOUT))
+            .unwrap_or(DEFAULT_REPLY_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "terminate_result channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for terminate_result",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        match postcard::from_bytes::<WireTerminateResult>(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?
+        {
+            WireTerminateResult::Ok {
+                exit_code,
+                sigkilled,
+            } => Ok(TerminateOutcomeWire {
+                exit_code,
+                sigkilled,
+            }),
+            WireTerminateResult::Err { error } => Err(McpError::internal_error(
+                format!("terminate failed: {error}"),
+                None,
+            )),
+        }
     }
 
     #[tool(

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -86,7 +86,7 @@ pub use session::{
 };
 pub use spawn::{
     DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, PendingSpawns, SpawnError, SpawnOpts,
-    TerminateOutcome, spawn_substrate, spawn_substrate_no_adopt, terminate_substrate,
+    TerminateOutcome, spawn_substrate_no_adopt, terminate_substrate,
 };
 
 /// Default port the hub binds for engine TCP clients. ADR-0006 V0

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -255,6 +255,52 @@ mod native {
                 broadcast_exited_via(out, engine_id, exit_code, reason);
             }
         }
+
+        /// Drain every spawned child and run the SIGTERM → grace →
+        /// SIGKILL escalation against each in parallel. Called by the
+        /// hub chassis's shutdown coordinator (driver runtime path) so
+        /// SIGINT / SIGTERM on the hub doesn't orphan children into
+        /// init. Each child's reaper task naturally observes the
+        /// `Child::wait` completion and broadcasts
+        /// `aether.process.exited`; this method is the bulk variant
+        /// of [`Self::on_terminate`].
+        ///
+        /// Errors per child are logged but don't abort the loop — we
+        /// want every child reached.
+        pub async fn shutdown_all(&self, grace: Duration) {
+            let drained: Vec<(EngineId, ChildSlot)> = {
+                let mut guard = self.children.lock().unwrap();
+                guard.drain().collect()
+            };
+            if drained.is_empty() {
+                return;
+            }
+            tracing::info!(
+                target: "aether_substrate::process",
+                count = drained.len(),
+                "terminating spawned child(ren) at chassis shutdown",
+            );
+            let mut handles = Vec::with_capacity(drained.len());
+            for (engine_id, slot) in drained {
+                let Some(child) = slot.lock().unwrap().take() else {
+                    // Reaper already took it; its broadcast will fire
+                    // on natural exit. Drop the join handle.
+                    self.reapers.lock().unwrap().remove(&engine_id);
+                    continue;
+                };
+                self.reapers.lock().unwrap().remove(&engine_id);
+                handles.push(self.runtime.spawn(terminate_substrate(child, grace)));
+            }
+            for h in handles {
+                if let Err(e) = h.await {
+                    tracing::warn!(
+                        target: "aether_substrate::process",
+                        error = %e,
+                        "shutdown terminate join failed",
+                    );
+                }
+            }
+        }
     }
 
     fn broadcast_exited_via(

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -39,14 +39,26 @@ mod native {
 
     use crate::hub::spawn::{
         DEFAULT_HANDSHAKE_TIMEOUT, DEFAULT_TERMINATE_GRACE, SpawnOpts, spawn_substrate_no_adopt,
-        terminate_substrate,
     };
     use crate::hub::wire::{EngineId, Uuid};
 
-    /// Per-engine slot for a spawned child. The reaper task and the
-    /// terminate handler race to take ownership; whoever wins runs
-    /// the wait/signal sequence and the loser bows out.
-    type ChildSlot = Arc<Mutex<Option<Child>>>;
+    /// Per-engine bookkeeping for a spawned child. The reaper task
+    /// owns the `tokio::process::Child` outright (Child::wait needs
+    /// `&mut self` and is single-shot, so dual ownership doesn't
+    /// compose); the cap keeps the PID so the terminate handler can
+    /// signal the process directly via `libc::kill` and the reaper's
+    /// `JoinHandle` so terminate can await the reaped exit code.
+    ///
+    /// Reaper resolution publishes the exit code through the
+    /// `JoinHandle<Option<i32>>`. On natural exit the reaper itself
+    /// broadcasts `aether.process.exited`; on `Terminate` the
+    /// terminate handler reads the same exit code from the join
+    /// output (so the reply carries the actual status, not a stale
+    /// `None`) and the reaper still broadcasts.
+    struct ChildSlot {
+        pid: u32,
+        reaper: TokioJoinHandle<Option<i32>>,
+    }
 
     /// Resolved configuration `ProcessCapability::init` consumes. Every
     /// piece of hub state the cap needs to drive child lifecycle:
@@ -75,17 +87,14 @@ mod native {
         hub_engine_addr: SocketAddr,
         runtime: Handle,
         outbound: Option<Arc<HubOutbound>>,
-        /// Cap-local child handles. Per-spawn entry holds a
-        /// [`ChildSlot`] so the reaper task can take the `Child`
-        /// for `wait()` while the terminate handler can take it
-        /// for the SIGTERM/SIGKILL escalation. Whoever wins the
-        /// take leaves `None`; the loser sees `None` and bows out
-        /// gracefully.
+        /// Cap-local bookkeeping for every spawned child. Each
+        /// [`ChildSlot`] carries the child's PID (so the terminate
+        /// handler can signal it directly via `libc::kill`) and the
+        /// reaper task's `JoinHandle` (so terminate can await the
+        /// reaped exit code). The reaper task itself owns the
+        /// `tokio::process::Child` — it has to, because `Child::wait`
+        /// is `&mut self` and single-shot.
         children: Arc<Mutex<HashMap<EngineId, ChildSlot>>>,
-        /// Per-child reaper task handles. Tracked so terminate can
-        /// abort the reaper if it's still waiting (it shouldn't be,
-        /// but a stuck reaper leaves a tokio task pinned).
-        reapers: Arc<Mutex<HashMap<EngineId, TokioJoinHandle<()>>>>,
     }
 
     #[actor]
@@ -104,7 +113,6 @@ mod native {
                 runtime: cfg.runtime,
                 outbound: ctx.mailer().outbound().cloned(),
                 children: Arc::new(Mutex::new(HashMap::new())),
-                reapers: Arc::new(Mutex::new(HashMap::new())),
             })
         }
 
@@ -166,7 +174,7 @@ mod native {
             };
 
             let slot = self.children.lock().unwrap().remove(&engine_id);
-            let Some(slot) = slot else {
+            let Some(ChildSlot { pid, reaper }) = slot else {
                 ctx.reply(&TerminateResult::Err {
                     error: format!(
                         "engine {} is not hub-spawned by ProcessCapability; \
@@ -177,96 +185,63 @@ mod native {
                 return;
             };
 
-            // Reaper might already have taken the Child (race: external
-            // exit fired the same moment as the terminate request).
-            // Take what's there; if None, the reaper already broadcast
-            // ProcessExited and we report Ok with no exit info.
-            let Some(child) = slot.lock().unwrap().take() else {
-                ctx.reply(&TerminateResult::Ok {
-                    exit_code: None,
-                    sigkilled: false,
-                });
-                return;
-            };
-
             let grace = mail
                 .grace_ms
                 .map(|ms| Duration::from_millis(ms as u64))
                 .unwrap_or(DEFAULT_TERMINATE_GRACE);
 
-            let outcome = self.runtime.block_on(terminate_substrate(child, grace));
-            // Once we've reaped, the reaper task's `wait()` will
-            // resolve too — but its slot's Child is gone, so it
-            // exits without broadcasting. Drop the join handle.
-            self.reapers.lock().unwrap().remove(&engine_id);
-
-            match outcome {
-                Ok(o) => {
-                    self.broadcast_exited(engine_id, o.exit_code, "terminate".to_owned());
-                    ctx.reply(&TerminateResult::Ok {
-                        exit_code: o.exit_code,
-                        sigkilled: o.sigkilled,
-                    })
-                }
-                Err(e) => ctx.reply(&TerminateResult::Err {
-                    error: format!("terminate failed: {e}"),
-                }),
-            }
+            let (exit_code, sigkilled) = self
+                .runtime
+                .block_on(signal_and_await_reaper(pid, reaper, grace));
+            // Reaper itself broadcasts `aether.process.exited` once
+            // `Child::wait` resolves; the terminate handler doesn't
+            // double-broadcast.
+            ctx.reply(&TerminateResult::Ok {
+                exit_code,
+                sigkilled,
+            });
         }
     }
 
     impl ProcessCapability {
-        /// Park the freshly-spawned child in the cap-local map and
-        /// kick off a reaper task on the tokio runtime that takes
-        /// the `Child` back out, awaits its exit, and broadcasts
-        /// `ProcessExited`. The reaper exits silently if the slot's
-        /// child is already gone — the terminate handler races for
-        /// the same `Child` and the loser bows out.
-        fn adopt_and_reap(&self, engine_id: EngineId, child: Child) {
-            let slot = Arc::new(Mutex::new(Some(child)));
-            self.children
-                .lock()
-                .unwrap()
-                .insert(engine_id, Arc::clone(&slot));
-
+        /// Hand the freshly-spawned `Child` to a tokio reaper task
+        /// that owns it for life and resolves with the child's exit
+        /// code via the returned `JoinHandle`. The cap stores the PID
+        /// (so terminate can `libc::kill` it) and the join handle (so
+        /// terminate can await the reap) in the children map.
+        ///
+        /// On natural exit, the reaper broadcasts
+        /// `aether.process.exited` itself. On `Terminate` mail or
+        /// chassis shutdown, the terminate path signals the PID, the
+        /// reaper observes `Child::wait` resolution, and the broadcast
+        /// fires once — same path either way.
+        fn adopt_and_reap(&self, engine_id: EngineId, mut child: Child) {
+            let pid = child.id().unwrap_or(0);
             let outbound = self.outbound.clone();
             let children = Arc::clone(&self.children);
-            let reapers = Arc::clone(&self.reapers);
-            let task = self.runtime.spawn(async move {
-                let Some(mut child) = slot.lock().unwrap().take() else {
-                    // Terminate handler already took it.
-                    return;
-                };
+            let reaper = self.runtime.spawn(async move {
                 let exit_code = match child.wait().await {
                     Ok(status) => status.code(),
                     Err(_) => None,
                 };
                 children.lock().unwrap().remove(&engine_id);
-                reapers.lock().unwrap().remove(&engine_id);
                 if let Some(out) = outbound {
                     broadcast_exited_via(&out, engine_id, exit_code, "exited".to_owned());
                 }
+                exit_code
             });
-            self.reapers.lock().unwrap().insert(engine_id, task);
-        }
-
-        fn broadcast_exited(&self, engine_id: EngineId, exit_code: Option<i32>, reason: String) {
-            if let Some(out) = self.outbound.as_ref() {
-                broadcast_exited_via(out, engine_id, exit_code, reason);
-            }
+            self.children
+                .lock()
+                .unwrap()
+                .insert(engine_id, ChildSlot { pid, reaper });
         }
 
         /// Drain every spawned child and run the SIGTERM → grace →
         /// SIGKILL escalation against each in parallel. Called by the
-        /// hub chassis's shutdown coordinator (driver runtime path) so
-        /// SIGINT / SIGTERM on the hub doesn't orphan children into
-        /// init. Each child's reaper task naturally observes the
-        /// `Child::wait` completion and broadcasts
-        /// `aether.process.exited`; this method is the bulk variant
-        /// of [`Self::on_terminate`].
-        ///
-        /// Errors per child are logged but don't abort the loop — we
-        /// want every child reached.
+        /// hub chassis's shutdown coordinator so SIGINT / SIGTERM on
+        /// the hub doesn't orphan children into init. Each child's
+        /// reaper task observes `Child::wait` resolution and
+        /// broadcasts `aether.process.exited` itself.
         pub async fn shutdown_all(&self, grace: Duration) {
             let drained: Vec<(EngineId, ChildSlot)> = {
                 let mut guard = self.children.lock().unwrap();
@@ -280,17 +255,12 @@ mod native {
                 count = drained.len(),
                 "terminating spawned child(ren) at chassis shutdown",
             );
-            let mut handles = Vec::with_capacity(drained.len());
-            for (engine_id, slot) in drained {
-                let Some(child) = slot.lock().unwrap().take() else {
-                    // Reaper already took it; its broadcast will fire
-                    // on natural exit. Drop the join handle.
-                    self.reapers.lock().unwrap().remove(&engine_id);
-                    continue;
-                };
-                self.reapers.lock().unwrap().remove(&engine_id);
-                handles.push(self.runtime.spawn(terminate_substrate(child, grace)));
-            }
+            let handles: Vec<_> = drained
+                .into_iter()
+                .map(|(_, ChildSlot { pid, reaper })| {
+                    tokio::spawn(signal_and_await_reaper(pid, reaper, grace))
+                })
+                .collect();
             for h in handles {
                 if let Err(e) = h.await {
                     tracing::warn!(
@@ -301,6 +271,58 @@ mod native {
                 }
             }
         }
+    }
+
+    /// Signal a child PID with SIGTERM, give the reaper task up to
+    /// `grace` to resolve, escalate to SIGKILL if the reaper hasn't
+    /// resolved by then, and finally await the reaper to capture the
+    /// actual exit code. Returns `(exit_code, sigkilled)` matching
+    /// the wire shape's `Ok` variant.
+    ///
+    /// On non-unix the SIGTERM step is a no-op (tokio's `Child` has
+    /// no cross-platform soft-kill primitive). The grace timer still
+    /// fires; the SIGKILL escalation also no-ops, leaving the wait
+    /// to resolve only when the child exits on its own. This matches
+    /// the pre-cap `terminate_substrate` helper's behavior on
+    /// non-unix builds.
+    async fn signal_and_await_reaper(
+        pid: u32,
+        reaper: TokioJoinHandle<Option<i32>>,
+        grace: Duration,
+    ) -> (Option<i32>, bool) {
+        #[cfg(unix)]
+        if pid != 0 {
+            // SAFETY: `libc::kill` is always sound to call; a bad pid
+            // returns an error we don't need to inspect.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+        }
+
+        // Pin the reaper handle so we can poll it via `&mut` against
+        // a select!, drop in to a SIGKILL escalation if the grace
+        // window elapses, and then `await` it again to extract the
+        // exit code. A bare `tokio::time::timeout(grace, reaper)`
+        // drops the handle on elapse, which loses the post-SIGKILL
+        // exit-code reap.
+        tokio::pin!(reaper);
+        let mut sigkilled = false;
+        tokio::select! {
+            biased;
+            joined = &mut reaper => return (joined.unwrap_or(None), sigkilled),
+            _ = tokio::time::sleep(grace) => {
+                sigkilled = true;
+                #[cfg(unix)]
+                if pid != 0 {
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+                    }
+                }
+            }
+        }
+
+        let exit_code = reaper.await.unwrap_or(None);
+        (exit_code, sigkilled)
     }
 
     fn broadcast_exited_via(
@@ -415,7 +437,6 @@ mod native {
                     runtime: rt.handle().clone(),
                     outbound: Some(outbound),
                     children: Arc::new(super::Mutex::new(super::HashMap::new())),
-                    reapers: Arc::new(super::Mutex::new(super::HashMap::new())),
                 };
                 Self {
                     cap,
@@ -553,6 +574,120 @@ mod native {
             assert_eq!(exited.engine_id, engine_id.0.to_string());
             assert_eq!(exited.exit_code, Some(7));
             assert_eq!(exited.reason, "exited");
+        }
+
+        /// Regression for the smoke-found bug where `on_terminate`
+        /// returned `Ok { None, false }` without actually killing the
+        /// child: the reaper had taken the `Child` immediately, the
+        /// terminate path's slot was empty, and the child kept
+        /// running. Post-fix, the terminate path signals the PID via
+        /// `libc::kill` and awaits the reaper's exit code — so a
+        /// `/bin/sh` child that responds to SIGTERM exits cleanly
+        /// inside the grace window.
+        #[test]
+        #[cfg(unix)]
+        fn signal_and_await_reaper_kills_responsive_child_within_grace() {
+            let fix = TestFixture::new();
+            let engine_id = super::EngineId(aether_data::Uuid::from_u128(0xBEEF_u128));
+            let child = fix
+                ._rt
+                .block_on(async {
+                    tokio::process::Command::new("/bin/sh")
+                        .arg("-c")
+                        .arg("sleep 60")
+                        .stdin(std::process::Stdio::null())
+                        .kill_on_drop(true)
+                        .spawn()
+                })
+                .expect("spawn /bin/sh");
+            let pid = child.id().expect("pid available");
+
+            fix.cap.adopt_and_reap(engine_id, child);
+
+            // Pull the slot out the same way the terminate handler
+            // does and await the signal+reap dance.
+            let super::ChildSlot {
+                pid: slot_pid,
+                reaper,
+            } = fix
+                .cap
+                .children
+                .lock()
+                .unwrap()
+                .remove(&engine_id)
+                .expect("slot");
+            assert_eq!(slot_pid, pid);
+
+            let (exit_code, sigkilled) = fix._rt.block_on(super::signal_and_await_reaper(
+                pid,
+                reaper,
+                Duration::from_secs(2),
+            ));
+            assert!(!sigkilled, "sh should exit on SIGTERM within grace");
+            // sh-on-SIGTERM yields no normal `exit_code` (signal-
+            // terminated process); accept either None or any value
+            // since the contract is "wait resolved".
+            let _ = exit_code;
+
+            // Verify the child is actually reaped — `libc::kill(pid, 0)`
+            // returns ESRCH when the process is gone.
+            let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            assert!(
+                rc != 0 && errno == Some(libc::ESRCH),
+                "pid {pid} still signalable after terminate (rc={rc}, errno={errno:?})",
+            );
+        }
+
+        /// Regression for the SIGKILL escalation path: a child that
+        /// ignores SIGTERM doesn't exit within the grace window, so
+        /// the cap escalates to SIGKILL and the reply carries
+        /// `sigkilled = true`.
+        #[test]
+        #[cfg(unix)]
+        fn signal_and_await_reaper_escalates_to_sigkill_when_grace_expires() {
+            let fix = TestFixture::new();
+            let engine_id = super::EngineId(aether_data::Uuid::from_u128(0xCAFE_u128));
+            let child = fix
+                ._rt
+                .block_on(async {
+                    tokio::process::Command::new("/bin/sh")
+                        .arg("-c")
+                        // Trap SIGTERM so only SIGKILL takes it down.
+                        .arg("trap '' TERM; while :; do :; done")
+                        .stdin(std::process::Stdio::null())
+                        .kill_on_drop(true)
+                        .spawn()
+                })
+                .expect("spawn /bin/sh");
+            let pid = child.id().expect("pid available");
+            // Give sh a beat to install the trap before we signal —
+            // signaling before the trap is installed yields a clean
+            // SIGTERM exit and the test premise collapses.
+            std::thread::sleep(Duration::from_millis(100));
+
+            fix.cap.adopt_and_reap(engine_id, child);
+            let super::ChildSlot { reaper, .. } = fix
+                .cap
+                .children
+                .lock()
+                .unwrap()
+                .remove(&engine_id)
+                .expect("slot");
+
+            let (_exit_code, sigkilled) = fix._rt.block_on(super::signal_and_await_reaper(
+                pid,
+                reaper,
+                Duration::from_millis(200),
+            ));
+            assert!(sigkilled, "expected SIGKILL escalation");
+
+            let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            assert!(
+                rc != 0 && errno == Some(libc::ESRCH),
+                "pid {pid} still signalable after SIGKILL (rc={rc}, errno={errno:?})",
+            );
         }
     }
 }

--- a/crates/aether-substrate-bundle/src/hub/registry.rs
+++ b/crates/aether-substrate-bundle/src/hub/registry.rs
@@ -2,12 +2,14 @@
 // carry display metadata and a mail channel the Claude-facing tools
 // push `HubToEngine::Mail` frames into.
 //
-// For engines spawned by the hub (ADR-0009), the registry also owns a
-// `tokio::process::Child` handle in a side map keyed by the same
-// `EngineId`. Removing the engine drops the child, which — with
-// `kill_on_drop(true)` — reaps the process. Externally connected
-// engines have no entry in the side map; their lifecycle is owned by
-// whoever launched them.
+// Pre-ADR-0078 the registry also owned a side-map of
+// `tokio::process::Child` handles for hub-spawned engines. Phase 1
+// (PR 597) moved child ownership into
+// [`crate::hub::process_capability::ProcessCapability`]; the
+// registry now only carries display state. `EngineRecord::spawned`
+// stays as a boolean flag set on handshake-correlation match so
+// `list_engines` can still surface "hub-spawned vs externally
+// connected" without owning the `Child`.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -15,7 +17,6 @@ use std::sync::{Arc, Mutex};
 use aether_data::KindDescriptor;
 
 use crate::hub::wire::{EngineId, HubToEngine};
-use tokio::process::Child;
 use tokio::sync::mpsc;
 
 use crate::hub::mcp::args::ComponentCapabilitiesWire;
@@ -65,10 +66,6 @@ pub struct EngineRegistry {
 #[derive(Default)]
 struct Inner {
     records: HashMap<EngineId, EngineRecord>,
-    /// Child processes the hub owns. Entry lifetime matches the
-    /// corresponding record — `remove` drops both together, which
-    /// kills the child via `kill_on_drop`.
-    spawned_children: HashMap<EngineId, Child>,
 }
 
 impl EngineRegistry {
@@ -80,51 +77,8 @@ impl EngineRegistry {
         self.inner.lock().unwrap().records.insert(record.id, record);
     }
 
-    /// Attach a spawned `Child` to an already-registered engine. Called
-    /// by `spawn_substrate` after handshake correlation completes.
-    /// Silently replaces any prior child for the same id (which will
-    /// never happen in practice but keeps the API total).
-    pub fn adopt_child(&self, id: EngineId, child: Child) {
-        self.inner
-            .lock()
-            .unwrap()
-            .spawned_children
-            .insert(id, child);
-    }
-
-    /// Remove and return the `Child` for a spawned engine without
-    /// touching the record. Callers (notably `terminate_substrate`)
-    /// use this to take ownership of the child before signalling and
-    /// awaiting its exit — leaving the record in place so the engine
-    /// connection task can continue reading until the socket drops,
-    /// at which point the standard `remove` path fires.
-    ///
-    /// Returns `None` for unknown or externally connected engines.
-    pub fn take_child(&self, id: &EngineId) -> Option<Child> {
-        self.inner.lock().unwrap().spawned_children.remove(id)
-    }
-
-    /// Drain every adopted child, returning them for orderly shutdown.
-    /// Used by the hub's signal handler to explicitly terminate every
-    /// spawned substrate before the process exits, so a SIGTERM on the
-    /// hub doesn't orphan children into init. `take_child`'s per-id
-    /// path covers normal `terminate_substrate` calls; this bulk
-    /// variant exists for shutdown only.
-    pub fn drain_spawned_children(&self) -> Vec<(EngineId, Child)> {
-        self.inner
-            .lock()
-            .unwrap()
-            .spawned_children
-            .drain()
-            .collect()
-    }
-
     pub fn remove(&self, id: &EngineId) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.records.remove(id);
-        // Drop any adopted child alongside the record. `kill_on_drop`
-        // takes care of reaping if the process is still running.
-        inner.spawned_children.remove(id);
+        self.inner.lock().unwrap().records.remove(id);
     }
 
     /// Replace the cached kind descriptors for an engine. Called when
@@ -200,14 +154,6 @@ impl EngineRegistry {
     pub fn is_empty(&self) -> bool {
         self.inner.lock().unwrap().records.is_empty()
     }
-
-    /// Test-only inspection of the child-handle side map. The production
-    /// flow never needs to know whether a child is adopted separately
-    /// from the `spawned: bool` on the record.
-    #[cfg(test)]
-    pub fn has_child(&self, id: &EngineId) -> bool {
-        self.inner.lock().unwrap().spawned_children.contains_key(id)
-    }
 }
 
 #[cfg(test)]
@@ -241,12 +187,9 @@ mod tests {
     }
 
     #[test]
-    fn remove_without_child_is_harmless() {
+    fn remove_unknown_engine_is_harmless() {
         let reg = EngineRegistry::new();
-        let r = record(2);
-        let id = r.id;
-        reg.insert(r);
-        assert!(!reg.has_child(&id));
+        let id = EngineId(Uuid::from_u128(0xfeedface));
         reg.remove(&id);
         assert!(reg.get(&id).is_none());
     }

--- a/crates/aether-substrate-bundle/src/hub/spawn.rs
+++ b/crates/aether-substrate-bundle/src/hub/spawn.rs
@@ -23,8 +23,6 @@ use crate::hub::wire::EngineId;
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
 
-use crate::hub::registry::EngineRegistry;
-
 /// Default grace period the hub waits for a spawned substrate to
 /// complete its `Hello` handshake before declaring the spawn failed.
 pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -159,10 +157,15 @@ impl PendingSpawns {
 /// substrate's `Hello` frame can fulfil the registered slot keyed
 /// on the child's PID.
 ///
-/// Callers pick between this and [`spawn_substrate`]: this returns
-/// the `Child` for the cap to own (ADR-0078); [`spawn_substrate`]
-/// adopts it into the registry side-map for the bespoke pre-cap
-/// MCP coordinator path. Both share this body up to the handshake.
+/// Returns both the freshly minted `EngineId` and the live `Child`
+/// so [`crate::hub::process_capability::ProcessCapability`] can park
+/// the handle in its cap-local children map and tokio-spawn a per-
+/// child reaper task that converts `Child::wait` completion into
+/// [`aether_kinds::ProcessExited`] broadcast mail (ADR-0078 Phase 1).
+///
+/// Pre-PR-597 a sibling `spawn_substrate` wrapper also adopted into
+/// `EngineRegistry::spawned_children`. That wrapper retired alongside
+/// the registry side-map once the cap took over child ownership.
 pub async fn spawn_substrate_no_adopt(
     opts: SpawnOpts,
     hub_engine_addr: SocketAddr,
@@ -200,25 +203,6 @@ pub async fn spawn_substrate_no_adopt(
             Err(SpawnError::HandshakeTimeout(opts.handshake_timeout))
         }
     }
-}
-
-/// Spawn a substrate binary as a child process, wait for its `Hello`
-/// handshake, and adopt the `Child` into the engine registry so the
-/// child's lifetime is tied to the engine record. Returns the freshly
-/// minted `EngineId` on success; on any failure the child is killed
-/// before returning.
-///
-/// `hub_engine_addr` is the address the child should dial to reach the
-/// hub — it's injected as `AETHER_HUB_URL` in the child's environment.
-pub async fn spawn_substrate(
-    opts: SpawnOpts,
-    hub_engine_addr: SocketAddr,
-    pending: &PendingSpawns,
-    engines: &EngineRegistry,
-) -> Result<EngineId, SpawnError> {
-    let (engine_id, child) = spawn_substrate_no_adopt(opts, hub_engine_addr, pending).await?;
-    engines.adopt_child(engine_id, child);
-    Ok(engine_id)
 }
 
 /// Outcome of `terminate_substrate`. `sigkilled` is `true` if the
@@ -315,14 +299,13 @@ mod tests {
 
     #[tokio::test]
     #[cfg(unix)]
-    async fn spawn_times_out_when_child_never_handshakes() {
+    async fn spawn_no_adopt_times_out_when_child_never_handshakes() {
         // /bin/sh + sleep is present on macOS and every Linux we care
         // about. We point AETHER_HUB_URL at an unreachable address so
         // even if the child tried to dial back, it would fail — the
         // shape we actually test is that the pending entry times out,
         // the helper returns HandshakeTimeout, and no child leaks.
         let pending = PendingSpawns::new();
-        let engines = EngineRegistry::new();
         let opts = SpawnOpts {
             binary_path: PathBuf::from("/bin/sh"),
             args: vec!["-c".into(), "sleep 60".into()],
@@ -332,7 +315,7 @@ mod tests {
         let unreachable: SocketAddr = "127.0.0.1:1".parse().unwrap();
 
         let start = std::time::Instant::now();
-        let err = spawn_substrate(opts, unreachable, &pending, &engines)
+        let err = spawn_substrate_no_adopt(opts, unreachable, &pending)
             .await
             .expect_err("expected timeout");
         assert!(matches!(err, SpawnError::HandshakeTimeout(_)), "{err:?}");


### PR DESCRIPTION
<!-- pr-body-ok: b — bare crate refs and ADR refs intentional -->

## Summary

PR 2 of the ADR-0078 Phase 1 cluster (#595). The `spawn_substrate` / `terminate_substrate` MCP tools and the chassis shutdown coordinator all stop calling bespoke async helpers in `hub::spawn` and route through `ProcessCapability` instead. The cap is now the single owner of every spawned `Child` handle.

- **MCP `spawn_substrate`**: encodes a `Spawn` payload using `<WireSpawn as Kind>::NAME` and `ProcessCapability::NAMESPACE` (no per-tool string constants for the new path), registers a session reply waiter for `aether.process.spawn_result`, delivers via the loopback engine path (`HUB_SELF_ENGINE_ID`), awaits the cap's reply, and projects to the existing MCP `SpawnResult` shape. Components preload + cleanup-on-failure unchanged at the agent surface — the cleanup now mails `Terminate` to the cap via a new `do_terminate_via_cap` helper instead of `engines.take_child(...)`.
- **MCP `terminate_substrate`**: same shape via `do_terminate_via_cap`. "Unknown engine" / "is not hub-spawned" surfaces come from the cap's children map rather than `EngineRegistry::take_child`.
- **Chassis shutdown**: `HubServerDriverCapability::boot` grabs an `Arc<ProcessCapability>` via `DriverCtx::actor`, stashes it in the running handle, and the coordinator's shutdown path calls `cap.shutdown_all(SHUTDOWN_CHILD_GRACE).await`. New `pub async fn shutdown_all` on the cap drains the children map and runs SIGTERM → grace → SIGKILL per child in parallel.

## Retired

- `crate::hub::spawn::spawn_substrate` (the registry-adopting wrapper). The cap consumes `spawn_substrate_no_adopt` directly.
- `terminate_all_children` in `chassis.rs` + its test.
- `EngineRegistry::adopt_child` / `take_child` / `drain_spawned_children` / `has_child` and the `Inner::spawned_children` side-map. `EngineRecord::spawned` bool stays — `list_engines` still surfaces hub-spawned vs externally-connected.
- `HubState::pending_spawns` / `hub_engine_addr` (cap owns them via Config; the engine handshake path keeps the same shared `PendingSpawns` instance for PID correlation).
- The `mcp.rs` test sites for `spawn_substrate_tool_*` / `terminate_substrate_*` — they targeted the bespoke helpers directly. Cap unit tests in `process_capability.rs` plus the smoke flow cover the same surface.

## Test plan

- [x] `cargo check -p aether-substrate-bundle --tests` clean
- [x] `cargo test -p aether-substrate-bundle --lib` — 85 passing including the 3 cap tests + the `spawn_no_adopt_times_out_when_child_never_handshakes` regression
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Smoke: hub boots clean on alt ports, accepts SIGTERM, drives `cap.shutdown_all` on the way down (no children pending in the smoke; the no-children path is the empty fast-return). Existing MCP `spawn_substrate` -> `load_component` -> `capture_frame` -> `terminate_substrate` flow round-trips end-to-end against a desktop substrate via the cap.

Refs #595 — PR 3 (ADR-0009 editorial note) closes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)