### PR TITLE
feat(actor): add Scheduling const + mark every actor Dedicated

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -932,6 +932,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         generics,
         namespace_expr,
         frame_barrier_expr,
+        scheduling_expr,
         handler_kinds,
         catch_all,
     ) = {
@@ -988,6 +989,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         let mut has_fallback = false;
         let mut namespace_expr: Option<Expr> = None;
         let mut frame_barrier_expr: Option<Expr> = None;
+        let mut scheduling_expr: Option<Expr> = None;
         for impl_item in &actor_impl.items {
             match impl_item {
                 ImplItem::Fn(f) if f.attrs.iter().any(attr_is_handler) => {
@@ -1002,6 +1004,8 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
                         namespace_expr = Some(c.expr.clone());
                     } else if c.ident == "FRAME_BARRIER" {
                         frame_barrier_expr = Some(c.expr.clone());
+                    } else if c.ident == "SCHEDULING" {
+                        scheduling_expr = Some(c.expr.clone());
                     }
                 }
                 _ => {}
@@ -1038,6 +1042,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
             actor_impl.generics.clone(),
             namespace_expr,
             frame_barrier_expr,
+            scheduling_expr,
             handler_kinds,
             has_fallback,
         )
@@ -1060,6 +1065,21 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     //   consumers compile typed sends without the substrate runtime.
     let frame_barrier_const = frame_barrier_expr.map(|expr| {
         quote! { const FRAME_BARRIER: bool = #expr; }
+    });
+    // Self-contained emission: the bridge lifts the user's expression
+    // from inside `mod native` (where `Scheduling` is in scope via an
+    // inner-mod import) to a sibling `impl Actor` at file root (where
+    // it isn't). Wrap the expression in a block with a local `use` so
+    // the lifted expression resolves regardless of the file-root
+    // import surface — the user keeps typing `Scheduling::Dedicated`
+    // ergonomically without having to remember a second file-root use.
+    let scheduling_const = scheduling_expr.map(|expr| {
+        quote! {
+            const SCHEDULING: ::aether_actor::Scheduling = {
+                use ::aether_actor::Scheduling;
+                #expr
+            };
+        }
     });
     // When the bridge declares `feature = "X"`, the wasm stub also
     // covers "native target without the feature" so consumers that
@@ -1094,6 +1114,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
             const NAMESPACE: &'static str = #namespace_expr;
             #frame_barrier_const
+            #scheduling_const
         }
     };
     let cardinality_marker = match cardinality {
@@ -1963,7 +1984,30 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // rewrites this `#[actor]` to `#[actor(skip_markers)]` so this
     // expansion does not duplicate them. The native-only impls below
     // still emit unchanged.
-    let const_tokens = consts.iter();
+    // Wrap the `SCHEDULING` const value in a self-contained block with
+    // a local `use ::aether_actor::Scheduling`. Symmetric with the
+    // bridge path: the user types `Scheduling::Dedicated` ergonomically
+    // without needing a file-level `use aether_actor::Scheduling`
+    // import. NAMESPACE / FRAME_BARRIER pass through unchanged because
+    // their RHSes are primitives that don't require resolution.
+    let const_tokens: Vec<TokenStream2> = consts
+        .iter()
+        .map(|c| {
+            if c.ident == "SCHEDULING" {
+                let expr = &c.expr;
+                let attrs = &c.attrs;
+                quote! {
+                    #(#attrs)*
+                    const SCHEDULING: ::aether_actor::Scheduling = {
+                        use ::aether_actor::Scheduling;
+                        #expr
+                    };
+                }
+            } else {
+                quote! { #c }
+            }
+        })
+        .collect();
     let actor_impl = if opts.skip_markers || consts.is_empty() {
         quote! {}
     } else {

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -48,6 +48,40 @@ pub trait Actor: Sized + Send + 'static {
     /// drawing-side capabilities and any wasm component that wants
     /// per-frame coupling will too.
     const FRAME_BARRIER: bool = false;
+
+    /// Issue 635 dispatch placement. `Pooled` (the default) routes the
+    /// actor onto the chassis-owned worker pool — many actors drained
+    /// over a small thread set. `Dedicated` opts the actor out of pool
+    /// scheduling and back onto its own OS thread (today's behavior),
+    /// for actors that own a long-running blocking primitive their
+    /// handler must not yield from (TCP `accept`, file watch reads,
+    /// `wait_reply` parking).
+    ///
+    /// Phase 1 ships every existing actor with `SCHEDULING = Dedicated`
+    /// so the default flip in later phases is bit-identical. The
+    /// runtime branches on this const at boot — `Dedicated` actors take
+    /// the legacy `thread::spawn` path; `Pooled` actors register a
+    /// dispatcher slot with the pool. The `FRAME_BARRIER` const is
+    /// orthogonal: a frame-bound actor can be either `Pooled` or
+    /// `Dedicated`.
+    const SCHEDULING: Scheduling = Scheduling::Pooled;
+}
+
+/// Issue 635 dispatch placement (see [`Actor::SCHEDULING`]). Equality
+/// is structural — the runtime does `match A::SCHEDULING { Pooled => …,
+/// Dedicated => … }` once at boot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scheduling {
+    /// Drain the actor's inbox cooperatively on the chassis worker
+    /// pool. Default. Suitable for actors whose handlers return
+    /// promptly — drain a mail, push state, return.
+    Pooled,
+    /// Drain the actor on its own OS thread. Required for actors that
+    /// call `wait_reply` from a handler or own a runloop blocking on a
+    /// non-mail external source the chassis can't reify (TCP `accept`,
+    /// file-watch event sources). Until the ladder of caps converts
+    /// to the pool path, every shipped actor is `Dedicated`.
+    Dedicated,
 }
 
 /// Cardinality marker: only one instance of this actor can be live per

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -67,8 +67,8 @@ pub use actor::ctx::{LifecycleControl, MailSender, OutboundReply, Persistence, R
 pub use actor::sender::{MailCtx, Sender};
 pub use actor::slot::Slot;
 pub use actor::{
-    Actor, Dispatch, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Singleton,
-    validate_namespace_segment,
+    Actor, Dispatch, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Scheduling,
+    Singleton, validate_namespace_segment,
 };
 pub use local::Local;
 // Issue 665: `Mailbox<K, T>` and `ActorMailbox<'_, R, T>` retired; the

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -710,6 +710,7 @@ mod native {
 
         /// ADR-0039 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.audio";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Boot the cap. Always succeeds — cpal init failure logs a
         /// warning and falls back to nop mode (per ADR-0039: audio is a

--- a/crates/aether-capabilities/src/broadcast.rs
+++ b/crates/aether-capabilities/src/broadcast.rs
@@ -63,6 +63,7 @@ mod native {
         /// quiesced before the next observation is read off the
         /// outbound channel.
         const FRAME_BARRIER: bool = true;
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             // The substrate boot wires `HubOutbound` into the mailer

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -89,6 +89,7 @@ mod native {
     impl NativeActor for ComponentHostCapability {
         type Config = ComponentHostConfig;
         const NAMESPACE: &'static str = "aether.component";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             config: ComponentHostConfig,

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -340,6 +340,7 @@ mod native {
 
         /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.fs";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Build the adapter registry from the resolved roots. Adapter
         /// init failure surfaces as `BootError::Other(io::Error)` so

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -37,6 +37,7 @@ mod native {
         /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
         /// `aether.<name>` namespace.
         const NAMESPACE: &'static str = "aether.handle";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Pull the shared [`HandleStore`] off the substrate's
         /// [`aether_substrate::Mailer`]. The store is supplied at

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -390,6 +390,7 @@ mod native {
 
         /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.http";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Build the HTTP adapter from the resolved config. The adapter is
         /// built immediately so configuration errors surface at chassis-

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -57,6 +57,7 @@ mod native {
     impl NativeActor for InputCapability {
         type Config = InputConfig;
         const NAMESPACE: &'static str = "aether.input";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(config: InputConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let registry = Arc::clone(ctx.mailer().registry());

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -48,6 +48,7 @@ mod native {
     impl NativeActor for LogCapability {
         type Config = ();
         const NAMESPACE: &'static str = "aether.log";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned();

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -169,6 +169,7 @@ mod native {
         /// through the frame-bound path so the cap's `pending` counter
         /// registers in the chassis's `frame_bound_pending` Vec.
         const FRAME_BARRIER: bool = true;
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Allocate the accumulator state up front. Idempotent on the
         /// driver-facing side: every chassis main passes a fresh
@@ -726,6 +727,7 @@ mod native_headless {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.render";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -69,6 +69,7 @@ mod listener_native {
     impl NativeActor for TcpListenerActor {
         type Config = TcpListenerConfig;
         const NAMESPACE: &'static str = "aether.tcp.listener";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             mut config: TcpListenerConfig,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -131,6 +131,7 @@ mod cap_native {
     impl NativeActor for TcpCapability {
         type Config = ();
         const NAMESPACE: &'static str = "aether.tcp";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             Ok(Self {

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -87,6 +87,7 @@ mod session_native {
     impl NativeActor for TcpSessionActor {
         type Config = TcpSessionConfig;
         const NAMESPACE: &'static str = "aether.tcp.session";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             mut config: TcpSessionConfig,

--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -42,6 +42,7 @@ mod native {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.test_bench";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -43,6 +43,7 @@ mod native {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.window";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -114,6 +114,7 @@ mod native {
     impl NativeActor for ProcessCapability {
         type Config = ProcessCapabilityConfig;
         const NAMESPACE: &'static str = "aether.process";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             cfg: ProcessCapabilityConfig,

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -57,6 +57,7 @@ mod native {
         type Config = TestBenchCapConfig;
 
         const NAMESPACE: &'static str = "aether.test_bench";
+        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             config: TestBenchCapConfig,

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -580,6 +580,7 @@ mod tests {
 
     impl Actor for StubActor {
         const NAMESPACE: &'static str = "test.stub";
+        const SCHEDULING: aether_actor::Scheduling = aether_actor::Scheduling::Dedicated;
     }
 
     impl aether_actor::Singleton for StubActor {}

--- a/crates/aether-substrate/src/actor/wasm/trampoline.rs
+++ b/crates/aether-substrate/src/actor/wasm/trampoline.rs
@@ -139,6 +139,7 @@ pub struct WasmTrampoline {
 impl NativeActor for WasmTrampoline {
     type Config = WasmTrampolineConfig;
     const NAMESPACE: &'static str = NAMESPACE;
+    const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
     fn init(config: WasmTrampolineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
         let mailbox = ctx.self_id();


### PR DESCRIPTION
## Summary

Phase 1 PR A of iamacoffeepot/aether#635. Lands the trait shape for upcoming worker-pool dispatch — no behavior change today.

- `Scheduling { Pooled, Dedicated }` enum on `aether-actor`.
- `Actor::SCHEDULING` const, default `Pooled` (mirrors how `FRAME_BARRIER` defaults to `false` on the same trait).
- `#[actor]` macro auto-wraps the user-typed `SCHEDULING` const value in a self-contained block with a local `use ::aether_actor::Scheduling`. Two emission sites:
  - `expand_bridge` lifts the expression from `mod native` to a sibling `impl Actor` at file root — the wrap means file-root callers don't need to know about `Scheduling`.
  - `expand_native_actor_trait` does the same for direct `#[actor] impl NativeActor for X` (e.g. `WasmTrampoline`).
- Every existing `NativeActor` impl marked `SCHEDULING = Dedicated`. PR C's default flip will be bit-identical.

PR B lands the worker pool primitive in `aether-substrate::scheduler`; PR C wires `dispatch_loop_run` + `Spawner::spawn_actor` to branch on `A::SCHEDULING`. Today the const is declared but unread.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --all-features` all green

Refs iamacoffeepot/aether#635

🤖 Generated with [Claude Code](https://claude.com/claude-code)