### PR TITLE
fix(hub): emit handler capability ids as tagged strings (issue 690)

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -429,15 +429,17 @@ mod tests {
     // the lookup path from the full load flow.
 
     fn stub_capabilities() -> args::ComponentCapabilitiesWire {
+        use aether_data::tagged_id::Tag;
+        use aether_data::with_tag;
         args::ComponentCapabilitiesWire {
             handlers: vec![
                 args::HandlerCapabilityWire {
-                    id: 42,
+                    id: aether_data::KindId(with_tag(Tag::Kind, 42)),
                     name: "aether.tick".into(),
                     doc: Some("heartbeat".into()),
                 },
                 args::HandlerCapabilityWire {
-                    id: 0xff,
+                    id: aether_data::KindId(with_tag(Tag::Kind, 0xff)),
                     name: "aether.ping".into(),
                     doc: None,
                 },
@@ -488,6 +490,13 @@ mod tests {
         assert_eq!(receives[1]["name"], "aether.ping");
         assert!(receives[1]["doc"].is_null());
         assert!(response["fallback"].is_null());
+        // Issue 690: handler ids surface as ADR-0064 tagged strings,
+        // not raw u64 numbers — JSON's f64 rounds 64-bit ids past 2^53
+        // so the wire form must be `knd-XXXX-XXXX-XXXX`.
+        let id0 = receives[0]["id"].as_str().expect("id must be a string");
+        assert!(id0.starts_with("knd-"), "id should be tagged: {id0}");
+        let id1 = receives[1]["id"].as_str().expect("id must be a string");
+        assert!(id1.starts_with("knd-"), "id should be tagged: {id1}");
     }
 
     #[tokio::test]

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -338,9 +338,20 @@ pub struct ComponentCapabilitiesWire {
 }
 
 /// One `#[handler]` method's capability entry — see `aether-kinds::HandlerCapability`.
+///
+/// `id` is the typed `KindId`. ADR-0064 / ADR-0065: `KindId`'s serde
+/// impl emits the tagged-string form (`knd-XXXX-XXXX-XXXX`) for
+/// human-readable serializers (JSON) and the raw `u64` for binary
+/// (postcard), so the same field deserializes from the substrate's
+/// postcard frame and serializes out to the MCP JSON response without
+/// any manual conversion. The `#[schemars(with = "String")]` attribute
+/// is required because `aether-data` is `no_std + alloc` and doesn't
+/// depend on schemars; the attribute publishes a `String` schema for
+/// the JSON wire form while leaving serde untouched.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HandlerCapabilityWire {
-    pub id: u64,
+    #[schemars(with = "String")]
+    pub id: aether_data::KindId,
     pub name: String,
     pub doc: Option<String>,
 }


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #690 requires the # for GitHub auto-close -->
## Summary

- Change `HandlerCapabilityWire.id` from raw `u64` to typed `aether_data::KindId` so MCP `describe_component` responses surface ADR-0064 tagged strings (`knd-XXXX-XXXX-XXXX`) instead of f64-rounded numbers.
- `KindId`'s existing serde branches do the work — postcard stays raw `u64` (substrate frame in), JSON emits the tagged form (MCP response out). No manual conversion at the wire boundary.
- `#[schemars(with = "String")]` keeps schemars happy without pulling it down into `aether-data`.

Closes #690

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace` (all suites green; existing `describe_component_returns_stored_capabilities` extended to assert the `knd-` prefix on serialized handler ids)
- [x] MCP smoke (load aether-camera, `describe_component`, confirm each handler `id` is a `knd-...` tagged string)