### PR TITLE
refactor(substrate): host fn wait_reply through NativeTransport, rename SubstrateCtx → ComponentCtx (issue 634)

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -43,7 +43,7 @@ mod native {
     use crate::wasm_trampoline::{self, WasmTrampoline, WasmTrampolineConfig};
     use aether_substrate::capability::BootError;
     use aether_substrate::control_helpers::register_or_match_all;
-    use aether_substrate::ctx::SubstrateCtx;
+    use aether_substrate::ctx::ComponentCtx;
     use aether_substrate::input::{self, InputSubscribers};
     use aether_substrate::kind_manifest;
     use aether_substrate::mail::{KindId, Mail, MailboxId};
@@ -62,7 +62,7 @@ mod native {
     /// table (shared with the platform thread + trampolines).
     pub struct ComponentHostConfig {
         pub engine: Arc<Engine>,
-        pub linker: Arc<Linker<SubstrateCtx>>,
+        pub linker: Arc<Linker<ComponentCtx>>,
         pub hub_outbound: Arc<HubOutbound>,
         pub input_subscribers: InputSubscribers,
     }
@@ -71,7 +71,7 @@ mod native {
     /// owner running on its dispatcher thread; no shared state.
     pub struct ComponentHostCapability {
         engine: Arc<Engine>,
-        linker: Arc<Linker<SubstrateCtx>>,
+        linker: Arc<Linker<ComponentCtx>>,
         registry: Arc<Registry>,
         mailer: Arc<Mailer>,
         outbound: Arc<HubOutbound>,

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -49,7 +49,7 @@ pub use audio::AudioConfig;
 pub use broadcast::BroadcastCapability;
 pub use component::ComponentHostCapability;
 // `ComponentHostConfig` is wasmtime-bound (it holds `Arc<Engine>` /
-// `Arc<Linker<SubstrateCtx>>`). It re-exports only on the native
+// `Arc<Linker<ComponentCtx>>`). It re-exports only on the native
 // target — wasm-component consumers see the cap stub via
 // `ComponentHostCapability` for typed `ctx.actor::<...>()` addressing
 // without dragging the wasmtime stack into the wasm graph.

--- a/crates/aether-capabilities/src/wasm_trampoline.rs
+++ b/crates/aether-capabilities/src/wasm_trampoline.rs
@@ -22,7 +22,7 @@
 //! loop can't accommodate that. That was wrong:
 //! [`NativeTransport::wait_reply`] already supports synchronous
 //! pulls from inside a handler — same `Mutex<Receiver>` + overflow
-//! buffer shape `SubstrateCtx::wait_reply` had. Unifying on the
+//! buffer shape `ComponentCtx::wait_reply` had. Unifying on the
 //! framework drops the parallel implementation.
 //!
 //! ## Lifecycle
@@ -50,7 +50,7 @@ use aether_kinds::{
 };
 use aether_substrate::capability::{BootError, Envelope};
 use aether_substrate::component::Component;
-use aether_substrate::ctx::SubstrateCtx;
+use aether_substrate::ctx::ComponentCtx;
 use aether_substrate::input::InputSubscribers;
 use aether_substrate::mail::{Mail, MailboxId};
 use aether_substrate::mailer::Mailer;
@@ -87,7 +87,7 @@ impl aether_actor::Instanced for WasmTrampoline {}
 /// trampoline's transport.
 pub struct WasmTrampolineConfig {
     pub engine: Arc<Engine>,
-    pub linker: Arc<Linker<SubstrateCtx>>,
+    pub linker: Arc<Linker<ComponentCtx>>,
     pub module: Module,
     pub registry: Arc<Registry>,
     pub outbound: Arc<HubOutbound>,
@@ -117,7 +117,7 @@ pub struct WasmTrampoline {
     /// `Component::instantiate` against the same engine + linker
     /// is reachable from the handler.
     engine: Arc<Engine>,
-    linker: Arc<Linker<SubstrateCtx>>,
+    linker: Arc<Linker<ComponentCtx>>,
     registry: Arc<Registry>,
     mailer: Arc<Mailer>,
     outbound: Arc<HubOutbound>,
@@ -137,13 +137,18 @@ impl NativeActor for WasmTrampoline {
     fn init(config: WasmTrampolineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
         let mailbox = ctx.self_id();
         let mailer = ctx.mailer();
-        let substrate_ctx = SubstrateCtx::new(
+        let mut substrate_ctx = ComponentCtx::new(
             mailbox,
             Arc::clone(&config.registry),
             Arc::clone(&mailer),
             Arc::clone(&config.outbound),
             Arc::clone(&config.input_subscribers),
         );
+        // Wire the trampoline's transport so `wait_reply_p32` host fn
+        // can drain *this* trampoline's inbox + overflow (issue 634
+        // Phase 4 PR 3 — single source of inbox truth lives on
+        // `NativeTransport`, not on `ComponentCtx`).
+        substrate_ctx.install_transport(Arc::clone(ctx.transport_arc()));
         let component = Component::instantiate(
             &config.engine,
             &config.linker,
@@ -282,11 +287,11 @@ impl WasmTrampoline {
             None
         };
 
-        // Build a fresh `SubstrateCtx` for the new instance — same
+        // Build a fresh `ComponentCtx` for the new instance — same
         // mailer + registry/outbound/input references, new
         // ReplyTable since wasm-side state resets. Mailbox id is
         // preserved across replace per ADR-0022 §4.
-        let substrate_ctx = SubstrateCtx::new(
+        let substrate_ctx = ComponentCtx::new(
             self.mailbox,
             Arc::clone(&self.registry),
             Arc::clone(&self.mailer),

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -21,7 +21,7 @@ use crate::{EngineId, MailboxId, SessionToken};
 /// (ADR-0008). `EngineMailbox` tags mail bubbled up from a component
 /// on another engine, so replies route to the originating engine's
 /// mailbox (ADR-0037 Phase 2). `Component` tags sink-bound mail that
-/// a local component pushed through `SubstrateCtx::send`, so sink
+/// a local component pushed through `ComponentCtx::send`, so sink
 /// reply paths (ADR-0041's io sink is the motivating case) can route
 /// the `*Result` back to the component via the mailer rather than
 /// the hub.

--- a/crates/aether-substrate-bundle/src/hub/wire.rs
+++ b/crates/aether-substrate-bundle/src/hub/wire.rs
@@ -166,7 +166,7 @@ pub struct EngineMailToHubSubstrateFrame {
     pub count: u32,
     pub source_mailbox_id: Option<MailboxId>,
     /// ADR-0042 correlation id the originating component's
-    /// `SubstrateCtx::send` minted. Carried across the hub so a
+    /// `ComponentCtx::send` minted. Carried across the hub so a
     /// bubbled-up mail's reply (ADR-0037 Phase 2) can echo back
     /// through `MailByIdFrame` and reach a parked `wait_reply_p32`
     /// on the original sender.

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -32,8 +32,8 @@ pub mod test_bench;
 pub use aether_capabilities as capabilities;
 pub use aether_capabilities::{BroadcastCapability, ComponentHostCapability, ComponentHostConfig};
 pub use aether_substrate::{
-    Chassis, Component, HubOutbound, InputSubscribers, KindId, Mail, MailKind, MailboxEntry,
-    MailboxHandler, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot, SubstrateCtx,
+    Chassis, Component, ComponentCtx, HubOutbound, InputSubscribers, KindId, Mail, MailKind,
+    MailboxEntry, MailboxHandler, MailboxId, Mailer, Registry, ReplyTarget, ReplyTo, SubstrateBoot,
     capture::{CaptureQueue, PendingCapture},
     component, ctx, frame_loop, host_fns, input, kind_manifest, log_install, mail, mailer,
     new_subscribers, registry, remove_from_all, reply_table, subscribers_for,

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -1,5 +1,5 @@
 //! Pre-Phase-4 end-to-end test: WAT-built component →
-//! `SubstrateCtx::send` → sink handler. Used `ComponentHostCapability`'s
+//! `ComponentCtx::send` → sink handler. Used `ComponentHostCapability`'s
 //! `for_test` / `attach_component_for_test` test helpers and the
 //! mailer's `drain_all` to drive a hand-built `Component` past the
 //! cap's dispatcher infrastructure.

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -41,8 +41,8 @@ use aether_data::KindDescriptor;
 use wasmtime::{Engine, Linker};
 
 use crate::{
-    AETHER_DIAGNOSTICS, BootedChassis, ChassisBuilder, HubOutbound, InputSubscribers, Mailer,
-    Registry, SubstrateCtx, handle_store::HandleStore, host_fns, input::new_subscribers,
+    AETHER_DIAGNOSTICS, BootedChassis, ChassisBuilder, ComponentCtx, HubOutbound, InputSubscribers,
+    Mailer, Registry, handle_store::HandleStore, host_fns, input::new_subscribers,
 };
 
 /// Everything a chassis needs after shared boot setup. Fields are
@@ -59,7 +59,7 @@ use crate::{
 pub struct SubstrateBoot {
     pub engine: Arc<Engine>,
     pub registry: Arc<Registry>,
-    pub linker: Arc<Linker<SubstrateCtx>>,
+    pub linker: Arc<Linker<ComponentCtx>>,
     pub queue: Arc<Mailer>,
     pub outbound: Arc<HubOutbound>,
     pub input_subscribers: InputSubscribers,
@@ -249,7 +249,7 @@ impl<'a> SubstrateBootBuilder<'a> {
             .build()
             .map_err(|e| wasmtime::Error::msg(format!("chassis capability boot: {e}")))?;
 
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
         host_fns::register(&mut linker)?;
         let linker = Arc::new(linker);
 

--- a/crates/aether-substrate/src/component.rs
+++ b/crates/aether-substrate/src/component.rs
@@ -1,13 +1,11 @@
-// A loaded WASM component: its wasmtime `Store<SubstrateCtx>`, instance,
+// A loaded WASM component: its wasmtime `Store<ComponentCtx>`, instance,
 // and the cached handles needed to deliver mail. Mail payloads are
 // written to the guest at a static `MAIL_OFFSET`; a guest-side
 // allocator is parked until an actual use case forces the question.
 
-use std::sync::mpsc::Receiver;
-
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
-use crate::ctx::{StateBundle, SubstrateCtx};
+use crate::ctx::{ComponentCtx, StateBundle};
 use crate::mail::{Mail, ReplyTarget};
 use crate::reply_table::{NO_REPLY_HANDLE, ReplyEntry};
 
@@ -48,7 +46,7 @@ const STATE_OFFSET: u32 = 8192;
 /// (no-op trait defaults compile down to no symbol under LTO, so
 /// components that don't override stay backwards-compat).
 pub struct Component {
-    store: Store<SubstrateCtx>,
+    store: Store<ComponentCtx>,
     memory: Memory,
     receive: TypedFunc<(u64, u32, u32, u32, u32), u32>,
     on_replace: Option<TypedFunc<(), u32>>,
@@ -62,9 +60,9 @@ impl Component {
     /// component will see.
     pub fn instantiate(
         engine: &Engine,
-        linker: &Linker<SubstrateCtx>,
+        linker: &Linker<ComponentCtx>,
         module: &Module,
-        ctx: SubstrateCtx,
+        ctx: ComponentCtx,
     ) -> wasmtime::Result<Self> {
         let mut store = Store::new(engine, ctx);
         let instance = linker.instantiate(&mut store, module)?;
@@ -145,7 +143,7 @@ impl Component {
     /// meaningful reply target — a Claude session (non-NIL
     /// `SessionToken`), a remote engine mailbox, or a peer component
     /// (`reply_to.target = ReplyTarget::Component(_)` populated by
-    /// `SubstrateCtx::send` / `NativeTransport::send_mail`).
+    /// `ComponentCtx::send` / `NativeTransport::send_mail`).
     /// Broadcast-origin and system-generated mail pass
     /// `NO_REPLY_HANDLE` so the guest's `mail.reply_to()` accessor
     /// returns `None`.
@@ -250,38 +248,6 @@ impl Component {
         Ok(())
     }
 
-    /// Install the mpsc `Receiver` the dispatcher will read from
-    /// (ADR-0042). Called by `ComponentEntry::spawn` right after the
-    /// mpsc pair is built; the host fn for `wait_reply_p32` later
-    /// drains the same receiver when a guest parks on a reply.
-    pub fn install_inbox_rx(&mut self, rx: Receiver<Mail>) {
-        self.store.data().install_inbox_rx(rx);
-    }
-
-    /// Pop the next mail for the dispatcher. Drains the overflow
-    /// buffer first (FIFO-preserved mail that a completed
-    /// `wait_reply_p32` set aside), then reads from the mpsc
-    /// receiver installed via `install_inbox_rx`. `None` means both
-    /// are empty and the inbox has been disconnected — the
-    /// dispatcher takes that as its exit signal.
-    pub fn next_mail(&mut self) -> Option<Mail> {
-        self.store.data().next_mail()
-    }
-
-    /// Push a mail onto this component's overflow buffer directly.
-    /// Test-only: lets unit tests seed the overflow and observe that
-    /// `next_mail` drains it before the mpsc. Production code only
-    /// feeds the overflow through `wait_reply_p32`'s drain path.
-    #[cfg(test)]
-    pub fn push_overflow_for_test(&mut self, mail: Mail) {
-        self.store
-            .data()
-            .inbox_overflow
-            .lock()
-            .unwrap()
-            .push_back(mail);
-    }
-
     /// Read a `u32` from guest linear memory at `offset`. Test-only
     /// accessor: the production mail path writes at `MAIL_OFFSET`
     /// and the guest interprets the bytes — nothing in non-test
@@ -320,8 +286,8 @@ mod tests {
     use crate::outbound::HubOutbound;
     use crate::registry::Registry;
 
-    fn ctx() -> SubstrateCtx {
-        SubstrateCtx::new(
+    fn ctx() -> ComponentCtx {
+        ComponentCtx::new(
             MailboxId(0),
             Arc::new(Registry::new()),
             Arc::new(Mailer::new()),
@@ -332,7 +298,7 @@ mod tests {
 
     fn instantiate(wat: &str) -> Component {
         let engine = Engine::default();
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
         crate::host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).expect("compile WAT");
         let module = Module::new(&engine, &wasm).expect("compile module");
@@ -611,7 +577,7 @@ mod tests {
     }
 
     fn plane_ctx_for_reply() -> (
-        SubstrateCtx,
+        ComponentCtx,
         std::sync::mpsc::Receiver<crate::outbound::EgressEvent>,
         aether_data::KindId,
     ) {
@@ -627,7 +593,7 @@ mod tests {
                 is_stream: false,
             })
             .expect("register kind");
-        let ctx = SubstrateCtx::new(
+        let ctx = ComponentCtx::new(
             M(0),
             registry,
             Arc::new(Mailer::new()),
@@ -637,9 +603,9 @@ mod tests {
         (ctx, rx, pong_id)
     }
 
-    fn instantiate_with_ctx(wat: &str, ctx: SubstrateCtx) -> Component {
+    fn instantiate_with_ctx(wat: &str, ctx: ComponentCtx) -> Component {
         let engine = Engine::default();
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
+        let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
         crate::host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).unwrap();
         let module = Module::new(&engine, &wasm).unwrap();
@@ -683,486 +649,5 @@ mod tests {
         let mail = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1);
         component.deliver(&mail).expect("deliver");
         assert!(rx.try_recv().is_err(), "no frame should have been sent");
-    }
-
-    /// ADR-0042 `wait_reply_p32` host fn. The guest expects a reply
-    /// of kind `0xAAAA_AAAA_AAAA_AAAA`, writes a maximum of 64 bytes
-    /// starting at offset 600, and uses the mail's `count` field as
-    /// the `timeout_ms` argument so tests can vary it per invocation.
-    /// The host fn's return value (bytes written, or a negative
-    /// sentinel) lands at offset 700.
-    const WAT_SYNC_WAIT: &str = r#"
-        (module
-            (import "aether" "wait_reply_p32"
-                (func $wait (param i64 i32 i32 i32 i64) (result i32)))
-            (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
-                i32.const 700
-                (call $wait
-                    (i64.const -6148914691236517206) ;; 0xAAAA_AAAA_AAAA_AAAA reinterpreted as i64
-                    (i32.const 600)                  ;; out_ptr
-                    (i32.const 64)                   ;; out_cap
-                    (local.get 3)                    ;; timeout_ms = count (param 3 after byte_len shifted in at 2)
-                    (i64.const 0))                   ;; expected_correlation = 0 (kind-only filter)
-                i32.store
-                i32.const 0))
-    "#;
-
-    const SYNC_WAIT_EXPECTED_KIND: aether_data::KindId = aether_data::KindId(0xAAAA_AAAA_AAAA_AAAA);
-
-    /// Helper: build a trigger mail whose `count` field carries the
-    /// timeout_ms argument into the WAT. The `kind` is irrelevant —
-    /// the guest ignores it and passes a hardcoded `expected_kind` to
-    /// the host fn.
-    fn trigger_wait(timeout_ms: u32) -> Mail {
-        use crate::mail::MailboxId;
-        Mail::new(
-            MailboxId(0),
-            aether_data::KindId(0xBEEF),
-            vec![],
-            timeout_ms,
-        )
-    }
-
-    /// Build a sync-wait component with an installed inbox so
-    /// `wait_reply_p32` has something to drain. Returns the
-    /// component + the `Sender<Mail>` the test can push matching /
-    /// non-matching mail through; drop the Sender to trigger
-    /// disconnect.
-    fn instantiate_sync_wait_with_inbox() -> (Component, std::sync::mpsc::Sender<Mail>) {
-        use std::sync::mpsc;
-
-        use wasmtime::{Engine, Linker, Module};
-
-        let engine = Engine::default();
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
-        crate::host_fns::register(&mut linker).expect("register host fns");
-        let wasm = wat::parse_str(WAT_SYNC_WAIT).expect("compile WAT");
-        let module = Module::new(&engine, &wasm).expect("compile module");
-        let mut component =
-            Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate");
-        let (tx, rx) = mpsc::channel::<Mail>();
-        component.install_inbox_rx(rx);
-        (component, tx)
-    }
-
-    #[test]
-    fn wait_reply_returns_timeout_when_no_match_arrives() {
-        let (mut component, _tx) = instantiate_sync_wait_with_inbox();
-        component.deliver(&trigger_wait(10)).expect("deliver");
-
-        let result = component.read_u32(700) as i32;
-        assert_eq!(
-            result,
-            crate::host_fns::WAIT_TIMEOUT,
-            "no matching mail pushed — expected WAIT_TIMEOUT",
-        );
-    }
-
-    #[test]
-    fn wait_reply_poll_mode_returns_timeout_immediately() {
-        // timeout_ms = 0 → try_recv path; no pre-queued mail → -1.
-        let (mut component, _tx) = instantiate_sync_wait_with_inbox();
-        component.deliver(&trigger_wait(0)).expect("deliver");
-
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, crate::host_fns::WAIT_TIMEOUT);
-    }
-
-    #[test]
-    fn wait_reply_writes_payload_and_returns_byte_count_on_match() {
-        use std::thread;
-        use std::time::Duration;
-
-        use crate::host_fns;
-        use crate::mail::MailboxId as M;
-
-        let (component, tx) = instantiate_sync_wait_with_inbox();
-
-        // Deliver on a worker so we can push matching mail from
-        // this thread while the guest is parked inside the host
-        // fn's drain loop.
-        let handle = thread::spawn(move || {
-            let mut component = component;
-            component.deliver(&trigger_wait(1000)).expect("deliver");
-            component
-        });
-
-        // Nudge past the host fn's entry so the drain is already
-        // parked on recv_timeout before our mail hits the mpsc.
-        thread::sleep(Duration::from_millis(50));
-
-        let payload = vec![1, 2, 3, 4, 5];
-        tx.send(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload.clone(), 1))
-            .expect("send matching mail");
-
-        let mut component = handle.join().expect("worker panicked");
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, payload.len() as i32, "byte count returned");
-        assert_eq!(
-            component.read_bytes(600, payload.len()),
-            payload,
-            "payload copied into guest memory at out_ptr",
-        );
-        let _ = host_fns::WAIT_TIMEOUT; // keep import live without warning
-    }
-
-    #[test]
-    fn wait_reply_buffers_non_matching_mail_into_overflow() {
-        // ADR-0042 drain loop: a non-matching mail arriving during
-        // the wait must end up on the overflow buffer so the
-        // dispatcher serves it ahead of new mpsc mail afterwards.
-        use std::thread;
-        use std::time::Duration;
-
-        use crate::mail::MailboxId as M;
-
-        let (component, tx) = instantiate_sync_wait_with_inbox();
-        let handle = thread::spawn(move || {
-            let mut component = component;
-            component.deliver(&trigger_wait(1000)).expect("deliver");
-            component
-        });
-
-        thread::sleep(Duration::from_millis(50));
-
-        // Non-match first; then the real reply.
-        tx.send(Mail::new(
-            M(0),
-            aether_data::KindId(0xDEAD_BEEF),
-            vec![42],
-            1,
-        ))
-        .expect("send non-match");
-        tx.send(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, vec![7], 1))
-            .expect("send match");
-
-        let component = handle.join().expect("worker panicked");
-        // Match drained cleanly; the non-match should now be sitting
-        // in overflow, waiting for the dispatcher to pick it up.
-        let overflow_len = component.store.data().inbox_overflow.lock().unwrap().len();
-        assert_eq!(overflow_len, 1, "non-match mail should be buffered");
-    }
-
-    #[test]
-    fn wait_reply_returns_buffer_too_small_when_payload_exceeds_cap() {
-        use std::thread;
-        use std::time::Duration;
-
-        use crate::host_fns;
-        use crate::mail::MailboxId as M;
-
-        let (component, tx) = instantiate_sync_wait_with_inbox();
-        let handle = thread::spawn(move || {
-            let mut component = component;
-            component.deliver(&trigger_wait(1000)).expect("deliver");
-            component
-        });
-
-        thread::sleep(Duration::from_millis(50));
-
-        // WAT's out_cap is 64; push a 128-byte payload.
-        let payload = vec![0x7Fu8; 128];
-        tx.send(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload, 1))
-            .expect("send matching-but-too-big mail");
-
-        let mut component = handle.join().expect("worker panicked");
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, host_fns::WAIT_BUFFER_TOO_SMALL);
-    }
-
-    /// ADR-0042 correlation: a sync wait filters on
-    /// `expected_correlation` so it picks *its own* reply out of
-    /// the inbox rather than the first `ReadResult`-kind mail that
-    /// happens to be queued. Regression guard — without the
-    /// correlation filter, a stale prior reply of the same kind
-    /// would be consumed as if it were the one we're waiting on.
-    #[test]
-    fn wait_reply_filters_by_correlation_not_just_kind() {
-        use std::sync::mpsc;
-
-        use wasmtime::{Engine, Linker, Module};
-
-        use crate::mail::{MailboxId as M, ReplyTarget, ReplyTo};
-
-        // WAT that waits on kind `SYNC_WAIT_EXPECTED_KIND` with
-        // expected_correlation = 42, timeout = 1s. Stores payload
-        // byte count at offset 700.
-        const WAT: &str = r#"
-            (module
-                (import "aether" "wait_reply_p32"
-                    (func $wait (param i64 i32 i32 i32 i64) (result i32)))
-                (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
-                    i32.const 700
-                    (call $wait
-                        (i64.const -6148914691236517206) ;; expected_kind = 0xAAAA...
-                        (i32.const 600)                  ;; out_ptr
-                        (i32.const 64)                   ;; out_cap
-                        (i32.const 1000)                 ;; timeout_ms
-                        (i64.const 42))                  ;; expected_correlation
-                    i32.store
-                    i32.const 0))
-        "#;
-
-        let engine = Engine::default();
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
-        crate::host_fns::register(&mut linker).expect("register host fns");
-        let wasm = wat::parse_str(WAT).expect("compile WAT");
-        let module = Module::new(&engine, &wasm).expect("compile module");
-        let mut component =
-            Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate");
-        let (tx, rx) = mpsc::channel::<Mail>();
-        component.install_inbox_rx(rx);
-
-        // Pre-queue a decoy reply: same kind, different correlation.
-        // Without the correlation filter the sync wait would consume
-        // THIS one (first-in) as if it were the one we're waiting on.
-        let decoy_payload = vec![0xDE, 0xAD];
-        tx.send(
-            Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, decoy_payload, 1)
-                .with_reply_to(ReplyTo::with_correlation(ReplyTarget::None, 10)),
-        )
-        .expect("send decoy");
-
-        // Now the reply we're actually waiting on: correlation = 42.
-        let real_payload = vec![1, 2, 3, 4, 5];
-        tx.send(
-            Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, real_payload.clone(), 1)
-                .with_reply_to(ReplyTo::with_correlation(ReplyTarget::None, 42)),
-        )
-        .expect("send real reply");
-
-        component.deliver(&trigger_wait(0)).expect("deliver");
-
-        let result = component.read_u32(700) as i32;
-        assert_eq!(
-            result,
-            real_payload.len() as i32,
-            "expected byte count for the correlation-42 reply"
-        );
-        assert_eq!(
-            component.read_bytes(600, real_payload.len()),
-            real_payload,
-            "host fn copied the wrong payload — decoy reply consumed instead of real one",
-        );
-        // Decoy should still be sitting in overflow — the dispatcher
-        // would deliver it on its next pass after the wait returned.
-        let overflow = component.store.data().inbox_overflow.lock().unwrap();
-        assert_eq!(overflow.len(), 1, "decoy mail should be in overflow");
-        assert_eq!(overflow[0].reply_to.correlation_id, 10);
-    }
-
-    #[test]
-    fn wait_reply_returns_cancelled_when_sender_drops() {
-        use std::thread;
-        use std::time::Duration;
-
-        use crate::host_fns;
-
-        let (component, tx) = instantiate_sync_wait_with_inbox();
-        let handle = thread::spawn(move || {
-            let mut component = component;
-            component.deliver(&trigger_wait(1000)).expect("deliver");
-            component
-        });
-
-        thread::sleep(Duration::from_millis(50));
-        // Teardown-style cancellation under the drain+buffer design
-        // is "drop the mpsc Sender" — the host fn's recv_timeout
-        // wakes with Disconnected.
-        drop(tx);
-
-        let mut component = handle.join().expect("worker panicked");
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, host_fns::WAIT_CANCELLED);
-    }
-
-    /// Issue 357: `wait_reply_p32` must scan `inbox_overflow` before
-    /// reading the mpsc. A non-matching mail parked on overflow must
-    /// stay there while the wait reads the matching mail off the rx;
-    /// reversing the order would let the parked mail leak out the
-    /// front of the wait path.
-    #[test]
-    fn wait_reply_drains_overflow_before_rx_with_no_match_in_overflow() {
-        use crate::mail::MailboxId as M;
-
-        let (mut component, tx) = instantiate_sync_wait_with_inbox();
-
-        // Park a non-matching mail on overflow (different kind).
-        component.push_overflow_for_test(Mail::new(
-            M(0),
-            aether_data::KindId(0xDEAD_BEEF),
-            vec![9, 9, 9],
-            1,
-        ));
-
-        // Push the matching mail on the rx.
-        let payload = vec![1, 2, 3];
-        tx.send(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload.clone(), 1))
-            .expect("send matching mail");
-
-        component.deliver(&trigger_wait(1000)).expect("deliver");
-
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, payload.len() as i32, "matching reply consumed");
-        assert_eq!(component.read_bytes(600, payload.len()), payload);
-
-        // Overflow should still hold exactly the parked non-match —
-        // the wait scanned past it without consuming it.
-        let overflow = component.store.data().inbox_overflow.lock().unwrap();
-        assert_eq!(overflow.len(), 1, "non-match must stay parked on overflow");
-        assert_eq!(overflow[0].kind, aether_data::KindId(0xDEAD_BEEF));
-    }
-
-    /// Issue 357: a matching mail already on overflow short-circuits
-    /// the rx. The wait pulls it from overflow and never touches the
-    /// channel, so unrelated mail still queued on rx is preserved for
-    /// the dispatcher.
-    #[test]
-    fn wait_reply_pulls_match_from_overflow_without_touching_rx() {
-        use crate::mail::MailboxId as M;
-
-        let (mut component, tx) = instantiate_sync_wait_with_inbox();
-
-        // Park a matching mail on overflow.
-        let payload = vec![7, 7, 7, 7];
-        component.push_overflow_for_test(Mail::new(
-            M(0),
-            SYNC_WAIT_EXPECTED_KIND,
-            payload.clone(),
-            1,
-        ));
-
-        // Pre-queue an unrelated mail on the rx — the wait must NOT
-        // consume this; the dispatcher should see it on its next pass.
-        tx.send(Mail::new(
-            M(0),
-            aether_data::KindId(0xCAFE_BABE),
-            vec![0xFF],
-            1,
-        ))
-        .expect("send rx-side filler");
-
-        // Use poll mode (timeout = 0) so the test fails loudly if the
-        // host fn falls into the rx-blocking path despite a hit on
-        // overflow.
-        component.deliver(&trigger_wait(0)).expect("deliver");
-
-        let result = component.read_u32(700) as i32;
-        assert_eq!(result, payload.len() as i32, "overflow match consumed");
-        assert_eq!(component.read_bytes(600, payload.len()), payload);
-
-        // Overflow drained empty; the unrelated rx mail should reach
-        // the dispatcher next pass.
-        let overflow_len = component.store.data().inbox_overflow.lock().unwrap().len();
-        assert_eq!(overflow_len, 0, "matching overflow entry was removed");
-        let next = component.next_mail().expect("rx mail still queued");
-        assert_eq!(next.kind, aether_data::KindId(0xCAFE_BABE));
-    }
-
-    /// Issue 357: simulate a `WAIT_BUFFER_TOO_SMALL` retry. A wait
-    /// that hits an oversized payload pushes the mail back on
-    /// overflow with `push_front`. A second wait with a bigger
-    /// buffer must rediscover that parked mail via the overflow
-    /// scan — without contributions from the rx.
-    #[test]
-    fn wait_reply_retries_after_buffer_too_small_via_overflow() {
-        use std::sync::mpsc;
-
-        use wasmtime::{Engine, Linker, Module};
-
-        use crate::host_fns;
-        use crate::mail::MailboxId as M;
-
-        // First WAT: 64-byte cap (the standard sync-wait shape) —
-        // returns WAIT_BUFFER_TOO_SMALL when the payload exceeds that
-        // and pushes the mail back on overflow.
-        // Second WAT: 256-byte cap. The 128-byte payload writes into
-        // 800..928; the result code stores at offset 1100 to leave a
-        // clear gap past the payload window so the assert can read
-        // both without aliasing.
-        const WAT_BIG_BUF: &str = r#"
-            (module
-                (import "aether" "wait_reply_p32"
-                    (func $wait (param i64 i32 i32 i32 i64) (result i32)))
-                (memory (export "memory") 1)
-                (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
-                    i32.const 1100
-                    (call $wait
-                        (i64.const -6148914691236517206) ;; expected_kind
-                        (i32.const 800)                  ;; out_ptr
-                        (i32.const 256)                  ;; out_cap (bigger)
-                        (i32.const 0)                    ;; timeout_ms = poll
-                        (i64.const 0))                   ;; expected_correlation
-                    i32.store
-                    i32.const 0))
-        "#;
-
-        // Run #1: small buffer, oversized payload — parks mail on
-        // overflow via push_front and returns WAIT_BUFFER_TOO_SMALL.
-        let (mut component_small, tx_small) = instantiate_sync_wait_with_inbox();
-        let payload = vec![0x42u8; 128];
-        tx_small
-            .send(Mail::new(M(0), SYNC_WAIT_EXPECTED_KIND, payload.clone(), 1))
-            .expect("send oversized matching mail");
-        component_small
-            .deliver(&trigger_wait(0))
-            .expect("first deliver");
-        assert_eq!(
-            component_small.read_u32(700) as i32,
-            host_fns::WAIT_BUFFER_TOO_SMALL,
-            "small-buffer wait should return WAIT_BUFFER_TOO_SMALL",
-        );
-
-        // Sanity: the parked mail is in overflow now.
-        {
-            let overflow = component_small.store.data().inbox_overflow.lock().unwrap();
-            assert_eq!(overflow.len(), 1, "oversized mail parked on overflow");
-        }
-
-        // Run #2 simulates the retry. Build a second component with
-        // a bigger out_cap. We can't reuse `component_small` because
-        // the WAT is hardwired to a 64-byte cap; instead, move the
-        // parked mail across by popping it out of `component_small`'s
-        // overflow and pushing it onto `component_big`'s overflow,
-        // which is exactly the state the SDK leaves behind for the
-        // retry inside one component.
-        let parked = component_small
-            .store
-            .data()
-            .inbox_overflow
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("parked mail present");
-
-        let engine = Engine::default();
-        let mut linker: Linker<SubstrateCtx> = Linker::new(&engine);
-        crate::host_fns::register(&mut linker).expect("register host fns");
-        let wasm = wat::parse_str(WAT_BIG_BUF).expect("compile WAT");
-        let module = Module::new(&engine, &wasm).expect("compile module");
-        let mut component_big =
-            Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate");
-        // Install an empty inbox; the retry must NOT need rx.
-        let (_tx_big, rx_big) = mpsc::channel::<Mail>();
-        component_big.install_inbox_rx(rx_big);
-        component_big.push_overflow_for_test(parked);
-
-        component_big
-            .deliver(&trigger_wait(0))
-            .expect("retry deliver");
-
-        let result = component_big.read_u32(1100) as i32;
-        assert_eq!(result, payload.len() as i32, "retry consumed parked mail");
-        assert_eq!(component_big.read_bytes(800, payload.len()), payload);
-        let overflow_len = component_big
-            .store
-            .data()
-            .inbox_overflow
-            .lock()
-            .unwrap()
-            .len();
-        assert_eq!(overflow_len, 0, "retry drained the parked mail");
     }
 }

--- a/crates/aether-substrate/src/ctx.rs
+++ b/crates/aether-substrate/src/ctx.rs
@@ -5,18 +5,17 @@
 //
 // Deliberately does NOT hold the scheduler's full shared state — doing
 // so would create an Arc cycle through `Scheduler owns Actor, Actor
-// owns Store<SubstrateCtx>, SubstrateCtx back to Scheduler`. By holding
+// owns Store<ComponentCtx>, ComponentCtx back to Scheduler`. By holding
 // only `Arc<Registry>` and `Arc<Mailer>` the cycle is broken: neither
 // of those owns any actor.
 
 use std::cell::Cell;
-use std::collections::VecDeque;
-use std::sync::mpsc::Receiver;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::input::InputSubscribers;
 use crate::mail::{Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 use crate::mailer::Mailer;
+use crate::native_transport::NativeTransport;
 use crate::outbound::HubOutbound;
 use crate::registry::{MailboxEntry, Registry};
 use crate::reply_table::ReplyTable;
@@ -32,7 +31,7 @@ pub struct StateBundle {
     pub bytes: Vec<u8>,
 }
 
-pub struct SubstrateCtx {
+pub struct ComponentCtx {
     pub sender: MailboxId,
     pub registry: Arc<Registry>,
     pub queue: Arc<Mailer>,
@@ -80,18 +79,18 @@ pub struct SubstrateCtx {
     /// `dispatch_load_component` reports it like any other
     /// instantiation error. None on the success path.
     pub init_failure: Option<String>,
-    /// ADR-0042 inbox machinery: the component's mpsc `Receiver`
-    /// lives here (not on the dispatcher's stack) so the
-    /// `wait_reply_p32` host fn can drain it directly, and a FIFO
-    /// overflow holds non-matching mail pulled during a wait until
-    /// the dispatcher drains it ahead of the mpsc on its next pass.
-    /// Both slots are populated by `ComponentEntry::spawn` after the
-    /// mpsc pair is built; `Component::instantiate` leaves the
-    /// `Mutex`es empty / default because it has no scheduler.
-    pub inbox_rx: Mutex<Option<Receiver<Mail>>>,
-    pub inbox_overflow: Mutex<VecDeque<Mail>>,
+    /// Trampoline transport whose `wait_reply` the
+    /// [`crate::host_fns::wait_reply_p32`] host fn delegates to.
+    /// `Some` for ctx instances built by [`WasmTrampoline::init`]
+    /// (issue 634 Phase 4 PR 3 — `transport.wait_reply` is now the
+    /// single source of inbox / overflow / correlation-filter
+    /// truth); `None` for the test paths that build `ComponentCtx`
+    /// without a real trampoline (the host fn returns
+    /// [`crate::host_fns::WAIT_CANCELLED`] in that case, matching
+    /// the pre-Phase-4 "no inbox installed" disposition).
+    pub transport: Option<Arc<NativeTransport>>,
     /// ADR-0042 correlation counter. Per-component (one
-    /// `SubstrateCtx` per component instance). Holds the *next* id
+    /// `ComponentCtx` per component instance). Holds the *next* id
     /// to mint; `prev_correlation()` reads `counter - 1` to return
     /// the last one minted. Starts at `1` so that `0` always means
     /// "no correlation" (backward-compat sentinel for waits that
@@ -103,7 +102,7 @@ pub struct SubstrateCtx {
     correlation_counter: Cell<u64>,
 }
 
-impl SubstrateCtx {
+impl ComponentCtx {
     /// Build a fresh ctx with empty state-migration slots and an
     /// empty sender table. Using this over the struct literal keeps
     /// the private fields (reply_table, saved_state,
@@ -116,7 +115,7 @@ impl SubstrateCtx {
         outbound: Arc<HubOutbound>,
         input_subscribers: InputSubscribers,
     ) -> Self {
-        SubstrateCtx {
+        ComponentCtx {
             sender,
             registry,
             queue,
@@ -126,14 +125,24 @@ impl SubstrateCtx {
             saved_state: None,
             save_state_error: None,
             init_failure: None,
-            inbox_rx: Mutex::new(None),
-            inbox_overflow: Mutex::new(VecDeque::new()),
+            transport: None,
             correlation_counter: Cell::new(1),
         }
     }
 
+    /// Wire the trampoline's `NativeTransport` into the ctx so the
+    /// [`crate::host_fns::wait_reply_p32`] host fn can route through
+    /// it. Called by [`WasmTrampoline::init`] right after constructing
+    /// the ctx (and before `Component::instantiate`, since the host
+    /// fn closure captures the ctx via the wasmtime `Store` data
+    /// pointer at instantiation time, not at host-fn call time, so
+    /// installing later than that is fine).
+    pub fn install_transport(&mut self, transport: Arc<NativeTransport>) {
+        self.transport = Some(transport);
+    }
+
     /// Mint the next correlation id and bump the counter. Private —
-    /// callers that want a correlation use `SubstrateCtx::send`,
+    /// callers that want a correlation use `ComponentCtx::send`,
     /// which mints internally and tags the outgoing mail.
     fn mint_correlation(&self) -> u64 {
         let id = self.correlation_counter.get();
@@ -142,7 +151,7 @@ impl SubstrateCtx {
     }
 
     /// Return the correlation id used by the most recent
-    /// `SubstrateCtx::send` call. The `prev_correlation_p32` host fn
+    /// `ComponentCtx::send` call. The `prev_correlation_p32` host fn
     /// surfaces this to the guest so sync wrappers know what to
     /// filter on in `wait_reply_p32`. Returns `0` (the "no
     /// correlation" sentinel) before any send has been made.
@@ -151,28 +160,6 @@ impl SubstrateCtx {
         // last one. `.saturating_sub(1)` covers the pre-send case
         // where counter is still `1` (initial) → returns `0`.
         self.correlation_counter.get().saturating_sub(1)
-    }
-
-    /// Install the mpsc `Receiver` the dispatcher will read from.
-    /// Called once by `ComponentEntry::spawn` right after the mpsc
-    /// pair is built; `wait_reply_p32` later drains the same
-    /// receiver when a guest parks on a reply.
-    pub fn install_inbox_rx(&self, rx: Receiver<Mail>) {
-        *self.inbox_rx.lock().unwrap() = Some(rx);
-    }
-
-    /// Pop one mail for the dispatcher. Drains the overflow buffer
-    /// first (FIFO-preserves mail that `wait_reply_p32` set aside
-    /// while it was parked), then blocks on the mpsc. `None` when
-    /// both are empty and the inbox has been disconnected —
-    /// dispatcher_loop treats that as its exit signal.
-    pub fn next_mail(&self) -> Option<Mail> {
-        if let Some(mail) = self.inbox_overflow.lock().unwrap().pop_front() {
-            return Some(mail);
-        }
-        let rx_guard = self.inbox_rx.lock().unwrap();
-        let rx = rx_guard.as_ref()?;
-        rx.recv().ok()
     }
 
     /// Dispatch mail. If the recipient is a sink, the handler runs inline
@@ -249,7 +236,7 @@ mod tests {
         mailer.wire(Arc::clone(&registry));
         mailer.wire_outbound(Arc::clone(&outbound));
 
-        let ctx = SubstrateCtx::new(
+        let ctx = ComponentCtx::new(
             sender,
             Arc::clone(&registry),
             Arc::clone(&mailer),
@@ -296,7 +283,7 @@ mod tests {
         mailer.wire(Arc::clone(&registry));
         // Deliberately no `wire_outbound`.
 
-        let ctx = SubstrateCtx::new(
+        let ctx = ComponentCtx::new(
             sender,
             Arc::clone(&registry),
             Arc::clone(&mailer),

--- a/crates/aether-substrate/src/host_fns.rs
+++ b/crates/aether-substrate/src/host_fns.rs
@@ -4,12 +4,10 @@
 // surface. Growth of this surface should be reviewed as deliberately
 // as any other architectural change.
 
-use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
-use std::time::{Duration, Instant};
-
+use aether_actor::MailTransport;
 use wasmtime::{Caller, Linker};
 
-use crate::ctx::{StateBundle, SubstrateCtx};
+use crate::ctx::{ComponentCtx, StateBundle};
 use crate::mail::{KindId, MailboxId, ReplyTarget};
 
 /// Status codes returned by the `reply_mail` host fn (ADR-0013 §3).
@@ -57,11 +55,11 @@ pub const MAX_WAIT_TIMEOUT_MS: u32 = 30_000;
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
 /// function has been called on.
-pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
+pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "send_mail_p32",
-        |mut caller: Caller<'_, SubstrateCtx>,
+        |mut caller: Caller<'_, ComponentCtx>,
          recipient: u64,
          kind: u64,
          ptr: u32,
@@ -114,7 +112,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "save_state_p32",
-        |mut caller: Caller<'_, SubstrateCtx>, version: u32, ptr: u32, len: u32| -> u32 {
+        |mut caller: Caller<'_, ComponentCtx>, version: u32, ptr: u32, len: u32| -> u32 {
             if len as usize > MAX_STATE_BUNDLE_BYTES {
                 caller.data_mut().save_state_error = Some(format!(
                     "save_state: bundle size {} exceeds {} byte cap",
@@ -145,14 +143,14 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     //   - Session: ship as a `ClaudeAddress::Session` frame through
     //     `HubOutbound` (same route as ADR-0013's original design).
     //   - Component: enqueue on the local `Mailer` via
-    //     `SubstrateCtx::send`. Dropped-mailbox discard is handled
+    //     `ComponentCtx::send`. Dropped-mailbox discard is handled
     //     there already, so a component that vanished between the
     //     request and the reply silently drops — the same contract
     //     as any other send to a dropped mailbox.
     linker.func_wrap(
         "aether",
         "reply_mail_p32",
-        |mut caller: Caller<'_, SubstrateCtx>,
+        |mut caller: Caller<'_, ComponentCtx>,
          sender: u32,
          kind: u64,
          ptr: u32,
@@ -237,168 +235,68 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     // now a deterministic hash of the mailbox name, computed on the
     // guest side. The corresponding host fn is gone.
 
-    // ADR-0042: synchronous mail wait via drain + buffer. The host
-    // fn drains the component's own mpsc inbox in a loop (the same
-    // `Receiver<Mail>` the dispatcher reads from — moved onto
-    // `SubstrateCtx` at spawn so both sides can reach it). Matching
-    // mail is copied into the guest's `out` buffer and returned as
-    // a byte count; non-matching mail is pushed onto the component's
-    // overflow buffer, where the dispatcher drains it FIFO-ahead of
-    // the mpsc on its next pass. Timeout → `-1`. Reply too big →
-    // `-2`. Inbox disconnected (teardown) → `-3`.
+    // ADR-0042: synchronous mail wait, delegating to the trampoline's
+    // `NativeTransport::wait_reply` (issue 634 Phase 4 PR 3). The
+    // transport already owns inbox + overflow + correlation-filter;
+    // the host fn just bridges between wasm linear memory and the
+    // transport's `&mut [u8]` buffer.
     //
     // The drain runs on the dispatcher thread because the guest's
     // host call IS the dispatcher (ADR-0038 actor-per-component).
-    // Other senders keep pushing into the mpsc during the wait;
-    // non-match accumulates in overflow until drain returns.
+    // Other senders keep pushing into the transport's mpsc during
+    // the wait; non-match accumulates in the transport's overflow
+    // until drain returns.
+    //
+    // Sentinel codes: timeout → `-1`, reply too big for `out_cap` →
+    // `-2` (envelope is parked back on overflow so a retry with a
+    // larger buffer can pick it up), inbox disconnected → `-3`,
+    // ctx without a wired transport → `-3` (test-path
+    // pathological — production trampolines always wire one).
     linker.func_wrap(
         "aether",
         "wait_reply_p32",
-        |mut caller: Caller<'_, SubstrateCtx>,
+        |mut caller: Caller<'_, ComponentCtx>,
          expected_kind: u64,
          out_ptr: u32,
          out_cap: u32,
          timeout_ms: u32,
          expected_correlation: u64|
          -> i32 {
-            let expected_kind = KindId(expected_kind);
             let clamped = timeout_ms.min(MAX_WAIT_TIMEOUT_MS);
-            let deadline = Instant::now() + Duration::from_millis(clamped as u64);
-
-            // Drain loop. The inbox receiver lives on the ctx
-            // (`inbox_rx`); we lock it for the duration of this
-            // call. The same thread that owns the dispatcher is
-            // the thread running this host fn, so nobody else is
-            // contending for the lock — it's structural, not
-            // performance-critical.
-            //
-            // ADR-0042: scan the overflow buffer FIRST. A prior
-            // `wait_reply_p32` may have parked the matching reply
-            // (e.g. `WAIT_BUFFER_TOO_SMALL` push_front), or the
-            // dispatcher may have left non-matching mail behind for
-            // us to skip past. The dispatcher's `next_mail` already
-            // drains overflow ahead of `inbox_rx`; reading from
-            // `inbox_rx` here without first consulting overflow
-            // would let parked replies leak into normal dispatch.
-            let mail = {
-                let ctx = caller.data();
-                // Pop a matching entry out of overflow if there is
-                // one, preserving the relative FIFO order of the
-                // entries we leave behind.
-                let matched_from_overflow = {
-                    let mut overflow = ctx.inbox_overflow.lock().unwrap();
-                    let mut idx = None;
-                    for (i, m) in overflow.iter().enumerate() {
-                        if m.kind == expected_kind
-                            && (expected_correlation == 0
-                                || m.reply_to.correlation_id == expected_correlation)
-                        {
-                            idx = Some(i);
-                            break;
-                        }
-                    }
-                    idx.and_then(|i| overflow.remove(i))
-                };
-                if let Some(m) = matched_from_overflow {
-                    m
-                } else {
-                    let rx_guard = ctx.inbox_rx.lock().unwrap();
-                    let Some(rx) = rx_guard.as_ref() else {
-                        // No inbox installed — pathological. Treat
-                        // as disconnect so the guest aborts rather
-                        // than spins.
-                        return WAIT_CANCELLED;
-                    };
-                    loop {
-                        let recv = if clamped == 0 {
-                            // `timeout_ms == 0`: try_recv only — drain
-                            // whatever's already queued, stop without
-                            // parking.
-                            match rx.try_recv() {
-                                Ok(m) => Ok(m),
-                                Err(TryRecvError::Empty) => Err(RecvTimeoutError::Timeout),
-                                Err(TryRecvError::Disconnected) => {
-                                    Err(RecvTimeoutError::Disconnected)
-                                }
-                            }
-                        } else {
-                            let remaining = deadline.saturating_duration_since(Instant::now());
-                            if remaining.is_zero() {
-                                Err(RecvTimeoutError::Timeout)
-                            } else {
-                                rx.recv_timeout(remaining)
-                            }
-                        };
-                        match recv {
-                            Ok(m)
-                                if m.kind == expected_kind
-                                    && (expected_correlation == 0
-                                        || m.reply_to.correlation_id == expected_correlation) =>
-                            {
-                                break m;
-                            }
-                            Ok(m) => {
-                                // Non-match (wrong kind, or right kind but
-                                // not our correlation): park on overflow
-                                // so the dispatcher picks it up after we
-                                // unwind. ADR-0042 correlation filter.
-                                ctx.inbox_overflow.lock().unwrap().push_back(m);
-                            }
-                            Err(RecvTimeoutError::Timeout) => return WAIT_TIMEOUT,
-                            Err(RecvTimeoutError::Disconnected) => return WAIT_CANCELLED,
-                        }
-                    }
-                }
+            let Some(transport) = caller.data().transport.clone() else {
+                // No trampoline transport wired — the ctx was built by
+                // a test path that doesn't exercise wait_reply.
+                // Surface as cancelled so the guest doesn't spin.
+                tracing::error!(
+                    target: "aether_substrate::host_fns",
+                    "wait_reply_p32 called on a ComponentCtx with no transport wired",
+                );
+                return WAIT_CANCELLED;
             };
 
-            if mail.payload.len() > out_cap as usize {
-                // ADR-0042: oversized payload preserves the caller's
-                // right to retry with a larger buffer. Park the mail
-                // back on overflow so a follow-up `wait_reply_p32`
-                // with a bigger `out_cap` can pick it up via the
-                // same drain (overflow is FIFO-first, so the retry
-                // sees the saved mail before anything newer).
-                caller
-                    .data()
-                    .inbox_overflow
-                    .lock()
-                    .unwrap()
-                    .push_front(mail);
-                return WAIT_BUFFER_TOO_SMALL;
-            }
-
+            // Resolve wasm linear memory and bounds-check `out_ptr +
+            // out_cap` *before* calling into the transport so a bad
+            // pointer doesn't burn a real envelope. After this point,
+            // a `-2` from the transport means the payload exceeded
+            // `out_cap` and the transport already parked the envelope
+            // on its overflow for a retry.
             let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
-                // Guest exports no memory; treat as buffer-unusable.
-                // Put the mail back on overflow so it isn't lost.
-                caller
-                    .data()
-                    .inbox_overflow
-                    .lock()
-                    .unwrap()
-                    .push_front(mail);
                 return WAIT_BUFFER_TOO_SMALL;
             };
             let start = out_ptr as usize;
-            let Some(end) = start.checked_add(mail.payload.len()) else {
-                caller
-                    .data()
-                    .inbox_overflow
-                    .lock()
-                    .unwrap()
-                    .push_front(mail);
+            let Some(end) = start.checked_add(out_cap as usize) else {
                 return WAIT_BUFFER_TOO_SMALL;
             };
             let data = memory.data_mut(&mut caller);
             if end > data.len() {
-                // Can't restore mail here — we've already moved past
-                // the ctx borrow by grabbing `data_mut`. The mail is
-                // dropped. Callers hitting this are misusing out_ptr;
-                // the loss is on them.
                 return WAIT_BUFFER_TOO_SMALL;
             }
-            data[start..end].copy_from_slice(&mail.payload);
-
-            mail.payload.len() as i32
+            transport.wait_reply(
+                expected_kind,
+                &mut data[start..end],
+                clamped,
+                expected_correlation,
+            )
         },
     )?;
 
@@ -413,7 +311,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "prev_correlation_p32",
-        |caller: Caller<'_, SubstrateCtx>| -> u64 { caller.data().prev_correlation() },
+        |caller: Caller<'_, ComponentCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
     // HOST_FN_OK: ADR-0002 / issue 531. The BootError plumbing
@@ -435,7 +333,7 @@ pub fn register(linker: &mut Linker<SubstrateCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",
         "init_failed_p32",
-        |mut caller: Caller<'_, SubstrateCtx>, ptr: u32, len: u32| {
+        |mut caller: Caller<'_, ComponentCtx>, ptr: u32, len: u32| {
             let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
                 return;
             };

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -79,7 +79,7 @@ pub use chassis_builder::{
     NeverDriver, NeverDriverRunning, NoDriver, PassiveChassis, RunError,
 };
 pub use component::Component;
-pub use ctx::SubstrateCtx;
+pub use ctx::ComponentCtx;
 pub use input::{InputSubscribers, new_subscribers, remove_from_all, subscribers_for};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use mailer::Mailer;

--- a/crates/aether-substrate/src/mail.rs
+++ b/crates/aether-substrate/src/mail.rs
@@ -35,7 +35,7 @@ pub type MailKind = KindId;
 /// - `Session` — reply routes back to a Claude MCP session.
 /// - `EngineMailbox` — reply routes to a component on another engine.
 /// - `Component` — reply routes back to a local peer component
-///   (set by `SubstrateCtx::send` / `NativeTransport::send_mail`).
+///   (set by `ComponentCtx::send` / `NativeTransport::send_mail`).
 /// - `None` — no reply target (broadcast-origin or substrate-
 ///   generated mail).
 ///
@@ -65,7 +65,7 @@ impl Mail {
     /// Attach a reply-to destination. Used by the hub client when
     /// forwarding inbound frames (ADR-0008), the hub-chassis loopback
     /// when delivering bubbled-up mail (ADR-0037 Phase 2), and
-    /// `SubstrateCtx::send` / `NativeTransport::send_mail` for
+    /// `ComponentCtx::send` / `NativeTransport::send_mail` for
     /// peer-to-peer component sends (target = `Component(sender)`).
     /// Other mail paths leave the default `ReplyTo::None`.
     pub fn with_reply_to(mut self, reply_to: ReplyTo) -> Self {

--- a/crates/aether-substrate/src/mailer.rs
+++ b/crates/aether-substrate/src/mailer.rs
@@ -279,7 +279,7 @@ fn route_mail(
             // came from substrate core or a chassis (e.g. the frame
             // loop's FrameStats push, platform input fan-out). Per
             // ADR-0011 origin is `None`. Components reach
-            // closure-bound mailboxes via `SubstrateCtx::send` inline
+            // closure-bound mailboxes via `ComponentCtx::send` inline
             // and never enter `push`.
             handler(
                 mail.kind,
@@ -315,7 +315,7 @@ fn route_mail(
                 // with no local component origin (broadcast-
                 // originated, substrate-generated). Recovered from
                 // `reply_to.target = Component(_)` set by
-                // `SubstrateCtx::send` / `NativeTransport::send_mail`
+                // `ComponentCtx::send` / `NativeTransport::send_mail`
                 // (issue #644).
                 let source_mailbox_id = match mail.reply_to.target {
                     ReplyTarget::Component(id) => Some(id),

--- a/crates/aether-substrate/src/native_actor.rs
+++ b/crates/aether-substrate/src/native_actor.rs
@@ -383,7 +383,7 @@ impl<'a> MailCtx for NativeCtx<'a> {
 /// [`Self::publish_handle`] and the consumer retrieves it through
 /// [`crate::DriverCtx::handle`].
 pub struct NativeInitCtx<'a> {
-    transport: &'a NativeTransport,
+    transport: &'a Arc<NativeTransport>,
     handles: &'a mut ExportedHandles,
     mailer: Arc<Mailer>,
 }
@@ -392,7 +392,7 @@ impl<'a> NativeInitCtx<'a> {
     /// Internal constructor — only [`crate::chassis_builder::Builder::with_actor`]
     /// builds these.
     pub(crate) fn new(
-        transport: &'a NativeTransport,
+        transport: &'a Arc<NativeTransport>,
         handles: &'a mut ExportedHandles,
         mailer: Arc<Mailer>,
     ) -> Self {
@@ -401,6 +401,14 @@ impl<'a> NativeInitCtx<'a> {
             handles,
             mailer,
         }
+    }
+
+    /// Borrow the Arc'd cap-bound transport. Used by the wasm
+    /// trampoline at init to install itself on the
+    /// [`crate::ctx::ComponentCtx`] so the `wait_reply_p32` host fn
+    /// can route through this transport.
+    pub fn transport_arc(&self) -> &Arc<NativeTransport> {
+        self.transport
     }
 
     /// Borrow the cap-bound transport. Caps rarely reach for this —

--- a/crates/aether-substrate/src/native_transport.rs
+++ b/crates/aether-substrate/src/native_transport.rs
@@ -50,7 +50,7 @@ use crate::mailer::Mailer;
 /// - `wait_reply` — pulls from `self.inbox` with timeout, filters
 ///   by `(kind, correlation)`, parks non-matching envelopes into
 ///   `self.overflow` for a future `wait_reply` to find, mirrors the
-///   wasm side's `SubstrateCtx::wait_reply` semantics.
+///   wasm side's `ComponentCtx::wait_reply` semantics.
 /// - `prev_correlation` — reads the atomic counter.
 pub struct NativeTransport {
     mailer: Arc<Mailer>,
@@ -436,8 +436,7 @@ impl MailTransport for NativeTransport {
         let rc = loop {
             // Drain overflow first — a previous `wait_reply` may
             // have parked envelopes that match this kind /
-            // correlation. Mirrors `SubstrateCtx::wait_reply` on
-            // the wasm side (component.rs).
+            // correlation.
             let from_overflow = {
                 let mut overflow = self.overflow.lock().unwrap();
                 let pos = overflow
@@ -446,7 +445,14 @@ impl MailTransport for NativeTransport {
                 pos.and_then(|i| overflow.remove(i))
             };
             if let Some(env) = from_overflow {
-                break write_payload(&env, out);
+                let rc = write_payload(&env, out);
+                if rc == -2 {
+                    // Buffer too small: park back at the front so a
+                    // retry with a larger buffer picks it up before
+                    // anything newer.
+                    self.overflow.lock().unwrap().push_front(env);
+                }
+                break rc;
             }
 
             // No overflow match — pull from the inbox with whatever
@@ -460,7 +466,13 @@ impl MailTransport for NativeTransport {
             match recv_outcome {
                 Ok(env) => {
                     if matches_filter(&env, expected_kind, expected_correlation) {
-                        break write_payload(&env, out);
+                        let rc = write_payload(&env, out);
+                        if rc == -2 {
+                            // Same retry-friendly disposition as
+                            // overflow-matched: park at the front.
+                            self.overflow.lock().unwrap().push_front(env);
+                        }
+                        break rc;
                     }
                     self.overflow.lock().unwrap().push_back(env);
                     // Loop continues — try again with whatever time
@@ -497,17 +509,13 @@ fn matches_filter(env: &Envelope, expected_kind: u64, expected_correlation: u64)
 
 /// Copy `env.payload` into `out` and return the number of bytes
 /// written, matching the wasm `wait_reply_p32` ABI:
-/// `>= 0` = bytes written, `-2` = payload too large for the buffer
-/// (envelope is dropped — wasm re-parks but native callers should
-/// retry with a bigger buffer).
+/// `>= 0` = bytes written, `-2` = payload too large for the buffer.
+/// Caller is responsible for parking the envelope back on overflow
+/// when -2 is returned so a retry with a bigger buffer can pick it up
+/// (the helper is byte-only so it can also be used for peek-style
+/// callers that don't have an overflow to park on).
 fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
     if env.payload.len() > out.len() {
-        tracing::warn!(
-            target: "aether_substrate::native_transport",
-            payload_len = env.payload.len(),
-            buffer_len = out.len(),
-            "wait_reply buffer too small — envelope dropped"
-        );
         return -2;
     }
     out[..env.payload.len()].copy_from_slice(&env.payload);
@@ -786,5 +794,134 @@ mod tests {
         let rc = transport.wait_reply(1, &mut buf, 1, correlation);
         assert_eq!(rc, -1);
         assert_eq!(transport.pending_recipients.lock().unwrap().len(), 0);
+    }
+
+    fn make_envelope(kind: u64, payload: Vec<u8>, correlation: u64) -> Envelope {
+        Envelope {
+            kind: KindId(kind),
+            kind_name: String::new(),
+            origin: None,
+            sender: ReplyTo::with_correlation(ReplyTarget::None, correlation),
+            payload,
+            count: 1,
+        }
+    }
+
+    /// `wait_reply` returns the matched envelope when it arrives via
+    /// the inbox while the wait is parked.
+    #[test]
+    fn wait_reply_returns_payload_when_match_arrives() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+
+        tx.send(make_envelope(0xABCD, vec![1, 2, 3, 4, 5], 0))
+            .unwrap();
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut buf, 100, 0);
+        assert_eq!(rc, 5);
+        assert_eq!(&buf[..5], &[1, 2, 3, 4, 5]);
+    }
+
+    /// `wait_reply` parks non-matching envelopes onto overflow so the
+    /// dispatcher's next `recv` (or a follow-up wait) sees them.
+    #[test]
+    fn wait_reply_parks_non_matching_into_overflow() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+
+        tx.send(make_envelope(0x1111, vec![9], 0)).unwrap();
+        tx.send(make_envelope(0xABCD, vec![1], 0)).unwrap();
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut buf, 100, 0);
+        assert_eq!(rc, 1);
+        assert_eq!(transport.overflow.lock().unwrap().len(), 1);
+    }
+
+    /// `wait_reply` filters by correlation when one is supplied — a
+    /// matching kind with a different correlation parks; only the
+    /// correlation-matched envelope returns.
+    #[test]
+    fn wait_reply_filters_by_correlation_not_just_kind() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+
+        tx.send(make_envelope(0xABCD, vec![0xFF], 11)).unwrap();
+        tx.send(make_envelope(0xABCD, vec![0x42], 22)).unwrap();
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut buf, 100, 22);
+        assert_eq!(rc, 1);
+        assert_eq!(buf[0], 0x42);
+        assert_eq!(transport.overflow.lock().unwrap().len(), 1);
+    }
+
+    /// `wait_reply` checks overflow before recv — a matching envelope
+    /// already on overflow returns without touching the inbox.
+    #[test]
+    fn wait_reply_pulls_match_from_overflow_before_recv() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+
+        transport
+            .overflow
+            .lock()
+            .unwrap()
+            .push_back(make_envelope(0xABCD, vec![7], 0));
+        drop(tx);
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut buf, 100, 0);
+        assert_eq!(rc, 1);
+        assert_eq!(buf[0], 7);
+    }
+
+    /// `wait_reply` returns -2 when payload exceeds the buffer and
+    /// parks the envelope back on overflow with `push_front` so a
+    /// retry with a larger buffer rediscovers it.
+    #[test]
+    fn wait_reply_parks_on_buffer_too_small_for_retry() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+
+        let big_payload = vec![0xAA; 10];
+        tx.send(make_envelope(0xABCD, big_payload.clone(), 0))
+            .unwrap();
+
+        let mut small = [0u8; 4];
+        let rc = transport.wait_reply(0xABCD, &mut small, 100, 0);
+        assert_eq!(rc, -2);
+        assert_eq!(transport.overflow.lock().unwrap().len(), 1);
+
+        let mut big = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut big, 100, 0);
+        assert_eq!(rc, big_payload.len() as i32);
+        assert_eq!(&big[..big_payload.len()], &big_payload[..]);
+    }
+
+    /// `wait_reply` returns -3 cancelled when the inbox sender drops
+    /// (the receiver disconnects) before any matching mail arrives.
+    #[test]
+    fn wait_reply_returns_cancelled_when_sender_drops() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeTransport::new_for_test(mailer, MailboxId(1));
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        transport.install_inbox(rx);
+        drop(tx);
+
+        let mut buf = [0u8; 16];
+        let rc = transport.wait_reply(0xABCD, &mut buf, 100, 0);
+        assert_eq!(rc, -3);
     }
 }

--- a/crates/aether-substrate/src/reply_table.rs
+++ b/crates/aether-substrate/src/reply_table.rs
@@ -13,10 +13,10 @@
 // 2³² dispatches is out of scope for V0; when it becomes real, the
 // handle becomes a generational index.
 //
-// The table lives on `SubstrateCtx` rather than `Component` because
+// The table lives on `ComponentCtx` rather than `Component` because
 // the host fn touches it via `Caller::data_mut()`. Putting it there
 // also means replace/drop on the component naturally clears it — the
-// old `Store<SubstrateCtx>` is dropped and the table with it.
+// old `Store<ComponentCtx>` is dropped and the table with it.
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
Closes issue 634.

## Summary

- `wait_reply_p32` host fn now delegates to `NativeTransport::wait_reply`. Phase 4 PR 1 silently broke wasm-side wait_reply by retiring the dispatcher that called `install_inbox_rx`; nothing in tree caught it because no component happened to use sync wait_reply. The host fn becomes a 5-line bridge: clamp the timeout, bounds-check wasm memory, hand `&mut [u8]` to the transport.
- `NativeTransport::wait_reply` parks on overflow (push_front) when the payload exceeds the caller's buffer. The pre-fix behavior silently dropped oversized envelopes — retries with a bigger buffer would block forever waiting for a reply that already arrived.
- Rename `SubstrateCtx` to `ComponentCtx`. The type is the per-wasm-component context (Store data + reply table + saved state + transport handle for that one component); the substrate-level naming was a leftover from the pre-trampoline architecture.
- Retires the `inbox_rx`, `inbox_overflow`, `install_inbox_rx`, `next_mail` machinery on both `ComponentCtx` and `Component`. The WAT-driven host-fn integration tests in component.rs (~480 lines) move to focused `NativeTransport` tests at the proper layer (overflow drain order, correlation filter, buffer-too-small retry, cancel on disconnect).

Net **−480** lines.

## Test plan

- [x] cargo check --workspace --tests
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace (incl. 6 new wait_reply tests in native_transport.rs)
- [x] cargo fmt --check
- [x] MCP smoke: spawn substrate + load camera component + capture frame + engine_logs --level warn empty
- [x] No in-tree component currently uses sync wait_reply, so end-to-end wasm-guest exercise of the host fn relies on the transport-level tests + future component need

🤖 Generated with [Claude Code](https://claude.com/claude-code)