### PR TITLE
refactor(test-bench): pre-validate fs roots, drop post-build add_actor

### DIFF
--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -234,6 +234,25 @@ pub fn build_registry(
     Ok((Arc::new(registry), roots))
 }
 
+impl NamespaceRoots {
+    /// Pre-validate the configured roots: create each directory if
+    /// missing, then canonicalize. Mirrors what `LocalFileAdapter::new`
+    /// does inside [`FsCapability::init`], but exposed so embedders
+    /// can validate before building the chassis. Used by chassis
+    /// builders that want to surface root-validity as a "skip the
+    /// `aether.fs` cap and continue" decision rather than letting
+    /// init failure abort the whole boot.
+    pub fn ensure_dirs(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.save)?;
+        std::fs::create_dir_all(&self.assets)?;
+        std::fs::create_dir_all(&self.config)?;
+        self.save.canonicalize()?;
+        self.assets.canonicalize()?;
+        self.config.canonicalize()?;
+        Ok(())
+    }
+}
+
 #[aether_actor::bridge(singleton)]
 mod native {
     use std::path::{Path, PathBuf};

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -1,12 +1,12 @@
 // Test-bench chassis binary entry point.
 //
 // Reads chassis-relevant env vars into a `TestBenchEnv`, asks
-// `TestBenchChassis::build_passive` to assemble the substrate +
-// passive capabilities (Log + Render) via the chassis_builder
-// `Builder`, adds the io capability on the legacy
-// `boot.add_capability` path, creates the offscreen `Gpu`, then
-// drives the events_rx loop on the main thread. The chassis is
-// embedder-driven (no `DriverCapability`) — `main()` IS the driver.
+// `TestBenchChassis::build_passive` to assemble the substrate plus
+// every capability (Log, Render, Io if roots pre-validate, etc.)
+// through the chassis_builder `Builder`, creates the offscreen
+// `Gpu`, then drives the events_rx loop on the main thread. The
+// chassis is embedder-driven (no `DriverCapability`) — `main()` IS
+// the driver.
 //
 // In-process counterpart lives in `aether-substrate-test-bench::TestBench`
 // (the `TestBench::start()` API ADR-0067 introduced); both paths
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use aether_capabilities::FsCapability;
 use aether_data::{Kind, encode_empty};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
 use aether_substrate::{
@@ -76,21 +75,17 @@ fn main() -> anyhow::Result<()> {
         observed_kinds: None,
         events_tx,
         capture_queue: capture_queue.clone(),
+        namespace_roots: Some(namespace_roots),
     };
 
     let TestBenchBuild {
         passive,
-        mut boot,
+        boot,
         render_handles,
         kind_tick,
         kind_frame_stats,
         hub,
     } = TestBenchChassis::build_passive(env)?;
-
-    // Io cap on the `boot.add_actor` path — the binary fails fast on
-    // adapter init failure (the in-process API silent-skips for
-    // systems without writable default roots).
-    boot.add_actor::<FsCapability>(namespace_roots)?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height, render_handles.clone());

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -31,7 +31,7 @@ use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, Tic
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use crate::hub::HubProtocolBackend;
 use aether_actor::Actor;
-use aether_capabilities::{FsCapability, RenderCapability, fs::NamespaceRoots};
+use aether_capabilities::{RenderCapability, fs::NamespaceRoots};
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, PassiveChassis, ReplyTarget, ReplyTo, SubstrateBoot,
     capture::CaptureQueue,
@@ -252,11 +252,13 @@ impl TestBench {
         let (events_tx, events_rx) = event_channel();
         let observed_kinds = Arc::new(Mutex::new(Vec::<String>::new()));
 
-        // ADR-0071 phase 6: substrate boot + Log + Render passives go
-        // through `TestBenchChassis::build_passive` — the same path
-        // the binary uses. The build hands back the SubstrateBoot for
-        // io / further capability adds plus the render handles the
-        // bench's frame loop reads each tick.
+        // ADR-0071 phase 6: substrate boot + every cap goes through
+        // `TestBenchChassis::build_passive` — the same path the
+        // binary uses. Io is part of the chain when
+        // `namespace_roots` is supplied and pre-validation passes;
+        // the chassis warns and skips Io otherwise. Tests that care
+        // about io supply tempdir roots through
+        // `start_with_namespace_roots`; otherwise the bench skips Io.
         let env = TestBenchEnv {
             name: "test-bench".to_owned(),
             version: env!("CARGO_PKG_VERSION").to_owned(),
@@ -267,10 +269,11 @@ impl TestBench {
             observed_kinds: Some(Arc::clone(&observed_kinds)),
             events_tx,
             capture_queue: capture_queue.clone(),
+            namespace_roots,
         };
         let TestBenchBuild {
             passive,
-            mut boot,
+            boot,
             render_handles,
             kind_tick,
             kind_frame_stats,
@@ -283,21 +286,6 @@ impl TestBench {
         let (loopback_tx, loopback_rx) = mpsc::channel::<EngineToHub>();
         boot.outbound
             .attach_backend(Arc::new(HubProtocolBackend::new(loopback_tx)));
-
-        // Io cap booted post-build via `SubstrateBoot::add_actor` so
-        // adapter init failures (no writable default roots, missing
-        // env, etc.) warn-and-skip rather than failing the harness.
-        // Tests that care about io supply tempdir roots through
-        // `start_with_namespace_roots`; otherwise the bench skips Io.
-        if let Some(roots) = namespace_roots
-            && let Err(e) = boot.add_actor::<FsCapability>(roots)
-        {
-            tracing::warn!(
-                target: "aether_substrate::fs",
-                error = %e,
-                "io cap boot failed in TestBench (expected on systems without writable default roots)",
-            );
-        }
 
         let gpu = Gpu::new(width, height, render_handles.clone());
 

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -12,9 +12,9 @@ use std::sync::{Arc, Mutex};
 
 use crate::hub::HubClient;
 use aether_capabilities::{
-    BroadcastCapability, CaptureBackend, HandleCapability, HeadlessWindowCapability,
+    BroadcastCapability, CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability,
     InputCapability, InputConfig, LogCapability, RenderCapability, RenderConfig, RenderHandles,
-    TcpCapability,
+    TcpCapability, fs::NamespaceRoots,
 };
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
@@ -98,6 +98,15 @@ pub struct TestBenchEnv {
     /// embedder's frame loop drains it on each `RedrawRequested`-
     /// equivalent step.
     pub capture_queue: CaptureQueue,
+    /// Optional `aether.fs` roots. When `Some`, the chassis
+    /// pre-validates the roots via [`NamespaceRoots::ensure_dirs`]
+    /// and chains `with_actor::<FsCapability>(roots)` into the
+    /// builder. If pre-validation fails (e.g. a save root that
+    /// points at a regular file), the chassis warns and skips the
+    /// fs cap rather than aborting the whole boot — matches the
+    /// pre-issue-673 silent-skip semantics. When `None`, fs is not
+    /// booted at all.
+    pub namespace_roots: Option<NamespaceRoots>,
 }
 
 /// Output of [`TestBenchChassis::build_passive`]. Bundles the
@@ -147,6 +156,7 @@ impl TestBenchChassis {
             observed_kinds,
             events_tx,
             capture_queue,
+            namespace_roots,
         } = env;
 
         let boot = SubstrateBoot::builder(&name, &version).build()?;
@@ -195,7 +205,33 @@ impl TestBenchChassis {
             input_subscribers: Arc::clone(&boot.input_subscribers),
         };
 
-        let passive =
+        // Pre-validate fs roots if supplied. Pre-validation
+        // mirrors what `LocalFileAdapter::new` does inside
+        // `FsCapability::init`: create_dir_all + canonicalize each
+        // root. If validation succeeds, chain `with_actor`. If it
+        // fails (e.g. save root pointing at a regular file on a CI
+        // machine without writable defaults), warn and skip the fs cap —
+        // the chassis still boots, components addressing
+        // `aether.fs` see "unknown mailbox" mail-drops. Pre-issue-673
+        // this was a post-build `boot.add_actor::<FsCapability>` call
+        // with the same silent-skip semantics; the new shape moves
+        // the validation up so all caps go through one boot path.
+        let io_roots = match namespace_roots {
+            Some(roots) => match roots.ensure_dirs() {
+                Ok(()) => Some(roots),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::fs",
+                        error = %e,
+                        "io cap boot skipped in TestBench (root pre-validation failed; expected on systems without writable default roots)",
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let mut builder =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
                 .with_actor::<BroadcastCapability>(())
                 .with_actor::<HandleCapability>(())
@@ -205,9 +241,11 @@ impl TestBenchChassis {
                 .with_actor::<TcpCapability>(())
                 .with_actor::<RenderCapability>(render_config)
                 .with_actor::<HeadlessWindowCapability>(())
-                .with_actor::<TestBenchCapability>(test_bench_cap_config)
-                .with_log_drain::<LogCapability>()
-                .build_passive()?;
+                .with_actor::<TestBenchCapability>(test_bench_cap_config);
+        if let Some(roots) = io_roots {
+            builder = builder.with_actor::<FsCapability>(roots);
+        }
+        let passive = builder.with_log_drain::<LogCapability>().build_passive()?;
 
         // Issue 629 / Phase A: render publishes its `RenderHandles`
         // bundle on the chassis's `ExportedHandles` map during `init`.


### PR DESCRIPTION
## Summary

Phase 2 of issue 673: move `FsCapability` from the post-build `SubstrateBoot.add_actor` path onto the chassis `Builder`, with pre-validation gating whether fs chains in. After this PR, no caller of `SubstrateBoot::add_actor` remains, clearing the way for Phase 3 to delete that surface plus `ChassisBuilder` / `BootedChassis` / `boot_native_actor`.

Rebased onto current main post-PRs 676 + 677 (the `IoCapability` / `IoError` / `IoResult` rename to `Fs*`), so this PR speaks the renamed types throughout.

## What changed

- **`NamespaceRoots::ensure_dirs()`** (new): the same `create_dir_all` + `canonicalize` sequence `LocalFileAdapter::new` runs inside `FsCapability::init`, exposed publicly so embedders can validate pre-build.
- **`TestBenchEnv::namespace_roots: Option<NamespaceRoots>`** (new field): the chassis env carries the optional fs config alongside everything else.
- **`TestBenchChassis::build_passive`**: pre-validates roots when supplied. On Ok, chains `.with_actor::<FsCapability>(roots)` into the builder. On Err, warns and skips the fs cap — preserves the silent-skip semantics for systems without writable default roots. When `None`, fs is not booted at all.
- **`bin/test-bench.rs`**: passes `namespace_roots` through `TestBenchEnv`, drops the post-build `boot.add_actor::<FsCapability>(namespace_roots)?` line. Behavior shift: previously the binary failed-fast on init failure; now it warns and continues (consistent with the in-process bench).
- **`bench.rs::start_inner`**: passes `namespace_roots` through `TestBenchEnv`, drops the post-build add block.

## Behavior changes

- `bin/test-bench.rs` now warns + skips fs on root pre-validation failure rather than aborting `main()`. Aligns with the in-process bench. Tests on dev environments without writable defaults degrade gracefully; tests that need fs see "unknown mailbox" mail-drops.
- The four `test_bench_scenario::io_*` tests still exercise fs through the new path — they pass tempdir roots which validate cleanly.

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` 1016/1016 pass — including the four `io_*` test_bench_scenario tests that exercise fs end-to-end through the new path
- [x] `aether-capabilities/src/fs.rs::cap_init_fails_when_adapter_init_fails` continues to pass (pre-validation catches the same regular-file-as-save-root case `LocalFileAdapter::new` does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)