### PR TITLE
refactor(substrate): drop Mail::from_component in favour of reply_to.target

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/wire.rs
+++ b/crates/aether-substrate-bundle/src/hub/wire.rs
@@ -154,10 +154,10 @@ pub enum LogLevel {
 /// local mailbox id so the hub-chassis's reply peripheral can
 /// route replies back to it. The source `engine_id` isn't on the
 /// wire — the hub knows which TCP connection the frame arrived on.
-/// `None` means "no reply target" (broadcast-origin, substrate-
-/// generated, no `from_component` attribution); the hub-side
-/// sender handle will be `NO_REPLY_HANDLE` for the receiving
-/// component.
+/// `None` means "no reply target" (broadcast-origin or substrate-
+/// generated mail, where `Mail::reply_to.target != Component(_)`);
+/// the hub-side sender handle will be `NO_REPLY_HANDLE` for the
+/// receiving component.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineMailToHubSubstrateFrame {
     pub recipient_mailbox_id: MailboxId,

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -143,10 +143,12 @@ impl Component {
     /// ADR-0013 + ADR-0017: a fresh sender handle is allocated from
     /// the per-instance `ReplyTable` for every inbound that has a
     /// meaningful reply target — a Claude session (non-NIL
-    /// `SessionToken`) or another component (`from_component`
-    /// populated by `SubstrateCtx::send`). Broadcast-origin and
-    /// system-generated mail pass `NO_REPLY_HANDLE` so the guest's
-    /// `mail.reply_to()` accessor returns `None`.
+    /// `SessionToken`), a remote engine mailbox, or a peer component
+    /// (`reply_to.target = ReplyTarget::Component(_)` populated by
+    /// `SubstrateCtx::send` / `NativeTransport::send_mail`).
+    /// Broadcast-origin and system-generated mail pass
+    /// `NO_REPLY_HANDLE` so the guest's `mail.reply_to()` accessor
+    /// returns `None`.
     pub fn deliver(&mut self, mail: &Mail) -> wasmtime::Result<u32> {
         // ADR-0042: carry the incoming correlation through to the
         // ReplyEntry so a subsequent `reply_mail` echoes it on the
@@ -167,15 +169,10 @@ impl Component {
                 },
                 correlation,
             )),
-            // Component-variant reply_to reaches a real component's
-            // `deliver` only via the mailer-routed reply path (the
-            // sink replied to a local component): the reply itself
-            // has no one to reply back to, so the guest sees no
-            // `reply_to`. Falls through to the `from_component`
-            // check, matching the None path.
-            ReplyTarget::None | ReplyTarget::Component(_) => mail
-                .from_component
-                .map(|m| ReplyEntry::new(ReplyTarget::Component(m), correlation)),
+            ReplyTarget::Component(m) => {
+                Some(ReplyEntry::new(ReplyTarget::Component(*m), correlation))
+            }
+            ReplyTarget::None => None,
         };
         let handle = match entry {
             Some(e) => self.store.data_mut().reply_table.allocate(e),
@@ -594,14 +591,16 @@ mod tests {
     }
 
     #[test]
-    fn deliver_with_from_component_allocates_component_handle() {
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+    fn deliver_with_component_reply_target_allocates_component_handle() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
         use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
         let mut component = instantiate(WAT_STORES_SENDER);
-        // ADR-0017: component-origin mail (no session token, but a
-        // populated `from_component`) gets a Component-variant handle.
-        let mail = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1).with_origin(M(7));
+        // ADR-0017 / issue #644: component-origin mail (peer-to-peer
+        // send sets `reply_to.target = Component(sender)`) gets a
+        // Component-variant handle.
+        let mail = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1)
+            .with_reply_to(ReplyTo::to(ReplyTarget::Component(M(7))));
         component.deliver(&mail).expect("deliver");
         let observed = component.read_u32(500);
         assert_ne!(observed, NO_REPLY_HANDLE);
@@ -609,32 +608,6 @@ mod tests {
             component.store.data().reply_table.resolve(observed),
             Some(ReplyEntry::component(M(7))),
         );
-    }
-
-    #[test]
-    fn deliver_session_takes_priority_over_component_origin() {
-        // If both a session token and a from_component are set (which
-        // can happen if hub-originated mail somehow gets re-routed
-        // through SubstrateCtx::send), the Session variant wins. The
-        // session is the more specific reply target.
-        use crate::mail::{Mail as SubstrateMail, MailboxId as M, ReplyTarget, ReplyTo};
-        use crate::reply_table::ReplyEntry;
-        use aether_data::{SessionToken, Uuid};
-
-        let mut component = instantiate(WAT_STORES_SENDER);
-        let token = SessionToken(Uuid::from_u128(0xbbbb));
-        let mail = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1)
-            .with_reply_to(ReplyTo::to(ReplyTarget::Session(token)))
-            .with_origin(M(99));
-        component.deliver(&mail).expect("deliver");
-        let observed = component.read_u32(500);
-        match component.store.data().reply_table.resolve(observed) {
-            Some(ReplyEntry {
-                target: ReplyTarget::Session(t),
-                ..
-            }) => assert_eq!(t, token),
-            other => panic!("expected Session, got {other:?}"),
-        }
     }
 
     fn plane_ctx_for_reply() -> (

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -213,17 +213,16 @@ impl SubstrateCtx {
 
         // Component / dropped / unknown all funnel through `Mailer::push`:
         // - Component (ADR-0017): mail enters the recipient's inbox with
-        //   `from_component = self.sender` so `Component::deliver` can
-        //   allocate a Component-variant `ReplyEntry`.
+        //   `reply_to.target = Component(self.sender)` so
+        //   `Component::deliver` can allocate a Component-variant
+        //   `ReplyEntry`.
         // - Dropped: warn-drops in `route_mail`.
         // - Unknown (ADR-0037): bubbles up to the hub-substrate via
-        //   `MailToHubSubstrate` with `source_mailbox_id = self.sender`
-        //   when a `HubOutbound` is connected; warn-drops otherwise.
-        self.queue.push(
-            Mail::new(recipient, kind, payload, count)
-                .with_reply_to(reply_to)
-                .with_origin(self.sender),
-        );
+        //   `MailToHubSubstrate`; the `source_mailbox_id` it carries is
+        //   recovered from `reply_to.target` when it's a Component
+        //   variant (warn-drops otherwise).
+        self.queue
+            .push(Mail::new(recipient, kind, payload, count).with_reply_to(reply_to));
     }
 }
 

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -28,20 +28,20 @@ pub type MailKind = KindId;
 /// implies; `count` is the number of items the layout implies, where
 /// applicable.
 ///
-/// Reply routing is carried in two complementary fields. Neither
-/// describes where the mail came from; both describe where a reply
-/// would go if the receiver chooses to make one.
-/// - `reply_to` is the remote destination (ADR-0008 / ADR-0037).
-///   `Session` means reply routes back to a Claude MCP session;
-///   `EngineMailbox` means reply routes to a component on another
-///   engine; `None` means no remote reply target.
-/// - `from_component` is the `MailboxId` of a local originating
-///   component for mail enqueued by `SubstrateCtx::send` (ADR-0017).
-///   `Some` means reply routes back to that local mailbox.
+/// `reply_to` describes where a reply would go if the receiver chooses
+/// to make one (ADR-0008 / ADR-0037 / ADR-0017). It is *not* a "from"
+/// field — it is the structural reply destination, which happens to
+/// double as "who sent me this" when the variant is `Component`.
+/// - `Session` — reply routes back to a Claude MCP session.
+/// - `EngineMailbox` — reply routes to a component on another engine.
+/// - `Component` — reply routes back to a local peer component
+///   (set by `SubstrateCtx::send` / `NativeTransport::send_mail`).
+/// - `None` — no reply target (broadcast-origin or substrate-
+///   generated mail).
 ///
-/// Both-absent (`reply_to = None`, `from_component = None`) means
-/// broadcast-origin or substrate-generated mail with no reply
-/// target.
+/// Pre-issue-#644 a redundant `from_component: Option<MailboxId>`
+/// also rode here, set by `with_origin` to the same id
+/// `reply_to.target = Component(_)` already carried.
 #[derive(Debug)]
 pub struct Mail {
     pub recipient: MailboxId,
@@ -49,7 +49,6 @@ pub struct Mail {
     pub payload: Vec<u8>,
     pub count: u32,
     pub reply_to: ReplyTo,
-    pub from_component: Option<MailboxId>,
 }
 
 impl Mail {
@@ -60,26 +59,17 @@ impl Mail {
             payload,
             count,
             reply_to: ReplyTo::NONE,
-            from_component: None,
         }
     }
 
-    /// Attach a reply-to destination (session or engine mailbox).
-    /// Used by the hub client when forwarding inbound frames
-    /// (ADR-0008) and by the hub-chassis loopback when delivering
-    /// bubbled-up mail (ADR-0037 Phase 2); other mail paths leave
-    /// the default `ReplyTo::None`.
+    /// Attach a reply-to destination. Used by the hub client when
+    /// forwarding inbound frames (ADR-0008), the hub-chassis loopback
+    /// when delivering bubbled-up mail (ADR-0037 Phase 2), and
+    /// `SubstrateCtx::send` / `NativeTransport::send_mail` for
+    /// peer-to-peer component sends (target = `Component(sender)`).
+    /// Other mail paths leave the default `ReplyTo::None`.
     pub fn with_reply_to(mut self, reply_to: ReplyTo) -> Self {
         self.reply_to = reply_to;
-        self
-    }
-
-    /// Attach the originating component's mailbox id. Set by
-    /// `SubstrateCtx::send` when enqueueing component-to-component
-    /// mail (ADR-0017) so `Component::deliver` can allocate a
-    /// Component-variant reply handle for the receiving guest.
-    pub fn with_origin(mut self, origin: MailboxId) -> Self {
-        self.from_component = Some(origin);
         self
     }
 }

--- a/crates/aether-substrate/src/mailer.rs
+++ b/crates/aether-substrate/src/mailer.rs
@@ -419,8 +419,14 @@ fn route_mail(
                 // `ReplyTo::EngineMailbox { engine_id, mailbox_id }`
                 // for the receiving component. `None` for mail
                 // with no local component origin (broadcast-
-                // originated, substrate-generated).
-                let source_mailbox_id = mail.from_component;
+                // originated, substrate-generated). Recovered from
+                // `reply_to.target = Component(_)` set by
+                // `SubstrateCtx::send` / `NativeTransport::send_mail`
+                // (issue #644).
+                let source_mailbox_id = match mail.reply_to.target {
+                    ReplyTarget::Component(id) => Some(id),
+                    _ => None,
+                };
                 // ADR-0042: carry the correlation through the bubble-
                 // up frame so a reply coming back via Phase-2 reply
                 // routing lands at the originator's `wait_reply_p32`.

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -329,9 +329,8 @@ impl MailTransport for NativeTransport {
         let recipient_id = MailboxId(recipient);
         let reply_to =
             ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
-        let mail = Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count)
-            .with_reply_to(reply_to)
-            .with_origin(self.self_mailbox);
+        let mail =
+            Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count).with_reply_to(reply_to);
         // Record `correlation -> recipient` for the cross-class
         // `wait_reply` guard. We record on every send (the FFI here
         // can't tell fire-and-forget from request/reply) and let


### PR DESCRIPTION
<!-- pr-body-ok: b — bare #NNN required for GitHub auto-close keyword -->

## Summary

- `Mail::from_component` and `reply_to.target = Component(_)` carried the same `MailboxId`. `SubstrateCtx::send` / `NativeTransport::send_mail` set both to `self.sender`; `Component::deliver` read the second one and ignored the first.
- The `with_origin` method (which set `from_component`, not the diagnostic origin string) was misleadingly named.
- Drop the redundant field + method; `Component::deliver` now reads `reply_to.target` directly. The bubble-up `source_mailbox_id` in `route_mail` likewise pulls from `reply_to.target = Component(_)`.

## Why now

Pre-cursor cleanup before issue 634 Phase 4 (`WasmTrampoline`) re-routes wasm mail through the standard actor sink path. Without this, the trampoline would need bespoke envelope plumbing to carry `from_component`; with this, it reads `reply_to.target` like every other reply path.

Closes #644

## Test plan

- [x] cargo check --workspace clean
- [x] cargo test --workspace all green
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)