### PR TITLE
refactor(substrate): collapse Mailer wire_* setters into a constructor

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -886,7 +886,11 @@ mod native {
             for d in aether_kinds::descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
-            (registry, Arc::new(Mailer::new()))
+            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+            (registry, mailer)
         }
 
         #[test]

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -94,14 +94,7 @@ mod native {
             ctx: &mut NativeInitCtx<'_>,
         ) -> Result<Self, BootError> {
             let mailer = ctx.mailer();
-            let registry = mailer.registry().cloned().ok_or_else(|| {
-                BootError::Other(
-                    std::io::Error::other(
-                        "registry must be wired on Mailer before ComponentHostCapability::init",
-                    )
-                    .into(),
-                )
-            })?;
+            let registry = Arc::clone(mailer.registry());
             Ok(Self {
                 engine: config.engine,
                 linker: config.linker,

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -533,7 +533,11 @@ mod native {
             for d in aether_kinds::descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
-            (registry, Arc::new(Mailer::new()))
+            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+            (registry, mailer)
         }
 
         fn roots_under(root: &Path) -> NamespaceRoots {
@@ -732,9 +736,11 @@ mod native {
         /// outbound channel.
         fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
             let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new());
-            mailer.wire(Arc::new(Registry::new()));
-            mailer.wire_outbound(outbound);
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
             (mailer, rx)
         }
 

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -38,22 +38,14 @@ mod native {
         /// `aether.<name>` namespace.
         const NAMESPACE: &'static str = "aether.handle";
 
-        /// Pull the shared [`HandleStore`] off the substrate's wired
-        /// [`aether_substrate::Mailer`]. The store is wired by `SubstrateBoot::build`
-        /// before the chassis builder runs, so a `None` here is a
-        /// substrate-level boot ordering bug rather than user input —
-        /// surface it as a `BootError`.
+        /// Pull the shared [`HandleStore`] off the substrate's
+        /// [`aether_substrate::Mailer`]. The store is supplied at
+        /// `Mailer` construction by `SubstrateBoot::build` (issue 657
+        /// retired the post-construction `wire_handle_store` setter),
+        /// so the cap can clone it directly without a `None`-arm
+        /// bootstrap-ordering check.
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let store = ctx
-                .mailer()
-                .handle_store()
-                .ok_or_else(|| {
-                    BootError::Other(Box::new(std::io::Error::other(
-                        "HandleCapability::init: substrate Mailer has no HandleStore wired \
-                         (call wire_handle_store before chassis build)",
-                    )))
-                })?
-                .clone();
+            let store = Arc::clone(ctx.mailer().handle_store());
             Ok(Self { store })
         }
 
@@ -178,10 +170,9 @@ mod native {
                 let _ = registry.register_kind_with_descriptor(d);
             }
             let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new());
-            mailer.wire(Arc::clone(&registry));
-            mailer.wire_outbound(outbound);
-            mailer.wire_handle_store(Arc::clone(&store));
+            let mailer = Arc::new(
+                Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
+            );
             (store, mailer, registry, rx)
         }
 

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -463,7 +463,11 @@ mod native {
             for d in aether_kinds::descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
-            (registry, Arc::new(Mailer::new()))
+            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+            (registry, mailer)
         }
 
         struct StubAdapter {
@@ -507,9 +511,11 @@ mod native {
 
         fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
             let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new());
-            mailer.wire(Arc::new(aether_substrate::mail::registry::Registry::new()));
-            mailer.wire_outbound(outbound);
+            let registry = Arc::new(aether_substrate::mail::registry::Registry::new());
+            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
             (mailer, rx)
         }
 

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -58,14 +58,7 @@ mod native {
         const NAMESPACE: &'static str = "aether.input";
 
         fn init(config: InputConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let registry = ctx.mailer().registry().cloned().ok_or_else(|| {
-                BootError::Other(
-                    std::io::Error::other(
-                        "registry must be wired on Mailer before InputCapability::init",
-                    )
-                    .into(),
-                )
-            })?;
+            let registry = Arc::clone(ctx.mailer().registry());
             Ok(Self {
                 registry,
                 subscribers: config.input_subscribers,

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -137,7 +137,14 @@ mod native {
         }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-            (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+            {
+                let registry = Arc::new(Registry::new());
+                let store = ::std::sync::Arc::new(
+                    ::aether_substrate::handle_store::HandleStore::new(1024 * 1024),
+                );
+                let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+                (registry, mailer)
+            }
         }
 
         /// End-to-end: boot the cap through `with_actor`, push a

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -185,11 +185,7 @@ mod native {
                 gpu: Arc::new(OnceLock::new()),
             };
             let mailer = ctx.mailer();
-            let registry = mailer.registry().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
-                    "registry must be wired on Mailer before RenderCapability::init",
-                )))
-            })?;
+            let registry = Arc::clone(mailer.registry());
             // Issue 629 / Phase A: publish the driver-facing handle
             // bundle on the chassis's `ExportedHandles` map so the
             // desktop driver retrieves it via `DriverCtx::handle::<RenderHandles>()`.
@@ -560,11 +556,13 @@ mod native {
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());
-            let mailer = Arc::new(Mailer::new());
             // Issue 603 Phase 2: `RenderCapability::init` reads
             // `mailer.registry()` to keep the substrate registry handle
             // for `capture_frame`'s resolve-bundle path.
-            mailer.wire(Arc::clone(&registry));
+            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
             (registry, mailer)
         }
 

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -349,9 +349,11 @@ mod cap_native {
                 let _ = registry.register_kind_with_descriptor(d);
             }
             let (outbound, rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new());
-            mailer.wire(Arc::clone(&registry));
-            mailer.wire_outbound(outbound);
+            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer =
+                Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
             (registry, mailer, rx)
         }
 

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -406,7 +406,15 @@ mod native {
             for d in aether_kinds::descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
-            (registry, Arc::new(Mailer::new()))
+            {
+                let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                    1024 * 1024,
+                ));
+                (
+                    Arc::clone(&registry),
+                    Arc::new(Mailer::new(registry, store)),
+                )
+            }
         }
 
         fn cfg(rt: &Runtime, addr: SocketAddr) -> ProcessCapabilityConfig {
@@ -479,9 +487,12 @@ mod native {
 
         fn test_mailer_and_rx() -> (Arc<Mailer>, Arc<HubOutbound>, mpsc::Receiver<EgressEvent>) {
             let (outbound, rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new());
-            mailer.wire(Arc::new(Registry::new()));
-            mailer.wire_outbound(Arc::clone(&outbound));
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+                1024 * 1024,
+            ));
+            let mailer =
+                Arc::new(Mailer::new(registry, store).with_outbound(Arc::clone(&outbound)));
             (mailer, outbound, rx)
         }
 

--- a/crates/aether-substrate-bundle/tests/hub_client.rs
+++ b/crates/aether-substrate-bundle/tests/hub_client.rs
@@ -40,7 +40,10 @@ fn handshake_exchanges_hello_and_welcome() {
     let (addr, conn_rx) = accept_one();
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(Mailer::new());
+    let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+        1024 * 1024,
+    ));
+    let queue = Arc::new(Mailer::new(Arc::clone(&registry), store));
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -118,8 +121,10 @@ fn inbound_mail_lands_in_queue_after_resolution() {
         ),
     );
     registry.register_kind("aether.tick");
-    let queue = Arc::new(Mailer::new());
-    queue.wire(Arc::clone(&registry));
+    let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+        1024 * 1024,
+    ));
+    let queue = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
@@ -214,7 +219,10 @@ fn client_sends_periodic_heartbeats() {
     let (addr, conn_rx) = accept_one();
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(Mailer::new());
+    let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+        1024 * 1024,
+    ));
+    let queue = Arc::new(Mailer::new(Arc::clone(&registry), store));
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -264,7 +272,10 @@ fn goodbye_stops_reader_thread() {
     // long as nothing hangs past the deadline.
     let (addr, conn_rx) = accept_one();
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(Mailer::new());
+    let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+        1024 * 1024,
+    ));
+    let queue = Arc::new(Mailer::new(Arc::clone(&registry), store));
     let client_handle = thread::spawn({
         let registry = Arc::clone(&registry);
         let queue = Arc::clone(&queue);
@@ -315,7 +326,10 @@ fn outbound_sends_reach_the_hub_wire() {
     assert!(!outbound.is_connected());
 
     let registry = Arc::new(Registry::new());
-    let queue = Arc::new(Mailer::new());
+    let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+        1024 * 1024,
+    ));
+    let queue = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
     let connect_outbound = Arc::clone(&outbound);
     let client_handle = thread::spawn({

--- a/crates/aether-substrate/src/actor/native/transport.rs
+++ b/crates/aether-substrate/src/actor/native/transport.rs
@@ -531,8 +531,8 @@ mod tests {
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         (registry, mailer)
     }
 

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -503,10 +503,12 @@ mod tests {
     use crate::mail::registry::Registry;
 
     fn ctx() -> ComponentCtx {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
         ComponentCtx::new(
             MailboxId(0),
-            Arc::new(Registry::new()),
-            Arc::new(Mailer::new()),
+            Arc::clone(&registry),
+            Arc::new(Mailer::new(registry, store)),
             HubOutbound::disconnected(),
             crate::input::new_subscribers(),
         )
@@ -809,10 +811,12 @@ mod tests {
                 is_stream: false,
             })
             .expect("register kind");
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         let ctx = ComponentCtx::new(
             M(0),
             registry,
-            Arc::new(Mailer::new()),
+            mailer,
             outbound,
             crate::input::new_subscribers(),
         );
@@ -882,9 +886,10 @@ mod tests {
             .try_register_closure("client", Arc::new(|_, _, _, _, _, _| {}))
             .expect("register client mailbox");
 
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
-        mailer.wire_outbound(Arc::clone(&outbound));
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(
+            Mailer::new(Arc::clone(&registry), store).with_outbound(Arc::clone(&outbound)),
+        );
 
         let ctx = ComponentCtx::new(
             sender,
@@ -929,9 +934,9 @@ mod tests {
             .try_register_closure("client", Arc::new(|_, _, _, _, _, _| {}))
             .expect("register client mailbox");
 
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
-        // Deliberately no `wire_outbound`.
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        // Deliberately no `with_outbound` — exercises the local warn-drop path.
 
         let ctx = ComponentCtx::new(
             sender,

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -243,11 +243,11 @@ impl<'a> SubstrateBootBuilder<'a> {
             ),
         );
 
-        let queue = Arc::new(Mailer::new());
-        queue.wire(Arc::clone(&registry));
-        queue.wire_outbound(Arc::clone(&outbound));
         let handle_store = Arc::new(HandleStore::from_env());
-        queue.wire_handle_store(Arc::clone(&handle_store));
+        let queue = Arc::new(
+            Mailer::new(Arc::clone(&registry), Arc::clone(&handle_store))
+                .with_outbound(Arc::clone(&outbound)),
+        );
         let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&queue))
             .build()
             .map_err(|e| wasmtime::Error::msg(format!("chassis capability boot: {e}")))?;

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1347,13 +1347,8 @@ mod tests {
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());
-        let mailer = Arc::new(Mailer::new());
-        // Wire the mailer's registry so any test that pushes mail
-        // (Phase 4b's close-time MonitorNotice fan-out, future
-        // close-side mail) doesn't trip the "Mailer not wired" assert
-        // in `Mailer::push`. Pre-Phase-4b tests that never reach
-        // `mailer.push` are unaffected — wiring is one-shot and idle.
-        mailer.wire(Arc::clone(&registry));
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         (registry, mailer)
     }
 

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -1407,7 +1407,12 @@ mod tests {
     use aether_data::ReplyTo;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+        {
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+            (registry, mailer)
+        }
     }
 
     /// Hand-rolled `Actor + Dispatch` fixture for the legacy

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -161,8 +161,8 @@ mod tests {
                 },
             ),
         );
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
         let kind_id = FrameStats::ID;
         emit_frame_stats(&mailer, kind_id, 1, 0);
@@ -186,8 +186,8 @@ mod tests {
                 },
             ),
         );
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
+        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
         emit_frame_stats(&mailer, FrameStats::ID, LOG_EVERY_FRAMES, 42);
         let frames = captured.read().unwrap();

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -17,7 +17,7 @@
 // thread.
 
 use std::borrow::Cow;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::outbound::HubOutbound;
@@ -26,86 +26,74 @@ use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use aether_data::{HandleId, KindId};
 
 pub struct Mailer {
-    /// Registry handle for resolving recipients on `push`. Wired once
-    /// by `SubstrateBoot::build`; expected to be set by the time any
-    /// mail can land.
-    registry: OnceLock<Arc<Registry>>,
+    /// Registry handle for resolving recipients on `push`. Owned for
+    /// the `Mailer`'s lifetime; supplied at construction time alongside
+    /// the `HandleStore` (issue 657 collapsed the prior `wire`-after-
+    /// `new` setter pair into a required-pair constructor).
+    registry: Arc<Registry>,
+    /// ADR-0045 typed-handle resolver. `route_mail` runs each mail
+    /// through the ref-walker before dispatching; missing handles
+    /// park the mail in the store. Required at construction time —
+    /// `SubstrateBoot::build` builds one with `HandleStore::from_env()`,
+    /// tests pass `Arc::new(HandleStore::new(1024 * 1024))`. Schemas
+    /// with no `Ref` nodes hit the no-op fast path inside `route_mail`,
+    /// so passing a store on tests that don't exercise handles costs
+    /// nothing.
+    handle_store: Arc<HandleStore>,
     /// Hub outbound handle. When set and connected, mail to unknown
     /// mailbox ids bubbles up to the hub-substrate (ADR-0037
-    /// Phase 1) instead of being warn-dropped locally. Wired by
-    /// `SubstrateBoot::build` right after the `Mailer` exists; the
-    /// boot holds the only `Arc<HubOutbound>` on the fresh side of
-    /// construction. Absent on chassis that skip hub connection
-    /// (today: the hub chassis itself), which keeps local warn-drop
-    /// semantics intact — the hub is the end of the bubbles-up
-    /// line.
-    outbound: OnceLock<Arc<HubOutbound>>,
-    /// ADR-0045 typed-handle resolver. When wired, `route_mail`
-    /// runs each mail through the ref-walker before dispatching;
-    /// missing handles park the mail in the store. Optional so
-    /// pre-PR-2 test paths (and any chassis that opts out by not
-    /// calling `wire_handle_store`) keep the original verbatim-
-    /// dispatch behaviour. `SubstrateBoot::build` wires this with
-    /// `HandleStore::from_env()` for every chassis.
-    handle_store: OnceLock<Arc<HandleStore>>,
+    /// Phase 1) instead of being warn-dropped locally. Optional —
+    /// chassis that skip hub connection (today: the hub chassis
+    /// itself) construct a `Mailer` without an outbound and keep
+    /// local warn-drop semantics intact (the hub is the end of the
+    /// bubbles-up line). Pre-issue-657 this rode an `OnceLock` set
+    /// post-construction via `wire_outbound`; the constructor +
+    /// `with_outbound` pair below replaces that.
+    outbound: Option<Arc<HubOutbound>>,
 }
 
 impl Mailer {
-    pub fn new() -> Self {
+    /// Construct a `Mailer` against the substrate's registry and
+    /// handle store. `SubstrateBoot::build` is the production caller;
+    /// tests build the same trio with `Registry::new()` and
+    /// `HandleStore::new(1024 * 1024)` (or any byte budget). Call
+    /// [`Self::with_outbound`] to attach a hub outbound if the
+    /// chassis needs ADR-0037 bubble-up.
+    pub fn new(registry: Arc<Registry>, handle_store: Arc<HandleStore>) -> Self {
         Self {
-            registry: OnceLock::new(),
-            outbound: OnceLock::new(),
-            handle_store: OnceLock::new(),
+            registry,
+            handle_store,
+            outbound: None,
         }
     }
 
-    /// Wire the registry. Called by `SubstrateBoot::build` once it
-    /// exists; panics on re-wiring to surface construction-order bugs
-    /// loud rather than silent.
-    pub fn wire(&self, registry: Arc<Registry>) {
-        self.registry
-            .set(registry)
-            .unwrap_or_else(|_| panic!("Mailer::wire called twice"));
-    }
-
-    /// Wire the `HubOutbound` so mail to unknown mailbox ids bubbles
+    /// Attach a `HubOutbound` so mail to unknown mailbox ids bubbles
     /// up to the hub-substrate (ADR-0037 Phase 1) instead of being
-    /// warn-dropped. Called by `SubstrateBoot::build` after the
-    /// `HubOutbound` exists; harmless to skip for chassis that are
-    /// their own hub (the hub chassis doesn't bubble up to itself).
-    pub fn wire_outbound(&self, outbound: Arc<HubOutbound>) {
-        self.outbound
-            .set(outbound)
-            .unwrap_or_else(|_| panic!("Mailer::wire_outbound called twice"));
+    /// warn-dropped. Fluent — returns `self` so the call site can
+    /// chain after `Mailer::new`. Skip the call entirely for chassis
+    /// that are their own hub or for tests that want local warn-drop
+    /// semantics (the hub chassis, the warn-drop test in
+    /// `actor::wasm::component`).
+    pub fn with_outbound(mut self, outbound: Arc<HubOutbound>) -> Self {
+        self.outbound = Some(outbound);
+        self
     }
 
-    /// Wire the ADR-0045 handle store. With a store wired, every
-    /// mail's payload walks through the ref-resolver before dispatch
-    /// (kinds whose schema contains no `Ref` nodes hit the no-op
-    /// fast path). Without a store, dispatch behaves exactly like
-    /// the pre-PR-2 path. Called by `SubstrateBoot::build`.
-    pub fn wire_handle_store(&self, store: Arc<HandleStore>) {
-        self.handle_store
-            .set(store)
-            .unwrap_or_else(|_| panic!("Mailer::wire_handle_store called twice"));
-    }
-
-    /// Borrow the wired `HandleStore`, or `None` if no store was
-    /// wired (pre-boot / test path). Read-only handle exposed so
+    /// Borrow the wired `HandleStore`. Read-only handle exposed so
     /// chassis-side handlers (PR 3 host-fn shims) can publish into
     /// the same store the dispatch path resolves against.
-    pub fn handle_store(&self) -> Option<&Arc<HandleStore>> {
-        self.handle_store.get()
+    pub fn handle_store(&self) -> &Arc<HandleStore> {
+        &self.handle_store
     }
 
     /// Borrow the wired [`HubOutbound`], or `None` if no outbound was
-    /// wired (test paths, or chassis that skip hub connection).
-    /// Issue 576: surfaced so the broadcast cap's `init` can grab the
-    /// outbound at boot and lift catch-all envelopes through
+    /// attached (the hub chassis, or tests). Issue 576: surfaced so
+    /// the broadcast cap's `init` can grab the outbound at boot and
+    /// lift catch-all envelopes through
     /// [`HubOutbound::egress_broadcast`] without the substrate
     /// holding a registry closure for it.
     pub fn outbound(&self) -> Option<&Arc<HubOutbound>> {
-        self.outbound.get()
+        self.outbound.as_ref()
     }
 
     /// Borrow the wired [`Registry`]. Issue 603: surfaced so
@@ -113,8 +101,8 @@ impl Mailer {
     /// internal state without requiring it on `ComponentHostConfig` —
     /// per Resolved Decision §2 registry arrives via init ctx, not
     /// via the cap's config struct.
-    pub fn registry(&self) -> Option<&Arc<Registry>> {
-        self.registry.get()
+    pub fn registry(&self) -> &Arc<Registry> {
+        &self.registry
     }
 
     /// Hand `mail` to the substrate for dispatch. Closure-bound
@@ -124,9 +112,9 @@ impl Mailer {
     pub fn push(&self, mail: Mail) {
         route_mail(
             mail,
-            self.registry.get().expect("Mailer not wired"),
-            self.outbound.get(),
-            self.handle_store.get(),
+            &self.registry,
+            self.outbound.as_ref(),
+            &self.handle_store,
         );
     }
 
@@ -142,23 +130,17 @@ impl Mailer {
     /// in those cases parked mail stays parked and the caller decides
     /// how to recover.
     ///
-    /// Without a wired store this is a no-op success: chassis that
-    /// don't expose handles never park mail in the first place.
     pub fn resolve_handle(
         &self,
         handle: HandleId,
         kind: KindId,
         bytes: Vec<u8>,
     ) -> Result<(), PutError> {
-        let Some(store) = self.handle_store.get() else {
-            return Ok(());
-        };
-        store.put(handle, kind, bytes)?;
-        let parked = store.take_parked(handle);
-        let registry = self.registry.get().expect("Mailer not wired");
-        let outbound = self.outbound.get();
+        self.handle_store.put(handle, kind, bytes)?;
+        let parked = self.handle_store.take_parked(handle);
+        let outbound = self.outbound.as_ref();
         for mail in parked {
-            route_mail(mail, registry, outbound, Some(store));
+            route_mail(mail, &self.registry, outbound, &self.handle_store);
         }
         Ok(())
     }
@@ -182,7 +164,7 @@ impl Mailer {
         match sender.target {
             ReplyTarget::None => false,
             ReplyTarget::Session(_) | ReplyTarget::EngineMailbox { .. } => {
-                match self.outbound.get() {
+                match self.outbound.as_ref() {
                     Some(outbound) => outbound.send_reply(sender, result),
                     None => false,
                 }
@@ -212,12 +194,6 @@ impl Mailer {
     }
 }
 
-impl Default for Mailer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Resolve `mail.recipient` against the registry and dispatch
 /// inline. Closure-bound mailboxes run their handler on the caller
 /// thread (or fan out via the cap's mpsc, depending on the closure).
@@ -233,10 +209,9 @@ fn route_mail(
     mut mail: Mail,
     registry: &Registry,
     outbound: Option<&Arc<HubOutbound>>,
-    store: Option<&Arc<HandleStore>>,
+    store: &Arc<HandleStore>,
 ) {
-    if let Some(store) = store
-        && let Some(descriptor) = registry.kind_descriptor(mail.kind)
+    if let Some(descriptor) = registry.kind_descriptor(mail.kind)
         && handle_store::schema_contains_ref(&descriptor.schema)
     {
         match handle_store::walk_and_resolve(&descriptor.schema, &mail.payload, store) {
@@ -365,10 +340,9 @@ mod tests {
     fn unknown_mailbox_with_connected_outbound_bubbles_up() {
         let (outbound, outbound_rx) = crate::mail::outbound::HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(64 * 1024));
 
-        let mailer = Mailer::new();
-        mailer.wire(Arc::clone(&registry));
-        mailer.wire_outbound(Arc::clone(&outbound));
+        let mailer = Mailer::new(Arc::clone(&registry), store).with_outbound(Arc::clone(&outbound));
 
         let unknown = MailboxId(0xDEADBEEF_u64);
         let kind = KindId(0xABCD_u64);
@@ -400,10 +374,11 @@ mod tests {
     #[test]
     fn unknown_mailbox_without_outbound_warn_drops() {
         let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(64 * 1024));
 
-        let mailer = Mailer::new();
-        mailer.wire(Arc::clone(&registry));
-        // Deliberately no wire_outbound.
+        let mailer = Mailer::new(Arc::clone(&registry), store);
+        // Deliberately no `with_outbound` — exercises the local
+        // warn-drop path (the hub chassis path).
 
         let unknown = MailboxId(0xDEADBEEF_u64);
         mailer.push(Mail::new(unknown, KindId(0xABCD), vec![], 0));
@@ -501,9 +476,7 @@ mod tests {
     fn make_mailer() -> (Arc<Registry>, Arc<Mailer>, Arc<HandleStore>) {
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(64 * 1024));
-        let mailer = Arc::new(Mailer::new());
-        mailer.wire(Arc::clone(&registry));
-        mailer.wire_handle_store(Arc::clone(&store));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), Arc::clone(&store)));
         (registry, mailer, store)
     }
 
@@ -602,20 +575,6 @@ mod tests {
             }
             Ref::Handle { .. } => panic!("walker must replace Handle with Inline"),
         }
-    }
-
-    /// `resolve_handle` with no `Mailer::wire_handle_store` is a
-    /// no-op success — the original pre-PR-2 mailer paths (no store
-    /// wired) keep working without panicking.
-    #[test]
-    fn resolve_handle_without_wired_store_is_noop() {
-        let registry = Arc::new(Registry::new());
-        let mailer = Mailer::new();
-        mailer.wire(Arc::clone(&registry));
-        // No wire_handle_store call.
-        mailer
-            .resolve_handle(HandleId(1), KindId(2), vec![3])
-            .unwrap();
     }
 
     /// Mail whose payload is malformed against the registered

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -113,7 +113,14 @@ impl Chassis for TestChassis {
 }
 
 fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-    (Arc::new(Registry::new()), Arc::new(Mailer::new()))
+    {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
+            1024 * 1024,
+        ));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        (registry, mailer)
+    }
 }
 
 fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {


### PR DESCRIPTION
## Summary

- Replaces three post-construction setters (`wire`, `wire_outbound`, `wire_handle_store`) backed by `OnceLock` fields with a required-pair constructor + one fluent optional setter:
  ```rust
  Mailer::new(registry: Arc<Registry>, handle_store: Arc<HandleStore>) -> Self
  Mailer::with_outbound(self, outbound: Arc<HubOutbound>) -> Self
  ```
- `registry` and `handle_store` are non-optional fields stored as `Arc<...>` (not `OnceLock<Arc<...>>`); `outbound` stays optional as `Option<Arc<HubOutbound>>` to preserve ADR-0037 warn-drop-vs-bubble-up semantics
- `Mailer::registry()` and `Mailer::handle_store()` return `&Arc<X>` directly (not `Option<&Arc<X>>`), so callers like `ComponentHostCapability::init` drop the `.ok_or_else` boot-error arm and clone directly
- The "deliberately no outbound" warn-drop test in `actor::wasm::component` preserves its intent by omitting `.with_outbound`
- Closes #657

<!-- pr-body-ok: b — Closes #657 auto-link is intended -->

## Test plan

- [x] `cargo build --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` — 1020/1020 passing (one fewer than before because the obsolete `resolve_handle_without_wired_store_is_noop` test was deleted: the semantic it asserted — that calling `resolve_handle` without a store is a no-op — no longer exists since the store is mandatory at construction)
- [x] One production callsite (`SubstrateBoot::build`) and ~20 test sites converted; the warn-drop test path stays exercised through `Mailer::new` without `.with_outbound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)