### PR TITLE
refactor(actor): retire NativeCtx::binding accessor for typed methods

### DIFF
--- a/crates/aether-actor/examples/echoer.rs
+++ b/crates/aether-actor/examples/echoer.rs
@@ -3,7 +3,7 @@
 //! `demo.response { seq }` to whatever component sent it.
 //!
 //! ADR-0033 phase 3: uses `#[actor]` as the only receive path.
-//! The synthesized dispatcher reads `ctx.reply_to()` (threaded from the
+//! The synthesized dispatcher reads `ctx.reply_target()` (threaded from the
 //! inbound mail by `#[actor]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
@@ -44,7 +44,7 @@ impl FfiActor for Echoer {
 
     #[handler]
     fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: Request) {
-        if let Some(sender) = ctx.reply_to() {
+        if let Some(sender) = ctx.reply_target() {
             ctx.reply_kind(sender, self.response, &Response { seq: req.seq });
         }
     }

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -96,7 +96,7 @@ impl FfiActor for Hello {
     /// are in flight.
     #[handler]
     fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
-        if let Some(sender) = ctx.reply_to() {
+        if let Some(sender) = ctx.reply_target() {
             ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
         }
     }

--- a/crates/aether-actor/src/actor/ctx/outbound_reply.rs
+++ b/crates/aether-actor/src/actor/ctx/outbound_reply.rs
@@ -39,7 +39,7 @@ pub trait OutboundReply: MailSender {
     /// component-origin and broadcast-origin mail; `Some(_)` when the
     /// inbound carries a routable originator (Claude session, peer
     /// component, remote engine mailbox).
-    fn reply_to(&self) -> Option<Self::ReplyHandle>;
+    fn reply_target(&self) -> Option<Self::ReplyHandle>;
 
     /// Local-component origin of the mail currently being dispatched,
     /// or `None` for mail with no local sender (broadcast,
@@ -59,4 +59,16 @@ pub trait OutboundReply: MailSender {
     /// `Serialize` so the bound is documentation, not a breaking
     /// change.
     fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K);
+
+    /// Reply to an explicit `sender` rather than the dispatcher-stamped
+    /// reply target. Used by the parked-sender pattern: caps that stash
+    /// a [`Self::ReplyHandle`] from one inbound and answer it later from
+    /// a different handler (e.g. `aether-tcp`'s pending-unbinds, where
+    /// the bind ack waits for the listener's monitor notice before
+    /// firing).
+    ///
+    /// Same wire-shape contract as [`Self::reply`]. Native impls route
+    /// through `NativeBinding::send_reply_for_handler`; FFI impls route
+    /// through [`crate::ffi::bridge::MAIL_BRIDGE::reply_mail`].
+    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: Self::ReplyHandle, payload: &K);
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -208,8 +208,8 @@ impl<'a> FfiCtx<'a> {
     }
 
     /// Reply target for the mail currently being dispatched. Mirrors
-    /// [`OutboundReply::reply_to`].
-    pub fn reply_to(&self) -> Option<ReplyTo> {
+    /// [`OutboundReply::reply_target`].
+    pub fn reply_target(&self) -> Option<ReplyTo> {
         self.sender.map(ReplyTo::__from_raw)
     }
 
@@ -223,6 +223,16 @@ impl<'a> FfiCtx<'a> {
     /// from a runtime instance name.
     pub fn resolve_actor<R: Actor>(&self, name: &str) -> FfiActorMailbox<R> {
         FfiActorMailbox::__new(mailbox_id_from_name(name).0)
+    }
+
+    /// ADR-0063 fail-fast: bring the substrate down with `reason`.
+    /// Diverging — does not return. The body `panic!`s; the substrate's
+    /// wasm runtime catches the trap and ADR-0063 escalates the
+    /// substrate-side fatal_abort path. Symmetric to
+    /// `aether_substrate::actor::native::NativeCtx::fatal_abort` so
+    /// trap-escalation reads the same on both sides.
+    pub fn fatal_abort(&self, reason: alloc::string::String) -> ! {
+        panic!("aether-actor: fatal_abort: {reason}")
     }
 }
 
@@ -263,7 +273,7 @@ impl<'a> MailSender for FfiCtx<'a> {
 impl<'a> OutboundReply for FfiCtx<'a> {
     type ReplyHandle = ReplyTo;
 
-    fn reply_to(&self) -> Option<ReplyTo> {
+    fn reply_target(&self) -> Option<ReplyTo> {
         self.sender.map(ReplyTo::__from_raw)
     }
 
@@ -276,6 +286,11 @@ impl<'a> OutboundReply for FfiCtx<'a> {
             let bytes = payload.encode_into_bytes();
             MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);
         }
+    }
+
+    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        MAIL_BRIDGE.reply_mail(sender.raw(), K::ID.0, &bytes, 1);
     }
 }
 

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -34,6 +34,7 @@ mod native {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use aether_actor::actor;
+    use aether_actor::actor::ctx::OutboundReply;
     use aether_data::Kind;
     use aether_kinds::LoadResult;
     use wasmtime::{Engine, Linker, Module};
@@ -123,8 +124,7 @@ mod native {
         #[handler]
         fn on_load_component(&mut self, ctx: &mut NativeCtx<'_>, payload: LoadComponent) {
             let result = self.handle_load(ctx, payload);
-            ctx.binding()
-                .send_reply_for_handler(ctx.reply_target(), &result);
+            ctx.reply(&result);
         }
 
         /// Drop a component by its mailbox id. Forwards

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -25,6 +25,7 @@ pub use native::InputConfig;
 mod native {
     use super::{SubscribeInput, SubscribeInputResult, UnsubscribeInput};
     use aether_actor::actor;
+    use aether_actor::actor::ctx::OutboundReply;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::input::InputSubscribers;
@@ -84,8 +85,7 @@ mod native {
                 }
                 Err(error) => SubscribeInputResult::Err { error },
             };
-            ctx.binding()
-                .send_reply_for_handler(ctx.reply_target(), &result);
+            ctx.reply(&result);
         }
 
         /// Unsubscribe a mailbox from an input stream (ADR-0021).
@@ -104,8 +104,7 @@ mod native {
                 }
                 Err(error) => SubscribeInputResult::Err { error },
             };
-            ctx.binding()
-                .send_reply_for_handler(ctx.reply_target(), &result);
+            ctx.reply(&result);
         }
     }
 

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -76,7 +76,8 @@ mod cap_native {
         BindListenerResult, Close, ListListenersResult, ListenerInfo, TcpListenerActor,
         TcpListenerConfig, UnbindListenerResult,
     };
-    use aether_actor::{MailCtx, actor};
+    use aether_actor::actor;
+    use aether_actor::actor::ctx::OutboundReply;
     use aether_substrate::actor::monitor::MonitorHandle;
     use aether_substrate::actor::native::spawn::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
@@ -311,7 +312,7 @@ mod cap_native {
             // Fire the parked unbind reply if one was waiting.
             let parked = self.pending_unbinds.remove(&notice.target);
             if let Some(parked) = parked {
-                ctx.binding().send_reply_for_handler(
+                ctx.reply_to(
                     parked.sender,
                     &UnbindListenerResult::Ok {
                         listener_name: parked.listener_name,

--- a/crates/aether-capabilities/src/wasm_trampoline.rs
+++ b/crates/aether-capabilities/src/wasm_trampoline.rs
@@ -45,6 +45,7 @@
 use std::sync::Arc;
 
 use aether_actor::actor;
+use aether_actor::actor::ctx::OutboundReply;
 use aether_kinds::{
     ComponentCapabilities, DropComponent, DropResult, ReplaceComponent, ReplaceResult,
 };
@@ -148,7 +149,7 @@ impl NativeActor for WasmTrampoline {
         // can drain *this* trampoline's inbox + overflow (issue 634
         // Phase 4 PR 3 — single source of inbox truth lives on
         // `NativeBinding`, not on `ComponentCtx`).
-        substrate_ctx.install_binding(Arc::clone(ctx.binding_arc()));
+        substrate_ctx.install_binding(Arc::clone(ctx.__binding_arc()));
         let component = Component::instantiate(
             &config.engine,
             &config.linker,
@@ -188,8 +189,7 @@ impl NativeActor for WasmTrampoline {
         if let Some(mut component) = self.component.take() {
             component.on_drop();
         }
-        ctx.binding()
-            .send_reply_for_handler(ctx.reply_target(), &DropResult::Ok);
+        ctx.reply(&DropResult::Ok);
     }
 
     /// Replace the wasm component with a fresh module. ADR-0022 +
@@ -202,8 +202,7 @@ impl NativeActor for WasmTrampoline {
     #[handler]
     fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
         let result = self.handle_replace(payload);
-        ctx.binding()
-            .send_reply_for_handler(ctx.reply_target(), &result);
+        ctx.reply(&result);
     }
 
     /// Forward un-handled mail to the wasm guest.
@@ -233,7 +232,7 @@ impl NativeActor for WasmTrampoline {
             // substrate. Wedge detection (CPU-loop guests) waits on a
             // future epoch-deadline ADR — symmetric with native
             // actors, which have no wedge guard either today.
-            ctx.binding().fatal_abort(format!(
+            ctx.fatal_abort(format!(
                 "component {} (kind {}) trapped: {e}",
                 self.mailbox, env.kind_name,
             ));

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -61,13 +61,6 @@ impl<'a> NativeCtx<'a> {
         Self { binding, sender }
     }
 
-    /// Borrow the actor's [`NativeBinding`]. Exposed for stage-2 caps
-    /// that need to call low-level binding helpers the SDK doesn't yet
-    /// wrap.
-    pub fn binding(&self) -> &NativeBinding {
-        self.binding
-    }
-
     /// The reply target for the mail currently being dispatched.
     /// Useful when a handler wants to inspect the originator (audit
     /// trails, multi-tenant routing) without going through
@@ -118,6 +111,17 @@ impl<'a> NativeCtx<'a> {
     /// can call `shutdown()` to opt in to flag-based exit.
     pub fn shutdown(&self) {
         self.binding.signal_shutdown();
+    }
+
+    /// ADR-0063 fail-fast: bring the substrate down with `reason`.
+    /// Diverging — does not return. Used by handlers that observe a
+    /// non-recoverable invariant violation (today: the wasm trampoline
+    /// on a guest trap). Native impl forwards to
+    /// [`NativeBinding::fatal_abort`]. See also the [`crate::ffi::FfiCtx`]
+    /// counterpart, which `panic!`s — the substrate's wasm runtime
+    /// catches the trap and ADR-0063 escalates symmetrically.
+    pub fn fatal_abort(&self, reason: String) -> ! {
+        self.binding.fatal_abort(reason);
     }
 
     /// Issue 607 Phase 4b (ADR-0079): register the calling actor as a
@@ -268,19 +272,19 @@ impl<'a> NativeInitCtx<'a> {
         }
     }
 
-    /// Borrow the Arc'd cap-bound [`NativeBinding`]. Used by the wasm
-    /// trampoline at init to install itself on the
-    /// [`crate::actor::wasm::component::ComponentCtx`] so the
-    /// `wait_reply_p32` host fn can route through this binding.
-    pub fn binding_arc(&self) -> &Arc<NativeBinding> {
-        self.binding
-    }
-
-    /// Borrow the cap-bound [`NativeBinding`]. Caps rarely reach for
-    /// this — `Sender::send::<R>(...)` covers the typed-send path —
-    /// but stage-2 migrations may want it during init for one-shot
-    /// outbound mail.
-    pub fn binding(&self) -> &NativeBinding {
+    /// Substrate-internal: borrow the Arc'd cap-bound
+    /// [`NativeBinding`]. Used by the wasm trampoline at init to
+    /// install itself on the [`crate::actor::wasm::component::ComponentCtx`]
+    /// so the `wait_reply_p32` host fn can route through this binding.
+    ///
+    /// Double-underscore "not part of the public API" marker
+    /// (matching `__new` / `__set_reply_to` elsewhere). Issue #668
+    /// relocates the wasm trampoline into a substrate-internal
+    /// location so this can become `pub(crate)` cleanly; in the
+    /// meantime the trampoline lives in `aether-capabilities` and
+    /// needs `pub` reachability.
+    #[doc(hidden)]
+    pub fn __binding_arc(&self) -> &Arc<NativeBinding> {
         self.binding
     }
 
@@ -420,7 +424,7 @@ impl<'a> OutboundReply for NativeCtx<'a> {
     /// [`Self::reply`] inspecting the inner `ReplyTarget`; the trait's
     /// `Option<Self::ReplyHandle>` shape exists for the FFI side,
     /// where a guest genuinely sees no reply target.
-    fn reply_to(&self) -> Option<ReplyTo> {
+    fn reply_target(&self) -> Option<ReplyTo> {
         Some(self.sender)
     }
 
@@ -433,6 +437,10 @@ impl<'a> OutboundReply for NativeCtx<'a> {
 
     fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
         self.binding.send_reply_for_handler(self.sender, payload);
+    }
+
+    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+        self.binding.send_reply_for_handler(sender, payload);
     }
 }
 

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -354,7 +354,7 @@ impl Sokoban {
     }
 
     fn reply_state(&self, ctx: &mut FfiCtx<'_>) {
-        let Some(sender) = ctx.reply_to() else {
+        let Some(sender) = ctx.reply_target() else {
             return;
         };
         ctx.reply_kind(sender, self.state_kind, &self.state);

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -147,7 +147,7 @@ impl TicTacToe {
     }
 
     fn reply(&self, ctx: &mut FfiCtx<'_>, status: u8) {
-        let Some(sender) = ctx.reply_to() else {
+        let Some(sender) = ctx.reply_target() else {
             return;
         };
         let result = MoveResult {


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #667 keyword -->

## Summary

- `OutboundReply::reply_to(&self)` accessor renames to `reply_target()` to free the name. New `OutboundReply::reply_to(sender, &K)` is the explicit-sender reply for the parked-sender pattern.
- `fatal_abort` becomes inherent per ctx (NativeCtx routes to `NativeBinding::fatal_abort`; FfiCtx panics so wasm trap → ADR-0063 escalation).
- All 6 user-facing `ctx.binding().*` call sites migrate to typed methods: 4 simple reply paths to `ctx.reply(&result)`, 1 parked-sender to `ctx.reply_to(sender, &result)`, 1 trap-escalation to `ctx.fatal_abort(...)`.
- `NativeInitCtx::binding_arc()` renames to `__binding_arc()` (substrate-internal stopgap; issue 668 relocates the wasm trampoline so this can go `pub(crate)` cleanly).
- `NativeCtx::binding()` and `NativeInitCtx::binding()` delete.

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` — 1016 passed, 0 skipped
- [x] `cargo build -p aether-actor --target wasm32-unknown-unknown` clean

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)