### PR TITLE
refactor(capabilities): rename IoCapability to FsCapability

### DIFF
--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -1,8 +1,8 @@
 //! `aether.fs` cap. Owns the full ADR-0041 stack — `FileAdapter` trait,
 //! `LocalFileAdapter`, `AdapterRegistry`, env-driven `NamespaceRoots`,
-//! and the [`IoCapability`] itself. Chassis mains resolve a
+//! and the [`FsCapability`] itself. Chassis mains resolve a
 //! [`NamespaceRoots`] (typically via [`NamespaceRoots::from_env`]) and
-//! pass it through `with_actor::<IoCapability>(roots)` — `init` builds
+//! pass it through `with_actor::<FsCapability>(roots)` — `init` builds
 //! the adapter registry and returns `BootError` on failure (per
 //! ADR-0063 fail-fast).
 //!
@@ -308,15 +308,15 @@ mod native {
     /// routes envelopes through the macro-emitted `NativeDispatch` impl;
     /// replies route via `ctx.reply(&result)` through the substrate's
     /// `Mailer::send_reply`.
-    pub struct IoCapability {
+    pub struct FsCapability {
         registry: Arc<AdapterRegistry>,
     }
 
     #[actor]
-    impl NativeActor for IoCapability {
+    impl NativeActor for FsCapability {
         /// Resolved namespace roots threaded through to `init`. Chassis
         /// mains build this via [`NamespaceRoots::from_env`] (or hand-roll
-        /// for tests) and pass to `with_actor::<IoCapability>(roots)`.
+        /// for tests) and pass to `with_actor::<FsCapability>(roots)`.
         type Config = NamespaceRoots;
 
         /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
@@ -457,9 +457,9 @@ mod native {
     }
 
     #[cfg(test)]
-    impl IoCapability {
+    impl FsCapability {
         /// Test-only direct constructor. Production boots through
-        /// `Builder::with_actor::<IoCapability>(roots)` which calls `init`;
+        /// `Builder::with_actor::<FsCapability>(roots)` which calls `init`;
         /// tests that want to drive handlers without spinning up a full
         /// chassis hand a pre-built registry directly.
         pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
@@ -475,7 +475,7 @@ mod native {
             AdapterRegistry, Delete, FileAdapter, IoError, List, LocalFileAdapter, NamespaceRoots,
             Read, Write,
         };
-        use super::{Arc, IoCapability, Path, PathBuf};
+        use super::{Arc, FsCapability, Path, PathBuf};
         use aether_actor::Actor;
         use aether_data::MailboxId;
         use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
@@ -501,7 +501,7 @@ mod native {
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.
         struct TestFixture {
-            cap: IoCapability,
+            cap: FsCapability,
             rx: std::sync::mpsc::Receiver<EgressEvent>,
             transport: NativeBinding,
         }
@@ -511,7 +511,7 @@ mod native {
                 let (mailer, rx) = test_mailer_and_rx();
                 let transport = NativeBinding::new_for_test(mailer, MailboxId(0));
                 Self {
-                    cap: IoCapability::from_registry(reg),
+                    cap: FsCapability::from_registry(reg),
                     rx,
                     transport,
                 }
@@ -776,11 +776,11 @@ mod native {
             let root = scratch_root("boots");
             let (registry, mailer) = fresh_substrate();
             let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<IoCapability>(roots_under(&root))
+                .with_actor::<FsCapability>(roots_under(&root))
                 .build_passive()
                 .expect("io capability boots");
             assert!(
-                registry.lookup(IoCapability::NAMESPACE).is_some(),
+                registry.lookup(FsCapability::NAMESPACE).is_some(),
                 "io mailbox registered"
             );
             drop(chassis);
@@ -806,7 +806,7 @@ mod native {
 
             let (registry, mailer) = fresh_substrate();
             let result = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<IoCapability>(roots)
+                .with_actor::<FsCapability>(roots)
                 .build_passive();
             assert!(result.is_err(), "save root being a file must fail cap init");
             cleanup(&root);
@@ -818,16 +818,16 @@ mod native {
         fn duplicate_claim_rejects_with_typed_error() {
             let root = scratch_root("collide");
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(IoCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(FsCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<IoCapability>(roots_under(&root))
+                .with_actor::<FsCapability>(roots_under(&root))
                 .build_passive()
                 .expect_err("collision must surface as BootError");
             assert!(matches!(
                 err,
                 BootError::MailboxAlreadyClaimed { ref name }
-                    if name == IoCapability::NAMESPACE
+                    if name == FsCapability::NAMESPACE
             ));
             cleanup(&root);
         }

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -59,7 +59,7 @@ pub use input::InputCapability;
 #[cfg(not(target_arch = "wasm32"))]
 pub use input::InputConfig;
 
-pub use fs::IoCapability;
+pub use fs::FsCapability;
 pub use log::LogCapability;
 #[cfg(feature = "render")]
 pub use render::HeadlessRenderCapability;

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -32,7 +32,7 @@
 //!    `"aether.render"`.
 
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
-use aether_capabilities::{IoCapability, RenderCapability};
+use aether_capabilities::{FsCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Read, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
@@ -112,7 +112,7 @@ impl FfiActor for MeshViewer {
             path = %msg.path,
             "load requested; issuing read",
         );
-        ctx.actor::<IoCapability>().send(&Read {
+        ctx.actor::<FsCapability>().send(&Read {
             namespace: msg.namespace,
             path: msg.path,
         });

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use aether_capabilities::IoCapability;
+use aether_capabilities::FsCapability;
 use aether_data::{Kind, encode_empty};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
 use aether_substrate::{
@@ -90,7 +90,7 @@ fn main() -> anyhow::Result<()> {
     // Io cap on the `boot.add_actor` path — the binary fails fast on
     // adapter init failure (the in-process API silent-skips for
     // systems without writable default roots).
-    boot.add_actor::<IoCapability>(namespace_roots)?;
+    boot.add_actor::<FsCapability>(namespace_roots)?;
 
     let (width, height) = parse_size_env();
     let gpu = Gpu::new(width, height, render_handles.clone());

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 
 use aether_capabilities::{
     AudioCapability, BroadcastCapability, CaptureBackend, ComponentHostCapability,
-    ComponentHostConfig, HandleCapability, HttpCapability, InputCapability, InputConfig,
-    IoCapability, LogCapability, RenderCapability, RenderConfig, TcpCapability,
+    ComponentHostConfig, FsCapability, HandleCapability, HttpCapability, InputCapability,
+    InputConfig, LogCapability, RenderCapability, RenderConfig, TcpCapability,
     UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf, fs::NamespaceRoots,
     http::HttpConfig as HttpConf,
 };
@@ -234,7 +234,7 @@ impl DesktopChassis {
             .with_actor::<LogCapability>(())
             .with_actor::<InputCapability>(input_config)
             .with_actor::<ComponentHostCapability>(component_host_config)
-            .with_actor::<IoCapability>(namespace_roots)
+            .with_actor::<FsCapability>(namespace_roots)
             .with_actor::<HttpCapability>(http)
             .with_actor::<TcpCapability>(())
             .with_actor::<AudioCapability>(audio)

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -6,7 +6,7 @@
 //! `AETHER_WINDOW_MODE` parser. Wraps everything in a
 //! [`DesktopDriverCapability`] so [`crate::chassis::DesktopChassis`]
 //! composes one driver alongside its passive capabilities
-//! (LogCapability, IoCapability, HttpCapability, AudioCapability,
+//! (LogCapability, FsCapability, HttpCapability, AudioCapability,
 //! RenderCapability — composed via `chassis_builder::Builder::with`
 //! per ADR-0071 phase B).
 //!

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_capabilities::{
-    BroadcastCapability, ComponentHostCapability, ComponentHostConfig, HandleCapability,
-    HeadlessRenderCapability, HeadlessWindowCapability, HttpCapability, InputCapability,
-    InputConfig, IoCapability, LogCapability, TcpCapability, UnsupportedTestBenchCapability,
+    BroadcastCapability, ComponentHostCapability, ComponentHostConfig, FsCapability,
+    HandleCapability, HeadlessRenderCapability, HeadlessWindowCapability, HttpCapability,
+    InputCapability, InputConfig, LogCapability, TcpCapability, UnsupportedTestBenchCapability,
     fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
 use aether_data::{Kind, KindId};
@@ -182,7 +182,7 @@ impl HeadlessChassis {
             .with_actor::<LogCapability>(())
             .with_actor::<InputCapability>(input_config)
             .with_actor::<ComponentHostCapability>(component_host_config)
-            .with_actor::<IoCapability>(namespace_roots)
+            .with_actor::<FsCapability>(namespace_roots)
             .with_actor::<HttpCapability>(http)
             .with_actor::<TcpCapability>(())
             .with_actor::<HeadlessRenderCapability>(())

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -31,7 +31,7 @@ use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, Tic
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use crate::hub::HubProtocolBackend;
 use aether_actor::Actor;
-use aether_capabilities::{IoCapability, RenderCapability, fs::NamespaceRoots};
+use aether_capabilities::{FsCapability, RenderCapability, fs::NamespaceRoots};
 use aether_substrate::{
     HubOutbound, InputSubscribers, Mailer, PassiveChassis, ReplyTarget, ReplyTo, SubstrateBoot,
     capture::CaptureQueue,
@@ -290,7 +290,7 @@ impl TestBench {
         // Tests that care about io supply tempdir roots through
         // `start_with_namespace_roots`; otherwise the bench skips Io.
         if let Some(roots) = namespace_roots
-            && let Err(e) = boot.add_actor::<IoCapability>(roots)
+            && let Err(e) = boot.add_actor::<FsCapability>(roots)
         {
             tracing::warn!(
                 target: "aether_substrate::io",
@@ -537,7 +537,7 @@ impl TestBench {
     /// fully drains the queue and processes any pending events.
     /// Quiet iterations (no events surfaced, no reply on loopback)
     /// sleep briefly to give ADR-0070 capability dispatcher threads
-    /// time to wake up — `IoCapability` and friends poll their mpsc
+    /// time to wake up — `FsCapability` and friends poll their mpsc
     /// receivers on a 100ms `recv_timeout`, so without this sleep a
     /// capability-mediated reply (e.g. `aether.fs.write` →
     /// `WriteResult`) can't beat the bail-out check.

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -3,7 +3,7 @@
 //! subscription, drop, capture_frame round-trip, replace_component
 //! (all via `aether-test-fixture-probe`), or the IO sink's
 //! read/write/delete/list round trips (which talk directly to the
-//! chassis `aether.io` via `TestBench::send_and_await_reply`).
+//! chassis `aether.fs` via `TestBench::send_and_await_reply`).
 //!
 //! Skipped when:
 //! - No wgpu adapter is available (driverless Linux runners without

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -1258,7 +1258,7 @@ impl BootedChassis {
     /// Used by chassis mains to compose chassis-conditional
     /// capabilities on top of the universal capabilities
     /// `SubstrateBoot::build` already installed (today: the bundle
-    /// hooks `IoCapability` here in TestBench because adapter init
+    /// hooks `FsCapability` here in TestBench because adapter init
     /// can fail silently on systems without writable default roots).
     /// Boots run in call order; shutdown tears down in reverse,
     /// exactly like the build-time path.


### PR DESCRIPTION
## Summary

Aligns the type name with the post-issue-633 mailbox rename. The mailbox flipped `aether.io` to `aether.fs` to match `std::fs` muscle memory and disambiguate from the network IO sinks (`aether.tcp`, `aether.http`); the cap struct kept the legacy `Io` prefix as residue from when the file was `io.rs`. This PR closes that drift.

`IoError` and `IoResult<T>` (live in `aether-kinds` and the adapter layer) are wire-adjacent and keep their names for now — renaming them touches the SDK kinds catalogue and is a separate scope.

## Files touched

10 files, mechanical rename:

- `crates/aether-capabilities/src/fs.rs` (cap definition + impl, 16 sites)
- `crates/aether-capabilities/src/lib.rs` (re-export)
- `crates/aether-mesh-viewer/src/runtime.rs` (consumer)
- `crates/aether-substrate/src/chassis/ctx.rs` (doc comment)
- `crates/aether-substrate-bundle/src/desktop/{chassis,driver}.rs`
- `crates/aether-substrate-bundle/src/headless/chassis.rs`
- `crates/aether-substrate-bundle/src/test_bench/bench.rs`
- `crates/aether-substrate-bundle/src/bin/test-bench.rs`
- `crates/aether-substrate-bundle/tests/test_bench_scenario.rs` (one stale `aether.io` doc-comment fixed alongside)

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` 1016/1016 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)