### PR TITLE
feat(substrate): shutdown + on_close + Live→Dead transition (issue 607)

### DIFF
--- a/crates/aether-substrate/src/actor_registry.rs
+++ b/crates/aether-substrate/src/actor_registry.rs
@@ -29,10 +29,16 @@ use crate::mail::MailboxId;
 /// for entries whose dispatcher has joined and whose actor has
 /// dropped — mail addressed to the slot warn-drops, and `spawn_child`
 /// rejects the name for reuse. ADR-0079 §Drop / lifecycle.
+///
+/// `sender` is `Arc<Sender<Envelope>>` so the registry's sink
+/// handler can hold a `Weak<Sender>` and upgrade only while the
+/// actor is `Live`; on `mark_dead` the Arc drops and the weak
+/// upgrade fails, making mail addressed to a dead instanced
+/// mailbox warn-drop.
 #[derive(Clone)]
 pub enum ActorEntry {
     Live {
-        sender: Sender<Envelope>,
+        sender: Arc<Sender<Envelope>>,
         actor: Arc<dyn std::any::Any + Send + Sync>,
         type_id: TypeId,
     },
@@ -81,14 +87,14 @@ impl ActorRegistry {
         }
     }
 
-    /// `Some(sender)` only if the slot at `id` is `Live`. `Sender` is
-    /// `Clone`, so the returned handle can be used to push mail
-    /// directly into the actor's inbox without holding the registry
-    /// lock across the send.
+    /// `Some(sender)` only if the slot at `id` is `Live`. The returned
+    /// `Sender` is cloned out of the registry's `Arc<Sender>` so the
+    /// caller can push mail directly into the actor's inbox without
+    /// holding the registry lock or affecting the Arc's strong count.
     pub fn live_sender(&self, id: MailboxId) -> Option<Sender<Envelope>> {
         let actors = self.actors.read().unwrap();
         match actors.get(&id) {
-            Some(ActorEntry::Live { sender, .. }) => Some(sender.clone()),
+            Some(ActorEntry::Live { sender, .. }) => Some((**sender).clone()),
             _ => None,
         }
     }
@@ -145,7 +151,7 @@ impl ActorRegistry {
     pub(crate) fn insert_live(
         &self,
         id: MailboxId,
-        sender: Sender<Envelope>,
+        sender: Arc<Sender<Envelope>>,
         actor: Arc<dyn std::any::Any + Send + Sync>,
         type_id: TypeId,
     ) -> Result<(), ()> {
@@ -167,6 +173,21 @@ impl ActorRegistry {
                 Ok(())
             }
         }
+    }
+
+    /// Issue 607 Phase 4a (ADR-0079): flip the slot at `id` from
+    /// `Live` to `Dead` and insert the id into `tombstones`. Called
+    /// by the instanced-actor dispatcher after `on_close` runs so
+    /// future `spawn_child` calls reject reuse of the retired name
+    /// with `SpawnError::SubnameRetired`. Idempotent — re-running on
+    /// an already-`Dead` slot leaves it `Dead` and doesn't double-
+    /// insert into `tombstones`.
+    pub(crate) fn mark_dead(&self, id: MailboxId) {
+        let mut actors = self.actors.write().unwrap();
+        actors.insert(id, ActorEntry::Dead);
+        drop(actors);
+        let mut tombstones = self.tombstones.write().unwrap();
+        tombstones.insert(id);
     }
 }
 

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -883,7 +883,18 @@ where
     let thread = std::thread::Builder::new()
         .name(thread_name)
         .spawn(move || {
-            while let Some(env) = transport_for_thread.recv_blocking() {
+            // Issue 607 Phase 4a (ADR-0079): legacy singleton dispatcher
+            // mirrors the new chassis_builder shape — flag-poll for
+            // self-shutdown, channel-disconnect for substrate shutdown,
+            // both flow through drain → on_close → exit.
+            loop {
+                if transport_for_thread.should_shutdown() {
+                    break;
+                }
+                let env = match transport_for_thread.recv_blocking() {
+                    Some(e) => e,
+                    None => break,
+                };
                 aether_actor::local::with_stamped(&slots, || {
                     aether_actor::log::with_actor_dispatch(
                         &*transport_for_thread as &dyn aether_actor::log::MailDispatch,
@@ -921,6 +932,41 @@ where
                     p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
                 }
             }
+            while let Some(env) = transport_for_thread.try_recv() {
+                aether_actor::local::with_stamped(&slots, || {
+                    aether_actor::log::with_actor_dispatch(
+                        &*transport_for_thread as &dyn aether_actor::log::MailDispatch,
+                        || {
+                            let mut native_ctx = crate::native_actor::NativeCtx::new(
+                                &transport_for_thread,
+                                env.sender,
+                            );
+                            let _ = actor_for_thread.__aether_dispatch_envelope(
+                                &mut native_ctx,
+                                env.kind,
+                                &env.payload,
+                            );
+                            aether_actor::log::drain_buffer();
+                        },
+                    );
+                });
+                if let Some(p) = &pending {
+                    p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+                }
+            }
+            aether_actor::local::with_stamped(&slots, || {
+                aether_actor::log::with_actor_dispatch(
+                    &*transport_for_thread as &dyn aether_actor::log::MailDispatch,
+                    || {
+                        let mut close_ctx = crate::native_actor::NativeCtx::new(
+                            &transport_for_thread,
+                            crate::mail::ReplyTo::NONE,
+                        );
+                        actor_for_thread.on_close(&mut close_ctx);
+                        aether_actor::log::drain_buffer();
+                    },
+                );
+            });
         })
         .map_err(|e| BootError::Other(Box::new(e)))?;
 

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -392,7 +392,23 @@ where
         let thread = std::thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                while let Some(env) = transport_for_thread.recv_blocking() {
+                // Issue 607 Phase 4a (ADR-0079): the singleton
+                // dispatcher polls the self-shutdown flag the same
+                // way the instanced dispatcher does in `spawn.rs`.
+                // Channel-disconnect is the chassis-shutdown path;
+                // both flow through the same drain → on_close → exit
+                // sequence below. Singletons don't tombstone (their
+                // mailbox slot stays in `Registry`); the chassis's
+                // `BootedPassives::shutdown_in_place` reverse-drops
+                // the SinkSender to fully disconnect the sink.
+                loop {
+                    if transport_for_thread.should_shutdown() {
+                        break;
+                    }
+                    let env = match transport_for_thread.recv_blocking() {
+                        Some(e) => e,
+                        None => break,
+                    };
                     aether_actor::local::with_stamped(&slots, || {
                         // Issue #581: stamp the actor's transport as
                         // the in-actor `MailDispatch` so the actor-
@@ -435,6 +451,43 @@ where
                         p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
                     }
                 }
+                // Drain remaining inbox synchronously so any in-flight
+                // mail dispatched during the shutdown signal is
+                // observed before `on_close` runs.
+                while let Some(env) = transport_for_thread.try_recv() {
+                    aether_actor::local::with_stamped(&slots, || {
+                        aether_actor::log::with_actor_dispatch(
+                            &*transport_for_thread as &dyn aether_actor::log::MailDispatch,
+                            || {
+                                let mut ctx =
+                                    NativeCtx::new(&transport_for_thread, env.sender);
+                                let _ = actor_for_thread
+                                    .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
+                                aether_actor::log::drain_buffer();
+                            },
+                        );
+                    });
+                    if let Some(p) = &pending {
+                        p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+                    }
+                }
+                // Last-chance close hook. Runs whether the trigger was
+                // self-shutdown (flag) or substrate shutdown (channel
+                // disconnect). Default empty for singletons that don't
+                // need it; opt-in for caps with cleanup state.
+                aether_actor::local::with_stamped(&slots, || {
+                    aether_actor::log::with_actor_dispatch(
+                        &*transport_for_thread as &dyn aether_actor::log::MailDispatch,
+                        || {
+                            let mut close_ctx = NativeCtx::new(
+                                &transport_for_thread,
+                                crate::mail::ReplyTo::NONE,
+                            );
+                            actor_for_thread.on_close(&mut close_ctx);
+                            aether_actor::log::drain_buffer();
+                        },
+                    );
+                });
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
@@ -1644,6 +1697,151 @@ mod tests {
         assert!(
             chassis.actor_registry().live_actor(child_id).is_some(),
             "spawned child should be Live in the actor registry under the deterministic full-name id"
+        );
+
+        drop(chassis);
+    }
+
+    /// Issue 607 Phase 4a verify: `ctx.shutdown()` from inside an
+    /// instanced actor's handler triggers the drain → on_close → exit
+    /// path, flips the actor_registry slot to `Dead`, and inserts the
+    /// id into `tombstones`. A reused subname after retirement returns
+    /// `SpawnError::SubnameRetired`.
+    #[test]
+    fn ctx_shutdown_marks_dead_runs_on_close_tombstones_id() {
+        use crate::registry::MailboxEntry;
+        use crate::spawn::{SpawnError, Subname};
+        use aether_actor::{HandlesKind, Instanced};
+        use aether_data::{Kind, KindId as DataKindId};
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Quit {
+            tag: u32,
+        }
+        impl Kind for Quit {
+            const NAME: &'static str = "test.shutdown.quit";
+            const ID: DataKindId = DataKindId(0xE0E1_E2E3_E4E5_E6E7);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        struct Closer {
+            close_observed: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for Closer {
+            const NAMESPACE: &'static str = "test.shutdown.closer";
+        }
+        impl Instanced for Closer {}
+        impl HandlesKind<Quit> for Closer {}
+        impl crate::native_actor::NativeActor for Closer {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    close_observed: config,
+                })
+            }
+            fn on_close(&self, _ctx: &mut crate::native_actor::NativeCtx<'_>) {
+                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
+        impl crate::native_actor::NativeDispatch for Closer {
+            fn __aether_dispatch_envelope(
+                &self,
+                ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Quit::ID.0 {
+                    let _ = Quit::decode_from_bytes(payload)?;
+                    ctx.shutdown();
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let close_observed = Arc::new(AtomicU32::new(0));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        let id = chassis
+            .spawn_actor::<Closer>(Subname::Counter, Arc::clone(&close_observed))
+            .finish()
+            .expect("spawn instanced actor");
+
+        // Push a Quit envelope at the spawned mailbox via the
+        // registered sink handler. The handler's `ctx.shutdown()`
+        // flips the dispatcher's flag; after the handler returns the
+        // trampoline drains, runs `on_close`, marks Dead, tombstones.
+        let MailboxEntry::Sink(handler) = registry.entry(id).expect("sink registered") else {
+            panic!("expected sink entry for instanced actor");
+        };
+        let bytes = (Quit { tag: 1 }).encode_into_bytes();
+        handler(
+            <Quit as Kind>::ID,
+            Quit::NAME,
+            None,
+            aether_data::ReplyTo::NONE,
+            &bytes,
+            1,
+        );
+
+        // Wait for on_close to run + the registry slot to flip Dead.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while close_observed.load(AtomicOrdering::SeqCst) == 0
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            close_observed.load(AtomicOrdering::SeqCst),
+            1,
+            "on_close fired exactly once after the dispatcher drained"
+        );
+        // Spin until the slot transitions Dead — the dispatcher
+        // thread runs `mark_dead` after `on_close`, so there's a
+        // small window between the close-observed bump above and the
+        // registry update.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while chassis.actor_registry().live_actor(id).is_some()
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            chassis.actor_registry().live_actor(id).is_none(),
+            "registry slot should transition Live → Dead after on_close runs"
+        );
+        assert!(
+            chassis.actor_registry().is_tombstoned(id),
+            "tombstone insertion forbids reuse of the retired full name"
+        );
+
+        // Spawning again under the same `Subname::Counter` would
+        // increment the per-Spawner counter (so it'd target a fresh
+        // id, not collide); reuse the same `Named` subname to land
+        // back at the tombstoned id.
+        let err = chassis
+            .spawn_actor::<Closer>(Subname::Named("0"), Arc::clone(&close_observed))
+            .finish()
+            .expect_err("retired subname must reject");
+        assert!(
+            matches!(err, SpawnError::SubnameRetired { .. }),
+            "expected SubnameRetired, got {err:?}"
         );
 
         drop(chassis);

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -96,6 +96,25 @@ pub trait NativeActor: Actor + Sync {
     fn init(config: Self::Config, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError>
     where
         Self: Sized;
+
+    /// Issue 607 Phase 4a (ADR-0079): last-chance close hook. Runs
+    /// after the dispatcher's inbox drain, before the actor value
+    /// drops. Triggers:
+    ///
+    /// - Self-shutdown — actor's handler called `ctx.shutdown()`;
+    ///   dispatcher saw the flag set after the handler returned.
+    /// - Substrate shutdown — chassis dropped its registry, the sink
+    ///   handler's `Weak<Sender>` upgrade fails, the inbox channel
+    ///   disconnects, and `recv_blocking` returns `None`.
+    /// - Cooperative external — a peer mailed the actor a "please
+    ///   close" kind; the actor's handler did its cleanup and called
+    ///   `ctx.shutdown()`. From the dispatcher's perspective this is
+    ///   identical to self-shutdown.
+    ///
+    /// `&self` matches the handler convention: caps put any mutable
+    /// state behind interior mutability. Default empty — opt-in for
+    /// caps that need to publish a final broadcast or flush state.
+    fn on_close(&self, _ctx: &mut NativeCtx<'_>) {}
 }
 
 /// Sum dispatch entry-point — emitted once per `#[actor] impl
@@ -202,6 +221,24 @@ impl<'a> NativeCtx<'a> {
     /// runtime instance name. Mirrors [`aether_actor::Ctx::resolve_actor`].
     pub fn resolve_actor<R: Actor>(&self, name: &str) -> ActorMailbox<'_, R, NativeTransport> {
         ActorMailbox::__new(mailbox_id_from_name(name).0, self.transport)
+    }
+
+    /// Issue 607 Phase 4a (ADR-0079): self-shutdown signal. Sets a
+    /// flag the actor's dispatcher polls after each handler returns;
+    /// when set, the trampoline drains any remaining inbox mail
+    /// synchronously, runs `NativeActor::on_close`, and exits the
+    /// dispatch loop. After exit the actor's [`crate::MailboxId`]
+    /// transitions from `Live` to `Dead` in the chassis's
+    /// [`crate::ActorRegistry`] and is added to `tombstones` —
+    /// `spawn_child` rejects reuse of the retired full name with
+    /// `SpawnError::SubnameRetired`.
+    ///
+    /// Idempotent — flipping the flag twice is the same as flipping
+    /// it once. Singletons booted through `with_actor` rely on the
+    /// chassis-shutdown channel-drop path instead of this flag, but
+    /// can call `shutdown()` to opt in to flag-based exit.
+    pub fn shutdown(&self) {
+        self.transport.signal_shutdown();
     }
 
     /// Issue 607 Phase 3b (ADR-0079): spawn an instanced actor as a

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
@@ -107,6 +107,13 @@ pub struct NativeTransport {
     /// (those tests never spawn instances); production constructors
     /// (`new` / `from_ctx`) pass `Some` from the chassis.
     spawner: Option<Arc<crate::Spawner>>,
+    /// Issue 607 Phase 4a (ADR-0079): self-shutdown flag. The actor's
+    /// dispatcher polls this between handler dispatches; flipping it
+    /// (via [`Self::signal_shutdown`] / `NativeCtx::shutdown`) tells
+    /// the dispatcher to drain the inbox, run `on_close`, and exit.
+    /// Substrate-shutdown (channel disconnect) flows through the same
+    /// drain → close → exit path without setting the flag.
+    shutdown_flag: Arc<AtomicBool>,
 }
 
 /// Soft cap on [`NativeTransport::pending_recipients`]. A
@@ -158,6 +165,7 @@ impl NativeTransport {
             aborter,
             pending_recipients: Mutex::new(HashMap::new()),
             spawner,
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -231,6 +239,24 @@ impl NativeTransport {
     /// separate per-handler plumbing.
     pub fn spawner(&self) -> Option<&Arc<crate::Spawner>> {
         self.spawner.as_ref()
+    }
+
+    /// Issue 607 Phase 4a (ADR-0079): set the self-shutdown flag the
+    /// actor's dispatcher polls between handler dispatches. Subsequent
+    /// `recv_blocking` calls still process incoming mail, but
+    /// `should_shutdown` reports `true` so the trampoline can drain
+    /// the inbox synchronously, run `on_close`, and exit. Idempotent.
+    pub fn signal_shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::Release);
+    }
+
+    /// Read the self-shutdown flag. Polled by the dispatcher trampoline
+    /// after each handler dispatch — substrate-shutdown
+    /// (channel-disconnect) flows through the same drain path without
+    /// setting this flag, so the trampoline takes either signal as a
+    /// trigger to wind down.
+    pub fn should_shutdown(&self) -> bool {
+        self.shutdown_flag.load(Ordering::Acquire)
     }
 
     /// Block until the next envelope arrives on this actor's inbox.

--- a/crates/aether-substrate/src/spawn.rs
+++ b/crates/aether-substrate/src/spawn.rs
@@ -208,8 +208,14 @@ impl Spawner {
         // only op that can fail with a name collision against a peer
         // singleton claim — the actor_registry slot is keyed on
         // MailboxId which already passed the tombstone check).
-        let tx_for_sink = Arc::new(tx.clone());
-        let weak_for_handler = Arc::downgrade(&tx_for_sink);
+        //
+        // The strong `Arc<Sender>` lives in the actor_registry's
+        // Live entry. The sink handler's `Weak<Sender>` upgrades only
+        // while the Arc is alive — i.e. while the actor's slot is
+        // Live. On `mark_dead` the Arc drops, the weak upgrade fails,
+        // and external mail addressed to the dead mailbox warn-drops.
+        let strong_sender: Arc<mpsc::Sender<Envelope>> = Arc::new(tx.clone());
+        let weak_for_handler = Arc::downgrade(&strong_sender);
         let registered = self.registry.try_register_sink(
             full_name.clone(),
             Arc::new(
@@ -255,11 +261,14 @@ impl Spawner {
 
         // Insert before pre-loading mail: the actor_registry holding
         // the sender is the canonical record that the slot is live.
+        // The Arc<Sender> here is the same one the sink handler's
+        // Weak references — when `mark_dead` drops this entry, the
+        // weak upgrade fails for any further external mail.
         if self
             .actor_registry
             .insert_live(
                 id,
-                tx.clone(),
+                Arc::clone(&strong_sender),
                 Arc::clone(&actor_arc) as Arc<dyn std::any::Any + Send + Sync>,
                 TypeId::of::<A>(),
             )
@@ -290,16 +299,31 @@ impl Spawner {
         // free-running per the comment above).
         let actor_for_thread = Arc::clone(&actor_arc);
         let transport_for_thread = Arc::clone(&transport);
+        let actor_registry_for_thread = Arc::clone(&self.actor_registry);
         let thread_name = alloc_instanced_thread_name(&full_name);
-        // The strong sink Arc was held only to populate the Weak
-        // handler reference; drop the local strong here so the
-        // handler's upgrade tracks dispatcher liveness through the
-        // tx clone the actor_registry holds.
-        drop(tx_for_sink);
+        // The local strong Arc was the populator for the Weak handler
+        // ref; the actor_registry now holds an `Arc::clone` of the
+        // same Arc, so dropping the local doesn't break the weak.
+        drop(strong_sender);
         let _ = std::thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                while let Some(env) = transport_for_thread.recv_blocking() {
+                // Issue 607 Phase 4a (ADR-0079): the dispatcher loop
+                // observes two shutdown signals: the self-shutdown
+                // flag (set by `NativeCtx::shutdown`) checked after
+                // each handler return, and channel-disconnect
+                // (substrate shutdown — registry dropped, sender
+                // gone) signalled by `recv_blocking` returning None.
+                // Both flow through the same drain → on_close → exit
+                // path below.
+                loop {
+                    if transport_for_thread.should_shutdown() {
+                        break;
+                    }
+                    let env = match transport_for_thread.recv_blocking() {
+                        Some(e) => e,
+                        None => break,
+                    };
                     let mut native_ctx =
                         crate::native_actor::NativeCtx::new(&transport_for_thread, env.sender);
                     if actor_for_thread
@@ -314,9 +338,46 @@ impl Spawner {
                         );
                     }
                 }
-                // Dispatcher exit — actor_arc drops here when the loop
-                // ends. Phase 4 will wire `on_close` here and flip the
-                // registry slot to `Dead` + insert a tombstone.
+
+                // Drain remaining mail synchronously. The flag/disconnect
+                // raced against any in-flight mail the sink handler
+                // already pushed; the actor sees it before `on_close`
+                // runs so a "please close" handler that flushes state
+                // observes the full inbox.
+                while let Some(env) = transport_for_thread.try_recv() {
+                    let mut native_ctx =
+                        crate::native_actor::NativeCtx::new(&transport_for_thread, env.sender);
+                    if actor_for_thread
+                        .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
+                        .is_none()
+                    {
+                        tracing::warn!(
+                            target: "aether_substrate::spawn",
+                            actor = A::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "instanced actor drain dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                }
+
+                // Last-chance close hook. ReplyTo is None because no
+                // inbound envelope produced this call.
+                let mut close_ctx = crate::native_actor::NativeCtx::new(
+                    &transport_for_thread,
+                    crate::mail::ReplyTo::NONE,
+                );
+                actor_for_thread.on_close(&mut close_ctx);
+
+                // Mark Dead + tombstone before actor_arc drops so
+                // peer lookups serialise: any send racing the close
+                // either finds Live (and gets dispatched in the drain
+                // loop above) or finds the slot already retired.
+                actor_registry_for_thread.mark_dead(id);
+
+                // actor_arc and transport_for_thread drop here on
+                // thread exit. The chassis-stored sender was already
+                // dropped when the actor_registry's `mark_dead` flipped
+                // the entry from Live to Dead.
             })
             .expect("dispatcher thread spawn must succeed");
 


### PR DESCRIPTION
<!-- pr-body-ok: b — bare issue refs in body are intended cross-link auto-references -->

Phase 4a of #607 (ADR-0079) — termination lifecycle. Phase 4b follows with the monitor primitive (`MonitorNotice`, `monitors_of` / `monitoring` indices, `MonitorHandle`, close-time fan-out).

## What lands

**Self-shutdown signal.** `NativeTransport::shutdown_flag: Arc<AtomicBool>` + `signal_shutdown` / `should_shutdown` accessors. The dispatcher trampoline polls between handler dispatches; setting the flag tells it to drain the inbox synchronously and exit.

**Per-handler API.** `NativeCtx::shutdown(&self)` flips the flag — handler code can self-terminate at any point. Idempotent.

**Close hook.** `NativeActor::on_close(&self, ctx: &mut NativeCtx<'_>)` with default-empty body. Fires after the dispatcher's drain pass, before the actor value drops. Three triggers, one path:
- Self-shutdown (`ctx.shutdown()`)
- Substrate shutdown (channel disconnect)
- Cooperative external ("please close" mail handler that calls shutdown)

All three flow through the same drain → on_close → exit sequence.

**Registry transition.** `ActorRegistry::mark_dead(id)` flips the slot `Live → Dead` and inserts the id into `tombstones`. Called by the instanced-actor dispatcher after `on_close` runs so future `spawn_child` rejects the retired full name with `SpawnError::SubnameRetired`.

**Dispatcher wiring.** Both instanced (`spawn.rs`) and singleton (`make_native_actor_boot`, legacy `boot_native_actor`) dispatchers got the same shape:

```
loop {
    if should_shutdown() { break; }
    let env = recv_blocking() else break;  // disconnect
    dispatch(env);
}
while let Some(env) = try_recv() { dispatch(env); }  // synchronous drain
on_close(&mut close_ctx);
// instanced only: mark_dead(id);
```

Singletons don't tombstone (their mailbox slot stays in `Registry`); the chassis's `BootedPassives::shutdown_in_place` reverse-drops the SinkSender to fully disconnect after on_close.

## Pre-existing fix folded in

`ActorEntry::Live::sender` is now `Arc<Sender<Envelope>>` (was `Sender<Envelope>`). The sink handler's `Weak<Sender>` upgrades only while the registry's Arc is alive — i.e. while the slot is Live. `mark_dead` drops the Arc, the weak fails to upgrade, and external mail addressed to a retired instanced mailbox warn-drops cleanly.

Phase 3a's smoke test never exercised the sink handler (only `after_init` mail, which bypasses it), so the dangling-weak bug hadn't surfaced until the new `ctx_shutdown_marks_dead_runs_on_close_tombstones_id` test pushed external mail through the registered handler.

## Doesn't change

Monitor fan-out — Phase 4b adds `MonitorNotice`, `monitors_of` / `monitoring` indices, `NativeCtx::monitor` + `MonitorHandle`, and the close-time fan-out that fires after `on_close` returns.

## Verify

- `cargo build --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace --lib` — 142 passing in aether-substrate including the new `ctx_shutdown_marks_dead_runs_on_close_tombstones_id` test: boots an empty chassis, spawns a Closer instanced actor, dispatches a Quit envelope through the registered sink handler, asserts on_close ran, asserts the registry slot flipped Live→Dead, asserts the tombstone was inserted, asserts a re-spawn under the retired name returns `SpawnError::SubnameRetired`.

Refs #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)