### PR TITLE
feat(substrate): per-handler spawn_child + namespace ownership (issue 607)

### DIFF
--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -294,11 +294,24 @@ pub struct ChassisCtx<'a> {
     /// `Registry::register_sink` directly and do *not* land here —
     /// they're not actors and have no `LogDrainSlot` to install.
     claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
+    /// Issue 607 Phase 3b (ADR-0079): the chassis's
+    /// [`crate::Spawner`], cloned into every booted actor's
+    /// [`crate::NativeTransport`] (via [`crate::NativeTransport::from_ctx`])
+    /// so per-handler `NativeCtx::spawn_child` can reach the spawn
+    /// machinery without separate plumbing. Built once at boot in
+    /// `boot_passives` (chassis_builder) / `ChassisBuilder::build`
+    /// (legacy).
+    spawner: &'a Arc<crate::Spawner>,
 }
 
 impl<'a> ChassisCtx<'a> {
     /// Internal constructor used by [`ChassisBuilder::build`] and the
-    /// ADR-0071 [`crate::chassis_builder::Builder`].
+    /// ADR-0071 [`crate::chassis_builder::Builder`]. Eight refs is one
+    /// over clippy's default; the alternative — a builder-of-the-builder
+    /// — pays the same plumbing cost without adding clarity, since
+    /// every chassis path that constructs a `ChassisCtx` already has
+    /// every ref in scope.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         registry: &'a Arc<Registry>,
         mailer: &'a Arc<Mailer>,
@@ -307,6 +320,7 @@ impl<'a> ChassisCtx<'a> {
         frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
         aborter: &'a Arc<dyn FatalAborter>,
         claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
+        spawner: &'a Arc<crate::Spawner>,
     ) -> Self {
         Self {
             registry,
@@ -316,6 +330,7 @@ impl<'a> ChassisCtx<'a> {
             frame_bound_set,
             aborter,
             claimed_actor_mailboxes,
+            spawner,
         }
     }
 
@@ -597,6 +612,14 @@ impl<'a> ChassisCtx<'a> {
         Arc::clone(self.aborter)
     }
 
+    /// Borrow the chassis's [`crate::Spawner`]. Used by
+    /// [`crate::NativeTransport::from_ctx`] to clone an `Arc<Spawner>`
+    /// into every booted actor's transport so per-handler
+    /// `NativeCtx::spawn_child` can reach the spawn machinery.
+    pub fn spawner_arc(&self) -> &Arc<crate::Spawner> {
+        self.spawner
+    }
+
     /// Install the fallback-router handler. At most one capability
     /// may claim the slot; a second call returns
     /// [`BootError::FallbackRouterAlreadyClaimed`].
@@ -779,6 +802,21 @@ fn boot_native_actor<A>(
 where
     A: crate::NativeActor + crate::NativeDispatch,
 {
+    // Issue 607 Phase 3b (ADR-0079): claim namespace ownership for
+    // this singleton. Mirrors the new builder path; cross-cardinality
+    // collisions surface as a typed BootError that the legacy
+    // ChassisBuilder unwinds.
+    if let Err(_existing) = ctx
+        .spawner_arc()
+        .actor_registry()
+        .try_claim_namespace(A::NAMESPACE, std::any::TypeId::of::<A>())
+    {
+        return Err(BootError::Other(Box::new(std::io::Error::other(format!(
+            "namespace {:?} already owned by a different TypeId — fix the conflicting actor's NAMESPACE const",
+            A::NAMESPACE
+        )))));
+    }
+
     // Stage 2d: frame-bound caps go through `claim_frame_bound_mailbox`
     // so the chassis's `frame_bound_pending` Vec sees the pending
     // counter; the dispatcher decrements after each handler dispatch
@@ -1052,6 +1090,19 @@ impl ChassisBuilder {
         // owns that surface). Track claims here for shape parity with
         // the new path; the vec stays unused.
         let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
+        // Issue 607 Phase 3 / Phase 3b (ADR-0079): per-chassis actor
+        // registry + spawner. Mirrors `chassis_builder::Builder`'s
+        // `boot_passives` so caps booted through either path expose
+        // the same `NativeCtx::spawn_child` surface to runtime
+        // handlers.
+        let actor_registry: Arc<crate::ActorRegistry> = Arc::new(crate::ActorRegistry::new());
+        let spawner: Arc<crate::Spawner> = Arc::new(crate::Spawner::new(
+            Arc::clone(&registry),
+            Arc::clone(&actor_registry),
+            Arc::clone(&mailer),
+            Arc::clone(&frame_bound_set),
+            Arc::clone(&aborter),
+        ));
         let mut booted: Vec<Box<dyn ActorErased>> = Vec::with_capacity(pending.len());
         for boot in pending {
             let mut ctx = ChassisCtx::new(
@@ -1062,6 +1113,7 @@ impl ChassisBuilder {
                 &frame_bound_set,
                 &aborter,
                 &mut claimed_actor_mailboxes,
+                &spawner,
             );
             match boot(&mut ctx) {
                 Ok(actor) => booted.push(actor),
@@ -1093,6 +1145,8 @@ impl ChassisBuilder {
             frame_bound_pending,
             frame_bound_set,
             aborter,
+            actor_registry,
+            spawner,
         })
     }
 }
@@ -1125,6 +1179,18 @@ pub struct BootedChassis {
     /// [`crate::lifecycle::OutboundFatalAborter`] via
     /// [`ChassisBuilder::with_aborter`].
     aborter: Arc<dyn FatalAborter>,
+    /// Issue 607 Phase 2 / Phase 3 (ADR-0079): per-chassis actor
+    /// lifecycle registry. Mirror of `chassis_builder::BootedPassives`'
+    /// field; held here so caps booted through the legacy
+    /// `ChassisBuilder` path also see the registry through
+    /// `NativeCtx::spawn_child` (Phase 3b).
+    #[allow(dead_code)]
+    actor_registry: Arc<crate::ActorRegistry>,
+    /// Issue 607 Phase 3b (ADR-0079): chassis-level spawn machinery
+    /// cloned into every booted actor's transport. Held here for the
+    /// chassis lifetime; `add` / `add_actor` thread it through
+    /// post-build cap claims so they see the same machinery.
+    spawner: Arc<crate::Spawner>,
 }
 
 impl fmt::Debug for BootedChassis {
@@ -1196,6 +1262,7 @@ impl BootedChassis {
             &self.frame_bound_set,
             &self.aborter,
             &mut claimed_actor_mailboxes,
+            &self.spawner,
         );
         let handle = ctx.spawn_actor_dispatcher(cap)?;
         self.running.push(Box::new(handle));
@@ -1232,6 +1299,7 @@ impl BootedChassis {
             &self.frame_bound_set,
             &self.aborter,
             &mut claimed_actor_mailboxes,
+            &self.spawner,
         );
         let erased = boot_native_actor::<A>(&mut ctx, config)?;
         self.running.push(erased);

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -297,6 +297,28 @@ where
     A: NativeActor + NativeDispatch,
 {
     Box::new(move |ctx, actors| {
+        // Issue 607 Phase 3b (ADR-0079): claim namespace ownership for
+        // this singleton's `Actor::NAMESPACE`. The actor registry
+        // tracks one TypeId per namespace across both cardinalities
+        // (Singleton/Instanced), so a later `spawn_child::<X>` whose
+        // `X::NAMESPACE` collides with this singleton's namespace
+        // surfaces as `SpawnError::NamespaceOwnedByOtherType`. Same
+        // TypeId re-claiming the same namespace is idempotent.
+        if let Err(_existing) = ctx
+            .spawner_arc()
+            .actor_registry()
+            .try_claim_namespace(A::NAMESPACE, std::any::TypeId::of::<A>())
+        {
+            // The other claim is on the same namespace by a different
+            // TypeId — a chassis-build collision. Surface as a typed
+            // BootError; the chassis builder unwinds the partially
+            // booted caps before propagating.
+            return Err(BootError::Other(Box::new(std::io::Error::other(format!(
+                "namespace {:?} already owned by a different TypeId — fix the conflicting actor's NAMESPACE const",
+                A::NAMESPACE
+            )))));
+        }
+
         // Frame-bound caps (today: render) claim through the
         // frame-bound path so the `pending` counter feeds the chassis
         // frame loop. Free-running caps take the regular drop-on-
@@ -708,6 +730,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
                 &booted.frame_bound_set,
                 &booted.aborter,
                 &mut booted.claimed_actor_mailboxes,
+                &booted.spawner,
             );
             let mut driver_ctx = DriverCtx::new(chassis_ctx, &booted.actors);
             driver_boot(&mut driver_ctx)?
@@ -838,6 +861,7 @@ fn boot_passives(
             &frame_bound_set,
             aborter,
             &mut claimed_actor_mailboxes,
+            &spawner,
         );
         match boot(&mut ctx, &mut actors) {
             Ok(shutdown) => shutdowns.push(shutdown),
@@ -904,7 +928,12 @@ impl<C: Chassis> BuiltChassis<C> {
     where
         A: aether_actor::Instanced + NativeActor + NativeDispatch,
     {
-        crate::SpawnBuilder::new(&self.booted.spawner, subname, config, crate::ReplyTo::NONE)
+        crate::SpawnBuilder::new(
+            Arc::clone(&self.booted.spawner),
+            subname,
+            config,
+            crate::ReplyTo::NONE,
+        )
     }
 
     /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only;
@@ -990,7 +1019,12 @@ impl<C: Chassis> PassiveChassis<C> {
     where
         A: aether_actor::Instanced + NativeActor + NativeDispatch,
     {
-        crate::SpawnBuilder::new(&self.booted.spawner, subname, config, crate::ReplyTo::NONE)
+        crate::SpawnBuilder::new(
+            Arc::clone(&self.booted.spawner),
+            subname,
+            config,
+            crate::ReplyTo::NONE,
+        )
     }
 
     /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only;
@@ -1428,6 +1462,188 @@ mod tests {
             103,
             "init seeded 100 + 3 handler bumps ⇒ Local at 103 (proves the same \
              ActorSlots is stamped across init and dispatch)"
+        );
+
+        drop(chassis);
+    }
+
+    /// Issue 607 Phase 3b verify: a singleton parent's handler calls
+    /// `ctx.spawn_child::<Child>(...)` to launch an instanced actor.
+    /// Asserts the child's `MailboxId` lands in the chassis's
+    /// `ActorRegistry` as a Live entry, and that the parent-pre-loaded
+    /// `after_init` mail dispatches as the child's first envelope.
+    #[test]
+    fn ctx_spawn_child_routes_through_handler() {
+        use crate::registry::MailboxEntry;
+        use crate::spawn::Subname;
+        use aether_actor::{HandlesKind, Instanced};
+        use aether_data::{Kind, KindId as DataKindId, ReplyTo as DataReplyTo};
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Hatch {
+            tag: u32,
+        }
+        impl Kind for Hatch {
+            const NAME: &'static str = "test.spawn_child.hatch";
+            const ID: DataKindId = DataKindId(0xC0C1_C2C3_C4C5_C6C7);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Ping {
+            tag: u32,
+        }
+        impl Kind for Ping {
+            const NAME: &'static str = "test.spawn_child.ping";
+            const ID: DataKindId = DataKindId(0xD0D1_D2D3_D4D5_D6D7);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        struct ChildCap {
+            received: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for ChildCap {
+            const NAMESPACE: &'static str = "test.spawn_child.child";
+        }
+        impl Instanced for ChildCap {}
+        impl HandlesKind<Ping> for ChildCap {}
+        impl crate::native_actor::NativeActor for ChildCap {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self { received: config })
+            }
+        }
+        impl crate::native_actor::NativeDispatch for ChildCap {
+            fn __aether_dispatch_envelope(
+                &self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Ping::ID.0 {
+                    let _ = Ping::decode_from_bytes(payload)?;
+                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        struct ParentCap {
+            spawn_count: Arc<AtomicU32>,
+            child_received: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for ParentCap {
+            const NAMESPACE: &'static str = "test.spawn_child.parent";
+        }
+        impl aether_actor::Singleton for ParentCap {}
+        impl HandlesKind<Hatch> for ParentCap {}
+        impl crate::native_actor::NativeActor for ParentCap {
+            type Config = (Arc<AtomicU32>, Arc<AtomicU32>);
+            fn init(
+                (spawn_count, child_received): Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    spawn_count,
+                    child_received,
+                })
+            }
+        }
+        impl crate::native_actor::NativeDispatch for ParentCap {
+            fn __aether_dispatch_envelope(
+                &self,
+                ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Hatch::ID.0 {
+                    let _ = Hatch::decode_from_bytes(payload)?;
+                    let _id = ctx
+                        .spawn_child::<ChildCap>(Subname::Counter, Arc::clone(&self.child_received))
+                        .after_init(Ping { tag: 42 })
+                        .finish()
+                        .expect("spawn_child must succeed");
+                    self.spawn_count.fetch_add(1, AtomicOrdering::SeqCst);
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let spawn_count = Arc::new(AtomicU32::new(0));
+        let child_received = Arc::new(AtomicU32::new(0));
+
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<ParentCap>((Arc::clone(&spawn_count), Arc::clone(&child_received)))
+            .build_passive()
+            .expect("ParentCap boots");
+
+        // Push Hatch at the parent's mailbox; the parent's handler
+        // calls `ctx.spawn_child::<ChildCap>` which in turn pushes a
+        // Ping at the new child via the after_init bootstrap.
+        let parent_id = registry
+            .lookup(<ParentCap as aether_actor::Actor>::NAMESPACE)
+            .expect("ParentCap claimed");
+        let MailboxEntry::Sink(handler) = registry.entry(parent_id).expect("sink") else {
+            panic!("expected sink entry");
+        };
+        let bytes = (Hatch { tag: 1 }).encode_into_bytes();
+        handler(
+            <Hatch as Kind>::ID,
+            Hatch::NAME,
+            None,
+            DataReplyTo::NONE,
+            &bytes,
+            1,
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while child_received.load(AtomicOrdering::SeqCst) < 1
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            spawn_count.load(AtomicOrdering::SeqCst),
+            1,
+            "parent's handler ran spawn_child exactly once"
+        );
+        assert_eq!(
+            child_received.load(AtomicOrdering::SeqCst),
+            1,
+            "spawn_child's after_init mail dispatched as the child's first envelope"
+        );
+
+        // Child is Live in the chassis's actor registry.
+        let child_id =
+            crate::mail::MailboxId(aether_data::mailbox_id_from_name("test.spawn_child.child:0").0);
+        assert!(
+            chassis.actor_registry().live_actor(child_id).is_some(),
+            "spawned child should be Live in the actor registry under the deterministic full-name id"
         );
 
         drop(chassis);

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -203,6 +203,39 @@ impl<'a> NativeCtx<'a> {
     pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, NativeTransport> {
         ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
     }
+
+    /// Issue 607 Phase 3b (ADR-0079): spawn an instanced actor as a
+    /// child of the calling actor. The new actor's [`crate::ReplyTo`]
+    /// stamps the calling actor's mailbox so any reply addressed to
+    /// `ReplyTarget::Component` routes back here.
+    ///
+    /// Returns a [`crate::SpawnBuilder`] the caller chains
+    /// `after_init` / `finish` against. Mirrors the chassis-level
+    /// `PassiveChassis::spawn_actor` / `BuiltChassis::spawn_actor`
+    /// shape; both flow through the same [`crate::Spawner`].
+    ///
+    /// Panics if the transport was constructed via
+    /// [`NativeTransport::new_for_test`] (which doesn't wire a
+    /// spawner). Production transports always carry one, so handler
+    /// code never reaches the panic.
+    pub fn spawn_child<'b, A>(
+        &'b self,
+        subname: crate::spawn::Subname<'b>,
+        config: A::Config,
+    ) -> crate::SpawnBuilder<'b, A>
+    where
+        A: aether_actor::Instanced + NativeActor + crate::NativeDispatch,
+    {
+        let spawner = self
+            .transport
+            .spawner()
+            .expect("NativeCtx::spawn_child requires a chassis-built transport (no spawner installed — likely a `new_for_test` transport)");
+        let sender = ReplyTo {
+            target: crate::mail::ReplyTarget::Component(self.transport.self_mailbox()),
+            correlation_id: ReplyTo::NO_CORRELATION,
+        };
+        crate::SpawnBuilder::new(Arc::clone(spawner), subname, config, sender)
+    }
 }
 
 impl<'a> Sender for NativeCtx<'a> {

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -100,6 +100,13 @@ pub struct NativeTransport {
     /// `MAX_PENDING_RECIPIENTS`); a runaway sender that never paired
     /// a wait would otherwise leak entries here.
     pending_recipients: Mutex<HashMap<u64, MailboxId>>,
+    /// Issue 607 Phase 3b (ADR-0079): the chassis's [`crate::Spawner`]
+    /// cloned into every booted actor's transport so per-handler
+    /// `NativeCtx::spawn_child` can reach the spawn machinery without
+    /// separate plumbing. `None` for [`Self::new_for_test`] transports
+    /// (those tests never spawn instances); production constructors
+    /// (`new` / `from_ctx`) pass `Some` from the chassis.
+    spawner: Option<Arc<crate::Spawner>>,
 }
 
 /// Soft cap on [`NativeTransport::pending_recipients`]. A
@@ -138,6 +145,7 @@ impl NativeTransport {
         caller_frame_bound: bool,
         frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
         aborter: Arc<dyn FatalAborter>,
+        spawner: Option<Arc<crate::Spawner>>,
     ) -> Self {
         Self {
             mailer,
@@ -149,6 +157,7 @@ impl NativeTransport {
             frame_bound_set,
             aborter,
             pending_recipients: Mutex::new(HashMap::new()),
+            spawner,
         }
     }
 
@@ -174,6 +183,7 @@ impl NativeTransport {
             frame_bound,
             ctx.frame_bound_set(),
             ctx.fatal_aborter(),
+            Some(Arc::clone(ctx.spawner_arc())),
         )
     }
 
@@ -190,6 +200,7 @@ impl NativeTransport {
             false,
             Arc::new(RwLock::new(HashSet::new())),
             Arc::new(PanicAborter),
+            None,
         )
     }
 
@@ -209,6 +220,17 @@ impl NativeTransport {
     /// transport's send path.
     pub fn self_mailbox(&self) -> MailboxId {
         self.self_mailbox
+    }
+
+    /// The chassis's [`crate::Spawner`], if one was wired in at
+    /// construction. `Some` for production transports built through
+    /// [`Self::from_ctx`] (the chassis builds + threads its `Spawner`
+    /// into every cap); `None` for [`Self::new_for_test`] transports
+    /// (those tests don't exercise spawn). Used by
+    /// `NativeCtx::spawn_child` to reach the spawn machinery without
+    /// separate per-handler plumbing.
+    pub fn spawner(&self) -> Option<&Arc<crate::Spawner>> {
+        self.spawner.as_ref()
     }
 
     /// Block until the next envelope arrives on this actor's inbox.
@@ -566,6 +588,7 @@ mod tests {
             caller_frame_bound,
             frame_bound_set,
             Arc::new(PanicAborter),
+            None,
         )
     }
 

--- a/crates/aether-substrate/src/spawn.rs
+++ b/crates/aether-substrate/src/spawn.rs
@@ -134,7 +134,7 @@ impl Spawner {
     /// 7. Pre-load `after_init_mail` into the inbox.
     /// 8. Spawn dispatcher thread, move actor in.
     fn spawn_actor<A>(
-        &self,
+        self: Arc<Self>,
         subname: Subname<'_>,
         config: A::Config,
         after_init_mail: Vec<Envelope>,
@@ -183,6 +183,10 @@ impl Spawner {
             false,
             Arc::clone(&self.frame_bound_set),
             Arc::clone(&self.aborter),
+            // Pass the chassis's `Spawner` through so the spawned
+            // actor can in turn `ctx.spawn_child` from its own
+            // handlers.
+            Some(Arc::clone(&self)),
         ));
         transport.install_inbox(rx);
 
@@ -337,12 +341,17 @@ fn alloc_instanced_thread_name(full_name: &str) -> String {
 /// running list of after-init envelopes. `finish` consumes the
 /// builder and runs the spawn lifecycle.
 pub struct SpawnBuilder<'ctx, A: Instanced + NativeActor + NativeDispatch> {
-    spawner: &'ctx Spawner,
+    spawner: Arc<Spawner>,
     subname: Subname<'ctx>,
     config: Option<A::Config>,
     sender: ReplyTo,
     after_init: Vec<Envelope>,
     _marker: PhantomData<fn() -> A>,
+    /// Carries the `'ctx` lifetime even though `spawner` is `Arc`
+    /// (no longer borrowed). The lifetime ties `Subname::Named(&str)`
+    /// to whatever borrow it was constructed from at the call site,
+    /// so a stack-local subname doesn't dangle past `finish()`.
+    _ctx: PhantomData<&'ctx ()>,
 }
 
 impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
@@ -350,7 +359,7 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
     /// `spawn_actor` entry points (on `BuiltChassis` / `PassiveChassis`)
     /// build these too.
     pub(crate) fn new(
-        spawner: &'ctx Spawner,
+        spawner: Arc<Spawner>,
         subname: Subname<'ctx>,
         config: A::Config,
         sender: ReplyTo,
@@ -362,6 +371,7 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
             sender,
             after_init: Vec::new(),
             _marker: PhantomData,
+            _ctx: PhantomData,
         }
     }
 
@@ -404,6 +414,6 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
             ..
         } = self;
         let config = config.expect("SpawnBuilder::finish consumed exactly once");
-        spawner.spawn_actor::<A>(subname, config, after_init, sender)
+        Spawner::spawn_actor::<A>(spawner, subname, config, after_init, sender)
     }
 }


### PR DESCRIPTION
<!-- pr-body-ok: b — bare issue refs in body are intended cross-link auto-references -->

Phase 3b of #607 (ADR-0079) — closes the per-handler spawn surface deferred from Phase 3a (PR 619).

## What lands

**Transport wiring.** `Arc<Spawner>` flows through every booted actor's `NativeTransport` so handler context reaches the spawn machinery without separate plumbing:

- `NativeTransport` gains `spawner: Option<Arc<Spawner>>` + `spawner()` accessor. `from_ctx` wires from the chassis; `new_for_test` passes `None`.
- `ChassisCtx` gains `spawner: &Arc<Spawner>` + `spawner_arc()` accessor used by `from_ctx`.
- Legacy `ChassisBuilder::build` now constructs an `ActorRegistry` + `Spawner` (mirrors `chassis_builder::Builder::boot_passives`) so caps booted through either path see the same surface.
- `BootedChassis` carries the spawner; `add` / `add_actor` thread it through to post-build cap claims.

**Per-handler entry.** `NativeCtx::spawn_child<A: Instanced + NativeActor + NativeDispatch>` returns a `SpawnBuilder<'_, A>`. The new actor's reply target stamps the calling actor's mailbox so any reply addressed to `ReplyTarget::Component` routes back to the spawner.

**Recursive spawn.** `SpawnBuilder` switches from `&'ctx Spawner` to `Arc<Spawner>` (a `PhantomData<&'ctx ()>` carries the lifetime so `Subname::Named(&str)` still can't outlive its borrow). `Spawner::spawn_actor` becomes `self: Arc<Self>` and passes the chassis-wide spawner forward into the spawned actor's `NativeTransport`, so a freshly spawned actor's handlers can `ctx.spawn_child` in turn.

**Namespace ownership.** Both singleton boot paths (`make_native_actor_boot` in the new builder, `boot_native_actor` in the legacy builder) now claim `Actor::NAMESPACE` against the chassis's `ActorRegistry::name_owners`. Cross-cardinality collisions surface as `BootError::Other` during boot (the chassis builder unwinds partial boots) and as `SpawnError::NamespaceOwnedByOtherType` at spawn time. Same-TypeId re-claim is idempotent.

## Doesn't change

Termination semantics — instanced actors still live for the chassis's lifetime; their dispatcher thread exits when the registry drops. Phase 4 wires `on_close`, the monitor primitive, and tombstone population.

## Verify

- `cargo build --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace --lib` — 141 passing in aether-substrate including the new `ctx_spawn_child_routes_through_handler` test: boots a singleton parent, dispatches a `Hatch` mail through the sink handler, asserts the parent's `ctx.spawn_child::<Child>` ran, asserts the `after_init` `Ping` landed as the child's first envelope, asserts the child is Live in the chassis's actor registry under the deterministic full-name id.

Closes the Phase 3 deferral noted in PR 619's body.

Refs #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)