### PR TITLE
refactor(capabilities): log cap to &mut self + plain u64 sequence (issue 629 phase B)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -2150,31 +2150,28 @@ struct NativeFallbackFn {
 }
 
 /// Validate a native `#[fallback]` method signature. Required shape:
-/// `(&self, ctx: &mut NativeCtx<'_>, env: &Envelope)`. The third
-/// argument's exact type isn't checked here — the synthesized
-/// override calls `self.<fallback>(ctx, env)` and the user's fn body
-/// will type-error against `&Envelope` if they wrote the wrong
-/// parameter type.
+/// `(&self | &mut self, ctx: &mut NativeCtx<'_>, env: &Envelope)`.
+/// The third argument's exact type isn't checked here — the
+/// synthesized override calls `self.<fallback>(ctx, env)` and the
+/// user's fn body will type-error against `&Envelope` if they wrote
+/// the wrong parameter type.
+///
+/// Issue 629 / Phase B: `&mut self` is now allowed alongside `&self`.
+/// The dispatcher owns the cap as `Box<A>` and calls the fallback
+/// through `&mut Box<A>`, so either receiver shape works.
 fn validate_native_fallback_sig(sig: &Signature) -> syn::Result<()> {
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
             "#[fallback] on `impl NativeActor for X` must have signature \
-             `(&self, ctx: &mut NativeCtx<'_>, env: &Envelope)`",
+             `(&self | &mut self, ctx: &mut NativeCtx<'_>, env: &Envelope)`",
         ));
     }
     let first = &sig.inputs[0];
-    let FnArg::Receiver(recv) = first else {
+    if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
-            "#[fallback] first parameter must be `&self`",
-        ));
-    };
-    if recv.mutability.is_some() {
-        return Err(syn::Error::new_spanned(
-            recv,
-            "#[fallback] receiver must be `&self`, not `&mut self` — \
-             native caps share state across threads via interior mutability behind `Arc<Self>`",
+            "#[fallback] first parameter must be `&self` or `&mut self`",
         ));
     }
     let third = &sig.inputs[2];
@@ -2188,42 +2185,38 @@ fn validate_native_fallback_sig(sig: &Signature) -> syn::Result<()> {
 }
 
 /// Extract `K` from a `#[actor] impl NativeActor` handler method's
-/// third parameter. Required signature: `(&self, ctx: &mut NativeCtx<'_>, mail: K)`.
-/// The `&self` (vs `&mut self`) is load-bearing — the actor lives
-/// behind `Arc<Self>` and shares the ref across dispatcher / lookup
-/// consumers.
-/// Extract `K` from a NativeActor handler's third parameter and a
-/// flag for slice-handler shape. Accepts:
-///   - `(&self, ctx: &mut NativeCtx<'_>, mail: K)` — single-payload
-///     handler, decodes via `Kind::decode_from_bytes`.
-///   - `(&self, ctx: &mut NativeCtx<'_>, mails: &[K])` — batched
-///     cast-shape handler, decodes the whole envelope as a contiguous
-///     `&[K]` slice via `decode_cast_slice` so a single envelope with
-///     `count > 1` (`Mailbox::send_many`, ADR-0019) reaches the
-///     handler intact. Only meaningful for cast-shape kinds; postcard
-///     kinds have no batch wire.
+/// third parameter and a flag for slice-handler shape. Accepts:
+///   - `(&self | &mut self, ctx: &mut NativeCtx<'_>, mail: K)` —
+///     single-payload handler, decodes via `Kind::decode_from_bytes`.
+///   - `(&self | &mut self, ctx: &mut NativeCtx<'_>, mails: &[K])` —
+///     batched cast-shape handler, decodes the whole envelope as a
+///     contiguous `&[K]` slice via `decode_cast_slice` so a single
+///     envelope with `count > 1` (`Mailbox::send_many`, ADR-0019)
+///     reaches the handler intact. Only meaningful for cast-shape
+///     kinds; postcard kinds have no batch wire.
+///
+/// Issue 629 / Phase B: `&mut self` is now allowed alongside `&self`.
+/// The dispatcher owns the cap as `Box<A>` and calls each handler
+/// through `&mut Box<A>`, so either receiver shape works. Caps with
+/// mutable state migrate from interior mutability (`Mutex` / `Atomic`)
+/// to plain fields by flipping handler signatures to `&mut self` per
+/// cap.
 fn extract_native_actor_handler_kind(sig: &Signature) -> syn::Result<(Type, bool)> {
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
             "#[actor] impl NativeActor #[handler] method must have signature \
-             `(&self, ctx: &mut NativeCtx<'_>, arg: K)` (or `mail: &[K]` for batched cast kinds)",
+             `(&self | &mut self, ctx: &mut NativeCtx<'_>, arg: K)` \
+             (or `mail: &[K]` for batched cast kinds)",
         ));
     }
     let first = &sig.inputs[0];
-    let FnArg::Receiver(recv) = first else {
+    if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
-            "#[handler] first parameter must be `&self` (NativeActor caps share state via Arc)",
+            "#[handler] first parameter must be `&self` or `&mut self`",
         ));
     };
-    if recv.mutability.is_some() {
-        return Err(syn::Error::new_spanned(
-            recv,
-            "#[actor] impl NativeActor #[handler] receiver must be `&self`, not `&mut self` — \
-             native caps share state across threads via interior mutability behind `Arc<Self>`",
-        ));
-    }
     let third = &sig.inputs[2];
     let FnArg::Typed(pt) = third else {
         return Err(syn::Error::new_spanned(

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -27,7 +27,6 @@ mod native {
     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::outbound::{HubOutbound, LogEntry, LogLevel};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     /// `aether.log` mailbox cap. Receives [`LogBatch`] mail, converts
@@ -35,9 +34,14 @@ mod native {
     /// monotonic sequence stamped on receipt; `origin` plucked from
     /// the mail envelope's sender), and forwards via
     /// [`HubOutbound::egress_log_batch`].
+    ///
+    /// Issue 629 / Phase B: `sequence` is a plain `u64` field. The
+    /// dispatcher thread is the sole writer (one handler at a time),
+    /// so the pre-Phase-A `AtomicU64` was a worker-pool-era artifact
+    /// rather than a contention point.
     pub struct LogCapability {
         outbound: Option<Arc<HubOutbound>>,
-        sequence: AtomicU64,
+        sequence: u64,
     }
 
     #[actor]
@@ -49,7 +53,7 @@ mod native {
             let outbound = ctx.mailer().outbound().cloned();
             Ok(Self {
                 outbound,
-                sequence: AtomicU64::new(1),
+                sequence: 1,
             })
         }
 
@@ -63,7 +67,7 @@ mod native {
         /// rides on the mail envelope; this cap reads `ctx.sender()`
         /// to populate `LogEntry::origin`.
         #[handler]
-        fn on_log_batch(&self, ctx: &mut NativeCtx<'_>, batch: LogBatch) {
+        fn on_log_batch(&mut self, ctx: &mut NativeCtx<'_>, batch: LogBatch) {
             let Some(outbound) = self.outbound.as_ref() else {
                 return;
             };
@@ -72,13 +76,17 @@ mod native {
             let entries: Vec<LogEntry> = batch
                 .entries
                 .into_iter()
-                .map(|e| LogEntry {
-                    timestamp_unix_ms: now,
-                    level: u8_to_level(e.level),
-                    target: e.target,
-                    message: e.message,
-                    sequence: self.sequence.fetch_add(1, Ordering::Relaxed),
-                    origin,
+                .map(|e| {
+                    let sequence = self.sequence;
+                    self.sequence += 1;
+                    LogEntry {
+                        timestamp_unix_ms: now,
+                        level: u8_to_level(e.level),
+                        target: e.target,
+                        message: e.message,
+                        sequence,
+                        origin,
+                    }
                 })
                 .collect();
             outbound.egress_log_batch(entries);


### PR DESCRIPTION
## Summary

First Phase B sweep of issue 629. Drops the `AtomicU64` sequence counter from `LogCapability` in favor of a plain `u64` field — the dispatcher thread is the sole writer post-ADR-0038, so the atomic was a worker-pool-era artifact rather than a contention point.

**Macro relaxation**: `#[handler]` and `#[fallback]` now accept either `&self` or `&mut self`. The dispatcher owns the cap as `Box<A>` (Phase A) and calls handlers through `&mut Box<A>`, so either receiver shape works. The previous hard-error rejecting `&mut self` reflected the pre-Phase-A `Arc<Self>` share. Caps migrate per their state needs: read-only handlers keep `&self`; mutating handlers go `&mut self`.

The macro change is bundled because it's the prerequisite for any Phase B cap migration; LogCapability is the first cap to exercise the new shape.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)