### PR TITLE
refactor(substrate): extract shared dispatch_loop_run helper

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -1,0 +1,157 @@
+//! Shared dispatcher loop for native actors (issue 672).
+//!
+//! `dispatch_loop_run<A>` is the body every native-actor dispatcher
+//! thread runs. Singleton boots through `chassis::builder` and
+//! instanced spawns through `actor::native::spawn` both call into
+//! this — eliminating the historical divergence where instanced
+//! actors lacked the `local::with_stamped` + `log_install::with_actor_dispatch`
+//! wrapping the singleton path had.
+//!
+//! ## Lifecycle
+//!
+//! 1. **Outer loop.** Polls `binding.should_shutdown()` (set by
+//!    `NativeCtx::shutdown`), then `binding.recv_blocking()`. Either
+//!    signal exits the loop.
+//! 2. **Per-envelope dispatch.** Each envelope runs inside
+//!    `local::with_stamped(slots, ...)` so the per-actor `ActorSlots`
+//!    are visible to `Local<T>` lookups, and inside
+//!    `log_install::with_actor_dispatch(binding, ...)` so the actor-
+//!    aware `tracing` layer attributes events with the actor's
+//!    `MailboxId` and the priority-flush + post-handler drain ship a
+//!    `LogBatch` to `LogCapability`. Two-step typed → fallback dispatch.
+//! 3. **Drain after shutdown.** Any envelope already in the inbox
+//!    when the shutdown signal fired is processed synchronously
+//!    before `on_close` runs (matches the existing singleton
+//!    semantics).
+//! 4. **`on_close`.** Last-chance hook with `ReplyTo::NONE`. Wrapped
+//!    in the same `with_stamped` + `with_actor_dispatch` so any
+//!    final tracing or `Local<T>` access works.
+//! 5. **Registry close + monitor fan-out.** `actor_registry.close_actor(id)`
+//!    drains `monitors_of[id]`, prunes `monitoring[id]` from each
+//!    target, marks the slot Dead. Returned watchers receive a
+//!    `MonitorNotice` mail through the supplied `Mailer`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use aether_actor::local::ActorSlots;
+
+use crate::actor::native::binding::NativeBinding;
+use crate::actor::native::ctx::NativeCtx;
+use crate::actor::native::{NativeActor, NativeDispatch};
+use crate::actor::registry::ActorRegistry;
+use crate::mail::mailer::Mailer;
+use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
+
+/// Run one actor's dispatcher loop on the calling thread. Returns
+/// when the binding signals shutdown (self-shutdown flag set or
+/// inbox sender disconnected). See module doc-comment for the full
+/// lifecycle.
+///
+/// `pending` is decremented after every dispatched envelope when
+/// `Some` — singletons pass it for `FRAME_BARRIER` caps (the chassis
+/// frame-loop drain barrier reads it); instanced actors pass their
+/// per-actor counter (`Spawner::wait_instanced_quiesce` reads it).
+pub(crate) fn dispatch_loop_run<A>(
+    binding: &Arc<NativeBinding>,
+    actor: &mut Box<A>,
+    slots: &ActorSlots,
+    pending: Option<&Arc<AtomicU64>>,
+    actor_registry: &Arc<ActorRegistry>,
+    mailer: &Arc<Mailer>,
+    self_id: MailboxId,
+) where
+    A: NativeActor + NativeDispatch,
+{
+    // Phase 1: main dispatch loop.
+    loop {
+        if binding.should_shutdown() {
+            break;
+        }
+        let env = match binding.recv_blocking() {
+            Some(e) => e,
+            None => break,
+        };
+        aether_actor::local::with_stamped(slots, || {
+            crate::runtime::log_install::with_actor_dispatch(
+                &**binding as &dyn crate::runtime::log_install::MailDispatch,
+                || {
+                    let mut ctx = NativeCtx::new(binding, env.sender);
+                    if actor
+                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
+                        .is_none()
+                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)
+                    {
+                        // Issue 576: catch-all caps override
+                        // `__aether_dispatch_fallback` and return
+                        // `true` after their fallback runs,
+                        // suppressing this warn. Strict receivers
+                        // keep the default (returns `false`) and
+                        // surface the miss.
+                        tracing::warn!(
+                            target: "aether_substrate::dispatch",
+                            actor = A::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "actor dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                    aether_actor::log::drain_buffer();
+                },
+            );
+        });
+        if let Some(p) = pending {
+            p.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    // Phase 2: drain remaining inbox synchronously. The shutdown
+    // flag / disconnect raced against any in-flight mail the sink
+    // handler already pushed; the actor sees it before `on_close`
+    // runs so a "please close" handler that flushes state observes
+    // the full inbox.
+    while let Some(env) = binding.try_recv() {
+        aether_actor::local::with_stamped(slots, || {
+            crate::runtime::log_install::with_actor_dispatch(
+                &**binding as &dyn crate::runtime::log_install::MailDispatch,
+                || {
+                    let mut ctx = NativeCtx::new(binding, env.sender);
+                    let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
+                    aether_actor::log::drain_buffer();
+                },
+            );
+        });
+        if let Some(p) = pending {
+            p.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    // Phase 3: last-chance close hook. ReplyTo is None — no inbound
+    // envelope produced this call.
+    aether_actor::local::with_stamped(slots, || {
+        crate::runtime::log_install::with_actor_dispatch(
+            &**binding as &dyn crate::runtime::log_install::MailDispatch,
+            || {
+                let mut close_ctx = NativeCtx::new(binding, ReplyTo::NONE);
+                actor.on_close(&mut close_ctx);
+                aether_actor::log::drain_buffer();
+            },
+        );
+    });
+
+    // Phase 4: close in the registry — drains `monitors_of[id]` for
+    // fan-out, prunes `monitoring[id]` from each watched target,
+    // marks Dead + tombstones the id. Singletons today don't sit in
+    // `actors` as `Live`, so the slot transition is purely sentinel;
+    // the reverse-prune is the load-bearing step. Instanced actors
+    // do sit Live and transition Live → Dead here.
+    let watchers = actor_registry.close_actor(self_id);
+    if !watchers.is_empty() {
+        let notice = aether_kinds::MonitorNotice { target: self_id };
+        let payload =
+            <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(&notice);
+        let kind = KindId(<aether_kinds::MonitorNotice as aether_data::Kind>::ID.0);
+        for watcher in watchers {
+            mailer.push(Mail::new(watcher, kind, payload.clone(), 1));
+        }
+    }
+}

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -64,6 +64,7 @@
 
 pub mod binding;
 pub mod ctx;
+pub(crate) mod dispatch;
 pub mod envelope;
 pub mod mailbox;
 pub mod spawn;

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -234,6 +234,15 @@ impl Spawner {
         ));
         transport.install_inbox(rx);
 
+        // Per-actor scratch storage (issue 582 / ADR-0074). Stamped
+        // into TLS via `local::with_stamped` for the duration of
+        // `init` and each handler dispatch so library code inside
+        // the actor (e.g., the issue-581 log buffer, `Local<T>`
+        // slots) can reach `Local::with_mut` without threading a
+        // ctx through. Mirrors the singleton path in
+        // `chassis::builder::make_native_actor_boot` (issue 672).
+        let slots = Box::new(aether_actor::local::ActorSlots::new());
+
         let actor = {
             // Instanced actors don't publish driver-facing sub-handles
             // today — Phase 4+ may revisit. Pass a throwaway
@@ -242,7 +251,23 @@ impl Spawner {
             let mut throwaway_handles = crate::ExportedHandles::new();
             let mut init_ctx =
                 NativeInitCtx::new(&transport, &mut throwaway_handles, Arc::clone(&self.mailer));
-            match A::init(config, &mut init_ctx) {
+            // Issue 581: wrap `init` in `with_stamped` +
+            // `with_actor_dispatch` so any `tracing::*` event the
+            // actor fires during boot drains to LogCapability with
+            // sender attribution when init returns. Singletons get
+            // this through `make_native_actor_boot`; instanced
+            // actors join the pattern in issue 672.
+            let init_result = aether_actor::local::with_stamped(&slots, || {
+                crate::runtime::log_install::with_actor_dispatch(
+                    &*transport as &dyn crate::runtime::log_install::MailDispatch,
+                    || {
+                        let r = A::init(config, &mut init_ctx);
+                        aether_actor::log::drain_buffer();
+                        r
+                    },
+                )
+            });
+            match init_result {
                 Ok(a) => a,
                 Err(e) => return Err(SpawnError::InitFailed(e)),
             }
@@ -375,14 +400,14 @@ impl Spawner {
             .unwrap()
             .push((id, Arc::clone(&pending)));
 
-        // 8. Spawn dispatcher thread, move actor in. Mirrors the
-        // existing `boot_native_actor` shape minus the frame-bound
-        // pending-counter decrement (instanced actors are
-        // free-running per the comment above).
-        //
-        // Issue 629 / Phase A: the dispatcher takes the Box<A> by
-        // move — the actor is owned exclusively by this thread for
-        // its lifetime; no Arc share with the chassis or registry.
+        // 8. Spawn dispatcher thread, move actor + slots in.
+        // Issue 672: delegates to the shared `dispatch_loop_run`
+        // helper — same loop body the singleton path uses, with
+        // `local::with_stamped` + `log_install::with_actor_dispatch`
+        // wrapping every dispatch, drain, and `on_close`. Issue 629 /
+        // Phase A: the dispatcher takes the Box<A> by move — the
+        // actor is owned exclusively by this thread for its lifetime;
+        // no Arc share with the chassis or registry.
         let transport_for_thread = Arc::clone(&transport);
         let actor_registry_for_thread = Arc::clone(&self.actor_registry);
         let mailer_for_thread = Arc::clone(&self.mailer);
@@ -395,109 +420,15 @@ impl Spawner {
         let _ = std::thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                // Issue 607 Phase 4a (ADR-0079): the dispatcher loop
-                // observes two shutdown signals: the self-shutdown
-                // flag (set by `NativeCtx::shutdown`) checked after
-                // each handler return, and channel-disconnect
-                // (substrate shutdown — registry dropped, sender
-                // gone) signalled by `recv_blocking` returning None.
-                // Both flow through the same drain → on_close → exit
-                // path below.
-                loop {
-                    if transport_for_thread.should_shutdown() {
-                        break;
-                    }
-                    let env = match transport_for_thread.recv_blocking() {
-                        Some(e) => e,
-                        None => break,
-                    };
-                    let mut native_ctx =
-                        crate::actor::native::ctx::NativeCtx::new(&transport_for_thread, env.sender);
-                    // Issue 634 Phase 4: trampolines are instanced
-                    // actors that route every un-typed kind through
-                    // `#[fallback]` to the wasm guest. Mirror the
-                    // chassis_builder singleton dispatcher's two-step
-                    // (typed → fallback) so the fallback override
-                    // takes effect.
-                    if actor
-                        .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
-                        .is_none()
-                        && !actor.__aether_dispatch_fallback(&mut native_ctx, &env)
-                    {
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            actor = A::NAMESPACE,
-                            kind = env.kind_name.as_str(),
-                            "instanced actor dispatch missed: kind not handled or decode failed"
-                        );
-                    }
-                    pending_for_thread.fetch_sub(1, Ordering::AcqRel);
-                }
-
-                // Drain remaining mail synchronously. The flag/disconnect
-                // raced against any in-flight mail the sink handler
-                // already pushed; the actor sees it before `on_close`
-                // runs so a "please close" handler that flushes state
-                // observes the full inbox.
-                while let Some(env) = transport_for_thread.try_recv() {
-                    let mut native_ctx =
-                        crate::actor::native::ctx::NativeCtx::new(&transport_for_thread, env.sender);
-                    if actor
-                        .__aether_dispatch_envelope(&mut native_ctx, env.kind, &env.payload)
-                        .is_none()
-                        && !actor.__aether_dispatch_fallback(&mut native_ctx, &env)
-                    {
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            actor = A::NAMESPACE,
-                            kind = env.kind_name.as_str(),
-                            "instanced actor drain dispatch missed: kind not handled or decode failed"
-                        );
-                    }
-                    pending_for_thread.fetch_sub(1, Ordering::AcqRel);
-                }
-
-                // Last-chance close hook. ReplyTo is None because no
-                // inbound envelope produced this call.
-                let mut close_ctx = crate::actor::native::ctx::NativeCtx::new(
+                crate::actor::native::dispatch::dispatch_loop_run::<A>(
                     &transport_for_thread,
-                    crate::mail::ReplyTo::NONE,
+                    &mut actor,
+                    &slots,
+                    Some(&pending_for_thread),
+                    &actor_registry_for_thread,
+                    &mailer_for_thread,
+                    id,
                 );
-                actor.on_close(&mut close_ctx);
-
-                // Issue 607 Phase 4b (ADR-0079): close path. Drain
-                // monitors_of[id] for fan-out, prune monitoring[id]
-                // from each target's forward list, then mark Dead +
-                // tombstone. `close_actor` runs all three steps under
-                // its own locks; we fan out the returned watcher list
-                // here so the MonitorNotice mails ride the substrate's
-                // ordinary `Mailer::push` path (sinks dispatch on the
-                // calling thread; component recipients route through
-                // the supervisor).
-                let watchers = actor_registry_for_thread.close_actor(id);
-                if !watchers.is_empty() {
-                    let notice = aether_kinds::MonitorNotice { target: id };
-                    let payload =
-                        <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(
-                            &notice,
-                        );
-                    let kind = crate::mail::KindId(
-                        <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0,
-                    );
-                    for watcher in watchers {
-                        mailer_for_thread.push(crate::mail::Mail::new(
-                            watcher,
-                            kind,
-                            payload.clone(),
-                            1,
-                        ));
-                    }
-                }
-
-                // actor (Box) and transport_for_thread drop here on
-                // thread exit. The chassis-stored sender was already
-                // dropped when `close_actor`'s `mark_dead` flipped the
-                // entry from Live to Dead.
             })
             .expect("dispatcher thread spawn must succeed");
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -26,9 +26,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
 use crate::actor::native::binding::NativeBinding;
-use crate::actor::native::{
-    ExportedHandles, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx,
-};
+use crate::actor::native::{ExportedHandles, NativeActor, NativeDispatch, NativeInitCtx};
 use crate::chassis::Chassis;
 use crate::chassis::ctx::{ChassisCtx, FacadeHandle, FallbackRouter, MailboxClaim};
 use crate::chassis::error::BootError;
@@ -421,12 +419,10 @@ where
 
         // Spawn the dispatcher thread. The thread owns the Box<A>,
         // an Arc<NativeBinding>, and the per-actor `ActorSlots`
-        // (moved in by value); it loops `recv_blocking()` on the
-        // transport (which pulls from the installed inbox and
-        // disconnects when the chassis drops its `mailbox_sender`) and
-        // routes each envelope through `__aether_dispatch_envelope`,
-        // wrapped in `local::with_stamped` so handler bodies
-        // see the per-actor storage.
+        // (moved in by value); it delegates to the shared
+        // `dispatch_loop_run` helper (issue 672) which runs the
+        // outer loop, drain, on_close, and registry close-actor
+        // sequence — same shape the instanced path uses.
         let transport_for_thread = Arc::clone(&transport);
         let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
         let mailer_for_thread = ctx.mail_send_handle();
@@ -435,133 +431,15 @@ where
         let thread = std::thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                // Issue 607 Phase 4a (ADR-0079): the singleton
-                // dispatcher polls the self-shutdown flag the same
-                // way the instanced dispatcher does in `spawn.rs`.
-                // Channel-disconnect is the chassis-shutdown path;
-                // both flow through the same drain → on_close → exit
-                // sequence below. Singletons don't tombstone (their
-                // mailbox slot stays in `Registry`); the chassis's
-                // `BootedPassives::shutdown_in_place` reverse-drops
-                // the MailboxSender to fully disconnect the sink.
-                loop {
-                    if transport_for_thread.should_shutdown() {
-                        break;
-                    }
-                    let env = match transport_for_thread.recv_blocking() {
-                        Some(e) => e,
-                        None => break,
-                    };
-                    aether_actor::local::with_stamped(&slots, || {
-                        // Issue #581: stamp the actor's transport as
-                        // the in-actor `MailDispatch` so the actor-
-                        // aware tracing layer's priority flush + the
-                        // post-handler drain hook ship `LogBatch`
-                        // mail with sender attribution.
-                        crate::runtime::log_install::with_actor_dispatch(
-                            &*transport_for_thread as &dyn crate::runtime::log_install::MailDispatch,
-                            || {
-                                let mut ctx =
-                                    NativeCtx::new(&transport_for_thread, env.sender);
-                                if actor
-                                    .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
-                                    .is_none()
-                                    && !actor
-                                        .__aether_dispatch_fallback(&mut ctx, &env)
-                                {
-                                    // Issue 576: catch-all caps override
-                                    // `__aether_dispatch_fallback` and return
-                                    // `true` after their fallback runs,
-                                    // suppressing this warn. Strict receivers
-                                    // keep the default (returns `false`) and
-                                    // surface the miss.
-                                    tracing::warn!(
-                                        target: "aether_substrate::chassis_builder",
-                                        actor = A::NAMESPACE,
-                                        kind = env.kind_name.as_str(),
-                                        "native actor dispatch missed: kind not handled or decode failed"
-                                    );
-                                }
-                                aether_actor::log::drain_buffer();
-                            },
-                        );
-                    });
-                    // Decrement matches the sink-handler's increment —
-                    // the chassis frame-bound drain barrier
-                    // (`drain_frame_bound_or_abort`) reads this counter
-                    // to know when the dispatcher is caught up.
-                    if let Some(p) = &pending {
-                        p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
-                    }
-                }
-                // Drain remaining inbox synchronously so any in-flight
-                // mail dispatched during the shutdown signal is
-                // observed before `on_close` runs.
-                while let Some(env) = transport_for_thread.try_recv() {
-                    aether_actor::local::with_stamped(&slots, || {
-                        crate::runtime::log_install::with_actor_dispatch(
-                            &*transport_for_thread as &dyn crate::runtime::log_install::MailDispatch,
-                            || {
-                                let mut ctx =
-                                    NativeCtx::new(&transport_for_thread, env.sender);
-                                let _ = actor
-                                    .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
-                                aether_actor::log::drain_buffer();
-                            },
-                        );
-                    });
-                    if let Some(p) = &pending {
-                        p.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
-                    }
-                }
-                // Last-chance close hook. Runs whether the trigger was
-                // self-shutdown (flag) or substrate shutdown (channel
-                // disconnect). Default empty for singletons that don't
-                // need it; opt-in for caps with cleanup state.
-                aether_actor::local::with_stamped(&slots, || {
-                    crate::runtime::log_install::with_actor_dispatch(
-                        &*transport_for_thread as &dyn crate::runtime::log_install::MailDispatch,
-                        || {
-                            let mut close_ctx = NativeCtx::new(
-                                &transport_for_thread,
-                                crate::mail::ReplyTo::NONE,
-                            );
-                            actor.on_close(&mut close_ctx);
-                            aether_actor::log::drain_buffer();
-                        },
-                    );
-                });
-                // Issue 607 Phase 4b (ADR-0079): close the actor in
-                // the registry — drains monitors_of[id] for fan-out,
-                // walks monitoring[id] to prune the singleton from
-                // each watched target's forward index, then marks
-                // Dead + tombstones the id. Singletons today don't
-                // sit in `actors` as `Live`, so the slot transition
-                // is purely sentinel; the reverse-prune is the
-                // load-bearing step (a singleton that monitored
-                // instanced actors must not leave dangling forward
-                // refs after its dispatcher exits).
-                let watchers = actor_registry_for_thread.close_actor(self_id_for_thread);
-                if !watchers.is_empty() {
-                    let notice = aether_kinds::MonitorNotice {
-                        target: self_id_for_thread,
-                    };
-                    let payload =
-                        <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(
-                            &notice,
-                        );
-                    let kind = crate::mail::KindId(
-                        <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0,
-                    );
-                    for watcher in watchers {
-                        mailer_for_thread.push(crate::mail::Mail::new(
-                            watcher,
-                            kind,
-                            payload.clone(),
-                            1,
-                        ));
-                    }
-                }
+                crate::actor::native::dispatch::dispatch_loop_run::<A>(
+                    &transport_for_thread,
+                    &mut actor,
+                    &slots,
+                    pending.as_ref(),
+                    &actor_registry_for_thread,
+                    &mailer_for_thread,
+                    self_id_for_thread,
+                );
             })
             .map_err(|e| BootError::Other(Box::new(e)))?;
 


### PR DESCRIPTION
## Summary

Issue 672. Extract `actor::native::dispatch::dispatch_loop_run<A>` and route both surviving native-actor dispatcher loops through it. Brings instanced actors up to parity with the singleton wrapping (`local::with_stamped` + `log_install::with_actor_dispatch` + `drain_buffer`) rather than parameterising the helper to handle both shapes.

## Background

The issue body originally claimed sites 2/3/4 share an identical loop body wrapped in the singleton's `with_stamped` + `log_install` + `drain_buffer` pattern. Audit-on-implementation showed that's wrong — the instanced site (`Spawner::spawn_actor`) had a bare loop. Three real consequences:

1. Instanced actors using `tracing::*` from a handler emitted to stderr instead of routing to `LogCapability` with sender attribution. The TcpSessionActor and TcpListenerActor handlers fire `tracing::info!`; the wasm `WasmTrampoline` fires `tracing::warn!`.
2. Instanced-actor handlers couldn't use `Local<T>` (issue 582 / PR 585) — `with_stamped` is the surface that publishes `ActorSlots` into TLS, and instanced never called it.
3. The `init` call on instanced actors was bare; tracing during init didn't drain.

Issue 672's body was updated mid-implementation to reflect this drift and the choice to fix rather than paper over it.

## What changed

- **`crates/aether-substrate/src/actor/native/dispatch.rs`** (new, +157 lines) — `dispatch_loop_run<A>` runs the four-phase lifecycle: outer loop (shutdown-flag + recv + two-step typed→fallback dispatch), drain after shutdown, `on_close`, `actor_registry.close_actor` + monitor fan-out. Every phase is wrapped in `with_stamped(slots, ...)` + `with_actor_dispatch(binding, ...)`.
- **`actor/native/spawn.rs`** — `Spawner::spawn_actor` allocates `Box<ActorSlots>` at boot, wraps `init` in the same `with_stamped` + `with_actor_dispatch` shell the singleton path uses, and replaces the inline dispatcher loop with a `dispatch_loop_run` call. Pending counter wraps in `Some(&pending_for_thread)` (instanced actors always have one — the per-actor `Spawner::pending`).
- **`chassis/builder.rs`** — `make_native_actor_boot` replaces its inline loop with the same `dispatch_loop_run` call. Pending stays `Option` (only `Some` for `FRAME_BARRIER` caps).

Net diff: **+213 / -246**. Both call sites' inline loops collapse to a single helper call.

## Behavior changes (instanced actors only)

- `Local<T>` now works from instanced-actor handlers.
- `tracing::*` from instanced-actor handlers routes to `LogCapability` with sender attribution (was stderr fallback).
- `init` runs inside the same wrapping (was bare; matches the singleton path now).

## What this doesn't touch

`spawn_actor_dispatcher` (the legacy `Dispatch`-trait facade-cap path at `chassis/ctx.rs:589`) stays separate. It has zero in-tree consumers post-PR 678 — `Builder::with(cap)` is dead code in production. Retiring it is a candidate for a separate cleanup; out of scope here.

## Test plan

- [x] `cargo build --workspace --all-features` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace` 1013/1013 pass
- [x] **Instanced-actor regression coverage:** the `test_bench_scenario::replace_component_preserves_mailbox_identity`, `drop_component_silences_tick_echoes`, and `input_subscription_yields_one_tick_observed_per_advance` tests exercise the `WasmTrampoline` (an instanced actor) end-to-end through the new wrapping. They pass — confirms the upgrade didn't break trampoline lifecycle.
- [x] **MCP smoke** — spawned a headless substrate built from this branch via `spawn_substrate`, preloaded the camera wasm component, sent `aether.camera.set_active` (typed-handler path) and `aether.component.drop` (typed-handler path), then sent post-drop mail to trigger the trampoline's `#[fallback] forward_to_wasm` `tracing::warn!`. **30/30 expected warn entries observed in `engine_logs --level warn`** with target `aether_substrate::actor::wasm::trampoline` and the trampoline's exact mailbox id in the attribution — the new behavior is end-to-end live. Pre-PR-679 these warns would have only reached stderr.

Closes 672

🤖 Generated with [Claude Code](https://claude.com/claude-code)