### PR TITLE
refactor(actor): add wire/unwire trait methods, rename on_close to unwire

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1541,7 +1541,10 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                     });
                 } else if name == "init" {
                     init_method = Some(f);
-                } else if matches!(name.as_str(), "on_replace" | "on_drop" | "on_rehydrate") {
+                } else if matches!(
+                    name.as_str(),
+                    "wire" | "unwire" | "on_replace" | "on_drop" | "on_rehydrate"
+                ) {
                     lifecycle_methods.push(f);
                 } else if name == "receive" {
                     return Err(syn::Error::new_spanned(
@@ -1698,14 +1701,15 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     let mut fallback: Option<NativeFallbackFn> = None;
     let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
     let mut consts: Vec<syn::ImplItemConst> = Vec::new();
-    // Issue 607 Phase 4a (ADR-0079): `on_close` is a `NativeActor` trait
-    // method with a default empty body. When a cap overrides it, the
-    // override must land inside the trait impl block (so the
-    // dispatcher trampoline's `actor.on_close(...)` resolves to the
-    // override via trait dispatch). Pre-issue-625 the macro routed
-    // every non-handler / non-init fn into the inherent impl, so
-    // `on_close` overrides triggered a dead_code warning and (worse)
-    // didn't override the trait method at all.
+    // Issue 584 (ADR-0079 amended): `wire` and `unwire` are
+    // `NativeActor` trait methods with default empty bodies. When a
+    // cap overrides them, the override must land inside the trait
+    // impl block (so the dispatcher trampoline's `actor.wire(...)` /
+    // `actor.unwire(...)` resolves to the override via trait
+    // dispatch). Pre-issue-625 the macro routed every non-handler /
+    // non-init fn into the inherent impl, so lifecycle overrides
+    // triggered a dead_code warning and (worse) didn't override the
+    // trait method at all.
     let mut lifecycle_methods: Vec<syn::ImplItemFn> = Vec::new();
 
     for impl_item in item.items {
@@ -1752,7 +1756,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     fallback = Some(NativeFallbackFn { method: f });
                 } else if f.sig.ident == "init" {
                     init_method = Some(f);
-                } else if f.sig.ident == "on_close" {
+                } else if f.sig.ident == "wire" || f.sig.ident == "unwire" {
                     lifecycle_methods.push(f);
                 } else {
                     helpers.push(f);

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -163,6 +163,32 @@ pub trait FfiActor: crate::Actor {
     where
         C: Resolver + MailSender;
 
+    /// Post-init mail-allowed hook (issue 584, ADR-0079 amended
+    /// 2026-05-09). Runs after `init` returned `Ok` and the actor's
+    /// mailbox is published, but before the dispatcher pulls the
+    /// first envelope. The actor may send mail here — peers are
+    /// addressable. Default no-op; override to register subscriptions,
+    /// announce the actor, or kick off a poll loop via self-mail.
+    fn wire<C>(&mut self, ctx: &mut C)
+    where
+        C: Resolver + MailSender,
+    {
+        let _ = ctx;
+    }
+
+    /// Pre-shutdown mail-allowed hook (issue 584, ADR-0079 amended
+    /// 2026-05-09). Runs after the dispatcher's inbox drain, before
+    /// the actor value drops. Mail to live peers lands in their
+    /// mailboxes; sends to a dead peer warn-drop. Default no-op;
+    /// override to publish a final broadcast, signal monitors, or
+    /// flush state.
+    fn unwire<C>(&mut self, ctx: &mut C)
+    where
+        C: Resolver + MailSender,
+    {
+        let _ = ctx;
+    }
+
     /// Called once on the instance being dropped — both for
     /// `drop_component` and for the old instance of
     /// `replace_component` — immediately before the substrate tears

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -7,10 +7,10 @@
 //! actor's own mailbox. The wake handler drains the mpsc and does
 //! the spawn on the dispatcher thread.
 //!
-//! Shutdown: `on_close` flips the accept thread's shutdown flag, then
+//! Shutdown: `unwire` flips the accept thread's shutdown flag, then
 //! self-connects to the bound port to wake the blocked accept call.
 //! The accept returns, sees the flag, breaks; the dispatcher thread
-//! (in `on_close`) joins the accept thread.
+//! (in `unwire`) joins the accept thread.
 
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
@@ -81,7 +81,7 @@ mod listener_native {
             let addr = config.addr;
             let port = config.port;
             // Stay blocking — the accept loop wakes via self-connect
-            // on `on_close`. Nonblocking would require a poll loop +
+            // on `unwire`. Nonblocking would require a poll loop +
             // CPU burn for no win.
             listener
                 .set_nonblocking(false)
@@ -156,7 +156,7 @@ mod listener_native {
             })
         }
 
-        fn on_close(&mut self, _ctx: &mut NativeCtx<'_>) {
+        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
             self.shutdown.store(true, Ordering::Release);
             // Wake the blocked accept(). Self-connect to the bound
             // port; the accept returns, sees the flag, breaks. Short
@@ -178,7 +178,7 @@ mod listener_native {
 
         /// Cooperative external close. The unbind path on
         /// `TcpCapability` mails this; we shut down so the dispatcher
-        /// drains, runs `on_close`, and the close fan-out fires
+        /// drains, runs `unwire`, and the close fan-out fires
         /// `MonitorNotice` to the cap.
         #[handler]
         fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: Close) {

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! Each listener owns one sidecar OS thread that holds the
 //! `std::net::TcpListener` and runs a blocking accept loop. On
-//! `on_close` the listener flips a shutdown flag and self-connects
+//! `unwire` the listener flips a shutdown flag and self-connects
 //! to its bound port to wake the blocked accept; the accept returns,
 //! sees the flag, breaks; the dispatcher thread joins.
 

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -14,7 +14,7 @@
 //! caller initiates writes synchronously and they're typically
 //! fast.
 //!
-//! Shutdown: `on_close` flips the read thread's shutdown flag and
+//! Shutdown: `unwire` flips the read thread's shutdown flag and
 //! calls `stream.shutdown(Both)` on the write half. The kernel
 //! aborts any blocked `read()` on the read half, the read thread
 //! sees the error / EOF, exits. The dispatcher joins the thread
@@ -79,7 +79,7 @@ mod session_native {
         mailer: Arc<Mailer>,
         // Sticks to true once a `SessionClosed` broadcast has fired
         // so duplicate broadcasts don't pile up if both the read
-        // path and `on_close` see the close.
+        // path and `unwire` see the close.
         closed_emitted: bool,
     }
 
@@ -190,7 +190,7 @@ mod session_native {
             })
         }
 
-        fn on_close(&mut self, _ctx: &mut NativeCtx<'_>) {
+        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
             self.shutdown.store(true, Ordering::Release);
             // Aborting the socket from the write half wakes any
             // blocked `read()` on the read half (same underlying fd).
@@ -286,7 +286,7 @@ mod session_native {
 
         /// Cooperative external close. Same shape as the listener
         /// pattern: peer mails this, we call `ctx.shutdown()`, the
-        /// dispatcher drains remaining inbox mail, runs `on_close`
+        /// dispatcher drains remaining inbox mail, runs `unwire`
         /// (which joins the read thread and emits `SessionClosed`).
         #[handler]
         fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionClose) {
@@ -300,7 +300,7 @@ mod session_native {
         ctx.send_to_named::<K>(HUB_BROADCAST_MAILBOX_NAME, payload);
     }
 
-    /// Broadcast variant for `on_close` where we want to use the
+    /// Broadcast variant for `unwire` where we want to use the
     /// stored `mailer` reference directly (still inside the
     /// dispatcher thread). Functionally equivalent — the
     /// `send_to_named` path also goes through `Mailer::push` —

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -436,7 +436,7 @@ pub struct UnresolvedMail {
 /// Issue 607 Phase 4b (ADR-0079): framework-emitted close
 /// notification. Sent to every monitor a closing actor accumulated via
 /// `NativeCtx::monitor` — the substrate drains `monitors_of[target]`
-/// after the target's `on_close` runs, fires one `MonitorNotice` per
+/// after the target's `unwire` runs, fires one `MonitorNotice` per
 /// watcher, and only then flips the target's slot from `Live` to
 /// `Dead`.
 ///

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -116,7 +116,7 @@ pub struct NativeBinding {
     /// Issue 607 Phase 4a (ADR-0079): self-shutdown flag. The actor's
     /// dispatcher polls this between handler dispatches; flipping it
     /// (via [`Self::signal_shutdown`] / `NativeCtx::shutdown`) tells
-    /// the dispatcher to drain the inbox, run `on_close`, and exit.
+    /// the dispatcher to drain the inbox, run `unwire`, and exit.
     /// Substrate-shutdown (channel disconnect) flows through the same
     /// drain → close → exit path without setting the flag.
     shutdown_flag: Arc<AtomicBool>,
@@ -251,7 +251,7 @@ impl NativeBinding {
     /// actor's dispatcher polls between handler dispatches. Subsequent
     /// `recv_blocking` calls still process incoming mail, but
     /// `should_shutdown` reports `true` so the trampoline can drain
-    /// the inbox synchronously, run `on_close`, and exit. Idempotent.
+    /// the inbox synchronously, run `unwire`, and exit. Idempotent.
     pub fn signal_shutdown(&self) {
         self.shutdown_flag.store(true, Ordering::Release);
     }

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -98,7 +98,7 @@ impl<'a> NativeCtx<'a> {
     /// Issue 607 Phase 4a (ADR-0079): self-shutdown signal. Sets a
     /// flag the actor's dispatcher polls after each handler returns;
     /// when set, the trampoline drains any remaining inbox mail
-    /// synchronously, runs `NativeActor::on_close`, and exits the
+    /// synchronously, runs `NativeActor::unwire`, and exits the
     /// dispatch loop. After exit the actor's [`crate::MailboxId`]
     /// transitions from `Live` to `Dead` in the chassis's
     /// [`crate::ActorRegistry`] and is added to `tombstones` —

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -21,9 +21,9 @@
 //!    `LogBatch` to `LogCapability`. Two-step typed → fallback dispatch.
 //! 3. **Drain after shutdown.** Any envelope already in the inbox
 //!    when the shutdown signal fired is processed synchronously
-//!    before `on_close` runs (matches the existing singleton
+//!    before `unwire` runs (matches the existing singleton
 //!    semantics).
-//! 4. **`on_close`.** Last-chance hook with `ReplyTo::NONE`. Wrapped
+//! 4. **`unwire`.** Last-chance hook with `ReplyTo::NONE`. Wrapped
 //!    in the same `with_stamped` + `with_actor_dispatch` so any
 //!    final tracing or `Local<T>` access works.
 //! 5. **Registry close + monitor fan-out.** `actor_registry.close_actor(id)`
@@ -106,7 +106,7 @@ pub(crate) fn dispatch_loop_run<A>(
 
     // Phase 2: drain remaining inbox synchronously. The shutdown
     // flag / disconnect raced against any in-flight mail the sink
-    // handler already pushed; the actor sees it before `on_close`
+    // handler already pushed; the actor sees it before `unwire`
     // runs so a "please close" handler that flushes state observes
     // the full inbox.
     while let Some(env) = binding.try_recv() {
@@ -132,7 +132,7 @@ pub(crate) fn dispatch_loop_run<A>(
             &**binding as &dyn crate::runtime::log_install::MailDispatch,
             || {
                 let mut close_ctx = NativeCtx::new(binding, ReplyTo::NONE);
-                actor.on_close(&mut close_ctx);
+                actor.unwire(&mut close_ctx);
                 aether_actor::log::drain_buffer();
             },
         );

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -6,7 +6,7 @@
 //! [`crate::actor::native::dispatch::dispatch_loop_run`] is the loop a
 //! `Dedicated` actor runs on its own thread. It owns the actor, blocks
 //! on `recv_blocking`, and runs the four-phase lifecycle
-//! (main loop → drain after shutdown → on_close → registry close).
+//! (main loop → drain after shutdown → unwire → registry close).
 //!
 //! `DispatcherSlot::run_cycle` is the *budget-bounded* version of the
 //! same logic for the `Pooled` path. Each call to `run_cycle` does:
@@ -25,7 +25,7 @@
 //!    - [`CycleResult::Requeue`] — budget hit (state `Ready`) or
 //!      post-empty recheck won the requeue CAS; worker re-pushes.
 //!    - [`CycleResult::Closed`] — shutdown observed; the slot ran the
-//!      post-shutdown drain + `on_close` hook + registry finalize
+//!      post-shutdown drain + `unwire` hook + registry finalize
 //!      sequence and is done forever.
 //!
 //! ## Today (PR C)
@@ -76,7 +76,7 @@ use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
 use crate::scheduler::{BatchBudget, CycleResult, Drainable, SlotState};
 
 /// Worker-pool-side wrapper for a native actor. One instance per
-/// `Pooled` actor; held strongly by the chassis (so `on_close` and
+/// `Pooled` actor; held strongly by the chassis (so `unwire` and
 /// registry finalize run when the cap shuts down) and weakly by the
 /// pool's [`crate::scheduler::WakeHandle`] (so a wake after the cap
 /// is gone silently no-ops).
@@ -90,7 +90,7 @@ where
     /// is in `Running` at a time, so the `Mutex` is uncontested in
     /// production — used here over `UnsafeCell` only for the simpler
     /// safety story. `Option` so the `Closed` finalize path can take
-    /// the box and run `on_close` on the consumed actor.
+    /// the box and run `unwire` on the consumed actor.
     actor: Mutex<Option<Box<A>>>,
     /// Per-actor binding (inbox + shutdown flag + reply machinery).
     binding: Arc<NativeBinding>,
@@ -129,7 +129,7 @@ where
     /// Borrow this slot's [`NativeBinding`]. The chassis-cap shutdown
     /// path uses this to call [`NativeBinding::signal_shutdown`] when
     /// the cap is going down — the next call into [`Self::run_cycle`]
-    /// observes the flag and runs the `on_close` + registry finalize
+    /// observes the flag and runs the `unwire` + registry finalize
     /// sequence.
     pub(crate) fn binding(&self) -> &Arc<NativeBinding> {
         &self.binding
@@ -189,7 +189,7 @@ where
         }
     }
 
-    /// Phase 3 of the dispatch_loop_run lifecycle. Wraps `actor.on_close`
+    /// Phase 3 of the dispatch_loop_run lifecycle. Wraps `actor.unwire`
     /// in the same `with_stamped` + `with_actor_dispatch` envelope so a
     /// final tracing event from the close hook still routes to
     /// `LogCapability`.
@@ -199,7 +199,7 @@ where
                 &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
                 || {
                     let mut close_ctx = NativeCtx::new(&self.binding, ReplyTo::NONE);
-                    actor.on_close(&mut close_ctx);
+                    actor.unwire(&mut close_ctx);
                     aether_actor::log::drain_buffer();
                 },
             );
@@ -285,7 +285,7 @@ where
             while let Some(env) = self.binding.try_recv() {
                 self.dispatch_one(actor, env);
             }
-            // Phase 3: on_close hook.
+            // Phase 3: unwire hook.
             self.run_close_hook(actor);
             // Phase 4: registry close + monitor fan-out.
             self.finalize_registry();

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -108,9 +108,18 @@ pub trait NativeActor: Actor {
     where
         Self: Sized;
 
-    /// Issue 607 Phase 4a (ADR-0079): last-chance close hook. Runs
-    /// after the dispatcher's inbox drain, before the actor value
-    /// drops. Triggers:
+    /// Post-init mail-allowed hook (issue 584, ADR-0079 amended
+    /// 2026-05-09). Runs after `init` returned `Ok` and the actor's
+    /// mailbox is published, but before the dispatcher pulls the
+    /// first envelope. The actor may send mail here — peers are
+    /// addressable and the chassis is past the boot barrier. Default
+    /// empty — opt-in for actors that need to register subscriptions,
+    /// announce themselves, or kick off a poll loop via self-mail.
+    fn wire(&mut self, _ctx: &mut NativeCtx<'_>) {}
+
+    /// Pre-shutdown mail-allowed hook (issue 584, ADR-0079 amended
+    /// 2026-05-09). Runs after the dispatcher's inbox drain, before
+    /// the actor value drops. Triggers:
     ///
     /// - Self-shutdown — actor's handler called `ctx.shutdown()`;
     ///   dispatcher saw the flag set after the handler returned.
@@ -122,10 +131,14 @@ pub trait NativeActor: Actor {
     ///   `ctx.shutdown()`. From the dispatcher's perspective this is
     ///   identical to self-shutdown.
     ///
+    /// Mail emitted from `unwire` lands in peer mailboxes if those
+    /// peers are still alive; sends to a dead peer warn-drop. Use this
+    /// to publish a final broadcast, flush state, or signal monitors.
+    /// Default empty — opt-in.
+    ///
     /// Issue 629 / Phase A: `&mut self` since the dispatcher thread
-    /// owns the cap exclusively. Default empty — opt-in for caps that
-    /// need to publish a final broadcast or flush state.
-    fn on_close(&mut self, _ctx: &mut NativeCtx<'_>) {}
+    /// owns the cap exclusively.
+    fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {}
 }
 
 /// Sum dispatch entry-point — emitted once per `#[actor] impl

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -12,7 +12,7 @@
 //! Termination not implemented yet — instanced actors live for the
 //! chassis's lifetime; their dispatcher thread exits when the
 //! `Registry` drops (the sink handler's `Weak<Sender>` upgrade fails,
-//! the mpsc disconnects). Phase 4 wires `on_close` + the monitor
+//! the mpsc disconnects). Phase 4 wires `unwire` + the monitor
 //! primitive + tombstone population.
 
 use std::any::TypeId;
@@ -165,7 +165,7 @@ impl Spawner {
 
     /// Issue 685: walk every spawned instanced slot, signal shutdown
     /// on its binding, fire one wake so a pool worker picks it up and
-    /// runs the close path (drain residual → `on_close` → registry
+    /// runs the close path (drain residual → `unwire` → registry
     /// close + monitor fan-out), then poll [`crate::scheduler::Drainable::is_closed`]
     /// until every slot has finished or `timeout` elapses.
     ///
@@ -180,7 +180,7 @@ impl Spawner {
     ///
     /// On timeout: logs at warn level and returns. The slot Arcs we
     /// drained out of `instanced_slots` will then drop, and any actor
-    /// whose close cycle didn't run misses its `on_close` (matches
+    /// whose close cycle didn't run misses its `unwire` (matches
     /// the today behavior pre-685).
     pub(crate) fn shutdown_instanced(&self, timeout: std::time::Duration) {
         let entries: Vec<InstancedSlotEntry> = {

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -301,7 +301,7 @@ impl ActorRegistry {
 
     /// Issue 607 Phase 4a (ADR-0079): flip the slot at `id` from
     /// `Live` to `Dead` and insert the id into `tombstones`. Called
-    /// by the instanced-actor dispatcher after `on_close` runs so
+    /// by the instanced-actor dispatcher after `unwire` runs so
     /// future `spawn_child` calls reject reuse of the retired name
     /// with `SpawnError::SubnameRetired`. Idempotent — re-running on
     /// an already-`Dead` slot leaves it `Dead` and doesn't double-

--- a/crates/aether-substrate/src/actor/wasm/trampoline.rs
+++ b/crates/aether-substrate/src/actor/wasm/trampoline.rs
@@ -35,7 +35,7 @@
 //! - **Drop**: [`DropComponent`] mail addressed to the trampoline's
 //!   mailbox lands on [`Self::on_drop_component`], which calls
 //!   `ctx.shutdown()`. The framework drains the inbox, runs
-//!   `on_close`, and the dispatcher exits.
+//!   `unwire`, and the dispatcher exits.
 //! - **Replace**: [`ReplaceComponent`] mail lands on
 //!   [`Self::on_replace_component`], which instantiates a new
 //!   [`Component`] against the same binding and swaps `self.component`.

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -465,7 +465,7 @@ where
 /// On chassis shutdown:
 /// 1. Sets the binding's `should_shutdown` flag so the next
 ///    [`crate::scheduler::DispatcherSlot::run_cycle`] observes the
-///    signal and runs `on_close` + registry finalize.
+///    signal and runs `unwire` + registry finalize.
 /// 2. Drops the [`crate::chassis::ctx::MailboxSender`] so subsequent
 ///    sends warn-and-discard.
 /// 3. Drops the slot Arc — the chassis-held strong ref. The pool
@@ -1852,12 +1852,12 @@ mod tests {
     }
 
     /// Issue 607 Phase 4a verify: `ctx.shutdown()` from inside an
-    /// instanced actor's handler triggers the drain → on_close → exit
+    /// instanced actor's handler triggers the drain → unwire → exit
     /// path, flips the actor_registry slot to `Dead`, and inserts the
     /// id into `tombstones`. A reused subname after retirement returns
     /// `SpawnError::SubnameRetired`.
     #[test]
-    fn ctx_shutdown_marks_dead_runs_on_close_tombstones_id() {
+    fn ctx_shutdown_marks_dead_runs_unwire_tombstones_id() {
         use crate::actor::native::spawn::{SpawnError, Subname};
         use crate::mail::registry::MailboxEntry;
         use aether_actor::{HandlesKind, Instanced};
@@ -1901,7 +1901,7 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn on_close(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
@@ -1935,7 +1935,7 @@ mod tests {
         // Push a Quit envelope at the spawned mailbox via the
         // registered sink handler. The handler's `ctx.shutdown()`
         // flips the dispatcher's flag; after the handler returns the
-        // trampoline drains, runs `on_close`, marks Dead, tombstones.
+        // trampoline drains, runs `unwire`, marks Dead, tombstones.
         let MailboxEntry::Closure(handler) = registry.entry(id).expect("sink registered") else {
             panic!("expected mailbox entry for instanced actor");
         };
@@ -1949,7 +1949,7 @@ mod tests {
             1,
         );
 
-        // Wait for on_close to run + the registry slot to flip Dead.
+        // Wait for unwire to run + the registry slot to flip Dead.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
         while close_observed.load(AtomicOrdering::SeqCst) == 0
             && std::time::Instant::now() < deadline
@@ -1959,10 +1959,10 @@ mod tests {
         assert_eq!(
             close_observed.load(AtomicOrdering::SeqCst),
             1,
-            "on_close fired exactly once after the dispatcher drained"
+            "unwire fired exactly once after the dispatcher drained"
         );
         // Spin until the slot transitions Dead — the dispatcher
-        // thread runs `mark_dead` after `on_close`, so there's a
+        // thread runs `mark_dead` after `unwire`, so there's a
         // small window between the close-observed bump above and the
         // registry update.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -1971,7 +1971,7 @@ mod tests {
         }
         assert!(
             !chassis.actor_registry().is_live(id),
-            "registry slot should transition Live → Dead after on_close runs"
+            "registry slot should transition Live → Dead after unwire runs"
         );
         assert!(
             chassis.actor_registry().is_tombstoned(id),
@@ -1994,7 +1994,7 @@ mod tests {
         drop(chassis);
     }
 
-    /// Issue 685: chassis teardown drives `on_close` on every spawned
+    /// Issue 685: chassis teardown drives `unwire` on every spawned
     /// instanced actor, even those that never received a self-shutdown
     /// trigger. Pre-685 the Pooled spawn path's slot was reachable
     /// from the chassis only through the wake's `Weak`, and nothing
@@ -2003,7 +2003,7 @@ mod tests {
     /// step now signals + wakes every spawned slot before the pool
     /// drops, and the chassis waits for each `Drainable::is_closed`.
     #[test]
-    fn chassis_teardown_runs_on_close_for_pooled_spawned_actors() {
+    fn chassis_teardown_runs_unwire_for_pooled_spawned_actors() {
         use crate::actor::native::spawn::Subname;
         use aether_actor::Instanced;
         use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
@@ -2025,7 +2025,7 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn on_close(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
@@ -2062,7 +2062,7 @@ mod tests {
         assert_eq!(
             close_observed.load(AtomicOrdering::SeqCst),
             1,
-            "chassis teardown must drive on_close exactly once for a quiet spawned actor",
+            "chassis teardown must drive unwire exactly once for a quiet spawned actor",
         );
         // Drop the unused id binding so clippy stays quiet — its
         // referent (the actor_registry's Live entry) drops with the
@@ -2432,7 +2432,7 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn on_close(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
@@ -2521,7 +2521,7 @@ mod tests {
         assert_eq!(
             close_observed.load(AtomicOrdering::SeqCst),
             1,
-            "watcher's on_close fired exactly once",
+            "watcher's unwire fired exactly once",
         );
 
         // Watcher slot tombstones; target slot still Live; target's

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -247,14 +247,14 @@ pub trait Drainable: Send + Sync + 'static {
     /// pool drops; a real slot forwards to its
     /// [`crate::actor::native::NativeBinding::signal_shutdown`] so the
     /// next [`Self::run_cycle`] observes `should_shutdown` and runs
-    /// the close path (drain residual → `on_close` → registry close +
+    /// the close path (drain residual → `unwire` → registry close +
     /// monitor fan-out). Default no-op so mock fixtures don't have to
     /// care.
     fn signal_shutdown(&self) {}
 
     /// Issue 685: chassis-teardown wait predicate. Returns `true` once
     /// the slot has finished its `CycleResult::Closed` cycle and the
-    /// actor's `on_close` + registry close have run. Default `true`
+    /// actor's `unwire` + registry close have run. Default `true`
     /// (mock fixtures are trivially "closed" — they don't have a
     /// real lifecycle).
     fn is_closed(&self) -> bool {


### PR DESCRIPTION
## Summary

Phase 1 of issue 584 (ADR-0079 amended): introduce the `wire` / `unwire` lifecycle hook surface. Phases 2a/2b wire native + wasm dispatch; Phase 3 migrates init-time mail to `wire` and retires `FfiActor::on_drop`.

- `NativeActor`: adds `wire` (default no-op); renames `on_close` to `unwire`.
- `FfiActor`: adds `wire` and `unwire` defaults over `Resolver + MailSender` for symmetry — FFI exports land in Phase 2b.
- `#[actor]` macro allow-list updated for both arms.
- Caps + dispatch + test stubs renamed; doc-comment sweep across substrate + `aether-kinds`.

`wire` is unused at runtime in Phase 1 by design — the trait surface lands now so Phase 2a can wire dispatch sites without a second trait edit.

Refs iamacoffeepot/aether#584

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --workspace`
- [x] `cargo check -p aether-camera --target wasm32-unknown-unknown`