### PR TITLE
refactor(actor): drop MailSender from init ctxs; introduce Subscriber trait (issue 703)

### DIFF
--- a/crates/aether-actor/examples/caller.rs
+++ b/crates/aether-actor/examples/caller.rs
@@ -52,7 +52,7 @@ impl FfiActor for Caller {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(Caller { next_seq: 0 })
     }

--- a/crates/aether-actor/examples/echoer.rs
+++ b/crates/aether-actor/examples/echoer.rs
@@ -7,7 +7,7 @@
 //! inbound mail by `#[actor]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, KindId, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -35,7 +35,7 @@ impl FfiActor for Echoer {
 
     fn init<C>(ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(Echoer {
             response: ctx.resolve::<Response>(),

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -16,7 +16,7 @@
 //! MCP via the same section so the harness sees typed capabilities
 //! plus author-written intent for each inbox.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, KindId, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
 use aether_capabilities::RenderCapability;
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
@@ -68,7 +68,7 @@ impl FfiActor for Hello {
 
     fn init<C>(ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(Hello {
             pong: ctx.resolve::<Pong>(),

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -14,7 +14,7 @@
 //! kind at init, so the test harness just loads the component and
 //! starts driving input — no manual `subscribe_input` needed.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::BroadcastCapability;
 use aether_data::{Kind, Schema};
 use aether_kinds::{Key, MouseButton, MouseMove, Tick};
@@ -36,7 +36,7 @@ impl FfiActor for InputLogger {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(InputLogger)
     }

--- a/crates/aether-actor/examples/postcard_echoer.rs
+++ b/crates/aether-actor/examples/postcard_echoer.rs
@@ -13,7 +13,7 @@
 //! to wasm; load via `mcp__aether-hub__load_component` and send
 //! `demo.postcard_request` to verify the dispatch.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::BroadcastCapability;
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
@@ -48,7 +48,7 @@ impl FfiActor for PostcardEchoer {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(PostcardEchoer)
     }

--- a/crates/aether-actor/src/actor/ctx/mod.rs
+++ b/crates/aether-actor/src/actor/ctx/mod.rs
@@ -24,6 +24,7 @@ pub mod mail_sender;
 pub mod outbound_reply;
 pub mod persistence;
 pub mod resolver;
+pub mod subscriber;
 pub mod sync_waiter;
 
 pub use lifecycle::LifecycleControl;
@@ -31,4 +32,5 @@ pub use mail_sender::MailSender;
 pub use outbound_reply::OutboundReply;
 pub use persistence::Persistence;
 pub use resolver::Resolver;
+pub use subscriber::Subscriber;
 pub use sync_waiter::SyncWaiter;

--- a/crates/aether-actor/src/actor/ctx/resolver.rs
+++ b/crates/aether-actor/src/actor/ctx/resolver.rs
@@ -5,26 +5,26 @@
 //! belongs at boot — runtime resolution after init isn't a supported
 //! shape).
 //!
-//! Today the FFI side is the only consumer: wasm guests resolve their
-//! own mailbox id and subscribe to input streams via the trait.
-//! Substrate's `NativeInitCtx` skips this trait — native caps use the
-//! const paths (`mailbox_id_from_name`, `K::ID`) directly because they
-//! sit on the same side of the FFI boundary as the registry.
+//! Issue 703 narrowed the trait to pure addressing (no [`MailSender`]
+//! supertrait, no subscribe surface). The init stage genuinely needs
+//! to look up its own mailbox id and resolve kind / mailbox tokens,
+//! but it must NOT send mail — ADR-0079's `init` is the sync
+//! constructor and mailing belongs in `wire`. Stripping the supertrait
+//! makes that boundary structural rather than convention.
+//!
+//! [`MailSender`]: crate::actor::ctx::MailSender
 
 use aether_data::Kind;
 
-use crate::actor::ctx::mail_sender::MailSender;
 use crate::mail::mailbox::{KindId, Mailbox};
 
-/// Init-time resolution surface. Issue 665 dropped the
-/// `Self::Transport`-keyed mailbox return type — the trait now hands
-/// back a transport-free [`Mailbox<K>`] addressing token; per-side
-/// dispatch happens through each ctx's inherent send methods.
-pub trait Resolver: MailSender {
+/// Init-time resolution surface. Pure addressing — no mail sends. Use
+/// [`crate::actor::ctx::Subscriber::subscribe_input`] from `wire`
+/// (where the ctx impls both `Resolver` and
+/// [`crate::actor::ctx::MailSender`]) to register input subscriptions.
+pub trait Resolver {
     /// The component's own mailbox id — the value the substrate uses
-    /// to address `receive` calls to this instance. Useful for
-    /// hand-rolled subscribe / self-mailing at init time when the
-    /// SDK's higher-level wrappers don't fit.
+    /// to address `receive` calls to this instance.
     fn mailbox_id(&self) -> u64;
 
     /// Resolve a kind by its `const ID`. Pure compile-time construction
@@ -37,12 +37,4 @@ pub trait Resolver: MailSender {
     /// ctx's inherent / trait-provided `send` methods, not through
     /// the mailbox itself.
     fn resolve_mailbox<K: Kind>(&self, name: &str) -> Mailbox<K>;
-
-    /// Send `aether.input.subscribe` with this component's mailbox as
-    /// the subscriber for `K`. ADR-0068 keys subscriber sets by
-    /// `KindId` directly, so this collapses to a one-line send: any
-    /// `Kind` is sendable, the substrate's platform thread fans out
-    /// only for kinds it actually publishes, and a subscribe for a
-    /// non-stream kind is a harmless no-op.
-    fn subscribe_input<K: Kind + 'static>(&self);
 }

--- a/crates/aether-actor/src/actor/ctx/subscriber.rs
+++ b/crates/aether-actor/src/actor/ctx/subscriber.rs
@@ -1,0 +1,42 @@
+//! [`Subscriber`] — input-stream subscription surface, blanket-impl'd
+//! for any ctx that has both [`Resolver`] (to know its own mailbox id)
+//! and [`MailSender`] (to dispatch the subscribe mail).
+//!
+//! Issue 703 split this off [`Resolver`]. Pre-703 `Resolver` carried
+//! a `subscribe_input` method and a `MailSender` supertrait, conflating
+//! "address lookup" with "mail-sending" and making `subscribe_input`
+//! reachable from init contexts. ADR-0079's init stage is the sync
+//! constructor; subscribing belongs in `wire`. The two-trait split
+//! lets the type system enforce that — only ctxs that genuinely impl
+//! both `Resolver` and `MailSender` (i.e. wire / runtime ctxs) pick
+//! up `Subscriber`'s blanket impl.
+//!
+//! [`Resolver`]: crate::actor::ctx::Resolver
+//! [`MailSender`]: crate::actor::ctx::MailSender
+
+use aether_data::{Kind, KindId, MailboxId};
+
+use crate::actor::ctx::mail_sender::MailSender;
+use crate::actor::ctx::resolver::Resolver;
+
+/// Subscribe to an input stream. The default body mails
+/// `aether.input.subscribe { kind: K::ID, mailbox: self.mailbox_id() }`
+/// to the input cap; the cap fans out matching events back to this
+/// actor's mailbox.
+///
+/// Blanket impl'd for any `T: Resolver + MailSender` — call sites
+/// don't impl this directly, they just bring the trait into scope and
+/// `ctx.subscribe_input::<Tick>()` works wherever both supertraits do.
+pub trait Subscriber: Resolver + MailSender {
+    /// Mail `aether.input.subscribe` for `K`, naming this actor's
+    /// mailbox as the subscriber.
+    fn subscribe_input<K: Kind + 'static>(&mut self) {
+        let payload = aether_kinds::SubscribeInput {
+            kind: KindId(K::ID.0),
+            mailbox: MailboxId(self.mailbox_id()),
+        };
+        self.send_to_named("aether.input", &payload);
+    }
+}
+
+impl<T: Resolver + MailSender> Subscriber for T {}

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -63,12 +63,6 @@ impl<'a> FfiInitCtx<'a> {
         resolve_mailbox::<K>(name)
     }
 
-    /// Send `aether.input.subscribe` for kind `K`. Mirrors
-    /// [`Resolver::subscribe_input`].
-    pub fn subscribe_input<K: Kind + 'static>(&self) {
-        <Self as Resolver>::subscribe_input::<K>(self)
-    }
-
     /// Singleton sender shortcut. Returns a typed [`FfiActorMailbox`]
     /// addressing the unique instance of receiver actor `R`.
     pub fn actor<R: Singleton>(&self) -> FfiActorMailbox<R> {
@@ -79,40 +73,6 @@ impl<'a> FfiInitCtx<'a> {
     /// from a runtime instance name.
     pub fn resolve_actor<R: Actor>(&self, name: &str) -> FfiActorMailbox<R> {
         FfiActorMailbox::__new(mailbox_id_from_name(name).0)
-    }
-}
-
-impl<'a> MailSender for FfiInitCtx<'a> {
-    fn send<R, K>(&mut self, payload: &K)
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind,
-    {
-        let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
-    }
-
-    fn send_many<R, K>(&mut self, payloads: &[K])
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind + bytemuck::NoUninit,
-    {
-        let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        MAIL_BRIDGE.send_mail(
-            mailbox_id_from_name(R::NAMESPACE).0,
-            K::ID.0,
-            bytes,
-            payloads.len() as u32,
-        );
-    }
-
-    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
-        let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1);
-    }
-
-    fn prev_correlation(&self) -> u64 {
-        MAIL_BRIDGE.prev_correlation()
     }
 }
 
@@ -128,49 +88,16 @@ impl<'a> Resolver for FfiInitCtx<'a> {
     fn resolve_mailbox<K: Kind>(&self, name: &str) -> Mailbox<K> {
         resolve_mailbox::<K>(name)
     }
-
-    fn subscribe_input<K: Kind + 'static>(&self) {
-        use aether_kinds::SubscribeInput;
-        let payload = SubscribeInput {
-            kind: <K as Kind>::ID,
-            mailbox: aether_data::MailboxId(self.mailbox),
-        };
-        let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(
-            mailbox_id_from_name("aether.input").0,
-            SubscribeInput::ID.0,
-            &bytes,
-            1,
-        );
-    }
 }
 
-impl<'a> Sender for FfiInitCtx<'a> {
-    fn send<R, K>(&mut self, payload: &K)
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind,
-    {
-        <Self as MailSender>::send::<R, K>(self, payload);
-    }
-
-    fn send_many<R, K>(&mut self, payloads: &[K])
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind + bytemuck::NoUninit,
-    {
-        <Self as MailSender>::send_many::<R, K>(self, payloads);
-    }
-
-    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
-        <Self as MailSender>::send_to_named::<K>(self, name, payload);
-    }
-}
-
-/// Per-receive capability handle for FFI guests. Exposes send and
-/// reply primitives; resolution is intentionally absent (resolution
-/// belongs at init).
+/// Per-receive (and post-init `wire` / pre-shutdown `unwire`)
+/// capability handle for FFI guests. Exposes send, reply, and
+/// resolution primitives. Issue 703 added [`Resolver`] + a
+/// `mailbox_id` field so `wire`-stage explicit subscribes
+/// (`ctx.subscribe_input::<K>()`, gated by the [`crate::actor::ctx::Subscriber`]
+/// blanket) can self-address.
 pub struct FfiCtx<'a> {
+    mailbox: u64,
     sender: Option<u32>,
     _borrow: PhantomData<&'a ()>,
 }
@@ -178,8 +105,9 @@ pub struct FfiCtx<'a> {
 impl<'a> FfiCtx<'a> {
     /// Not part of the public API; called only by [`crate::export!`].
     #[doc(hidden)]
-    pub fn __new() -> Self {
+    pub fn __new(mailbox: u64) -> Self {
         Self {
+            mailbox,
             sender: None,
             _borrow: PhantomData,
         }
@@ -233,6 +161,20 @@ impl<'a> FfiCtx<'a> {
     /// trap-escalation reads the same on both sides.
     pub fn fatal_abort(&self, reason: alloc::string::String) -> ! {
         panic!("aether-actor: fatal_abort: {reason}")
+    }
+}
+
+impl<'a> Resolver for FfiCtx<'a> {
+    fn mailbox_id(&self) -> u64 {
+        self.mailbox
+    }
+
+    fn resolve<K: Kind>(&self) -> KindId<K> {
+        resolve::<K>()
+    }
+
+    fn resolve_mailbox<K: Kind>(&self, name: &str) -> Mailbox<K> {
+        resolve_mailbox::<K>(name)
     }
 }
 

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -160,9 +160,13 @@ pub trait FfiActor: crate::Actor {
     /// unrecoverable startup condition (config parse failure, required
     /// handle missing, malformed env var) can surface its own message
     /// in `LoadResult::Err { error }`.
+    ///
+    /// Issue 703: the bound is `C: Resolver` only — init is the sync
+    /// constructor (ADR-0079) and must NOT mail. Use [`Self::wire`]
+    /// for mail-driven setup (subscriptions, peer hellos, etc.).
     fn init<C>(ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender;
+        C: Resolver;
 
     /// Post-init mail-allowed hook (issue 584, ADR-0079 amended
     /// 2026-05-09). Runs after `init` returned `Ok` and the actor's
@@ -355,13 +359,17 @@ macro_rules! __export_internal {
         /// first `receive` (issue 584 Phase 2b, ADR-0079 amended).
         /// Mail-allowed — peer mailboxes are addressable. Receives the
         /// component's own mailbox id so the SDK ctx can self-address.
+        ///
+        /// Issue 703: uses `FfiCtx` (Resolver + MailSender) so
+        /// `Subscriber::subscribe_input::<K>()` resolves; `FfiInitCtx`
+        /// is intentionally Resolver-only and can't mail.
         #[cfg(target_arch = "wasm32")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn wire(mailbox_id: u64) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiInitCtx<'_> = $crate::FfiInitCtx::__new(mailbox_id);
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
             <$component as $crate::FfiActor>::wire(instance, &mut ctx);
             $crate::log::drain_buffer();
             0
@@ -378,7 +386,7 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiInitCtx<'_> = $crate::FfiInitCtx::__new(mailbox_id);
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
             <$component as $crate::FfiActor>::unwire(instance, &mut ctx);
             $crate::log::drain_buffer();
             0
@@ -400,7 +408,13 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new();
+            // Issue 703: derive the actor's own mailbox id at the
+            // call site so `FfiCtx` can self-address (needed for
+            // `Subscriber::subscribe_input::<K>()` from a handler).
+            let mailbox_id = $crate::__macro_internals::mailbox_id_from_name(
+                <$component as $crate::Actor>::NAMESPACE,
+            ).0;
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
             let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
             let status = instance.__aether_dispatch(&mut ctx, mail);
             // Issue #598: ship buffered tracing events at handler exit.
@@ -434,7 +448,10 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new();
+            let mailbox_id = $crate::__macro_internals::mailbox_id_from_name(
+                <$component as $crate::Actor>::NAMESPACE,
+            ).0;
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
             let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
             $crate::__export_internal!(@on_rehydrate $replaceable, $component, instance, ctx, prior);
             $crate::log::drain_buffer();

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -116,7 +116,7 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 #[doc(hidden)]
 pub mod __macro_internals {
     pub use aether_data::__derive_runtime::{Cow, KindLabels, SchemaType, canonical};
-    pub use aether_data::{Kind, Schema};
+    pub use aether_data::{Kind, Schema, mailbox_id_from_name};
     /// Issue #601: `#[actor]` / `#[handlers]` auto-emit a synthetic
     /// dispatch arm for `ConfigureLogDrain` so every actor accepts the
     /// chassis's log-drain push without user code declaring a handler.

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -49,7 +49,7 @@ impl FfiActor for ManifestProbe {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(Self)
     }

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -35,7 +35,7 @@
 
 use std::collections::HashMap;
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::RenderCapability;
 use aether_kinds::{Camera, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
@@ -251,7 +251,7 @@ impl FfiActor for CameraComponent {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         let mut cameras = HashMap::new();
         cameras.insert(

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -31,7 +31,7 @@
 //! 4. Every `aether.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::{FsCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Read, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
@@ -76,7 +76,7 @@ impl FfiActor for MeshViewer {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(MeshViewer {
             triangles: Vec::new(),

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -328,37 +328,10 @@ impl<'a> NativeInitCtx<'a> {
     }
 }
 
-impl<'a> Sender for NativeInitCtx<'a> {
-    fn send<R, K>(&mut self, payload: &K)
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind,
-    {
-        let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
-    }
-
-    fn send_many<R, K>(&mut self, payloads: &[K])
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind + bytemuck::NoUninit,
-    {
-        let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        self.binding.send_mail(
-            mailbox_id_from_name(R::NAMESPACE).0,
-            K::ID.0,
-            bytes,
-            payloads.len() as u32,
-        );
-    }
-
-    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
-        let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1);
-    }
-}
+// Issue 703: NativeInitCtx no longer impls `Sender` / `MailSender`.
+// `init` is the sync constructor (ADR-0079) and must NOT mail —
+// subscriptions, peer hellos, and self-mail kickoffs all belong in
+// `wire`, where `NativeCtx` provides the full mail surface.
 
 // Issue 663 phase B layers the per-stage capability trait impls on top
 // of the existing `Sender` / `MailCtx` impls. Default-impl bodies on
@@ -472,42 +445,6 @@ impl<'a> LifecycleControl for NativeCtx<'a> {
         let watcher = self.binding.self_mailbox();
         registry.register_monitor(watcher, target)?;
         Ok(MonitorHandle::new(registry, watcher, target))
-    }
-}
-
-impl<'a> MailSender for NativeInitCtx<'a> {
-    fn send<R, K>(&mut self, payload: &K)
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind,
-    {
-        let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
-    }
-
-    fn send_many<R, K>(&mut self, payloads: &[K])
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind + bytemuck::NoUninit,
-    {
-        let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        self.binding.send_mail(
-            mailbox_id_from_name(R::NAMESPACE).0,
-            K::ID.0,
-            bytes,
-            payloads.len() as u32,
-        );
-    }
-
-    fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
-        let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1);
-    }
-
-    fn prev_correlation(&self) -> u64 {
-        self.binding.prev_correlation()
     }
 }
 

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -22,7 +22,7 @@
 //!   `capture_frame` scenarios can observe pre-mail effects in the
 //!   captured PNG.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::{BroadcastCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
@@ -65,7 +65,7 @@ impl FfiActor for Probe {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(Probe {
             tick_count: 0,

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -142,7 +142,7 @@ impl FfiActor for Sokoban {
 
     fn init<C>(ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         let mut me = Sokoban {
             state: SokobanState::default(),

--- a/demos/tic-tac-toe-client/src/lib.rs
+++ b/demos/tic-tac-toe-client/src/lib.rs
@@ -128,7 +128,7 @@ impl FfiActor for TicTacToeClient {
 
     fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(TicTacToeClient::default())
     }

--- a/demos/tic-tac-toe-server/src/lib.rs
+++ b/demos/tic-tac-toe-server/src/lib.rs
@@ -62,7 +62,7 @@ impl FfiActor for TicTacToe {
 
     fn init<C>(ctx: &mut C) -> Result<Self, BootError>
     where
-        C: Resolver + MailSender,
+        C: Resolver,
     {
         Ok(TicTacToe {
             state: GameState::new_game(),


### PR DESCRIPTION
## Summary

- `Resolver` loses its `MailSender` supertrait and its `subscribe_input` method. Becomes pure addressing (`mailbox_id`, `resolve`, `resolve_mailbox`).
- New `Subscriber` trait with a default `subscribe_input::<K>()` body and a blanket impl for `T: Resolver + MailSender`. Wire / runtime ctxs pick it up automatically; init ctxs don't.
- `FfiInitCtx` and `NativeInitCtx` lose their `MailSender` (and `Sender`) impls. `FfiInitCtx` also loses the `subscribe_input` inherent.
- `FfiActor::init` bound narrows to `C: Resolver`. Mailing in init now fails to compile.
- `FfiCtx` (already the per-receive ctx) gains a `mailbox_id` field and `Resolver` impl so the `Subscriber` blanket resolves there. The `export!()` shim's `wire` / `unwire` shims construct `FfiCtx` instead of `FfiInitCtx`; `receive` / `on_rehydrate` shims derive `mailbox_id` from `<C as Actor>::NAMESPACE`.

Closes iamacoffeepot/aether#703.

## Why

ADR-0079's amended lifecycle (init / wire / unwire) defined `init` as the sync constructor that must NOT mail — `wire` is the post-init mail-allowed hook. The lifecycle was load-bearing but the trait surface didn't track: both init ctxs impl'd `MailSender`, `Resolver: MailSender`, and `subscribe_input` lived on `Resolver` (so it was reachable from init). Mailing in init was convention rather than contract.

Surfaced 2026-05-09 while implementing issue 640 Phase 2 (explicit `ctx.subscribe_input::<K>()` calls replacing the retired auto-subscribe walker). 640 wants those calls in `wire` because they mail; with this PR landed, the type system enforces that placement.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo check -p aether-camera -p aether-mesh-viewer -p aether-test-fixture-probe -p aether-demo-tic-tac-toe-client -p aether-demo-tic-tac-toe-server -p aether-demo-sokoban --target wasm32-unknown-unknown` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo nextest run --workspace` — 1031 tests pass

## Blocks

Issue 640 Phase 2 (explicit subscribes in `wire`) parked on `wip/640-phase2-park` pending this. Once this lands, that branch rebases, moves the parked `subscribe_input::<K>()` calls from `init` to `wire`, and ships the `is_stream` retirement + auto-subscribe drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)