### PR TITLE
docs: refresh stale references after wasm trampoline relocation

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -151,12 +151,12 @@ mod native {
         /// handler swaps `Component` internally and replies
         /// `ReplaceResult`. ADR-0022 + ADR-0038 splice invariants
         /// hold because the inbox channel is the trampoline's
-        /// framework transport, which outlives the swap.
+        /// `NativeBinding`, which outlives the swap.
         ///
         /// # Agent
         /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms }`.
         /// `drain_timeout_ms` is accepted for wire compatibility but
-        /// ignored under the trampoline's transport-stable replace.
+        /// ignored under the trampoline's binding-stable replace.
         #[handler]
         fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
             self.forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
@@ -208,7 +208,7 @@ mod native {
             // claims the namespace, registers the closure-bound
             // mailbox at `aether.component.trampoline:NAME`, runs
             // `WasmTrampoline::init` (which instantiates `Component`
-            // against the trampoline's transport), and starts the
+            // against the trampoline's binding), and starts the
             // dispatcher thread. The returned id is the trampoline's
             // mailbox.
             let trampoline_config = WasmTrampolineConfig {

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -5,12 +5,11 @@
 //! peripherals (window, GPU, TCP listener, event loop) live in the
 //! chassis crate that binds this as a dependency. See ADR-0035.
 //!
-//! Each loaded wasm component runs as a `WasmTrampoline` —
+//! Each loaded wasm component runs as a [`actor::wasm::trampoline::WasmTrampoline`] —
 //! a `NativeActor` instanced under `aether.component.trampoline:NAME`
 //! that delegates incoming mail to the wasm guest via `#[fallback]`
-//! (issue 634 Phase 4). The trampoline lives in
-//! `aether-capabilities`; the substrate-side
-//! `ComponentHostCapability` shrinks to a `LoadComponent` handler
+//! (issue 634 Phase 4). The chassis-side `ComponentHostCapability`
+//! (in `aether-capabilities`) shrinks to a `LoadComponent` handler
 //! that spawns the trampoline (and forwarders for `DropComponent` /
 //! `ReplaceComponent`). Phase 4 PR 2 retired the per-frame drain
 //! barrier and the `DrainSummary` / `DrainDeath` / `DrainOutcome`
@@ -26,11 +25,11 @@
 //! The chassis instance you `run()` is the [`BuiltChassis<Self>`] the
 //! trait method returns, not a value of `Self` itself.
 
-// Issue 552 stage 2: the `#[actor] impl NativeActor for X` macro
-// emits `impl ::aether_substrate::NativeDispatch for X` so external
-// callers (caps in user crates, `aether-capabilities` once the move
-// in stage 2c lands) resolve unambiguously. For caps written *inside*
-// aether-substrate (today: every cap under `capabilities/`) the
+// The `#[actor] impl NativeActor for X` macro emits
+// `impl ::aether_substrate::NativeDispatch for X` so external callers
+// (caps in `aether-capabilities`, user-crate caps) resolve
+// unambiguously. For impls written *inside* aether-substrate (today:
+// the wasm trampoline at `actor::wasm::trampoline`) the
 // `::aether_substrate` prefix is in-crate; the self-alias makes
 // absolute paths resolve without a separate "internal vs external"
 // macro arm.


### PR DESCRIPTION
## Summary

Two doc-comment leftovers PR 670 didn't catch:

- **`aether-substrate/src/lib.rs`** module preamble — said "trampoline lives in `aether-capabilities`" (now stale post-relocation). Rephrased to "`ComponentHostCapability` (in `aether-capabilities`) spawns the trampoline" with an intra-doc link `[`actor::wasm::trampoline::WasmTrampoline`]`. Bonus: the `extern crate self` macro comment also dropped its reference to `capabilities/` (the in-substrate cap directory retired during stage 2e).
- **`aether-capabilities/src/component.rs`** — two leftovers from the issue 665 `NativeTransport → NativeBinding` rename ("framework transport", "transport-stable replace") flipped to "`NativeBinding`" / "binding-stable".

ADRs were checked too; ADR-0077 + ADR-0078 mention `aether-capabilities` housing chassis caps, which is still accurate. No actionable ADR drift — they're time-stamped artifacts and the trampoline isn't pinned to a location in any of them.

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo fmt --all -- --check` clean
- Docs-only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)