### PR TITLE
refactor(capabilities): flip LogCapability to Scheduling::Pooled

### DIFF
--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -48,7 +48,7 @@ mod native {
     impl NativeActor for LogCapability {
         type Config = ();
         const NAMESPACE: &'static str = "aether.log";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
+        const SCHEDULING: Scheduling = Scheduling::Pooled;
 
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned();

--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -1,0 +1,249 @@
+//! Issue 635 Phase 2 stress test: drive 10k `LogBatch` mails through
+//! `LogCapability` on the worker pool path. Exercises end-to-end the
+//! macro-emitted `__dispatch` arm, the
+//! [`aether_substrate::runtime::log_install::with_actor_dispatch`] +
+//! `local::with_stamped` wrapping inside [`aether_substrate::actor::native::dispatcher_slot::DispatcherSlot`],
+//! the cap's handler-side egress to a recording outbound, and the
+//! `SlotState` requeue/idle transitions across batched cycles.
+//!
+//! Compared against a parallel `DedicatedBenchLogCap` fixture (same
+//! struct shape + handler body, `Scheduling::Dedicated`) so the perf
+//! check normalises against the host's clock instead of a hard
+//! wallclock bound. Issue 635 Phase 2 spec: throughput within 2× of
+//! the dedicated baseline.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aether_data::{Kind, ReplyTo};
+use aether_kinds::{LogBatch, LogEvent};
+
+use aether_capabilities::LogCapability;
+use aether_substrate::{
+    Actor, BootError, Builder, BuiltChassis, Chassis, EgressEvent, HubOutbound, Mailer,
+    NativeActor, NativeCtx, NativeInitCtx, NeverDriver, PassiveChassis, Registry,
+    handle_store::HandleStore, mail::registry::MailboxEntry,
+};
+
+const STRESS_BATCHES: u32 = 10_000;
+/// Pooled-vs-dedicated wallclock ratio cap. Issue 635 Phase 2 spec is
+/// 2×; we ship 3× as the assertion to leave CI-runner slack — the
+/// printed ratio is the load-bearing metric for human review.
+const RATIO_CAP: f64 = 3.0;
+/// Hard wallclock cap on the drain wait per run. Either flavour
+/// completing within this budget is comfortably above any pool /
+/// dedicated baseline observed locally; if a regression pushes drain
+/// wallclock past this, the stress test is the right place to see it.
+const DRAIN_BUDGET: Duration = Duration::from_secs(30);
+
+struct TestChassis;
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("driven by Builder directly in this test")
+    }
+}
+
+/// Dedicated-thread baseline cap. Mirrors `LogCapability`'s handler
+/// body so the per-mail work is comparable; only `SCHEDULING` differs,
+/// which is the variable under test.
+struct DedicatedBenchLogCap {
+    outbound: Option<Arc<HubOutbound>>,
+    sequence: u64,
+}
+
+impl aether_actor::Singleton for DedicatedBenchLogCap {}
+
+#[aether_data::actor]
+impl NativeActor for DedicatedBenchLogCap {
+    type Config = ();
+    const NAMESPACE: &'static str = "test.bench.log_dedicated";
+    const SCHEDULING: Scheduling = Scheduling::Dedicated;
+
+    fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        let outbound = ctx.mailer().outbound().cloned();
+        Ok(Self {
+            outbound,
+            sequence: 1,
+        })
+    }
+
+    #[aether_data::handler]
+    fn on_log_batch(&mut self, ctx: &mut NativeCtx<'_>, batch: LogBatch) {
+        let Some(outbound) = self.outbound.as_ref() else {
+            return;
+        };
+        let origin = ctx.origin();
+        let entries: Vec<aether_substrate::LogEntry> = batch
+            .entries
+            .into_iter()
+            .map(|e| {
+                let sequence = self.sequence;
+                self.sequence += 1;
+                aether_substrate::LogEntry {
+                    timestamp_unix_ms: 0,
+                    level: u8_to_level(e.level),
+                    target: e.target,
+                    message: e.message,
+                    sequence,
+                    origin,
+                }
+            })
+            .collect();
+        outbound.egress_log_batch(entries);
+    }
+}
+
+fn u8_to_level(level: u8) -> aether_substrate::LogLevel {
+    match level {
+        0 => aether_substrate::LogLevel::Trace,
+        1 => aether_substrate::LogLevel::Debug,
+        2 => aether_substrate::LogLevel::Info,
+        3 => aether_substrate::LogLevel::Warn,
+        4 => aether_substrate::LogLevel::Error,
+        _ => aether_substrate::LogLevel::Info,
+    }
+}
+
+fn fresh_substrate_with_outbound() -> (
+    Arc<Registry>,
+    Arc<Mailer>,
+    std::sync::mpsc::Receiver<EgressEvent>,
+) {
+    let registry = Arc::new(Registry::new());
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let (outbound, rx) = HubOutbound::attached_loopback();
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+    (registry, mailer, rx)
+}
+
+fn push_log_batch(registry: &Registry, recipient: &str, payload: &[u8]) {
+    let id = registry.lookup(recipient).expect("mailbox registered");
+    let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
+        panic!("expected mailbox entry under {recipient}");
+    };
+    handler(
+        <LogBatch as Kind>::ID,
+        LogBatch::NAME,
+        None,
+        ReplyTo::NONE,
+        payload,
+        1,
+    );
+}
+
+fn drain_n_log_batches(rx: &std::sync::mpsc::Receiver<EgressEvent>, target: u32) -> u32 {
+    let deadline = Instant::now() + DRAIN_BUDGET;
+    let mut count = 0u32;
+    while count < target {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(EgressEvent::LogBatch { .. }) => count += 1,
+            Ok(_other) => {}
+            Err(_) => break,
+        }
+    }
+    count
+}
+
+/// Build one `LogBatch` mail with a single entry and return its
+/// postcard-encoded bytes. Every push reuses the same buffer so the
+/// stress measurement reflects dispatch cost, not encode churn.
+fn encoded_one_entry_batch() -> Vec<u8> {
+    let batch = LogBatch {
+        entries: vec![LogEvent {
+            level: 2,
+            target: "stress.bench".into(),
+            message: "log_pool_stress".into(),
+        }],
+    };
+    LogBatch::encode_into_bytes(&batch)
+}
+
+fn run_pool_stress() -> Duration {
+    let (registry, mailer, rx) = fresh_substrate_with_outbound();
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<LogCapability>(())
+            .build_passive()
+            .expect("LogCapability boots");
+
+    let bytes = encoded_one_entry_batch();
+    let start = Instant::now();
+    for _ in 0..STRESS_BATCHES {
+        push_log_batch(&registry, LogCapability::NAMESPACE, &bytes);
+    }
+    let received = drain_n_log_batches(&rx, STRESS_BATCHES);
+    let elapsed = start.elapsed();
+
+    drop(chassis);
+
+    assert_eq!(
+        received,
+        STRESS_BATCHES,
+        "pool-path LogCapability dropped {} of {} mails",
+        STRESS_BATCHES - received,
+        STRESS_BATCHES
+    );
+
+    elapsed
+}
+
+fn run_dedicated_baseline() -> Duration {
+    let (registry, mailer, rx) = fresh_substrate_with_outbound();
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<DedicatedBenchLogCap>(())
+            .build_passive()
+            .expect("DedicatedBenchLogCap boots");
+
+    let bytes = encoded_one_entry_batch();
+    let start = Instant::now();
+    for _ in 0..STRESS_BATCHES {
+        push_log_batch(&registry, DedicatedBenchLogCap::NAMESPACE, &bytes);
+    }
+    let received = drain_n_log_batches(&rx, STRESS_BATCHES);
+    let elapsed = start.elapsed();
+
+    drop(chassis);
+
+    assert_eq!(
+        received,
+        STRESS_BATCHES,
+        "dedicated-baseline cap dropped {} of {} mails",
+        STRESS_BATCHES - received,
+        STRESS_BATCHES
+    );
+
+    elapsed
+}
+
+/// Issue 635 Phase 2 stress gate. Runs the dedicated baseline first
+/// (so JIT warm-up doesn't tilt the comparison), then the pooled path,
+/// asserts no drops on either, and bounds the pooled wallclock at
+/// `RATIO_CAP` × the dedicated baseline.
+#[test]
+fn pool_path_drains_10k_log_batches_within_dedicated_budget() {
+    let dedicated = run_dedicated_baseline();
+    let pooled = run_pool_stress();
+
+    let ratio = pooled.as_secs_f64() / dedicated.as_secs_f64().max(f64::MIN_POSITIVE);
+    eprintln!(
+        "log_pool_stress: {} mails — dedicated={:?} pooled={:?} ratio={:.2}x",
+        STRESS_BATCHES, dedicated, pooled, ratio
+    );
+
+    assert!(
+        ratio <= RATIO_CAP,
+        "pooled drain wallclock {:.2}x dedicated baseline (cap {:.2}x); pooled={:?} dedicated={:?}",
+        ratio,
+        RATIO_CAP,
+        pooled,
+        dedicated,
+    );
+}


### PR DESCRIPTION
## Summary

- Issue 635 Phase 2 — flips `LogCapability` from `Scheduling::Dedicated` to `Scheduling::Pooled`, the first cap onto the worker-pool dispatch path landed in PR 682.
- LogCapability's handler is a pure forwarder (drain a `LogBatch`, hand entries to `HubOutbound::egress_log_batch`, return), so it's a clean fit for cooperative pool drain.
- New 10k-mail stress test in `crates/aether-capabilities/tests/log_pool_stress.rs` bounds pool wallclock at 3x of a parallel `Scheduling::Dedicated` baseline cap. Local: pool=15ms, dedicated=17ms, ratio=0.86x.
- MCP smoke confirmed end-to-end: `send_mail` -> mailbox closure -> wake hook -> pool worker -> `on_log_batch` -> recording outbound -> hub ring -> `engine_logs` returns the entry with sequence=1.

## Test plan

- [x] `cargo nextest run --workspace` (1025/1025 pass)
- [x] `cargo nextest run -p aether-capabilities --test log_pool_stress` (passes)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] MCP smoke: spawn a headless substrate + `send_mail` an `aether.log.batch` to `aether.log` — `engine_logs` returns the entry with sequence=1, level=warn, target/message echoed.

Refs iamacoffeepot/aether#635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)