### PR TITLE
fix(demos): address loaded components by trampoline name (issue 634)

### DIFF
--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -35,6 +35,16 @@ use aether_substrate_bundle::test_bench::TestBench;
 // "unknown kind".
 use aether_mesh_viewer as _;
 
+/// User-facing component name passed to `LoadComponent`.
+const COMPONENT_NAME: &str = "mv";
+
+/// Full mailbox address the substrate registers for the loaded
+/// component (issue 634 Phase 4 PR 1). Mail to the bare
+/// `COMPONENT_NAME` warn-drops as unknown — agents address the
+/// trampoline by its full `aether.component.trampoline:NAME` form,
+/// which is what `LoadResult.name` returns.
+const COMPONENT_ADDRESS: &str = "aether.component.trampoline:mv";
+
 const BOX_DSL: &[u8] = b"(box 1 1 1 :color 0)\n";
 const QUAD_OBJ: &[u8] = b"\
 v -0.5 -0.5 0
@@ -63,20 +73,20 @@ fn dsl_box_loads_and_renders() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("mv".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             // First tick triggers the load; the read reply lands on
             // a later tick. A handful of ticks ensures the cache is
             // populated and several render-sink emissions land.
             Step::Advance { ticks: 1 },
             Step::SendMail {
-                recipient: "mv".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "aether.mesh.load".to_owned(),
                 params: serde_yml::from_str(&format!("namespace: save\npath: {path}"))
                     .expect("dsl load params parse"),
             },
             Step::Advance { ticks: 5 },
-            tick_to("mv"),
+            tick_to(COMPONENT_ADDRESS),
             Step::Capture,
             Step::Assert {
                 check: Check::MailObserved {
@@ -115,17 +125,17 @@ fn obj_quad_loads_and_renders() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("mv".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             Step::SendMail {
-                recipient: "mv".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "aether.mesh.load".to_owned(),
                 params: serde_yml::from_str(&format!("namespace: save\npath: {path}"))
                     .expect("obj load params parse"),
             },
             Step::Advance { ticks: 5 },
-            tick_to("mv"),
+            tick_to(COMPONENT_ADDRESS),
             Step::Capture,
             Step::Assert {
                 check: Check::MailObserved {
@@ -167,11 +177,11 @@ fn parse_failure_keeps_prior_mesh() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("mv".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             Step::SendMail {
-                recipient: "mv".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "aether.mesh.load".to_owned(),
                 params: serde_yml::from_str(&format!("namespace: save\npath: {good}"))
                     .expect("good load params parse"),
@@ -186,13 +196,13 @@ fn parse_failure_keeps_prior_mesh() {
             },
             // Now hand the viewer something it can't parse.
             Step::SendMail {
-                recipient: "mv".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "aether.mesh.load".to_owned(),
                 params: serde_yml::from_str(&format!("namespace: save\npath: {bad}"))
                     .expect("bad load params parse"),
             },
             Step::Advance { ticks: 5 },
-            tick_to("mv"),
+            tick_to(COMPONENT_ADDRESS),
             Step::Capture,
             // The cached triangle list should be intact — the
             // captured frame still has non-clear-color geometry.

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -27,6 +27,16 @@ use aether_substrate_bundle::test_bench::TestBench;
 // pattern.
 use aether_demo_sokoban as _;
 
+/// User-facing component name passed to `LoadComponent`.
+const COMPONENT_NAME: &str = "world";
+
+/// Full mailbox address the substrate registers for the loaded
+/// component (issue 634 Phase 4 PR 1). Mail to the bare
+/// `COMPONENT_NAME` warn-drops as unknown — agents address the
+/// trampoline by its full `aether.component.trampoline:NAME` form,
+/// which is what `LoadResult.name` returns.
+const COMPONENT_ADDRESS: &str = "aether.component.trampoline:world";
+
 /// Probe for any usable wgpu adapter.
 fn has_wgpu_adapter() -> bool {
     let instance =
@@ -131,10 +141,10 @@ fn default_level_renders_grid_and_player() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("world".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 3 },
-            tick_to("world"),
+            tick_to(COMPONENT_ADDRESS),
             Step::Capture,
             Step::Assert {
                 check: Check::MailObserved {
@@ -173,18 +183,18 @@ fn key_press_keeps_render_path_alive() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("world".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 2 },
             // Press D — sokoban steps the player east; the WASD/arrow
             // mapping lives in `step_delta` inside the demo's lib.rs.
             Step::SendMail {
-                recipient: "world".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "aether.key".to_owned(),
                 params: serde_yml::from_str(&key_d_yaml).expect("key params parse"),
             },
             Step::Advance { ticks: 2 },
-            tick_to("world"),
+            tick_to(COMPONENT_ADDRESS),
             Step::Capture,
             Step::Assert {
                 check: Check::MailObserved {

--- a/demos/tic-tac-toe-client/tests/scenario.rs
+++ b/demos/tic-tac-toe-client/tests/scenario.rs
@@ -31,6 +31,20 @@ use aether_substrate_bundle::test_bench::TestBench;
 use aether_demo_tic_tac_toe as _;
 use aether_demo_tic_tac_toe_client as _;
 
+/// User-facing component names passed to `LoadComponent`.
+const SERVER_NAME: &str = "tic_tac_toe";
+const CLIENT_NAME: &str = "tic_tac_toe.client";
+
+/// Full mailbox address the substrate registers for the loaded
+/// client component (issue 634 Phase 4 PR 1). Mail to the bare
+/// `CLIENT_NAME` warn-drops as unknown — agents address the
+/// trampoline by its full `aether.component.trampoline:NAME` form,
+/// which is what `LoadResult.name` returns. The server's address
+/// isn't needed here because the click-flow scenario only mails
+/// the client; the client emits `PlayMove` to the server's bare
+/// short name (the SDK resolves it inside the wasm).
+const CLIENT_ADDRESS: &str = "aether.component.trampoline:tic_tac_toe.client";
+
 /// Probe for any usable wgpu adapter.
 fn has_wgpu_adapter() -> bool {
     let instance =
@@ -156,12 +170,12 @@ fn default_render_paints_grid() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("tic_tac_toe.client".to_owned()),
+                name: Some(CLIENT_NAME.to_owned()),
             },
             // First tick: SDK auto-subscribes inputs, on_tick renders.
             // Two more ticks settle the renderer.
             Step::Advance { ticks: 3 },
-            tick_to("tic_tac_toe.client"),
+            tick_to(CLIENT_ADDRESS),
             Step::Capture,
             Step::Assert {
                 check: Check::MailObserved {
@@ -210,30 +224,30 @@ fn click_center_cell_drives_server_broadcast() {
             // load order matching the agent-workflow docstring.
             Step::LoadComponent {
                 path: server_path.to_string_lossy().into_owned(),
-                name: Some("tic_tac_toe".to_owned()),
+                name: Some(SERVER_NAME.to_owned()),
             },
             Step::LoadComponent {
                 path: client_path.to_string_lossy().into_owned(),
-                name: Some("tic_tac_toe.client".to_owned()),
+                name: Some(CLIENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             // Cache window size + cursor in the client. The
             // `on_mouse_button` handler bails early if either is None.
             Step::SendMail {
-                recipient: "tic_tac_toe.client".to_owned(),
+                recipient: CLIENT_ADDRESS.to_owned(),
                 kind: "aether.window_size".to_owned(),
                 params: serde_yml::from_str("width: 64\nheight: 48")
                     .expect("window_size params parse"),
             },
             Step::SendMail {
-                recipient: "tic_tac_toe.client".to_owned(),
+                recipient: CLIENT_ADDRESS.to_owned(),
                 kind: "aether.mouse_move".to_owned(),
                 params: serde_yml::from_str("x: 32.0\ny: 24.0").expect("mouse_move params parse"),
             },
             // The click. Hit-test → cell (1,1) → PlayMove(1,1) sent
             // to the server. Server accepts, broadcasts game_state.
             Step::SendMail {
-                recipient: "tic_tac_toe.client".to_owned(),
+                recipient: CLIENT_ADDRESS.to_owned(),
                 kind: "aether.mouse_button".to_owned(),
                 params: serde_yml::Value::Null,
             },

--- a/demos/tic-tac-toe-server/tests/scenario.rs
+++ b/demos/tic-tac-toe-server/tests/scenario.rs
@@ -33,6 +33,16 @@ use aether_substrate_bundle::test_bench::TestBench;
 // PR 432 / 434 / 436 used for the trunk-rlib pattern.
 use aether_demo_tic_tac_toe as _;
 
+/// User-facing component name passed to `LoadComponent`.
+const COMPONENT_NAME: &str = "ttt";
+
+/// Full mailbox address the substrate registers for the loaded
+/// component (issue 634 Phase 4 PR 1). Mail to the bare
+/// `COMPONENT_NAME` warn-drops as unknown — agents address the
+/// trampoline by its full `aether.component.trampoline:NAME` form,
+/// which is what `LoadResult.name` returns.
+const COMPONENT_ADDRESS: &str = "aether.component.trampoline:ttt";
+
 /// Probe for any usable wgpu adapter.
 fn has_wgpu_adapter() -> bool {
     let instance =
@@ -114,12 +124,12 @@ fn legal_move_broadcasts_game_state() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("ttt".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             // X plays top-left.
             Step::SendMail {
-                recipient: "ttt".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "tic_tac_toe.play_move".to_owned(),
                 params: serde_yml::from_str("row: 0\ncol: 0\n_pad: [0, 0]")
                     .expect("play_move params parse"),
@@ -161,12 +171,12 @@ fn out_of_bounds_move_does_not_broadcast() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("ttt".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             // Row 5 is out of bounds (board is 3×3).
             Step::SendMail {
-                recipient: "ttt".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "tic_tac_toe.play_move".to_owned(),
                 params: serde_yml::from_str("row: 5\ncol: 0\n_pad: [0, 0]")
                     .expect("play_move params parse"),
@@ -203,11 +213,11 @@ fn reset_broadcasts_game_state() {
         steps: vec![
             Step::LoadComponent {
                 path: wasm_path.to_string_lossy().into_owned(),
-                name: Some("ttt".to_owned()),
+                name: Some(COMPONENT_NAME.to_owned()),
             },
             Step::Advance { ticks: 1 },
             Step::SendMail {
-                recipient: "ttt".to_owned(),
+                recipient: COMPONENT_ADDRESS.to_owned(),
                 kind: "tic_tac_toe.reset".to_owned(),
                 params: serde_yml::Value::Null,
             },

--- a/demos/tic-tac-toe/src/lib.rs
+++ b/demos/tic-tac-toe/src/lib.rs
@@ -117,21 +117,27 @@ pub struct MoveResult {
     pub state: GameState,
 }
 
-/// Well-known local mailbox name the server fans `GameState` to in
-/// addition to `hub.claude.broadcast`. Any component loaded under
-/// this name on the same substrate as the server will receive every
-/// state update — the intended consumer is the `aether-demo-tic-tac-
-/// toe-client` renderer, but any observer-style component works.
-/// If no component is registered under this name the send is a
-/// harmless "mailbox unknown" warn-drop.
-pub const CLIENT_OBSERVER: &str = "tic_tac_toe.client";
+/// Full mailbox address the server fans `GameState` to in addition to
+/// `hub.claude.broadcast`. Any component loaded under the subname
+/// `tic_tac_toe.client` on the same substrate as the server will
+/// receive every state update — the intended consumer is the
+/// `aether-demo-tic-tac-toe-client` renderer, but any observer-style
+/// component works. If no component is registered under that subname
+/// the send is a harmless "mailbox unknown" warn-drop.
+///
+/// Issue 634 Phase 4 PR 1 (2026-05-08) moved loaded wasm components
+/// from bare names to the `aether.component.trampoline:NAME` form;
+/// `send_to_named` against the bare name warn-drops. The constants
+/// here carry the full trampoline form so the existing shipping
+/// components keep working without a per-call address rewrite.
+pub const CLIENT_OBSERVER: &str = "aether.component.trampoline:tic_tac_toe.client";
 
-/// Well-known mailbox name the authoritative server is conventionally
+/// Full mailbox address the authoritative server is conventionally
 /// loaded under. Callers that want to mail `PlayMove` / `Reset` to
-/// the server can resolve this name at init; matches the default
-/// `load_component` name the server advertises via its top-level
-/// rustdoc.
-pub const SERVER: &str = "tic_tac_toe";
+/// the server can resolve this name at init; matches the trampoline
+/// the server's `load_component` produces when invoked with the
+/// canonical subname `tic_tac_toe`.
+pub const SERVER: &str = "aether.component.trampoline:tic_tac_toe";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Issue 634 Phase 4 PR 1 (PR 649) moved loaded wasm components from bare names to `aether.component.trampoline:NAME`. Mail to the bare name warn-drops; agents use the full address `LoadResult.name` returns. Five scenario suites and the tic-tac-toe demo's shipping constants were missed in the original sweep — they only run in CI when their own crate changes, so the latent breakage didn't surface until the nextest migration (PR 615) ran the full workspace.

## Fixes

- `demos/tic-tac-toe/src/lib.rs`: `SERVER` + `CLIENT_OBSERVER` constants now carry the full trampoline form so the running components address each other correctly without per-call rewrite.
- `demos/tic-tac-toe-server/tests/scenario.rs`: `COMPONENT_ADDRESS` constant + recipient updates.
- `demos/tic-tac-toe-client/tests/scenario.rs`: `CLIENT_ADDRESS` constant + recipient + tick_to updates.
- `demos/sokoban/tests/scenario.rs`: `COMPONENT_ADDRESS` constant + recipient + tick_to updates.
- `crates/aether-mesh-viewer/tests/scenario.rs`: `COMPONENT_ADDRESS` constant + four recipients + three `tick_to` updates.

`crates/aether-camera/tests/scenario.rs` was already correct. `crates/aether-substrate-bundle/tests/test_bench_scenario.rs` (PR 1's reference fix) served as the pattern.

## Test plan

- [x] cargo test --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] All five scenario crates green locally with prebuilt wasm: 13 tests across sokoban / tic-tac-toe-server / tic-tac-toe-client / mesh-viewer / camera

## Follow-up worth filing

Add an SDK helper like `ctx.send_to_component(name, ...)` that prepends `aether.component.trampoline:` so user components don't have to know the addressing convention. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)