### PR TITLE
refactor(capabilities): migrate cap tests from ChassisBuilder to Builder

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -876,10 +876,21 @@ mod native {
     mod tests {
         use super::*;
         use aether_actor::Actor;
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());
@@ -1028,18 +1039,18 @@ mod native {
         #[test]
         fn capability_boots_and_registers_mailbox() {
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<AudioCapability>(AudioConfig {
                     disabled: true,
                     ..AudioConfig::default()
                 })
-                .build()
+                .build_passive()
                 .expect("audio capability boots");
             assert!(
                 registry.lookup(AudioCapability::NAMESPACE).is_some(),
                 "audio mailbox registered"
             );
-            chassis.shutdown();
+            drop(chassis);
         }
 
         /// Builder rejects a duplicate claim.
@@ -1048,12 +1059,12 @@ mod native {
             let (registry, mailer) = fresh_substrate();
             registry.register_closure(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<AudioCapability>(AudioConfig {
                     disabled: true,
                     ..AudioConfig::default()
                 })
-                .build()
+                .build_passive()
                 .expect_err("collision must surface as BootError");
             assert!(matches!(
                 err,

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -481,11 +481,22 @@ mod native {
         use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.
@@ -764,15 +775,15 @@ mod native {
         fn capability_boots_and_registers_mailbox() {
             let root = scratch_root("boots");
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<IoCapability>(roots_under(&root))
-                .build()
+                .build_passive()
                 .expect("io capability boots");
             assert!(
                 registry.lookup(IoCapability::NAMESPACE).is_some(),
                 "io mailbox registered"
             );
-            chassis.shutdown();
+            drop(chassis);
             cleanup(&root);
         }
 
@@ -794,9 +805,9 @@ mod native {
             std::fs::create_dir_all(&roots.config).unwrap();
 
             let (registry, mailer) = fresh_substrate();
-            let result = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let result = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<IoCapability>(roots)
-                .build();
+                .build_passive();
             assert!(result.is_err(), "save root being a file must fail cap init");
             cleanup(&root);
         }
@@ -809,9 +820,9 @@ mod native {
             let (registry, mailer) = fresh_substrate();
             registry.register_closure(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<IoCapability>(roots_under(&root))
-                .build()
+                .build_passive()
                 .expect_err("collision must surface as BootError");
             assert!(matches!(
                 err,

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -152,11 +152,22 @@ mod native {
         use super::{
             Arc, BootError, HandleCapability, HandlePublish, HandlePublishResult, HandleStore,
         };
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::EgressEvent;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         fn fresh_substrate() -> (
             Arc<HandleStore>,
@@ -190,9 +201,9 @@ mod native {
         fn capability_routes_publish_through_dispatcher_thread() {
             let (store, mailer, registry, rx) = fresh_substrate();
 
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HandleCapability>(())
-                .build()
+                .build_passive()
                 .expect("capability boots");
 
             let id = registry
@@ -246,7 +257,7 @@ mod native {
             assert_eq!(stored_kind, KindId(0xCAFE));
             assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
 
-            chassis.shutdown();
+            drop(chassis);
         }
 
         /// Channel-drop shutdown: drop the chassis, the cap's dispatcher
@@ -255,13 +266,13 @@ mod native {
         fn shutdown_joins_dispatcher_thread() {
             let (_store, mailer, registry, _rx) = fresh_substrate();
 
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HandleCapability>(())
-                .build()
+                .build_passive()
                 .expect("capability boots");
 
             let start = Instant::now();
-            chassis.shutdown();
+            drop(chassis);
             let elapsed = start.elapsed();
             assert!(
                 elapsed < Duration::from_millis(500),
@@ -276,9 +287,9 @@ mod native {
             let (_store, mailer, registry, _rx) = fresh_substrate();
             registry.register_closure(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
-            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HandleCapability>(())
-                .build()
+                .build_passive()
                 .expect_err("collision must surface as BootError");
             assert!(matches!(
                 err,

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -452,11 +452,22 @@ mod native {
         use aether_data::{Kind, MailboxId};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());
@@ -542,15 +553,15 @@ mod native {
                 disabled: true,
                 ..HttpConfig::default()
             };
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HttpCapability>(config)
-                .build()
+                .build_passive()
                 .expect("http capability boots");
             assert!(
                 registry.lookup(HttpCapability::NAMESPACE).is_some(),
                 "http mailbox registered"
             );
-            chassis.shutdown();
+            drop(chassis);
         }
 
         /// Builder rejects a duplicate claim.
@@ -563,9 +574,9 @@ mod native {
                 ..HttpConfig::default()
             };
 
-            let err = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HttpCapability>(config)
-                .build()
+                .build_passive()
                 .expect_err("collision must surface as BootError");
             assert!(matches!(
                 err,

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -549,10 +549,22 @@ mod native {
 
         use super::*;
         use aether_actor::Actor;
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{KindId, ReplyTo};
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());
@@ -577,9 +589,9 @@ mod native {
         #[test]
         fn capability_claims_render_mailbox_only() {
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<RenderCapability>(RenderConfig::default())
-                .build()
+                .build_passive()
                 .expect("build succeeds");
             assert_eq!(chassis.len(), 1);
             assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
@@ -587,20 +599,18 @@ mod native {
             assert!(registry.lookup("aether.sink.camera").is_none());
         }
 
-        /// Boots render through the legacy `ChassisBuilder.with_actor`
-        /// path and asserts a `DrawTriangle` mail accumulates into the
-        /// frame_vertices buffer. The `RenderHandles` here is reached
-        /// via the chassis post-build (legacy ChassisBuilder doesn't
-        /// expose an actors map; the test asserts via the registry sink
-        /// the dispatcher drains rather than reading the cap state
-        /// directly). Coverage of `handles` accessor is in the desktop
-        /// chassis path post-2d.
+        /// Boots render through `Builder::with_actor` and asserts a
+        /// `DrawTriangle` mail accumulates into the frame_vertices
+        /// buffer. The `RenderHandles` here is reached via the chassis
+        /// post-build by waiting on the per-mailbox pending counter
+        /// the FRAME_BARRIER claim populates. Coverage of the
+        /// `handles` accessor is in the desktop chassis path.
         #[test]
         fn render_dispatcher_appends_triangles_to_frame_vertices() {
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<RenderCapability>(RenderConfig::default())
-                .build()
+                .build_passive()
                 .expect("build succeeds");
 
             let one_triangle = vec![0u8; DRAW_TRIANGLE_BYTES];
@@ -611,60 +621,56 @@ mod native {
                 &one_triangle,
             );
 
-            // Wait briefly for the dispatcher thread to drain. The legacy
-            // `ChassisBuilder` boot path doesn't expose an Actors map for
-            // direct lookup, so the test waits on the per-mailbox pending
-            // counter the FRAME_BARRIER claim populates and treats a
-            // drain-to-zero as the dispatch happening. Pre-2d the test
-            // peeked at `cap.handles()` directly; the new shape doesn't
-            // expose that without a chassis-side actors map.
+            // Wait briefly for the dispatcher thread to drain. The
+            // test waits on the per-mailbox pending counter the
+            // FRAME_BARRIER claim populates and treats a drain-to-zero
+            // as the dispatch happening.
             for _ in 0..50 {
-                if chassis.frame_bound_pending().is_empty()
-                    || chassis.frame_bound_pending()[0].1.load(Ordering::Acquire) == 0
-                {
+                let pending = chassis.frame_bound_pending();
+                if pending.is_empty() || pending[0].1.load(Ordering::Acquire) == 0 {
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(5));
             }
             // The pending counter must have hit zero — the dispatcher
             // ran the handler.
-            assert_eq!(chassis.frame_bound_pending().len(), 1);
+            let pending = chassis.frame_bound_pending();
+            assert_eq!(pending.len(), 1);
             assert_eq!(
-                chassis.frame_bound_pending()[0].1.load(Ordering::Acquire),
+                pending[0].1.load(Ordering::Acquire),
                 0,
                 "dispatcher should have processed the DrawTriangle"
             );
 
-            chassis.shutdown();
+            drop(chassis);
         }
 
         /// Frame-bound claim populates the chassis's `frame_bound_pending`
-        /// Vec. Direct render-internal-state assertions live on the
-        /// `with_actor`-via-`Builder` path (chassis_builder tests +
-        /// integration tests in the bundle), where the chassis-side
+        /// Vec. Direct render-internal-state assertions live on
+        /// integration tests in the bundle, where the chassis-side
         /// actors map exposes `Arc<RenderCapability>` for `handles()`
         /// access.
         #[test]
         fn render_registers_frame_bound_pending_counter() {
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<RenderCapability>(RenderConfig::default())
-                .build()
+                .build_passive()
                 .expect("build succeeds");
             assert_eq!(
                 chassis.frame_bound_pending().len(),
                 1,
                 "render claimed through frame-bound path"
             );
-            chassis.shutdown();
+            drop(chassis);
         }
 
         #[test]
         fn camera_kind_drops_wrong_length_payload() {
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<RenderCapability>(RenderConfig::default())
-                .build()
+                .build_passive()
                 .expect("build succeeds");
 
             // 16 bytes — wrong length, decode fails, macro miss path
@@ -677,12 +683,12 @@ mod native {
             );
 
             std::thread::sleep(Duration::from_millis(50));
-            // No further assertion on internal state — the legacy
-            // `ChassisBuilder` boot path doesn't expose `Arc<RenderCapability>`.
-            // Decode failure is observable via the macro miss path's
-            // warn-log; this test asserts shutdown still proceeds cleanly
-            // (no dispatcher panic on malformed input).
-            chassis.shutdown();
+            // No further assertion on internal state — passive chassis
+            // doesn't expose `Arc<RenderCapability>`. Decode failure is
+            // observable via the macro miss path's warn-log; this test
+            // asserts shutdown still proceeds cleanly (no dispatcher
+            // panic on malformed input).
+            drop(chassis);
         }
     }
 }

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -338,11 +338,23 @@ mod cap_native {
         };
         use aether_actor::Actor;
         use aether_data::{Kind, SessionToken, Uuid};
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
             let registry = Arc::new(Registry::new());
@@ -409,9 +421,9 @@ mod cap_native {
         #[test]
         fn bind_then_list_then_unbind_roundtrip() {
             let (registry, mailer, rx) = fresh_substrate();
-            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<TcpCapability>(())
-                .build()
+                .build_passive()
                 .expect("TcpCapability boots");
 
             // Bind to port 0 — let the OS pick a free port.
@@ -485,9 +497,9 @@ mod cap_native {
         #[test]
         fn bind_port_in_use_returns_err() {
             let (registry, mailer, rx) = fresh_substrate();
-            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<TcpCapability>(())
-                .build()
+                .build_passive()
                 .expect("TcpCapability boots");
 
             let first: BindListenerResult = drive_and_decode(
@@ -531,9 +543,9 @@ mod cap_native {
         #[test]
         fn unbind_unknown_listener_errors() {
             let (registry, mailer, rx) = fresh_substrate();
-            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<TcpCapability>(())
-                .build()
+                .build_passive()
                 .expect("TcpCapability boots");
 
             let reply: UnbindListenerResult = drive_and_decode(
@@ -569,10 +581,10 @@ mod cap_native {
             use std::net::TcpStream;
 
             let (registry, mailer, rx) = fresh_substrate();
-            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<crate::BroadcastCapability>(())
                 .with_actor::<TcpCapability>(())
-                .build()
+                .build_passive()
                 .expect("caps boot");
 
             // Bind to OS-picked port.
@@ -650,9 +662,9 @@ mod cap_native {
         #[test]
         fn list_enumerates_two_concurrent_listeners() {
             let (registry, mailer, rx) = fresh_substrate();
-            let _chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<TcpCapability>(())
-                .build()
+                .build_passive()
                 .expect("TcpCapability boots");
 
             let _: BindListenerResult = drive_and_decode(

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -391,11 +391,23 @@ mod native {
         use aether_kinds::{EnvVar, ProcessExited, Spawn, SpawnResult};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::ctx::ChassisBuilder;
+        use aether_substrate::chassis::Chassis;
+        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::Registry;
+
+        struct TestChassis;
+        impl Chassis for TestChassis {
+            const PROFILE: &'static str = "test";
+            type Driver = NeverDriver;
+            type Env = ();
+            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+            }
+        }
         use std::net::SocketAddr;
         use std::sync::mpsc;
         use std::time::Duration;
@@ -437,15 +449,15 @@ mod native {
         fn capability_boots_and_registers_mailbox() {
             let rt = Runtime::new().expect("tokio runtime");
             let (registry, mailer) = fresh_substrate();
-            let chassis = ChassisBuilder::new(Arc::clone(&registry), Arc::clone(&mailer))
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<ProcessCapability>(cfg(&rt, unreachable_addr()))
-                .build()
+                .build_passive()
                 .expect("process capability boots");
             assert!(
                 registry.lookup(ProcessCapability::NAMESPACE).is_some(),
                 "aether.process mailbox registered",
             );
-            chassis.shutdown();
+            drop(chassis);
         }
 
         /// Manually constructed cap + a fully-wired test mailer so we


### PR DESCRIPTION
## Summary

Phase 1 of issue 673: every cap unit test in `aether-capabilities` (plus one in `aether-substrate-bundle`) lifts off the legacy `chassis::ctx::ChassisBuilder` boot path and onto the new `chassis::builder::Builder<TestChassis>` / `PassiveChassis` shape. No behavior change — both paths spawn the same dispatcher loop and tear down identically.

## What changed

Per-file pattern, applied to 7 files (~20 call sites):

- Imports: drop `ChassisBuilder`, add `Chassis` trait + `Builder` / `BuiltChassis` / `NeverDriver` + `BootError`.
- Add a `TestChassis` stub at the top of the test mod (matches the existing pattern in `crates/aether-capabilities/src/log.rs`).
- `ChassisBuilder::new(...)` -> `Builder::<TestChassis>::new(...)`.
- `.build()` -> `.build_passive()`.
- `chassis.shutdown()` -> `drop(chassis)` (`PassiveChassis::Drop` runs the same teardown).

`render.rs` additionally adjusts `frame_bound_pending()` callers for the `&[...]` -> `Vec<...>` return-type shift between `BootedChassis` and `PassiveChassis`. Where the test reads pending in a loop, it hoists into a local. Functionally equivalent.

## Files touched

- `crates/aether-capabilities/src/handle.rs` (3 sites)
- `crates/aether-capabilities/src/audio.rs` (2 sites)
- `crates/aether-capabilities/src/render.rs` (4 sites)
- `crates/aether-capabilities/src/http.rs` (2 sites)
- `crates/aether-capabilities/src/fs.rs` (3 sites)
- `crates/aether-capabilities/src/tcp/mod.rs` (5 sites)
- `crates/aether-substrate-bundle/src/hub/process_capability.rs` (1 site)

## What this doesn't do

This is the mechanical migration only. Phase 2 (refactor test-bench's `IoCapability` conditional-boot to pre-`build_passive` `with_actor`) and Phase 3 (decouple `SubstrateBoot::build` from `ChassisBuilder`, delete `BootedChassis` / `boot_native_actor` / `ChassisBuilder` types) follow as separate PRs. Issue 673 closes on the last of the three.

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` 1016/1016 pass — every migrated cap test continues to assert the same dispatcher behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)