### PR TITLE
feat(data,actor): add MailId type and Sender::send_detached api surface

### DIFF
--- a/crates/aether-actor/src/actor/ctx/mail_sender.rs
+++ b/crates/aether-actor/src/actor/ctx/mail_sender.rs
@@ -61,4 +61,32 @@ pub trait MailSender {
     /// here; sync wrappers thread the value into
     /// [`crate::actor::ctx::SyncWaiter::wait_reply`].
     fn prev_correlation(&self) -> u64;
+
+    /// ADR-0080 §7 fire-and-forget escape hatch: send `payload` to `R`
+    /// without inheriting the caller's in-flight causal chain. The
+    /// recipient processes the mail as the root of a new tree.
+    ///
+    /// **Fire-and-forget only.** Detached sends mint no parent linkage,
+    /// so any reply the recipient issues inherits the *recipient's*
+    /// tree rather than the sender's. Reply-correlated requests always
+    /// go through [`Self::send`].
+    ///
+    /// PR 1 ships only the API surface (default body delegates to
+    /// [`Self::send`]). PR 2's tracing layer specialises this on each
+    /// per-target impl to suppress the `TraceEvent::Sent` push that
+    /// `send` would otherwise emit, breaking the recursion when the
+    /// drainer's outbound `BatchedTraceEvents` mail is itself a send.
+    fn send_detached<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind,
+    {
+        self.send::<R, K>(payload);
+    }
+
+    /// String-keyed counterpart to [`Self::send_detached`]. Same
+    /// fire-and-forget contract; same default-body delegation in PR 1.
+    fn send_detached_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
+        self.send_to_named::<K>(name, payload);
+    }
 }

--- a/crates/aether-actor/src/actor/sender.rs
+++ b/crates/aether-actor/src/actor/sender.rs
@@ -76,6 +76,37 @@ pub trait Sender {
     /// substrate registered without a corresponding Rust type).
     /// Survives stage 4 alongside the actor-typed sends.
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K);
+
+    /// ADR-0080 §7 fire-and-forget escape hatch: send `payload` to `R`
+    /// without inheriting the caller's in-flight causal chain. The
+    /// recipient processes the mail as the root of a new tree.
+    ///
+    /// **Fire-and-forget only.** Detached sends mint no parent linkage,
+    /// so any reply the recipient issues inherits the *recipient's*
+    /// tree rather than the sender's. The reply still routes back to
+    /// the sender's reply slot via `(sender, correlation_id)` — the
+    /// correlation echo is unchanged — but the causal-graph linkage
+    /// between request and reply is broken by design. Reply-correlated
+    /// requests always go through [`Self::send`].
+    ///
+    /// PR 1 ships only the API surface (default body delegates to
+    /// [`Self::send`]). PR 2's tracing layer specialises this on each
+    /// per-target impl to suppress the `TraceEvent::Sent` push that
+    /// `send` would otherwise emit, breaking the recursion when the
+    /// drainer's outbound `BatchedTraceEvents` mail is itself a send.
+    fn send_detached<R, K>(&mut self, payload: &K)
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind,
+    {
+        self.send::<R, K>(payload);
+    }
+
+    /// String-keyed counterpart to [`Self::send_detached`]. Same
+    /// fire-and-forget contract; same default-body delegation in PR 1.
+    fn send_detached_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
+        self.send_to_named::<K>(name, payload);
+    }
 }
 
 /// Per-handler ctx surface, on top of [`Sender`]. Adds reply-to-

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -54,7 +54,7 @@ pub use hash::{
     mailbox_id_from_name,
 };
 pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
-pub use mail::{ReplyTarget, ReplyTo};
+pub use mail::{MailId, ReplyTarget, ReplyTo};
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};
 pub use wire_id::{EngineId, SessionToken, Uuid};

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -11,6 +11,46 @@
 
 use crate::{EngineId, MailboxId, SessionToken};
 
+/// ADR-0080 §1: the unique identity of a mail. A 128-bit composite of
+/// the producer's mailbox id and the producer's per-actor monotonic
+/// `correlation_id`. Exact-by-construction — no central minter to
+/// contend on, no hash to collide.
+///
+/// `sender` is `MailboxId::NONE` for chassis-originated mail (the
+/// reserved sentinel for "no actor mailbox"). Per-actor mints use the
+/// owning actor's `MailboxId`.
+///
+/// Ships in PR 1 of issue #707 as a foundation for PR 2's producer-
+/// side `TraceEvent::Sent` emission. PR 2 plumbs `MailId` onto every
+/// substrate envelope and into per-handler context; PR 1 only
+/// introduces the type so downstream code can name it.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MailId {
+    pub sender: MailboxId,
+    pub correlation_id: u64,
+}
+
+impl MailId {
+    /// Sentinel for "not yet stamped" / "chassis root". Equivalent to
+    /// `MailId::default()`. The PR 2 dispatch path treats this value
+    /// as the chassis-as-originator marker.
+    pub const NONE: MailId = MailId {
+        sender: MailboxId::NONE,
+        correlation_id: 0,
+    };
+
+    /// Construct a `MailId` from a sender mailbox and correlation id.
+    /// Producer paths (`NativeBinding::send_mail`, plus the future
+    /// drainer and chassis-pushed sites) call this immediately after
+    /// fetching the next correlation from the per-actor counter.
+    pub const fn new(sender: MailboxId, correlation_id: u64) -> Self {
+        Self {
+            sender,
+            correlation_id,
+        }
+    }
+}
+
 /// Where a reply-bearing mail should route when the recipient
 /// answers. Strictly a routing hint: mail is pushed at a recipient,
 /// not sent from a mailbox.


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue references (#707, ADR-0080 PR-phasing) -->

## Summary

PR 1 of 4 for [ADR-0080](docs/adr/0080-substrate-mail-tracing-and-settlement.md) phase 1 (issue iamacoffeepot/aether#707). Lands the foundation types other PRs in the phase build on:

- **`aether_data::MailId { sender: MailboxId, correlation_id: u64 }`** — the 128-bit composite identity for every mail (ADR-0080 §1). Exact-by-construction (no central minter, no hash, no birthday-paradox risk). `MailId::NONE` is the chassis-root sentinel; `MailId::new(sender, correlation_id)` is the producer constructor.
- **`Sender::send_detached` and `Sender::send_detached_to_named`** on the legacy `aether_actor::actor::sender::Sender` trait and the per-stage `aether_actor::actor::ctx::MailSender` trait (ADR-0080 §7). Fire-and-forget escape hatch the recipient processes as the root of a new tree. PR 1 default-bodies delegate to `send` / `send_to_named`; PR 2's tracing layer specialises on each per-target impl to suppress the `TraceEvent::Sent` push and break the drainer-to-observer recursion.

## Scope shrink vs. issue plan

Issue iamacoffeepot/aether#707's plan grouped envelope-shape changes (`mail_id` / `root` / `parent_mail` on `Envelope`) into PR 1. Deferred to PR 2 here: the producer-side population logic that knows the right values to stamp at every send / reply / mailer-push site lives more naturally with the trace-event emission, and threading `MailId` through `MailboxHandler` is one structural change worth pairing with its consumers. PR 2 will land `MailId` envelope fields alongside the per-handler-context plumbing that populates them.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run --workspace` — 1037/1038 pass; the 1 fail (`aether-camera::scenario camera_destroy_main_keeps_substrate_alive`) is the pre-existing load-then-tick race ADR-0080 settlement gating retires structurally (PR 4 of phase 1). Reproduces against main, passes 5/5 in isolation; unrelated to this PR's pure-additive changes (a new type and two trait methods nothing yet calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)