### PR TITLE
chore(ci): enforce type and crate or design labels on issues

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,75 @@
+name: Issue labels
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  enforce:
+    name: Require type and crate (or design)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+
+            const hasType = labels.some(n => n.startsWith('type:'));
+            const hasCrate = labels.some(n => n.startsWith('crate:'));
+            const hasDesign = labels.includes('design');
+
+            const missing = [];
+            if (!hasType) {
+              missing.push('a `type:*` label (`type:fix`, `type:feat`, `type:refactor`, `type:chore`, `type:docs`, `type:perf`)');
+            }
+            if (!hasCrate && !hasDesign) {
+              missing.push('a `crate:*` label (or `design` for cross-cutting / architectural issues)');
+            }
+
+            const marker = '<!-- issue-label-bot -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (missing.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              'This issue is missing ' + missing.join(' and ') + '.',
+              '',
+              'Add via the labels sidebar — this comment auto-resolves once the labels are present.',
+            ].join('\n');
+
+            if (existing) {
+              if (existing.body !== body) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/issue-labels.yml` — runs on every issue event and posts a sticky comment listing what's missing when an issue lacks required labels.
- Required labels: one `type:*` label, AND either one `crate:*` label OR the `design` label.
- Comment auto-resolves (deletes itself) once the labels are present. Marker comment `<!-- issue-label-bot -->` lets the workflow find / update / replace itself.
- Same `actions/github-script@v7` pattern as the existing `pr-title.yml` workflow.

## Test plan

- [x] Workflow YAML parses (verified locally; `actions/github-script@v7` is already in use in `pr-title.yml`).
- [ ] After merge: edit a labeled-correctly issue (e.g. one of the freshly-tagged ones) — bot should not comment.
- [ ] After merge: open a fresh issue with no labels — bot should post a comment listing both missing label classes.
- [ ] After merge: add the missing labels — bot should delete its own comment on the next event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)