### PR TITLE
refactor(actor): flip Actor::SCHEDULING default to Pooled + audit sweep

### DIFF
--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -49,22 +49,25 @@ pub trait Actor: Sized + Send + 'static {
     /// per-frame coupling will too.
     const FRAME_BARRIER: bool = false;
 
-    /// Issue 635 dispatch placement. `Dedicated` (today's default)
-    /// keeps the actor on its own OS thread — the legacy
-    /// `thread::spawn` path. `Pooled` registers a dispatcher slot with
-    /// the chassis worker pool so many actors share a small thread set.
+    /// Issue 635 dispatch placement. `Pooled` (the default) registers
+    /// a dispatcher slot with the chassis worker pool so many actors
+    /// share a small thread set. `Dedicated` is the opt-in escape
+    /// hatch: it keeps the actor on its own OS thread for actors
+    /// whose handlers can park the dispatcher (today: `wait_reply`,
+    /// `ureq.fetch`, sync disk I/O, blocking external sources the
+    /// chassis can't reify as mail — see `Scheduling::Dedicated`).
     ///
-    /// Phase 1 ships every existing actor with `SCHEDULING = Dedicated`
-    /// (the default), so the runtime takes the today path everywhere.
-    /// Phase 3 flips this default to `Scheduling::Pooled` after every
-    /// actor that genuinely needs its own thread is explicitly
-    /// annotated `Dedicated`.
+    /// Phase 3 flipped this default from `Dedicated` (Phase 1's
+    /// behavior-preserving choice) to `Pooled` after the entire cap
+    /// set was audited. Today only `ProcessCapability` (which uses
+    /// `tokio::Runtime::block_on` to coordinate child-process
+    /// lifecycle) opts back into `Dedicated`.
     ///
     /// `FRAME_BARRIER` and `SCHEDULING` are orthogonal: a frame-bound
     /// actor can be either `Pooled` or `Dedicated`; the per-actor
     /// `pending` counter is read by the chassis frame loop regardless
     /// of where the dispatch happens.
-    const SCHEDULING: Scheduling = Scheduling::Dedicated;
+    const SCHEDULING: Scheduling = Scheduling::Pooled;
 }
 
 /// Issue 635 dispatch placement (see [`Actor::SCHEDULING`]). Equality

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -710,7 +710,6 @@ mod native {
 
         /// ADR-0039 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.audio";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Boot the cap. Always succeeds — cpal init failure logs a
         /// warning and falls back to nop mode (per ADR-0039: audio is a

--- a/crates/aether-capabilities/src/broadcast.rs
+++ b/crates/aether-capabilities/src/broadcast.rs
@@ -63,7 +63,6 @@ mod native {
         /// quiesced before the next observation is read off the
         /// outbound channel.
         const FRAME_BARRIER: bool = true;
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             // The substrate boot wires `HubOutbound` into the mailer

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -89,7 +89,6 @@ mod native {
     impl NativeActor for ComponentHostCapability {
         type Config = ComponentHostConfig;
         const NAMESPACE: &'static str = "aether.component";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             config: ComponentHostConfig,

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -340,7 +340,6 @@ mod native {
 
         /// ADR-0041 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.fs";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Build the adapter registry from the resolved roots. Adapter
         /// init failure surfaces as `BootError::Other(io::Error)` so

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -37,7 +37,6 @@ mod native {
         /// ADR-0045 + ADR-0074 Phase 5: chassis-owned mailbox under the
         /// `aether.<name>` namespace.
         const NAMESPACE: &'static str = "aether.handle";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Pull the shared [`HandleStore`] off the substrate's
         /// [`aether_substrate::Mailer`]. The store is supplied at

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -390,7 +390,6 @@ mod native {
 
         /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.http";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Build the HTTP adapter from the resolved config. The adapter is
         /// built immediately so configuration errors surface at chassis-

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -57,7 +57,6 @@ mod native {
     impl NativeActor for InputCapability {
         type Config = InputConfig;
         const NAMESPACE: &'static str = "aether.input";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(config: InputConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let registry = Arc::clone(ctx.mailer().registry());

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -48,7 +48,6 @@ mod native {
     impl NativeActor for LogCapability {
         type Config = ();
         const NAMESPACE: &'static str = "aether.log";
-        const SCHEDULING: Scheduling = Scheduling::Pooled;
 
         fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned();

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -169,7 +169,6 @@ mod native {
         /// through the frame-bound path so the cap's `pending` counter
         /// registers in the chassis's `frame_bound_pending` Vec.
         const FRAME_BARRIER: bool = true;
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         /// Allocate the accumulator state up front. Idempotent on the
         /// driver-facing side: every chassis main passes a fresh
@@ -727,7 +726,6 @@ mod native_headless {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.render";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -69,7 +69,6 @@ mod listener_native {
     impl NativeActor for TcpListenerActor {
         type Config = TcpListenerConfig;
         const NAMESPACE: &'static str = "aether.tcp.listener";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             mut config: TcpListenerConfig,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -131,7 +131,6 @@ mod cap_native {
     impl NativeActor for TcpCapability {
         type Config = ();
         const NAMESPACE: &'static str = "aether.tcp";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             Ok(Self {

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -87,7 +87,6 @@ mod session_native {
     impl NativeActor for TcpSessionActor {
         type Config = TcpSessionConfig;
         const NAMESPACE: &'static str = "aether.tcp.session";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             mut config: TcpSessionConfig,

--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -42,7 +42,6 @@ mod native {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.test_bench";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -43,7 +43,6 @@ mod native {
         type Config = ();
 
         const NAMESPACE: &'static str = "aether.window";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -114,6 +114,12 @@ mod native {
     impl NativeActor for ProcessCapability {
         type Config = ProcessCapabilityConfig;
         const NAMESPACE: &'static str = "aether.process";
+        // Issue 635 Phase 3: opts back into Dedicated. Every spawn /
+        // signal handler drives the tokio runtime via
+        // `runtime.block_on(...)`, parking the dispatcher thread for
+        // up to the SIGTERM-grace window. Under a worker pool that
+        // would proportionally reduce capacity for every other Pooled
+        // actor; on its own thread the parking is local.
         const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -57,7 +57,6 @@ mod native {
         type Config = TestBenchCapConfig;
 
         const NAMESPACE: &'static str = "aether.test_bench";
-        const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
         fn init(
             config: TestBenchCapConfig,

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -16,11 +16,11 @@
 //! primitive + tombstone population.
 
 use std::any::TypeId;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use aether_actor::{HandlesKind, Instanced, NamespaceError, validate_namespace_segment};
 use aether_data::{Kind, mailbox_id_from_name};
@@ -104,9 +104,17 @@ pub struct Spawner {
     instanced_pending: RwLock<Vec<(MailboxId, Arc<AtomicU64>)>>,
     /// Issue 635 PR C: chassis worker pool's ready-queue sender.
     /// Cloned into [`crate::scheduler::WakeHandle`]s when the
-    /// Pooled spawn branch lands a slot. Today every actor is
-    /// Dedicated so this clone is unused; PR D flips that.
+    /// Pooled spawn branch lands a slot.
     pool_ready_tx: crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>>,
+    /// Issue 635 Phase 3: strong-Arc store for instanced
+    /// [`crate::scheduler::Drainable`] slots spawned via the Pooled
+    /// branch. Without this the slot dropped at end of `spawn_actor`
+    /// and the [`crate::scheduler::WakeHandle`]'s `Weak` failed to
+    /// upgrade — every wake after spawn would silently no-op.
+    /// Slots live until the Spawner itself drops (chassis teardown);
+    /// self-closing actors leave their slot Arc here as a small
+    /// metadata leak (~80 B) that's reclaimed at teardown.
+    instanced_slots: Mutex<HashMap<MailboxId, Arc<dyn crate::scheduler::Drainable>>>,
 }
 
 impl Spawner {
@@ -127,6 +135,7 @@ impl Spawner {
             counter: AtomicU64::new(0),
             instanced_pending: RwLock::new(Vec::new()),
             pool_ready_tx,
+            instanced_slots: Mutex::new(HashMap::new()),
         }
     }
 
@@ -456,12 +465,10 @@ impl Spawner {
                     .expect("dispatcher thread spawn must succeed");
             }
             aether_actor::Scheduling::Pooled => {
-                // Issue 635 PR C: register a `DispatcherSlot` with the
-                // chassis worker pool. No per-actor thread. The wake
-                // hook on the closure pushes the slot to the ready
-                // queue when an envelope lands. Today no
-                // `Instanced + Pooled` actors ship; this branch is
-                // reachable but unused at runtime.
+                // Issue 635 PR C + Phase 3: register a `DispatcherSlot`
+                // with the chassis worker pool. No per-actor thread.
+                // The wake hook on the closure pushes the slot to the
+                // ready queue when an envelope lands.
                 let slot = crate::actor::native::dispatcher_slot::DispatcherSlot::<A>::new(
                     actor,
                     Arc::clone(&transport),
@@ -474,22 +481,30 @@ impl Spawner {
                 let slot_dyn: Arc<dyn crate::scheduler::Drainable> = slot.clone();
                 let weak: std::sync::Weak<dyn crate::scheduler::Drainable> =
                     Arc::downgrade(&slot_dyn);
-                drop(slot_dyn);
                 let wake = crate::scheduler::WakeHandle::new(
                     Arc::clone(slot.state()),
                     weak,
                     self.pool_ready_tx.clone(),
                 );
+                // Stash the slot's strong Arc so wakes can upgrade their
+                // `Weak`. PR C dropped it here, which broke every wake
+                // after spawn (the registry only holds the inbox
+                // sender, not the slot — the comment claiming
+                // otherwise was wrong). Slots live until the Spawner
+                // itself drops at chassis teardown.
+                drop(slot);
+                self.instanced_slots.lock().unwrap().insert(id, slot_dyn);
+                // Pre-loaded `after_init` mail (lines above) was sent
+                // straight to the inbox via `tx.send`, which bypasses
+                // the closure's wake hook. Fire one wake now so the
+                // slot enters the ready queue and the worker drains
+                // those envelopes; subsequent peer sends route through
+                // the closure and wake on their own.
+                let manual_wake = wake.clone();
                 wake_slot.set(Arc::new(move || {
                     wake.wake();
                 }));
-                // Drop the held strong ref. The actor_registry
-                // holds the slot indirectly through the registered
-                // sender + sink handler; the pool's queue holds an
-                // Arc when the slot is woken. On chassis shutdown,
-                // dropping the registry entries + pool joins the
-                // workers; the slot drops at end of its last cycle.
-                drop(slot);
+                manual_wake.wake();
             }
         }
 

--- a/crates/aether-substrate/src/actor/wasm/trampoline.rs
+++ b/crates/aether-substrate/src/actor/wasm/trampoline.rs
@@ -139,7 +139,6 @@ pub struct WasmTrampoline {
 impl NativeActor for WasmTrampoline {
     type Config = WasmTrampolineConfig;
     const NAMESPACE: &'static str = NAMESPACE;
-    const SCHEDULING: Scheduling = Scheduling::Dedicated;
 
     fn init(config: WasmTrampolineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
         let mailbox = ctx.self_id();


### PR DESCRIPTION
## Summary

- Issue 635 Phase 3 — load-bearing default flip after auditing every actor in the workspace.
- `Actor::SCHEDULING` defaults to `Scheduling::Pooled` again (PR C parked it on `Dedicated` to keep hand-rolled test fixtures on the proven path until the cap audit was done).
- Every production cap that was explicitly `Dedicated` drops the annotation and inherits the new default. `WasmTrampoline` (every loaded wasm component runs as one of these) and the `test_bench` cap follow.
- Only `ProcessCapability` opts back into `Dedicated`, with a comment explaining why — its handlers drive the tokio runtime via `runtime.block_on(...)` for spawn / SIGTERM coordination, parking the dispatcher across the operation.

### Bug fix uncovered by the flip

PR C's `Spawner::spawn_actor` Pooled branch (instanced spawn path) `drop(slot)`-ed the `DispatcherSlot` Arc immediately after registering the wake handle, leaving only a `Weak`. Every wake after spawn would silently fail to upgrade — the actor registry only holds the inbox `Sender`, not the slot.

Fixed by stashing the strong Arc in a new `Spawner.instanced_slots: Mutex<HashMap<MailboxId, Arc<dyn Drainable>>>`. Slots live until the `Spawner` itself drops at chassis teardown. Pre-loaded `after_init` mail also needed an explicit one-shot wake, since it lands on the inbox via `tx.send` (bypassing the closure's wake hook); the Pooled branch now fires one wake at the end of spawn so the worker picks up the bootstrap envelopes.

This bug never surfaced under PR C because no production actor was instanced + Pooled. Phase 3 makes everything Pooled, including `WasmTrampoline`, `TcpListenerActor`, `TcpSessionActor` — all instanced.

### What's deferred

The blocking-primitive lint (Phase 3 § Open Question 4 — flag `wait_reply` / `ureq.fetch` / sync disk IO inside Pooled handlers) is parked as a separate ladder PR; it's a non-trivial chunk of work and the audit sweep already lands the structural change.

## Test plan

- [x] `cargo nextest run --workspace` (1026/1026 pass — including the chassis-builder test fixtures that broke under Phase 1 PR C and now route correctly through the fixed Pooled spawn path)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] MCP smoke: spawn a headless substrate, load `aether_camera.wasm` (loads through `ComponentHostCapability` → spawns `WasmTrampoline` on the new Pooled path), send `aether.log.batch` to `aether.log` — `engine_logs` returns the entry with sequence=1; substrate runs stable at ~49fps with the Pooled trampoline servicing per-tick mail.
- [x] The 7 `test_bench_scenario` integration tests cover wasm component lifecycle (load + tick + drop + replace) end-to-end through `WasmTrampoline` on the new Pooled spawn path; all pass.

Refs iamacoffeepot/aether#635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)