### PR TITLE
refactor(macros): explicit cardinality on bridge attribute

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -815,46 +815,87 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
 /// feature pulling its native dep set in.
 #[proc_macro_attribute]
 pub fn bridge(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let feature = match parse_bridge_attr(attr) {
-        Ok(f) => f,
+    let opts = match parse_bridge_attr(attr) {
+        Ok(o) => o,
         Err(e) => return e.to_compile_error().into(),
     };
     let item = parse_macro_input!(item as ItemMod);
-    match expand_bridge(item, feature) {
+    match expand_bridge(item, opts) {
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }
 }
 
-/// Parse the optional `feature = "name"` argument on `#[bridge]`.
-/// Empty attr returns `None` (the default no-feature mode); anything
-/// else parses as a `syn::MetaNameValue` whose path must be `feature`
-/// and value must be a string literal.
-fn parse_bridge_attr(attr: TokenStream) -> syn::Result<Option<String>> {
-    if attr.is_empty() {
-        return Ok(None);
-    }
-    let meta: syn::MetaNameValue = syn::parse(attr)?;
-    if !meta.path.is_ident("feature") {
-        return Err(syn::Error::new_spanned(
-            &meta.path,
-            "#[bridge] only accepts `feature = \"name\"`",
-        ));
-    }
-    let syn::Expr::Lit(syn::ExprLit {
-        lit: syn::Lit::Str(s),
-        ..
-    }) = meta.value
-    else {
-        return Err(syn::Error::new_spanned(
-            &meta.path,
-            "#[bridge(feature = ...)] expects a string literal",
-        ));
-    };
-    Ok(Some(s.value()))
+/// Cardinality declaration on `#[bridge]`. The bridge attribute is the
+/// natural site for this because the bridge owns two struct definition
+/// sites (the wasm stub at file root + the native struct in `mod
+/// native`), and a cardinality marker impl needs to land at file root
+/// to cover both. Pre-issue-625 the bridge auto-emitted Singleton; the
+/// refactor makes the choice explicit (and adds Instanced as the
+/// counterpart).
+#[derive(Clone, Copy)]
+enum BridgeCardinality {
+    Singleton,
+    Instanced,
 }
 
-fn expand_bridge(mut item_mod: ItemMod, feature: Option<String>) -> syn::Result<TokenStream2> {
+#[derive(Default)]
+struct BridgeOpts {
+    cardinality: Option<BridgeCardinality>,
+    feature: Option<String>,
+}
+
+/// Parse `#[bridge]`'s optional arguments. Recognised:
+/// - `singleton` (positional flag) — emit `impl Singleton for X`
+/// - `instanced` (positional flag) — emit `impl Instanced for X`
+/// - `feature = "name"` — gate the inner mod on the named feature
+///
+/// Empty attr (`#[bridge]`) emits no cardinality marker; the author is
+/// expected to hand-roll one (test fixtures, future cases). Mixing
+/// `singleton` and `instanced` is rejected — a cap is one or the other.
+fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
+    let mut opts = BridgeOpts::default();
+    if attr.is_empty() {
+        return Ok(opts);
+    }
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("singleton") {
+            if matches!(opts.cardinality, Some(BridgeCardinality::Instanced)) {
+                return Err(meta.error(
+                    "#[bridge] cannot declare both `singleton` and `instanced` — \
+                     cardinality is mutually exclusive (ADR-0079)",
+                ));
+            }
+            opts.cardinality = Some(BridgeCardinality::Singleton);
+            Ok(())
+        } else if meta.path.is_ident("instanced") {
+            if matches!(opts.cardinality, Some(BridgeCardinality::Singleton)) {
+                return Err(meta.error(
+                    "#[bridge] cannot declare both `singleton` and `instanced` — \
+                     cardinality is mutually exclusive (ADR-0079)",
+                ));
+            }
+            opts.cardinality = Some(BridgeCardinality::Instanced);
+            Ok(())
+        } else if meta.path.is_ident("feature") {
+            let value = meta.value()?;
+            let lit: syn::LitStr = value.parse()?;
+            opts.feature = Some(lit.value());
+            Ok(())
+        } else {
+            Err(meta
+                .error("#[bridge] only accepts `singleton`, `instanced`, or `feature = \"name\"`"))
+        }
+    });
+    syn::parse::Parser::parse(parser, attr)?;
+    Ok(opts)
+}
+
+fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenStream2> {
+    let BridgeOpts {
+        cardinality,
+        feature,
+    } = opts;
     let Some((brace, items)) = item_mod.content.take() else {
         return Err(syn::Error::new_spanned(
             &item_mod,
@@ -1042,14 +1083,27 @@ fn expand_bridge(mut item_mod: ItemMod, feature: Option<String>) -> syn::Result<
         #native_cfg
         pub use #mod_ident::#type_ident;
     };
-    let singleton_marker = quote! {
-        impl #impl_generics ::aether_actor::Singleton for #self_ty #where_clause {}
-    };
+    // Issue 625: cardinality is an explicit declaration on the bridge
+    // attribute per ADR-0079. The bridge sits over two struct
+    // definition sites — the wasm stub at file root and the native
+    // struct inside `mod native` — and the cardinality marker impl
+    // must land at file root to cover both. The author writes
+    // `#[bridge(singleton)]` or `#[bridge(instanced)]`; absence is
+    // hand-rolled (test fixtures, future cases that don't fit either).
     let actor_marker = quote! {
         impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
             const NAMESPACE: &'static str = #namespace_expr;
             #frame_barrier_const
         }
+    };
+    let cardinality_marker = match cardinality {
+        Some(BridgeCardinality::Singleton) => Some(quote! {
+            impl #impl_generics ::aether_actor::Singleton for #self_ty #where_clause {}
+        }),
+        Some(BridgeCardinality::Instanced) => Some(quote! {
+            impl #impl_generics ::aether_actor::Instanced for #self_ty #where_clause {}
+        }),
+        None => None,
     };
     // Issue 576 + issue 603: only-fallback (true catch-all) caps emit
     // one blanket `impl<K: Kind> HandlesKind<K> for X {}` so typed
@@ -1107,8 +1161,8 @@ fn expand_bridge(mut item_mod: ItemMod, feature: Option<String>) -> syn::Result<
     let mod_attrs = std::mem::take(&mut item_mod.attrs);
     Ok(quote! {
         #stub_and_reexport
-        #singleton_marker
         #actor_marker
+        #cardinality_marker
         #(#handles_kind_markers)*
 
         #(#mod_attrs)*
@@ -1204,17 +1258,15 @@ pub fn local(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// `#[derive(Singleton)]` — emits `impl ::aether_actor::Singleton for T {}`.
 ///
-/// Issue 552 stage 0: explicit opt-in marker that an actor type is
-/// the sole instance of its kind in a chassis. The trait itself is a
-/// simple marker — no methods. Future stages may grow `Singleton`
-/// into a richer trait (e.g. an associated `unique_name() -> &str`)
-/// at which point this derive emits the additional bodies; today
-/// it's just the marker.
-///
-/// Kept as `#[derive(Singleton)]` rather than auto-emitted by
-/// `#[actor]` so opting OUT (multi-instance actors, when stage 5+
-/// introduces them) is non-breaking — the absence of the derive
-/// becomes the opt-out signal instead of a new attribute syntax.
+/// Per ADR-0079 (issue 607) cardinality is first-class:
+/// [`Singleton`] and [`Instanced`] are mutually exclusive at the type
+/// level. Issue 625 made the choice explicit at the struct
+/// definition rather than auto-emitted by `#[bridge]` — `Singleton`
+/// is a property of the type, not of any one trait it implements.
+/// Authors place `#[derive(Singleton)]` on the cap struct alongside
+/// `pub struct X` inside the bridge mod; absence selects the other
+/// cardinality (and the type-system catches mistakes — `Builder::with_actor`
+/// requires `Singleton`, `ctx.spawn_child` requires `Instanced`).
 #[proc_macro_derive(Singleton)]
 pub fn derive_singleton(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -1222,6 +1274,27 @@ pub fn derive_singleton(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     quote! {
         impl #impl_generics ::aether_actor::Singleton for #name #ty_generics #where_clause {}
+    }
+    .into()
+}
+
+/// `#[derive(Instanced)]` — emits `impl ::aether_actor::Instanced for T {}`.
+///
+/// The instanced counterpart of [`derive_singleton`]. Per ADR-0079
+/// (issue 607), instanced actors carry a runtime subname under their
+/// `NAMESPACE` prefix — full names hash to `"{NAMESPACE}:{subname}"`
+/// (e.g. `aether.tcp.listener:8080`). Authors place
+/// `#[derive(Instanced)]` on the cap struct inside the bridge mod;
+/// `Builder::with_actor` rejects instanced types at compile time
+/// (the chassis-builder boots singletons only), and
+/// `ctx.spawn_child` requires the `Instanced` bound.
+#[proc_macro_derive(Instanced)]
+pub fn derive_instanced(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    quote! {
+        impl #impl_generics ::aether_actor::Instanced for #name #ty_generics #where_clause {}
     }
     .into()
 }

--- a/crates/aether-actor/src/actor.rs
+++ b/crates/aether-actor/src/actor.rs
@@ -172,3 +172,36 @@ pub trait HandlesKind<K: Kind>: Actor {}
 pub trait Dispatch {
     fn __dispatch(&mut self, sender: ReplyTo, kind: u64, payload: &[u8]) -> Option<()>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue 625 (ADR-0079): `#[derive(Singleton)]` and
+    /// `#[derive(Instanced)]` are the explicit author-side surface
+    /// for cardinality. Trait mutual exclusion is documentation +
+    /// use-site bounds (no sealed-trait enforcement); this smoke
+    /// confirms both derives produce reachable marker impls
+    /// independently.
+    #[test]
+    fn singleton_derive_emits_marker_impl() {
+        #[derive(crate::Singleton)]
+        struct UniqueCap;
+        impl Actor for UniqueCap {
+            const NAMESPACE: &'static str = "test.cardinality.unique";
+        }
+        fn requires_singleton<T: Singleton>() {}
+        requires_singleton::<UniqueCap>();
+    }
+
+    #[test]
+    fn instanced_derive_emits_marker_impl() {
+        #[derive(crate::Instanced)]
+        struct PerThing;
+        impl Actor for PerThing {
+            const NAMESPACE: &'static str = "test.cardinality.per_thing";
+        }
+        fn requires_instanced<T: Instanced>() {}
+        requires_instanced::<PerThing>();
+    }
+}

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -161,21 +161,24 @@ pub mod __macro_internals {
 pub use aether_data::{
     Kind, KindId as DataKindId, Schema, actor, bridge, capability, fallback, handler, local,
 };
-// `Singleton` lives in two namespaces:
+// `Singleton` and `Instanced` each live in two namespaces:
 //   - the type namespace for the marker trait (`Actor` super-trait),
 //     re-exported above as part of `actor::*`.
-//   - the macro namespace for the `#[derive(Singleton)]` proc-macro,
-//     forwarded through `aether-data::Singleton` (which itself
-//     re-exports `aether-actor-derive::Singleton` behind the `derive`
-//     feature).
+//   - the macro namespace for the `#[derive(Singleton)]` /
+//     `#[derive(Instanced)]` proc-macros, forwarded through
+//     `aether-data` (which itself re-exports them from
+//     `aether-actor-derive` behind the `derive` feature).
 // Rust resolves derive names from the macro namespace and type names
-// from the type namespace, so the same `Singleton` identifier covers
-// both `impl Singleton for X` and `#[derive(Singleton)]` without
-// ambiguity at the user's call site. The `#[doc(inline)]` flattens
-// the rustdoc page so the derive shows up at `aether_actor::Singleton`
-// rather than under a synthetic re-export shim.
+// from the type namespace, so the same identifier covers both
+// `impl Singleton for X` / `impl Instanced for X` and the
+// `#[derive(...)]` form without ambiguity at the user's call site.
+// The `#[doc(inline)]` flattens the rustdoc page so the derives show
+// up at `aether_actor::{Singleton, Instanced}` rather than under
+// synthetic re-export shims. Issue 625 (ADR-0079) made the cardinality
+// derives the explicit author-side surface — `#[bridge]` no longer
+// auto-emits either.
 #[doc(inline)]
-pub use aether_data::Singleton;
+pub use aether_data::{Instanced, Singleton};
 
 /// Wrap one-or-more items in `#[cfg(not(target_arch = "wasm32"))]`.
 /// Issue 552 stage 4's wasm-header-only build of `aether-capabilities`

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -61,7 +61,7 @@ use aether_kinds::{NoteOff, NoteOn, SetMasterGain};
 #[cfg(all(not(target_arch = "wasm32"), feature = "audio-native"))]
 pub use native::AudioConfig;
 
-#[aether_actor::bridge(feature = "audio-native")]
+#[aether_actor::bridge(singleton, feature = "audio-native")]
 mod native {
     use std::f32::consts::TAU;
     use std::sync::Arc;

--- a/crates/aether-capabilities/src/broadcast.rs
+++ b/crates/aether-capabilities/src/broadcast.rs
@@ -27,7 +27,7 @@
 // need cfg gating.
 use aether_kinds::HUB_BROADCAST_MAILBOX_NAME;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/control.rs
+++ b/crates/aether-capabilities/src/control.rs
@@ -43,7 +43,7 @@ use aether_kinds::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::ControlPlaneConfig;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::collections::HashMap;
     use std::panic::AssertUnwindSafe;

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -13,7 +13,7 @@
 // of the mod (always-on, outside the cfg gate).
 use aether_kinds::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -161,7 +161,7 @@ fn parse_default_timeout_env() -> Duration {
     Duration::from_millis(ms as u64)
 }
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::collections::HashSet;
     use std::sync::Arc;

--- a/crates/aether-capabilities/src/io.rs
+++ b/crates/aether-capabilities/src/io.rs
@@ -234,7 +234,7 @@ pub fn build_registry(
     Ok((Arc::new(registry), roots))
 }
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -19,7 +19,7 @@
 
 use aether_kinds::LogBatch;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use super::LogBatch;
     use aether_actor::actor;

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -37,7 +37,7 @@ pub use native::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
 // auto-emitted re-export. It carries no auxiliary native-only types,
 // so nothing extra to surface here.
 
-#[aether_actor::bridge(feature = "render-native")]
+#[aether_actor::bridge(singleton, feature = "render-native")]
 mod native {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -685,7 +685,7 @@ mod native {
     }
 }
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native_headless {
     use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -17,7 +17,7 @@
 // of the mod (always-on, outside the cfg gate).
 use aether_kinds::Advance;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -13,7 +13,7 @@
 // of the mod (always-on, outside the cfg gate).
 use aether_kinds::{SetWindowMode, SetWindowTitle};
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -72,7 +72,7 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 /// SDK and the derive share a home.
 #[cfg(feature = "derive")]
 pub use aether_actor_derive::{
-    Kind, Schema, Singleton, actor, bridge, capability, fallback, handler, local,
+    Instanced, Kind, Schema, Singleton, actor, bridge, capability, fallback, handler, local,
 };
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -17,7 +17,7 @@ use aether_kinds::{ProcessExited, Spawn, SpawnResult, Terminate, TerminateResult
 use crate::hub::registry::EngineRegistry;
 use crate::hub::spawn::PendingSpawns;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use super::{
         EngineRegistry, PendingSpawns, ProcessExited, Spawn, SpawnResult, Terminate,

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -23,7 +23,7 @@ use aether_kinds::Advance;
 // don't have to reach into `native::`.
 pub use native::TestBenchCapConfig;
 
-#[aether_actor::bridge]
+#[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

Closes issue 625. ADR-0079 made Singleton/Instanced first-class, but `#[bridge]` auto-emitted `impl Singleton for X` for every cap. The first instanced cap arriving (Phase 6a TcpListenerActor) showed the gap: cardinality was on the macro layer with the wrong default for instanced caps.

This refactor makes cardinality an **explicit declaration on the bridge attribute** — the natural site because the bridge owns two struct definition sites (wasm stub at file root + native struct in `mod native`) and the cardinality marker impl must land at file root to cover both. An earlier draft of this PR put `#[derive(Singleton)]` on the inner native struct alone; CI surfaced the gap (the wasm stub had no Singleton impl, breaking wasm-component builds where `ctx.actor::<X>()` requires `Singleton`).

## Changes

- **aether-actor-derive**: bridge accepts `singleton` / `instanced` positional flag plus the existing `feature = "..."`. Mixing the two is rejected. Bridge no longer auto-emits cardinality; absence emits no marker (hand-rolled). The matching `Singleton` or `Instanced` impl lands at file root next to the always-on Actor + HandlesKind impls so both wasm stub and native struct see the marker.
- **`#[derive(Instanced)]` derive added**, mirroring the existing `Singleton` derive. Re-exported through aether-data and aether-actor. Available for hand-rolled types (test fixtures, future cases that don't fit the bridge pattern).
- **Sweep**: 13 bridge sites switch from `#[aether_actor::bridge]` to `#[aether_actor::bridge(singleton)]` (or `#[aether_actor::bridge(singleton, feature = "...")]` for the gated ones). audio, broadcast, control, handle, http, io, log, render (RenderCapability + HeadlessRenderCapability), test_bench, window, plus bundle's process_capability and test_bench cap.
- **Smoke tests** in aether-actor::actor confirm both derives produce reachable marker impls independently. The cap files themselves are the integration test of the bridge attribute.

## Doesn't change

- Wire format, mailbox hashing, kind ids — untouched.
- Runtime dispatch behavior — Singleton/Instanced are markers; no methods.
- Cap mail surfaces — no new kinds, no schema additions.
- `#[bridge(feature = "X")]` ergonomics — feature gating still works the same way.

## Test plan

- [x] cargo build --workspace --all-targets clean
- [x] cargo build --target wasm32-unknown-unknown for component crates clean (the path that broke earlier)
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean
- [x] Full workspace cargo test passes — zero FAILED, no regressions
- [x] Two new derive smoke tests in aether-actor pass
- [x] Phase 6a unparks: TcpListenerActor will ship with `#[bridge(instanced)]` cleanly