### PR TITLE
feat(substrate): monitor primitive + close fan-out (issue 607)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -433,6 +433,36 @@ pub struct UnresolvedMail {
     pub kind_id: aether_data::KindId,
 }
 
+/// Issue 607 Phase 4b (ADR-0079): framework-emitted close
+/// notification. Sent to every monitor a closing actor accumulated via
+/// `NativeCtx::monitor` — the substrate drains `monitors_of[target]`
+/// after the target's `on_close` runs, fires one `MonitorNotice` per
+/// watcher, and only then flips the target's slot from `Live` to
+/// `Dead`.
+///
+/// The watcher receives this kind as ordinary mail; its `#[handler]`
+/// reads `target` to identify which actor it was monitoring. v1 carries
+/// only the target id — no `CloseReason` field — so the wire shape is
+/// purely additive if a future revision wants to surface trap vs
+/// shutdown vs cooperative close.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.observation.monitor_notice")]
+pub struct MonitorNotice {
+    pub target: aether_data::MailboxId,
+}
+
 // Reserved control-plane vocabulary (ADR-0010). The substrate handles
 // these kinds inline rather than dispatching to a component — the
 // namespace itself is the routing discriminator. ADR-0019 PR 5 turned

--- a/crates/aether-substrate/src/actor_registry.rs
+++ b/crates/aether-substrate/src/actor_registry.rs
@@ -1,12 +1,14 @@
 //! Actor-lifecycle registry (ADR-0079, issue 607). Keyed by full-name
 //! `MailboxId`, tracks live actor entries plus tombstones (retired
-//! full names) and namespace ownership.
+//! full names), namespace ownership, and the bidirectional monitor
+//! indices (Phase 4b).
 //!
-//! Phase 2 of issue 607 lands the storage shape; nothing populates it
-//! yet. Phase 3 wires `NativeCtx::spawn_child` as the first writer
-//! (`Live` slot insertion); Phase 4 adds the close path
-//! (`Live` → `Dead`, plus `tombstones` insertion) and the monitor
-//! forward/reverse indices.
+//! Phase 2 of issue 607 lands the storage shape; Phase 3 wires
+//! `NativeCtx::spawn_child` as the first writer (`Live` slot
+//! insertion); Phase 4a flips `Live` → `Dead` and inserts tombstones
+//! at close; Phase 4b adds [`Self::monitors_of`] / [`Self::monitoring`]
+//! plus the [`Self::register_monitor`] / [`Self::deregister_monitor`]
+//! / [`Self::close_actor`] surface.
 //!
 //! Distinct from [`crate::registry::Registry`] — that one owns
 //! mailbox-name → handler routing and kind descriptors. This one owns
@@ -68,6 +70,47 @@ pub struct ActorRegistry {
     /// owns the namespace — the ADR-0079 guard against
     /// Singleton/Instanced or Instanced/Instanced name collisions.
     name_owners: RwLock<HashMap<&'static str, TypeId>>,
+
+    /// Forward monitor index: `monitors_of[target]` is the list of
+    /// watchers that registered a monitor against `target`. Drained at
+    /// `target`'s close to fan out [`aether_kinds::MonitorNotice`].
+    /// ADR-0079 §Discovery and monitoring.
+    monitors_of: RwLock<HashMap<MailboxId, Vec<MonitorEntry>>>,
+
+    /// Reverse monitor index: `monitoring[watcher]` is the list of
+    /// targets `watcher` is watching. Walked at `watcher`'s close to
+    /// remove `watcher` from each target's `monitors_of` (so a dead
+    /// watcher doesn't accumulate as a stale entry on every target it
+    /// was monitoring).
+    monitoring: RwLock<HashMap<MailboxId, Vec<MailboxId>>>,
+}
+
+/// One entry in [`ActorRegistry::monitors_of`]. Today only carries the
+/// watcher's id; the struct shape leaves room for a future per-monitor
+/// option (monitor reason, reply-target override) without rewriting the
+/// vec storage.
+#[derive(Debug, Clone, Copy)]
+pub struct MonitorEntry {
+    pub watcher: MailboxId,
+}
+
+/// Failure modes for [`ActorRegistry::register_monitor`] /
+/// [`crate::native_actor::NativeCtx::monitor`]. ADR-0079 v1: monitors
+/// must address an actor that is currently `Live`. Tombstoned targets
+/// (retired-and-closed full names) can't be monitored — the mail
+/// wouldn't fire anyway, since the close fan-out already ran when the
+/// slot flipped `Live` → `Dead`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MonitorError {
+    /// No `Live` entry at the target id. Either the actor never existed
+    /// or it was removed without going through the close path
+    /// (impossible in production today; future replacements may flow
+    /// through here instead of `mark_dead`).
+    TargetNotFound,
+    /// The target's full name is in `tombstones` — it lived and
+    /// closed, and `MonitorNotice` already fired (or would have, if any
+    /// monitor were registered). Registering now is meaningless.
+    TargetTombstoned,
 }
 
 impl ActorRegistry {
@@ -189,6 +232,145 @@ impl ActorRegistry {
         let mut tombstones = self.tombstones.write().unwrap();
         tombstones.insert(id);
     }
+
+    /// Issue 607 Phase 4b (ADR-0079): register `watcher` as a monitor
+    /// of `target`. Caller is responsible for sending the resulting
+    /// [`MonitorEntry`] back through a [`crate::native_actor::MonitorHandle`]
+    /// so `Drop` deregisters the entry — bare callers (tests, internal
+    /// fixtures) own the cleanup themselves.
+    ///
+    /// Uses the reverse `monitoring[watcher]` index to support the
+    /// watcher-died case: when the watcher closes, the close path
+    /// walks `monitoring[watcher]` and prunes `watcher` from each
+    /// target's `monitors_of` so dead watchers don't accumulate.
+    ///
+    /// Validation: target must be `Live` (a `Dead` slot or missing
+    /// returns `TargetNotFound`); a tombstoned id returns
+    /// `TargetTombstoned` (takes priority over `TargetNotFound` when
+    /// both apply, so a closed actor surfaces as tombstoned rather
+    /// than not-found).
+    pub(crate) fn register_monitor(
+        &self,
+        watcher: MailboxId,
+        target: MailboxId,
+    ) -> Result<(), MonitorError> {
+        if self.is_tombstoned(target) {
+            return Err(MonitorError::TargetTombstoned);
+        }
+        // Live check goes through the actors map so callers see a
+        // consistent "is the actor running" answer regardless of
+        // whether the target slot is `Live`, `Dead`, or never inserted.
+        // Singletons booted through the chassis builder land in this
+        // map alongside instanced actors (issue 607 Phase 4b lifts the
+        // boot path to insert `Live`); callers who reach for monitor
+        // before that lift see `TargetNotFound`, which matches the
+        // wire contract for "this id has no live actor."
+        let actors = self.actors.read().unwrap();
+        if !matches!(actors.get(&target), Some(ActorEntry::Live { .. })) {
+            return Err(MonitorError::TargetNotFound);
+        }
+        drop(actors);
+        let entry = MonitorEntry { watcher };
+        // Forward + reverse insert under separate locks. Both maps are
+        // readable individually under read locks; transient
+        // observability of forward without reverse (or vice versa) is
+        // benign — the close path also looks at both, and either
+        // direction missing just means one cleanup step is a no-op.
+        self.monitors_of
+            .write()
+            .unwrap()
+            .entry(target)
+            .or_default()
+            .push(entry);
+        self.monitoring
+            .write()
+            .unwrap()
+            .entry(watcher)
+            .or_default()
+            .push(target);
+        Ok(())
+    }
+
+    /// Issue 607 Phase 4b (ADR-0079): undo a prior `register_monitor`
+    /// call. Idempotent — removing a monitor that was already pruned
+    /// (e.g. because the target closed and the close path drained the
+    /// forward index) is a no-op. Called by [`crate::native_actor::MonitorHandle::Drop`]
+    /// when the handle goes out of scope.
+    pub(crate) fn deregister_monitor(&self, watcher: MailboxId, target: MailboxId) {
+        if let Some(entries) = self.monitors_of.write().unwrap().get_mut(&target) {
+            entries.retain(|e| e.watcher != watcher);
+        }
+        if let Some(targets) = self.monitoring.write().unwrap().get_mut(&watcher) {
+            targets.retain(|t| *t != target);
+        }
+    }
+
+    /// Issue 607 Phase 4b (ADR-0079): close path. Drains
+    /// `monitors_of[id]` (returning the watcher list for the caller to
+    /// fan out [`aether_kinds::MonitorNotice`] mail), walks
+    /// `monitoring[id]` to prune `id` from each watched target's
+    /// forward index, then calls [`Self::mark_dead`] to flip the slot
+    /// `Live` → `Dead` and insert the tombstone.
+    ///
+    /// One method (rather than three separate calls) so the dispatcher
+    /// trampoline can't accidentally skip a step on close — the
+    /// fan-out + reverse-prune + tombstone are all part of the same
+    /// retire-this-id transaction. Idempotent: a second call on an
+    /// already-`Dead` slot returns an empty watcher list and does no
+    /// further work.
+    pub(crate) fn close_actor(&self, id: MailboxId) -> Vec<MailboxId> {
+        // Forward index: take the watcher list whole. Future sends
+        // through `register_monitor` against this id now hit the
+        // tombstone branch (set by `mark_dead` below), so no race here
+        // can leak a registration past the close.
+        let watchers: Vec<MailboxId> = self
+            .monitors_of
+            .write()
+            .unwrap()
+            .remove(&id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| e.watcher)
+            .collect();
+        // Reverse index: walk each target the closing actor was
+        // monitoring and remove it from that target's forward list.
+        // Mirrors `deregister_monitor` per-target, but in bulk.
+        let monitoring_targets = self.monitoring.write().unwrap().remove(&id);
+        if let Some(targets) = monitoring_targets {
+            let mut forward = self.monitors_of.write().unwrap();
+            for target in targets {
+                if let Some(entries) = forward.get_mut(&target) {
+                    entries.retain(|e| e.watcher != id);
+                }
+            }
+        }
+        self.mark_dead(id);
+        watchers
+    }
+
+    /// Number of watchers registered against `target` right now. Test-
+    /// facing only — callers in production don't peek at the index.
+    #[cfg(test)]
+    pub(crate) fn monitor_count(&self, target: MailboxId) -> usize {
+        self.monitors_of
+            .read()
+            .unwrap()
+            .get(&target)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+
+    /// Number of targets `watcher` is monitoring right now. Test-facing
+    /// only.
+    #[cfg(test)]
+    pub(crate) fn monitoring_count(&self, watcher: MailboxId) -> usize {
+        self.monitoring
+            .read()
+            .unwrap()
+            .get(&watcher)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
 }
 
 #[cfg(test)]
@@ -203,5 +385,122 @@ mod tests {
         assert!(r.type_id_at(MailboxId(1)).is_none());
         assert!(!r.is_tombstoned(MailboxId(1)));
         assert!(r.namespace_owner("aether.example").is_none());
+        assert_eq!(r.monitor_count(MailboxId(1)), 0);
+        assert_eq!(r.monitoring_count(MailboxId(1)), 0);
+    }
+
+    /// Helper: insert a `Live` slot at `id` so `register_monitor`'s
+    /// liveness check passes. Uses a throwaway sender + actor so the
+    /// test doesn't drag in `NativeActor`.
+    fn insert_live_stub(r: &ActorRegistry, id: MailboxId) {
+        let (tx, _rx) = std::sync::mpsc::channel::<crate::capability::Envelope>();
+        struct Stub;
+        let actor: Arc<dyn std::any::Any + Send + Sync> = Arc::new(Stub);
+        r.insert_live(id, Arc::new(tx), actor, std::any::TypeId::of::<Stub>())
+            .expect("fresh slot");
+    }
+
+    #[test]
+    fn register_monitor_rejects_unknown_target() {
+        let r = ActorRegistry::new();
+        let watcher = MailboxId(1);
+        let target = MailboxId(2);
+        assert_eq!(
+            r.register_monitor(watcher, target),
+            Err(MonitorError::TargetNotFound),
+        );
+    }
+
+    #[test]
+    fn register_monitor_rejects_tombstoned_target() {
+        let r = ActorRegistry::new();
+        let watcher = MailboxId(1);
+        let target = MailboxId(2);
+        insert_live_stub(&r, target);
+        // close_actor flips the slot Dead and tombstones the id.
+        let _ = r.close_actor(target);
+        assert!(r.is_tombstoned(target));
+        assert_eq!(
+            r.register_monitor(watcher, target),
+            Err(MonitorError::TargetTombstoned),
+        );
+    }
+
+    #[test]
+    fn register_monitor_populates_both_indices() {
+        let r = ActorRegistry::new();
+        let watcher = MailboxId(1);
+        let target = MailboxId(2);
+        insert_live_stub(&r, target);
+        r.register_monitor(watcher, target).expect("live target");
+        assert_eq!(r.monitor_count(target), 1);
+        assert_eq!(r.monitoring_count(watcher), 1);
+    }
+
+    #[test]
+    fn deregister_monitor_clears_both_indices() {
+        let r = ActorRegistry::new();
+        let watcher = MailboxId(1);
+        let target = MailboxId(2);
+        insert_live_stub(&r, target);
+        r.register_monitor(watcher, target).unwrap();
+        r.deregister_monitor(watcher, target);
+        assert_eq!(r.monitor_count(target), 0);
+        assert_eq!(r.monitoring_count(watcher), 0);
+    }
+
+    #[test]
+    fn deregister_monitor_is_idempotent() {
+        let r = ActorRegistry::new();
+        // Calling deregister with no prior register is a no-op (used by
+        // MonitorHandle::Drop after the close path already cleaned up).
+        r.deregister_monitor(MailboxId(1), MailboxId(2));
+    }
+
+    #[test]
+    fn close_actor_returns_watchers_and_tombstones() {
+        let r = ActorRegistry::new();
+        let target = MailboxId(2);
+        let watcher_a = MailboxId(10);
+        let watcher_b = MailboxId(11);
+        insert_live_stub(&r, target);
+        r.register_monitor(watcher_a, target).unwrap();
+        r.register_monitor(watcher_b, target).unwrap();
+        let watchers = r.close_actor(target);
+        assert_eq!(watchers.len(), 2);
+        assert!(watchers.contains(&watcher_a));
+        assert!(watchers.contains(&watcher_b));
+        assert!(r.is_tombstoned(target));
+        // Forward index for the closed target is empty.
+        assert_eq!(r.monitor_count(target), 0);
+    }
+
+    #[test]
+    fn close_actor_prunes_reverse_index_for_dead_watcher() {
+        // A monitors B; A dies. B's forward index must drop A.
+        let r = ActorRegistry::new();
+        let a = MailboxId(10);
+        let b = MailboxId(20);
+        insert_live_stub(&r, a);
+        insert_live_stub(&r, b);
+        r.register_monitor(a, b).unwrap();
+        assert_eq!(r.monitor_count(b), 1);
+        let _ = r.close_actor(a);
+        assert_eq!(
+            r.monitor_count(b),
+            0,
+            "dead watcher should be pruned from b's monitors_of",
+        );
+    }
+
+    #[test]
+    fn close_actor_idempotent_when_already_dead() {
+        let r = ActorRegistry::new();
+        let target = MailboxId(2);
+        insert_live_stub(&r, target);
+        let first = r.close_actor(target);
+        let second = r.close_actor(target);
+        assert!(first.is_empty(), "no monitors registered");
+        assert!(second.is_empty(), "no replay of watchers on second call");
     }
 }

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -879,6 +879,9 @@ where
 
     let actor_for_thread = Arc::clone(&actor_arc);
     let transport_for_thread = Arc::clone(&transport);
+    let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
+    let mailer_for_thread = ctx.mail_send_handle();
+    let self_id_for_thread = mailbox_id;
     let thread_name = alloc_legacy_native_actor_thread_name::<A>();
     let thread = std::thread::Builder::new()
         .name(thread_name)
@@ -967,6 +970,32 @@ where
                     },
                 );
             });
+            // Issue 607 Phase 4b (ADR-0079): mirror the new builder
+            // path's close-time monitor cleanup — drain monitors_of,
+            // fan out MonitorNotice mails, prune the reverse index,
+            // tombstone the id. Singletons aren't `Live` in `actors`
+            // today, but a singleton that called `ctx.monitor` left
+            // entries in `monitoring`; the prune is what keeps those
+            // forward indices clean after the dispatcher exits.
+            let watchers = actor_registry_for_thread.close_actor(self_id_for_thread);
+            if !watchers.is_empty() {
+                let notice = aether_kinds::MonitorNotice {
+                    target: self_id_for_thread,
+                };
+                let payload = <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(
+                    &notice,
+                );
+                let kind =
+                    crate::mail::KindId(<aether_kinds::MonitorNotice as aether_data::Kind>::ID.0);
+                for watcher in watchers {
+                    mailer_for_thread.push(crate::mail::Mail::new(
+                        watcher,
+                        kind,
+                        payload.clone(),
+                        1,
+                    ));
+                }
+            }
         })
         .map_err(|e| BootError::Other(Box::new(e)))?;
 

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -388,6 +388,9 @@ where
         // see the per-actor storage.
         let actor_for_thread = Arc::clone(&actor_arc);
         let transport_for_thread = Arc::clone(&transport);
+        let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
+        let mailer_for_thread = ctx.mail_send_handle();
+        let self_id_for_thread = mailbox_id;
         let thread_name = alloc_native_actor_thread_name::<A>();
         let thread = std::thread::Builder::new()
             .name(thread_name)
@@ -488,6 +491,37 @@ where
                         },
                     );
                 });
+                // Issue 607 Phase 4b (ADR-0079): close the actor in
+                // the registry — drains monitors_of[id] for fan-out,
+                // walks monitoring[id] to prune the singleton from
+                // each watched target's forward index, then marks
+                // Dead + tombstones the id. Singletons today don't
+                // sit in `actors` as `Live`, so the slot transition
+                // is purely sentinel; the reverse-prune is the
+                // load-bearing step (a singleton that monitored
+                // instanced actors must not leave dangling forward
+                // refs after its dispatcher exits).
+                let watchers = actor_registry_for_thread.close_actor(self_id_for_thread);
+                if !watchers.is_empty() {
+                    let notice = aether_kinds::MonitorNotice {
+                        target: self_id_for_thread,
+                    };
+                    let payload =
+                        <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(
+                            &notice,
+                        );
+                    let kind = crate::mail::KindId(
+                        <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0,
+                    );
+                    for watcher in watchers {
+                        mailer_for_thread.push(crate::mail::Mail::new(
+                            watcher,
+                            kind,
+                            payload.clone(),
+                            1,
+                        ));
+                    }
+                }
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 
@@ -1171,7 +1205,15 @@ mod tests {
     }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new());
+        // Wire the mailer's registry so any test that pushes mail
+        // (Phase 4b's close-time MonitorNotice fan-out, future
+        // close-side mail) doesn't trip the "Mailer not wired" assert
+        // in `Mailer::push`. Pre-Phase-4b tests that never reach
+        // `mailer.push` are unaffected — wiring is one-shot and idle.
+        mailer.wire(Arc::clone(&registry));
+        (registry, mailer)
     }
 
     /// Driver build path: passives boot, driver runs, passives tear
@@ -1842,6 +1884,487 @@ mod tests {
         assert!(
             matches!(err, SpawnError::SubnameRetired { .. }),
             "expected SubnameRetired, got {err:?}"
+        );
+
+        drop(chassis);
+    }
+
+    /// Issue 607 Phase 4b verify: a `ctx.monitor(target)` registration
+    /// fires exactly one `MonitorNotice` at the watcher when the
+    /// target self-shuts. Two-actor scenario: Watcher (instanced)
+    /// holds a `MonitorHandle` against Target (instanced) and counts
+    /// the notices it receives; Target self-shuts on `Quit`. After
+    /// the close fan-out we assert (1) the watcher saw the notice
+    /// once with the right target id, (2) the target's slot is Dead +
+    /// tombstoned, and (3) the registry's forward index drained.
+    #[test]
+    fn ctx_monitor_fires_notice_at_target_close() {
+        use crate::registry::MailboxEntry;
+        use crate::spawn::Subname;
+        use aether_actor::{HandlesKind, Instanced};
+        use aether_data::{Kind, KindId as DataKindId};
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
+
+        // Self-shutdown trigger for the target.
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Quit {
+            tag: u32,
+        }
+        impl Kind for Quit {
+            const NAME: &'static str = "test.monitor.quit";
+            const ID: DataKindId = DataKindId(0xC0DE_C0DE_4B4B_4B4B);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        // Tells the watcher which target to monitor. The watcher's
+        // handler reads `target_id` and calls `ctx.monitor`.
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct WatchOrder {
+            target_id: u64,
+        }
+        impl Kind for WatchOrder {
+            const NAME: &'static str = "test.monitor.watch_order";
+            const ID: DataKindId = DataKindId(0x4B4B_C0DE_C0DE_C0DE);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        // Target — handles Quit by self-shutting.
+        struct Target;
+        impl aether_actor::Actor for Target {
+            const NAMESPACE: &'static str = "test.monitor.target";
+        }
+        impl Instanced for Target {}
+        impl HandlesKind<Quit> for Target {}
+        impl crate::native_actor::NativeActor for Target {
+            type Config = ();
+            fn init(
+                _: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self)
+            }
+        }
+        impl crate::native_actor::NativeDispatch for Target {
+            fn __aether_dispatch_envelope(
+                &self,
+                ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == Quit::ID.0 {
+                    let _ = Quit::decode_from_bytes(payload)?;
+                    ctx.shutdown();
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        // Watcher — handles WatchOrder by registering a monitor;
+        // handles MonitorNotice by recording the target id and
+        // bumping a counter.
+        struct Watcher {
+            notice_count: Arc<AtomicU32>,
+            last_target: Arc<AtomicU64>,
+            handle: Mutex<Option<crate::native_actor::MonitorHandle>>,
+        }
+        impl aether_actor::Actor for Watcher {
+            const NAMESPACE: &'static str = "test.monitor.watcher";
+        }
+        impl Instanced for Watcher {}
+        impl HandlesKind<WatchOrder> for Watcher {}
+        impl HandlesKind<aether_kinds::MonitorNotice> for Watcher {}
+        impl crate::native_actor::NativeActor for Watcher {
+            type Config = (Arc<AtomicU32>, Arc<AtomicU64>);
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    notice_count: config.0,
+                    last_target: config.1,
+                    handle: Mutex::new(None),
+                })
+            }
+        }
+        impl crate::native_actor::NativeDispatch for Watcher {
+            fn __aether_dispatch_envelope(
+                &self,
+                ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == WatchOrder::ID.0 {
+                    let order = WatchOrder::decode_from_bytes(payload)?;
+                    let target = aether_data::MailboxId(order.target_id);
+                    let h = ctx
+                        .monitor(target)
+                        .expect("target must be Live at order time");
+                    *self.handle.lock().unwrap() = Some(h);
+                    return Some(());
+                }
+                if kind.0 == <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0 {
+                    let notice =
+                        <aether_kinds::MonitorNotice as aether_data::Kind>::decode_from_bytes(
+                            payload,
+                        )?;
+                    self.last_target
+                        .store(notice.target.0, AtomicOrdering::SeqCst);
+                    self.notice_count.fetch_add(1, AtomicOrdering::SeqCst);
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        // Spawn target first so the watcher can register against a
+        // Live id.
+        let target_id = chassis
+            .spawn_actor::<Target>(Subname::Counter, ())
+            .finish()
+            .expect("spawn target");
+
+        let notice_count = Arc::new(AtomicU32::new(0));
+        let last_target = Arc::new(AtomicU64::new(0));
+        let watcher_id = chassis
+            .spawn_actor::<Watcher>(
+                Subname::Counter,
+                (Arc::clone(&notice_count), Arc::clone(&last_target)),
+            )
+            .finish()
+            .expect("spawn watcher");
+
+        // Drive the watcher to register the monitor by pushing a
+        // WatchOrder through its sink handler. After this returns
+        // the watcher's handle is stored in `self.handle`.
+        let MailboxEntry::Sink(watcher_handler) =
+            registry.entry(watcher_id).expect("watcher sink registered")
+        else {
+            panic!("expected sink entry for watcher");
+        };
+        let order = WatchOrder {
+            target_id: target_id.0,
+        };
+        watcher_handler(
+            <WatchOrder as Kind>::ID,
+            WatchOrder::NAME,
+            None,
+            aether_data::ReplyTo::NONE,
+            &order.encode_into_bytes(),
+            1,
+        );
+
+        // Wait until the registry sees the monitor entry.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while chassis.actor_registry().monitor_count(target_id) == 0
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            chassis.actor_registry().monitor_count(target_id),
+            1,
+            "watcher's monitor should be registered against target",
+        );
+        assert_eq!(
+            chassis.actor_registry().monitoring_count(watcher_id),
+            1,
+            "watcher should appear in the reverse index",
+        );
+
+        // Fire Quit at the target — its handler self-shuts; the
+        // dispatcher's close path runs `close_actor`, which fans out
+        // a MonitorNotice mail to watcher_id.
+        let MailboxEntry::Sink(target_handler) =
+            registry.entry(target_id).expect("target sink registered")
+        else {
+            panic!("expected sink entry for target");
+        };
+        target_handler(
+            <Quit as Kind>::ID,
+            Quit::NAME,
+            None,
+            aether_data::ReplyTo::NONE,
+            &(Quit { tag: 1 }).encode_into_bytes(),
+            1,
+        );
+
+        // Wait for the notice to land at the watcher.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while notice_count.load(AtomicOrdering::SeqCst) == 0 && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            notice_count.load(AtomicOrdering::SeqCst),
+            1,
+            "watcher should have received exactly one MonitorNotice",
+        );
+        assert_eq!(
+            last_target.load(AtomicOrdering::SeqCst),
+            target_id.0,
+            "MonitorNotice.target should match the closed actor's id",
+        );
+
+        // Wait for target slot to flip Dead (the close path runs
+        // close_actor → mark_dead after fan-out).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while chassis.actor_registry().live_actor(target_id).is_some()
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            chassis.actor_registry().live_actor(target_id).is_none(),
+            "target slot should transition Live → Dead after close fan-out",
+        );
+        assert!(
+            chassis.actor_registry().is_tombstoned(target_id),
+            "target id should be tombstoned",
+        );
+        // Forward index for target was drained.
+        assert_eq!(
+            chassis.actor_registry().monitor_count(target_id),
+            0,
+            "monitors_of[target] must drain after fan-out",
+        );
+
+        drop(chassis);
+    }
+
+    /// Issue 607 Phase 4b verify: when the *watcher* dies first, the
+    /// reverse-index walk prunes the watcher's entry from each
+    /// monitored target's `monitors_of`. No `MonitorNotice` fires (the
+    /// watcher is the one closing; targets are still alive).
+    #[test]
+    fn watcher_close_prunes_targets_forward_index() {
+        use crate::registry::MailboxEntry;
+        use crate::spawn::Subname;
+        use aether_actor::{HandlesKind, Instanced};
+        use aether_data::{Kind, KindId as DataKindId};
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        // Re-use Quit + WatchOrder shape inline (test isolation).
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct Quit {
+            tag: u32,
+        }
+        impl Kind for Quit {
+            const NAME: &'static str = "test.monitor.quit2";
+            const ID: DataKindId = DataKindId(0xCAFE_BABE_DEAD_BEEF);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+        struct WatchOrder {
+            target_id: u64,
+        }
+        impl Kind for WatchOrder {
+            const NAME: &'static str = "test.monitor.watch_order2";
+            const ID: DataKindId = DataKindId(0xBEEF_DEAD_BABE_CAFE);
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
+            }
+            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != core::mem::size_of::<Self>() {
+                    return None;
+                }
+                Some(bytemuck::pod_read_unaligned(bytes))
+            }
+        }
+
+        struct Target;
+        impl aether_actor::Actor for Target {
+            const NAMESPACE: &'static str = "test.monitor.target2";
+        }
+        impl Instanced for Target {}
+        impl crate::native_actor::NativeActor for Target {
+            type Config = ();
+            fn init(
+                _: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self)
+            }
+        }
+        impl crate::native_actor::NativeDispatch for Target {
+            fn __aether_dispatch_envelope(
+                &self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        struct Watcher {
+            handle: Mutex<Option<crate::native_actor::MonitorHandle>>,
+            close_observed: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for Watcher {
+            const NAMESPACE: &'static str = "test.monitor.watcher2";
+        }
+        impl Instanced for Watcher {}
+        impl HandlesKind<WatchOrder> for Watcher {}
+        impl HandlesKind<Quit> for Watcher {}
+        impl crate::native_actor::NativeActor for Watcher {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    handle: Mutex::new(None),
+                    close_observed: config,
+                })
+            }
+            fn on_close(&self, _ctx: &mut crate::native_actor::NativeCtx<'_>) {
+                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
+        impl crate::native_actor::NativeDispatch for Watcher {
+            fn __aether_dispatch_envelope(
+                &self,
+                ctx: &mut crate::native_actor::NativeCtx<'_>,
+                kind: crate::mail::KindId,
+                payload: &[u8],
+            ) -> Option<()> {
+                if kind.0 == WatchOrder::ID.0 {
+                    let order = WatchOrder::decode_from_bytes(payload)?;
+                    let target = aether_data::MailboxId(order.target_id);
+                    let h = ctx.monitor(target).expect("target Live");
+                    *self.handle.lock().unwrap() = Some(h);
+                    return Some(());
+                }
+                if kind.0 == Quit::ID.0 {
+                    let _ = Quit::decode_from_bytes(payload)?;
+                    ctx.shutdown();
+                    return Some(());
+                }
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        let target_id = chassis
+            .spawn_actor::<Target>(Subname::Counter, ())
+            .finish()
+            .expect("spawn target");
+        let close_observed = Arc::new(AtomicU32::new(0));
+        let watcher_id = chassis
+            .spawn_actor::<Watcher>(Subname::Counter, Arc::clone(&close_observed))
+            .finish()
+            .expect("spawn watcher");
+
+        // Watcher registers monitor against target.
+        let MailboxEntry::Sink(watcher_handler) =
+            registry.entry(watcher_id).expect("watcher sink registered")
+        else {
+            panic!("expected sink entry for watcher");
+        };
+        let order = WatchOrder {
+            target_id: target_id.0,
+        };
+        watcher_handler(
+            <WatchOrder as Kind>::ID,
+            WatchOrder::NAME,
+            None,
+            aether_data::ReplyTo::NONE,
+            &order.encode_into_bytes(),
+            1,
+        );
+
+        // Wait for register to land.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while chassis.actor_registry().monitor_count(target_id) == 0
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(chassis.actor_registry().monitor_count(target_id), 1);
+
+        // Quit watcher — its close path walks `monitoring[watcher]` and
+        // prunes watcher from `monitors_of[target]`.
+        watcher_handler(
+            <Quit as Kind>::ID,
+            Quit::NAME,
+            None,
+            aether_data::ReplyTo::NONE,
+            &(Quit { tag: 1 }).encode_into_bytes(),
+            1,
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while close_observed.load(AtomicOrdering::SeqCst) == 0
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            close_observed.load(AtomicOrdering::SeqCst),
+            1,
+            "watcher's on_close fired exactly once",
+        );
+
+        // Watcher slot tombstones; target slot still Live; target's
+        // forward index drained of the dead watcher.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while chassis.actor_registry().live_actor(watcher_id).is_some()
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            chassis.actor_registry().is_tombstoned(watcher_id),
+            "watcher tombstoned",
+        );
+        assert!(
+            chassis.actor_registry().live_actor(target_id).is_some(),
+            "target should still be Live (watcher closed, not target)",
+        );
+        assert_eq!(
+            chassis.actor_registry().monitor_count(target_id),
+            0,
+            "target's monitors_of should drop the dead watcher",
         );
 
         drop(chassis);

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -65,7 +65,7 @@ pub mod reply_table;
 pub mod spawn;
 pub mod supervisor;
 
-pub use actor_registry::{ActorEntry, ActorRegistry};
+pub use actor_registry::{ActorEntry, ActorRegistry, MonitorEntry, MonitorError};
 pub use aether_actor::Actor;
 pub use boot::{SubstrateBoot, SubstrateBootBuilder};
 pub use capability::{
@@ -82,7 +82,9 @@ pub use ctx::SubstrateCtx;
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;
-pub use native_actor::{Actors, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx};
+pub use native_actor::{
+    Actors, MonitorHandle, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx,
+};
 pub use native_transport::NativeTransport;
 pub use outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, LogEntry, LogLevel, RecordingBackend,

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -241,6 +241,42 @@ impl<'a> NativeCtx<'a> {
         self.transport.signal_shutdown();
     }
 
+    /// Issue 607 Phase 4b (ADR-0079): register the calling actor as a
+    /// monitor of `target`. Returns a [`MonitorHandle`] whose `Drop`
+    /// deregisters the entry, so a handler that wants to unwatch
+    /// before the watcher itself dies just drops the handle.
+    ///
+    /// On the target's close, the substrate drains its monitor list
+    /// and fires one [`aether_kinds::MonitorNotice`] per watcher
+    /// before the slot transitions `Live` → `Dead`. The watcher
+    /// receives that notice as ordinary mail and reads the `target`
+    /// field to identify the closing actor.
+    ///
+    /// Validation: `target` must currently be `Live` in the
+    /// [`crate::ActorRegistry`]; tombstoned (closed) and unknown ids
+    /// surface as [`crate::MonitorError`]. Singletons today don't sit
+    /// in the actor registry as `Live` entries (their entries live in
+    /// the routing [`crate::Registry`] only); a future lift inserts
+    /// them so monitoring a singleton works the same way. Until then,
+    /// monitor only addresses instanced actors.
+    ///
+    /// Panics if the transport was constructed via
+    /// [`NativeTransport::new_for_test`] (no spawner / actor registry
+    /// wired). Production transports always carry both.
+    pub fn monitor(
+        &self,
+        target: aether_data::MailboxId,
+    ) -> Result<MonitorHandle, crate::actor_registry::MonitorError> {
+        let spawner = self
+            .transport
+            .spawner()
+            .expect("NativeCtx::monitor requires a chassis-built transport (no spawner installed — likely a `new_for_test` transport)");
+        let registry = Arc::clone(spawner.actor_registry());
+        let watcher = self.transport.self_mailbox();
+        registry.register_monitor(watcher, target)?;
+        Ok(MonitorHandle::new(registry, watcher, target))
+    }
+
     /// Issue 607 Phase 3b (ADR-0079): spawn an instanced actor as a
     /// child of the calling actor. The new actor's [`crate::ReplyTo`]
     /// stamps the calling actor's mailbox so any reply addressed to
@@ -490,6 +526,57 @@ impl Actors {
     /// Number of booted actors. Useful for tests.
     pub fn len(&self) -> usize {
         self.by_type.len()
+    }
+}
+
+/// Issue 607 Phase 4b (ADR-0079): RAII handle returned by
+/// [`NativeCtx::monitor`]. Holds the registered `(watcher, target)`
+/// pair plus an `Arc` to the chassis's [`crate::ActorRegistry`] so
+/// `Drop` can deregister without rethreading the registry through the
+/// caller.
+///
+/// The framework also prunes the monitor entry on either party's
+/// close (the target's close drains `monitors_of[target]` after firing
+/// `MonitorNotice`; the watcher's close walks `monitoring[watcher]` to
+/// remove `watcher` from each target's forward list). `Drop` calls
+/// [`crate::ActorRegistry::deregister_monitor`] which is idempotent —
+/// dropping a handle whose entry the close path already removed is a
+/// no-op.
+///
+/// Not `Clone` — a monitor is a unique (watcher, target) registration;
+/// duplicating the handle would duplicate the deregistration on Drop
+/// (still benign because deregister is idempotent, but cloneable
+/// handles encourage holding multiple references whose semantics
+/// surface as silent multi-prune).
+pub struct MonitorHandle {
+    registry: Arc<crate::actor_registry::ActorRegistry>,
+    watcher: aether_data::MailboxId,
+    target: aether_data::MailboxId,
+}
+
+impl MonitorHandle {
+    pub(crate) fn new(
+        registry: Arc<crate::actor_registry::ActorRegistry>,
+        watcher: aether_data::MailboxId,
+        target: aether_data::MailboxId,
+    ) -> Self {
+        Self {
+            registry,
+            watcher,
+            target,
+        }
+    }
+
+    /// The target this handle is monitoring. Useful for handlers that
+    /// hold many handles and need to identify which one fired a notice.
+    pub fn target(&self) -> aether_data::MailboxId {
+        self.target
+    }
+}
+
+impl Drop for MonitorHandle {
+    fn drop(&mut self) {
+        self.registry.deregister_monitor(self.watcher, self.target);
     }
 }
 

--- a/crates/aether-substrate/src/spawn.rs
+++ b/crates/aether-substrate/src/spawn.rs
@@ -300,6 +300,7 @@ impl Spawner {
         let actor_for_thread = Arc::clone(&actor_arc);
         let transport_for_thread = Arc::clone(&transport);
         let actor_registry_for_thread = Arc::clone(&self.actor_registry);
+        let mailer_for_thread = Arc::clone(&self.mailer);
         let thread_name = alloc_instanced_thread_name(&full_name);
         // The local strong Arc was the populator for the Weak handler
         // ref; the actor_registry now holds an `Arc::clone` of the
@@ -368,16 +369,39 @@ impl Spawner {
                 );
                 actor_for_thread.on_close(&mut close_ctx);
 
-                // Mark Dead + tombstone before actor_arc drops so
-                // peer lookups serialise: any send racing the close
-                // either finds Live (and gets dispatched in the drain
-                // loop above) or finds the slot already retired.
-                actor_registry_for_thread.mark_dead(id);
+                // Issue 607 Phase 4b (ADR-0079): close path. Drain
+                // monitors_of[id] for fan-out, prune monitoring[id]
+                // from each target's forward list, then mark Dead +
+                // tombstone. `close_actor` runs all three steps under
+                // its own locks; we fan out the returned watcher list
+                // here so the MonitorNotice mails ride the substrate's
+                // ordinary `Mailer::push` path (sinks dispatch on the
+                // calling thread; component recipients route through
+                // the supervisor).
+                let watchers = actor_registry_for_thread.close_actor(id);
+                if !watchers.is_empty() {
+                    let notice = aether_kinds::MonitorNotice { target: id };
+                    let payload =
+                        <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(
+                            &notice,
+                        );
+                    let kind = crate::mail::KindId(
+                        <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0,
+                    );
+                    for watcher in watchers {
+                        mailer_for_thread.push(crate::mail::Mail::new(
+                            watcher,
+                            kind,
+                            payload.clone(),
+                            1,
+                        ));
+                    }
+                }
 
                 // actor_arc and transport_for_thread drop here on
                 // thread exit. The chassis-stored sender was already
-                // dropped when the actor_registry's `mark_dead` flipped
-                // the entry from Live to Dead.
+                // dropped when `close_actor`'s `mark_dead` flipped the
+                // entry from Live to Dead.
             })
             .expect("dispatcher thread spawn must succeed");
 


### PR DESCRIPTION
## Summary

ADR-0079 Phase 4b. The instanced-actor close path now fans out a framework-emitted notice to every monitor a closing actor accumulated.

- **aether_kinds::MonitorNotice** — cast-shape kind aether.observation.monitor_notice { target: MailboxId }. Watchers handler it the same way they handle any other inbound mail.
- **ActorRegistry** gains monitors_of (forward) + monitoring (reverse) indices, plus register_monitor / deregister_monitor / close_actor. close_actor runs the drain → reverse-prune → mark_dead + tombstone sequence under its own locks and returns the watcher list for the caller to fan out.
- **NativeCtx::monitor(target)** returns Result<MonitorHandle, MonitorError>. MonitorHandle::Drop deregisters; the close path's drain pre-empts the Drop (idempotent — dropping a handle whose entry the close path already removed is a no-op).
- **Close-time fan-out** wired into all three dispatcher trampolines: instanced spawn (spawn.rs), new singleton builder (chassis_builder.rs), legacy singleton boot (capability.rs). All three: on_close → close_actor → for each returned watcher push MonitorNotice through mailer.push.

The v1 forcing function (NetCapability listener watching SessionActor instances) is the next phase; this lands the framework primitive that listener will sit on.

## Notes

- register_monitor requires the target to be Live in the actor registry. Singletons aren't currently inserted as Live entries, so monitoring a singleton returns TargetNotFound today. A future lift extends Live-tracking to singletons; until then, monitor only addresses instanced actors.
- Singleton trampolines still run close_actor(self_id) so a singleton-watcher's reverse refs are pruned at close — the load-bearing step for the aether.net listener case where the singleton is the watcher and the targets it monitored need their forward indices cleaned.
- Issue 607's plan splits Phase 4 into 4a (termination, shipped via PR 621) and 4b (this PR — monitors). Phase 5 (resolve_actor accessors, independent) and Phase 6 (NetCapability + SessionActor, depends on this) follow.
- MonitorError::TargetTombstoned takes priority over TargetNotFound so a closed actor surfaces as tombstoned rather than not-found — diagnostically louder for callers who hold a stale id.

## Test plan

- [x] cargo build -p aether-substrate clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean
- [x] 9 actor_registry unit tests cover register / deregister / close + reverse-prune / idempotency
- [x] Two integration tests in chassis_builder: target-close fires notice at watcher; watcher-close prunes target's forward index
- [x] Full workspace cargo test passes (no regressions)

Phase 4b of issue 607.