### PR TITLE
refactor(actor): wire runtime-spawned instanced actors after init

### DIFF
--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -481,6 +481,27 @@ impl Spawner {
             return Err(SpawnError::SubnameInUse { full_name });
         }
 
+        // Issue 584 Phase 2a (ADR-0079 amended): post-init mail-allowed
+        // hook. Sink + actor_registry insert_live above means the
+        // mailbox is fully published; peers are addressable and any
+        // wire-time self-mail lands in this binding's inbox before the
+        // dispatcher pulls. Runtime-spawn doesn't need the chassis-boot
+        // multi-pass barrier (issue 697) because the substrate is
+        // already steady-state when `Spawner::spawn_actor` runs — the
+        // child wire→dispatcher transition is sequential within this
+        // ctx, peers are running, all mailboxes claimed.
+        aether_actor::local::with_stamped(&slots, || {
+            crate::runtime::log_install::with_actor_dispatch(
+                &*transport as &dyn crate::runtime::log_install::MailDispatch,
+                || {
+                    let mut wire_ctx =
+                        crate::actor::native::NativeCtx::new(&transport, ReplyTo::NONE);
+                    actor.wire(&mut wire_ctx);
+                    aether_actor::log::drain_buffer();
+                },
+            );
+        });
+
         // Pre-load bootstrap mail. tx is alive (rx is held by the
         // transport; nobody's polling yet), so these sends always
         // succeed. Each pre-load increments the pending counter so

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -3643,4 +3643,67 @@ mod tests {
 
         drop(chassis);
     }
+
+    /// Issue 584 Phase 2a runtime sibling: `Spawner::spawn_actor` runs
+    /// `wire` exactly once on a freshly-spawned instanced actor —
+    /// after `init` Ok and after the mailbox is published, before
+    /// pre-load mail or the dispatcher pull. Runtime spawn doesn't
+    /// need the chassis-boot multi-pass barrier (the substrate is
+    /// already steady-state).
+    #[test]
+    fn spawn_actor_runs_wire_once_after_init() {
+        use crate::actor::native::spawn::Subname;
+        use aether_actor::Instanced;
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        struct WireSpawnProbe {
+            wire_count: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for WireSpawnProbe {
+            const NAMESPACE: &'static str = "test.spawn_wire.probe";
+        }
+        impl Instanced for WireSpawnProbe {}
+        impl crate::actor::native::NativeActor for WireSpawnProbe {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self { wire_count: config })
+            }
+            fn wire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+                self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
+        impl crate::actor::native::NativeDispatch for WireSpawnProbe {
+            fn __aether_dispatch_envelope(
+                &mut self,
+                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        let (registry, mailer) = fresh_substrate();
+        let wire_count = Arc::new(AtomicU32::new(0));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        let id = chassis
+            .spawn_actor::<WireSpawnProbe>(Subname::Counter, Arc::clone(&wire_count))
+            .finish()
+            .expect("spawn instanced actor");
+
+        assert_eq!(
+            wire_count.load(AtomicOrdering::SeqCst),
+            1,
+            "wire must fire exactly once on Spawner::spawn_actor",
+        );
+
+        drop(chassis);
+        let _ = id;
+    }
 }


### PR DESCRIPTION
## Summary

Issue 584 Phase 2a follow-on. `Spawner::spawn_actor` now calls `actor.wire(&mut NativeCtx)` after init Ok and after the mailbox is fully published (sink registered + actor_registry `insert_live`), before pre-load mail and dispatcher spawn. Wrapped in the same `with_stamped` + `with_actor_dispatch` envelope as init/handler dispatch.

Runtime spawn doesn't need the chassis-boot multi-pass barrier (PR iamacoffeepot/aether#698 / issue 697) because the substrate is already steady-state when `spawn_actor` runs — peers are running, mailboxes claimed, child `wire`→dispatcher is sequential within one ctx.

Test: `spawn_actor_runs_wire_once_after_init` covers the new call site.

Phasing recap:
- 584 Phase 1: trait surface (PR iamacoffeepot/aether#696, merged).
- 697: chassis-boot multi-pass + builder wire pass (PR iamacoffeepot/aether#698, queued).
- **This PR: Spawner::spawn_actor wires.**
- 584 Phase 2b: wasm FFI exports for wire/unwire.
- 584 Phase 3: migrate init-time mail to wire; retire `FfiActor::on_drop`.

## Test plan

- [x] `cargo nextest run --workspace` (1025 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo check -p aether-camera --target wasm32-unknown-unknown`