### PR TITLE
fix(actor): per-actor log drain via ConfigureLogDrain (issue 601)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1925,6 +1925,29 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             .collect()
     };
 
+    // Issue #601: auto-emitted dispatch arm for the chassis-pushed
+    // `ConfigureLogDrain` mail. Runs before user handlers AND before
+    // the `#[fallback]` envelope check. For catch-all caps
+    // (BroadcastCapability) this means chassis log-drain config is
+    // installed inline and never re-broadcast through the fallback.
+    let auto_log_drain_arm = quote! {
+        if __aether_kind.0 == <
+            ::aether_actor::__macro_internals::ConfigureLogDrain
+            as ::aether_data::Kind
+        >::ID.0 {
+            if let ::core::option::Option::Some(__aether_cfg) =
+                <
+                    ::aether_actor::__macro_internals::ConfigureLogDrain
+                    as ::aether_data::Kind
+                >::decode_from_bytes(__aether_payload)
+            {
+                ::aether_actor::log::set_drain(__aether_cfg.mailbox);
+                return ::core::option::Option::Some(());
+            }
+            return ::core::option::Option::None;
+        }
+    };
+
     let dispatch_arms = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         let method_ident = &h.method.sig.ident;
@@ -2016,6 +2039,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                 __aether_kind: ::aether_substrate::mail::KindId,
                 __aether_payload: &[u8],
             ) -> ::core::option::Option<()> {
+                #auto_log_drain_arm
                 #(#dispatch_arms)*
                 ::core::option::Option::None
             }
@@ -2313,9 +2337,33 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
         None => quote! { ::aether_actor::DISPATCH_UNKNOWN_KIND },
     };
 
+    // Issue #601: auto-emitted dispatch arm for the chassis-pushed
+    // `ConfigureLogDrain` mail. Runs before user handlers and the
+    // fallback so it preempts catch-all `#[fallback]` actors (issue
+    // 576's BroadcastCapability would otherwise re-broadcast chassis
+    // config). Decodes the mail and installs the slot via
+    // `aether_actor::log::set_drain`; user code never declares this
+    // handler.
+    let auto_log_drain_arm = quote! {
+        if __aether_kind == <
+            ::aether_actor::__macro_internals::ConfigureLogDrain
+            as ::aether_actor::__macro_internals::Kind
+        >::ID.0 {
+            if let ::core::option::Option::Some(__aether_cfg) =
+                __aether_mail.decode_kind::<
+                    ::aether_actor::__macro_internals::ConfigureLogDrain
+                >()
+            {
+                ::aether_actor::log::set_drain(__aether_cfg.mailbox);
+            }
+            return ::aether_actor::DISPATCH_HANDLED;
+        }
+    };
+
     quote! {
         let __aether_kind = __aether_mail.kind();
         __aether_ctx.__set_reply_to(__aether_mail.reply_to());
+        #auto_log_drain_arm
         #( #arms )*
         #tail
     }

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -135,6 +135,13 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 pub mod __macro_internals {
     pub use aether_data::__derive_runtime::{Cow, KindLabels, SchemaType, canonical};
     pub use aether_data::{Kind, Schema};
+    /// Issue #601: `#[actor]` / `#[handlers]` auto-emit a synthetic
+    /// dispatch arm for `ConfigureLogDrain` so every actor accepts the
+    /// chassis's log-drain push without user code declaring a handler.
+    /// Re-exported here so the macro emits a path through `aether-actor`
+    /// and consumer crates aren't forced to depend on `aether-kinds`
+    /// directly.
+    pub use aether_kinds::ConfigureLogDrain;
 }
 
 /// ADR-0033 attribute macros and `Kind` / `Schema` derives, behind

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -1,36 +1,39 @@
-//! Issue #581 unified actor-aware logging.
+//! Issue #581 unified actor-aware logging — actor-bound only.
 //!
-//! Single tracing path across wasm and native: every `tracing::*`
-//! event (and every `aether::log_*!` macro call) flows into the
-//! per-actor [`LogBuffer`] via [`Local`]. The chassis dispatcher
-//! drains the buffer at handler exit (and on `WARN`/`ERROR` priority
-//! flush) by calling [`drain_buffer`], which ships a [`LogBatch`] to
-//! the well-known `aether.log` mailbox owned by `LogCapability`
-//! (`aether-capabilities`).
+//! Per-actor `tracing::*` events buffer into [`LogBuffer`] (a
+//! [`Local`]); the chassis-pushed `ConfigureLogDrain` mail (auto-
+//! handled by every `#[handlers]` derive, issue #601) installs
+//! [`LogDrainSlot`] with the chassis-declared drain mailbox.
+//! [`drain_buffer`] reads both slots and ships a [`LogBatch`] to that
+//! mailbox at handler exit (and on `WARN`/`ERROR` priority flush
+//! within the layer). The chassis dispatcher stamps the actor's own
+//! transport-backed dispatch per handler via [`with_actor_dispatch`],
+//! so the egress runs through the actor's own send path.
 //!
-//! `aether-actor` knows nothing about `LogCapability` — the cap
-//! registers a [`MailDispatch`] impl + the `aether.log` mailbox id
-//! at install time via [`install_log_target`]; the chassis dispatcher
-//! stamps the actor's own transport-backed dispatch per handler via
-//! [`with_actor_dispatch`]. Both branches funnel through the same
-//! trait surface.
+//! There is no host branch. `tracing::*` events fired outside any
+//! actor stamp (substrate boot, scheduler thread, panic hook) do NOT
+//! enter the mail system — they hit stderr via the substrate's
+//! registered fmt::Layer for operator visibility but never reach
+//! `engine_logs`. The actor model's invariant is that every piece of
+//! engine logic eventually runs as an actor; the host-branch shortcut
+//! retired in issue #601 alongside `PROCESS` / `install_log_target` /
+//! `ship_host_event`. Code that wants to surface in `engine_logs`
+//! emits its events from inside an actor.
 //!
-//! Recursion guard: code inside [`drain_buffer`] / [`ship_host_event`]
-//! routes through `Mailer::push`, which can emit its own
+//! Recursion guard: code inside [`drain_buffer`] routes through the
+//! stamped transport's `send_mail`, which can emit its own
 //! `tracing::*` events (e.g. the `capability mailbox sender dropped`
 //! warn fired from a dead sink handler). Without a guard, those
-//! events re-enter the layer, push the actor's buffer, priority-
-//! flush at WARN, and recurse — observable as a stack overflow
-//! during chassis shutdown. The [`in_log_pipeline`] TLS flag
-//! short-circuits the actor-aware path while a drain or host-ship
-//! is in flight; events still flow to the registered `tsfmt::Layer`
-//! so operators see them on stderr.
+//! events re-enter the layer, push the actor's buffer, priority-flush
+//! at WARN, and recurse — observable as a stack overflow during
+//! shutdown. The [`is_in_pipeline`] TLS flag short-circuits the
+//! actor-aware path while a drain is in flight; events still flow to
+//! the registered fmt::Layer so operators see them on stderr.
 
 extern crate alloc;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use core::cell::Cell;
 use core::fmt::Write as _;
 
 use aether_data::{Kind, KindId, MailboxId};
@@ -46,7 +49,7 @@ use tracing::{
 #[cfg(target_arch = "wasm32")]
 use tracing::{Subscriber, span};
 
-use crate::Local;
+use crate::{Local, local};
 
 /// Per-actor log buffer, drained by the chassis dispatcher at
 /// handler exit and on `WARN`/`ERROR` priority flush. Backed by
@@ -57,17 +60,54 @@ pub struct LogBuffer(pub Vec<LogEvent>);
 
 impl Local for LogBuffer {}
 
-/// Mail egress hook the actor-aware layer + drain path call into.
-/// `aether-actor` never names `LogCapability` or `"aether.log"`;
-/// the cap installs an impl + mailbox id at boot and we stash both
-/// behind the [`install_log_target`] / [`with_actor_dispatch`]
-/// surface.
+/// Per-actor log drain target — the `aether.log` (or chassis-
+/// configured override) mailbox id [`drain_buffer`] ships
+/// [`LogBatch`] mails to. Issue #601: replaces the retired
+/// `PROCESS.log_mailbox` cell with a per-actor slot the chassis
+/// installs via the `aether.control.configure_log_drain` mail
+/// every actor's `#[handlers]` derive auto-handles.
+///
+/// Default `MailboxId(0)` — meaning "no drain configured." Until
+/// the chassis-pushed `ConfigureLogDrain` mail arrives, drain calls
+/// are no-ops, so init-body events buffer in [`LogBuffer`] without
+/// being shipped (they flush at the first handler exit, which is
+/// the `ConfigureLogDrain` handler installing this slot).
+#[derive(Default)]
+#[local]
+pub struct LogDrainSlot(pub MailboxId);
+
+/// Install `mailbox` as this actor's log drain target. Called from
+/// the `#[handlers]`-derived `ConfigureLogDrain` handler the chassis
+/// dispatches at instantiation; user code never names this directly.
+///
+/// Idempotent — overwriting is fine; the chassis sends one
+/// `ConfigureLogDrain` per actor at boot, and a future per-actor
+/// override extension would call this from the actor's own init.
+pub fn set_drain(mailbox: MailboxId) {
+    let _ = LogDrainSlot::try_with_mut(|s| s.0 = mailbox);
+}
+
+/// The currently-installed drain mailbox for the active actor, if
+/// any. Returns `None` when no actor is stamped (host code, panic
+/// hook) or when the slot is still at its default `MailboxId(0)`
+/// (chassis hasn't dispatched `ConfigureLogDrain` yet, or chassis
+/// declared no drain).
+pub fn current_drain() -> Option<MailboxId> {
+    let raw = LogDrainSlot::try_with(|s| s.0)?;
+    if raw.0 == 0 { None } else { Some(raw) }
+}
+
+/// Mail egress hook the actor-aware drain path call into. The
+/// chassis stamps an actor's transport per-handler via
+/// [`with_actor_dispatch`]; [`drain_buffer`] reads the stamp to
+/// route the actor's [`LogBatch`] through the same transport every
+/// other outbound `send` uses. `aether-actor` doesn't name
+/// `LogCapability` — the destination mailbox is per-actor-stamped via
+/// [`LogDrainSlot`] (issue #601).
 pub trait MailDispatch: Send + Sync {
     /// Push `payload` (already postcard-encoded `LogBatch` bytes) to
-    /// the registered log mailbox. Implementer attaches the actor's
-    /// sender id automatically (when the dispatch wraps the actor's
-    /// own transport) or `None` (when the dispatch wraps the
-    /// substrate's process-global mailer for host-branch events).
+    /// `mailbox`. The implementer's `send_mail` attaches the actor's
+    /// sender id automatically.
     fn send(&self, mailbox: MailboxId, kind: KindId, payload: &[u8]);
 }
 
@@ -83,47 +123,6 @@ where
     fn send(&self, mailbox: MailboxId, kind: KindId, payload: &[u8]) {
         let _ = crate::transport::MailTransport::send_mail(self, mailbox.0, kind.0, payload, 1);
     }
-}
-
-/// Process-global host-branch dispatch + the registered `aether.log`
-/// mailbox id. Set once by [`install_log_target`]; the actor-aware
-/// layer reads them when a `tracing::*` event fires outside any
-/// actor's dispatch (substrate boot, scheduler, panic hook).
-///
-/// `Sync` is justified by the install contract: only the first
-/// [`install_log_target`] call mutates the cells, and that call
-/// happens on the boot thread before any subscriber observes them
-/// (see ADR-0023's `log_capture::init` predecessor for precedent).
-struct ProcessGlobals {
-    host: Cell<Option<&'static dyn MailDispatch>>,
-    log_mailbox: Cell<u64>,
-}
-
-unsafe impl Sync for ProcessGlobals {}
-
-static PROCESS: ProcessGlobals = ProcessGlobals {
-    host: Cell::new(None),
-    log_mailbox: Cell::new(0),
-};
-
-/// Install the registered log target — the `aether.log` mailbox id
-/// and the host-branch dispatch the actor-aware layer hits when a
-/// `tracing::*` event fires outside an actor's dispatch.
-///
-/// Idempotent: only the first call wins; subsequent calls are
-/// no-ops (substrate / wasm install paths may both reach this; the
-/// first one to win is the source of truth).
-pub fn install_log_target(host: &'static dyn MailDispatch, mailbox: MailboxId) {
-    if PROCESS.host.get().is_some() {
-        return;
-    }
-    PROCESS.host.set(Some(host));
-    PROCESS.log_mailbox.set(mailbox.0);
-}
-
-fn registered_log_mailbox() -> Option<MailboxId> {
-    let raw = PROCESS.log_mailbox.get();
-    if raw == 0 { None } else { Some(MailboxId(raw)) }
 }
 
 /// Native-only per-handler dispatch stamp. Wasm runs single-
@@ -183,9 +182,11 @@ pub fn with_actor_dispatch<R>(dispatch: &dyn MailDispatch, f: impl FnOnce() -> R
 }
 
 /// Pop the current actor's [`LogBuffer`] and ship the contents as
-/// one [`LogBatch`] mail to the registered target. No-op when the
-/// buffer is empty, the log target is unregistered, or (on native)
-/// no [`with_actor_dispatch`] is active.
+/// one [`LogBatch`] mail to the configured target. No-op when the
+/// buffer is empty, the [`LogDrainSlot`] is still at its default
+/// (chassis hasn't dispatched `ConfigureLogDrain` yet, or chassis
+/// declared no drain), or (on native) no [`with_actor_dispatch`] is
+/// active.
 pub fn drain_buffer() {
     let entries = match LogBuffer::try_with_mut(|b| core::mem::take(&mut b.0)) {
         Some(es) => es,
@@ -194,7 +195,12 @@ pub fn drain_buffer() {
     if entries.is_empty() {
         return;
     }
-    let Some(mailbox) = registered_log_mailbox() else {
+    // Issue #601: read the per-actor `LogDrainSlot` instead of the
+    // retired `PROCESS.log_mailbox` cell. The chassis-pushed
+    // `ConfigureLogDrain` mail (auto-handled by every `#[handlers]`
+    // derive) installs the slot at the actor's first dispatched
+    // handler.
+    let Some(mailbox) = current_drain() else {
         return;
     };
     let batch = LogBatch { entries };
@@ -216,13 +222,15 @@ pub fn drain_buffer() {
 }
 
 /// Re-entry guard for the log pipeline. While set, [`is_in_pipeline`]
-/// returns `true` and the actor-aware tracing layer skips the in-
-/// actor and host branches (events still reach the registered
-/// `tsfmt::Layer` for stderr). The guard wraps every code path that
-/// might trigger a `tracing::*` event from inside the egress
-/// machinery — chiefly [`drain_buffer`] / [`ship_host_event`], whose
-/// `Mailer::push` ↦ sink-handler chain emits its own warns when a
-/// recipient is dead.
+/// returns `true` and the actor-aware tracing layer skips its
+/// in-actor branch (events still reach the registered `tsfmt::Layer`
+/// for stderr). The guard wraps the [`drain_buffer`] code path,
+/// whose `MailDispatch::send` ↦ sink-handler chain can emit its own
+/// `tracing::*` events (e.g. the `capability mailbox sender dropped`
+/// warn fired from a dead sink handler). Without the guard, those
+/// events re-enter the layer, push the actor's buffer, priority-
+/// flush at WARN, and recurse — observable as a stack overflow
+/// during shutdown.
 #[cfg(not(target_arch = "wasm32"))]
 mod pipeline_tls {
     extern crate std;
@@ -281,27 +289,6 @@ fn ship_batch_via_wasm_transport(mailbox: MailboxId, batch: LogBatch) {
         Err(_) => return,
     };
     crate::WASM_TRANSPORT.send_mail(mailbox.0, <LogBatch as Kind>::ID.0, &bytes, 1);
-}
-
-/// Ship a single host-emitted event through the registered host
-/// dispatch. Called by the actor-aware layer when `tracing::*`
-/// fires outside any actor's dispatch (substrate boot, scheduler,
-/// panic hook). No-op if [`install_log_target`] hasn't run yet.
-pub fn ship_host_event(entry: LogEvent) {
-    let Some(host) = PROCESS.host.get() else {
-        return;
-    };
-    let Some(mailbox) = registered_log_mailbox() else {
-        return;
-    };
-    let _guard = PipelineGuard::enter();
-    ship_batch(
-        host,
-        mailbox,
-        LogBatch {
-            entries: alloc::vec![entry],
-        },
-    );
 }
 
 fn ship_batch(dispatch: &dyn MailDispatch, mailbox: MailboxId, batch: LogBatch) {

--- a/crates/aether-actor/src/wasm.rs
+++ b/crates/aether-actor/src/wasm.rs
@@ -425,7 +425,7 @@ macro_rules! __export_internal {
             $crate::log::install_wasm_subscriber();
             let mut ctx: $crate::WasmInitCtx<'_> =
                 $crate::WasmInitCtx::__new(&$crate::WASM_TRANSPORT, mailbox_id);
-            match <$component as $crate::WasmActor>::init(&mut ctx) {
+            let status = match <$component as $crate::WasmActor>::init(&mut ctx) {
                 Ok(instance) => {
                     unsafe {
                         __AETHER_COMPONENT.set(instance);
@@ -443,7 +443,16 @@ macro_rules! __export_internal {
                     }
                     1
                 }
-            }
+            };
+            // Issue #598: flush any tracing events emitted during init
+            // so the substrate can surface them. The drain is a no-op
+            // until the chassis-pushed `ConfigureLogDrain` mail arrives
+            // and the auto-emitted handler installs `LogDrainSlot`;
+            // events buffered here drain at the *first* dispatched
+            // handler instead. Trap-during-init still loses events
+            // (handled separately via the panic hook).
+            $crate::log::drain_buffer();
+            status
         }
 
         /// # Safety
@@ -474,7 +483,13 @@ macro_rules! __export_internal {
             };
             let mut ctx: $crate::WasmCtx<'_> = $crate::WasmCtx::__new(&$crate::WASM_TRANSPORT);
             let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
-            instance.__aether_dispatch(&mut ctx, mail)
+            let status = instance.__aether_dispatch(&mut ctx, mail);
+            // Issue #598: ship buffered tracing events at handler exit.
+            // Pre-#601 only WARN/ERROR drained (priority flush in the
+            // layer); INFO/DEBUG/TRACE buffered indefinitely. With the
+            // exit drain every level surfaces predictably.
+            $crate::log::drain_buffer();
+            status
         }
 
         /// # Safety
@@ -493,6 +508,9 @@ macro_rules! __export_internal {
             let mut ctx: $crate::WasmDropCtx<'_> =
                 $crate::WasmDropCtx::__new(&$crate::WASM_TRANSPORT);
             $crate::__export_internal!(@on_replace $replaceable, $component, instance, ctx);
+            // Issue #598: drain buffered tracing events emitted from
+            // the swap hook before linear memory is replaced.
+            $crate::log::drain_buffer();
             0
         }
 
@@ -508,6 +526,11 @@ macro_rules! __export_internal {
             let mut ctx: $crate::WasmDropCtx<'_> =
                 $crate::WasmDropCtx::__new(&$crate::WASM_TRANSPORT);
             <$component as $crate::WasmActor>::on_drop(instance, &mut ctx);
+            // Issue #598: drain buffered tracing events from the
+            // teardown hook before linear memory is torn down. Last
+            // chance to surface anything the cap logged on its way
+            // out.
+            $crate::log::drain_buffer();
             0
         }
 
@@ -528,6 +551,8 @@ macro_rules! __export_internal {
             let mut ctx: $crate::WasmCtx<'_> = $crate::WasmCtx::__new(&$crate::WASM_TRANSPORT);
             let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
             $crate::__export_internal!(@on_rehydrate $replaceable, $component, instance, ctx, prior);
+            // Issue #598: drain rehydrate-time tracing events.
+            $crate::log::drain_buffer();
             0
         }
     };

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -600,6 +600,30 @@ mod control_plane {
         Err { error: String },
     }
 
+    /// `aether.control.configure_log_drain` — chassis-pushed mail every
+    /// actor handles to pick up the configured log drain mailbox
+    /// (issue #601). The chassis dispatches one of these to every
+    /// freshly-instantiated actor before any other inbound mail; the
+    /// SDK's `#[actor]` / `#[handlers]` derive auto-emits a handler
+    /// that installs `mailbox` into the per-actor `LogDrainSlot` so
+    /// `aether-actor::log::drain_buffer` knows where to ship the
+    /// `LogBatch`. Cast-shape — one `MailboxId`, fixed size.
+    ///
+    /// Fire-and-forget; no reply. If the chassis didn't declare a
+    /// drain via `Builder::with_log_drain<T>()` no `ConfigureLogDrain`
+    /// is dispatched and the slot stays at its default (`MailboxId(0)`,
+    /// drain disabled).
+    use bytemuck::{Pod, Zeroable};
+
+    #[repr(C)]
+    #[derive(
+        Copy, Clone, Debug, PartialEq, Eq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+    )]
+    #[kind(name = "aether.control.configure_log_drain")]
+    pub struct ConfigureLogDrain {
+        pub mailbox: aether_data::MailboxId,
+    }
+
     /// `aether.control.capture_frame` — request the substrate grab the
     /// current frame contents and reply-to-sender with an encoded
     /// PNG. Carries two optional bundles: `mails` dispatched *before*

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -358,6 +358,7 @@ impl DesktopChassis {
             .with_actor::<NetCapability>(net)
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(RenderConfig::default())
+            .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -234,6 +234,7 @@ impl HeadlessChassis {
             .with_actor::<LogCapability>(())
             .with_actor::<IoCapability>(namespace_roots)
             .with_actor::<NetCapability>(net)
+            .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()
     }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -276,6 +276,7 @@ impl TestBenchChassis {
                 .with_actor::<HandleCapability>(())
                 .with_actor::<LogCapability>(())
                 .with_actor::<RenderCapability>(render_config)
+                .with_log_drain::<LogCapability>()
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;
 

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -90,6 +90,7 @@ fn make_harness() -> Harness {
         input_subscribers: Arc::clone(&input_subscribers),
         default_name_counter: Arc::new(AtomicU64::new(0)),
         chassis_handler: None,
+        log_drain: Arc::new(std::sync::OnceLock::new()),
     };
 
     Harness {

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -338,6 +338,7 @@ impl<'a> SubstrateBootBuilder<'a> {
             input_subscribers: Arc::clone(&input_subscribers),
             default_name_counter: Arc::new(AtomicU64::new(0)),
             chassis_handler,
+            log_drain: Arc::new(std::sync::OnceLock::new()),
         };
         registry.register_sink(AETHER_CONTROL, control_plane.into_sink_handler());
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -281,6 +281,18 @@ pub struct ChassisCtx<'a> {
     /// [`ChassisBuilder::with_aborter`] /
     /// [`crate::chassis_builder::Builder::with_aborter`].
     aborter: &'a Arc<dyn FatalAborter>,
+    /// Issue #601: every actor-mailbox claim (`claim_mailbox_*`,
+    /// `claim_frame_bound_mailbox_*`, `claim_mailbox_drop_on_shutdown_*`)
+    /// appends its `MailboxId` here. The chassis builder reads the
+    /// list after `boot_passives` to dispatch
+    /// `aether.control.configure_log_drain` mail to each booted actor
+    /// so its `LogDrainSlot` resolves to the chassis's declared drain
+    /// (`Builder::with_log_drain<T>()`).
+    ///
+    /// Sink-only registrations (e.g. `AETHER_DIAGNOSTICS`) go through
+    /// `Registry::register_sink` directly and do *not* land here —
+    /// they're not actors and have no `LogDrainSlot` to install.
+    claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
 }
 
 impl<'a> ChassisCtx<'a> {
@@ -293,6 +305,7 @@ impl<'a> ChassisCtx<'a> {
         frame_bound_pending: &'a mut Vec<(MailboxId, Arc<AtomicU64>)>,
         frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
         aborter: &'a Arc<dyn FatalAborter>,
+        claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
     ) -> Self {
         Self {
             registry,
@@ -301,6 +314,7 @@ impl<'a> ChassisCtx<'a> {
             frame_bound_pending,
             frame_bound_set,
             aborter,
+            claimed_actor_mailboxes,
         }
     }
 
@@ -358,6 +372,7 @@ impl<'a> ChassisCtx<'a> {
                 },
             ),
         )?;
+        self.claimed_actor_mailboxes.push(id);
         Ok(MailboxClaim { id, receiver: rx })
     }
 
@@ -431,6 +446,7 @@ impl<'a> ChassisCtx<'a> {
                 },
             ),
         )?;
+        self.claimed_actor_mailboxes.push(id);
         Ok(DropOnShutdownClaim {
             id,
             receiver: rx,
@@ -519,6 +535,7 @@ impl<'a> ChassisCtx<'a> {
         // read-lock — without each transport having to scan the
         // pending-counter Vec on every check.
         self.frame_bound_set.write().unwrap().insert(id);
+        self.claimed_actor_mailboxes.push(id);
         Ok(FrameBoundClaim {
             id,
             receiver: rx,
@@ -1029,6 +1046,11 @@ impl ChassisBuilder {
         let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
         let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> =
             Arc::new(RwLock::new(HashSet::new()));
+        // Issue #601: legacy `ChassisBuilder` boot path doesn't carry a
+        // `log_drain` configuration (the new `chassis_builder::Builder`
+        // owns that surface). Track claims here for shape parity with
+        // the new path; the vec stays unused.
+        let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
         let mut booted: Vec<Box<dyn ActorErased>> = Vec::with_capacity(pending.len());
         for boot in pending {
             let mut ctx = ChassisCtx::new(
@@ -1038,6 +1060,7 @@ impl ChassisBuilder {
                 &mut frame_bound_pending,
                 &frame_bound_set,
                 &aborter,
+                &mut claimed_actor_mailboxes,
             );
             match boot(&mut ctx) {
                 Ok(actor) => booted.push(actor),
@@ -1054,10 +1077,15 @@ impl ChassisBuilder {
                 }
             }
         }
-        // Issue #581: legacy chassis-builder path also finalises
-        // the host-branch log dispatch. Same shape as the typed
-        // `Builder::build` path.
-        crate::log_install::install_log_target_if_registered(Arc::clone(&mailer), &registry);
+        // Issue #601 retired the host-branch dispatch shortcut. The
+        // legacy chassis-builder path used to wire a process-global
+        // egress here so out-of-actor `tracing::*` events surfaced
+        // in `engine_logs`; the new model is "log iff the emitter is
+        // an actor," so legacy callers either migrate to the
+        // `chassis_builder::Builder` path (which carries
+        // `with_log_drain<T>()` + per-actor `LogDrainSlot` through
+        // mail) or accept that out-of-actor events stay on stderr
+        // only. No install dance to run.
         Ok(BootedChassis {
             running: booted,
             _fallback: fallback,
@@ -1158,6 +1186,7 @@ impl BootedChassis {
     where
         C: Actor + Dispatch + Send + 'static,
     {
+        let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
         let mut ctx = ChassisCtx::new(
             registry,
             mailer,
@@ -1165,9 +1194,16 @@ impl BootedChassis {
             &mut self.frame_bound_pending,
             &self.frame_bound_set,
             &self.aborter,
+            &mut claimed_actor_mailboxes,
         );
         let handle = ctx.spawn_actor_dispatcher(cap)?;
         self.running.push(Box::new(handle));
+        // Issue #601: post-build `add` doesn't have access to a
+        // chassis-declared log_drain; runtime drain configuration via
+        // `ConfigureLogDrain` lands when the post-build dispatch path
+        // grows that surface. For now the claimed mailboxes are
+        // tracked-but-not-dispatched.
+        let _ = claimed_actor_mailboxes;
         Ok(())
     }
 
@@ -1186,6 +1222,7 @@ impl BootedChassis {
     where
         A: crate::NativeActor + crate::NativeDispatch,
     {
+        let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
         let mut ctx = ChassisCtx::new(
             registry,
             mailer,
@@ -1193,9 +1230,13 @@ impl BootedChassis {
             &mut self.frame_bound_pending,
             &self.frame_bound_set,
             &self.aborter,
+            &mut claimed_actor_mailboxes,
         );
         let erased = boot_native_actor::<A>(&mut ctx, config)?;
         self.running.push(erased);
+        // Same disposition as `add` above — runtime log-drain dispatch
+        // is a follow-up.
+        let _ = claimed_actor_mailboxes;
         Ok(())
     }
 

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -38,6 +38,9 @@ use crate::native_transport::NativeTransport;
 use crate::registry::Registry;
 use aether_actor::Actor;
 use aether_actor::Dispatch;
+use aether_actor::HandlesKind;
+use aether_data::mailbox_id_from_name;
+use aether_kinds::{ConfigureLogDrain, LogBatch};
 
 /// Failure mode raised by [`DriverRunning::run`].
 #[derive(Debug)]
@@ -472,6 +475,19 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     passives: Vec<PassiveBoot>,
     driver: Option<DriverBoot>,
     aborter: Arc<dyn FatalAborter>,
+    /// Issue #601: chassis-declared log-drain target. `None` until the
+    /// chassis calls [`Self::with_log_drain`]; on `build()` the
+    /// mailbox id is dispatched as `aether.control.configure_log_drain`
+    /// mail to every booted actor so each actor's `LogDrainSlot` is
+    /// installed. The same mail also goes to `aether.control` so the
+    /// [`crate::control::ControlPlane`]'s dispatch arm stores the
+    /// drain for the runtime `load_component` path — runtime-loaded
+    /// components receive `ConfigureLogDrain` themselves on
+    /// registration. The chassis Builder declares the drain; the
+    /// runtime state lives entirely in `ControlPlane` and per-actor
+    /// `LogDrainSlot`s, set the same way every actor's slot is set:
+    /// via mail.
+    log_drain: Option<MailboxId>,
     _chassis: PhantomData<fn() -> C>,
     _state: PhantomData<fn() -> S>,
 }
@@ -489,6 +505,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             passives: Vec::new(),
             driver: None,
             aborter: Arc::new(PanicAborter),
+            log_drain: None,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -554,6 +571,26 @@ impl<C: Chassis> Builder<C, NoDriver> {
         self
     }
 
+    /// Issue #601: declare the chassis-wide log drain target. `T` must
+    /// be a [`NativeActor`] that handles [`LogBatch`] (the cap's
+    /// mailbox id is derived from `T::NAMESPACE` at compile time).
+    /// On `build()` / `build_passive()` the chassis dispatches a
+    /// `aether.control.configure_log_drain` mail to every booted actor
+    /// so each actor's `LogDrainSlot` resolves to this mailbox; the
+    /// auto-emitted handler in `#[actor]` does the install.
+    ///
+    /// No call → `log_drain` stays `None`, no `ConfigureLogDrain`
+    /// dispatched, actors keep their default unset slot, and
+    /// `drain_buffer` is a silent no-op (chassis intentionally
+    /// skipping logging).
+    pub fn with_log_drain<T>(mut self) -> Self
+    where
+        T: NativeActor + HandlesKind<LogBatch>,
+    {
+        self.log_drain = Some(mailbox_id_from_name(T::NAMESPACE));
+        self
+    }
+
     /// Supply the chassis's driver. Transitions to [`HasDriver`] —
     /// further `.driver(_)` calls are forbidden by the type system.
     /// Per ADR-0071 the driver type is fixed by `C::Driver`, so the
@@ -567,6 +604,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             passives: self.passives,
             driver: self.driver,
             aborter: self.aborter,
+            log_drain: self.log_drain,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -577,13 +615,16 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// for driving the loop manually (TestBench).
     pub fn build_passive(self) -> Result<PassiveChassis<C>, BootError> {
         let booted = boot_passives(&self.registry, &self.mailer, &self.aborter, self.passives)?;
-        // Issue #581: finalise actor-aware logging by wiring the
-        // host-branch dispatch + log mailbox id once `LogCapability`
-        // has claimed `"aether.log"`. No-op if the chassis skipped
-        // the cap.
-        crate::log_install::install_log_target_if_registered(
-            Arc::clone(&self.mailer),
+        // Issue #601: push `ConfigureLogDrain` to every booted actor
+        // and to `aether.control` so every per-actor `LogDrainSlot`
+        // (auto-emitted handler) plus the `ControlPlane`'s drain slot
+        // (for the runtime load path) resolve to the chassis-declared
+        // target. No-op if the chassis didn't call `with_log_drain`.
+        dispatch_configure_log_drain(
             &self.registry,
+            &self.mailer,
+            &booted.claimed_actor_mailboxes,
+            self.log_drain,
         );
         Ok(PassiveChassis {
             booted,
@@ -622,6 +663,16 @@ impl<C: Chassis> Builder<C, HasDriver> {
         self
     }
 
+    /// Mirror of [`Builder::with_log_drain`][Builder<C, NoDriver>::with_log_drain]
+    /// for the post-driver state. Issue #601.
+    pub fn with_log_drain<T>(mut self) -> Self
+    where
+        T: NativeActor + HandlesKind<LogBatch>,
+    {
+        self.log_drain = Some(mailbox_id_from_name(T::NAMESPACE));
+        self
+    }
+
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via
@@ -638,10 +689,16 @@ impl<C: Chassis> Builder<C, HasDriver> {
         let driver_boot = driver.expect("HasDriver state implies driver was supplied");
 
         let mut booted = boot_passives(&registry, &mailer, &aborter, passives)?;
-        // Issue #581: finalise actor-aware logging once passives
-        // have booted. Lookups `"aether.log"`; no-op if the cap
-        // wasn't registered (chassis intentionally skipping logging).
-        crate::log_install::install_log_target_if_registered(Arc::clone(&mailer), &registry);
+        // Issue #601: push `ConfigureLogDrain` to every booted actor
+        // and to `aether.control` so the runtime load path picks up
+        // the chassis-declared drain through the same mail every
+        // actor receives.
+        dispatch_configure_log_drain(
+            &registry,
+            &mailer,
+            &booted.claimed_actor_mailboxes,
+            self.log_drain,
+        );
         let driver_running = {
             let chassis_ctx = ChassisCtx::new(
                 &registry,
@@ -650,6 +707,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
                 &mut booted.frame_bound_pending,
                 &booted.frame_bound_set,
                 &booted.aborter,
+                &mut booted.claimed_actor_mailboxes,
             );
             let mut driver_ctx = DriverCtx::new(chassis_ctx, &booted.actors);
             driver_boot(&mut driver_ctx)?
@@ -691,6 +749,53 @@ struct BootedPassives {
     /// guard has somewhere to abort to. Inherited from the
     /// [`Builder`]'s configured aborter.
     aborter: Arc<dyn FatalAborter>,
+    /// Issue #601: every actor mailbox claimed during passive boot.
+    /// `Builder::build` / `build_passive` reads this list to dispatch
+    /// `ConfigureLogDrain` mail to each actor before the driver runs,
+    /// installing every actor's `LogDrainSlot` to the chassis-declared
+    /// drain.
+    claimed_actor_mailboxes: Vec<MailboxId>,
+}
+
+/// Issue #601: dispatch a `ConfigureLogDrain { mailbox: drain }` mail
+/// to every actor whose mailbox was claimed during boot, plus the
+/// well-known `aether.control` sink so the substrate's
+/// [`crate::control::ControlPlane`] can record the drain for the
+/// runtime `load_component` path. Called by `Builder::build` /
+/// `build_passive` after `boot_passives` returns. No-op if `drain` is
+/// `None` (chassis didn't declare a log target).
+///
+/// Sends through the same `Mailer` every other mail uses — every
+/// actor mailbox routes the envelope to the auto-emitted
+/// `ConfigureLogDrain` arm in `#[handlers]`, which installs the
+/// per-actor `LogDrainSlot`. `aether.control` routes through the
+/// `ControlPlane`'s explicit `ConfigureLogDrain` arm, which writes
+/// its own drain slot for `handle_load` to read.
+fn dispatch_configure_log_drain(
+    registry: &Arc<Registry>,
+    mailer: &Arc<Mailer>,
+    targets: &[MailboxId],
+    drain: Option<MailboxId>,
+) {
+    let Some(drain) = drain else {
+        return;
+    };
+    let kind = <ConfigureLogDrain as aether_data::Kind>::ID;
+    let mut recipients: Vec<MailboxId> = targets.to_vec();
+    // `aether.control` is registered by `SubstrateBoot::build` (a
+    // sink, not an actor claim), so it won't appear in the
+    // boot-tracked `claimed_actor_mailboxes` list. Look it up here so
+    // the runtime load path picks up the chassis-declared drain via
+    // the same mail flow every other recipient gets.
+    if let Some(control_id) = registry.lookup(crate::control::AETHER_CONTROL) {
+        recipients.push(control_id);
+    }
+    for target in recipients {
+        let cfg = ConfigureLogDrain { mailbox: drain };
+        let payload = bytemuck::bytes_of(&cfg).to_vec();
+        let mail = crate::mail::Mail::new(target, kind, payload, 1);
+        mailer.push(mail);
+    }
 }
 
 impl BootedPassives {
@@ -718,6 +823,7 @@ fn boot_passives(
     let mut actors = Actors::new();
     let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
     let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
+    let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
     for boot in passives {
         let mut ctx = ChassisCtx::new(
             registry,
@@ -726,6 +832,7 @@ fn boot_passives(
             &mut frame_bound_pending,
             &frame_bound_set,
             aborter,
+            &mut claimed_actor_mailboxes,
         );
         match boot(&mut ctx, &mut actors) {
             Ok(shutdown) => shutdowns.push(shutdown),
@@ -744,6 +851,7 @@ fn boot_passives(
         frame_bound_pending,
         frame_bound_set,
         aborter: Arc::clone(aborter),
+        claimed_actor_mailboxes,
     })
 }
 

--- a/crates/aether-substrate/src/control/mod.rs
+++ b/crates/aether-substrate/src/control/mod.rs
@@ -29,8 +29,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use aether_data::KindDescriptor;
 use aether_data::{Kind, KindId};
 use aether_kinds::{
-    ComponentCapabilities, DropComponent, DropResult, LoadComponent, LoadResult, MailEnvelope,
-    ReplaceComponent, ReplaceResult, SubscribeInput, SubscribeInputResult, UnsubscribeInput,
+    ComponentCapabilities, ConfigureLogDrain, DropComponent, DropResult, LoadComponent, LoadResult,
+    MailEnvelope, ReplaceComponent, ReplaceResult, SubscribeInput, SubscribeInputResult,
+    UnsubscribeInput,
 };
 use wasmtime::{Engine, Linker, Module};
 
@@ -194,6 +195,14 @@ pub struct ControlPlane {
     /// drop-warn log — fine for tests and the hub chassis that
     /// inherits nothing peripheral.
     pub chassis_handler: Option<ChassisControlHandler>,
+    /// Issue #601: chassis-declared log drain target. Shared with
+    /// [`crate::SubstrateBoot::log_drain`]; the chassis Builder writes
+    /// it via `with_log_drain<T>()` when the cap chain finishes
+    /// booting. `handle_load` reads it to decide whether to push
+    /// `ConfigureLogDrain` to a freshly-loaded component. `None`
+    /// means the chassis declared no drain — runtime-loaded
+    /// components stay drainless, matching boot-time behaviour.
+    pub log_drain: Arc<std::sync::OnceLock<MailboxId>>,
 }
 
 /// Closure contract for a chassis-registered control-plane handler.
@@ -246,6 +255,18 @@ impl ControlPlane {
             UnsubscribeInput::ID => {
                 let result = self.handle_unsubscribe(bytes);
                 self.outbound.send_reply(sender, &result);
+            }
+            ConfigureLogDrain::ID => {
+                // Issue #601: chassis dispatches this at boot so the
+                // runtime `load_component` path picks up the chassis-
+                // declared drain through the same mail flow every
+                // actor receives. Cast-shape decode; `OnceLock::set`
+                // is a no-op on subsequent calls so a hypothetical
+                // re-dispatch (e.g. future per-chassis-restart) is
+                // tolerated as "first wins" rather than panicking.
+                if let Ok(cfg) = bytemuck::try_pod_read_unaligned::<ConfigureLogDrain>(bytes) {
+                    let _ = self.log_drain.set(cfg.mailbox);
+                }
             }
             _ => {
                 if let Some(handler) = &self.chassis_handler {
@@ -392,6 +413,23 @@ impl ControlPlane {
 
         self.insert_component(mailbox, component);
         self.announce_kinds();
+
+        // Issue #601: dispatch the chassis-declared log drain to the
+        // freshly-registered component so its `LogDrainSlot` resolves
+        // to the same target boot-time actors received. Reads from
+        // the chassis-owned slot (`SubstrateBoot::log_drain`) — `None`
+        // if the chassis didn't declare a drain via
+        // `Builder::with_log_drain<T>()`, in which case runtime-loaded
+        // components stay drainless like every other actor on a
+        // drainless chassis. No process-globals; the slot is owned
+        // by `SubstrateBoot` and shared via `Arc`.
+        if let Some(drain) = self.log_drain.get().copied() {
+            let cfg = aether_kinds::ConfigureLogDrain { mailbox: drain };
+            let payload = bytemuck::bytes_of(&cfg).to_vec();
+            let kind = <aether_kinds::ConfigureLogDrain as aether_data::Kind>::ID;
+            self.queue
+                .push(crate::mail::Mail::new(mailbox, kind, payload, 1));
+        }
 
         LoadResult::Ok {
             mailbox_id: mailbox,

--- a/crates/aether-substrate/src/control/tests.rs
+++ b/crates/aether-substrate/src/control/tests.rs
@@ -150,6 +150,7 @@ fn make_plane() -> ControlPlane {
         input_subscribers: input::new_subscribers(),
         default_name_counter: Arc::new(AtomicU64::new(0)),
         chassis_handler: None,
+        log_drain: Arc::new(std::sync::OnceLock::new()),
     }
 }
 

--- a/crates/aether-substrate/src/log_install.rs
+++ b/crates/aether-substrate/src/log_install.rs
@@ -1,28 +1,22 @@
-//! Issue #581 substrate-side install for the actor-aware logging
-//! path. Replaces ADR-0023's `log_capture` module: the ring + flush
-//! thread + sync `flush_now` retired; the cap is the egress owner
-//! now.
+//! Issue #601 substrate-side install for the actor-aware logging
+//! path. The host branch retired alongside `PROCESS` /
+//! `install_log_target` / `ship_host_event` from `aether-actor::log`:
+//! `tracing::*` events emitted outside any actor stamp (substrate
+//! boot, scheduler thread, panic hook) hit stderr via the registered
+//! fmt::Layer for operator visibility but do not enter the mail
+//! system. Until those code paths run as actors, their events stay
+//! out of `engine_logs`. The chassis-pushed `ConfigureLogDrain` mail
+//! and per-actor [`aether_actor::log::LogDrainSlot`] handle every
+//! actor-bound case.
 //!
-//! Two entry points:
-//!   - [`init_subscriber`] — called from `SubstrateBoot::build`
-//!     before any cap boots. Installs `EnvFilter` +
-//!     `tsfmt::Layer` + [`ActorAwareLayer`] as `tracing`'s global
-//!     default. With no log target registered yet, the
-//!     [`ActorAwareLayer`] drops the mail-egress half of host-branch
-//!     events; `tsfmt::Layer` keeps stderr live so operators don't
-//!     lose early-boot diagnostics.
-//!   - [`install_log_target_if_registered`] — called from
-//!     [`crate::chassis_builder::Builder::build`] after the cap
-//!     chain has booted. Looks up the well-known `"aether.log"`
-//!     mailbox; if present, registers the [`MailerHostDispatch`]
-//!     so the host branch starts shipping single-entry batches to
-//!     the cap.
-
-use std::sync::Arc;
+//! Single entry point:
+//!   - [`init_subscriber`] — called from `SubstrateBoot::build`.
+//!     Installs `EnvFilter` + `tsfmt::Layer` + [`ActorAwareLayer`]
+//!     as `tracing`'s global default. Idempotent (later calls
+//!     no-op via `try_init`).
 
 use aether_actor::Local;
-use aether_actor::log::{LogBuffer, MailDispatch, drain_buffer, encode_event, ship_host_event};
-use aether_data::{KindId, MailboxId};
+use aether_actor::log::{LogBuffer, drain_buffer, encode_event};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::{Context, SubscriberExt};
@@ -30,15 +24,15 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, fmt as tsfmt};
 
-use crate::mail::Mail;
-use crate::mailer::Mailer;
-use crate::registry::Registry;
-
-/// Tracing layer that splits events between the in-actor and host
-/// paths. In-actor: push the event into the per-actor [`LogBuffer`];
-/// priority-flush at `WARN`/`ERROR`. Host code (no actor stamped):
-/// ship a single-entry batch through `aether-actor::log`'s
-/// registered host dispatch.
+/// Tracing layer that routes in-actor events into the per-actor
+/// [`LogBuffer`] for the chassis-installed drain to ship as
+/// [`aether_kinds::LogBatch`] mail. Out-of-actor events drop here —
+/// stderr fmt::Layer, registered alongside in [`init_subscriber`],
+/// keeps them visible to operators. Issue #601 retired the
+/// host-branch shortcut that previously routed out-of-actor events
+/// through a process-global egress; the actor model's invariant is
+/// that engine logic eventually runs as an actor, and code that
+/// hasn't been migrated yet stays out of `engine_logs`.
 pub struct ActorAwareLayer;
 
 impl<S> Layer<S> for ActorAwareLayer
@@ -46,41 +40,22 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        // Re-entry guard: events emitted from inside
-        // `drain_buffer` / `ship_host_event` (e.g. the
-        // `capability mailbox sender dropped` warn fired during
-        // shutdown) would otherwise loop the pipeline. Stderr fmt
-        // still receives the event via the registered fmt::Layer.
+        // Re-entry guard: events emitted from inside `drain_buffer`
+        // (e.g. the `capability mailbox sender dropped` warn fired
+        // during shutdown) would otherwise loop the pipeline. Stderr
+        // fmt still receives the event via the registered fmt::Layer.
         if aether_actor::log::is_in_pipeline() {
             return;
         }
         let entry = encode_event(event);
         let level = entry.level;
-        let entry_for_host = entry.clone();
-        let buffered = LogBuffer::try_with_mut(|b| b.0.push(entry)).is_some();
-        if buffered {
-            if level >= 3 {
-                drain_buffer();
-            }
-        } else {
-            ship_host_event(entry_for_host);
+        // `try_with_mut` returns `Some` only when the chassis
+        // dispatcher has stamped an actor's slots (in-actor branch).
+        // Out-of-actor events drop here and leave `engine_logs`
+        // unchanged.
+        if LogBuffer::try_with_mut(|b| b.0.push(entry)).is_some() && level >= 3 {
+            drain_buffer();
         }
-    }
-}
-
-/// `MailDispatch` impl that routes a single host-branch `LogBatch`
-/// mail through the substrate's process-global `Mailer`. Lives behind
-/// `aether-actor::log`'s registered host slot; reached when
-/// [`ActorAwareLayer`] sees a `tracing::*` event outside any actor's
-/// dispatch.
-pub(crate) struct MailerHostDispatch {
-    mailer: Arc<Mailer>,
-}
-
-impl MailDispatch for MailerHostDispatch {
-    fn send(&self, mailbox: MailboxId, kind: KindId, payload: &[u8]) {
-        let mail = Mail::new(mailbox, kind, payload.to_vec(), 1);
-        self.mailer.push(mail);
     }
 }
 
@@ -88,8 +63,8 @@ const FILTER_ENV: &str = "AETHER_LOG_FILTER";
 
 /// Install the tracing subscriber stack: `EnvFilter` (reads
 /// `AETHER_LOG_FILTER`, default `info`) + `tsfmt::Layer` to stderr +
-/// [`ActorAwareLayer`]. Called from `SubstrateBoot::build` before
-/// any cap is booted; idempotent (later calls no-op via `try_init`).
+/// [`ActorAwareLayer`]. Called from `SubstrateBoot::build`;
+/// idempotent (later calls no-op via `try_init`).
 pub fn init_subscriber() {
     let filter = EnvFilter::try_from_env(FILTER_ENV).unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::registry()
@@ -97,21 +72,4 @@ pub fn init_subscriber() {
         .with(tsfmt::layer().with_writer(std::io::stderr))
         .with(ActorAwareLayer)
         .try_init();
-}
-
-/// Wire `aether-actor::log`'s host-branch dispatch + log mailbox id.
-/// Called after `Builder::build` has booted every cap. Looks up
-/// `"aether.log"` in the registry; if `LogCapability` registered it,
-/// installs a [`MailerHostDispatch`] over the substrate's `Mailer`.
-/// No-op if the mailbox isn't claimed (chassis that intentionally
-/// skip `LogCapability`).
-///
-/// Idempotent — `aether-actor::log::install_log_target` itself
-/// honours "first call wins."
-pub fn install_log_target_if_registered(mailer: Arc<Mailer>, registry: &Registry) {
-    let Some(log_mailbox) = registry.lookup("aether.log") else {
-        return;
-    };
-    let dispatch: &'static dyn MailDispatch = Box::leak(Box::new(MailerHostDispatch { mailer }));
-    aether_actor::log::install_log_target(dispatch, log_mailbox);
 }


### PR DESCRIPTION
<!-- pr-body-ok: b — bare crate refs, ADR refs, sibling issue refs intentional -->

## Summary

- **Retires `aether-actor::log::PROCESS`** (the process-global host-egress cell) and the install machinery around it (`install_log_target`, `registered_log_mailbox`, `ship_host_event`, `MailerHostDispatch`, `install_log_target_if_registered`).
- **Per-actor `LogDrainSlot`** populated via a chassis-pushed `aether.control.configure_log_drain` mail. The `#[actor]` / `#[handlers]` derive auto-emits the handler that installs the slot; user code never names it.
- **Chassis Builder declares the target** via `with_log_drain<T: NativeActor + HandlesKind<LogBatch>>()` — `T::NAMESPACE` derives the mailbox id at compile time, no hardcoded strings.
- **`ControlPlane` learns the drain by mail** like any actor (handles `ConfigureLogDrain::ID` in its dispatch); `handle_load` reads the stored value to push `ConfigureLogDrain` to runtime-loaded components on registration.
- **Wasm handler-exit drain hook** (#598): `init` / `receive_p32` / `on_replace` / `on_drop` / `on_rehydrate_p32` shims call `drain_buffer()` at exit so INFO-level guest events flush at handler boundaries instead of waiting for a WARN priority flush.
- **`ActorAwareLayer`'s host branch retires.** Out-of-actor `tracing::*` events (substrate boot, scheduler thread, panic hook) still hit stderr via the registered fmt::Layer but no longer enter the mail system. Trajectory: every piece of engine logic eventually runs as an actor; code that hasn't migrated yet stays out of `engine_logs`.

## Test plan

- [x] `cargo build --workspace --tests`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test -p aether-substrate --lib` (192 passed)
- [x] `cargo test -p aether-substrate-bundle --lib` (87 passed)
- [x] `cargo test -p aether-actor-derive` (4 passed)
- [x] `cargo test -p aether-kinds` (38 passed)
- [x] **MCP smoke**: spawn headless substrate, load `aether-mesh-viewer` wasm guest, send `aether.mesh.load` against a missing path. Observed `info` ("load requested; issuing read") and `warn` ("read failed; keeping prior mesh") from `aether_mesh_viewer` (the wasm guest) both appear in `engine_logs`. Substrate-internal `boot` / `frame_loop` events stay on stderr only — confirms host branch retirement.
- [x] Wasm cdylib builds via `cargo build --target wasm32-unknown-unknown --example hello -p aether-actor`.

## Out of scope (followup)

- Per-actor opt-in/override (e.g. `#[log(CustomCap)]` for actors that want a non-default drain). The `LogDrainSlot` mechanism supports it; lands when a real use case appears.
- Migrating substrate-internal code paths (boot init, frame_loop, scheduler, panic hook) to run as actors so their tracing events surface in `engine_logs` again. Tracked as a trajectory; this PR accepts that they live on stderr only until then.

---

Implements #601.
Closes #597.
Closes #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)