### PR TITLE
feat(tcp): tcp session actor + read sidecar (issue 607 phase 6b)

### DIFF
--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -1,7 +1,11 @@
 //! `aether.tcp.listener` — instanced actor, one per bound port. Owns
 //! a `std::net::TcpListener` and a sidecar accept thread that loops
-//! on `accept()`. Phase 6a drops accepted streams; Phase 6b spawns a
-//! `TcpSessionActor` per accepted connection.
+//! on blocking `accept()`. Phase 6b: each accepted connection spawns
+//! a `TcpSessionActor` as a child; the sidecar can't call
+//! `spawn_child` (no dispatcher ctx), so it pushes the `TcpStream`
+//! over an mpsc and fires a `ConnectionReady` wake mail at this
+//! actor's own mailbox. The wake handler drains the mpsc and does
+//! the spawn on the dispatcher thread.
 //!
 //! Shutdown: `on_close` flips the accept thread's shutdown flag, then
 //! self-connects to the bound port to wake the blocked accept call.
@@ -11,7 +15,7 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
-use aether_kinds::Close;
+use aether_kinds::{Close, ConnectionReady};
 
 // `TcpListenerConfig` carries `std::net::TcpListener` (native-only) so
 // it lives inside the bridge mod. Re-export at file root for the cap
@@ -21,15 +25,20 @@ pub use listener_native::TcpListenerConfig;
 
 #[aether_actor::bridge(instanced)]
 mod listener_native {
-    use super::Close;
+    use super::{Close, ConnectionReady};
     use aether_actor::actor;
+    use aether_data::Kind;
     use aether_substrate::capability::BootError;
     use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
-    use std::net::{TcpListener, TcpStream};
+    use aether_substrate::{KindId, Mail, Mailer};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
     use std::thread::JoinHandle;
     use std::time::Duration;
+
+    use crate::tcp::session::{TcpSessionActor, TcpSessionConfig};
 
     /// Init config for [`TcpListenerActor`]. `TcpCapability::on_bind`
     /// binds the socket on the dispatcher thread (so addr-parse / port-
@@ -42,13 +51,18 @@ mod listener_native {
         pub port: u16,
     }
 
-    /// Issue 629 / Phase B: `accept_thread` is a plain `Option`.
-    /// `shutdown` stays `Arc<AtomicBool>` because it's genuinely
-    /// cross-thread shared with the sidecar accept thread.
+    /// Issue 607 Phase 6b: the accept thread can't call
+    /// `ctx.spawn_child` (no dispatcher ctx), so it pushes accepted
+    /// streams over `connection_rx` and fires a [`ConnectionReady`]
+    /// wake mail. The dispatcher's `on_connection_ready` handler
+    /// drains the mpsc and spawns one `TcpSessionActor` per pending
+    /// stream.
     pub struct TcpListenerActor {
         local_port: u16,
         shutdown: Arc<AtomicBool>,
         accept_thread: Option<JoinHandle<()>>,
+        connection_rx: mpsc::Receiver<(TcpStream, SocketAddr)>,
+        next_subname: u64,
     }
 
     #[actor]
@@ -58,7 +72,7 @@ mod listener_native {
 
         fn init(
             mut config: TcpListenerConfig,
-            _ctx: &mut NativeInitCtx<'_>,
+            ctx: &mut NativeInitCtx<'_>,
         ) -> Result<Self, BootError> {
             let listener = config
                 .listener
@@ -74,19 +88,46 @@ mod listener_native {
                 .map_err(|e| BootError::Other(Box::new(e)))?;
             let shutdown = Arc::new(AtomicBool::new(false));
             let shutdown_for_thread = Arc::clone(&shutdown);
+
+            // mpsc for accept→dispatcher stream handoff. Unbounded —
+            // the kernel's accept backlog already bounds incoming
+            // connections, and the dispatcher drains the channel on
+            // every `ConnectionReady` mail.
+            let (connection_tx, connection_rx) = mpsc::channel::<(TcpStream, SocketAddr)>();
+
+            // Wake-mail plumbing: capture the mailer + this actor's
+            // own MailboxId so the accept thread can fire a
+            // ConnectionReady mail at us per accept.
+            let mailer: Arc<Mailer> = ctx.mailer();
+            let self_id = ctx.self_id();
+            let connection_ready_kind = KindId(<ConnectionReady as Kind>::ID.0);
+
             let thread = std::thread::Builder::new()
                 .name(format!("aether-tcp-accept-{port}"))
                 .spawn(move || {
                     while !shutdown_for_thread.load(Ordering::Acquire) {
                         match listener.accept() {
-                            Ok((stream, _peer)) => {
+                            Ok((stream, peer)) => {
                                 if shutdown_for_thread.load(Ordering::Acquire) {
                                     drop(stream);
                                     break;
                                 }
-                                // Phase 6a: close the stream.
-                                // Phase 6b spawns TcpSessionActor.
-                                drop(stream);
+                                if connection_tx.send((stream, peer)).is_err() {
+                                    // Dispatcher's receiver gone — actor
+                                    // is shutting down or already dropped.
+                                    break;
+                                }
+                                // Wake the dispatcher: the actual
+                                // stream is in the mpsc; this mail
+                                // just signals "drain me". Empty
+                                // payload (postcard encodes a unit
+                                // struct as zero bytes).
+                                mailer.push(Mail::new(
+                                    self_id,
+                                    connection_ready_kind,
+                                    Vec::new(),
+                                    1,
+                                ));
                             }
                             Err(_) => {
                                 if shutdown_for_thread.load(Ordering::Acquire) {
@@ -110,6 +151,8 @@ mod listener_native {
                 local_port: port,
                 shutdown,
                 accept_thread: Some(thread),
+                connection_rx,
+                next_subname: 0,
             })
         }
 
@@ -140,6 +183,56 @@ mod listener_native {
         #[handler]
         fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: Close) {
             ctx.shutdown();
+        }
+
+        /// Sidecar wake. Drain every pending accepted connection and
+        /// spawn a `TcpSessionActor` per stream. Each session is a
+        /// child of this listener (parent ReplyTo stamps as our own
+        /// mailbox), so on session close the close fan-out reaches
+        /// us via the standard monitor path.
+        ///
+        /// The accept thread fires one wake mail per accepted
+        /// connection, but the handler drains until empty regardless
+        /// — if multiple wakes coalesce into one dispatcher tick,
+        /// we'll see the queue already drained on the second handler
+        /// call and exit fast.
+        #[handler]
+        fn on_connection_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: ConnectionReady) {
+            while let Ok((stream, peer)) = self.connection_rx.try_recv() {
+                let subname = format!("conn-{}", self.next_subname);
+                self.next_subname += 1;
+                let peer_str = peer.to_string();
+                let session_config = TcpSessionConfig {
+                    stream: Some(stream),
+                    peer: peer_str.clone(),
+                    session_name: subname.clone(),
+                };
+                match ctx
+                    .spawn_child::<TcpSessionActor>(
+                        aether_substrate::Subname::Named(&subname),
+                        session_config,
+                    )
+                    .finish()
+                {
+                    Ok(_) => {
+                        tracing::debug!(
+                            target: "aether_substrate::tcp",
+                            session = %subname,
+                            peer = %peer_str,
+                            "tcp session spawned",
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "aether_substrate::tcp",
+                            session = %subname,
+                            peer = %peer_str,
+                            error = ?e,
+                            "tcp session spawn failed; closing stream",
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -39,14 +39,18 @@
 //! sees the flag, breaks; the dispatcher thread joins.
 
 mod listener;
+mod session;
 
 pub use listener::TcpListenerActor;
-// TcpListenerConfig lives inside the native bridge mod (gated
-// non-wasm32) and is only consumed by the cap's spawn path on
-// native — re-exporting unconditionally would fail to resolve on
-// wasm32 builds where the bridge emits a stub.
+// TcpListenerConfig and TcpSessionActor / TcpSessionConfig live
+// inside the native bridge mod (gated non-wasm32) and are only
+// consumed by the cap's spawn path on native — re-exporting
+// unconditionally would fail to resolve on wasm32 builds where
+// the bridge emits a stub.
 #[cfg(not(target_arch = "wasm32"))]
 pub use listener::TcpListenerConfig;
+#[cfg(not(target_arch = "wasm32"))]
+pub use session::{TcpSessionActor, TcpSessionConfig};
 
 // Trait-marker kinds the wasm32 bridge stub references via HandlesKind.
 use aether_kinds::{BindListener, ListListeners, MonitorNotice, UnbindListener};
@@ -542,6 +546,99 @@ mod cap_native {
                 }
                 UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
             }
+        }
+
+        /// Issue 607 Phase 6b: connect a real TCP client to a bound
+        /// listener, write bytes, observe `SessionData` broadcast on
+        /// the egress, then drop the client and observe
+        /// `SessionClosed`. Exercises the full pipeline:
+        /// listener accept thread → mpsc → ConnectionReady wake →
+        /// listener spawns TcpSessionActor → session read thread →
+        /// mpsc → SessionDataReady wake → session broadcasts.
+        ///
+        /// Boots [`crate::BroadcastCapability`] alongside `TcpCapability`
+        /// so the broadcast mailbox is registered; sessions broadcast
+        /// `SessionData` / `SessionClosed` through it.
+        #[test]
+        fn session_round_trip_data_then_close() {
+            use std::io::Write;
+            use std::net::TcpStream;
+
+            let (registry, mailer, rx) = fresh_substrate();
+            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<crate::BroadcastCapability>(())
+                .with_actor::<TcpCapability>(())
+                .build()
+                .expect("caps boot");
+
+            // Bind to OS-picked port.
+            let bind_reply: BindListenerResult = drive_and_decode(
+                &registry,
+                &rx,
+                TcpCapability::NAMESPACE,
+                &BindListener {
+                    addr: "127.0.0.1:0".into(),
+                    name: None,
+                },
+            );
+            let local_port = match bind_reply {
+                BindListenerResult::Ok { local_port, .. } => local_port,
+                BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+            };
+
+            // Connect a real client to the listener and write a
+            // tagged payload. Drop the client to trigger EOF on the
+            // session's read path.
+            let payload_text = b"hello session";
+            {
+                let mut client = TcpStream::connect(format!("127.0.0.1:{local_port}"))
+                    .expect("client connects to listener");
+                client.write_all(payload_text).expect("client write");
+                // Explicit flush + drop. `Drop` on TcpStream calls
+                // shutdown which triggers EOF on the server read.
+            }
+
+            // Drain egress until we observe both SessionData and
+            // SessionClosed broadcasts. The chassis driver thread
+            // (the loopback HubOutbound) ships every broadcast over
+            // `rx`. We tolerate other egress events (e.g. Tick
+            // broadcasts) interleaved.
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut saw_data = false;
+            let mut saw_closed = false;
+            while Instant::now() < deadline && (!saw_data || !saw_closed) {
+                let frame = match rx.try_recv() {
+                    Ok(f) => f,
+                    Err(_) => {
+                        thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                };
+                let (kind_name, payload) = match frame {
+                    EgressEvent::Broadcast {
+                        kind_name, payload, ..
+                    } => (kind_name, payload),
+                    EgressEvent::ToSession {
+                        kind_name, payload, ..
+                    } => (kind_name, payload),
+                    _ => continue,
+                };
+                if kind_name == <aether_kinds::SessionData as Kind>::NAME {
+                    let decoded: aether_kinds::SessionData =
+                        postcard::from_bytes(&payload).expect("decode SessionData");
+                    assert_eq!(decoded.bytes, payload_text);
+                    assert!(decoded.peer.starts_with("127.0.0.1:"));
+                    assert!(decoded.session_name.starts_with("conn-"));
+                    saw_data = true;
+                } else if kind_name == <aether_kinds::SessionClosed as Kind>::NAME {
+                    let decoded: aether_kinds::SessionClosed =
+                        postcard::from_bytes(&payload).expect("decode SessionClosed");
+                    assert_eq!(decoded.reason, "eof");
+                    saw_closed = true;
+                }
+            }
+            assert!(saw_data, "SessionData broadcast did not arrive");
+            assert!(saw_closed, "SessionClosed broadcast did not arrive");
         }
 
         /// Two concurrent binds on different ports both surface in

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -1,0 +1,323 @@
+//! `aether.tcp.session` — instanced actor, one per accepted
+//! connection. Owns a `TcpStream` (split for read/write) and a
+//! sidecar read thread that loops on blocking `read()`. Mirrors
+//! [`crate::tcp::listener::TcpListenerActor`]'s wake-mail shape:
+//! the read thread pushes byte chunks (or an EOF / error signal)
+//! over an mpsc and fires a [`SessionDataReady`] mail at this
+//! actor's own mailbox; the dispatcher's handler drains and
+//! broadcasts each chunk as [`SessionData`].
+//!
+//! Writes go directly from the dispatcher thread (`on_session_write`
+//! does a blocking `write_all` on the write half). The read path
+//! needs the sidecar because `read()` blocks indefinitely until
+//! peer data or close; the write path doesn't need it because the
+//! caller initiates writes synchronously and they're typically
+//! fast.
+//!
+//! Shutdown: `on_close` flips the read thread's shutdown flag and
+//! calls `stream.shutdown(Both)` on the write half. The kernel
+//! aborts any blocked `read()` on the read half, the read thread
+//! sees the error / EOF, exits. The dispatcher joins the thread
+//! and emits a single `SessionClosed` broadcast (suppressed if the
+//! read path already broadcast one for an EOF / error).
+
+// Handler-signature kinds need to be importable at file root for
+// the `#[bridge]`-emitted `HandlesKind` markers.
+use aether_kinds::{SessionClose, SessionDataReady, SessionWrite};
+
+// `TcpSessionActor` is auto-re-exported by `#[bridge]` at file
+// root; only `TcpSessionConfig` needs the manual re-export.
+#[cfg(not(target_arch = "wasm32"))]
+pub use session_native::TcpSessionConfig;
+
+#[aether_actor::bridge(instanced)]
+mod session_native {
+    use super::{SessionClose, SessionDataReady, SessionWrite};
+    use aether_actor::{Sender, actor};
+    use aether_data::Kind;
+    use aether_kinds::{HUB_BROADCAST_MAILBOX_NAME, SessionClosed, SessionData};
+    use aether_substrate::capability::BootError;
+    use aether_substrate::native_actor::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::{KindId, Mail, Mailer};
+    use std::io::{Read, Write};
+    use std::net::{Shutdown, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::thread::JoinHandle;
+
+    /// Default per-read buffer size. 64 KiB matches the typical
+    /// kernel TCP buffer; any larger and we just block waiting for
+    /// the kernel to fill it. Smaller adds syscall overhead per
+    /// chunk. Not currently configurable; agents that want
+    /// different framing can broadcast on top of `SessionData` and
+    /// re-chunk in user-space.
+    const READ_BUFFER_BYTES: usize = 64 * 1024;
+
+    /// Init config for [`TcpSessionActor`]. The listener's
+    /// `on_connection_ready` builds this per accepted stream and
+    /// hands it through `spawn_child`. `stream` is `Option` so init
+    /// can `.take()` and split it; `peer` and `session_name` are
+    /// echoed in every broadcast for agent-side correlation.
+    pub struct TcpSessionConfig {
+        pub stream: Option<TcpStream>,
+        pub peer: String,
+        pub session_name: String,
+    }
+
+    /// One end of a split `TcpStream`. The read sidecar owns the
+    /// read half; the dispatcher owns the write half (used by
+    /// `on_session_write`). Read-side errors / EOF flow back to the
+    /// dispatcher via the `bytes_rx` channel as `Err(reason)`.
+    pub struct TcpSessionActor {
+        peer: String,
+        session_name: String,
+        write_half: TcpStream,
+        shutdown: Arc<AtomicBool>,
+        read_thread: Option<JoinHandle<()>>,
+        bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+        mailer: Arc<Mailer>,
+        // Sticks to true once a `SessionClosed` broadcast has fired
+        // so duplicate broadcasts don't pile up if both the read
+        // path and `on_close` see the close.
+        closed_emitted: bool,
+    }
+
+    #[actor]
+    impl NativeActor for TcpSessionActor {
+        type Config = TcpSessionConfig;
+        const NAMESPACE: &'static str = "aether.tcp.session";
+
+        fn init(
+            mut config: TcpSessionConfig,
+            ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            let stream = config
+                .stream
+                .take()
+                .expect("TcpSessionConfig::stream consumed exactly once");
+            // Split read/write via try_clone — both halves point at
+            // the same underlying socket, but each is independently
+            // owned. Read sidecar uses one for blocking reads; the
+            // dispatcher uses the other for writes + Shutdown.
+            let read_half = stream
+                .try_clone()
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+            let write_half = stream;
+
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_for_thread = Arc::clone(&shutdown);
+
+            // mpsc carrying read chunks OR an Err signaling EOF /
+            // read error. The dispatcher drains in `on_data_ready`
+            // and turns each item into a SessionData broadcast (Ok)
+            // or a SessionClosed broadcast + ctx.shutdown() (Err).
+            let (bytes_tx, bytes_rx) = mpsc::channel::<Result<Vec<u8>, String>>();
+
+            let mailer: Arc<Mailer> = ctx.mailer();
+            let mailer_for_thread = Arc::clone(&mailer);
+            let self_id = ctx.self_id();
+            let data_ready_kind = KindId(<SessionDataReady as Kind>::ID.0);
+
+            let thread_name = format!("aether-tcp-read-{}", config.session_name);
+            let thread = std::thread::Builder::new()
+                .name(thread_name)
+                .spawn(move || {
+                    let mut read_half = read_half;
+                    let mut buf = vec![0u8; READ_BUFFER_BYTES];
+                    loop {
+                        if shutdown_for_thread.load(Ordering::Acquire) {
+                            break;
+                        }
+                        match read_half.read(&mut buf) {
+                            Ok(0) => {
+                                let _ = bytes_tx.send(Err("eof".to_owned()));
+                                mailer_for_thread.push(Mail::new(
+                                    self_id,
+                                    data_ready_kind,
+                                    Vec::new(),
+                                    1,
+                                ));
+                                break;
+                            }
+                            Ok(n) => {
+                                let chunk = buf[..n].to_vec();
+                                if bytes_tx.send(Ok(chunk)).is_err() {
+                                    break;
+                                }
+                                mailer_for_thread.push(Mail::new(
+                                    self_id,
+                                    data_ready_kind,
+                                    Vec::new(),
+                                    1,
+                                ));
+                            }
+                            Err(e) => {
+                                if shutdown_for_thread.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                let reason = format!("read error: {e}");
+                                let _ = bytes_tx.send(Err(reason));
+                                mailer_for_thread.push(Mail::new(
+                                    self_id,
+                                    data_ready_kind,
+                                    Vec::new(),
+                                    1,
+                                ));
+                                break;
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+
+            tracing::info!(
+                target: "aether_substrate::tcp",
+                session = %config.session_name,
+                peer = %config.peer,
+                "tcp session opened",
+            );
+
+            Ok(Self {
+                peer: config.peer,
+                session_name: config.session_name,
+                write_half,
+                shutdown,
+                read_thread: Some(thread),
+                bytes_rx,
+                mailer,
+                closed_emitted: false,
+            })
+        }
+
+        fn on_close(&mut self, _ctx: &mut NativeCtx<'_>) {
+            self.shutdown.store(true, Ordering::Release);
+            // Aborting the socket from the write half wakes any
+            // blocked `read()` on the read half (same underlying fd).
+            // Best-effort: a peer that already closed gives EBADF or
+            // ENOTCONN here, which is fine.
+            let _ = self.write_half.shutdown(Shutdown::Both);
+            if let Some(t) = self.read_thread.take() {
+                let _ = t.join();
+            }
+            // Emit one SessionClosed if the read path didn't already
+            // (e.g. an explicit close before EOF was observed).
+            if !self.closed_emitted {
+                self.closed_emitted = true;
+                broadcast_via_mailer(
+                    &self.mailer,
+                    &SessionClosed {
+                        session_name: self.session_name.clone(),
+                        peer: self.peer.clone(),
+                        reason: "explicit close".to_owned(),
+                    },
+                );
+            }
+            tracing::info!(
+                target: "aether_substrate::tcp",
+                session = %self.session_name,
+                peer = %self.peer,
+                "tcp session closed",
+            );
+        }
+
+        /// Sidecar read wake. Drain every pending chunk: each `Ok`
+        /// becomes a [`SessionData`] broadcast; an `Err` ends the
+        /// session (broadcast `SessionClosed`, call `ctx.shutdown()`).
+        ///
+        /// One wake fires per chunk, but the handler drains until
+        /// the queue is empty so coalesced wakes process all
+        /// outstanding chunks in one dispatcher tick.
+        #[handler]
+        fn on_data_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionDataReady) {
+            while let Ok(item) = self.bytes_rx.try_recv() {
+                match item {
+                    Ok(bytes) => {
+                        let payload = SessionData {
+                            session_name: self.session_name.clone(),
+                            peer: self.peer.clone(),
+                            bytes,
+                        };
+                        broadcast(ctx, &payload);
+                    }
+                    Err(reason) => {
+                        if !self.closed_emitted {
+                            self.closed_emitted = true;
+                            let payload = SessionClosed {
+                                session_name: self.session_name.clone(),
+                                peer: self.peer.clone(),
+                                reason,
+                            };
+                            broadcast(ctx, &payload);
+                        }
+                        ctx.shutdown();
+                        return;
+                    }
+                }
+            }
+        }
+
+        /// Write `bytes` to the connected peer. Blocking write on
+        /// the dispatcher thread; for chunks larger than the kernel
+        /// buffer this can block briefly, but typical request /
+        /// response traffic clears in microseconds.
+        #[handler]
+        fn on_session_write(&mut self, ctx: &mut NativeCtx<'_>, mail: SessionWrite) {
+            if let Err(e) = self.write_half.write_all(&mail.bytes) {
+                tracing::warn!(
+                    target: "aether_substrate::tcp",
+                    session = %self.session_name,
+                    peer = %self.peer,
+                    error = %e,
+                    "tcp session write failed",
+                );
+                if !self.closed_emitted {
+                    self.closed_emitted = true;
+                    let payload = SessionClosed {
+                        session_name: self.session_name.clone(),
+                        peer: self.peer.clone(),
+                        reason: format!("write error: {e}"),
+                    };
+                    broadcast(ctx, &payload);
+                }
+                ctx.shutdown();
+            }
+        }
+
+        /// Cooperative external close. Same shape as the listener
+        /// pattern: peer mails this, we call `ctx.shutdown()`, the
+        /// dispatcher drains remaining inbox mail, runs `on_close`
+        /// (which joins the read thread and emits `SessionClosed`).
+        #[handler]
+        fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionClose) {
+            ctx.shutdown();
+        }
+    }
+
+    /// Best-effort hub broadcast from inside a handler — uses the
+    /// ctx's `Sender::send_to_named` path for typed addressing.
+    fn broadcast<K: Kind + serde::Serialize>(ctx: &mut NativeCtx<'_>, payload: &K) {
+        ctx.send_to_named::<K>(HUB_BROADCAST_MAILBOX_NAME, payload);
+    }
+
+    /// Broadcast variant for `on_close` where we want to use the
+    /// stored `mailer` reference directly (still inside the
+    /// dispatcher thread). Functionally equivalent — the
+    /// `send_to_named` path also goes through `Mailer::push` —
+    /// kept separate to avoid borrowing `&mut self` and `ctx`
+    /// simultaneously when computing the payload from `self` fields.
+    fn broadcast_via_mailer<K: Kind + serde::Serialize>(mailer: &Arc<Mailer>, payload: &K) {
+        let bytes = match postcard::to_allocvec(payload) {
+            Ok(b) => b,
+            Err(_) => return,
+        };
+        let kind = KindId(K::ID.0);
+        let mailbox = aether_data::mailbox_id_from_name(HUB_BROADCAST_MAILBOX_NAME);
+        mailer.push(Mail::new(
+            aether_substrate::MailboxId(mailbox.0),
+            kind,
+            bytes,
+            1,
+        ));
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -598,6 +598,82 @@ mod tcp {
     )]
     #[kind(name = "aether.tcp.close")]
     pub struct Close {}
+
+    /// `aether.tcp.connection_ready` — sidecar accept thread → listener
+    /// dispatcher wake. Issue 607 Phase 6b: the listener's accept
+    /// thread blocks on `accept()`, pushes the resulting `TcpStream`
+    /// over an mpsc into the dispatcher, then fires this mail at its
+    /// own listener mailbox to wake the handler. The handler drains
+    /// the mpsc and spawns a `TcpSessionActor` per pending stream.
+    /// Empty payload — the actual stream rides the mpsc, not the mail
+    /// envelope (a live `TcpStream` is not wire-shaped).
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.connection_ready")]
+    pub struct ConnectionReady {}
+
+    /// `aether.tcp.session_data_ready` — sidecar read thread → session
+    /// dispatcher wake. Mirror of [`ConnectionReady`] for the session
+    /// read path: the read thread blocks on `read()`, pushes bytes via
+    /// mpsc, fires this mail at its own session mailbox. The handler
+    /// drains the mpsc and broadcasts each chunk as [`SessionData`].
+    /// Empty payload.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.session_data_ready")]
+    pub struct SessionDataReady {}
+
+    /// `aether.tcp.session_data` — broadcast emitted by a
+    /// `TcpSessionActor` on each chunk read from its peer. Carries
+    /// the session subname (`conn-N`), the peer address as a string,
+    /// and the bytes received in one `read()` call. Postcard-shaped
+    /// (variable-length payload) — agents drain via `receive_mail`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.session_data")]
+    pub struct SessionData {
+        pub session_name: String,
+        pub peer: String,
+        pub bytes: Vec<u8>,
+    }
+
+    /// `aether.tcp.session_write` — peer mails this to a
+    /// `TcpSessionActor` to write `bytes` to the connected stream.
+    /// Fire-and-forget; the session's handler does a blocking write
+    /// on the dispatcher thread (writes are typically fast and
+    /// dispatcher-thread initiated, so a sidecar isn't needed for
+    /// the write path).
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.session_write")]
+    pub struct SessionWrite {
+        pub bytes: Vec<u8>,
+    }
+
+    /// `aether.tcp.session_close` — peer asks the session to close
+    /// gracefully. Mailed via `ctx.actor::<TcpSessionActor>(...)` or
+    /// resolved by subname. The session's handler calls
+    /// `ctx.shutdown()`; the close fan-out fires `MonitorNotice` to
+    /// the parent listener (which spawned it).
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.tcp.session_close")]
+    pub struct SessionClose {}
+
+    /// `aether.tcp.session_closed` — broadcast emitted on session
+    /// close. Carries the session subname, the peer address, and a
+    /// human-readable reason ("eof", "read error: ...", "explicit
+    /// close", etc.). Agents observe via `receive_mail` to know when
+    /// a session terminated and clean up any per-session state they
+    /// were tracking.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.tcp.session_closed")]
+    pub struct SessionClosed {
+        pub session_name: String,
+        pub peer: String,
+        pub reason: String,
+    }
 }
 
 mod control_plane {

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -917,7 +917,15 @@ where
                                     &env.payload,
                                 )
                                 .is_none()
+                                && !actor
+                                    .__aether_dispatch_fallback(&mut native_ctx, &env)
                             {
+                                // Issue 576: catch-all caps override
+                                // `__aether_dispatch_fallback` and
+                                // return `true` after their fallback
+                                // runs, suppressing this warn. Strict
+                                // receivers keep the default (returns
+                                // `false`) and surface the miss.
                                 tracing::warn!(
                                     target: "aether_substrate::capability",
                                     actor = A::NAMESPACE,
@@ -948,11 +956,17 @@ where
                                 &transport_for_thread,
                                 env.sender,
                             );
-                            let _ = actor.__aether_dispatch_envelope(
-                                &mut native_ctx,
-                                env.kind,
-                                &env.payload,
-                            );
+                            if actor
+                                .__aether_dispatch_envelope(
+                                    &mut native_ctx,
+                                    env.kind,
+                                    &env.payload,
+                                )
+                                .is_none()
+                            {
+                                let _ = actor
+                                    .__aether_dispatch_fallback(&mut native_ctx, &env);
+                            }
                             aether_actor::log::drain_buffer();
                         },
                     );


### PR DESCRIPTION
## Summary

ADR-0079 Phase 6b. Final tier of the three-tier TCP shape: per-accepted-connection session actor with bidirectional byte streaming. Mirrors Phase 6a's listener pattern.

**Sidecar + wake-mail design** (after exploring polling alternatives — see PR discussion on issue 607):

- Listener accept thread can't call `ctx.spawn_child` (no dispatcher ctx), so it pushes the accepted `TcpStream` over an mpsc and fires a `ConnectionReady` wake mail at its own mailbox. The listener's `on_connection_ready` handler drains the mpsc and spawns a `TcpSessionActor` as a child per pending stream.
- `TcpSessionActor` splits the `TcpStream` via `try_clone` — read half goes to a sidecar read thread, write half stays on the dispatcher for `SessionWrite` handling. Read thread blocks on `read()`, pushes `Result<Vec<u8>, String>` over an mpsc, fires `SessionDataReady` wake. Handler drains: `Ok(bytes)` broadcasts `SessionData`; `Err(reason)` broadcasts `SessionClosed` and calls `ctx.shutdown()`.

The wake-mail design preserves the actor model — handlers take `&mut self`, cap state is plain fields, and the only sync primitives (`Arc<AtomicBool>` shutdown + `mpsc` + `Arc<Mailer>`) are the unavoidable cross-thread bridge between the blocking I/O sidecar and the dispatcher. No interior mutability bleeds into actor state.

**New kinds in `aether-kinds`**:
- `ConnectionReady` / `SessionDataReady` — empty cast-shape internal wakes (sidecar → dispatcher), pushed via `mailer.push`.
- `SessionData { session_name, peer, bytes }` — broadcast on each read chunk, postcard.
- `SessionWrite { bytes }` — peer → session, postcard.
- `SessionClose` — peer → session cooperative close, empty cast.
- `SessionClosed { session_name, peer, reason }` — broadcast on session termination, postcard.

**Bug fix**: the legacy `ChassisBuilder` boot path in `capability.rs` called `__aether_dispatch_envelope` but never `__aether_dispatch_fallback`. Caps with `#[fallback]` (`BroadcastCapability`) booted via the legacy path silently swallowed every envelope. Both the active dispatch and shutdown-drain loops now mirror the new builder's pattern: fallback fires when the typed dispatch returns `None`. Surfaced because Phase 6b's session test broadcasts `SessionData` through `BroadcastCapability` — without the fix the test sees no broadcast.

**Phase 6b integration test** (`tcp/mod.rs::session_round_trip_data_then_close`): connects a real TCP client to a bound listener, writes bytes, observes `SessionData` broadcast on egress, drops the client, observes `SessionClosed` with reason `"eof"`. Exercises the full pipeline: listener accept thread → mpsc → ConnectionReady wake → listener spawns TcpSessionActor → session read thread → mpsc → SessionDataReady wake → session broadcasts.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` — all suites pass (added `session_round_trip_data_then_close`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --target wasm32-unknown-unknown -p aether-camera` clean (wasm component build, exercised by CI's pre-build step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)