### PR TITLE
test(bundle): rewrite end_to_end + input_subscriptions against TestBench

### DIFF
--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -1,15 +1,134 @@
-//! Pre-Phase-4 end-to-end test: WAT-built component →
-//! `ComponentCtx::send` → sink handler. Used `ComponentHostCapability`'s
-//! `for_test` / `attach_component_for_test` test helpers and the
-//! mailer's `drain_all` to drive a hand-built `Component` past the
-//! cap's dispatcher infrastructure.
+//! Post-issue-634-Phase-4 end-to-end smoke for the trampoline-as-actor
+//! routing path. Boots a [`TestBench`], loads `aether-test-fixture-probe`
+//! into it via the same `aether.component` mail surface a hub-driven
+//! session uses, and asserts the wasm host-fn call chain
+//! (`ctx.actor::<BroadcastCapability>().send(&TickObserved)`) reaches
+//! the bench's loopback observation queue.
 //!
-//! Issue 634 Phase 4 PR 1 retired the dispatcher infrastructure
-//! along with the cap-side test helpers. The trampoline migration
-//! moves component routing onto the framework's `NativeActor`
-//! dispatcher; there's no path to attach a hand-built `Component`
-//! synchronously anymore. This test needs rewriting against
-//! `aether-substrate-bundle::test_bench::TestBench` (in-process
-//! chassis driver) — tracked under issue 648.
+//! Replaces the pre-Phase-4 WAT-driven harness which drove a hand-built
+//! `Component` past the cap's dispatcher infrastructure via the retired
+//! `ComponentHostCapability::for_test` / `attach_component_for_test`
+//! helpers. Phase 4 moved that dispatch onto the framework's
+//! `NativeActor` trampoline, so the equivalent coverage runs through a
+//! real load + advance against a wasm component. Tracked under issue 648.
 
-#![cfg(any())]
+use std::path::Path;
+
+use aether_actor::Actor;
+use aether_capabilities::{ComponentHostCapability, InputCapability};
+use aether_data::{Kind, MailboxId};
+use aether_kinds::{LoadComponent, LoadResult, SubscribeInput, SubscribeInputResult, Tick};
+use aether_scenario::test_helpers::require_runtime;
+use aether_substrate_bundle::test_bench::TestBench;
+use aether_test_fixture_probe::TickObserved;
+
+const PROBE_NAME: &str = "probe";
+
+fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
+    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    let result: LoadResult = bench
+        .send_and_await_reply(
+            ComponentHostCapability::NAMESPACE,
+            &LoadComponent {
+                wasm,
+                name: Some(PROBE_NAME.to_owned()),
+            },
+        )
+        .expect("await load_component reply");
+    match result {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("load_component: {error}"),
+    }
+}
+
+/// The probe self-subscribes to `Tick` from its `wire` handler via
+/// fire-and-forget mail; `LoadResult` returns before that mail has
+/// necessarily been drained by `InputCapability`'s actor. Mailing a
+/// redundant `SubscribeInput` from the test side and awaiting its
+/// reply gives a deterministic happens-before: `InputCapability` is
+/// single-threaded mpsc-FIFO, so once our reply arrives the probe's
+/// prior wire-time subscribe has been processed too. The set is a
+/// `BTreeSet` so the duplicate insert is a no-op.
+fn await_tick_subscribed(bench: &mut TestBench, mailbox: MailboxId) {
+    let r: SubscribeInputResult = bench
+        .send_and_await_reply(
+            InputCapability::NAMESPACE,
+            &SubscribeInput {
+                kind: Tick::ID,
+                mailbox,
+            },
+        )
+        .expect("await redundant subscribe reply");
+    match r {
+        SubscribeInputResult::Ok => {}
+        SubscribeInputResult::Err { error } => panic!("redundant subscribe failed: {error}"),
+    }
+}
+
+/// Run one no-tick `capture()` after a measurement window so the
+/// last advanced frame's trampoline broadcast (which can still be
+/// in `BroadcastCapability`'s inbox if `wait_instanced_quiesce`
+/// gave up early under heavy parallel-test CPU pressure) lands in
+/// `observed_kinds` before we read the count. Capture runs a full
+/// frame with `dispatch_tick = false`, so no new `tick_observed`
+/// is produced — the count delta stays at exactly N.
+fn settle_observations(bench: &mut TestBench) {
+    let _png = bench.capture().expect("settle capture");
+}
+
+/// Tick fanout reaches a freshly-loaded wasm component, the
+/// component's `ctx.actor::<BroadcastCapability>().send(...)` host
+/// call lands a kind-tagged broadcast on the bench's loopback, and
+/// `count_observed` sees it. End-to-end proof of host-fn linking,
+/// trampoline dispatch, `wire`-time input subscription, and outbound
+/// broadcast routing.
+#[test]
+fn tick_roundtrip_component_to_sink() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe(&mut bench, &wasm_path);
+    await_tick_subscribed(&mut bench, mbox);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(3).expect("advance 3");
+    settle_observations(&mut bench);
+    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    assert_eq!(
+        delta,
+        3,
+        "expected 3 tick_observed broadcasts after advance(3); observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// No-drops guard for the trampoline dispatch loop under volume.
+/// Pre-ADR-0038 a worker-pool race could invert per-mailbox order
+/// under contention; ADR-0038 collapsed dispatch to one mpsc consumer
+/// per actor so the original strand-claim race is structurally
+/// impossible. The "no drops at N" property still matters as a smoke
+/// for the trampoline pump — pushes 200 ticks through one component
+/// and asserts every broadcast made the round trip back.
+#[test]
+fn batched_ticks_preserve_per_mailbox_count() {
+    const N: u32 = 200;
+
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe(&mut bench, &wasm_path);
+    await_tick_subscribed(&mut bench, mbox);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(N).expect("advance N");
+    settle_observations(&mut bench);
+    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    assert_eq!(
+        delta,
+        N as usize,
+        "expected {N} tick_observed broadcasts after advance({N}); observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -1,13 +1,235 @@
-//! Pre-Phase-4 input-subscription round-trip test (ADR-0021).
-//! Drove `subscribe` / `unsubscribe` against the cap's
-//! `for_test` / `load_for_test` helpers and used `mailer.drain_all`
-//! to synchronise.
-//!
-//! Issue 634 Phase 4 PR 1 retired both surfaces — the cap's
-//! synthetic load helpers along with the dispatcher-side
-//! drain barrier. This test needs rewriting against
-//! `aether-substrate-bundle::test_bench::TestBench` so the
-//! subscribe/unsubscribe flow runs through a real chassis. Tracked
-//! under issue 648.
+//! ADR-0021 publish/subscribe round-trip via [`TestBench`]. Loads
+//! `aether-test-fixture-probe` into a real chassis and exercises
+//! `aether.input.subscribe` / `aether.input.unsubscribe` and the
+//! `aether.component.drop` lifecycle's effect on the input subscriber
+//! set. Replaces the pre-issue-634-Phase-4 harness which drove the
+//! retired `InputCapability::for_test` / `subscribe_for_test` /
+//! `unsubscribe_for_test` helpers and used `mailer.drain_all` to
+//! synchronise. Tracked under issue 648.
 
-#![cfg(any())]
+use std::path::Path;
+
+use aether_actor::Actor;
+use aether_capabilities::{ComponentHostCapability, InputCapability};
+use aether_data::{Kind, KindId, MailboxId};
+use aether_kinds::{
+    DropComponent, DropResult, LoadComponent, LoadResult, SubscribeInput, SubscribeInputResult,
+    Tick, UnsubscribeInput,
+};
+use aether_scenario::test_helpers::require_runtime;
+use aether_substrate_bundle::test_bench::TestBench;
+use aether_test_fixture_probe::TickObserved;
+
+fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId {
+    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    let result: LoadResult = bench
+        .send_and_await_reply(
+            ComponentHostCapability::NAMESPACE,
+            &LoadComponent {
+                wasm,
+                name: Some(name.to_owned()),
+            },
+        )
+        .expect("await load_component reply");
+    match result {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("load_component({name}): {error}"),
+    }
+}
+
+fn unsubscribe(bench: &mut TestBench, kind: KindId, mailbox: MailboxId) {
+    let r: SubscribeInputResult = bench
+        .send_and_await_reply(
+            InputCapability::NAMESPACE,
+            &UnsubscribeInput { kind, mailbox },
+        )
+        .expect("await unsubscribe reply");
+    match r {
+        SubscribeInputResult::Ok => {}
+        SubscribeInputResult::Err { error } => panic!("unsubscribe failed: {error}"),
+    }
+}
+
+fn drop_component(bench: &mut TestBench, mailbox_id: MailboxId) {
+    let r: DropResult = bench
+        .send_and_await_reply(
+            ComponentHostCapability::NAMESPACE,
+            &DropComponent { mailbox_id },
+        )
+        .expect("await drop reply");
+    match r {
+        DropResult::Ok => {}
+        DropResult::Err { error } => panic!("drop failed: {error}"),
+    }
+}
+
+/// The probe self-subscribes to `Tick` from its `wire` handler via
+/// fire-and-forget mail; `LoadResult` returns before that mail has
+/// necessarily been drained by `InputCapability`'s actor. Mailing a
+/// redundant `SubscribeInput` from the test side and awaiting its
+/// reply gives a deterministic happens-before: `InputCapability` is
+/// single-threaded mpsc-FIFO, so once our reply arrives the probe's
+/// prior wire-time subscribe has been processed too. The set is a
+/// `BTreeSet` so the duplicate insert is a no-op.
+fn await_tick_subscribed(bench: &mut TestBench, mailbox: MailboxId) {
+    let r: SubscribeInputResult = bench
+        .send_and_await_reply(
+            InputCapability::NAMESPACE,
+            &SubscribeInput {
+                kind: Tick::ID,
+                mailbox,
+            },
+        )
+        .expect("await redundant subscribe reply");
+    match r {
+        SubscribeInputResult::Ok => {}
+        SubscribeInputResult::Err { error } => panic!("redundant subscribe failed: {error}"),
+    }
+}
+
+/// Run one no-tick `capture()` after a measurement window so the
+/// last advanced frame's trampoline broadcast (which can still be
+/// in `BroadcastCapability`'s inbox if `wait_instanced_quiesce`
+/// gave up early under heavy parallel-test CPU pressure) lands in
+/// `observed_kinds` before we read the count. Capture runs a full
+/// frame with `dispatch_tick = false`, so no new `tick_observed`
+/// is produced.
+fn settle_observations(bench: &mut TestBench) {
+    let _png = bench.capture().expect("settle capture");
+}
+
+/// No probes loaded ⇒ no Tick subscribers ⇒ advance generates zero
+/// `tick_observed` broadcasts. Confirms the input fanout is gated on
+/// the subscriber set rather than firing unconditionally.
+#[test]
+fn empty_subscribers_means_no_delivery() {
+    if require_runtime("aether_test_fixture_probe").is_none() {
+        return;
+    }
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    bench.advance(2).expect("advance 2");
+    settle_observations(&mut bench);
+    assert_eq!(
+        bench.count_observed(TickObserved::NAME),
+        0,
+        "no probe loaded but tick_observed was broadcast; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// One subscribed probe broadcasts once per tick.
+#[test]
+fn subscribed_component_receives_published_ticks() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
+    await_tick_subscribed(&mut bench, mbox);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(3).expect("advance 3");
+    settle_observations(&mut bench);
+    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    assert_eq!(
+        delta,
+        3,
+        "expected 3 tick_observed broadcasts; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// Two independently-loaded probes each subscribe their own mailbox
+/// in `wire`; tick fanout reaches both. 2 subscribers × 2 ticks ⇒
+/// 4 broadcasts.
+#[test]
+fn two_subscribers_each_receive_every_tick() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox_a = load_probe_named(&mut bench, &wasm_path, "a");
+    let mbox_b = load_probe_named(&mut bench, &wasm_path, "b");
+    await_tick_subscribed(&mut bench, mbox_a);
+    await_tick_subscribed(&mut bench, mbox_b);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(2).expect("advance 2");
+    settle_observations(&mut bench);
+    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    assert_eq!(
+        delta,
+        4,
+        "2 subscribers × 2 ticks should yield 4 broadcasts; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// `aether.input.unsubscribe` removes the mailbox from the Tick
+/// subscriber set; subsequent advances stop producing broadcasts
+/// from that probe.
+#[test]
+fn unsubscribe_stops_delivery() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
+    await_tick_subscribed(&mut bench, mbox);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(1).expect("pre-unsubscribe advance");
+    settle_observations(&mut bench);
+    assert_eq!(
+        bench.count_observed(TickObserved::NAME) - baseline,
+        1,
+        "expected 1 broadcast in the pre-unsubscribe window; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+    let pre_unsub = bench.count_observed(TickObserved::NAME);
+
+    unsubscribe(&mut bench, Tick::ID, mbox);
+    bench.advance(2).expect("post-unsubscribe advance");
+    settle_observations(&mut bench);
+    assert_eq!(
+        bench.count_observed(TickObserved::NAME),
+        pre_unsub,
+        "tick_observed climbed after unsubscribe; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
+/// `aether.component.drop` clears the dropped mailbox from the input
+/// subscriber set as a side effect of lifecycle teardown
+/// (ADR-0021 + ADR-0038). Subsequent advances don't broadcast from
+/// the dropped probe.
+#[test]
+fn drop_clears_subscriptions() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe_named(&mut bench, &wasm_path, "victim");
+    await_tick_subscribed(&mut bench, mbox);
+    let baseline = bench.count_observed(TickObserved::NAME);
+
+    bench.advance(1).expect("pre-drop advance");
+    settle_observations(&mut bench);
+    assert_eq!(
+        bench.count_observed(TickObserved::NAME) - baseline,
+        1,
+        "expected 1 broadcast in the pre-drop window; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+    let pre_drop = bench.count_observed(TickObserved::NAME);
+
+    drop_component(&mut bench, mbox);
+    bench.advance(2).expect("post-drop advance");
+    settle_observations(&mut bench);
+    assert_eq!(
+        bench.count_observed(TickObserved::NAME),
+        pre_drop,
+        "tick_observed climbed after drop; observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}


### PR DESCRIPTION
## Summary

Restores the two integration test files that issue 634 Phase 4 PR 1 had to gut to `#![cfg(any())]` when it retired `ComponentHostCapability::for_test` / `attach_component_for_test` / `load_for_test` / `drop_for_test` and the cap's `subscribe_for_test` / `unsubscribe_for_test` helpers. The new tests drive the same coverage through the in-process `TestBench` plus `aether-test-fixture-probe` — same shape as the existing `test_bench_scenario.rs`, no synthetic helpers.

- `end_to_end.rs`: `tick_roundtrip_component_to_sink` (host-fn linking + trampoline dispatch + wire-time subscription + broadcast routing round trip) + `batched_ticks_preserve_per_mailbox_count` (N=200 no-drops guard, with a note that ADR-0038 made the original strand-claim race structurally impossible).
- `input_subscriptions.rs`: empty-subscribers / one-subscriber / two-subscribers / unsubscribe-stops / drop-clears.

Two helpers handle substrate-side timing windows:

- `await_tick_subscribed` — redundant `SubscribeInput` via `send_and_await_reply`. `InputCapability` is single-threaded mpsc-FIFO, so once our reply lands the probe's earlier wire-time subscribe must have been processed too. The `BTreeSet` makes the duplicate insert a no-op.
- `settle_observations` — one no-tick `bench.capture()` after the measurement window so the last advanced frame's trampoline broadcast lands in `observed_kinds` even when `wait_instanced_quiesce` gives up early under heavy parallel-test CPU pressure.

Closes iamacoffeepot/aether#648

## Test plan

- [x] `cargo check -p aether-substrate-bundle --tests` — compiles clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -p aether-substrate-bundle --tests -- -D warnings` — clean
- [x] `cargo nextest run -p aether-substrate-bundle --test end_to_end --test input_subscriptions` — 12+ parallel runs, all 7 tests pass every time (single-threaded was already passing pre-settle, parallel needed the `settle_observations` step)
- [x] `cargo nextest run -p aether-substrate-bundle --test test_bench_scenario` — neighbor file unaffected, all 9 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)