### PR TITLE
refactor(driver): driver-as-actor for aether.window; rename window kinds (issue 603)

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -35,6 +35,7 @@ pub mod log;
 pub mod net;
 #[cfg(feature = "render")]
 pub mod render;
+pub mod window;
 
 #[cfg(feature = "audio")]
 pub use audio::AudioCapability;
@@ -60,3 +61,4 @@ pub use render::HeadlessRenderCapability;
 pub use render::RenderCapability;
 #[cfg(feature = "render-native")]
 pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+pub use window::HeadlessWindowCapability;

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -1,0 +1,81 @@
+//! `aether.window` cap surface (issue 603 Phase 3).
+//!
+//! On desktop the chassis driver claims `aether.window` directly and
+//! drains the inbox between frames — window mutations require the
+//! chassis main thread (winit / macOS), and the driver is already
+//! there. The driver-as-actor path lives in
+//! `crate::desktop::driver`; this module hosts the chassis-without-window
+//! companion that headless and test-bench compose to fail-fast with
+//! `Err`-replies on `set_mode` / `set_title`.
+
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
+use aether_kinds::{SetWindowMode, SetWindowTitle};
+
+#[aether_actor::bridge]
+mod native {
+    use std::sync::Arc;
+
+    use aether_actor::actor;
+    use aether_kinds::{SetWindowModeResult, SetWindowTitleResult};
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::outbound::HubOutbound;
+
+    use super::{SetWindowMode, SetWindowTitle};
+
+    /// Chassis-without-window companion to the desktop driver's
+    /// driver-as-actor `aether.window` claim. Mirrors
+    /// [`crate::HeadlessRenderCapability`]: same mailbox the desktop
+    /// owner claims, `Err`-replying handlers so MCP `set_window_mode`
+    /// / `set_window_title` fail fast on chassis without a window
+    /// (headless and test-bench).
+    ///
+    /// Each chassis composes one of {desktop driver, this cap}, never
+    /// both — the chassis builder rejects double-claiming a mailbox.
+    pub struct HeadlessWindowCapability {
+        outbound: Arc<HubOutbound>,
+    }
+
+    #[actor]
+    impl NativeActor for HeadlessWindowCapability {
+        type Config = ();
+
+        const NAMESPACE: &'static str = "aether.window";
+
+        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
+                BootError::Other(Box::new(std::io::Error::other(
+                    "HubOutbound must be wired on Mailer before \
+                     HeadlessWindowCapability::init (chassis main connects the hub before \
+                     the Builder chain)",
+                )))
+            })?;
+            Ok(Self { outbound })
+        }
+
+        /// Reply `Err` so MCP `set_window_mode` fails fast instead of
+        /// hanging on a reply that never comes.
+        #[handler]
+        fn on_set_mode(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowMode) {
+            self.outbound.send_reply(
+                ctx.reply_target(),
+                &SetWindowModeResult::Err {
+                    error: "unsupported on this chassis — no window peripheral".to_owned(),
+                },
+            );
+        }
+
+        /// Reply `Err` for the same reason as `on_set_mode`.
+        #[handler]
+        fn on_set_title(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowTitle) {
+            self.outbound.send_reply(
+                ctx.reply_target(),
+                &SetWindowTitleResult::Err {
+                    error: "unsupported on this chassis — no window peripheral".to_owned(),
+                },
+            );
+        }
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -845,7 +845,7 @@ mod control_plane {
         },
     }
 
-    /// `aether.control.set_window_mode` — switch the substrate's
+    /// `aether.window.set_mode` — switch the substrate's
     /// window presentation mode. `width` / `height` apply only when
     /// `mode == Windowed`; fullscreen modes size themselves from the
     /// monitor / requested video mode. Reply carries the new state
@@ -857,7 +857,7 @@ mod control_plane {
     /// height, refresh_mhz)` triple exactly. Use `platform_info`
     /// first to enumerate supported modes.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.control.set_window_mode")]
+    #[kind(name = "aether.window.set_mode")]
     pub struct SetWindowMode {
         pub mode: WindowMode,
         pub width: Option<u32>,
@@ -869,7 +869,7 @@ mod control_plane {
     /// request was rejected (unknown video mode, window not ready,
     /// etc.) with no state change.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.control.set_window_mode_result")]
+    #[kind(name = "aether.window.set_mode_result")]
     pub enum SetWindowModeResult {
         Ok {
             mode: WindowMode,
@@ -881,7 +881,7 @@ mod control_plane {
         },
     }
 
-    /// `aether.control.set_window_title` — update the substrate
+    /// `aether.window.set_title` — update the substrate
     /// window's title at runtime. `winit::Window::set_title` is
     /// infallible on every supported platform, so the desktop reply
     /// always echoes the applied title back on `Ok`. Headless and hub
@@ -889,7 +889,7 @@ mod control_plane {
     /// Boot-time default comes from `AETHER_WINDOW_TITLE`; unset falls
     /// back to the substrate's name.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.control.set_window_title")]
+    #[kind(name = "aether.window.set_title")]
     pub struct SetWindowTitle {
         pub title: String,
     }
@@ -900,7 +900,7 @@ mod control_plane {
     /// chassis that don't own a window (headless, hub) or for a
     /// pre-window-ready request.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.control.set_window_title_result")]
+    #[kind(name = "aether.window.set_title_result")]
     pub enum SetWindowTitleResult {
         Ok { title: String },
         Err { error: String },
@@ -1573,16 +1573,10 @@ mod tests {
             PlatformInfoResult::NAME,
             "aether.control.platform_info_result"
         );
-        assert_eq!(SetWindowMode::NAME, "aether.control.set_window_mode");
-        assert_eq!(
-            SetWindowModeResult::NAME,
-            "aether.control.set_window_mode_result"
-        );
-        assert_eq!(SetWindowTitle::NAME, "aether.control.set_window_title");
-        assert_eq!(
-            SetWindowTitleResult::NAME,
-            "aether.control.set_window_title_result"
-        );
+        assert_eq!(SetWindowMode::NAME, "aether.window.set_mode");
+        assert_eq!(SetWindowModeResult::NAME, "aether.window.set_mode_result");
+        assert_eq!(SetWindowTitle::NAME, "aether.window.set_title");
+        assert_eq!(SetWindowTitleResult::NAME, "aether.window.set_title_result");
         assert_eq!(Camera::NAME, "aether.camera");
         // ADR-0066: aether.camera.{create,destroy,set_active,set_mode,
         // orbit.set,topdown.set} kind-name asserts live in

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -22,13 +22,9 @@ use aether_capabilities::{
     io::NamespaceRoots, net::NetConfig as NetConf,
 };
 use aether_data::Kind;
-use aether_kinds::{
-    Advance, PlatformInfo, SetWindowMode, SetWindowModeResult, SetWindowTitle,
-    SetWindowTitleResult, WindowMode,
-};
+use aether_kinds::{Advance, PlatformInfo, WindowMode};
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
-use aether_substrate::control_helpers::decode_payload;
 use aether_substrate::{
     Chassis, HubOutbound, ReplyTo, SubstrateBoot,
     capture::{CaptureQueue, reply_unsupported_advance},
@@ -39,8 +35,12 @@ use super::driver::{DesktopDriverCapability, WORKERS, parse_window_mode_env};
 
 /// Event the event-loop thread consumes from the desktop chassis.
 /// Either a chassis-originated request for work that needs winit/wgpu
-/// context (platform info, window mode, capture) or a wake-up so the
-/// loop picks up a queued capture on the next redraw.
+/// context (platform info, capture) or a wake-up so the loop picks up
+/// a queued capture on the next redraw.
+///
+/// `aether.window.set_mode` / `aether.window.set_title` (issue 603
+/// Phase 3) don't ride this enum any more — the desktop driver claims
+/// `aether.window` directly and drains the inbox in `about_to_wait`.
 #[derive(Debug, Clone)]
 pub enum UserEvent {
     /// A capture was just enqueued on `CaptureQueue`; wake the loop
@@ -50,110 +50,45 @@ pub enum UserEvent {
     /// An MCP session asked for a `platform_info` snapshot. The
     /// event-loop thread snapshots + replies via outbound.
     PlatformInfo { reply_to: ReplyTo },
-    /// An MCP session asked to switch the window mode. The event
-    /// loop resolves fullscreen modes against the current monitor,
-    /// applies the change, and replies with the new state.
-    SetWindowMode {
-        reply_to: ReplyTo,
-        mode: WindowMode,
-        width: Option<u32>,
-        height: Option<u32>,
-    },
-    /// An MCP session asked to update the window title. The event
-    /// loop calls `Window::set_title` and echoes the applied title
-    /// back on the reply. A missing window (before `resumed`) replies
-    /// with an `Err`.
-    SetWindowTitle { reply_to: ReplyTo, title: String },
 }
 
 /// Build the `ChassisControlHandler` closure desktop installs on
-/// `ControlPlane::chassis_handler`. Captures the handles each
-/// chassis-specific kind needs: the event-loop proxy for hand-off to
-/// winit/wgpu context; the capture queue for render-thread handoff;
-/// the registry + queue for capture_frame's mail-bundle orchestration;
-/// the outbound handle for inline error replies.
+/// `ControlPlane::chassis_handler`. Today only `platform_info` and
+/// `advance` ride here — `set_window_mode` / `set_window_title` moved
+/// to the driver-as-actor `aether.window` mailbox in issue 603 Phase 3,
+/// `capture_frame` to `RenderCapability` in Phase 2, and Phase 4 will
+/// retire `platform_info` and the closure itself.
 pub fn chassis_control_handler(
     proxy: EventLoopProxy<UserEvent>,
     outbound: Arc<HubOutbound>,
 ) -> ChassisControlHandler {
     Arc::new(
-        move |kind: aether_data::KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| match kind
-        {
-            PlatformInfo::ID => {
-                // Empty payload; forward the sender straight to the
-                // event loop and let it snapshot + reply on its own
-                // thread (winit monitor / scale-factor APIs require it).
-                let _ = proxy.send_event(UserEvent::PlatformInfo { reply_to: sender });
-            }
-            SetWindowMode::ID => {
-                handle_set_window_mode(&proxy, &outbound, sender, bytes);
-            }
-            SetWindowTitle::ID => {
-                handle_set_window_title(&proxy, &outbound, sender, bytes);
-            }
-            Advance::ID => {
-                reply_unsupported_advance(
-                    &outbound,
-                    sender,
-                    "unsupported on desktop chassis — aether.test_bench.advance is \
-                     test-bench-only (ADR-0067)",
-                );
-            }
-            _ => {
-                tracing::warn!(
-                    target: "aether_substrate::chassis",
-                    kind = %kind_name,
-                    "desktop chassis has no handler for control kind — dropping",
-                );
+        move |kind: aether_data::KindId, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| {
+            match kind {
+                PlatformInfo::ID => {
+                    // Empty payload; forward the sender straight to the
+                    // event loop and let it snapshot + reply on its own
+                    // thread (winit monitor / scale-factor APIs require it).
+                    let _ = proxy.send_event(UserEvent::PlatformInfo { reply_to: sender });
+                }
+                Advance::ID => {
+                    reply_unsupported_advance(
+                        &outbound,
+                        sender,
+                        "unsupported on desktop chassis — aether.test_bench.advance is \
+                         test-bench-only (ADR-0067)",
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        target: "aether_substrate::chassis",
+                        kind = %kind_name,
+                        "desktop chassis has no handler for control kind — dropping",
+                    );
+                }
             }
         },
     )
-}
-
-/// Decode + forward to the event loop. Applying the mode requires
-/// winit APIs that only live on the main thread, so this handler
-/// doesn't reply inline on the happy path — the event loop does.
-fn handle_set_window_mode(
-    proxy: &EventLoopProxy<UserEvent>,
-    outbound: &HubOutbound,
-    sender: ReplyTo,
-    bytes: &[u8],
-) {
-    let payload: SetWindowMode = match decode_payload(bytes) {
-        Ok(p) => p,
-        Err(error) => {
-            outbound.send_reply(sender, &SetWindowModeResult::Err { error });
-            return;
-        }
-    };
-    let _ = proxy.send_event(UserEvent::SetWindowMode {
-        reply_to: sender,
-        mode: payload.mode,
-        width: payload.width,
-        height: payload.height,
-    });
-}
-
-/// Decode + forward to the event loop. `Window::set_title` needs to
-/// run on the main thread on every winit platform, so the same
-/// event-loop proxy hand-off `set_window_mode` uses.
-fn handle_set_window_title(
-    proxy: &EventLoopProxy<UserEvent>,
-    outbound: &HubOutbound,
-    sender: ReplyTo,
-    bytes: &[u8],
-) {
-    let payload: SetWindowTitle = match decode_payload(bytes) {
-        Ok(p) => p,
-        Err(error) => {
-            outbound.send_reply(sender, &SetWindowTitleResult::Err { error });
-            return;
-        }
-    };
-    let _ = proxy.send_event(UserEvent::SetWindowTitle {
-        reply_to: sender,
-        title: payload.title,
-    });
 }
 
 /// Marker type for the desktop chassis. Carries no fields — the

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -26,11 +26,11 @@ use aether_data::Kind;
 use aether_data::{encode, encode_empty};
 use aether_kinds::{
     CaptureFrameResult, EngineInfo, FrameStats, GpuBackend, GpuDeviceType, GpuInfo, Key,
-    KeyRelease, MonitorInfo, MouseButton, MouseMove, OsInfo, PlatformInfoResult,
-    SetWindowModeResult, SetWindowTitleResult, Tick, VideoMode, WindowInfo, WindowMode, WindowSize,
-    keycode,
+    KeyRelease, MonitorInfo, MouseButton, MouseMove, OsInfo, PlatformInfoResult, SetWindowMode,
+    SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, Tick, VideoMode, WindowInfo,
+    WindowMode, WindowSize, keycode,
 };
-use aether_substrate::capability::BootError;
+use aether_substrate::capability::{BootError, Envelope};
 use aether_substrate::chassis_builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, SubstrateBoot, frame_loop,
@@ -115,6 +115,19 @@ pub struct App {
     /// and read by `platform_info`'s window-state field. Starts as
     /// `boot_mode`.
     current_mode: WindowMode,
+    /// `aether.window` inbox claimed via `DriverCtx::claim_mailbox`
+    /// at boot (issue 603 Phase 3). The driver is the cap — drained
+    /// inside [`ApplicationHandler::about_to_wait`] between frames to
+    /// apply `SetWindowMode` / `SetWindowTitle` inline on the chassis
+    /// main thread (winit / macOS require window mutations there). No
+    /// dispatcher thread, no `EventLoopProxy` bounce; the receiver
+    /// is the wake. Under `ControlFlow::Wait` (set when the window
+    /// occludes) `about_to_wait` only fires after a winit event, so
+    /// window-kind mail can stall briefly until the user nudges the
+    /// window — accepted limitation for v1.
+    window_inbox: std::sync::mpsc::Receiver<Envelope>,
+    kind_set_window_mode: aether_data::KindId,
+    kind_set_window_title: aether_data::KindId,
 }
 
 /// Translate a winit `KeyCode` into the engine's stable named-key u32
@@ -447,6 +460,60 @@ impl App {
         SetWindowTitleResult::Ok { title }
     }
 
+    /// Drain the `aether.window` inbox without blocking. Called from
+    /// `about_to_wait` (per-frame cadence). Each envelope dispatches
+    /// inline against `kind_set_window_mode` / `kind_set_window_title`;
+    /// any other kind warns and drops.
+    fn drain_window_inbox(&mut self) {
+        use std::sync::mpsc::TryRecvError;
+        loop {
+            match self.window_inbox.try_recv() {
+                Ok(env) => self.dispatch_window_envelope(env),
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => return,
+            }
+        }
+    }
+
+    fn dispatch_window_envelope(&mut self, env: Envelope) {
+        if env.kind == self.kind_set_window_mode {
+            let payload: SetWindowMode = match postcard::from_bytes(&env.payload) {
+                Ok(p) => p,
+                Err(e) => {
+                    self.outbound.send_reply(
+                        env.sender,
+                        &SetWindowModeResult::Err {
+                            error: format!("postcard decode failed: {e}"),
+                        },
+                    );
+                    return;
+                }
+            };
+            let result = self.apply_window_mode(payload.mode, payload.width, payload.height);
+            self.outbound.send_reply(env.sender, &result);
+        } else if env.kind == self.kind_set_window_title {
+            let payload: SetWindowTitle = match postcard::from_bytes(&env.payload) {
+                Ok(p) => p,
+                Err(e) => {
+                    self.outbound.send_reply(
+                        env.sender,
+                        &SetWindowTitleResult::Err {
+                            error: format!("postcard decode failed: {e}"),
+                        },
+                    );
+                    return;
+                }
+            };
+            let result = self.apply_window_title(payload.title);
+            self.outbound.send_reply(env.sender, &result);
+        } else {
+            tracing::warn!(
+                target: "aether_substrate::driver",
+                kind = %env.kind_name,
+                "desktop driver dropped unrecognised aether.window kind",
+            );
+        }
+    }
+
     fn publish_window_size(&self, width: u32, height: u32) {
         let subs = subscribers_for(&self.input_subscribers, WindowSize::ID);
         if subs.is_empty() {
@@ -487,20 +554,15 @@ impl ApplicationHandler<UserEvent> for App {
                 let result = self.snapshot_platform_info(event_loop);
                 self.outbound.send_reply(reply_to, &result);
             }
-            UserEvent::SetWindowMode {
-                reply_to,
-                mode,
-                width,
-                height,
-            } => {
-                let result = self.apply_window_mode(mode, width, height);
-                self.outbound.send_reply(reply_to, &result);
-            }
-            UserEvent::SetWindowTitle { reply_to, title } => {
-                let result = self.apply_window_title(title);
-                self.outbound.send_reply(reply_to, &result);
-            }
         }
+    }
+
+    /// winit fires this between events. Issue 603 Phase 3 makes the
+    /// driver itself the cap for `aether.window`, so the per-frame
+    /// drain happens here instead of riding through `EventLoopProxy`
+    /// from a separate dispatcher thread.
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        self.drain_window_inbox();
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
@@ -771,6 +833,19 @@ impl DriverCapability for DesktopDriverCapability {
             .registry
             .kind_id(FrameStats::NAME)
             .expect("FrameStats registered");
+        let kind_set_window_mode = boot
+            .registry
+            .kind_id(SetWindowMode::NAME)
+            .expect("SetWindowMode registered");
+        let kind_set_window_title = boot
+            .registry
+            .kind_id(SetWindowTitle::NAME)
+            .expect("SetWindowTitle registered");
+
+        // Issue 603 Phase 3: the desktop driver is the cap for
+        // `aether.window`. Claim the inbox here; the receiver lives on
+        // `App` and `about_to_wait` drains it inline between frames.
+        let window_claim = ctx.claim_mailbox("aether.window")?;
 
         let app = App {
             queue: Arc::clone(&boot.queue),
@@ -797,6 +872,9 @@ impl DriverCapability for DesktopDriverCapability {
             boot_size,
             boot_title,
             current_mode: boot_mode,
+            window_inbox: window_claim.receiver,
+            kind_set_window_mode,
+            kind_set_window_title,
         };
 
         Ok(DesktopDriverRunning {

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -14,23 +14,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_capabilities::{
-    BroadcastCapability, HandleCapability, HeadlessRenderCapability, IoCapability, LogCapability,
-    NetCapability, io::NamespaceRoots, net::NetConfig as NetConf,
+    BroadcastCapability, HandleCapability, HeadlessRenderCapability, HeadlessWindowCapability,
+    IoCapability, LogCapability, NetCapability, io::NamespaceRoots, net::NetConfig as NetConf,
 };
 use aether_capabilities::{ChassisControlHandler, ControlPlaneCapability, ControlPlaneConfig};
 use aether_data::{Kind, KindId};
-use aether_kinds::{
-    Advance, FrameStats, PlatformInfo, SetMasterGain, SetMasterGainResult, SetWindowMode,
-    SetWindowTitle, Tick,
-};
+use aether_kinds::{Advance, FrameStats, PlatformInfo, SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis};
 use aether_substrate::{
     Chassis, HubOutbound, ReplyTo, SubstrateBoot,
-    capture::{
-        reply_unsupported_advance, reply_unsupported_platform_info, reply_unsupported_window_mode,
-        reply_unsupported_window_title,
-    },
+    capture::{reply_unsupported_advance, reply_unsupported_platform_info},
 };
 
 use super::driver::{HeadlessTimerCapability, WORKERS, parse_tick_hz_env};
@@ -42,12 +36,6 @@ const UNSUPPORTED_ADVANCE: &str =
 pub fn chassis_control_handler(outbound: Arc<HubOutbound>) -> ChassisControlHandler {
     Arc::new(
         move |kind: KindId, kind_name: &str, sender: ReplyTo, _bytes: &[u8]| match kind {
-            SetWindowMode::ID => {
-                reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED);
-            }
-            SetWindowTitle::ID => {
-                reply_unsupported_window_title(&outbound, sender, UNSUPPORTED);
-            }
             Advance::ID => {
                 reply_unsupported_advance(&outbound, sender, UNSUPPORTED_ADVANCE);
             }
@@ -227,6 +215,7 @@ impl HeadlessChassis {
             .with_actor::<IoCapability>(namespace_roots)
             .with_actor::<NetCapability>(net)
             .with_actor::<HeadlessRenderCapability>(())
+            .with_actor::<HeadlessWindowCapability>(())
             .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -22,24 +22,19 @@ use std::sync::{Arc, Mutex};
 
 use crate::hub::HubClient;
 use aether_capabilities::{
-    BroadcastCapability, CaptureBackend, HandleCapability, LogCapability, RenderCapability,
-    RenderConfig, RenderHandles,
+    BroadcastCapability, CaptureBackend, HandleCapability, HeadlessWindowCapability, LogCapability,
+    RenderCapability, RenderConfig, RenderHandles,
 };
 use aether_capabilities::{ChassisControlHandler, ControlPlaneCapability, ControlPlaneConfig};
 use aether_data::Kind;
 use aether_data::KindId;
-use aether_kinds::{
-    Advance, AdvanceResult, FrameStats, PlatformInfo, SetWindowMode, SetWindowTitle, Tick,
-};
+use aether_kinds::{Advance, AdvanceResult, FrameStats, PlatformInfo, Tick};
 use aether_substrate::capability::BootError;
 use aether_substrate::chassis_builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::control_helpers::decode_payload;
 use aether_substrate::{
     Chassis, HubOutbound, ReplyTo, SubstrateBoot,
-    capture::{
-        CaptureQueue, reply_unsupported_platform_info, reply_unsupported_window_mode,
-        reply_unsupported_window_title,
-    },
+    capture::{CaptureQueue, reply_unsupported_platform_info},
     render::VERTEX_BUFFER_BYTES,
 };
 
@@ -61,12 +56,6 @@ pub fn chassis_control_handler(
         move |kind: KindId, kind_name: &str, sender: ReplyTo, bytes: &[u8]| match kind {
             Advance::ID => {
                 handle_advance(&events, &outbound, sender, bytes);
-            }
-            SetWindowMode::ID => {
-                reply_unsupported_window_mode(&outbound, sender, UNSUPPORTED_WINDOW);
-            }
-            SetWindowTitle::ID => {
-                reply_unsupported_window_title(&outbound, sender, UNSUPPORTED_WINDOW);
             }
             PlatformInfo::ID => {
                 reply_unsupported_platform_info(&outbound, sender, UNSUPPORTED_WINDOW);
@@ -268,6 +257,7 @@ impl TestBenchChassis {
                 .with_actor::<LogCapability>(())
                 .with_actor::<ControlPlaneCapability>(control_plane_config)
                 .with_actor::<RenderCapability>(render_config)
+                .with_actor::<HeadlessWindowCapability>(())
                 .with_log_drain::<LogCapability>()
                 .build_passive()
                 .map_err(|e: BootError| wasmtime::Error::msg(format!("chassis build: {e}")))?;


### PR DESCRIPTION
<!-- pr-body-ok: ab — Refs #603 closing-keyword needs the # prefix -->

## Summary

Phase 3 of issue 603. Window kinds migrate to their structurally correct namespace and the desktop driver becomes the cap for `aether.window` — claiming the inbox at boot and draining it inline in `about_to_wait`. Mutations apply directly on the chassis main thread where winit / macOS require them; the previous `EventLoopProxy` bounce retires.

- **Kind rename** (Resolved Decision 7): `aether.control.set_window_mode` → `aether.window.set_mode`; `aether.control.set_window_title` → `aether.window.set_title`; matching `*_result` renames. Same wire-break pattern as Phase 2; agents rediscover via `describe_kinds`.
- **Driver-as-actor** (Resolved Decision 6): `DesktopDriverCapability::boot` calls `ctx.claim_mailbox("aether.window")`; the receiver lives on `App`. New `ApplicationHandler::about_to_wait` impl drains per-frame and dispatches `SetWindowMode` / `SetWindowTitle` against the existing `apply_window_mode` / `apply_window_title` helpers. `UserEvent::SetWindowMode` / `UserEvent::SetWindowTitle` retire (only `Capture` and `PlatformInfo` remain on `UserEvent`). Note: under `ControlFlow::Wait` (set on occlusion) `about_to_wait` only fires after a winit event, so window-kind mail can stall briefly until the user nudges the window — accepted limitation for v1.
- **HeadlessWindowCapability** (Resolved Decision 8): new `aether-capabilities::window` cap claiming `aether.window`. `Err`-replying `#[handler]` for `SetWindowMode` / `SetWindowTitle`. Headless and test-bench chassis compose it in place of the desktop driver-as-actor claim.
- **Substrate cleanup**: retires `aether_substrate::capture::reply_unsupported_window_mode` / `reply_unsupported_window_title` and the desktop chassis-handler `handle_set_window_mode` / `handle_set_window_title` helpers.

`chassis_handler` survives Phase 3 with just `platform_info` (desktop forwards via `EventLoopProxy`; headless / test-bench reply `Err`) and `advance` reject paths. Phase 4 retires both the kind and the closure entirely.

## Test plan
- [x] cargo check --workspace
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] cargo test --workspace (existing tests still pass; window kinds covered by chassis bringup smoke)
- [x] aether-substrate-headless boots clean with `HeadlessRenderCapability` + `HeadlessWindowCapability` claiming their mailboxes
- [x] aether-substrate (desktop) boots clean with the driver claiming `aether.window` directly; frame loop runs and `about_to_wait` drain quiesces an empty inbox without warnings

Refs #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)