### PR TITLE
refactor(kinds): rename ConfigureLogDrain to aether.log.configure_drain (issue 638 phase 1)

### DIFF
--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -64,8 +64,8 @@ impl Local for LogBuffer {}
 /// configured override) mailbox id [`drain_buffer`] ships
 /// [`LogBatch`] mails to. Issue #601: replaces the retired
 /// `PROCESS.log_mailbox` cell with a per-actor slot the chassis
-/// installs via the `aether.control.configure_log_drain` mail
-/// every actor's `#[handlers]` derive auto-handles.
+/// installs via the `aether.log.configure_drain` mail every
+/// actor's `#[handlers]` derive auto-handles.
 ///
 /// Default `MailboxId(0)` — meaning "no drain configured." Until
 /// the chassis-pushed `ConfigureLogDrain` mail arrives, drain calls

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -835,9 +835,9 @@ mod control_plane {
         Err { error: String },
     }
 
-    /// `aether.control.configure_log_drain` — chassis-pushed mail every
-    /// actor handles to pick up the configured log drain mailbox
-    /// (issue #601). The chassis dispatches one of these to every
+    /// `aether.log.configure_drain` — chassis-pushed mail every actor
+    /// handles to pick up the configured log drain mailbox (issue
+    /// #601). The chassis dispatches one of these to every
     /// freshly-instantiated actor before any other inbound mail; the
     /// SDK's `#[actor]` / `#[handlers]` derive auto-emits a handler
     /// that installs `mailbox` into the per-actor `LogDrainSlot` so
@@ -854,7 +854,7 @@ mod control_plane {
     #[derive(
         Copy, Clone, Debug, PartialEq, Eq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
     )]
-    #[kind(name = "aether.control.configure_log_drain")]
+    #[kind(name = "aether.log.configure_drain")]
     pub struct ConfigureLogDrain {
         pub mailbox: aether_data::MailboxId,
     }

--- a/crates/aether-substrate/src/capability.rs
+++ b/crates/aether-substrate/src/capability.rs
@@ -286,7 +286,7 @@ pub struct ChassisCtx<'a> {
     /// `claim_frame_bound_mailbox_*`, `claim_mailbox_drop_on_shutdown_*`)
     /// appends its `MailboxId` here. The chassis builder reads the
     /// list after `boot_passives` to dispatch
-    /// `aether.control.configure_log_drain` mail to each booted actor
+    /// `aether.log.configure_drain` mail to each booted actor
     /// so its `LogDrainSlot` resolves to the chassis's declared drain
     /// (`Builder::with_log_drain<T>()`).
     ///

--- a/crates/aether-substrate/src/chassis_builder.rs
+++ b/crates/aether-substrate/src/chassis_builder.rs
@@ -626,11 +626,10 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     aborter: Arc<dyn FatalAborter>,
     /// Issue #601: chassis-declared log-drain target. `None` until the
     /// chassis calls [`Self::with_log_drain`]; on `build()` the
-    /// mailbox id is dispatched as `aether.control.configure_log_drain`
-    /// mail to every booted actor so each actor's `LogDrainSlot` is
-    /// installed. The same mail also goes to `aether.control` so the
-    /// [`crate::control::ControlPlane`]'s dispatch arm stores the
-    /// drain for the runtime `load_component` path — runtime-loaded
+    /// mailbox id is dispatched as `aether.log.configure_drain` mail
+    /// to every booted actor so each actor's `LogDrainSlot` is
+    /// installed. `ControlPlaneCapability` snapshots the same drain
+    /// for the runtime `load_component` path — runtime-loaded
     /// components receive `ConfigureLogDrain` themselves on
     /// registration. The chassis Builder declares the drain; the
     /// runtime state lives entirely in `ControlPlane` and per-actor
@@ -724,8 +723,8 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// be a [`NativeActor`] that handles [`LogBatch`] (the cap's
     /// mailbox id is derived from `T::NAMESPACE` at compile time).
     /// On `build()` / `build_passive()` the chassis dispatches a
-    /// `aether.control.configure_log_drain` mail to every booted actor
-    /// so each actor's `LogDrainSlot` resolves to this mailbox; the
+    /// `aether.log.configure_drain` mail to every booted actor so each
+    /// actor's `LogDrainSlot` resolves to this mailbox; the
     /// auto-emitted handler in `#[actor]` does the install.
     ///
     /// No call → `log_drain` stays `None`, no `ConfigureLogDrain`


### PR DESCRIPTION
## Summary

- Rename `ConfigureLogDrain` kind from `aether.control.configure_log_drain` → `aether.log.configure_drain`. Struct name unchanged; kind ID auto-derives from the new name (ADR-0030).
- Update doc comments referencing the old name in `aether-kinds`, `aether-actor::log`, `aether-substrate::{chassis_builder, capability}`.

## Why

Issue 638 splits the `aether.control` grab-bag before issue 634 anchors components to the cap as their structural parent. Three concerns rode `aether.control`: component lifecycle, input subscriptions, and log-drain config. This PR is Phase 1 — the smallest of the three rehomes, on the kind whose presence under `aether.control` was purely historical.

Audit found this is **per-actor** chassis-pushed configuration (every `#[handlers]` impl auto-emits the dispatch arm; the chassis builder pushes it to every booted actor's mailbox). There's no `LogCapability` handler to add or `ControlPlaneCapability` handler to drop — the rename is the entire move. The original phasing in issue 638 framed this as a handler-rehoming; the actual shape is simpler.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all green
- [x] `engine_logs.rs` integration tests pass — exercises chassis builder dispatch → auto-emitted handler → `LogDrainSlot` install → `LogBatch` drain → `engine_logs` query end-to-end. Would catch any kind-id mismatch.

Refs issue 638 phase 1.