### PR TITLE
feat(tcp): tcp cap + listener actor (issue 607 phase 6a, issue 629 phase B)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1847,6 +1847,15 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     let mut fallback: Option<NativeFallbackFn> = None;
     let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
     let mut consts: Vec<syn::ImplItemConst> = Vec::new();
+    // Issue 607 Phase 4a (ADR-0079): `on_close` is a `NativeActor` trait
+    // method with a default empty body. When a cap overrides it, the
+    // override must land inside the trait impl block (so the
+    // dispatcher trampoline's `actor.on_close(...)` resolves to the
+    // override via trait dispatch). Pre-issue-625 the macro routed
+    // every non-handler / non-init fn into the inherent impl, so
+    // `on_close` overrides triggered a dead_code warning and (worse)
+    // didn't override the trait method at all.
+    let mut lifecycle_methods: Vec<syn::ImplItemFn> = Vec::new();
 
     for impl_item in item.items {
         match impl_item {
@@ -1892,6 +1901,8 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     fallback = Some(NativeFallbackFn { method: f });
                 } else if f.sig.ident == "init" {
                     init_method = Some(f);
+                } else if f.sig.ident == "on_close" {
+                    lifecycle_methods.push(f);
                 } else {
                     helpers.push(f);
                 }
@@ -2100,6 +2111,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         impl #impl_generics #trait_path for #self_ty #where_clause {
             #config_type
             #init_method
+            #(#lifecycle_methods)*
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -35,6 +35,7 @@ pub mod io;
 pub mod log;
 #[cfg(feature = "render")]
 pub mod render;
+pub mod tcp;
 pub mod test_bench;
 pub mod window;
 
@@ -61,5 +62,6 @@ pub use render::HeadlessRenderCapability;
 pub use render::RenderCapability;
 #[cfg(feature = "render-native")]
 pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+pub use tcp::{TcpCapability, TcpListenerActor};
 pub use test_bench::UnsupportedTestBenchCapability;
 pub use window::HeadlessWindowCapability;

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -1,0 +1,145 @@
+//! `aether.tcp.listener` — instanced actor, one per bound port. Owns
+//! a `std::net::TcpListener` and a sidecar accept thread that loops
+//! on `accept()`. Phase 6a drops accepted streams; Phase 6b spawns a
+//! `TcpSessionActor` per accepted connection.
+//!
+//! Shutdown: `on_close` flips the accept thread's shutdown flag, then
+//! self-connects to the bound port to wake the blocked accept call.
+//! The accept returns, sees the flag, breaks; the dispatcher thread
+//! (in `on_close`) joins the accept thread.
+
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
+use aether_kinds::Close;
+
+// `TcpListenerConfig` carries `std::net::TcpListener` (native-only) so
+// it lives inside the bridge mod. Re-export at file root for the cap
+// module to consume.
+#[cfg(not(target_arch = "wasm32"))]
+pub use listener_native::TcpListenerConfig;
+
+#[aether_actor::bridge(instanced)]
+mod listener_native {
+    use super::Close;
+    use aether_actor::actor;
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    /// Init config for [`TcpListenerActor`]. `TcpCapability::on_bind`
+    /// binds the socket on the dispatcher thread (so addr-parse / port-
+    /// in-use failures surface synchronously) and hands the bound
+    /// listener through `spawn_child`. The `listener` field is
+    /// `Option` so init can move it out into the accept thread.
+    pub struct TcpListenerConfig {
+        pub listener: Option<TcpListener>,
+        pub addr: String,
+        pub port: u16,
+    }
+
+    /// Issue 629 / Phase B: `accept_thread` is a plain `Option`.
+    /// `shutdown` stays `Arc<AtomicBool>` because it's genuinely
+    /// cross-thread shared with the sidecar accept thread.
+    pub struct TcpListenerActor {
+        local_port: u16,
+        shutdown: Arc<AtomicBool>,
+        accept_thread: Option<JoinHandle<()>>,
+    }
+
+    #[actor]
+    impl NativeActor for TcpListenerActor {
+        type Config = TcpListenerConfig;
+        const NAMESPACE: &'static str = "aether.tcp.listener";
+
+        fn init(
+            mut config: TcpListenerConfig,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            let listener = config
+                .listener
+                .take()
+                .expect("TcpListenerConfig::listener consumed exactly once");
+            let addr = config.addr;
+            let port = config.port;
+            // Stay blocking — the accept loop wakes via self-connect
+            // on `on_close`. Nonblocking would require a poll loop +
+            // CPU burn for no win.
+            listener
+                .set_nonblocking(false)
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_for_thread = Arc::clone(&shutdown);
+            let thread = std::thread::Builder::new()
+                .name(format!("aether-tcp-accept-{port}"))
+                .spawn(move || {
+                    while !shutdown_for_thread.load(Ordering::Acquire) {
+                        match listener.accept() {
+                            Ok((stream, _peer)) => {
+                                if shutdown_for_thread.load(Ordering::Acquire) {
+                                    drop(stream);
+                                    break;
+                                }
+                                // Phase 6a: close the stream.
+                                // Phase 6b spawns TcpSessionActor.
+                                drop(stream);
+                            }
+                            Err(_) => {
+                                if shutdown_for_thread.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+
+            tracing::info!(
+                target: "aether_substrate::tcp",
+                addr = %addr,
+                port = port,
+                "tcp listener bound",
+            );
+
+            Ok(Self {
+                local_port: port,
+                shutdown,
+                accept_thread: Some(thread),
+            })
+        }
+
+        fn on_close(&mut self, _ctx: &mut NativeCtx<'_>) {
+            self.shutdown.store(true, Ordering::Release);
+            // Wake the blocked accept(). Self-connect to the bound
+            // port; the accept returns, sees the flag, breaks. Short
+            // connect timeout so a misconfigured listener (port
+            // unreachable) doesn't hang the close path.
+            let addr_str = format!("127.0.0.1:{}", self.local_port);
+            if let Ok(addr) = addr_str.parse::<std::net::SocketAddr>() {
+                let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+            }
+            if let Some(thread) = self.accept_thread.take() {
+                let _ = thread.join();
+            }
+            tracing::info!(
+                target: "aether_substrate::tcp",
+                port = self.local_port,
+                "tcp listener closed",
+            );
+        }
+
+        /// Cooperative external close. The unbind path on
+        /// `TcpCapability` mails this; we shut down so the dispatcher
+        /// drains, runs `on_close`, and the close fan-out fires
+        /// `MonitorNotice` to the cap.
+        #[handler]
+        fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: Close) {
+            ctx.shutdown();
+        }
+    }
+}

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -1,0 +1,587 @@
+//! `aether.tcp` cap (issue 607 Phase 6a, ADR-0079).
+//!
+//! Three-tier shape: [`TcpCapability`] (Singleton control plane) →
+//! [`TcpListenerActor`] (Instanced, one per bound port) → eventually
+//! `TcpSessionActor` (Instanced, Phase 6b — per connection). Phase 6a
+//! lands the singleton + listener and a stub accept handler that
+//! drops accepted streams; Phase 6b adds the session spawn and the
+//! read/write surface.
+//!
+//! ## Supervision shape
+//!
+//! `TcpCapability` is the supervisor of its listener fleet: it spawns
+//! listeners, monitors them, and replies to unbind requests on their
+//! close. The cap holds its own `MailboxId → ListenerEntry` map; it
+//! does NOT walk the chassis-wide actor registry to enumerate
+//! children. Cap handlers don't introspect the registry — the
+//! cap-as-supervisor pattern keeps the actor model intact (caps
+//! communicate via mail at runtime; chassis-level introspection is a
+//! test/embedder affordance, not a handler-side surface).
+//!
+//! ## Mail surface
+//!
+//! Control plane (mailed to `aether.tcp`):
+//! - `BindListener { addr, name? }` → `BindListenerResult`
+//! - `UnbindListener { listener_name }` → `UnbindListenerResult`
+//!   (asynchronous reply: the cap monitors the listener at spawn time
+//!   and replies only after `MonitorNotice` arrives)
+//! - `ListListeners` → `ListListenersResult`
+//!
+//! Listener (mailed to `aether.tcp.listener:<name>`):
+//! - `Close` → cooperative shutdown via `ctx.shutdown()`
+//!
+//! ## Threading
+//!
+//! Each listener owns one sidecar OS thread that holds the
+//! `std::net::TcpListener` and runs a blocking accept loop. On
+//! `on_close` the listener flips a shutdown flag and self-connects
+//! to its bound port to wake the blocked accept; the accept returns,
+//! sees the flag, breaks; the dispatcher thread joins.
+
+mod listener;
+
+pub use listener::TcpListenerActor;
+// TcpListenerConfig lives inside the native bridge mod (gated
+// non-wasm32) and is only consumed by the cap's spawn path on
+// native — re-exporting unconditionally would fail to resolve on
+// wasm32 builds where the bridge emits a stub.
+#[cfg(not(target_arch = "wasm32"))]
+pub use listener::TcpListenerConfig;
+
+// Trait-marker kinds the wasm32 bridge stub references via HandlesKind.
+use aether_kinds::{BindListener, ListListeners, MonitorNotice, UnbindListener};
+// Reply / payload kinds only consumed by native handler bodies. Gated to
+// avoid an unused-import warning on wasm32 where the bridge stub doesn't
+// reference them.
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::{
+    BindListenerResult, Close, ListListenersResult, ListenerInfo, UnbindListenerResult,
+};
+
+#[aether_actor::bridge(singleton)]
+mod cap_native {
+    // Trait-marker kinds the wasm32 bridge stub needs to satisfy
+    // HandlesKind; these stay always-imported.
+    use super::{BindListener, ListListeners, MonitorNotice, UnbindListener};
+    // Reply / payload kinds + native-only types (TcpListenerActor /
+    // TcpListenerConfig) only consumed by native handler bodies. The
+    // wasm32 stub bridge emits doesn't reference them, so they're
+    // gated to avoid an unused-import warning.
+    #[cfg(not(target_arch = "wasm32"))]
+    use super::{
+        BindListenerResult, Close, ListListenersResult, ListenerInfo, TcpListenerActor,
+        TcpListenerConfig, UnbindListenerResult,
+    };
+    use aether_actor::{MailCtx, actor};
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{MonitorHandle, NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::spawn::Subname;
+    use std::collections::HashMap;
+    use std::net::TcpListener;
+
+    /// Singleton control-plane cap. Owns the listener fleet directly
+    /// — the cap is the supervisor, not a thin shim over the chassis
+    /// registry. Each spawn registers a monitor on the new listener
+    /// and inserts a [`ListenerEntry`] into the cap-local map; the
+    /// `on_monitor_notice` handler removes the entry on listener
+    /// close.
+    ///
+    /// Issue 629 / Phase B: plain `HashMap` fields. The dispatcher
+    /// thread is the sole writer / reader; pre-Phase-A's
+    /// `Mutex<HashMap<...>>` was a worker-pool-era tax, not a
+    /// contention point.
+    pub struct TcpCapability {
+        /// Live listeners spawned by this cap. Key is the listener's
+        /// full-name `MailboxId`. Each entry holds the bind metadata
+        /// surfaced via `ListListeners` plus the monitor handle that
+        /// pins the cap's monitor on the listener until close.
+        listeners: HashMap<aether_data::MailboxId, ListenerEntry>,
+        /// Outstanding unbind replies parked until `MonitorNotice`
+        /// arrives from the listener being closed. Key is the same
+        /// `MailboxId` as `listeners`; the cap's monitor (registered
+        /// at spawn time) is what fires the notice.
+        pending_unbinds: HashMap<aether_data::MailboxId, PendingUnbind>,
+    }
+
+    /// Cap-local supervisor state for one live listener. Drops with
+    /// the entry; `MonitorHandle::Drop` is idempotent with the close
+    /// path's index drain.
+    struct ListenerEntry {
+        addr: String,
+        port: u16,
+        name: String,
+        // Held to keep the cap's monitor registered against the
+        // listener for its lifetime. Drops when the entry is removed
+        // (in `on_monitor_notice`).
+        _monitor_handle: MonitorHandle,
+    }
+
+    struct PendingUnbind {
+        sender: aether_data::ReplyTo,
+        listener_name: String,
+    }
+
+    #[actor]
+    impl NativeActor for TcpCapability {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.tcp";
+
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                listeners: HashMap::new(),
+                pending_unbinds: HashMap::new(),
+            })
+        }
+
+        /// Spawn a fresh `TcpListenerActor` bound to `mail.addr`.
+        ///
+        /// Binds the socket on the dispatcher thread (so a bind
+        /// failure replies `Err` synchronously), then hands the bound
+        /// listener through `spawn_child`. After spawn the cap
+        /// registers a monitor and inserts the listener into its
+        /// supervisor map.
+        ///
+        /// # Agent
+        /// Reply: `BindListenerResult`. `Ok` on successful bind +
+        /// spawn; `Err` on addr parse / bind / spawn / monitor failure.
+        #[handler]
+        fn on_bind(&mut self, ctx: &mut NativeCtx<'_>, mail: BindListener) {
+            let listener = match TcpListener::bind(&mail.addr) {
+                Ok(l) => l,
+                Err(e) => {
+                    ctx.reply(&BindListenerResult::Err {
+                        addr: mail.addr,
+                        reason: format!("bind failed: {e}"),
+                    });
+                    return;
+                }
+            };
+            let local_port = match listener.local_addr() {
+                Ok(addr) => addr.port(),
+                Err(e) => {
+                    ctx.reply(&BindListenerResult::Err {
+                        addr: mail.addr,
+                        reason: format!("local_addr failed: {e}"),
+                    });
+                    return;
+                }
+            };
+            let subname_str = mail.name.clone().unwrap_or_else(|| format!("{local_port}"));
+
+            let listener_id = match ctx
+                .spawn_child::<TcpListenerActor>(
+                    Subname::Named(&subname_str),
+                    TcpListenerConfig {
+                        listener: Some(listener),
+                        addr: mail.addr.clone(),
+                        port: local_port,
+                    },
+                )
+                .finish()
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    ctx.reply(&BindListenerResult::Err {
+                        addr: mail.addr,
+                        reason: format!("spawn failed: {e:?}"),
+                    });
+                    return;
+                }
+            };
+
+            // Register the cap's monitor on the freshly-spawned
+            // listener. The monitor pins until the entry is removed
+            // (in on_monitor_notice).
+            let monitor_handle = match ctx.monitor(listener_id) {
+                Ok(h) => h,
+                Err(e) => {
+                    // Listener spawned but monitor failed — extremely
+                    // unlikely (listener was just inserted Live). Reply
+                    // Err and let the listener live; chassis shutdown
+                    // will reap it.
+                    ctx.reply(&BindListenerResult::Err {
+                        addr: mail.addr,
+                        reason: format!("monitor failed: {e:?}"),
+                    });
+                    return;
+                }
+            };
+
+            self.listeners.insert(
+                listener_id,
+                ListenerEntry {
+                    addr: mail.addr.clone(),
+                    port: local_port,
+                    name: subname_str.clone(),
+                    _monitor_handle: monitor_handle,
+                },
+            );
+
+            ctx.reply(&BindListenerResult::Ok {
+                listener_name: subname_str,
+                listener_id,
+                local_port,
+            });
+        }
+
+        /// Mail `Close` to the named listener and park the
+        /// originator's reply target. Reply fires from
+        /// `on_monitor_notice` once the listener tombstones.
+        ///
+        /// # Agent
+        /// Reply: `UnbindListenerResult`. Asynchronous — the response
+        /// fires after the listener's accept thread joins and its
+        /// `MonitorNotice` arrives at this cap.
+        #[handler]
+        fn on_unbind(&mut self, ctx: &mut NativeCtx<'_>, mail: UnbindListener) {
+            // Resolve listener_id from the cap-local supervisor map by
+            // name. The cap is the source of truth for "what listeners
+            // exist"; no registry walk needed.
+            let listener_id = self
+                .listeners
+                .iter()
+                .find(|(_, entry)| entry.name == mail.listener_name)
+                .map(|(id, _)| *id);
+            let Some(listener_id) = listener_id else {
+                ctx.reply(&UnbindListenerResult::Err {
+                    listener_name: mail.listener_name,
+                    reason: "no such listener (or already closed)".into(),
+                });
+                return;
+            };
+            // Park the reply target keyed on listener_id. The cap's
+            // already-registered monitor (set at spawn time) fires
+            // MonitorNotice on close, which drives the reply.
+            self.pending_unbinds.insert(
+                listener_id,
+                PendingUnbind {
+                    sender: ctx.reply_target(),
+                    listener_name: mail.listener_name.clone(),
+                },
+            );
+            // Mail Close to the listener via the SDK typed-send
+            // shortcut. The listener's `on_close_request` handler
+            // calls `ctx.shutdown()`.
+            let full_name = format!(
+                "{}:{}",
+                <TcpListenerActor as aether_actor::Actor>::NAMESPACE,
+                mail.listener_name,
+            );
+            ctx.resolve_actor::<TcpListenerActor>(&full_name)
+                .send(&Close::default());
+        }
+
+        /// Walk the cap-local listener map and report metadata.
+        ///
+        /// # Agent
+        /// Reply: `ListListenersResult`.
+        #[handler]
+        fn on_list(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListListeners) {
+            let listeners: Vec<ListenerInfo> = self
+                .listeners
+                .values()
+                .map(|entry| ListenerInfo {
+                    name: entry.name.clone(),
+                    addr: entry.addr.clone(),
+                    port: entry.port,
+                })
+                .collect();
+            ctx.reply(&ListListenersResult { listeners });
+        }
+
+        /// Listener tombstoned — remove from the supervisor map and
+        /// fire the parked unbind reply if one is waiting.
+        ///
+        /// `MonitorNotice.target` identifies which listener closed.
+        /// The cap's monitor on every spawned listener (registered in
+        /// `on_bind`) fires this notice; if the close came from an
+        /// unbind request, `pending_unbinds` has an entry with the
+        /// originator to reply to.
+        #[handler]
+        fn on_monitor_notice(&mut self, ctx: &mut NativeCtx<'_>, notice: MonitorNotice) {
+            // Drop the supervisor entry. The held MonitorHandle drops
+            // here; deregister is idempotent with the close path's
+            // forward-index drain.
+            let _entry = self.listeners.remove(&notice.target);
+            // Fire the parked unbind reply if one was waiting.
+            let parked = self.pending_unbinds.remove(&notice.target);
+            if let Some(parked) = parked {
+                ctx.transport().send_reply_for_handler(
+                    parked.sender,
+                    &UnbindListenerResult::Ok {
+                        listener_name: parked.listener_name,
+                    },
+                );
+            }
+            // Else: notice came from a non-unbind close (chassis
+            // shutdown, future trap). Nothing to reply to; the
+            // supervisor entry is gone, that's the cleanup.
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::sync::Arc;
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        use super::{
+            BindListener, BindListenerResult, ListListeners, ListListenersResult, TcpCapability,
+            UnbindListener, UnbindListenerResult,
+        };
+        use aether_actor::Actor;
+        use aether_data::{Kind, SessionToken, Uuid};
+        use aether_substrate::capability::ChassisBuilder;
+        use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use aether_substrate::mailer::Mailer;
+        use aether_substrate::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::registry::{MailboxEntry, Registry};
+
+        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
+            let registry = Arc::new(Registry::new());
+            for d in aether_kinds::descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            let (outbound, rx) = HubOutbound::attached_loopback();
+            let mailer = Arc::new(Mailer::new());
+            mailer.wire(Arc::clone(&registry));
+            mailer.wire_outbound(outbound);
+            (registry, mailer, rx)
+        }
+
+        fn session_reply() -> ReplyTo {
+            ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
+        }
+
+        /// Push a postcard-encoded mail at the cap's mailbox via the
+        /// registered sink handler, then wait for the next outbound
+        /// reply on `rx` and decode as `R`.
+        fn drive_and_decode<K, R>(
+            registry: &Arc<Registry>,
+            rx: &mpsc::Receiver<EgressEvent>,
+            cap_namespace: &str,
+            mail: &K,
+        ) -> R
+        where
+            K: Kind + serde::Serialize,
+            R: serde::de::DeserializeOwned,
+        {
+            let id = registry
+                .lookup(cap_namespace)
+                .expect("cap mailbox registered");
+            let MailboxEntry::Sink(handler) = registry.entry(id).expect("cap entry") else {
+                panic!("expected sink entry");
+            };
+            let bytes = postcard::to_allocvec(mail).expect("encode");
+            handler(K::ID, K::NAME, None, session_reply(), &bytes, 1);
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let frame = loop {
+                if let Ok(f) = rx.try_recv() {
+                    break f;
+                }
+                if Instant::now() >= deadline {
+                    panic!("reply did not arrive within deadline for {}", K::NAME);
+                }
+                thread::sleep(Duration::from_millis(5));
+            };
+            let payload = match frame {
+                EgressEvent::ToSession { payload, .. } | EgressEvent::Broadcast { payload, .. } => {
+                    payload
+                }
+                other => panic!("expected ToSession/Broadcast egress, got {other:?}"),
+            };
+            postcard::from_bytes(&payload).expect("decode reply")
+        }
+
+        /// Issue 607 Phase 6a: bind → list → unbind round-trip on a
+        /// loopback port. Asserts the cap-local supervisor map
+        /// reflects every step (bound, listed, unbound).
+        #[test]
+        fn bind_then_list_then_unbind_roundtrip() {
+            let (registry, mailer, rx) = fresh_substrate();
+            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<TcpCapability>(())
+                .build()
+                .expect("TcpCapability boots");
+
+            // Bind to port 0 — let the OS pick a free port.
+            let bind_reply: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: "127.0.0.1:0".into(),
+                    name: None,
+                },
+            );
+            let (listener_name, local_port) = match bind_reply {
+                BindListenerResult::Ok {
+                    listener_name,
+                    local_port,
+                    ..
+                } => (listener_name, local_port),
+                BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+            };
+            assert_eq!(
+                listener_name,
+                local_port.to_string(),
+                "default subname should be the bound port",
+            );
+            assert!(local_port > 0, "OS-picked port should be non-zero");
+
+            // List enumerates the one listener.
+            let list_reply: ListListenersResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &ListListeners::default(),
+            );
+            assert_eq!(list_reply.listeners.len(), 1, "exactly one listener");
+            let entry = &list_reply.listeners[0];
+            assert_eq!(entry.name, listener_name);
+            assert_eq!(entry.port, local_port);
+            assert_eq!(entry.addr, "127.0.0.1:0");
+
+            // Unbind — asynchronous reply via MonitorNotice.
+            let unbind_reply: UnbindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &UnbindListener {
+                    listener_name: listener_name.clone(),
+                },
+            );
+            match unbind_reply {
+                UnbindListenerResult::Ok { listener_name: ln } => assert_eq!(ln, listener_name),
+                UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
+            }
+
+            // List should now be empty — cap-local supervisor map
+            // dropped the entry on MonitorNotice.
+            let list_reply: ListListenersResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &ListListeners::default(),
+            );
+            assert!(
+                list_reply.listeners.is_empty(),
+                "list should drop the unbound listener",
+            );
+        }
+
+        /// Binding the same port twice fails the second bind. Uses
+        /// the first bind's actually-bound port to drive the second.
+        #[test]
+        fn bind_port_in_use_returns_err() {
+            let (registry, mailer, rx) = fresh_substrate();
+            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<TcpCapability>(())
+                .build()
+                .expect("TcpCapability boots");
+
+            let first: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: "127.0.0.1:0".into(),
+                    name: Some("first".into()),
+                },
+            );
+            let local_port = match first {
+                BindListenerResult::Ok { local_port, .. } => local_port,
+                BindListenerResult::Err { reason, .. } => panic!("first bind failed: {reason}"),
+            };
+
+            // Second bind on the same port — must fail.
+            let second: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: format!("127.0.0.1:{local_port}"),
+                    name: Some("second".into()),
+                },
+            );
+            match second {
+                BindListenerResult::Ok { .. } => panic!("expected port-in-use Err"),
+                BindListenerResult::Err { reason, addr } => {
+                    assert_eq!(addr, format!("127.0.0.1:{local_port}"));
+                    assert!(
+                        reason.starts_with("bind failed:"),
+                        "expected bind-fail reason, got: {reason}",
+                    );
+                }
+            }
+        }
+
+        /// Unbind on an unknown name surfaces an Err with the name
+        /// echoed back.
+        #[test]
+        fn unbind_unknown_listener_errors() {
+            let (registry, mailer, rx) = fresh_substrate();
+            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<TcpCapability>(())
+                .build()
+                .expect("TcpCapability boots");
+
+            let reply: UnbindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &UnbindListener {
+                    listener_name: "nope".into(),
+                },
+            );
+            match reply {
+                UnbindListenerResult::Err { listener_name, .. } => {
+                    assert_eq!(listener_name, "nope");
+                }
+                UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
+            }
+        }
+
+        /// Two concurrent binds on different ports both surface in
+        /// `ListListeners`.
+        #[test]
+        fn list_enumerates_two_concurrent_listeners() {
+            let (registry, mailer, rx) = fresh_substrate();
+            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<TcpCapability>(())
+                .build()
+                .expect("TcpCapability boots");
+
+            let _: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: "127.0.0.1:0".into(),
+                    name: Some("admin".into()),
+                },
+            );
+            let _: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: "127.0.0.1:0".into(),
+                    name: Some("game".into()),
+                },
+            );
+
+            let list: ListListenersResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &ListListeners::default(),
+            );
+            let mut names: Vec<String> = list.listeners.iter().map(|l| l.name.clone()).collect();
+            names.sort();
+            assert_eq!(names, vec!["admin".to_string(), "game".to_string()]);
+        }
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -478,6 +478,127 @@ pub struct MonitorNotice {
 // components anyway).
 
 pub use control_plane::*;
+pub use tcp::*;
+
+mod tcp {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Serialize};
+
+    /// `aether.tcp.bind_listener` — request the singleton
+    /// `TcpCapability` to spawn a fresh `TcpListenerActor` bound to
+    /// `addr`. The cap parses `addr` via `std::net::ToSocketAddrs`
+    /// (so `"127.0.0.1:8080"` and `"0.0.0.0:0"` both work; the
+    /// latter asks the OS to pick a free port). Optional `name`
+    /// overrides the default subname (the bound port string); pass
+    /// `None` for the default. Reply: `BindListenerResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.bind_listener")]
+    pub struct BindListener {
+        pub addr: String,
+        pub name: Option<String>,
+    }
+
+    /// Reply to `BindListener`. `Ok` carries the resolved listener
+    /// name (the deterministic subname under
+    /// `aether.tcp.listener:<name>`), the listener's `MailboxId`,
+    /// and the actually-bound local port (load-bearing when `addr`
+    /// requested port 0). `Err` carries a human-readable reason —
+    /// addr parse failures, port-in-use, OS bind errors, namespace
+    /// collisions.
+    ///
+    /// Per project memory `feedback_mcp_mailbox_id_json_precision`:
+    /// `MailboxId` round-trips imprecisely over JSON. Agents
+    /// addressing the listener via subsequent MCP calls should use
+    /// `listener_name` (the deterministic full name); `listener_id`
+    /// is the wire id for native peers.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.bind_listener_result")]
+    pub enum BindListenerResult {
+        Ok {
+            listener_name: String,
+            listener_id: aether_data::MailboxId,
+            local_port: u16,
+        },
+        Err {
+            addr: String,
+            reason: String,
+        },
+    }
+
+    /// `aether.tcp.unbind_listener` — request the singleton
+    /// `TcpCapability` to close a listener by subname. The cap
+    /// resolves the listener via `chassis.resolve_actor`, mails
+    /// `Close` to it, monitors its close, and replies once
+    /// `MonitorNotice` arrives. Asynchronous reply: the response
+    /// only fires after the listener's accept thread has joined
+    /// and its slot has tombstoned.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.unbind_listener")]
+    pub struct UnbindListener {
+        pub listener_name: String,
+    }
+
+    /// Reply to `UnbindListener`. `Ok` once the listener has
+    /// tombstoned (the cap waited on `MonitorNotice` before
+    /// replying). `Err` for unknown listener names, listeners
+    /// already tombstoned at the time of the unbind request, or
+    /// fan-out failures.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.unbind_listener_result")]
+    pub enum UnbindListenerResult {
+        Ok {
+            listener_name: String,
+        },
+        Err {
+            listener_name: String,
+            reason: String,
+        },
+    }
+
+    /// `aether.tcp.list_listeners` — enumerate every live listener
+    /// the singleton knows about. The cap reaches for
+    /// `chassis.resolve_actors::<TcpListenerActor>()` (Phase 5)
+    /// and walks the live fleet. Reply: `ListListenersResult`.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.list_listeners")]
+    pub struct ListListeners {}
+
+    /// One entry in `ListListenersResult`. `name` is the subname
+    /// (e.g. `"8080"`); `addr` is the requested bind addr passed
+    /// to `BindListener`; `port` is the actually-bound local port.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct ListenerInfo {
+        pub name: String,
+        pub addr: String,
+        pub port: u16,
+    }
+
+    /// Reply to `ListListeners`. Always `Ok` — listing has no
+    /// failure mode that can't be expressed by an empty list.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.list_listeners_result")]
+    pub struct ListListenersResult {
+        pub listeners: Vec<ListenerInfo>,
+    }
+
+    /// `aether.tcp.close` — peer asks a `TcpListenerActor` to
+    /// gracefully close. Mailed by `TcpCapability::on_unbind`; the
+    /// listener's handler signals its accept thread, joins, and
+    /// calls `ctx.shutdown()`. Fire-and-forget at the kind level
+    /// (the close response rides via the cap's monitor on the
+    /// listener, not via this kind).
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.close")]
+    pub struct Close {}
+}
 
 mod control_plane {
     use alloc::string::String;

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use aether_capabilities::{
     AudioCapability, BroadcastCapability, CaptureBackend, ControlPlaneCapability,
     ControlPlaneConfig, HandleCapability, HttpCapability, IoCapability, LogCapability,
-    RenderCapability, RenderConfig, UnsupportedTestBenchCapability,
+    RenderCapability, RenderConfig, TcpCapability, UnsupportedTestBenchCapability,
     audio::AudioConfig as AudioConf, http::HttpConfig as HttpConf, io::NamespaceRoots,
 };
 use aether_kinds::WindowMode;
@@ -229,6 +229,7 @@ impl DesktopChassis {
             .with_actor::<ControlPlaneCapability>(control_plane_config)
             .with_actor::<IoCapability>(namespace_roots)
             .with_actor::<HttpCapability>(http)
+            .with_actor::<TcpCapability>(())
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<UnsupportedTestBenchCapability>(())

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use aether_capabilities::{
     BroadcastCapability, ControlPlaneCapability, ControlPlaneConfig, HandleCapability,
     HeadlessRenderCapability, HeadlessWindowCapability, HttpCapability, IoCapability,
-    LogCapability, UnsupportedTestBenchCapability, http::HttpConfig as HttpConf,
+    LogCapability, TcpCapability, UnsupportedTestBenchCapability, http::HttpConfig as HttpConf,
     io::NamespaceRoots,
 };
 use aether_data::{Kind, KindId};
@@ -177,6 +177,7 @@ impl HeadlessChassis {
             .with_actor::<ControlPlaneCapability>(control_plane_config)
             .with_actor::<IoCapability>(namespace_roots)
             .with_actor::<HttpCapability>(http)
+            .with_actor::<TcpCapability>(())
             .with_actor::<HeadlessRenderCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<UnsupportedTestBenchCapability>(())

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use crate::hub::HubClient;
 use aether_capabilities::{
     BroadcastCapability, CaptureBackend, HandleCapability, HeadlessWindowCapability, LogCapability,
-    RenderCapability, RenderConfig, RenderHandles,
+    RenderCapability, RenderConfig, RenderHandles, TcpCapability,
 };
 use aether_capabilities::{ControlPlaneCapability, ControlPlaneConfig};
 use aether_data::Kind;
@@ -196,6 +196,7 @@ impl TestBenchChassis {
                 .with_actor::<HandleCapability>(())
                 .with_actor::<LogCapability>(())
                 .with_actor::<ControlPlaneCapability>(control_plane_config)
+                .with_actor::<TcpCapability>(())
                 .with_actor::<RenderCapability>(render_config)
                 .with_actor::<HeadlessWindowCapability>(())
                 .with_actor::<TestBenchCapability>(test_bench_cap_config)

--- a/crates/aether-substrate/src/actor_registry.rs
+++ b/crates/aether-substrate/src/actor_registry.rs
@@ -241,8 +241,16 @@ impl ActorRegistry {
     /// Issue 607 Phase 5 (ADR-0079): walk every `Live` slot whose
     /// `TypeId` matches `T` and hand the caller `(subname, MailboxId)`.
     /// Used by [`super::PassiveChassis::resolve_actors`] /
-    /// [`super::BuiltChassis::resolve_actors`] to enumerate all
-    /// instances of a given type.
+    /// [`super::BuiltChassis::resolve_actors`] for chassis-level
+    /// enumeration of instanced actors.
+    ///
+    /// **Crate-private on purpose.** Cap handlers should not introspect
+    /// the registry at runtime — caps that supervise a fleet of
+    /// instances (e.g. `TcpCapability` over `TcpListenerActor`) hold
+    /// their own cap-local map of children and update it on
+    /// `MonitorNotice`. The chassis-level surface is for
+    /// embedder/test diagnostics, not in-handler state. ADR-0079
+    /// supervisor-as-cap pattern.
     ///
     /// Issue 629 / Phase A: returns `(subname, MailboxId)` instead of
     /// `(subname, Arc<T>)`. The actor itself no longer escapes its

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -1041,9 +1041,13 @@ impl<C: Chassis> BuiltChassis<C> {
     /// `(subname, MailboxId)` pairs (not `Arc<A>`); the actor itself
     /// never escapes its dispatcher thread.
     ///
-    /// Useful for chassis-level diagnostics (which sessions are
-    /// alive?) and for tests that need to assert against the full
-    /// fleet without holding a list of subnames externally.
+    /// **Diagnostic / embedder-test affordance.** Caps that supervise
+    /// a fleet of instances (e.g. `TcpCapability` over
+    /// `TcpListenerActor`) hold their own cap-local map of children
+    /// and update it on `MonitorNotice` — they don't enumerate via
+    /// the chassis registry from a handler. Reach for this from a
+    /// driver / TestBench / scenario inspection step, not from
+    /// production cap state. ADR-0079 supervisor-as-cap pattern.
     pub fn resolve_actors<A: aether_actor::Instanced + NativeActor>(
         &self,
     ) -> Vec<(String, MailboxId)> {
@@ -1173,7 +1177,9 @@ impl<C: Chassis> PassiveChassis<C> {
     /// Issue 607 Phase 5 (ADR-0079): mirror of
     /// [`BuiltChassis::resolve_actors`] for embedders that drive
     /// passive chassis directly. Issue 629 / Phase A: returns
-    /// `(subname, MailboxId)` pairs.
+    /// `(subname, MailboxId)` pairs. Diagnostic-only contract: caps
+    /// that supervise a fleet hold their own cap-local map; this is
+    /// for tests and chassis-level introspection only.
     pub fn resolve_actors<A: aether_actor::Instanced + NativeActor>(
         &self,
     ) -> Vec<(String, MailboxId)> {

--- a/crates/aether-substrate/src/spawn.rs
+++ b/crates/aether-substrate/src/spawn.rs
@@ -112,9 +112,16 @@ impl Spawner {
         }
     }
 
-    /// Borrow the actor registry. Read-only; spawn is the sole writer
-    /// in Phase 3 (Phase 4 adds the close path).
-    pub fn actor_registry(&self) -> &Arc<ActorRegistry> {
+    /// Borrow the actor registry. Crate-private — substrate-internal
+    /// dispatcher trampolines (instanced spawn close path, singleton
+    /// boot path) use this to call `close_actor` / `mark_dead` /
+    /// `try_claim_namespace` etc. Cap handlers reaching for the
+    /// registry through `transport.spawner().actor_registry()` is
+    /// the wrong shape — caps that supervise a fleet hold their own
+    /// child map; caps that just send mail use the typed `ctx.actor`
+    /// / `ctx.resolve_actor` shortcuts. ADR-0079 supervisor-as-cap
+    /// pattern.
+    pub(crate) fn actor_registry(&self) -> &Arc<ActorRegistry> {
         &self.actor_registry
     }
 


### PR DESCRIPTION
## Summary

ADR-0079 Phase 6a — first instanced cap shipped end-to-end. Three-tier shape:

- **TcpCapability** (Singleton, `aether.tcp`) — control plane, no sockets. Mail surface: `BindListener`, `UnbindListener`, `ListListeners`. Holds its own listener fleet via cap-local map.
- **TcpListenerActor** (Instanced, `aether.tcp.listener`) — one per bound port. Owns `std::net::TcpListener` + sidecar accept thread. Phase 6a drops accepted streams; 6b spawns sessions.

**Cap-as-supervisor pattern**: TcpCapability spawns each listener, registers a monitor at spawn time, replies to `UnbindListener` on the resulting `MonitorNotice`. The cap does not walk the chassis actor registry — it owns its children directly.

**Issue 629 Phase B simplification** (rebased onto post-Phase-A main):
- `TcpCapability.listeners`: `Mutex<HashMap<...>>` → plain `HashMap`.
- `TcpCapability.pending_unbinds`: `Mutex<HashMap<...>>` → plain `HashMap`.
- `TcpListenerActor.accept_thread`: `Mutex<Option<JoinHandle>>` → plain `Option<JoinHandle>`.
- All four TcpCapability handlers + both TcpListenerActor handlers take `&mut self`. Dispatcher owns the cap as `Box<A>` (Phase A); single-threaded ownership replaces the Mutex tax.
- `shutdown` stays `Arc<AtomicBool>` — genuine cross-thread share with the sidecar accept thread.

**Introspection visibility tightened** (review feedback from the original PR):
- `Spawner::actor_registry()` → `pub(crate)`. Cap handlers can no longer reach the registry through `transport.spawner()`.
- `ActorRegistry::live_subnames_of_type()` → `pub(crate)`. Chassis-level `resolve_actors` is the legitimate consumer.
- Doc warnings on `BuiltChassis`/`PassiveChassis::resolve_actors` marking them as diagnostic / embedder-test affordances.

**Macro fix**: native `#[actor]` arm now recognises `on_close` as a lifecycle method (routes into the trait impl block instead of the inherent helpers vec).

Wired into desktop, headless, and test-bench chassis bins. 4 integration tests cover `bind→list→unbind` roundtrip, port-in-use rejection, unknown-listener unbind error, two concurrent listeners enumeration.

Phase 6b (TcpSessionActor) lands next on its own branch.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)