### PR TITLE
feat(substrate): wire chassis worker pool into spawn paths

### DIFF
--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -49,22 +49,22 @@ pub trait Actor: Sized + Send + 'static {
     /// per-frame coupling will too.
     const FRAME_BARRIER: bool = false;
 
-    /// Issue 635 dispatch placement. `Pooled` (the default) routes the
-    /// actor onto the chassis-owned worker pool — many actors drained
-    /// over a small thread set. `Dedicated` opts the actor out of pool
-    /// scheduling and back onto its own OS thread (today's behavior),
-    /// for actors that own a long-running blocking primitive their
-    /// handler must not yield from (TCP `accept`, file watch reads,
-    /// `wait_reply` parking).
+    /// Issue 635 dispatch placement. `Dedicated` (today's default)
+    /// keeps the actor on its own OS thread — the legacy
+    /// `thread::spawn` path. `Pooled` registers a dispatcher slot with
+    /// the chassis worker pool so many actors share a small thread set.
     ///
     /// Phase 1 ships every existing actor with `SCHEDULING = Dedicated`
-    /// so the default flip in later phases is bit-identical. The
-    /// runtime branches on this const at boot — `Dedicated` actors take
-    /// the legacy `thread::spawn` path; `Pooled` actors register a
-    /// dispatcher slot with the pool. The `FRAME_BARRIER` const is
-    /// orthogonal: a frame-bound actor can be either `Pooled` or
-    /// `Dedicated`.
-    const SCHEDULING: Scheduling = Scheduling::Pooled;
+    /// (the default), so the runtime takes the today path everywhere.
+    /// Phase 3 flips this default to `Scheduling::Pooled` after every
+    /// actor that genuinely needs its own thread is explicitly
+    /// annotated `Dedicated`.
+    ///
+    /// `FRAME_BARRIER` and `SCHEDULING` are orthogonal: a frame-bound
+    /// actor can be either `Pooled` or `Dedicated`; the per-actor
+    /// `pending` counter is read by the chassis frame loop regardless
+    /// of where the dispatch happens.
+    const SCHEDULING: Scheduling = Scheduling::Dedicated;
 }
 
 /// Issue 635 dispatch placement (see [`Actor::SCHEDULING`]). Equality

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -1,0 +1,337 @@
+//! [`DispatcherSlot<A>`] — the [`Drainable`] adapter that wraps a
+//! native actor for chassis worker-pool dispatch (issue 635 PR C).
+//!
+//! ## Relationship to `dispatch_loop_run`
+//!
+//! [`crate::actor::native::dispatch::dispatch_loop_run`] is the loop a
+//! `Dedicated` actor runs on its own thread. It owns the actor, blocks
+//! on `recv_blocking`, and runs the four-phase lifecycle
+//! (main loop → drain after shutdown → on_close → registry close).
+//!
+//! `DispatcherSlot::run_cycle` is the *budget-bounded* version of the
+//! same logic for the `Pooled` path. Each call to `run_cycle` does:
+//!
+//! 1. CAS `Ready → Running` on the [`SlotState`] (caller invariant:
+//!    the slot was just popped from the ready queue).
+//! 2. Drains envelopes via [`crate::NativeBinding::try_recv`] until
+//!    inbox is empty, the budget is exhausted, or shutdown fires.
+//!    Per-envelope wrapping is `local::with_stamped(slots, ...)` +
+//!    `log_install::with_actor_dispatch(binding, ...)` — same as
+//!    `dispatch_loop_run`'s body so traces / `Local<T>` lookups behave
+//!    identically.
+//! 3. Returns one of:
+//!    - [`CycleResult::Idle`] — inbox drained, post-empty recheck saw
+//!      no race; worker drops the slot Arc.
+//!    - [`CycleResult::Requeue`] — budget hit (state `Ready`) or
+//!      post-empty recheck won the requeue CAS; worker re-pushes.
+//!    - [`CycleResult::Closed`] — shutdown observed; the slot ran the
+//!      post-shutdown drain + `on_close` hook + registry finalize
+//!      sequence and is done forever.
+//!
+//! ## Today (PR C)
+//!
+//! Every actor in the workspace ships `SCHEDULING = Dedicated`, so
+//! this slot is constructed by the `Pooled` branch of
+//! `make_native_actor_boot` / `Spawner::spawn_actor` but never
+//! actually reached at runtime. The branch + slot impl are shaped so
+//! Phase 2 (PR D) can flip a single cap to `Pooled` and have the
+//! pool drive it.
+
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use aether_actor::local::ActorSlots;
+
+/// `ActorSlots` uses `RefCell` internally because the dedicated-thread
+/// dispatcher path only ever reaches it from one OS thread. Worker-pool
+/// dispatch can have *different* worker threads hit the same slot
+/// across cycles — but the [`SlotState`] machine guarantees only one
+/// worker is in `Running` at a time. That serialization makes the
+/// `RefCell` accesses sound; this wrapper is the safety story.
+#[repr(transparent)]
+struct PooledSlots(Box<ActorSlots>);
+
+// SAFETY: see the doc-comment on `PooledSlots`. The SlotState
+// machine's `Idle → Ready → Running → Idle` invariant ensures at most
+// one worker thread holds an active reference to the inner
+// `ActorSlots` at any time, so the inner `RefCell` is effectively
+// single-threaded across the Pooled dispatch path.
+unsafe impl Sync for PooledSlots {}
+
+impl std::ops::Deref for PooledSlots {
+    type Target = ActorSlots;
+    fn deref(&self) -> &ActorSlots {
+        &self.0
+    }
+}
+
+use crate::actor::native::binding::NativeBinding;
+use crate::actor::native::ctx::NativeCtx;
+use crate::actor::native::{NativeActor, NativeDispatch};
+use crate::actor::registry::ActorRegistry;
+use crate::mail::mailer::Mailer;
+use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
+use crate::scheduler::{BatchBudget, CycleResult, Drainable, SlotState};
+
+/// Worker-pool-side wrapper for a native actor. One instance per
+/// `Pooled` actor; held strongly by the chassis (so `on_close` and
+/// registry finalize run when the cap shuts down) and weakly by the
+/// pool's [`crate::scheduler::WakeHandle`] (so a wake after the cap
+/// is gone silently no-ops).
+pub(crate) struct DispatcherSlot<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    /// The slot's atomic state machine. Shared with the WakeHandle.
+    pub(crate) state: Arc<SlotState>,
+    /// The actor itself. The state machine guarantees only one worker
+    /// is in `Running` at a time, so the `Mutex` is uncontested in
+    /// production — used here over `UnsafeCell` only for the simpler
+    /// safety story. `Option` so the `Closed` finalize path can take
+    /// the box and run `on_close` on the consumed actor.
+    actor: Mutex<Option<Box<A>>>,
+    /// Per-actor binding (inbox + shutdown flag + reply machinery).
+    binding: Arc<NativeBinding>,
+    /// Per-actor `Local<T>` storage. Stamped into TLS for each
+    /// envelope dispatch. Wrapped in [`PooledSlots`] for the `Sync`
+    /// safety story — see that type's doc-comment.
+    slots: PooledSlots,
+    /// `FRAME_BARRIER` counter for this actor's mailbox. `None` for
+    /// free-running caps; `Some` for frame-bound. Decremented after
+    /// every successful dispatch.
+    pending: Option<Arc<AtomicU64>>,
+    /// Chassis-level actor registry. Used by [`Self::finalize_registry`]
+    /// to drain `monitors_of[id]` and prune `monitoring[id]` from each
+    /// target on shutdown.
+    actor_registry: Arc<ActorRegistry>,
+    /// Mailer used to dispatch [`aether_kinds::MonitorNotice`] mail to
+    /// any watchers when the slot finalizes.
+    mailer: Arc<Mailer>,
+    /// This slot's mailbox id — passed to `actor_registry.close_actor`.
+    self_id: MailboxId,
+    /// Static label for tracing / fairness logs. Today this is the
+    /// actor's `NAMESPACE`.
+    label: &'static str,
+}
+
+impl<A> DispatcherSlot<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    /// Borrow this slot's [`SlotState`] — needed by callers building a
+    /// [`crate::scheduler::WakeHandle`] over the slot.
+    pub(crate) fn state(&self) -> &Arc<SlotState> {
+        &self.state
+    }
+
+    /// Borrow this slot's [`NativeBinding`]. The chassis-cap shutdown
+    /// path uses this to call [`NativeBinding::signal_shutdown`] when
+    /// the cap is going down — the next call into [`Self::run_cycle`]
+    /// observes the flag and runs the `on_close` + registry finalize
+    /// sequence.
+    pub(crate) fn binding(&self) -> &Arc<NativeBinding> {
+        &self.binding
+    }
+
+    pub(crate) fn new(
+        actor: Box<A>,
+        binding: Arc<NativeBinding>,
+        slots: Box<ActorSlots>,
+        pending: Option<Arc<AtomicU64>>,
+        actor_registry: Arc<ActorRegistry>,
+        mailer: Arc<Mailer>,
+        self_id: MailboxId,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            state: Arc::new(SlotState::new()),
+            actor: Mutex::new(Some(actor)),
+            binding,
+            slots: PooledSlots(slots),
+            pending,
+            actor_registry,
+            mailer,
+            self_id,
+            label: A::NAMESPACE,
+        })
+    }
+
+    /// Per-envelope dispatch matching
+    /// [`crate::actor::native::dispatch::dispatch_loop_run`]'s body.
+    /// Wraps the dispatch call in `local::with_stamped` +
+    /// `log_install::with_actor_dispatch` so tracing events carry the
+    /// actor's mailbox id and the per-handler `LogBatch` ships at exit.
+    fn dispatch_one(&self, actor: &mut Box<A>, env: crate::actor::native::Envelope) {
+        aether_actor::local::with_stamped(&self.slots, || {
+            crate::runtime::log_install::with_actor_dispatch(
+                &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
+                || {
+                    let mut ctx = NativeCtx::new(&self.binding, env.sender);
+                    if actor
+                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
+                        .is_none()
+                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)
+                    {
+                        tracing::warn!(
+                            target: "aether_substrate::dispatch",
+                            actor = A::NAMESPACE,
+                            kind = env.kind_name.as_str(),
+                            "actor dispatch missed: kind not handled or decode failed"
+                        );
+                    }
+                    aether_actor::log::drain_buffer();
+                },
+            );
+        });
+        if let Some(p) = &self.pending {
+            p.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    /// Phase 3 of the dispatch_loop_run lifecycle. Wraps `actor.on_close`
+    /// in the same `with_stamped` + `with_actor_dispatch` envelope so a
+    /// final tracing event from the close hook still routes to
+    /// `LogCapability`.
+    fn run_close_hook(&self, actor: &mut Box<A>) {
+        aether_actor::local::with_stamped(&self.slots, || {
+            crate::runtime::log_install::with_actor_dispatch(
+                &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
+                || {
+                    let mut close_ctx = NativeCtx::new(&self.binding, ReplyTo::NONE);
+                    actor.on_close(&mut close_ctx);
+                    aether_actor::log::drain_buffer();
+                },
+            );
+        });
+    }
+
+    /// Phase 4 — drain `monitors_of[self_id]`, prune `monitoring[id]`
+    /// from each target, mark Dead, fan `MonitorNotice` mail out via
+    /// the chassis mailer.
+    fn finalize_registry(&self) {
+        let watchers = self.actor_registry.close_actor(self.self_id);
+        if !watchers.is_empty() {
+            let notice = aether_kinds::MonitorNotice {
+                target: self.self_id,
+            };
+            let payload =
+                <aether_kinds::MonitorNotice as aether_data::Kind>::encode_into_bytes(&notice);
+            let kind = KindId(<aether_kinds::MonitorNotice as aether_data::Kind>::ID.0);
+            for watcher in watchers {
+                self.mailer
+                    .push(Mail::new(watcher, kind, payload.clone(), 1));
+            }
+        }
+    }
+}
+
+impl<A> Drainable for DispatcherSlot<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
+        if !self.state.enter_running() {
+            // Invariant violation: the worker popped this slot and
+            // its state should have been Ready. Defensive fallback
+            // — bail without touching the actor.
+            tracing::warn!(
+                target: "aether_substrate::scheduler",
+                actor = A::NAMESPACE,
+                "DispatcherSlot::run_cycle entered without Ready state — skipping",
+            );
+            return CycleResult::Idle;
+        }
+
+        let mut actor_guard = self
+            .actor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let actor = match actor_guard.as_mut() {
+            Some(a) => a,
+            None => {
+                // Slot already finalized. Nothing to do.
+                self.state.mark_idle();
+                return CycleResult::Closed;
+            }
+        };
+
+        let mut dispatched = 0u32;
+        let mut shutdown_observed = false;
+        let mut budget_hit = false;
+        let mut inbox_empty = false;
+        loop {
+            if self.binding.should_shutdown() {
+                shutdown_observed = true;
+                break;
+            }
+            let env = match self.binding.try_recv() {
+                Some(e) => e,
+                None => {
+                    inbox_empty = true;
+                    break;
+                }
+            };
+            self.dispatch_one(actor, env);
+            dispatched += 1;
+            if dispatched >= budget.max_mails || Instant::now() >= budget.deadline {
+                budget_hit = true;
+                break;
+            }
+        }
+
+        if shutdown_observed {
+            // Phase 2: drain residual inbox synchronously.
+            while let Some(env) = self.binding.try_recv() {
+                self.dispatch_one(actor, env);
+            }
+            // Phase 3: on_close hook.
+            self.run_close_hook(actor);
+            // Phase 4: registry close + monitor fan-out.
+            self.finalize_registry();
+            actor_guard.take();
+            self.state.mark_idle();
+            return CycleResult::Closed;
+        }
+
+        if budget_hit {
+            self.state.mark_ready();
+            return CycleResult::Requeue;
+        }
+
+        // Inbox observed empty. Post-empty recheck — close the
+        // classic send-vs-drain race. After `mark_idle`, a fresh send
+        // from a peer arrives in one of two timelines:
+        //
+        // (a) Sender pushes BEFORE our `mark_idle`: their `try_wake`
+        //     fails (state still `Running`); they skip the requeue.
+        //     Our `try_recv` after `mark_idle` finds the envelope; we
+        //     CAS `Idle → Ready`; we requeue.
+        //
+        // (b) Sender pushes AFTER our `mark_idle`: their `try_wake`
+        //     wins; they push the slot to the ready queue. Our CAS
+        //     `Idle → Ready` fails (state is `Ready` now). The slot
+        //     is already requeued — we return `Idle`.
+        debug_assert!(inbox_empty);
+        self.state.mark_idle();
+        match self.binding.try_recv() {
+            Some(env) => {
+                self.dispatch_one(actor, env);
+                if self.state.try_self_requeue() {
+                    CycleResult::Requeue
+                } else {
+                    CycleResult::Idle
+                }
+            }
+            None => CycleResult::Idle,
+        }
+    }
+
+    fn label(&self) -> &str {
+        self.label
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -65,6 +65,7 @@
 pub mod binding;
 pub mod ctx;
 pub(crate) mod dispatch;
+pub(crate) mod dispatcher_slot;
 pub mod envelope;
 pub mod mailbox;
 pub mod spawn;

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -102,6 +102,11 @@ pub struct Spawner {
     /// future epoch-deadline ADR; this counter is for synchronization,
     /// not fail-fast.
     instanced_pending: RwLock<Vec<(MailboxId, Arc<AtomicU64>)>>,
+    /// Issue 635 PR C: chassis worker pool's ready-queue sender.
+    /// Cloned into [`crate::scheduler::WakeHandle`]s when the
+    /// Pooled spawn branch lands a slot. Today every actor is
+    /// Dedicated so this clone is unused; PR D flips that.
+    pool_ready_tx: crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>>,
 }
 
 impl Spawner {
@@ -111,6 +116,7 @@ impl Spawner {
         mailer: Arc<Mailer>,
         frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
         aborter: Arc<dyn FatalAborter>,
+        pool_ready_tx: crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>>,
     ) -> Self {
         Self {
             registry,
@@ -120,7 +126,17 @@ impl Spawner {
             aborter,
             counter: AtomicU64::new(0),
             instanced_pending: RwLock::new(Vec::new()),
+            pool_ready_tx,
         }
+    }
+
+    /// Borrow the chassis worker pool's ready-queue sender. PR D
+    /// reaches for this when a Pooled instanced actor spawns.
+    #[allow(dead_code)] // wired in PR D
+    pub(crate) fn pool_ready_tx(
+        &self,
+    ) -> &crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>> {
+        &self.pool_ready_tx
     }
 
     /// Wait for every spawned instanced actor's inbox to quiesce
@@ -295,6 +311,13 @@ impl Spawner {
         // between ticks. Production drivers don't read this.
         let pending = Arc::new(AtomicU64::new(0));
         let pending_for_handler = Arc::clone(&pending);
+        // Issue 635 PR C: optional pool wake hook for `Pooled` actors.
+        // Populated post-init by the `Pooled` branch below; left empty
+        // for `Dedicated` (today's only path) so the closure's `get()`
+        // is a single relaxed atomic load.
+        let wake_slot: Arc<crate::chassis::ctx::MailboxWakeSlot> =
+            Arc::new(crate::chassis::ctx::MailboxWakeSlot::default());
+        let wake_for_handler = Arc::clone(&wake_slot);
         let registered = self.registry.try_register_closure(
             full_name.clone(),
             Arc::new(
@@ -332,6 +355,10 @@ impl Spawner {
                             kind = kind_name,
                             "instanced actor receiver dropped — mail discarded"
                         );
+                        return;
+                    }
+                    if let Some(wake) = wake_for_handler.get() {
+                        wake();
                     }
                 },
             ),
@@ -400,37 +427,71 @@ impl Spawner {
             .unwrap()
             .push((id, Arc::clone(&pending)));
 
-        // 8. Spawn dispatcher thread, move actor + slots in.
-        // Issue 672: delegates to the shared `dispatch_loop_run`
-        // helper — same loop body the singleton path uses, with
-        // `local::with_stamped` + `log_install::with_actor_dispatch`
-        // wrapping every dispatch, drain, and `on_close`. Issue 629 /
-        // Phase A: the dispatcher takes the Box<A> by move — the
-        // actor is owned exclusively by this thread for its lifetime;
-        // no Arc share with the chassis or registry.
-        let transport_for_thread = Arc::clone(&transport);
-        let actor_registry_for_thread = Arc::clone(&self.actor_registry);
-        let mailer_for_thread = Arc::clone(&self.mailer);
-        let pending_for_thread = Arc::clone(&pending);
-        let thread_name = alloc_instanced_thread_name(&full_name);
+        // 8. Spawn dispatcher (or pool-register) per `A::SCHEDULING`.
         // The local strong Arc was the populator for the Weak handler
         // ref; the actor_registry now holds an `Arc::clone` of the
         // same Arc, so dropping the local doesn't break the weak.
         drop(strong_sender);
-        let _ = std::thread::Builder::new()
-            .name(thread_name)
-            .spawn(move || {
-                crate::actor::native::dispatch::dispatch_loop_run::<A>(
-                    &transport_for_thread,
-                    &mut actor,
-                    &slots,
-                    Some(&pending_for_thread),
-                    &actor_registry_for_thread,
-                    &mailer_for_thread,
+        match A::SCHEDULING {
+            aether_actor::Scheduling::Dedicated => {
+                // Today's path: one OS thread per instanced actor.
+                let transport_for_thread = Arc::clone(&transport);
+                let actor_registry_for_thread = Arc::clone(&self.actor_registry);
+                let mailer_for_thread = Arc::clone(&self.mailer);
+                let pending_for_thread = Arc::clone(&pending);
+                let thread_name = alloc_instanced_thread_name(&full_name);
+                let _ = std::thread::Builder::new()
+                    .name(thread_name)
+                    .spawn(move || {
+                        crate::actor::native::dispatch::dispatch_loop_run::<A>(
+                            &transport_for_thread,
+                            &mut actor,
+                            &slots,
+                            Some(&pending_for_thread),
+                            &actor_registry_for_thread,
+                            &mailer_for_thread,
+                            id,
+                        );
+                    })
+                    .expect("dispatcher thread spawn must succeed");
+            }
+            aether_actor::Scheduling::Pooled => {
+                // Issue 635 PR C: register a `DispatcherSlot` with the
+                // chassis worker pool. No per-actor thread. The wake
+                // hook on the closure pushes the slot to the ready
+                // queue when an envelope lands. Today no
+                // `Instanced + Pooled` actors ship; this branch is
+                // reachable but unused at runtime.
+                let slot = crate::actor::native::dispatcher_slot::DispatcherSlot::<A>::new(
+                    actor,
+                    Arc::clone(&transport),
+                    slots,
+                    Some(Arc::clone(&pending)),
+                    Arc::clone(&self.actor_registry),
+                    Arc::clone(&self.mailer),
                     id,
                 );
-            })
-            .expect("dispatcher thread spawn must succeed");
+                let slot_dyn: Arc<dyn crate::scheduler::Drainable> = slot.clone();
+                let weak: std::sync::Weak<dyn crate::scheduler::Drainable> =
+                    Arc::downgrade(&slot_dyn);
+                drop(slot_dyn);
+                let wake = crate::scheduler::WakeHandle::new(
+                    Arc::clone(slot.state()),
+                    weak,
+                    self.pool_ready_tx.clone(),
+                );
+                wake_slot.set(Arc::new(move || {
+                    wake.wake();
+                }));
+                // Drop the held strong ref. The actor_registry
+                // holds the slot indirectly through the registered
+                // sender + sink handler; the pool's queue holds an
+                // Arc when the slot is woken. On chassis shutdown,
+                // dropping the registry entries + pool joins the
+                // workers; the slot drops at end of its last cycle.
+                drop(slot);
+            }
+        }
 
         Ok(id)
     }

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -34,6 +34,7 @@ use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
+use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 use aether_actor::Actor;
 use aether_actor::Dispatch;
 use aether_actor::HandlesKind;
@@ -342,13 +343,21 @@ where
                     claim.receiver,
                     claim.mailbox_sender,
                     Some(claim.pending),
+                    claim.wake_slot,
                 )
             })
         } else {
-            ctx.claim_mailbox_drop_on_shutdown::<A>()
-                .map(|claim| (claim.id, claim.receiver, claim.mailbox_sender, None))
+            ctx.claim_mailbox_drop_on_shutdown::<A>().map(|claim| {
+                (
+                    claim.id,
+                    claim.receiver,
+                    claim.mailbox_sender,
+                    None,
+                    claim.wake_slot,
+                )
+            })
         };
-        let (mailbox_id, receiver, mailbox_sender, pending) = match claim_result {
+        let (mailbox_id, receiver, mailbox_sender, pending, wake_slot) = match claim_result {
             Ok(c) => c,
             Err(e) => {
                 ctx.spawner_arc()
@@ -411,43 +420,116 @@ where
         };
 
         // Issue 629 / Phase A: dispatcher takes Box<A> ownership.
-        // The actor lives exclusively on the dispatcher thread —
-        // no chassis-side Arc share, no cross-thread access path.
-        // Drivers / embedders consume cap-published handle bundles
-        // from the chassis's `ExportedHandles` map instead.
-        let mut actor: Box<A> = Box::new(actor);
+        // The actor lives exclusively on the dispatcher thread (or,
+        // for `Pooled` actors, in the slot's mutex — accessed by one
+        // worker at a time per the SlotState machine).
+        let actor: Box<A> = Box::new(actor);
 
-        // Spawn the dispatcher thread. The thread owns the Box<A>,
-        // an Arc<NativeBinding>, and the per-actor `ActorSlots`
-        // (moved in by value); it delegates to the shared
-        // `dispatch_loop_run` helper (issue 672) which runs the
-        // outer loop, drain, on_close, and registry close-actor
-        // sequence — same shape the instanced path uses.
-        let transport_for_thread = Arc::clone(&transport);
-        let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
-        let mailer_for_thread = ctx.mail_send_handle();
-        let self_id_for_thread = mailbox_id;
-        let thread_name = alloc_native_actor_thread_name::<A>();
-        let thread = std::thread::Builder::new()
-            .name(thread_name)
-            .spawn(move || {
-                crate::actor::native::dispatch::dispatch_loop_run::<A>(
-                    &transport_for_thread,
-                    &mut actor,
-                    &slots,
-                    pending.as_ref(),
-                    &actor_registry_for_thread,
-                    &mailer_for_thread,
-                    self_id_for_thread,
+        match A::SCHEDULING {
+            aether_actor::Scheduling::Dedicated => {
+                // Today's path: spawn one OS thread per actor.
+                let mut actor = actor;
+                let transport_for_thread = Arc::clone(&transport);
+                let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
+                let mailer_for_thread = ctx.mail_send_handle();
+                let self_id_for_thread = mailbox_id;
+                let thread_name = alloc_native_actor_thread_name::<A>();
+                let thread = std::thread::Builder::new()
+                    .name(thread_name)
+                    .spawn(move || {
+                        crate::actor::native::dispatch::dispatch_loop_run::<A>(
+                            &transport_for_thread,
+                            &mut actor,
+                            &slots,
+                            pending.as_ref(),
+                            &actor_registry_for_thread,
+                            &mailer_for_thread,
+                            self_id_for_thread,
+                        );
+                    })
+                    .map_err(|e| BootError::Other(Box::new(e)))?;
+
+                Ok(Box::new(NativeActorShutdown {
+                    thread: Some(thread),
+                    mailbox_sender: Some(mailbox_sender),
+                }) as Box<dyn DynShutdown>)
+            }
+            aether_actor::Scheduling::Pooled => {
+                // Issue 635 PR C path: register a `DispatcherSlot`
+                // with the chassis worker pool. No per-actor thread.
+                // The `wake_slot` in the mailbox closure fires the
+                // pool wake hook on every accepted send.
+                //
+                // Today no cap ships `SCHEDULING = Pooled`, so this
+                // branch is reachable but unused at runtime. Phase 2
+                // (PR D) flips a single cap to exercise it.
+                let actor_registry = Arc::clone(ctx.spawner_arc().actor_registry());
+                let mailer_clone = ctx.mail_send_handle();
+                let slot = crate::actor::native::dispatcher_slot::DispatcherSlot::<A>::new(
+                    actor,
+                    Arc::clone(&transport),
+                    slots,
+                    pending,
+                    actor_registry,
+                    mailer_clone,
+                    mailbox_id,
                 );
-            })
-            .map_err(|e| BootError::Other(Box::new(e)))?;
-
-        Ok(Box::new(NativeActorShutdown {
-            thread: Some(thread),
-            mailbox_sender: Some(mailbox_sender),
-        }) as Box<dyn DynShutdown>)
+                let slot_dyn: Arc<dyn crate::scheduler::Drainable> = slot.clone();
+                let weak: std::sync::Weak<dyn crate::scheduler::Drainable> =
+                    Arc::downgrade(&slot_dyn);
+                drop(slot_dyn);
+                let wake = crate::scheduler::WakeHandle::new(
+                    Arc::clone(slot.state()),
+                    weak,
+                    ctx.pool_ready_tx().clone(),
+                );
+                wake_slot.set(Arc::new(move || {
+                    wake.wake();
+                }));
+                Ok(Box::new(PooledActorShutdown::<A> {
+                    slot: Some(slot),
+                    mailbox_sender: Some(mailbox_sender),
+                }) as Box<dyn DynShutdown>)
+            }
+        }
     })
+}
+
+/// Shutdown adapter for a `Pooled` [`NativeActor`] (issue 635 PR C).
+/// On chassis shutdown:
+/// 1. Sets the binding's `should_shutdown` flag so the next
+///    [`crate::scheduler::DispatcherSlot::run_cycle`] observes the
+///    signal and runs `on_close` + registry finalize.
+/// 2. Drops the [`crate::chassis::ctx::MailboxSender`] so subsequent
+///    sends warn-and-discard.
+/// 3. Drops the slot Arc — the chassis-held strong ref. The pool
+///    worker's strong ref (via the ready queue) drops at end of the
+///    final cycle. The pool's `Drop` joins workers, so any in-flight
+///    cycle finishes before chassis shutdown returns.
+///
+/// Today no production cap is `Pooled`, so this struct is reachable
+/// but unused at runtime.
+struct PooledActorShutdown<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    slot: Option<Arc<crate::actor::native::dispatcher_slot::DispatcherSlot<A>>>,
+    mailbox_sender: Option<crate::chassis::ctx::MailboxSender>,
+}
+
+impl<A> DynShutdown for PooledActorShutdown<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    fn shutdown_dyn(mut self: Box<Self>) {
+        if let Some(slot) = &self.slot {
+            slot.binding().signal_shutdown();
+        }
+        // Drop sender first so the inbox closes; subsequent wakes
+        // silently no-op via WakeHandle's Weak failing to upgrade.
+        self.mailbox_sender.take();
+        drop(self.slot.take());
+    }
 }
 
 /// Build a stable `aether-actor-<namespace>` thread name for the
@@ -789,6 +871,14 @@ struct BootedPassives {
     /// reaches them without separate plumbing.
     actor_registry: Arc<crate::ActorRegistry>,
     spawner: Arc<crate::Spawner>,
+    /// Issue 635 PR C: chassis-owned worker pool. Boots empty in
+    /// [`boot_passives`] before any cap; today no cap is `Pooled` so
+    /// the pool sits idle, but the infrastructure is live so PR D /
+    /// Phase 2 can flip individual caps without touching this layer
+    /// again. Drops *after* `shutdowns` (per `BootedPassives::Drop` +
+    /// implicit field-drop ordering), so every Dedicated dispatcher
+    /// thread is gone before pool workers join.
+    _pool: PoolHandle,
 }
 
 /// Issue #601: dispatch a `ConfigureLogDrain { mailbox: drain }` mail
@@ -848,12 +938,20 @@ fn boot_passives(
     let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
     let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
     let actor_registry: Arc<crate::ActorRegistry> = Arc::new(crate::ActorRegistry::new());
+    // Issue 635 PR C: stand up the worker pool before any cap boots.
+    // The pool's ready_tx is cloned into the Spawner (for instanced
+    // Pooled actors) and into the ChassisCtx (for singleton Pooled
+    // caps). Today every cap is Dedicated so the pool sits idle, but
+    // booting it here means PR D / Phase 2 can flip a cap to Pooled
+    // without re-plumbing the boot order.
+    let pool = Pool::start(PoolConfig::default(), Arc::clone(aborter));
     let spawner: Arc<crate::Spawner> = Arc::new(crate::Spawner::new(
         Arc::clone(registry),
         Arc::clone(&actor_registry),
         Arc::clone(mailer),
         Arc::clone(&frame_bound_set),
         Arc::clone(aborter),
+        pool.ready_tx(),
     ));
     for boot in passives {
         let mut ctx = ChassisCtx::new(
@@ -886,6 +984,7 @@ fn boot_passives(
         claimed_actor_mailboxes,
         actor_registry,
         spawner,
+        _pool: pool,
     })
 }
 

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -55,6 +55,53 @@ pub struct DropOnShutdownClaim {
     pub id: MailboxId,
     pub receiver: mpsc::Receiver<Envelope>,
     pub mailbox_sender: MailboxSender,
+    /// Issue 635 PR C: optional wake hook for `Pooled` actors. The
+    /// mailbox closure invokes this after a successful inbox push so
+    /// the chassis worker pool re-queues the actor's
+    /// [`crate::scheduler::DispatcherSlot`]. `Dedicated` actors
+    /// (today: every cap) leave this empty — the closure's `get()`
+    /// is a single atomic load, ~free.
+    ///
+    /// Populated post-claim by the `Pooled` branch of
+    /// `make_native_actor_boot` / `Spawner::spawn_actor` after the
+    /// slot exists.
+    pub wake_slot: Arc<MailboxWakeSlot>,
+}
+
+/// Cell holding the optional wake hook a `Pooled` mailbox fires after
+/// each accepted send. The mailbox closure captures `Arc<MailboxWakeSlot>`
+/// at registration time; the spawn path populates it once the
+/// [`crate::scheduler::DispatcherSlot`] exists.
+#[derive(Default)]
+pub struct MailboxWakeSlot {
+    inner: std::sync::OnceLock<MailboxWakeFn>,
+}
+
+impl std::fmt::Debug for MailboxWakeSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MailboxWakeSlot")
+            .field("installed", &self.inner.get().is_some())
+            .finish()
+    }
+}
+
+/// Type-erased wake hook stamped into [`MailboxWakeSlot`].
+pub type MailboxWakeFn = Arc<dyn Fn() + Send + Sync + 'static>;
+
+impl MailboxWakeSlot {
+    /// Install the wake hook. Idempotent on re-call (silently ignores
+    /// the second set), but in production every claim is paired with
+    /// a single set.
+    pub fn set(&self, fn_: MailboxWakeFn) {
+        let _ = self.inner.set(fn_);
+    }
+
+    /// Borrow the installed hook. Returns `None` when the claim is
+    /// for a `Dedicated` actor (no hook ever installed). Hot path —
+    /// `OnceLock::get` is a single relaxed load.
+    pub(crate) fn get(&self) -> Option<&MailboxWakeFn> {
+        self.inner.get()
+    }
 }
 
 /// Strong handle to the inbound `Sender<Envelope>` for a mailbox
@@ -103,6 +150,8 @@ pub struct FrameBoundClaim {
     /// before pushing into the mpsc; the capability's dispatcher must
     /// decrement after each `dispatch()` returns.
     pub pending: Arc<AtomicU64>,
+    /// Issue 635 PR C: see [`DropOnShutdownClaim::wake_slot`].
+    pub wake_slot: Arc<MailboxWakeSlot>,
 }
 
 /// Generic fallback-router handler: invoked by substrate dispatch when a
@@ -302,6 +351,8 @@ impl<'a> ChassisCtx<'a> {
         // and the dispatcher's `recv()` returns `Err(Disconnected)`.
         let tx = Arc::new(tx);
         let weak = Arc::downgrade(&tx);
+        let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
+        let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_closure(
             name.to_owned(),
             Arc::new(
@@ -333,6 +384,14 @@ impl<'a> ChassisCtx<'a> {
                             kind = kind_name,
                             "capability mailbox receiver dropped — mail discarded"
                         );
+                        return;
+                    }
+                    // Issue 635 PR C: fire the `Pooled` wake hook (if
+                    // installed). `Dedicated` actors leave it empty,
+                    // so this is a single relaxed atomic load on the
+                    // hot path.
+                    if let Some(wake) = wake_for_handler.get() {
+                        wake();
                     }
                 },
             ),
@@ -342,6 +401,7 @@ impl<'a> ChassisCtx<'a> {
             id,
             receiver: rx,
             mailbox_sender: MailboxSender::new(tx),
+            wake_slot,
         })
     }
 
@@ -375,6 +435,8 @@ impl<'a> ChassisCtx<'a> {
         let weak = Arc::downgrade(&tx);
         let pending = Arc::new(AtomicU64::new(0));
         let pending_for_handler = Arc::clone(&pending);
+        let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
+        let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_closure(
             name.to_owned(),
             Arc::new(
@@ -414,6 +476,16 @@ impl<'a> ChassisCtx<'a> {
                             kind = kind_name,
                             "frame-bound capability receiver dropped — mail discarded"
                         );
+                        return;
+                    }
+                    // Issue 635 PR C: fire the `Pooled` wake hook (if
+                    // installed). Frame-bound + pool-scheduled is a
+                    // valid combination per the issue's section 5
+                    // ("FRAME_BARRIER and SCHEDULING are orthogonal");
+                    // the chassis frame loop reads `pending` regardless
+                    // of where the dispatch happens.
+                    if let Some(wake) = wake_for_handler.get() {
+                        wake();
                     }
                 },
             ),
@@ -431,6 +503,7 @@ impl<'a> ChassisCtx<'a> {
             receiver: rx,
             mailbox_sender: MailboxSender::new(tx),
             pending,
+            wake_slot,
         })
     }
 
@@ -511,6 +584,16 @@ impl<'a> ChassisCtx<'a> {
     /// `NativeCtx::spawn_child` can reach the spawn machinery.
     pub fn spawner_arc(&self) -> &Arc<crate::Spawner> {
         self.spawner
+    }
+
+    /// Issue 635 PR C: borrow the chassis worker pool's ready-queue
+    /// sender. The `Pooled` branch of `make_native_actor_boot` clones
+    /// this into the [`crate::scheduler::WakeHandle`] that fires when
+    /// the actor's mailbox accepts a send.
+    pub(crate) fn pool_ready_tx(
+        &self,
+    ) -> &crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>> {
+        self.spawner.pool_ready_tx()
     }
 
     /// Install the fallback-router handler. At most one capability
@@ -603,6 +686,9 @@ impl<'a> ChassisCtx<'a> {
                 receiver,
                 mailbox_sender,
                 pending,
+                // Legacy facade path is `Actor + Dispatch`, never
+                // pool-scheduled — wake hook stays empty.
+                wake_slot: _,
             } = claim;
             (receiver, mailbox_sender, Some(pending))
         } else {
@@ -611,6 +697,7 @@ impl<'a> ChassisCtx<'a> {
                 id: _,
                 receiver,
                 mailbox_sender,
+                wake_slot: _,
             } = claim;
             (receiver, mailbox_sender, None)
         };

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -97,35 +97,59 @@ impl BudgetTemplate {
 /// blocking `recv` would never see a disconnect. The shutdown channel
 /// is held only by the pool — dropping it is the unambiguous signal.
 pub struct PoolHandle {
-    ready_tx: Sender<Arc<dyn Drainable>>,
-    shutdown_tx: Sender<()>,
+    // `Option` so `Drop` and the consuming `shutdown` method can both
+    // take the senders without a clone. Production drops on `PoolHandle`
+    // drop, tests consume via `shutdown_with_results` to inspect any
+    // worker-thread panics.
+    ready_tx: Option<Sender<Arc<dyn Drainable>>>,
+    shutdown_tx: Option<Sender<()>>,
     workers: Vec<PoolWorkerJoin>,
 }
 
 impl PoolHandle {
     /// Hand out a clone of the ready-queue sender. PR C wires this
     /// into [`crate::scheduler::WakeHandle`]s when registering
-    /// dispatcher slots.
+    /// dispatcher slots. Panics if the pool has been shut down.
     pub fn ready_tx(&self) -> Sender<Arc<dyn Drainable>> {
-        self.ready_tx.clone()
+        self.ready_tx
+            .as_ref()
+            .expect("pool already shut down")
+            .clone()
     }
 
-    /// Shut down the pool: drop the shutdown sender (which fires
-    /// every worker's `select!` exit arm), drop the ready-queue
-    /// sender (so any wakers' subsequent sends silently fail), then
-    /// join every worker thread. Returns the joined handles so callers
-    /// can inspect any panics the worker threads themselves emitted
-    /// (distinct from handler-induced panics, which the aborter
-    /// consumed before returning to the worker loop).
-    pub fn shutdown(mut self) -> Vec<thread::Result<()>> {
-        drop(self.shutdown_tx);
-        drop(self.ready_tx);
-        self.workers.drain(..).map(|w| w.handle.join()).collect()
+    /// Shut down the pool, joining every worker, and return each
+    /// worker's join result so tests can inspect handler-induced
+    /// panics (production goes through `Drop`, which discards results).
+    pub fn shutdown_with_results(mut self) -> Vec<thread::Result<()>> {
+        self.shutdown_inner()
+    }
+
+    fn shutdown_inner(&mut self) -> Vec<thread::Result<()>> {
+        // Drop the shutdown sender — fires every worker's `select!`
+        // shutdown arm. Then drop the ready-queue sender (any future
+        // wake.wake() calls silently no-op via SendError). Finally
+        // join every worker thread. Idempotent — re-calling drains the
+        // (empty) workers Vec and returns an empty Vec.
+        self.shutdown_tx.take();
+        self.ready_tx.take();
+        std::mem::take(&mut self.workers)
+            .into_iter()
+            .map(|w| w.handle.join())
+            .collect()
     }
 
     /// Worker count. Exposed for tracing / introspection.
     pub fn worker_count(&self) -> usize {
         self.workers.len()
+    }
+}
+
+impl Drop for PoolHandle {
+    fn drop(&mut self) {
+        // Discard join results — `Drop` is the chassis-shutdown path
+        // where the process is on its way down anyway. Tests that care
+        // about worker panics use `shutdown_with_results` instead.
+        let _ = self.shutdown_inner();
     }
 }
 
@@ -167,8 +191,8 @@ impl Pool {
             workers.push(PoolWorkerJoin { handle, name });
         }
         PoolHandle {
-            ready_tx,
-            shutdown_tx,
+            ready_tx: Some(ready_tx),
+            shutdown_tx: Some(shutdown_tx),
             workers,
         }
     }
@@ -295,7 +319,7 @@ mod tests {
 
         // Bring down the pool cleanly.
         drop(wake);
-        let results = handle.shutdown();
+        let results = handle.shutdown_with_results();
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
     }
@@ -351,7 +375,7 @@ mod tests {
 
         drop(wake_a);
         drop(wake_b);
-        let _ = handle.shutdown();
+        let _ = handle.shutdown_with_results();
     }
 
     /// A handler panic escalates via the [`FatalAborter`]. The test
@@ -383,7 +407,7 @@ mod tests {
         assert!(wait_until(Duration::from_secs(2), || slot.dispatched() >= 1));
 
         drop(wake);
-        let results = handle.shutdown();
+        let results = handle.shutdown_with_results();
         assert_eq!(results.len(), 1);
         assert!(
             results[0].is_err(),
@@ -457,7 +481,7 @@ mod tests {
         }
 
         drop(wakes);
-        let _ = handle.shutdown();
+        let _ = handle.shutdown_with_results();
     }
 
     // Reuse the standard wallclock budget for fairness tests — 200µs


### PR DESCRIPTION
## Summary

Phase 1 PR C of iamacoffeepot/aether#635. Boots the worker pool at chassis startup, adds `DispatcherSlot<A>`, and branches both spawn paths on `A::SCHEDULING`. Today every cap is `Dedicated` so the `Pooled` branch is reachable but never executed — Phase 2 / PR D flips a cap to exercise it.

## What lands

**Chassis lifecycle**
- `BootedPassives` owns a `PoolHandle`. Pool boots before any cap so its `ready_tx` is available; `Drop` joins workers after every Dedicated dispatcher thread is gone.
- `PoolHandle` gets a `Drop` impl. `shutdown_with_results` is the test variant.

**Mailbox claim plumbing**
- `DropOnShutdownClaim` / `FrameBoundClaim` carry an `Arc<MailboxWakeSlot>` (a `OnceLock<MailboxWakeFn>`). The closure handler fires the hook after a successful inbox push. Dedicated actors leave the lock empty — the `if let Some(wake) = ...` is a single relaxed atomic load on the hot path.
- Same shape in `Spawner::spawn_actor`'s closure.

**DispatcherSlot**
- `actor::native::dispatcher_slot::DispatcherSlot<A>: Drainable`. Holds `Mutex<Option<Box<A>>>` (uncontested — the SlotState machine serializes), binding, slots, pending, registry, mailer, self_id.
- `run_cycle` mirrors `dispatch_loop_run`'s four-phase body but bounded by `BatchBudget` with explicit `Idle` / `Requeue` / `Closed` outcomes.
- `Drainable: Send + Sync` via a `repr(transparent)` `PooledSlots` newtype that asserts `Sync` with a SAFETY comment pointing at the SlotState invariant — `ActorSlots` uses `RefCell` internally because the dedicated-thread path serializes naturally.

**Spawn-path branching**
- `make_native_actor_boot` matches `A::SCHEDULING`. Dedicated keeps today's `thread::spawn → dispatch_loop_run`. Pooled builds a slot, populates the mailbox wake hook, returns a `PooledActorShutdown` that signals shutdown + drops the slot Arc.
- `Spawner::spawn_actor` does the same for instanced actors.

**Trait default flip**
- `Actor::SCHEDULING` defaults to `Dedicated` (was `Pooled` per PR A). The Phase 3 milestone (issue 635 § Migration Phasing 3) is now the load-bearing flip — until then every actor ships `Dedicated` either explicitly or by default. PR A's `Pooled` default broke ~17 hand-rolled `impl Actor` test fixtures in `chassis::builder::tests` once the spawn path actually branches on the const; flipping the default avoids 17 mechanical edits.

## Test plan

- [x] `cargo nextest run --workspace` — 1025/1025 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Out of scope (Phase 2 / PR D)

- Flip `LogCapability` to `SCHEDULING = Pooled` and validate end-to-end.
- Stress test: 10k log mails through pool, throughput within 2× of dedicated baseline.
- Tune `BATCH_MAX_MAILS` / `BATCH_MAX_USEC` based on Phase 2 measurements if needed.

Refs iamacoffeepot/aether#635

🤖 Generated with [Claude Code](https://claude.com/claude-code)