### PR TITLE
fix(substrate): run on_close for pooled spawned actors at chassis teardown

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -331,6 +331,29 @@ where
         self.label
     }
 
+    /// Issue 685: chassis-teardown signal. Forwards to the binding's
+    /// `signal_shutdown` so the next [`Self::run_cycle`] observes
+    /// `should_shutdown` at the top of its drain loop and runs the
+    /// close path (phases 2-4 already implemented). Spawner walks
+    /// every instanced slot at chassis teardown and calls this before
+    /// firing a wake.
+    fn signal_shutdown(&self) {
+        self.binding.signal_shutdown();
+    }
+
+    /// Issue 685: chassis-teardown wait predicate. The Closed branch
+    /// of [`Self::run_cycle`] takes the actor out of the `Mutex<Option<Box<A>>>`
+    /// guard, so `actor_guard.is_none()` is equivalent to "close cycle
+    /// has run." Spawner polls this with a bounded timeout while
+    /// waiting for spawned actors to wind down before the pool drops.
+    fn is_closed(&self) -> bool {
+        let guard = self
+            .actor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.is_none()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -114,7 +114,22 @@ pub struct Spawner {
     /// Slots live until the Spawner itself drops (chassis teardown);
     /// self-closing actors leave their slot Arc here as a small
     /// metadata leak (~80 B) that's reclaimed at teardown.
-    instanced_slots: Mutex<HashMap<MailboxId, Arc<dyn crate::scheduler::Drainable>>>,
+    ///
+    /// Issue 685: each entry now also carries a [`WakeHandle`] clone
+    /// so [`Self::shutdown_instanced`] can fire one wake per slot at
+    /// chassis teardown — without it, a freshly-`signal_shutdown`-ed
+    /// slot whose inbox is empty would never enter `run_cycle` to
+    /// observe the flag.
+    instanced_slots: Mutex<HashMap<MailboxId, InstancedSlotEntry>>,
+}
+
+/// One entry in [`Spawner::instanced_slots`]. Holds both the strong
+/// `Arc<dyn Drainable>` (so the wake handle's `Weak` upgrades) and a
+/// [`crate::scheduler::WakeHandle`] clone (so the chassis-teardown
+/// path can wake the slot after signaling shutdown). Issue 685.
+struct InstancedSlotEntry {
+    slot: Arc<dyn crate::scheduler::Drainable>,
+    wake: crate::scheduler::WakeHandle,
 }
 
 impl Spawner {
@@ -146,6 +161,57 @@ impl Spawner {
         &self,
     ) -> &crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>> {
         &self.pool_ready_tx
+    }
+
+    /// Issue 685: walk every spawned instanced slot, signal shutdown
+    /// on its binding, fire one wake so a pool worker picks it up and
+    /// runs the close path (drain residual → `on_close` → registry
+    /// close + monitor fan-out), then poll [`crate::scheduler::Drainable::is_closed`]
+    /// until every slot has finished or `timeout` elapses.
+    ///
+    /// Called from [`crate::chassis::builder::BootedPassives::shutdown_in_place`]
+    /// before the singleton shutdowns walk. The ordering matters:
+    /// spawned actors close *first* so their `MonitorNotice` mail
+    /// reaches singleton watchers while they're still alive. The
+    /// pool stays alive through this method (it drops via the
+    /// `_pool: PoolHandle` field on `BootedPassives` which has a later
+    /// drop order than the explicit `shutdown_in_place` call), so
+    /// workers can drain the close cycles we just queued.
+    ///
+    /// On timeout: logs at warn level and returns. The slot Arcs we
+    /// drained out of `instanced_slots` will then drop, and any actor
+    /// whose close cycle didn't run misses its `on_close` (matches
+    /// the today behavior pre-685).
+    pub(crate) fn shutdown_instanced(&self, timeout: std::time::Duration) {
+        let entries: Vec<InstancedSlotEntry> = {
+            let mut guard = self.instanced_slots.lock().unwrap();
+            guard.drain().map(|(_id, entry)| entry).collect()
+        };
+        if entries.is_empty() {
+            return;
+        }
+        for entry in &entries {
+            entry.slot.signal_shutdown();
+            entry.wake.wake();
+        }
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let all_closed = entries.iter().all(|e| e.slot.is_closed());
+            if all_closed {
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                let stuck = entries.iter().filter(|e| !e.slot.is_closed()).count();
+                tracing::warn!(
+                    target: "aether_substrate::spawner",
+                    stuck_count = stuck,
+                    total = entries.len(),
+                    "shutdown_instanced timed out waiting for spawned actors to run close path",
+                );
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
     }
 
     /// Wait for every spawned instanced actor's inbox to quiesce
@@ -491,9 +557,18 @@ impl Spawner {
                 // after spawn (the registry only holds the inbox
                 // sender, not the slot — the comment claiming
                 // otherwise was wrong). Slots live until the Spawner
-                // itself drops at chassis teardown.
+                // itself drops at chassis teardown. Issue 685 also
+                // stashes a wake clone so chassis teardown can fire
+                // one wake per slot after signaling shutdown.
                 drop(slot);
-                self.instanced_slots.lock().unwrap().insert(id, slot_dyn);
+                let teardown_wake = wake.clone();
+                self.instanced_slots.lock().unwrap().insert(
+                    id,
+                    InstancedSlotEntry {
+                        slot: slot_dyn,
+                        wake: teardown_wake,
+                    },
+                );
                 // Pre-loaded `after_init` mail (lines above) was sent
                 // straight to the inbox via `tx.send`, which bypasses
                 // the closure's wake hook. Fire one wake now so the

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -913,6 +913,15 @@ fn dispatch_configure_log_drain(
 
 impl BootedPassives {
     fn shutdown_in_place(&mut self) {
+        // Issue 685: spawned-instanced actors close BEFORE the
+        // singleton shutdowns walk. Two reasons: (1) their close
+        // path's `MonitorNotice` fan-out targets singleton watchers
+        // that we want still alive, (2) the pool is still up at this
+        // point (drops via `_pool` field order after this method
+        // returns), so workers can drain the close cycles the
+        // `shutdown_instanced` wakes queue.
+        self.spawner
+            .shutdown_instanced(std::time::Duration::from_secs(2));
         while let Some(s) = self.shutdowns.pop() {
             s.shutdown_dyn();
         }
@@ -2048,6 +2057,82 @@ mod tests {
         );
 
         drop(chassis);
+    }
+
+    /// Issue 685: chassis teardown drives `on_close` on every spawned
+    /// instanced actor, even those that never received a self-shutdown
+    /// trigger. Pre-685 the Pooled spawn path's slot was reachable
+    /// from the chassis only through the wake's `Weak`, and nothing
+    /// signaled shutdown at chassis exit — so spawned actors silently
+    /// skipped their close path. The Spawner's `shutdown_instanced`
+    /// step now signals + wakes every spawned slot before the pool
+    /// drops, and the chassis waits for each `Drainable::is_closed`.
+    #[test]
+    fn chassis_teardown_runs_on_close_for_pooled_spawned_actors() {
+        use crate::actor::native::spawn::Subname;
+        use aether_actor::Instanced;
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        struct Quiet {
+            close_observed: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for Quiet {
+            const NAMESPACE: &'static str = "test.teardown.quiet";
+        }
+        impl Instanced for Quiet {}
+        impl crate::actor::native::NativeActor for Quiet {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    close_observed: config,
+                })
+            }
+            fn on_close(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
+        impl crate::actor::native::NativeDispatch for Quiet {
+            fn __aether_dispatch_envelope(
+                &mut self,
+                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let close_observed = Arc::new(AtomicU32::new(0));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        let id = chassis
+            .spawn_actor::<Quiet>(Subname::Counter, Arc::clone(&close_observed))
+            .finish()
+            .expect("spawn instanced actor");
+
+        // No mail at all — the actor sits idle from the moment it
+        // spawns. Pre-685 chassis teardown skipped its close path
+        // entirely; post-685 the teardown step signals + wakes it and
+        // the worker runs the close cycle before the pool drops.
+        assert_eq!(close_observed.load(AtomicOrdering::SeqCst), 0);
+
+        drop(chassis);
+
+        assert_eq!(
+            close_observed.load(AtomicOrdering::SeqCst),
+            1,
+            "chassis teardown must drive on_close exactly once for a quiet spawned actor",
+        );
+        // Drop the unused id binding so clippy stays quiet — its
+        // referent (the actor_registry's Live entry) drops with the
+        // chassis above.
+        let _ = id;
     }
 
     /// Issue 607 Phase 4b verify: a `ctx.monitor(target)` registration

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -242,6 +242,25 @@ pub trait Drainable: Send + Sync + 'static {
         "<unnamed>"
     }
 
+    /// Issue 685: chassis-teardown signal for `Pooled` instanced
+    /// actors. The chassis calls this on every spawned slot before the
+    /// pool drops; a real slot forwards to its
+    /// [`crate::actor::native::NativeBinding::signal_shutdown`] so the
+    /// next [`Self::run_cycle`] observes `should_shutdown` and runs
+    /// the close path (drain residual → `on_close` → registry close +
+    /// monitor fan-out). Default no-op so mock fixtures don't have to
+    /// care.
+    fn signal_shutdown(&self) {}
+
+    /// Issue 685: chassis-teardown wait predicate. Returns `true` once
+    /// the slot has finished its `CycleResult::Closed` cycle and the
+    /// actor's `on_close` + registry close have run. Default `true`
+    /// (mock fixtures are trivially "closed" — they don't have a
+    /// real lifecycle).
+    fn is_closed(&self) -> bool {
+        true
+    }
+
     /// Upcast helper for downcasting in tests. Production code doesn't
     /// reach for this.
     fn as_any(&self) -> &dyn Any;


### PR DESCRIPTION
## Summary

Fixes iamacoffeepot/aether#685.

Pre-fix: instanced actors spawned via `Spawner::spawn_actor` under `Scheduling::Pooled` skipped their entire close path (`on_close`, `actor_registry.close_actor`, monitor fan-out, tombstone) at chassis teardown. Three structural reasons compounded — `DispatcherSlot::run_cycle` only runs when a worker pops the slot, `try_recv` collapsed `Disconnected` into the same `None` as `Empty`, and nothing set `should_shutdown` on a spawned actor's binding at chassis teardown. Singletons were unaffected (`PooledActorShutdown` already signals shutdown for them); spawned actors that self-shut via `ctx.shutdown()` were unaffected too.

## What changed

- **`Drainable` trait** gains `signal_shutdown(&self)` (default no-op) + `is_closed(&self) -> bool` (default `true`) so mock fixtures don't have to care.
- **`DispatcherSlot<A>`** forwards `signal_shutdown` to the binding and reports `is_closed` from the actor-guard (`Mutex<Option<Box<A>>>` becomes `None` after the Closed branch takes the actor).
- **`Spawner.instanced_slots`** now stores both the `Drainable` Arc and a `WakeHandle` clone per entry — the wake clone is what teardown fires.
- **`Spawner::shutdown_instanced(timeout)`** drains the map, fires signal + wake on each, polls `is_closed` until every slot finishes or `timeout` elapses (default 2s).
- **`BootedPassives::shutdown_in_place`** calls `spawner.shutdown_instanced(...)` BEFORE the singleton-shutdowns walk so spawned-actor `MonitorNotice` mail still finds living singleton watchers, and before the pool drops so workers can drain the close cycles. Pool stays alive through this method via the `_pool` field's later drop order.

## Test plan

- [x] New unit test `chassis_teardown_runs_on_close_for_pooled_spawned_actors`: spawns a quiet `Quiet` cap (no mail dispatched), drops the chassis, asserts `on_close` fired exactly once. Passes.
- [x] `cargo nextest run --workspace` (1027/1027 — same coverage as pre-fix plus the new test)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] MCP smoke: spawn headless substrate, load `aether_camera.wasm` (instanced trampoline, Pooled), `terminate_substrate` — clean SIGTERM with `sigkilled: false`, no warnings in `engine_logs`. The wasm trampoline went through the new shutdown_instanced close path on chassis teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)