### PR TITLE
refactor(substrate): release singleton boot slots on init failure (issue 607 phase 7)

### DIFF
--- a/crates/aether-substrate/src/actor_registry.rs
+++ b/crates/aether-substrate/src/actor_registry.rs
@@ -201,6 +201,29 @@ impl ActorRegistry {
         }
     }
 
+    /// Issue 607 Phase 7: release ownership of `namespace` iff
+    /// `type_id` currently owns it. Used in the chassis-boot unwind
+    /// path when a singleton's `init` fails — without this release,
+    /// the failed cap's namespace stays claimed and a later cap with
+    /// a different `TypeId` legitimately claiming the same namespace
+    /// (after the failed cap is gone) collides. Returns `true` if the
+    /// entry was released, `false` if absent or owned by a different
+    /// type (typically a caller bug, but we don't panic — the boot
+    /// failure path runs even on weird states).
+    ///
+    /// Crate-private — only the boot-failure paths in
+    /// [`crate::capability`] / [`crate::chassis_builder`] call this.
+    pub(crate) fn release_namespace(&self, namespace: &'static str, type_id: TypeId) -> bool {
+        let mut owners = self.name_owners.write().unwrap();
+        match owners.get(namespace) {
+            Some(&existing) if existing == type_id => {
+                owners.remove(namespace);
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Insert a `Live` actor entry under `id`. Returns `Err(())` if a
     /// `Live` entry already exists at `id` (caller must check
     /// `is_tombstoned` separately for the retired-name case). Used by

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -560,6 +560,25 @@ impl<'a> ChassisCtx<'a> {
         })
     }
 
+    /// Issue 607 Phase 7: undo a previous `claim_*_mailbox` call.
+    /// Removes the sink from the chassis registry, the (id, counter)
+    /// entry from `frame_bound_pending`, the id from
+    /// `frame_bound_set`, and the id from `claimed_actor_mailboxes`.
+    /// Idempotent: calling on an id that wasn't claimed is a no-op.
+    ///
+    /// Used in the singleton-boot unwind path (chassis_builder /
+    /// capability) when `init` fails after the cap mailbox was
+    /// claimed. Without this, the failed cap leaves a sink registered
+    /// against its namespace and a stuck counter in
+    /// `frame_bound_pending` that the chassis frame loop would wait
+    /// for forever.
+    pub fn unclaim_mailbox(&mut self, id: MailboxId) {
+        self.registry.remove_sink(id);
+        self.frame_bound_pending.retain(|(i, _)| *i != id);
+        self.frame_bound_set.write().unwrap().remove(&id);
+        self.claimed_actor_mailboxes.retain(|i| *i != id);
+    }
+
     /// Clone-able mail-send handle. Capabilities stash this into
     /// their dispatcher state to send mail to other mailboxes
     /// (including other capabilities). Same `Arc<Mailer>` every
@@ -822,17 +841,30 @@ where
     // counter; the dispatcher decrements after each handler dispatch
     // so the per-frame drain barrier (ADR-0074 §Decision 5) sees the
     // counter drop in lock-step with handler progress.
-    let (mailbox_id, receiver, sink_sender, pending) = if A::FRAME_BARRIER {
-        let claim = ctx.claim_frame_bound_mailbox::<A>()?;
-        (
-            claim.id,
-            claim.receiver,
-            claim.sink_sender,
-            Some(claim.pending),
-        )
+    //
+    // Issue 607 Phase 7: if the mailbox claim fails, release the
+    // namespace claim we made above before propagating.
+    let claim_result = if A::FRAME_BARRIER {
+        ctx.claim_frame_bound_mailbox::<A>().map(|claim| {
+            (
+                claim.id,
+                claim.receiver,
+                claim.sink_sender,
+                Some(claim.pending),
+            )
+        })
     } else {
-        let claim = ctx.claim_mailbox_drop_on_shutdown::<A>()?;
-        (claim.id, claim.receiver, claim.sink_sender, None)
+        ctx.claim_mailbox_drop_on_shutdown::<A>()
+            .map(|claim| (claim.id, claim.receiver, claim.sink_sender, None))
+    };
+    let (mailbox_id, receiver, sink_sender, pending) = match claim_result {
+        Ok(c) => c,
+        Err(e) => {
+            ctx.spawner_arc()
+                .actor_registry()
+                .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+            return Err(e);
+        }
     };
 
     let transport = Arc::new(crate::NativeTransport::from_ctx(
@@ -857,7 +889,10 @@ where
     // `chassis_builder::make_native_actor_boot`.
     let slots = Box::new(aether_actor::local::ActorSlots::new());
 
-    let actor = {
+    // Issue 607 Phase 7: failed init releases the slot before any
+    // dispatcher thread is spawned — drop the transport (and its
+    // installed inbox), unclaim the mailbox, release the namespace.
+    let init_result = {
         let mailer_clone = ctx.mail_send_handle();
         let mut init_ctx = crate::native_actor::NativeInitCtx::new(
             &transport,
@@ -875,9 +910,21 @@ where
                     r
                 },
             )
-        })?
+        })
     };
     drop(throwaway_handles); // explicit shape — no shared state outlives init
+    let actor = match init_result {
+        Ok(a) => a,
+        Err(e) => {
+            drop(transport);
+            drop(sink_sender);
+            ctx.unclaim_mailbox(mailbox_id);
+            ctx.spawner_arc()
+                .actor_registry()
+                .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+            return Err(e);
+        }
+    };
 
     // Issue 629 / Phase A: dispatcher takes Box<A> ownership.
     let mut actor: Box<A> = Box::new(actor);

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -331,17 +331,33 @@ where
         // frame loop. Free-running caps take the regular drop-on-
         // shutdown claim. Both share the same dispatcher trampoline
         // shape apart from the post-dispatch decrement.
-        let (mailbox_id, receiver, sink_sender, pending) = if A::FRAME_BARRIER {
-            let claim = ctx.claim_frame_bound_mailbox::<A>()?;
-            (
-                claim.id,
-                claim.receiver,
-                claim.sink_sender,
-                Some(claim.pending),
-            )
+        //
+        // Issue 607 Phase 7: if the mailbox claim fails (name
+        // collision against a peer cap claiming the same mailbox
+        // through `register_sink`), release the namespace claim we
+        // just made — otherwise a later cap with a different TypeId
+        // legitimately claiming the same namespace can't.
+        let claim_result = if A::FRAME_BARRIER {
+            ctx.claim_frame_bound_mailbox::<A>().map(|claim| {
+                (
+                    claim.id,
+                    claim.receiver,
+                    claim.sink_sender,
+                    Some(claim.pending),
+                )
+            })
         } else {
-            let claim = ctx.claim_mailbox_drop_on_shutdown::<A>()?;
-            (claim.id, claim.receiver, claim.sink_sender, None)
+            ctx.claim_mailbox_drop_on_shutdown::<A>()
+                .map(|claim| (claim.id, claim.receiver, claim.sink_sender, None))
+        };
+        let (mailbox_id, receiver, sink_sender, pending) = match claim_result {
+            Ok(c) => c,
+            Err(e) => {
+                ctx.spawner_arc()
+                    .actor_registry()
+                    .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+                return Err(e);
+            }
         };
 
         // Per-cap transport. `NativeTransport::from_ctx` pulls the
@@ -364,7 +380,12 @@ where
         // stamp the actor's transport as the in-actor `MailDispatch`
         // around `init` so any `tracing::*` event the cap fires
         // during boot drains to LogCapability when init returns.
-        let actor = {
+        //
+        // Issue 607 Phase 7: failed init releases the slot before any
+        // dispatcher thread is spawned — drop the transport
+        // (including its installed inbox), unclaim the mailbox, and
+        // release the namespace.
+        let init_result = {
             let mailer_clone = ctx.mail_send_handle();
             let mut init_ctx = NativeInitCtx::new(&transport, handles, mailer_clone);
             aether_actor::local::with_stamped(&slots, || {
@@ -376,7 +397,19 @@ where
                         r
                     },
                 )
-            })?
+            })
+        };
+        let actor = match init_result {
+            Ok(a) => a,
+            Err(e) => {
+                drop(transport);
+                drop(sink_sender);
+                ctx.unclaim_mailbox(mailbox_id);
+                ctx.spawner_arc()
+                    .actor_registry()
+                    .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+                return Err(e);
+            }
         };
 
         // Issue 629 / Phase A: dispatcher takes Box<A> ownership.
@@ -1345,6 +1378,63 @@ mod tests {
             .expect_err("second passive must fail with duplicate claim");
 
         assert!(matches!(err, BootError::MailboxAlreadyClaimed { .. }));
+    }
+
+    /// Issue 607 Phase 7: a singleton whose `init` returns `Err`
+    /// releases its slot before `with_actor` propagates the error.
+    /// After the failed build, the chassis's `Registry` has no sink
+    /// at the cap's namespace and the `ActorRegistry`'s `name_owners`
+    /// no longer claims the namespace — so a fresh chassis can boot
+    /// a different cap with the same namespace string (or the same
+    /// cap with a different config) without colliding.
+    #[test]
+    fn failed_singleton_init_releases_namespace_and_sink() {
+        struct FailingCap;
+        impl aether_actor::Actor for FailingCap {
+            const NAMESPACE: &'static str = "test.phase7.failing_cap";
+        }
+        impl aether_actor::Singleton for FailingCap {}
+
+        impl crate::native_actor::NativeActor for FailingCap {
+            type Config = ();
+            fn init(
+                _: (),
+                _ctx: &mut crate::native_actor::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Err(BootError::Other(Box::new(std::io::Error::other(
+                    "intentional init failure for Phase 7 cleanup test",
+                ))))
+            }
+        }
+        impl crate::native_actor::NativeDispatch for FailingCap {
+            fn __aether_dispatch_envelope(
+                &mut self,
+                _ctx: &mut crate::native_actor::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<FailingCap>(())
+            .build_passive()
+            .expect_err("init failure must propagate");
+        // The error wraps init's std::io::Error message.
+        assert!(
+            format!("{err:?}").contains("intentional init failure"),
+            "expected init error to propagate, got {err:?}",
+        );
+
+        // Sink at the cap's namespace must be gone — Registry::lookup
+        // returns None for absent entries.
+        assert!(
+            registry.lookup(FailingCap::NAMESPACE).is_none(),
+            "sink at {} should be removed after failed init",
+            FailingCap::NAMESPACE,
+        );
     }
 
     /// Issue 552 stage 1: end-to-end smoke for the new

--- a/crates/aether-substrate/src/registry.rs
+++ b/crates/aether-substrate/src/registry.rs
@@ -260,6 +260,28 @@ impl Registry {
         self.insert(name.into(), MailboxEntry::Sink(handler))
     }
 
+    /// Issue 607 Phase 7: fully remove a sink entry. Used in the
+    /// chassis-boot unwind path when a singleton's `init` fails after
+    /// `try_register_sink` claimed the slot — the partial-boot state
+    /// must not leak into a later cap's namespace lookup. Returns
+    /// `true` if the entry existed and was a sink (and was removed),
+    /// `false` if the id is unknown or refers to a non-sink entry.
+    /// Component entries go through [`Self::drop_mailbox`] (which
+    /// transitions to `Dropped` rather than removing) — the lifecycle
+    /// difference is intentional: components can re-register the same
+    /// id after a drop, sinks are torn down on cap teardown and the
+    /// id can be freshly recreated.
+    pub(crate) fn remove_sink(&self, id: MailboxId) -> bool {
+        let mut inner = self.inner.write().unwrap();
+        match inner.mailboxes.get(&id) {
+            Some(slot) if matches!(slot.entry, MailboxEntry::Sink(_)) => {
+                inner.mailboxes.remove(&id);
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Does a live (non-`Dropped`) mailbox exist under `name`? Returns
     /// its id if so. The id itself is deterministic (ADR-0029) —
     /// callers that just want the id without a liveness check can use

--- a/crates/aether-substrate/src/spawn.rs
+++ b/crates/aether-substrate/src/spawn.rs
@@ -295,6 +295,13 @@ impl Spawner {
             // 64-bit id even with distinct names. Treat as
             // SubnameInUse for the caller; the singleton's claim wins
             // (it landed first).
+            //
+            // Issue 607 Phase 7: the sink WAS registered above; remove
+            // it before returning so the failed spawn doesn't leave
+            // a dangling sink that warn-drops mail. The actor itself
+            // (init succeeded) drops naturally as `actor` falls out
+            // of scope.
+            self.registry.remove_sink(id);
             return Err(SpawnError::SubnameInUse { full_name });
         }
 


### PR DESCRIPTION
## Summary

Closes out issue 607's optional Phase 7. Phase 7 had two intents:

1. **Singleton init runs on caller thread**, mirroring the instanced path. Already done as a side effect of issue 629 Phase A — when the dispatcher took `Box<A>` ownership, init naturally moved to the chassis builder thread before the dispatcher spawn. No work here.
2. **Failed singleton init releases the slot** before any thread is spawned. This was missing — the namespace claim, sink registration, `frame_bound_pending` entry, and `frame_bound_set` membership all leaked until chassis teardown.

## Implementation

- **`Registry::remove_sink(id)`** — fully removes a sink entry. Distinct from `drop_mailbox` (component-only, transitions to `Dropped`). Crate-private; only the boot-failure paths call it.
- **`ActorRegistry::release_namespace(namespace, type_id)`** — releases iff the same `TypeId` currently owns it. Idempotent on absence / type-mismatch (returns `false` rather than panicking).
- **`ChassisCtx::unclaim_mailbox(id)`** — undoes a previous `claim_*_mailbox`: removes the sink from registry, drops the `(id, counter)` from `frame_bound_pending`, removes `id` from `frame_bound_set`, drops it from `claimed_actor_mailboxes`. One method covers both frame-bound and drop-on-shutdown claims.
- **`make_native_actor_boot`** (chassis_builder) and **`boot_native_actor`** (capability) call release on each failure point: claim_mailbox fails → release_namespace; init fails → drop transport, drop sink_sender, unclaim_mailbox, release_namespace.

Instanced spawn (`spawn.rs`) gets one cleanup point: `insert_live` failure after sink registration removes the sink. Instanced namespace claims are idempotent across multiple instances of the same `TypeId`, so a single failed spawn doesn't release — future spawns of the same type re-use the existing claim.

## Test plan

- [x] New test `failed_singleton_init_releases_namespace_and_sink` — boots a `FailingCap` whose `init` returns `Err`, asserts `Registry::lookup(NAMESPACE)` returns `None` after the failed boot.
- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)