### PR TITLE
feat(substrate,capabilities): substrate-wide mail tracing + TraceObserver cap

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -1058,7 +1058,10 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(AudioCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(
+                AudioCapability::NAMESPACE,
+                aether_substrate::mail::registry::noop_handler(),
+            );
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<AudioCapability>(AudioConfig {

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -537,7 +537,12 @@ mod native {
             }
 
             fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
-                NativeCtx::new(&self.transport, sender)
+                NativeCtx::new(
+                    &self.transport,
+                    sender,
+                    aether_data::MailId::NONE,
+                    aether_data::MailId::NONE,
+                )
             }
         }
 
@@ -837,7 +842,10 @@ mod native {
         fn duplicate_claim_rejects_with_typed_error() {
             let root = scratch_root("collide");
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(FsCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(
+                FsCapability::NAMESPACE,
+                aether_substrate::mail::registry::noop_handler(),
+            );
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<FsCapability>(roots_under(&root))

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -218,14 +218,17 @@ mod native {
                 bytes: vec![1, 2, 3, 4, 5],
             };
             let bytes = postcard::to_allocvec(&req).unwrap();
-            handler(
-                <HandlePublish as Kind>::ID,
-                "aether.handle.publish",
-                None,
-                session_reply_to(),
-                &bytes,
-                1,
-            );
+            handler(aether_substrate::mail::registry::MailDispatch {
+                kind: <HandlePublish as Kind>::ID,
+                kind_name: "aether.handle.publish",
+                origin: None,
+                sender: session_reply_to(),
+                payload: &bytes,
+                count: 1,
+                mail_id: aether_substrate::mail::MailId::NONE,
+                root: aether_substrate::mail::MailId::NONE,
+                parent_mail: None,
+            });
 
             let deadline = Instant::now() + Duration::from_secs(2);
             let frame = loop {
@@ -285,7 +288,10 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (_store, mailer, registry, _rx) = fresh_substrate();
-            registry.register_closure(HandleCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(
+                HandleCapability::NAMESPACE,
+                aether_substrate::mail::registry::noop_handler(),
+            );
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HandleCapability>(())

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -568,7 +568,10 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(HttpCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(
+                HttpCapability::NAMESPACE,
+                aether_substrate::mail::registry::noop_handler(),
+            );
             let config = HttpConfig {
                 disabled: true,
                 ..HttpConfig::default()
@@ -593,7 +596,12 @@ mod native {
                 HttpConfig::default().default_timeout,
             );
             let transport = NativeBinding::new_for_test(mailer, MailboxId(0));
-            let mut ctx = NativeCtx::new(&transport, session_sender());
+            let mut ctx = NativeCtx::new(
+                &transport,
+                session_sender(),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
             cap.on_fetch(
                 &mut ctx,
                 Fetch {
@@ -702,7 +710,12 @@ mod native {
                 HttpConfig::default().default_timeout,
             );
             let transport = NativeBinding::new_for_test(mailer, MailboxId(0));
-            let mut ctx = NativeCtx::new(&transport, session_sender());
+            let mut ctx = NativeCtx::new(
+                &transport,
+                session_sender(),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
             cap.on_fetch(
                 &mut ctx,
                 Fetch {
@@ -737,7 +750,12 @@ mod native {
                 HttpConfig::default().default_timeout,
             );
             let transport = NativeBinding::new_for_test(mailer, MailboxId(0));
-            let mut ctx = NativeCtx::new(&transport, session_sender());
+            let mut ctx = NativeCtx::new(
+                &transport,
+                session_sender(),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
             cap.on_fetch(
                 &mut ctx,
                 Fetch {
@@ -771,7 +789,12 @@ mod native {
                 HttpConfig::default().default_timeout,
             );
             let transport = NativeBinding::new_for_test(mailer, MailboxId(0));
-            let mut ctx = NativeCtx::new(&transport, session_sender());
+            let mut ctx = NativeCtx::new(
+                &transport,
+                session_sender(),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
             cap.on_fetch(
                 &mut ctx,
                 Fetch {

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -38,6 +38,7 @@ pub mod log;
 pub mod render;
 pub mod tcp;
 pub mod test_bench;
+pub mod trace;
 pub mod window;
 
 #[cfg(feature = "audio")]

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -174,14 +174,17 @@ mod native {
                 }],
             };
             let bytes = postcard::to_allocvec(&batch).expect("encode");
-            handler(
-                <LogBatch as Kind>::ID,
-                "aether.log",
-                None,
-                aether_substrate::mail::ReplyTo::NONE,
-                &bytes,
-                1,
-            );
+            handler(aether_substrate::mail::registry::MailDispatch {
+                kind: <LogBatch as Kind>::ID,
+                kind_name: "aether.log",
+                origin: None,
+                sender: aether_substrate::mail::ReplyTo::NONE,
+                payload: &bytes,
+                count: 1,
+                mail_id: aether_substrate::mail::MailId::NONE,
+                root: aether_substrate::mail::MailId::NONE,
+                parent_mail: None,
+            });
 
             thread::sleep(Duration::from_millis(50));
             drop(chassis);
@@ -190,7 +193,10 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(LogCapability::NAMESPACE, Arc::new(|_, _, _, _, _, _| {}));
+            registry.register_closure(
+                LogCapability::NAMESPACE,
+                aether_substrate::mail::registry::noop_handler(),
+            );
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<LogCapability>(())

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -583,7 +583,17 @@ mod native {
             let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
                 panic!("expected mailbox entry for {name}");
             };
-            handler(kind, "test.kind", None, ReplyTo::NONE, payload, 1);
+            handler(aether_substrate::mail::registry::MailDispatch {
+                kind,
+                kind_name: "test.kind",
+                origin: None,
+                sender: ReplyTo::NONE,
+                payload,
+                count: 1,
+                mail_id: aether_substrate::mail::MailId::NONE,
+                root: aether_substrate::mail::MailId::NONE,
+                parent_mail: None,
+            });
         }
 
         #[test]

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -394,7 +394,17 @@ mod cap_native {
                 panic!("expected mailbox entry");
             };
             let bytes = postcard::to_allocvec(mail).expect("encode");
-            handler(K::ID, K::NAME, None, session_reply(), &bytes, 1);
+            handler(aether_substrate::mail::registry::MailDispatch {
+                kind: K::ID,
+                kind_name: K::NAME,
+                origin: None,
+                sender: session_reply(),
+                payload: &bytes,
+                count: 1,
+                mail_id: aether_substrate::mail::MailId::NONE,
+                root: aether_substrate::mail::MailId::NONE,
+                parent_mail: None,
+            });
 
             let deadline = Instant::now() + Duration::from_secs(2);
             let frame = loop {

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -1,0 +1,401 @@
+//! `aether.trace` cap (ADR-0080 §4). Receives [`BatchedTraceEvents`]
+//! from the chassis-owned drainer thread and folds each event into
+//! per-root counter maps + a parent → mail graph keyed by `MailId`.
+//!
+//! PR 2 of issue #707 ships only the state-tracking shape: the
+//! observer accumulates `RootState` and `MailNode` entries, applies
+//! retention + count-cap eviction, and exposes accessors for tests.
+//! `Settled` mail emission is deferred to PR 3 alongside the chassis
+//! sentinel + dispatcher switch that routes settlement replies into
+//! the gate-site notification map.
+//!
+//! The observer's own dispatch of `BatchedTraceEvents` does not
+//! generate further trace events: the drainer pushes its outbound
+//! mail bare through `Mailer::push` (no `Sent` event), and the
+//! producer hooks for `Received`/`Finished` short-circuit on
+//! `MailId::NONE` (the default for mail not minted via
+//! `NativeBinding::send_mail_with_lineage`). See ADR-0080 §7.
+
+use aether_kinds::trace::BatchedTraceEvents;
+
+#[aether_actor::bridge(singleton)]
+mod native {
+    use super::BatchedTraceEvents;
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    use aether_actor::actor;
+    use aether_data::{KindId, MailId, MailboxId};
+    use aether_kinds::trace::{Nanos, TraceEvent};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    /// ADR-0080 §11 retention defaults. Override via env vars.
+    /// `AETHER_TRACE_RETENTION_MS` — drop roots older than this many
+    /// milliseconds at end-of-handler. `AETHER_TRACE_MAX_ROOTS` —
+    /// hard cap on root count; oldest evicted first when exceeded.
+    /// Memory ceiling: ~50 MB at 100k roots × ~512 bytes/root
+    /// (RootState + the typical handful of MailNodes per root).
+    const RETENTION_MS_DEFAULT: u64 = 600_000;
+    const MAX_ROOTS_DEFAULT: usize = 100_000;
+
+    /// Per-root accumulator. `in_flight` tracks how many mails in
+    /// this chain are currently between `Sent` and `Finished` —
+    /// settlement is the moment this hits zero (PR 3 wires the
+    /// `Settled` mail emission). PR 2 keeps the count for tests and
+    /// future consumers.
+    #[derive(Debug, Clone)]
+    pub struct RootState {
+        pub in_flight: u32,
+        pub last_event_at: Instant,
+    }
+
+    /// Per-mail node in the parent → mail graph. `t_received` and
+    /// `t_finished` patch as `Received`/`Finished` events arrive
+    /// after the originating `Sent`.
+    #[derive(Debug, Clone)]
+    pub struct MailNode {
+        pub root: MailId,
+        pub parent: Option<MailId>,
+        pub sender: MailboxId,
+        pub recipient: MailboxId,
+        pub kind: KindId,
+        pub t_sent: Nanos,
+        pub t_received: Option<Nanos>,
+        pub t_finished: Option<Nanos>,
+    }
+
+    /// `aether.trace` mailbox cap. Folds [`BatchedTraceEvents`] into
+    /// per-root counters and a parent → mail graph.
+    pub struct TraceObserverCapability {
+        roots: HashMap<MailId, RootState>,
+        mails: HashMap<MailId, MailNode>,
+        retention: Duration,
+        max_roots: usize,
+    }
+
+    impl TraceObserverCapability {
+        /// Read-only access to the per-root state map. Used by tests
+        /// and (in PR 3) by `Settled` consumers; runtime callers
+        /// should query via mail rather than reaching across threads.
+        pub fn roots(&self) -> &HashMap<MailId, RootState> {
+            &self.roots
+        }
+
+        /// Read-only access to the per-mail graph. Same access shape
+        /// as [`Self::roots`].
+        pub fn mails(&self) -> &HashMap<MailId, MailNode> {
+            &self.mails
+        }
+
+        fn apply_event(&mut self, event: TraceEvent) {
+            match event {
+                TraceEvent::Sent {
+                    mail_id,
+                    root,
+                    parent_mail,
+                    sender,
+                    recipient,
+                    kind,
+                    t,
+                } => {
+                    let now = Instant::now();
+                    let root_state = self.roots.entry(root).or_insert(RootState {
+                        in_flight: 0,
+                        last_event_at: now,
+                    });
+                    root_state.in_flight = root_state.in_flight.saturating_add(1);
+                    root_state.last_event_at = now;
+                    self.mails.insert(
+                        mail_id,
+                        MailNode {
+                            root,
+                            parent: parent_mail,
+                            sender,
+                            recipient,
+                            kind,
+                            t_sent: t,
+                            t_received: None,
+                            t_finished: None,
+                        },
+                    );
+                }
+                TraceEvent::Received { mail_id, t } => {
+                    if let Some(node) = self.mails.get_mut(&mail_id) {
+                        node.t_received = Some(t);
+                        if let Some(state) = self.roots.get_mut(&node.root) {
+                            state.last_event_at = Instant::now();
+                        }
+                    }
+                    // Orphan `Received` (no matching `Sent` ever
+                    // observed) gets dropped. Eventual-consistency
+                    // per ADR-0080 §6.
+                }
+                TraceEvent::Finished { mail_id, t } => {
+                    if let Some(node) = self.mails.get_mut(&mail_id) {
+                        node.t_finished = Some(t);
+                        let root = node.root;
+                        if let Some(state) = self.roots.get_mut(&root) {
+                            state.in_flight = state.in_flight.saturating_sub(1);
+                            state.last_event_at = Instant::now();
+                            // PR 3 fires `Settled { root }` here when
+                            // `state.in_flight` hits zero. PR 2 just
+                            // observes the transition.
+                        }
+                    }
+                }
+            }
+        }
+
+        fn evict(&mut self) {
+            let cutoff = Instant::now().checked_sub(self.retention);
+            if let Some(cutoff) = cutoff {
+                self.roots.retain(|_, state| state.last_event_at >= cutoff);
+                self.mails
+                    .retain(|_, node| self.roots.contains_key(&node.root));
+            }
+            // Hard cap: if we still exceed `max_roots`, drop oldest
+            // by `last_event_at`. This is O(n) but only triggers on
+            // overflow, so it amortises across the steady state.
+            if self.roots.len() > self.max_roots {
+                let mut entries: Vec<(MailId, Instant)> = self
+                    .roots
+                    .iter()
+                    .map(|(id, state)| (*id, state.last_event_at))
+                    .collect();
+                entries.sort_by_key(|(_, t)| *t);
+                let drop_n = self.roots.len() - self.max_roots;
+                for (id, _) in entries.into_iter().take(drop_n) {
+                    self.roots.remove(&id);
+                }
+                self.mails
+                    .retain(|_, node| self.roots.contains_key(&node.root));
+            }
+        }
+    }
+
+    fn parse_env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(default)
+    }
+
+    fn parse_env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(default)
+    }
+
+    #[actor]
+    impl NativeActor for TraceObserverCapability {
+        type Config = ();
+        // ADR-0080 §3 — `aether.trace` (matches
+        // `aether_kinds::trace::TRACE_OBSERVER_MAILBOX_NAME`). Has to
+        // be a literal here for the `#[actor]` macro's expansion.
+        const NAMESPACE: &'static str = "aether.trace";
+
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let retention_ms = parse_env_u64("AETHER_TRACE_RETENTION_MS", RETENTION_MS_DEFAULT);
+            let max_roots = parse_env_usize("AETHER_TRACE_MAX_ROOTS", MAX_ROOTS_DEFAULT);
+            Ok(Self {
+                roots: HashMap::new(),
+                mails: HashMap::new(),
+                retention: Duration::from_millis(retention_ms),
+                max_roots,
+            })
+        }
+
+        /// ADR-0080 §4: fold every event in the batch into the
+        /// per-root counter map and the parent → mail graph. Eviction
+        /// runs once at end-of-handler so the per-event hot path is
+        /// just a HashMap insert/update.
+        ///
+        /// # Agent
+        /// Receives batched trace events from the chassis drainer
+        /// thread. Each event is one producer-site emission (`Sent`
+        /// at the sender, `Received` at the dispatcher entry,
+        /// `Finished` at the dispatcher exit). PR 2 ships state
+        /// only; PR 3 wires `Settled` reply emission for gate-site
+        /// consumers (lifecycle, frame-loop drain).
+        #[handler]
+        fn on_batched_trace_events(&mut self, _ctx: &mut NativeCtx<'_>, batch: BatchedTraceEvents) {
+            for event in batch.events {
+                self.apply_event(event);
+            }
+            self.evict();
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn boot_observer() -> TraceObserverCapability {
+            // Use deterministic-friendly knobs so the eviction tests
+            // don't have to wait on real time.
+            unsafe {
+                std::env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
+                std::env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");
+            }
+            // Construct directly via init's logic (no chassis needed
+            // for these state-fold tests).
+            TraceObserverCapability {
+                roots: HashMap::new(),
+                mails: HashMap::new(),
+                retention: Duration::from_millis(60_000),
+                max_roots: 1000,
+            }
+        }
+
+        fn mail(sender: u64, cid: u64) -> MailId {
+            MailId {
+                sender: MailboxId(sender),
+                correlation_id: cid,
+            }
+        }
+
+        #[test]
+        fn sent_creates_root_and_node() {
+            let mut obs = boot_observer();
+            let m = mail(1, 1);
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: m,
+                root: m,
+                parent_mail: None,
+                sender: MailboxId(1),
+                recipient: MailboxId(2),
+                kind: KindId(0xABCD),
+                t: Nanos(100),
+            });
+            assert_eq!(obs.roots.len(), 1);
+            assert_eq!(obs.roots.get(&m).unwrap().in_flight, 1);
+            assert_eq!(obs.mails.len(), 1);
+            assert_eq!(obs.mails.get(&m).unwrap().t_sent, Nanos(100));
+        }
+
+        #[test]
+        fn child_inherits_root_via_parent_mail() {
+            let mut obs = boot_observer();
+            let root = mail(1, 1);
+            let child = mail(2, 1);
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: root,
+                root,
+                parent_mail: None,
+                sender: MailboxId(1),
+                recipient: MailboxId(2),
+                kind: KindId(0xABCD),
+                t: Nanos(100),
+            });
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: child,
+                root,
+                parent_mail: Some(root),
+                sender: MailboxId(2),
+                recipient: MailboxId(3),
+                kind: KindId(0xCDEF),
+                t: Nanos(200),
+            });
+            assert_eq!(obs.roots.len(), 1);
+            assert_eq!(obs.roots.get(&root).unwrap().in_flight, 2);
+            assert_eq!(obs.mails.get(&child).unwrap().parent, Some(root));
+        }
+
+        #[test]
+        fn finished_decrements_root_in_flight() {
+            let mut obs = boot_observer();
+            let m = mail(1, 1);
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: m,
+                root: m,
+                parent_mail: None,
+                sender: MailboxId(1),
+                recipient: MailboxId(2),
+                kind: KindId(0xABCD),
+                t: Nanos(100),
+            });
+            obs.apply_event(TraceEvent::Received {
+                mail_id: m,
+                t: Nanos(200),
+            });
+            obs.apply_event(TraceEvent::Finished {
+                mail_id: m,
+                t: Nanos(300),
+            });
+            assert_eq!(obs.roots.get(&m).unwrap().in_flight, 0);
+            let node = obs.mails.get(&m).unwrap();
+            assert_eq!(node.t_received, Some(Nanos(200)));
+            assert_eq!(node.t_finished, Some(Nanos(300)));
+        }
+
+        #[test]
+        fn orphan_received_drops_silently() {
+            let mut obs = boot_observer();
+            let m = mail(1, 1);
+            obs.apply_event(TraceEvent::Received {
+                mail_id: m,
+                t: Nanos(100),
+            });
+            assert!(obs.mails.is_empty());
+            assert!(obs.roots.is_empty());
+        }
+
+        #[test]
+        fn max_roots_evicts_oldest() {
+            let mut obs = TraceObserverCapability {
+                roots: HashMap::new(),
+                mails: HashMap::new(),
+                retention: Duration::from_secs(3600),
+                max_roots: 3,
+            };
+            for cid in 1..=5 {
+                let m = mail(1, cid);
+                obs.apply_event(TraceEvent::Sent {
+                    mail_id: m,
+                    root: m,
+                    parent_mail: None,
+                    sender: MailboxId(1),
+                    recipient: MailboxId(2),
+                    kind: KindId(0xABCD),
+                    t: Nanos(cid * 100),
+                });
+                // Tiny delay so `Instant::now()` advances across
+                // each insert — cheap-enough for a 5-root test.
+                std::thread::sleep(Duration::from_millis(2));
+            }
+            obs.evict();
+            assert_eq!(obs.roots.len(), 3);
+            // Oldest two (cid 1, 2) evicted; cid 3, 4, 5 retained.
+            assert!(obs.roots.contains_key(&mail(1, 3)));
+            assert!(obs.roots.contains_key(&mail(1, 4)));
+            assert!(obs.roots.contains_key(&mail(1, 5)));
+        }
+
+        #[test]
+        fn retention_evicts_stale() {
+            let mut obs = TraceObserverCapability {
+                roots: HashMap::new(),
+                mails: HashMap::new(),
+                retention: Duration::from_millis(50),
+                max_roots: 1000,
+            };
+            let m = mail(1, 1);
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: m,
+                root: m,
+                parent_mail: None,
+                sender: MailboxId(1),
+                recipient: MailboxId(2),
+                kind: KindId(0xABCD),
+                t: Nanos(100),
+            });
+            assert_eq!(obs.roots.len(), 1);
+            std::thread::sleep(Duration::from_millis(80));
+            obs.evict();
+            assert!(obs.roots.is_empty());
+            assert!(obs.mails.is_empty());
+        }
+    }
+}

--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -124,14 +124,17 @@ fn push_log_batch(registry: &Registry, recipient: &str, payload: &[u8]) {
     let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
-    handler(
-        <LogBatch as Kind>::ID,
-        LogBatch::NAME,
-        None,
-        ReplyTo::NONE,
+    handler(aether_substrate::mail::registry::MailDispatch {
+        kind: <LogBatch as Kind>::ID,
+        kind_name: LogBatch::NAME,
+        origin: None,
+        sender: ReplyTo::NONE,
         payload,
-        1,
-    );
+        count: 1,
+        mail_id: aether_substrate::mail::MailId::NONE,
+        root: aether_substrate::mail::MailId::NONE,
+        parent_mail: None,
+    });
 }
 
 fn drain_n_log_batches(rx: &std::sync::mpsc::Receiver<EgressEvent>, target: u32) -> u32 {

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -9,7 +9,12 @@
 //! `aether-substrate` re-exports these from `aether_substrate::mail`
 //! so existing call sites compile unchanged.
 
-use crate::{EngineId, MailboxId, SessionToken};
+use alloc::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use crate::schema::{LabelNode, NamedField, Primitive, SchemaType};
+use crate::{EngineId, MailboxId, Schema, SessionToken};
 
 /// ADR-0080 §1: the unique identity of a mail. A 128-bit composite of
 /// the producer's mailbox id and the producer's per-actor monotonic
@@ -20,14 +25,40 @@ use crate::{EngineId, MailboxId, SessionToken};
 /// reserved sentinel for "no actor mailbox"). Per-actor mints use the
 /// owning actor's `MailboxId`.
 ///
-/// Ships in PR 1 of issue #707 as a foundation for PR 2's producer-
-/// side `TraceEvent::Sent` emission. PR 2 plumbs `MailId` onto every
-/// substrate envelope and into per-handler context; PR 1 only
-/// introduces the type so downstream code can name it.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Serde-serializable so PR 2's `TraceEvent` (and its postcard-shaped
+/// `BatchedTraceEvents` envelope) can carry `MailId` over the in-
+/// process trace pipeline. The substrate's host-side `Envelope` and
+/// `Mail` types do not serialize, so the field additions on those
+/// remain wire-free.
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct MailId {
     pub sender: MailboxId,
     pub correlation_id: u64,
+}
+
+/// ADR-0080 §1: hand-written `Schema` impl. Cannot use the derive
+/// because it lives in `aether-actor-derive` and emits
+/// `aether_data::...` paths that don't resolve from inside `aether-
+/// data` itself. The shape mirrors what the derive would produce for
+/// a two-field non-`#[repr(C)]` struct.
+impl Schema for MailId {
+    const SCHEMA: SchemaType = SchemaType::Struct {
+        fields: Cow::Borrowed(&[
+            NamedField {
+                name: Cow::Borrowed("sender"),
+                ty: SchemaType::TypeId(MailboxId::TYPE_ID),
+            },
+            NamedField {
+                name: Cow::Borrowed("correlation_id"),
+                ty: SchemaType::Scalar(Primitive::U64),
+            },
+        ]),
+        repr_c: false,
+    };
+    const LABEL: Option<&'static str> = Some("aether.mail_id");
+    const LABEL_NODE: LabelNode = LabelNode::Anonymous;
 }
 
 impl MailId {

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 
 pub mod descriptors;
 pub mod keycode;
+pub mod trace;
 
 use bytemuck::{Pod, Zeroable};
 

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -1,0 +1,108 @@
+//! ADR-0080 substrate-wide mail tracing wire vocabulary.
+//!
+//! - [`Nanos`] — monotonic timestamp in nanoseconds since substrate
+//!   boot. The chassis owns the `SUBSTRATE_START` reference (a
+//!   `Once<std::time::Instant>` set at boot); producer-side hooks
+//!   compute `now.duration_since(SUBSTRATE_START).as_nanos() as u64`
+//!   per ADR-0080 §2.
+//! - [`TraceEvent`] — one trace event emitted at a producer site.
+//!   Three variants: `Sent` at the sender (every outbound mail),
+//!   `Received` at the receiver's dispatcher entry, `Finished` at the
+//!   receiver's dispatcher exit. The observer folds these into per-
+//!   root counters and the parent → mail graph.
+//! - [`BatchedTraceEvents`] — what the chassis drainer thread mails
+//!   to the [`TRACE_OBSERVER_MAILBOX_NAME`] sink, batching events to
+//!   amortise dispatch cost (defaults: BATCH_MAX = 256, BATCH_INTERVAL
+//!   = 1ms; see ADR-0080 §3).
+
+use alloc::vec::Vec;
+
+use aether_data::{KindId, MailId, MailboxId};
+use serde::{Deserialize, Serialize};
+
+/// ADR-0080 §3: well-known mailbox name the chassis-owned drainer
+/// thread sends [`BatchedTraceEvents`] to. The
+/// `TraceObserverCapability` (in `aether-capabilities`) registers
+/// against this name at boot.
+pub const TRACE_OBSERVER_MAILBOX_NAME: &str = "aether.trace";
+
+/// ADR-0080 §2: monotonic-since-boot timestamp in nanoseconds. Cheap
+/// to read (~10–20 ns VDSO `clock_gettime(CLOCK_MONOTONIC)` on
+/// Linux/macOS); the subtraction against `SUBSTRATE_START` adds ~1–2
+/// ns. `u64` covers ~584 years from boot — wraparound is not a
+/// concern. Process-global / system-wide clock source means cross-
+/// actor events are directly comparable without skew correction.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    aether_data::Schema,
+)]
+pub struct Nanos(pub u64);
+
+/// ADR-0080 §2: one trace event emitted at a producer site.
+///
+/// `Sent` carries the full causal-graph context: the outgoing mail's
+/// own `mail_id`, the chain `root` it inherits or originates, the
+/// optional `parent_mail` at the sender (None for chassis-root), the
+/// producer mailbox, the recipient mailbox, the kind, and the
+/// timestamp. `Received` and `Finished` only carry `mail_id` + `t` —
+/// the observer joins them to the originating `Sent` via the mail-id
+/// key in its [`MailNode`](self) graph (defined in the observer cap,
+/// not on the wire).
+///
+/// Wire shape: postcard. The dispatcher delivers this through normal
+/// mail routing; no cast-shape optimisation because the variant tag +
+/// `Option<MailId>` would force padding gymnastics anyway.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub enum TraceEvent {
+    Sent {
+        mail_id: MailId,
+        root: MailId,
+        parent_mail: Option<MailId>,
+        sender: MailboxId,
+        recipient: MailboxId,
+        kind: KindId,
+        t: Nanos,
+    },
+    Received {
+        mail_id: MailId,
+        t: Nanos,
+    },
+    Finished {
+        mail_id: MailId,
+        t: Nanos,
+    },
+}
+
+/// ADR-0080 §3: a batch of [`TraceEvent`]s the chassis drainer ships
+/// to the [`TRACE_OBSERVER_MAILBOX_NAME`] sink. Batching amortises the
+/// per-mail observer dispatch cost — defaults `BATCH_MAX = 256` events
+/// or `BATCH_INTERVAL = 1ms`, whichever fires first.
+///
+/// The drainer pushes via `Sender::send_detached` (ADR-0080 §7) so the
+/// observer's own outbound mail does not recurse back through the
+/// trace pipeline.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.trace.batched_events")]
+pub struct BatchedTraceEvents {
+    pub events: Vec<TraceEvent>,
+}

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -18,7 +18,7 @@ use aether_capabilities::{
     ComponentHostConfig, FsCapability, HandleCapability, HttpCapability, InputCapability,
     InputConfig, LogCapability, RenderCapability, RenderConfig, TcpCapability,
     UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf, fs::NamespaceRoots,
-    http::HttpConfig as HttpConf,
+    http::HttpConfig as HttpConf, trace::TraceObserverCapability,
 };
 use aether_kinds::WindowMode;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
@@ -229,6 +229,7 @@ impl DesktopChassis {
             .with_actor::<BroadcastCapability>(())
             .with_actor::<HandleCapability>(())
             .with_actor::<LogCapability>(())
+            .with_actor::<TraceObserverCapability>(())
             .with_actor::<InputCapability>(input_config)
             .with_actor::<ComponentHostCapability>(component_host_config)
             .with_actor::<FsCapability>(namespace_roots)

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -20,9 +20,9 @@ use aether_capabilities::{
     BroadcastCapability, ComponentHostCapability, ComponentHostConfig, FsCapability,
     HandleCapability, HeadlessRenderCapability, HeadlessWindowCapability, HttpCapability,
     InputCapability, InputConfig, LogCapability, TcpCapability, UnsupportedTestBenchCapability,
-    fs::NamespaceRoots, http::HttpConfig as HttpConf,
+    fs::NamespaceRoots, http::HttpConfig as HttpConf, trace::TraceObserverCapability,
 };
-use aether_data::{Kind, KindId};
+use aether_data::Kind;
 use aether_kinds::{FrameStats, SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
@@ -118,15 +118,10 @@ impl HeadlessChassis {
         boot.registry.register_closure(
             "aether.audio",
             Arc::new(
-                move |kind: KindId,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      sender,
-                      _bytes: &[u8],
-                      _count: u32| {
-                    if kind == kind_set_master_gain {
+                move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {
+                    if dispatch.kind == kind_set_master_gain {
                         outbound_for_audio_sink.send_reply(
-                            sender,
+                            dispatch.sender,
                             &SetMasterGainResult::Err {
                                 error: "unsupported on headless chassis — no audio device"
                                     .to_owned(),
@@ -177,6 +172,7 @@ impl HeadlessChassis {
             .with_actor::<BroadcastCapability>(())
             .with_actor::<HandleCapability>(())
             .with_actor::<LogCapability>(())
+            .with_actor::<TraceObserverCapability>(())
             .with_actor::<InputCapability>(input_config)
             .with_actor::<ComponentHostCapability>(component_host_config)
             .with_actor::<FsCapability>(namespace_roots)

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -26,7 +26,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aether_capabilities::BroadcastCapability;
+use aether_capabilities::{BroadcastCapability, trace::TraceObserverCapability};
 use aether_substrate::Chassis;
 use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
@@ -153,6 +153,7 @@ impl HubChassis {
 
         Builder::<HubChassis>::new(registry_arc, mailer_arc)
             .with_actor::<BroadcastCapability>(())
+            .with_actor::<TraceObserverCapability>(())
             .with_actor::<ProcessCapability>(ProcessCapabilityConfig {
                 engines: registry,
                 pending,

--- a/crates/aether-substrate-bundle/src/hub/process_capability.rs
+++ b/crates/aether-substrate-bundle/src/hub/process_capability.rs
@@ -500,7 +500,12 @@ mod native {
             }
 
             fn ctx(&self, sender: ReplyTo) -> NativeCtx<'_> {
-                NativeCtx::new(&self.transport, sender)
+                NativeCtx::new(
+                    &self.transport,
+                    sender,
+                    aether_data::MailId::NONE,
+                    aether_data::MailId::NONE,
+                )
             }
         }
 

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -14,7 +14,7 @@ use crate::hub::HubClient;
 use aether_capabilities::{
     BroadcastCapability, CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability,
     InputCapability, InputConfig, LogCapability, RenderCapability, RenderConfig, RenderHandles,
-    TcpCapability, fs::NamespaceRoots,
+    TcpCapability, fs::NamespaceRoots, trace::TraceObserverCapability,
 };
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
@@ -234,6 +234,7 @@ impl TestBenchChassis {
                 .with_actor::<BroadcastCapability>(())
                 .with_actor::<HandleCapability>(())
                 .with_actor::<LogCapability>(())
+                .with_actor::<TraceObserverCapability>(())
                 .with_actor::<InputCapability>(input_config)
                 .with_actor::<ComponentHostCapability>(component_host_config)
                 .with_actor::<TcpCapability>(())

--- a/crates/aether-substrate-bundle/tests/hub_client.rs
+++ b/crates/aether-substrate-bundle/tests/hub_client.rs
@@ -105,17 +105,12 @@ fn inbound_mail_lands_in_queue_after_resolution() {
     let recipient = registry.register_closure(
         "hello",
         Arc::new(
-            move |_kind_id: aether_data::KindId,
-                  _kind: &str,
-                  _origin: Option<&str>,
-                  sender: ReplyTo,
-                  bytes: &[u8],
-                  count: u32| {
+            move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {
                 let (lock, cv) = &*seen_for_sink;
                 let mut s = lock.lock().unwrap();
-                s.count_sum += count;
-                s.payload_lens.push(bytes.len());
-                s.senders.push(sender);
+                s.count_sum += dispatch.count;
+                s.payload_lens.push(dispatch.payload.len());
+                s.senders.push(dispatch.sender);
                 cv.notify_all();
             },
         ),

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -19,7 +19,7 @@ render = ["dep:wgpu", "dep:png"]
 # ADR-0070 phase 3 (part 4): chassis with an audio device enable
 # `audio` to pull in the cpal-backed synth + the `aether.sink.audio`
 # capability. Headless and hub leave it off; desktop turns it on.
-audio = ["dep:cpal", "dep:crossbeam-queue"]
+audio = ["dep:cpal"]
 
 [dependencies]
 # ADR-0074 Phase 2: target-agnostic actor SDK. Capabilities own a
@@ -60,7 +60,8 @@ png = { version = "0.17", optional = true }
 # Audio-only deps; gated by the `audio` feature. Desktop enables it,
 # headless and hub do not.
 cpal = { version = "0.15", optional = true }
-crossbeam-queue = { version = "0.3", optional = true }
+# ADR-0080 trace queue (always on — substrate-wide tracing).
+crossbeam-queue = "0.3"
 # Issue 635 PR B worker-pool ready queue. MPMC channel — std mpsc is
 # single-consumer so it can't load-balance across pool workers.
 crossbeam-channel = "0.5"

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::ctx::ChassisCtx;
 use crate::mail::mailer::Mailer;
-use crate::mail::{KindId, Mail, MailboxId, ReplyTarget, ReplyTo};
+use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTarget, ReplyTo};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
 
 /// Per-actor binding state every native capability owns. Each
@@ -350,13 +350,57 @@ impl NativeBinding {
     /// routes back here, and pushes through the shared
     /// `Arc<Mailer>`. Returns `0` (channel-send failures collapse to
     /// the same scalar — there is no FFI surface here to differentiate).
+    ///
+    /// Stamps `MailId`/`root`/`parent_mail` as a chassis-root send
+    /// (no inheritance). Per-handler ctxs that have an in-flight mail
+    /// to inherit from go through [`Self::send_mail_with_lineage`]
+    /// instead — the four-arg shape preserves wire stability for the
+    /// FFI bridge and chassis-side log push paths that do not carry
+    /// a per-handler context.
     pub fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+        self.send_mail_with_lineage(recipient, kind, bytes, count, None, None)
+    }
+
+    /// ADR-0080 §1 / §5: variant of [`Self::send_mail`] that accepts
+    /// the in-flight handler's lineage so the outgoing [`Mail`] picks
+    /// up the correct `parent_mail` and inherited `root`. The
+    /// per-handler [`super::ctx::NativeCtx`]'s [`Sender`] impl reads
+    /// from its `in_flight_mail_id()` / `in_flight_root()` accessors
+    /// and threads them in.
+    ///
+    /// `parent_mail = None` and `inherited_root = None` mean
+    /// chassis-root: the outgoing mail's `MailId` becomes its own
+    /// `root`, marking the start of a new causal chain.
+    pub fn send_mail_with_lineage(
+        &self,
+        recipient: u64,
+        kind: u64,
+        bytes: &[u8],
+        count: u32,
+        parent_mail: Option<MailId>,
+        inherited_root: Option<MailId>,
+    ) -> u32 {
         let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
         let recipient_id = MailboxId(recipient);
         let reply_to =
             ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
-        let mail =
-            Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count).with_reply_to(reply_to);
+        let mail_id = MailId::new(self.self_mailbox, correlation);
+        let root = inherited_root.unwrap_or(mail_id);
+        // ADR-0080 §2 producer hook: emit `Sent` before pushing the
+        // mail. No-op when the global trace queue isn't installed
+        // (test fixtures bypassing the chassis); the drainer is the
+        // only consumer.
+        crate::runtime::trace::record_sent(
+            mail_id,
+            root,
+            parent_mail,
+            self.self_mailbox,
+            recipient_id,
+            KindId(kind),
+        );
+        let mail = Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count)
+            .with_reply_to(reply_to)
+            .with_lineage(mail_id, root, parent_mail);
         // Record `correlation -> recipient` for the cross-class
         // `wait_reply` guard. We record on every send (the FFI here
         // can't tell fire-and-forget from request/reply) and let
@@ -549,14 +593,17 @@ mod tests {
         // hitting the unknown-recipient warn.
         registry.register_closure(
             "test.sink",
-            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let _ = tx.send(Envelope {
-                    kind,
-                    kind_name: kind_name.to_owned(),
-                    origin: origin.map(str::to_owned),
-                    sender,
-                    payload: payload.to_vec(),
-                    count,
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
                 });
             }),
         );
@@ -641,14 +688,17 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Envelope>();
         registry.register_closure(
             "test.free.running",
-            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let _ = tx.send(Envelope {
-                    kind,
-                    kind_name: kind_name.to_owned(),
-                    origin: origin.map(str::to_owned),
-                    sender,
-                    payload: payload.to_vec(),
-                    count,
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
                 });
             }),
         );
@@ -679,14 +729,17 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Envelope>();
         registry.register_closure(
             "test.frame.bound",
-            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let _ = tx.send(Envelope {
-                    kind,
-                    kind_name: kind_name.to_owned(),
-                    origin: origin.map(str::to_owned),
-                    sender,
-                    payload: payload.to_vec(),
-                    count,
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
                 });
             }),
         );
@@ -724,14 +777,17 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Envelope>();
         registry.register_closure(
             "test.any",
-            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let _ = tx.send(Envelope {
-                    kind,
-                    kind_name: kind_name.to_owned(),
-                    origin: origin.map(str::to_owned),
-                    sender,
-                    payload: payload.to_vec(),
-                    count,
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
                 });
             }),
         );
@@ -762,14 +818,17 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Envelope>();
         registry.register_closure(
             "test.prune",
-            Arc::new(move |kind, kind_name, origin, sender, payload, count| {
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let _ = tx.send(Envelope {
-                    kind,
-                    kind_name: kind_name.to_owned(),
-                    origin: origin.map(str::to_owned),
-                    sender,
-                    payload: payload.to_vec(),
-                    count,
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
                 });
             }),
         );
@@ -797,6 +856,9 @@ mod tests {
             sender: ReplyTo::with_correlation(ReplyTarget::None, correlation),
             payload,
             count: 1,
+            mail_id: crate::mail::MailId::NONE,
+            root: crate::mail::MailId::NONE,
+            parent_mail: None,
         }
     }
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -26,7 +26,7 @@ use aether_actor::mail::sync::WaitError;
 use aether_actor::{Actor, HandlesKind, MailCtx, Sender, Singleton};
 
 use crate::actor::native::mailbox::NativeActorMailbox;
-use aether_data::{Kind, mailbox_id_from_name};
+use aether_data::{Kind, MailId, mailbox_id_from_name};
 
 use crate::actor::monitor::MonitorHandle;
 use crate::actor::native::binding::NativeBinding;
@@ -49,6 +49,18 @@ use super::{NativeActor, NativeDispatch};
 pub struct NativeCtx<'a> {
     binding: &'a NativeBinding,
     sender: ReplyTo,
+    /// ADR-0080 §5: identity of the mail this handler is dispatching.
+    /// Outbound `send` paths read this to stamp `parent_mail` on
+    /// child mail (so the receiver inherits the right parent in the
+    /// causal graph). `MailId::NONE` for ctxs without an inbound
+    /// (chassis-root sends, `unwire`, init).
+    in_flight_mail_id: MailId,
+    /// ADR-0080 §5: root of the causal chain this handler runs in.
+    /// Outbound `send` paths read this to stamp `root` on child mail
+    /// so descendants share the chain. `MailId::NONE` for ctxs without
+    /// an inbound — those sends mint a fresh root from their own
+    /// `mail_id` in `NativeBinding::send_mail`.
+    in_flight_root: MailId,
 }
 
 impl<'a> NativeCtx<'a> {
@@ -57,8 +69,35 @@ impl<'a> NativeCtx<'a> {
     /// `aether-capabilities` also reach for it directly so they can
     /// drive a handler without spinning up a full chassis; that's why
     /// it's `pub` rather than `pub(crate)`.
-    pub fn new(binding: &'a NativeBinding, sender: ReplyTo) -> Self {
-        Self { binding, sender }
+    pub fn new(
+        binding: &'a NativeBinding,
+        sender: ReplyTo,
+        in_flight_mail_id: MailId,
+        in_flight_root: MailId,
+    ) -> Self {
+        Self {
+            binding,
+            sender,
+            in_flight_mail_id,
+            in_flight_root,
+        }
+    }
+
+    /// ADR-0080 §5: the [`MailId`] of the mail currently being
+    /// dispatched. Read by outbound `send` paths to stamp
+    /// `parent_mail` on child mail. `MailId::NONE` when the ctx was
+    /// built without an inbound (close hook, init, chassis-pushed).
+    pub fn in_flight_mail_id(&self) -> MailId {
+        self.in_flight_mail_id
+    }
+
+    /// ADR-0080 §5: the root [`MailId`] of the causal chain this
+    /// handler is running in. Read by outbound `send` paths to inherit
+    /// `root` on child mail so descendants share the chain. The
+    /// chassis-root case (no inbound) leaves this `MailId::NONE` and
+    /// `NativeBinding::send_mail` mints a fresh root.
+    pub fn in_flight_root(&self) -> MailId {
+        self.in_flight_root
     }
 
     /// The reply target for the mail currently being dispatched.
@@ -191,6 +230,31 @@ impl<'a> NativeCtx<'a> {
     }
 }
 
+impl<'a> NativeCtx<'a> {
+    /// ADR-0080 §5: derive the `parent_mail` to stamp on outbound
+    /// mail from this ctx's in-flight context. `MailId::NONE` collapses
+    /// to `None` (chassis-root or close/init ctx).
+    fn outbound_parent(&self) -> Option<MailId> {
+        if self.in_flight_mail_id == MailId::NONE {
+            None
+        } else {
+            Some(self.in_flight_mail_id)
+        }
+    }
+
+    /// ADR-0080 §5: derive the inherited `root` to stamp on outbound
+    /// mail from this ctx's in-flight context. `MailId::NONE` collapses
+    /// to `None`, in which case `NativeBinding::send_mail_with_lineage`
+    /// mints a fresh root from the outbound's own `mail_id`.
+    fn outbound_root(&self) -> Option<MailId> {
+        if self.in_flight_root == MailId::NONE {
+            None
+        } else {
+            Some(self.in_flight_root)
+        }
+    }
+}
+
 impl<'a> Sender for NativeCtx<'a> {
     fn send<R, K>(&mut self, payload: &K)
     where
@@ -198,8 +262,14 @@ impl<'a> Sender for NativeCtx<'a> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
+        self.binding.send_mail_with_lineage(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            K::ID.0,
+            &bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+        );
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -208,18 +278,26 @@ impl<'a> Sender for NativeCtx<'a> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        self.binding.send_mail(
+        self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,
+            self.outbound_parent(),
+            self.outbound_root(),
         );
     }
 
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1);
+        self.binding.send_mail_with_lineage(
+            mailbox_id_from_name(name).0,
+            K::ID.0,
+            &bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+        );
     }
 }
 
@@ -350,8 +428,14 @@ impl<'a> MailSender for NativeCtx<'a> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
+        self.binding.send_mail_with_lineage(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            K::ID.0,
+            &bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+        );
     }
 
     fn send_many<R, K>(&mut self, payloads: &[K])
@@ -360,18 +444,26 @@ impl<'a> MailSender for NativeCtx<'a> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        self.binding.send_mail(
+        self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,
+            self.outbound_parent(),
+            self.outbound_root(),
         );
     }
 
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.binding
-            .send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1);
+        self.binding.send_mail_with_lineage(
+            mailbox_id_from_name(name).0,
+            K::ID.0,
+            &bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+        );
     }
 
     fn prev_correlation(&self) -> u64 {

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -41,7 +41,7 @@ use crate::actor::native::ctx::NativeCtx;
 use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
-use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
+use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
 
 /// Run one actor's dispatcher loop on the calling thread. Returns
 /// when the binding signals shutdown (self-shutdown flag set or
@@ -72,11 +72,14 @@ pub(crate) fn dispatch_loop_run<A>(
             Some(e) => e,
             None => break,
         };
+        let inbound_mail_id = env.mail_id;
+        // ADR-0080 §2 producer hook: `Received` at handler entry.
+        crate::runtime::trace::record_received(inbound_mail_id);
         aether_actor::local::with_stamped(slots, || {
             crate::runtime::log_install::with_actor_dispatch(
                 &**binding as &dyn crate::runtime::log_install::MailDispatch,
                 || {
-                    let mut ctx = NativeCtx::new(binding, env.sender);
+                    let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
                     if actor
                         .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
                         .is_none()
@@ -99,6 +102,13 @@ pub(crate) fn dispatch_loop_run<A>(
                 },
             );
         });
+        // ADR-0080 §2 producer hook: `Finished` at handler exit. PR 2
+        // does not bracket the panic-unwind path; if a handler panics
+        // mid-dispatch the actor's process-level panic hook brings
+        // the substrate down anyway, so a missing `Finished` is
+        // moot. A future PR may add `catch_unwind` here for graceful
+        // settlement-on-panic.
+        crate::runtime::trace::record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -110,16 +120,19 @@ pub(crate) fn dispatch_loop_run<A>(
     // runs so a "please close" handler that flushes state observes
     // the full inbox.
     while let Some(env) = binding.try_recv() {
+        let inbound_mail_id = env.mail_id;
+        crate::runtime::trace::record_received(inbound_mail_id);
         aether_actor::local::with_stamped(slots, || {
             crate::runtime::log_install::with_actor_dispatch(
                 &**binding as &dyn crate::runtime::log_install::MailDispatch,
                 || {
-                    let mut ctx = NativeCtx::new(binding, env.sender);
+                    let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
                     let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
                     aether_actor::log::drain_buffer();
                 },
             );
         });
+        crate::runtime::trace::record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -131,7 +144,8 @@ pub(crate) fn dispatch_loop_run<A>(
         crate::runtime::log_install::with_actor_dispatch(
             &**binding as &dyn crate::runtime::log_install::MailDispatch,
             || {
-                let mut close_ctx = NativeCtx::new(binding, ReplyTo::NONE);
+                let mut close_ctx =
+                    NativeCtx::new(binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
                 actor.unwire(&mut close_ctx);
                 aether_actor::log::drain_buffer();
             },

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -163,11 +163,13 @@ where
     /// `log_install::with_actor_dispatch` so tracing events carry the
     /// actor's mailbox id and the per-handler `LogBatch` ships at exit.
     fn dispatch_one(&self, actor: &mut Box<A>, env: crate::actor::native::Envelope) {
+        let inbound_mail_id = env.mail_id;
+        crate::runtime::trace::record_received(inbound_mail_id);
         aether_actor::local::with_stamped(&self.slots, || {
             crate::runtime::log_install::with_actor_dispatch(
                 &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
                 || {
-                    let mut ctx = NativeCtx::new(&self.binding, env.sender);
+                    let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
                     if actor
                         .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)
                         .is_none()
@@ -184,6 +186,7 @@ where
                 },
             );
         });
+        crate::runtime::trace::record_finished(inbound_mail_id);
         if let Some(p) = &self.pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -198,7 +201,12 @@ where
             crate::runtime::log_install::with_actor_dispatch(
                 &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
                 || {
-                    let mut close_ctx = NativeCtx::new(&self.binding, ReplyTo::NONE);
+                    let mut close_ctx = NativeCtx::new(
+                        &self.binding,
+                        ReplyTo::NONE,
+                        aether_data::MailId::NONE,
+                        aether_data::MailId::NONE,
+                    );
                     actor.unwire(&mut close_ctx);
                     aether_actor::log::drain_buffer();
                 },

--- a/crates/aether-substrate/src/actor/native/envelope.rs
+++ b/crates/aether-substrate/src/actor/native/envelope.rs
@@ -2,13 +2,21 @@
 //! mpsc inbox. Sinks today take borrowed args (`&str`, `&[u8]`); routing
 //! across an mpsc channel forces ownership.
 
-use crate::mail::{KindId, ReplyTo};
+use crate::mail::{KindId, MailId, ReplyTo};
 
 /// One mail delivered to a capability through its mpsc receiver.
 ///
 /// Sinks today receive borrowed args (`&str`, `&[u8]`); routing across
 /// an mpsc channel forces ownership. Capabilities that care about
 /// ergonomics destructure this once at the top of their loop.
+///
+/// `mail_id`, `root`, and `parent_mail` (ADR-0080 §1 / §5) carry the
+/// inbound mail's identity and causal-chain pointers. The native
+/// dispatcher reads them to populate the per-handler `NativeCtx`'s
+/// `in_flight()` accessors so child sends inherit the correct root.
+/// PR 2 of issue #707 plumbs the data; PR 2's TraceObserver hooks
+/// emit `TraceEvent::Received { mail_id, .. }` against the same value
+/// the producer's `Sent` event carried.
 #[derive(Debug)]
 pub struct Envelope {
     pub kind: KindId,
@@ -17,4 +25,7 @@ pub struct Envelope {
     pub sender: ReplyTo,
     pub payload: Vec<u8>,
     pub count: u32,
+    pub mail_id: MailId,
+    pub root: MailId,
+    pub parent_mail: Option<MailId>,
 }

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -32,7 +32,7 @@ use crate::actor::registry::ActorRegistry;
 use crate::chassis::error::BootError;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::{NameConflict, Registry};
-use crate::mail::{KindId, MailboxId, ReplyTo};
+use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
 
 /// How to derive the subname for a [`Spawner::spawn_actor`] call. The
@@ -395,48 +395,44 @@ impl Spawner {
         let wake_for_handler = Arc::clone(&wake_slot);
         let registered = self.registry.try_register_closure(
             full_name.clone(),
-            Arc::new(
-                move |kind: KindId,
-                      kind_name: &str,
-                      origin: Option<&str>,
-                      sender: ReplyTo,
-                      payload: &[u8],
-                      count: u32| {
-                    let Some(tx) = weak_for_handler.upgrade() else {
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            kind = kind_name,
-                            "instanced actor sender dropped — mail discarded"
-                        );
-                        return;
-                    };
-                    let env = Envelope {
-                        kind,
-                        kind_name: kind_name.to_owned(),
-                        origin: origin.map(str::to_owned),
-                        sender,
-                        payload: payload.to_vec(),
-                        count,
-                    };
-                    pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                    if tx.send(env).is_err() {
-                        // Receiver disconnected before we could deliver;
-                        // un-account for the increment so the counter
-                        // stays accurate (otherwise `wait_instanced_quiesce`
-                        // would never see zero).
-                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            kind = kind_name,
-                            "instanced actor receiver dropped — mail discarded"
-                        );
-                        return;
-                    }
-                    if let Some(wake) = wake_for_handler.get() {
-                        wake();
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                let Some(tx) = weak_for_handler.upgrade() else {
+                    tracing::warn!(
+                        target: "aether_substrate::spawn",
+                        kind = dispatch.kind_name,
+                        "instanced actor sender dropped — mail discarded"
+                    );
+                    return;
+                };
+                let env = Envelope {
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
+                };
+                pending_for_handler.fetch_add(1, Ordering::AcqRel);
+                if tx.send(env).is_err() {
+                    // Receiver disconnected before we could deliver;
+                    // un-account for the increment so the counter
+                    // stays accurate (otherwise `wait_instanced_quiesce`
+                    // would never see zero).
+                    pending_for_handler.fetch_sub(1, Ordering::AcqRel);
+                    tracing::warn!(
+                        target: "aether_substrate::spawn",
+                        kind = dispatch.kind_name,
+                        "instanced actor receiver dropped — mail discarded"
+                    );
+                    return;
+                }
+                if let Some(wake) = wake_for_handler.get() {
+                    wake();
+                }
+            }),
         );
         let _ = sender_for_init; // Phase 3 doesn't stamp pre-load mail with the spawner; envelopes are pre-built by SpawnBuilder.
         match registered {
@@ -494,8 +490,12 @@ impl Spawner {
             crate::runtime::log_install::with_actor_dispatch(
                 &*transport as &dyn crate::runtime::log_install::MailDispatch,
                 || {
-                    let mut wire_ctx =
-                        crate::actor::native::NativeCtx::new(&transport, ReplyTo::NONE);
+                    let mut wire_ctx = crate::actor::native::NativeCtx::new(
+                        &transport,
+                        ReplyTo::NONE,
+                        MailId::NONE,
+                        MailId::NONE,
+                    );
                     actor.wire(&mut wire_ctx);
                     aether_actor::log::drain_buffer();
                 },
@@ -680,6 +680,9 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
             sender: self.sender,
             payload,
             count: 1,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
         };
         self.after_init.push(env);
         self

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -191,14 +191,24 @@ impl ComponentCtx {
             // can route `*Result` back to this component via
             // `Mailer::send_reply`.
             let origin = self.registry.mailbox_name(self.sender);
-            handler(
+            // ADR-0080 §1: PR 2 plumbs the lineage triple through the
+            // `MailboxHandler` signature; producer-side population
+            // (mint MailId from the per-actor counter, inherit `root`
+            // from the component's in-flight context) lands in PR 3
+            // alongside the chassis sentinel and per-handler ctx
+            // accessors. PR 2 stamps `MailId::NONE` here so the
+            // envelope shape is honest while population catches up.
+            handler(crate::mail::registry::MailDispatch {
                 kind,
-                &kind_name,
-                origin.as_deref(),
-                reply_to,
-                &payload,
+                kind_name: &kind_name,
+                origin: origin.as_deref(),
+                sender: reply_to,
+                payload: &payload,
                 count,
-            );
+                mail_id: crate::mail::MailId::NONE,
+                root: crate::mail::MailId::NONE,
+                parent_mail: None,
+            });
             return;
         }
 
@@ -1025,7 +1035,7 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_closure("client", Arc::new(|_, _, _, _, _, _| {}))
+            .try_register_closure("client", crate::mail::registry::noop_handler())
             .expect("register client mailbox");
 
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
@@ -1067,7 +1077,7 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_closure("client", Arc::new(|_, _, _, _, _, _| {}))
+            .try_register_closure("client", crate::mail::registry::noop_handler())
             .expect("register client mailbox");
 
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -141,33 +141,28 @@ impl<'a> SubstrateBootBuilder<'a> {
         // needing another sink.
         registry.register_closure(
             AETHER_DIAGNOSTICS,
-            Arc::new(
-                |_kind: aether_data::KindId,
-                 kind_name: &str,
-                 _origin: Option<&str>,
-                 _sender,
-                 bytes: &[u8],
-                 _count: u32| {
-                    if kind_name == <aether_kinds::UnresolvedMail as aether_data::Kind>::NAME
-                        && let Ok(record) =
-                            bytemuck::try_from_bytes::<aether_kinds::UnresolvedMail>(bytes)
-                    {
-                        tracing::warn!(
-                            target: "aether_substrate::diagnostics",
-                            recipient_mailbox_id = %record.recipient_mailbox_id,
-                            kind_id = %record.kind_id,
-                            "hub could not resolve bubbled-up mail recipient (ADR-0037); \
-                             mail dropped. Likely a typoed mailbox name at the sender.",
-                        );
-                        return;
-                    }
+            Arc::new(|dispatch: crate::mail::registry::MailDispatch<'_>| {
+                let kind_name = dispatch.kind_name;
+                let bytes = dispatch.payload;
+                if kind_name == <aether_kinds::UnresolvedMail as aether_data::Kind>::NAME
+                    && let Ok(record) =
+                        bytemuck::try_from_bytes::<aether_kinds::UnresolvedMail>(bytes)
+                {
                     tracing::warn!(
                         target: "aether_substrate::diagnostics",
-                        kind = %kind_name,
-                        "aether.diagnostics received an unexpected kind or malformed payload",
+                        recipient_mailbox_id = %record.recipient_mailbox_id,
+                        kind_id = %record.kind_id,
+                        "hub could not resolve bubbled-up mail recipient (ADR-0037); \
+                         mail dropped. Likely a typoed mailbox name at the sender.",
                     );
-                },
-            ),
+                    return;
+                }
+                tracing::warn!(
+                    target: "aether_substrate::diagnostics",
+                    kind = %kind_name,
+                    "aether.diagnostics received an unexpected kind or malformed payload",
+                );
+            }),
         );
 
         let handle_store = Arc::new(HandleStore::from_env());
@@ -217,7 +212,7 @@ mod tests {
         // The boot is alive; chassis sinks can be registered without
         // racing a hub-driven load.
         boot.registry
-            .register_closure("test_chassis_sink", Arc::new(|_, _, _, _, _, _| {}));
+            .register_closure("test_chassis_sink", Arc::new(|_dispatch| {}));
         // No backend attached → `is_connected()` is false. Chassis
         // crates that want a hub bridge wire `HubClientCapability`
         // themselves through their `Builder`.

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -581,6 +581,8 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                     let mut wire_ctx = crate::actor::native::NativeCtx::new(
                         &resources.transport,
                         aether_data::ReplyTo::NONE,
+                        aether_data::MailId::NONE,
+                        aether_data::MailId::NONE,
                     );
                     actor.wire(&mut wire_ctx);
                     aether_actor::log::drain_buffer();
@@ -1058,6 +1060,13 @@ struct BootedPassives {
     /// implicit field-drop ordering), so every Dedicated dispatcher
     /// thread is gone before pool workers join.
     _pool: PoolHandle,
+    /// ADR-0080 §3 trace drainer thread. Boots alongside the worker
+    /// pool; its `Drop` signals + joins the thread (final flush
+    /// included). Dropped after `shutdowns` and `_pool` per field
+    /// order, so the last batch may target an already-dead
+    /// `TraceObserver` mailbox — that's acceptable: the observer cap
+    /// drained its inbox during its own dispatcher's phase-2 drain.
+    _trace_drainer: crate::runtime::trace::TraceDrainerHandle,
 }
 
 /// Issue #601: dispatch a `ConfigureLogDrain { mailbox: drain }` mail
@@ -1133,6 +1142,19 @@ fn boot_passives(
     // booting it here means PR D / Phase 2 can flip a cap to Pooled
     // without re-plumbing the boot order.
     let pool = Pool::start(PoolConfig::default(), Arc::clone(aborter));
+
+    // ADR-0080 §3 trace pipeline. `init_substrate_start` pins the
+    // monotonic-since-boot reference; `install_trace_queue` makes the
+    // global queue visible to producer-side hooks; `start_drainer`
+    // owns the thread that batches events into mail addressed to the
+    // `aether.trace` sink. The handle in `BootedPassives` joins the
+    // thread on chassis tear down.
+    crate::runtime::trace::init_substrate_start();
+    let trace_queue: Arc<crossbeam_queue::SegQueue<aether_kinds::trace::TraceEvent>> =
+        Arc::new(crossbeam_queue::SegQueue::new());
+    crate::runtime::trace::install_trace_queue(Arc::clone(&trace_queue));
+    let trace_drainer =
+        crate::runtime::trace::start_drainer(Arc::clone(&trace_queue), Arc::clone(mailer));
     let spawner: Arc<crate::Spawner> = Arc::new(crate::Spawner::new(
         Arc::clone(registry),
         Arc::clone(&actor_registry),
@@ -1305,6 +1327,7 @@ fn boot_passives(
         actor_registry,
         spawner,
         _pool: pool,
+        _trace_drainer: trace_drainer,
     })
 }
 
@@ -1750,7 +1773,7 @@ mod tests {
     #[test]
     fn with_actor_boots_dispatches_and_tears_down() {
         use crate::mail::registry::MailboxEntry;
-        use aether_data::{Kind, ReplyTo as DataReplyTo};
+        use aether_data::Kind;
         use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
         // Fixture kind: a 4-byte cast-shape payload so encode_into_bytes
@@ -1839,14 +1862,12 @@ mod tests {
 
         let payload = Ping { tag: 0xDEAD_BEEF };
         let bytes = payload.encode_into_bytes();
-        handler(
+        handler(crate::mail::registry::test_dispatch(
             <Ping as Kind>::ID,
             Ping::NAME,
-            None,
-            DataReplyTo::NONE,
             &bytes,
             1,
-        );
+        ));
 
         // Wait briefly for the dispatcher thread to dispatch.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -1923,7 +1944,7 @@ mod tests {
     fn with_actor_stamps_local_for_init_and_handler() {
         use crate::mail::registry::MailboxEntry;
         use aether_actor::Local;
-        use aether_data::{Kind, ReplyTo as DataReplyTo};
+        use aether_data::Kind;
         use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
         #[repr(C)]
@@ -2021,14 +2042,12 @@ mod tests {
         for seq in 0..3 {
             let payload = Tick { seq };
             let bytes = payload.encode_into_bytes();
-            handler(
+            handler(crate::mail::registry::test_dispatch(
                 <Tick as Kind>::ID,
                 Tick::NAME,
-                None,
-                DataReplyTo::NONE,
                 &bytes,
                 1,
-            );
+            ));
         }
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -2055,7 +2074,7 @@ mod tests {
         use crate::actor::native::spawn::Subname;
         use crate::mail::registry::MailboxEntry;
         use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId, ReplyTo as DataReplyTo};
+        use aether_data::{Kind, KindId as DataKindId};
         use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
         #[repr(C)]
@@ -2190,14 +2209,12 @@ mod tests {
             panic!("expected mailbox entry");
         };
         let bytes = (Hatch { tag: 1 }).encode_into_bytes();
-        handler(
+        handler(crate::mail::registry::test_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
-            None,
-            DataReplyTo::NONE,
             &bytes,
             1,
-        );
+        ));
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
         while child_received.load(AtomicOrdering::SeqCst) < 1
@@ -2316,14 +2333,12 @@ mod tests {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
-        handler(
+        handler(crate::mail::registry::test_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &bytes,
             1,
-        );
+        ));
 
         // Wait for unwire to run + the registry slot to flip Dead.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -2626,14 +2641,12 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler(
+        watcher_handler(crate::mail::registry::test_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &order.encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait until the registry sees the monitor entry.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -2661,14 +2674,12 @@ mod tests {
         else {
             panic!("expected mailbox entry for target");
         };
-        target_handler(
+        target_handler(crate::mail::registry::test_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &(Quit { tag: 1 }).encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait for the notice to land at the watcher.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -2859,14 +2870,12 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler(
+        watcher_handler(crate::mail::registry::test_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &order.encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait for register to land.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -2879,14 +2888,12 @@ mod tests {
 
         // Quit watcher — its close path walks `monitoring[watcher]` and
         // prunes watcher from `monitors_of[target]`.
-        watcher_handler(
+        watcher_handler(crate::mail::registry::test_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &(Quit { tag: 1 }).encode_into_bytes(),
             1,
-        );
+        ));
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
         while close_observed.load(AtomicOrdering::SeqCst) == 0
@@ -3051,14 +3058,12 @@ mod tests {
         else {
             panic!("expected mailbox entry for c");
         };
-        handler(
+        handler(crate::mail::registry::test_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &(Quit { tag: 1 }).encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait for c's slot to flip Dead.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
@@ -3360,14 +3365,12 @@ mod tests {
         else {
             panic!("expected mailbox entry for parent");
         };
-        parent_handler(
+        parent_handler(crate::mail::registry::test_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &(Hatch { tag: 1 }).encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait for the grandchild's after_init Ping to dispatch (proves
         // the recursive spawn happened AND the after_init plumbing
@@ -3412,14 +3415,12 @@ mod tests {
         // Closing the parent does NOT cascade-close the grandchild.
         // Parent-child shutdown coupling is opt-in via monitor; without
         // it, the grandchild keeps running.
-        parent_handler(
+        parent_handler(crate::mail::registry::test_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
-            None,
-            aether_data::ReplyTo::NONE,
             &(Quit { tag: 1 }).encode_into_bytes(),
             1,
-        );
+        ));
 
         // Wait for parent slot to flip Dead.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -15,9 +15,9 @@ use aether_actor::Actor;
 
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::error::BootError;
+use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
-use crate::mail::registry::Registry;
-use crate::mail::{KindId, MailboxId, ReplyTo};
+use crate::mail::registry::{MailDispatch, Registry};
 use crate::runtime::lifecycle::FatalAborter;
 
 /// Result returned from [`ChassisCtx::claim_mailbox`].
@@ -280,30 +280,26 @@ impl<'a> ChassisCtx<'a> {
         let tx = Arc::new(tx);
         let id = self.registry.try_register_closure(
             name.to_owned(),
-            Arc::new(
-                move |kind: KindId,
-                      kind_name: &str,
-                      origin: Option<&str>,
-                      sender: ReplyTo,
-                      payload: &[u8],
-                      count: u32| {
-                    let env = Envelope {
-                        kind,
-                        kind_name: kind_name.to_owned(),
-                        origin: origin.map(str::to_owned),
-                        sender,
-                        payload: payload.to_vec(),
-                        count,
-                    };
-                    if tx.send(env).is_err() {
-                        tracing::warn!(
-                            target: "aether_substrate::capability",
-                            kind = kind_name,
-                            "capability mailbox receiver dropped — mail discarded"
-                        );
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                let env = Envelope {
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
+                };
+                if tx.send(env).is_err() {
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        kind = dispatch.kind_name,
+                        "capability mailbox receiver dropped — mail discarded"
+                    );
+                }
+            }),
         )?;
         self.claimed_actor_mailboxes.push(id);
         Ok(MailboxClaim { id, receiver: rx })
@@ -348,46 +344,42 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_closure(
             name.to_owned(),
-            Arc::new(
-                move |kind: KindId,
-                      kind_name: &str,
-                      origin: Option<&str>,
-                      sender: ReplyTo,
-                      payload: &[u8],
-                      count: u32| {
-                    let Some(tx) = weak.upgrade() else {
-                        tracing::warn!(
-                            target: "aether_substrate::capability",
-                            kind = kind_name,
-                            "capability mailbox sender dropped — mail discarded"
-                        );
-                        return;
-                    };
-                    let env = Envelope {
-                        kind,
-                        kind_name: kind_name.to_owned(),
-                        origin: origin.map(str::to_owned),
-                        sender,
-                        payload: payload.to_vec(),
-                        count,
-                    };
-                    if tx.send(env).is_err() {
-                        tracing::warn!(
-                            target: "aether_substrate::capability",
-                            kind = kind_name,
-                            "capability mailbox receiver dropped — mail discarded"
-                        );
-                        return;
-                    }
-                    // Issue 635 PR C: fire the `Pooled` wake hook (if
-                    // installed). `Dedicated` actors leave it empty,
-                    // so this is a single relaxed atomic load on the
-                    // hot path.
-                    if let Some(wake) = wake_for_handler.get() {
-                        wake();
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                let Some(tx) = weak.upgrade() else {
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        kind = dispatch.kind_name,
+                        "capability mailbox sender dropped — mail discarded"
+                    );
+                    return;
+                };
+                let env = Envelope {
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
+                };
+                if tx.send(env).is_err() {
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        kind = dispatch.kind_name,
+                        "capability mailbox receiver dropped — mail discarded"
+                    );
+                    return;
+                }
+                // Issue 635 PR C: fire the `Pooled` wake hook (if
+                // installed). `Dedicated` actors leave it empty,
+                // so this is a single relaxed atomic load on the
+                // hot path.
+                if let Some(wake) = wake_for_handler.get() {
+                    wake();
+                }
+            }),
         )?;
         self.claimed_actor_mailboxes.push(id);
         Ok(DropOnShutdownClaim {
@@ -432,56 +424,52 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_closure(
             name.to_owned(),
-            Arc::new(
-                move |kind: KindId,
-                      kind_name: &str,
-                      origin: Option<&str>,
-                      sender: ReplyTo,
-                      payload: &[u8],
-                      count: u32| {
-                    let Some(tx) = weak.upgrade() else {
-                        tracing::warn!(
-                            target: "aether_substrate::capability",
-                            kind = kind_name,
-                            "frame-bound capability sender dropped — mail discarded"
-                        );
-                        return;
-                    };
-                    let env = Envelope {
-                        kind,
-                        kind_name: kind_name.to_owned(),
-                        origin: origin.map(str::to_owned),
-                        sender,
-                        payload: payload.to_vec(),
-                        count,
-                    };
-                    // Increment before send so the dispatcher's
-                    // matching decrement-after-dispatch sees a count
-                    // > 0 by the time it tries to decrement. If the
-                    // send itself fails (receiver dropped between the
-                    // upgrade and the send — shutdown race), undo
-                    // the increment so the counter doesn't drift up.
-                    pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                    if tx.send(env).is_err() {
-                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
-                        tracing::warn!(
-                            target: "aether_substrate::capability",
-                            kind = kind_name,
-                            "frame-bound capability receiver dropped — mail discarded"
-                        );
-                        return;
-                    }
-                    // Issue 635 PR C: fire the `Pooled` wake hook (if
-                    // installed). Frame-bound + pool-scheduled is a
-                    // valid combination per the issue's section 5
-                    // ("FRAME_BARRIER and SCHEDULING are orthogonal");
-                    // the chassis frame loop reads `pending` regardless
-                    // of where the dispatch happens.
-                    if let Some(wake) = wake_for_handler.get() {
-                        wake();
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                let Some(tx) = weak.upgrade() else {
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        kind = dispatch.kind_name,
+                        "frame-bound capability sender dropped — mail discarded"
+                    );
+                    return;
+                };
+                let env = Envelope {
+                    kind: dispatch.kind,
+                    kind_name: dispatch.kind_name.to_owned(),
+                    origin: dispatch.origin.map(str::to_owned),
+                    sender: dispatch.sender,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                    mail_id: dispatch.mail_id,
+                    root: dispatch.root,
+                    parent_mail: dispatch.parent_mail,
+                };
+                // Increment before send so the dispatcher's
+                // matching decrement-after-dispatch sees a count
+                // > 0 by the time it tries to decrement. If the
+                // send itself fails (receiver dropped between the
+                // upgrade and the send — shutdown race), undo
+                // the increment so the counter doesn't drift up.
+                pending_for_handler.fetch_add(1, Ordering::AcqRel);
+                if tx.send(env).is_err() {
+                    pending_for_handler.fetch_sub(1, Ordering::AcqRel);
+                    tracing::warn!(
+                        target: "aether_substrate::capability",
+                        kind = dispatch.kind_name,
+                        "frame-bound capability receiver dropped — mail discarded"
+                    );
+                    return;
+                }
+                // Issue 635 PR C: fire the `Pooled` wake hook (if
+                // installed). Frame-bound + pool-scheduled is a
+                // valid combination per the issue's section 5
+                // ("FRAME_BARRIER and SCHEDULING are orthogonal");
+                // the chassis frame loop reads `pending` regardless
+                // of where the dispatch happens.
+                if let Some(wake) = wake_for_handler.get() {
+                    wake();
+                }
+            }),
         )?;
         self.frame_bound_pending.push((id, Arc::clone(&pending)));
         // Mirror the membership into the shared set so each

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -155,11 +155,12 @@ mod tests {
         let captured_for_sink = Arc::clone(&captured);
         registry.register_closure(
             aether_kinds::HUB_BROADCAST_MAILBOX_NAME,
-            Arc::new(
-                move |_kind_id, _kind_name, _origin, _sender, bytes, _count| {
-                    captured_for_sink.write().unwrap().push(bytes.to_vec());
-                },
-            ),
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                captured_for_sink
+                    .write()
+                    .unwrap()
+                    .push(dispatch.payload.to_vec());
+            }),
         );
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
@@ -180,11 +181,12 @@ mod tests {
         let captured_for_sink = Arc::clone(&captured);
         registry.register_closure(
             aether_kinds::HUB_BROADCAST_MAILBOX_NAME,
-            Arc::new(
-                move |_kind_id, _kind_name, _origin, _sender, bytes, _count| {
-                    captured_for_sink.write().unwrap().push(bytes.to_vec());
-                },
-            ),
+            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                captured_for_sink
+                    .write()
+                    .unwrap()
+                    .push(dispatch.payload.to_vec());
+            }),
         );
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::outbound::HubOutbound;
-use crate::mail::registry::{MailboxEntry, Registry};
+use crate::mail::registry::{MailDispatch, MailboxEntry, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use aether_data::{HandleId, KindId};
 
@@ -256,14 +256,17 @@ fn route_mail(
             // ADR-0011 origin is `None`. Components reach
             // closure-bound mailboxes via `ComponentCtx::send` inline
             // and never enter `push`.
-            handler(
-                mail.kind,
-                &kind_name,
-                None,
-                mail.reply_to,
-                &mail.payload,
-                mail.count,
-            );
+            handler(MailDispatch {
+                kind: mail.kind,
+                kind_name: &kind_name,
+                origin: None,
+                sender: mail.reply_to,
+                payload: &mail.payload,
+                count: mail.count,
+                mail_id: mail.mail_id,
+                root: mail.root,
+                parent_mail: mail.parent_mail,
+            });
         }
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
@@ -459,17 +462,10 @@ mod tests {
         fn handler(&self) -> MailboxHandler {
             let captured = Arc::clone(&self.captured);
             let count = Arc::clone(&self.delivery_count);
-            Arc::new(
-                move |_kind_id: KindId,
-                      _kind_name: &str,
-                      _origin: Option<&str>,
-                      _sender: ReplyTo,
-                      bytes: &[u8],
-                      _count: u32| {
-                    captured.write().unwrap().push(bytes.to_vec());
-                    count.fetch_add(1, Ordering::SeqCst);
-                },
-            )
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                captured.write().unwrap().push(dispatch.payload.to_vec());
+                count.fetch_add(1, Ordering::SeqCst);
+            })
         }
     }
 

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -22,7 +22,7 @@ pub use registry::{MailboxEntry, MailboxHandler, Registry};
 /// ADR-0065 hoisted the canonical home into `aether_data` (per ADR-0069);
 /// this remains re-exported under the `aether_substrate::mail::MailboxId`
 /// path so existing call sites compile unchanged.
-pub use aether_data::{KindId, MailboxId};
+pub use aether_data::{KindId, MailId, MailboxId};
 /// Reply-routing types. Canonical home is `aether-data` (ADR-0076) —
 /// `aether-actor`'s `Dispatch` trait references them in its signature
 /// without taking an `aether-actor`-internal dep, and the location
@@ -66,6 +66,22 @@ pub struct Mail {
     pub payload: Vec<u8>,
     pub count: u32,
     pub reply_to: ReplyTo,
+    /// ADR-0080 §1: this mail's identity. The producer mints it from
+    /// `MailId::new(producer_mailbox, producer_per_actor_correlation)`
+    /// before pushing through `Mailer`. PR 2 stamps it inert (no
+    /// trace-event consumer reads it yet); PR 2's TraceObserver hooks
+    /// emit `TraceEvent::Sent { mail_id, .. }` against this value.
+    /// `MailId::NONE` for legacy paths that haven't migrated.
+    pub mail_id: MailId,
+    /// ADR-0080 §5: the root of this mail's causal chain — the
+    /// originating mail's `mail_id` for the chain. Inherited from the
+    /// sender's in-flight handler context; for chassis-root sends
+    /// (`Tick`, lifecycle, externally-bridged), `root == mail_id`.
+    /// `MailId::NONE` for legacy paths.
+    pub root: MailId,
+    /// ADR-0080 §5: the in-flight mail at the sender, or `None` for
+    /// chassis-root sends. The receiver's parent in the causal graph.
+    pub parent_mail: Option<MailId>,
 }
 
 impl Mail {
@@ -76,6 +92,9 @@ impl Mail {
             payload,
             count,
             reply_to: ReplyTo::NONE,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
         }
     }
 
@@ -87,6 +106,23 @@ impl Mail {
     /// Other mail paths leave the default `ReplyTo::None`.
     pub fn with_reply_to(mut self, reply_to: ReplyTo) -> Self {
         self.reply_to = reply_to;
+        self
+    }
+
+    /// ADR-0080 §1 / §5: stamp the producer-minted lineage triple
+    /// (`mail_id`, `root`, `parent_mail`) onto this mail. Producer
+    /// paths (`NativeBinding::send_mail`, `Mailer::send_reply`,
+    /// chassis-root push sites) call this immediately after minting.
+    /// Mail with no lineage stamped retains `MailId::NONE` defaults.
+    pub fn with_lineage(
+        mut self,
+        mail_id: MailId,
+        root: MailId,
+        parent_mail: Option<MailId>,
+    ) -> Self {
+        self.mail_id = mail_id;
+        self.root = root;
+        self.parent_mail = parent_mail;
         self
     }
 }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -14,24 +14,87 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
-use crate::mail::{KindId, MailboxId, ReplyTo};
+use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
+
+/// Test-only helper that builds a [`MailDispatch`] with empty
+/// `origin` / `ReplyTo::NONE` / `MailId::NONE` defaults from the
+/// minimum positional args. Used by chassis and capability tests
+/// that drive a registered handler synchronously without going
+/// through the full `Mail` → `Mailer::push` path.
+#[cfg(test)]
+pub(crate) fn test_dispatch<'a>(
+    kind: KindId,
+    kind_name: &'a str,
+    payload: &'a [u8],
+    count: u32,
+) -> MailDispatch<'a> {
+    MailDispatch {
+        kind,
+        kind_name,
+        origin: None,
+        sender: ReplyTo::NONE,
+        payload,
+        count,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
+        parent_mail: None,
+    }
+}
+
+/// No-op [`MailboxHandler`] for tests that just need a registered
+/// mailbox to route to *somewhere* without observing the mail. The
+/// explicit named helper documents intent at the call site and keeps
+/// the closure shape (post-ADR-0080 `MailDispatch`-based) hidden.
+pub fn noop_handler() -> MailboxHandler {
+    Arc::new(|_dispatch: MailDispatch<'_>| {})
+}
 use aether_data::canonical::{canonical_kind_bytes, kind_id_from_parts};
 use aether_data::{KindDescriptor, SchemaType};
 
+/// One mail's worth of dispatch metadata handed to a [`MailboxHandler`].
+/// Bundled into a single struct (rather than a positional argument
+/// list) so the producer-minted ADR-0080 §1 / §5 lineage fields
+/// (`mail_id` / `root` / `parent_mail`) ride alongside the existing
+/// envelope-style fields without exploding the closure's call shape.
+///
+/// Handlers that build an [`crate::actor::native::envelope::Envelope`]
+/// for an mpsc downstream copy `mail_id` / `root` / `parent_mail`
+/// onto it (the dispatcher reads them to populate the per-handler
+/// `NativeCtx`'s `in_flight()` accessors). Chassis-bound sinks that
+/// consume mail inline can ignore the lineage triple.
+#[derive(Copy, Clone, Debug)]
+pub struct MailDispatch<'a> {
+    /// Kind id (`K::ID`, ADR-0030 schema hash) the producer stamped.
+    pub kind: KindId,
+    /// Kind's registered name. Resolved by the dispatcher for
+    /// diagnostic logging; handlers that only match on `kind` ignore.
+    pub kind_name: &'a str,
+    /// Sending mailbox's registered name, if the mail came from a
+    /// component. `None` for substrate-core pushes with no sending
+    /// mailbox (ADR-0011).
+    pub origin: Option<&'a str>,
+    /// Remote reply target of the mail (ADR-0008 / ADR-0037 /
+    /// ADR-0042). Carries the correlation id for reply-routing.
+    pub sender: ReplyTo,
+    /// Payload bytes (the kind's encoded representation per ADR-0019).
+    pub payload: &'a [u8],
+    /// Kind-implied item count.
+    pub count: u32,
+    /// ADR-0080 §1: the producer-minted identity of this mail.
+    /// `MailId::NONE` for legacy paths that haven't migrated.
+    pub mail_id: MailId,
+    /// ADR-0080 §5: the root of this mail's causal chain.
+    pub root: MailId,
+    /// ADR-0080 §5: the in-flight mail at the sender, or `None` for
+    /// chassis-root sends.
+    pub parent_mail: Option<MailId>,
+}
+
 /// Closure invoked when mail is delivered to a chassis-bound mailbox.
 /// Called on the caller's thread (or the platform thread for input
-/// fan-out); must be `Send + Sync`. Arguments: the kind's id
-/// (`K::ID`, ADR-0030 schema hash), the kind's registered name
-/// (resolved by the dispatcher for diagnostic logging — handlers
-/// that only match on id can ignore it), the sending mailbox's
-/// registered name if the mail came from a component (`None` for
-/// substrate-core pushes with no sending mailbox, per ADR-0011),
-/// the remote reply target of the mail per ADR-0008 / ADR-0037
-/// (`Sender::Session` for hub-inbound, `ReplyTo::EngineMailbox` for
-/// bubbled-up, `ReplyTo::NONE` for substrate-local), payload bytes,
-/// and the kind-implied count.
-pub type MailboxHandler =
-    Arc<dyn Fn(KindId, &str, Option<&str>, ReplyTo, &[u8], u32) + Send + Sync + 'static>;
+/// fan-out); must be `Send + Sync`. The single [`MailDispatch`]
+/// argument bundles the per-mail metadata.
+pub type MailboxHandler = Arc<dyn for<'a> Fn(MailDispatch<'a>) + Send + Sync + 'static>;
 
 /// What a given mailbox actually is. The registry records this so the
 /// scheduler can dispatch appropriately without a per-mail type check.
@@ -462,7 +525,7 @@ mod tests {
     #[test]
     fn register_and_lookup_closure_mailbox() {
         let r = Registry::new();
-        let id = r.register_closure("physics", Arc::new(|_, _, _, _, _, _| {}));
+        let id = r.register_closure("physics", noop_handler());
         assert_eq!(id, MailboxId::from_name("physics"));
         assert_eq!(r.lookup("physics"), Some(id));
         assert!(matches!(r.entry(id), Some(MailboxEntry::Closure(_))));
@@ -475,32 +538,35 @@ mod tests {
         let c2 = Arc::clone(&counter);
         let id = r.register_closure(
             "heartbeat",
-            Arc::new(move |_kind_id, _kind, _origin, _sender, _bytes, count| {
-                c2.fetch_add(count, Ordering::SeqCst);
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                c2.fetch_add(dispatch.count, Ordering::SeqCst);
             }),
         );
         let Some(MailboxEntry::Closure(h)) = r.entry(id) else {
             panic!("expected closure entry")
         };
         // Test-side id is irrelevant — the handler ignores it.
-        h(KindId(0), "aether.tick", None, ReplyTo::NONE, &[], 7);
-        h(
-            KindId(0),
-            "aether.tick",
-            Some("physics"),
-            ReplyTo::NONE,
-            &[],
-            3,
-        );
+        h(test_dispatch(KindId(0), "aether.tick", &[], 7));
+        h(MailDispatch {
+            kind: KindId(0),
+            kind_name: "aether.tick",
+            origin: Some("physics"),
+            sender: ReplyTo::NONE,
+            payload: &[],
+            count: 3,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
+        });
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 
     #[test]
     fn mailbox_ids_are_name_derived() {
         let r = Registry::new();
-        let a = r.register_closure("a", Arc::new(|_, _, _, _, _, _| {}));
-        let b = r.register_closure("b", Arc::new(|_, _, _, _, _, _| {}));
-        let c = r.register_closure("c", Arc::new(|_, _, _, _, _, _| {}));
+        let a = r.register_closure("a", noop_handler());
+        let b = r.register_closure("b", noop_handler());
+        let c = r.register_closure("c", noop_handler());
         assert_eq!(a, MailboxId::from_name("a"));
         assert_eq!(b, MailboxId::from_name("b"));
         assert_eq!(c, MailboxId::from_name("c"));
@@ -515,8 +581,8 @@ mod tests {
     #[should_panic(expected = "mailbox name already registered")]
     fn duplicate_name_panics() {
         let r = Registry::new();
-        r.register_closure("x", Arc::new(|_, _, _, _, _, _| {}));
-        r.register_closure("x", Arc::new(|_, _, _, _, _, _| {}));
+        r.register_closure("x", noop_handler());
+        r.register_closure("x", noop_handler());
     }
 
     #[test]
@@ -529,8 +595,8 @@ mod tests {
     #[test]
     fn mailbox_name_reverse_lookup() {
         let r = Registry::new();
-        let a = r.register_closure("physics", Arc::new(|_, _, _, _, _, _| {}));
-        let b = r.register_closure("hub.claude.broadcast", Arc::new(|_, _, _, _, _, _| {}));
+        let a = r.register_closure("physics", noop_handler());
+        let b = r.register_closure("hub.claude.broadcast", noop_handler());
         assert_eq!(r.mailbox_name(a).as_deref(), Some("physics"));
         assert_eq!(r.mailbox_name(b).as_deref(), Some("hub.claude.broadcast"));
         assert!(r.mailbox_name(MailboxId(999)).is_none());
@@ -731,10 +797,10 @@ mod tests {
     fn try_register_closure_is_non_panicking_on_collision() {
         let r = Registry::new();
         let first = r
-            .try_register_closure("loaded", Arc::new(|_, _, _, _, _, _| {}))
+            .try_register_closure("loaded", noop_handler())
             .expect("fresh name");
         let err = r
-            .try_register_closure("loaded", Arc::new(|_, _, _, _, _, _| {}))
+            .try_register_closure("loaded", noop_handler())
             .expect_err("collision must not panic");
         assert_eq!(err.name, "loaded");
         assert_eq!(r.lookup("loaded"), Some(first));
@@ -745,9 +811,7 @@ mod tests {
     #[test]
     fn drop_mailbox_frees_name_and_marks_entry_dropped() {
         let r = Registry::new();
-        let id = r
-            .try_register_closure("loaded", Arc::new(|_, _, _, _, _, _| {}))
-            .unwrap();
+        let id = r.try_register_closure("loaded", noop_handler()).unwrap();
         let name = r.drop_mailbox(id).expect("drop");
         assert_eq!(name, "loaded");
         assert!(r.lookup("loaded").is_none(), "name should be reusable");
@@ -758,9 +822,7 @@ mod tests {
         // Under ADR-0029 the id is a function of the name, so a
         // re-register produces the *same* id and flips the entry back
         // to `Component`.
-        let reloaded = r
-            .try_register_closure("loaded", Arc::new(|_, _, _, _, _, _| {}))
-            .unwrap();
+        let reloaded = r.try_register_closure("loaded", noop_handler()).unwrap();
         assert_eq!(reloaded, id);
         assert_eq!(r.lookup("loaded"), Some(reloaded));
         assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Closure(_))));
@@ -773,9 +835,7 @@ mod tests {
             r.drop_mailbox(MailboxId(999)),
             Err(DropError::UnknownId(_))
         ));
-        let c = r
-            .try_register_closure("x", Arc::new(|_, _, _, _, _, _| {}))
-            .unwrap();
+        let c = r.try_register_closure("x", noop_handler()).unwrap();
         r.drop_mailbox(c).unwrap();
         assert!(matches!(
             r.drop_mailbox(c),
@@ -791,7 +851,7 @@ mod tests {
         // mailboxes and kinds from a handler that holds an Arc.
         let r = Arc::new(Registry::new());
         let r2 = Arc::clone(&r);
-        let id = r2.register_closure("late", Arc::new(|_, _, _, _, _, _| {}));
+        let id = r2.register_closure("late", noop_handler());
         assert_eq!(r.lookup("late"), Some(id));
         let kind_id = r.register_kind("aether.late");
         assert_eq!(

--- a/crates/aether-substrate/src/runtime/mod.rs
+++ b/crates/aether-substrate/src/runtime/mod.rs
@@ -7,5 +7,6 @@
 pub mod lifecycle;
 pub mod log_install;
 pub mod panic_hook;
+pub mod trace;
 
 pub use panic_hook::init_panic_hook;

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -1,0 +1,291 @@
+//! ADR-0080 substrate-wide mail tracing — chassis-side runtime.
+//!
+//! Two pieces:
+//!
+//! - **Producer-side helpers** (`record_sent` / `record_received` /
+//!   `record_finished`) push [`TraceEvent`]s onto a process-global
+//!   [`crossbeam_queue::SegQueue`]. The hooks live in
+//!   [`crate::actor::native::binding::NativeBinding::send_mail_with_lineage`]
+//!   (Sent), the native dispatcher trampoline (Received / Finished),
+//!   and the wasm trampoline forwarder (Received / Finished). Calls
+//!   are no-ops until the chassis [`install_trace_queue`]s the
+//!   queue at boot — silent drop is the right shape for tests that
+//!   don't bring up the chassis.
+//!
+//! - **[`start_drainer`]** spawns the chassis-owned drainer thread.
+//!   The thread loop-drains up to `BATCH_MAX` events and ships a
+//!   [`BatchedTraceEvents`] mail to the [`TRACE_OBSERVER_MAILBOX_NAME`]
+//!   sink via the [`Mailer`]; it parks for `BATCH_INTERVAL` between
+//!   drains. Shutdown is via channel-drop on the returned
+//!   [`TraceDrainerHandle`] — its `Drop` signals the thread and
+//!   joins.
+//!
+//! Why global rather than chassis-owned: producer-side hooks are
+//! reached from every actor's send path; threading an
+//! `Arc<SegQueue<TraceEvent>>` through every binding constructor is
+//! invasive churn for a feature that runs at most once per process.
+//! The global is initialised exactly once at chassis boot and never
+//! reset — multi-chassis test fixtures (TestBench) share the queue
+//! across their substrates, which is fine because each TraceEvent
+//! carries the producer's [`MailboxId`] so the observer can attribute
+//! events even if the queue is shared.
+
+use std::sync::OnceLock;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use aether_data::{KindId, MailId, MailboxId};
+use aether_kinds::trace::{BatchedTraceEvents, Nanos, TRACE_OBSERVER_MAILBOX_NAME, TraceEvent};
+use crossbeam_queue::SegQueue;
+
+use crate::mail::Mail;
+use crate::mail::mailer::Mailer;
+
+/// Monotonic-since-boot reference. Set once at chassis boot via
+/// [`init_substrate_start`]; producer-side hooks subtract from it to
+/// produce a [`Nanos`] for each event.
+static SUBSTRATE_START: OnceLock<Instant> = OnceLock::new();
+
+/// Process-global trace queue. Set by [`install_trace_queue`] at
+/// chassis boot; producer-side hooks push when present, no-op when
+/// absent. Wrapped in `OnceLock<Arc<SegQueue>>` so the drainer thread
+/// can hold a clone for `pop` without contending on the OnceLock
+/// itself on every read.
+static TRACE_QUEUE: OnceLock<Arc<SegQueue<TraceEvent>>> = OnceLock::new();
+
+/// Initialise the [`SUBSTRATE_START`] reference. Called once during
+/// chassis boot before any actor is wired so every subsequent
+/// timestamp has a stable origin. Safe to call multiple times — the
+/// `OnceLock` ignores subsequent calls.
+pub fn init_substrate_start() {
+    let _ = SUBSTRATE_START.set(Instant::now());
+}
+
+/// Install the process-global trace queue. The chassis builder
+/// constructs the queue + drainer pair at boot via
+/// [`start_drainer`]; this function exposes the queue handle so
+/// producer-side hooks can find it. Safe to call multiple times —
+/// subsequent calls return the existing queue.
+pub fn install_trace_queue(queue: Arc<SegQueue<TraceEvent>>) {
+    let _ = TRACE_QUEUE.set(queue);
+}
+
+/// Read the process-global trace queue, if installed. Returns `None`
+/// before chassis boot or in tests that bypass the chassis.
+pub fn trace_queue() -> Option<&'static Arc<SegQueue<TraceEvent>>> {
+    TRACE_QUEUE.get()
+}
+
+/// Compute the current [`Nanos`] timestamp relative to
+/// [`SUBSTRATE_START`]. `0` if `SUBSTRATE_START` was not initialised
+/// (the producer hooks early-out before this in that case, but the
+/// guard makes the function safe to call standalone).
+pub fn now_nanos() -> Nanos {
+    let start = match SUBSTRATE_START.get() {
+        Some(s) => *s,
+        None => return Nanos(0),
+    };
+    let elapsed = Instant::now().saturating_duration_since(start);
+    Nanos(elapsed.as_nanos() as u64)
+}
+
+/// ADR-0080 §2 producer hook for the `Sent` event. No-op if the
+/// global queue isn't installed yet (early-test paths, tests that
+/// bypass chassis boot). Allocates and pushes only when the queue
+/// is live.
+pub fn record_sent(
+    mail_id: MailId,
+    root: MailId,
+    parent_mail: Option<MailId>,
+    sender: MailboxId,
+    recipient: MailboxId,
+    kind: KindId,
+) {
+    let Some(queue) = TRACE_QUEUE.get() else {
+        return;
+    };
+    queue.push(TraceEvent::Sent {
+        mail_id,
+        root,
+        parent_mail,
+        sender,
+        recipient,
+        kind,
+        t: now_nanos(),
+    });
+}
+
+/// ADR-0080 §2 producer hook for the `Received` event. Pushed by the
+/// native dispatcher trampoline at handler entry. No-op when
+/// `mail_id == MailId::NONE` — that's the structural recursion break
+/// per ADR-0080 §7: the drainer's own outbound `BatchedTraceEvents`
+/// mail is pushed bare through the `Mailer` (skipping
+/// `NativeBinding::send_mail_with_lineage`), so it carries the
+/// default `MailId::NONE`. Suppressing `Received`/`Finished` for
+/// `NONE`-stamped mail prevents the observer's own dispatch from
+/// generating events that would re-feed the drainer.
+pub fn record_received(mail_id: MailId) {
+    if mail_id == MailId::NONE {
+        return;
+    }
+    let Some(queue) = TRACE_QUEUE.get() else {
+        return;
+    };
+    queue.push(TraceEvent::Received {
+        mail_id,
+        t: now_nanos(),
+    });
+}
+
+/// ADR-0080 §2 producer hook for the `Finished` event. Pushed by the
+/// native dispatcher trampoline at handler exit (normal return).
+/// Symmetric `MailId::NONE` short-circuit (see [`record_received`]).
+pub fn record_finished(mail_id: MailId) {
+    if mail_id == MailId::NONE {
+        return;
+    }
+    let Some(queue) = TRACE_QUEUE.get() else {
+        return;
+    };
+    queue.push(TraceEvent::Finished {
+        mail_id,
+        t: now_nanos(),
+    });
+}
+
+/// ADR-0080 §3 batch parameters: drain at most this many events per
+/// drainer cycle. Picked to amortise observer dispatch (~1k observer
+/// mails/sec at the busy-scene baseline of ~33k events/sec).
+const BATCH_MAX: usize = 256;
+
+/// ADR-0080 §3 drainer cadence: park between drains.
+const BATCH_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Lifetime guard for the trace drainer thread. Held by the chassis;
+/// dropping joins the thread.
+pub struct TraceDrainerHandle {
+    /// Signalled by `Drop` (channel disconnect → drainer exits its
+    /// `recv_timeout` loop). Wrapped in `Option` so `Drop` can take
+    /// it without consuming `self`.
+    shutdown_tx: Option<Sender<()>>,
+    /// Wrapped in `Mutex<Option>` so `Drop` can take ownership of the
+    /// `JoinHandle` without consuming `self`. The mutex is for the
+    /// `&mut self` borrow shape — only `Drop` ever reaches in.
+    join_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl Drop for TraceDrainerHandle {
+    fn drop(&mut self) {
+        // Disconnect the shutdown channel — the drainer's
+        // `recv_timeout` returns `Err(Disconnected)` and the loop
+        // exits.
+        drop(self.shutdown_tx.take());
+        if let Ok(mut guard) = self.join_handle.lock()
+            && let Some(handle) = guard.take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Spawn the chassis-owned drainer thread. The thread loop-drains up
+/// to [`BATCH_MAX`] events from the trace queue every
+/// [`BATCH_INTERVAL`] and ships a [`BatchedTraceEvents`] mail to the
+/// [`TRACE_OBSERVER_MAILBOX_NAME`] sink. Returns a handle whose
+/// `Drop` joins the thread.
+///
+/// Idempotent in the sense that calling [`install_trace_queue`]
+/// twice with the same `queue` Arc is a no-op; the chassis builder
+/// installs the queue exactly once and pairs it with one drainer.
+pub fn start_drainer(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>) -> TraceDrainerHandle {
+    let (shutdown_tx, shutdown_rx) = channel::<()>();
+    let handle = thread::Builder::new()
+        .name("aether-trace-drainer".to_owned())
+        .spawn(move || drainer_loop(queue, mailer, shutdown_rx))
+        .expect("spawn aether-trace-drainer thread");
+    TraceDrainerHandle {
+        shutdown_tx: Some(shutdown_tx),
+        join_handle: Mutex::new(Some(handle)),
+    }
+}
+
+fn drainer_loop(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>, shutdown_rx: Receiver<()>) {
+    let recipient = aether_data::mailbox_id_from_name(TRACE_OBSERVER_MAILBOX_NAME);
+    let kind = <BatchedTraceEvents as aether_data::Kind>::ID;
+
+    loop {
+        ship_batch(&queue, &mailer, recipient, kind);
+
+        // Park BATCH_INTERVAL or until shutdown.
+        match shutdown_rx.recv_timeout(BATCH_INTERVAL) {
+            Ok(()) | Err(RecvTimeoutError::Disconnected) => {
+                // One last drain on shutdown so events queued just
+                // before signal don't get lost.
+                ship_batch(&queue, &mailer, recipient, kind);
+                break;
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
+/// Drain up to [`BATCH_MAX`] events and ship one
+/// [`BatchedTraceEvents`] mail. Skipped silently if the
+/// [`TRACE_OBSERVER_MAILBOX_NAME`] sink is not registered on this
+/// substrate's [`crate::mail::registry::Registry`] — that's the
+/// case in unit tests that boot a chassis without
+/// `TraceObserverCapability`, and the bubble-up that would otherwise
+/// fire for the unknown mailbox would interfere with the test's own
+/// outbound assertions. Production chassis register the observer so
+/// the drop branch never fires.
+fn ship_batch(
+    queue: &Arc<SegQueue<TraceEvent>>,
+    mailer: &Arc<Mailer>,
+    recipient: MailboxId,
+    kind: aether_data::KindId,
+) {
+    let mut batch = Vec::with_capacity(BATCH_MAX);
+    for _ in 0..BATCH_MAX {
+        match queue.pop() {
+            Some(event) => batch.push(event),
+            None => break,
+        }
+    }
+    if batch.is_empty() {
+        return;
+    }
+    if !mailer
+        .registry()
+        .entry(recipient)
+        .map(|e| matches!(e, crate::mail::registry::MailboxEntry::Closure(_)))
+        .unwrap_or(false)
+    {
+        // Observer not registered (or dropped); silently discard the
+        // batch. Test isolation: a chassis without
+        // `TraceObserverCapability` should not surface trace mail as
+        // an `UnresolvedMail` egress event on its outbound.
+        return;
+    }
+    let envelope = BatchedTraceEvents { events: batch };
+    let payload = match postcard::to_allocvec(&envelope) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                target: "aether_substrate::trace",
+                error = %e,
+                "trace drainer: postcard encode failed; events dropped"
+            );
+            return;
+        }
+    };
+    // Drainer-originated mail is chassis-root; no inheritance,
+    // no `parent_mail`. We push directly through the Mailer
+    // (no `Sender::send_detached` wrapper) — the recursion
+    // break (ADR-0080 §7) is structural here: the producer
+    // hook in `NativeBinding::send_mail_with_lineage` is what
+    // would push a `TraceEvent::Sent` for an outbound, and we
+    // bypass that path by going straight to `Mailer::push`.
+    mailer.push(Mail::new(recipient, kind, payload, 1));
+}

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -130,7 +130,17 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
         panic!("expected mailbox entry under {recipient}");
     };
     let bytes = payload.encode_into_bytes();
-    handler(<K as Kind>::ID, K::NAME, None, ReplyTo::NONE, &bytes, 1);
+    handler(aether_substrate::mail::registry::MailDispatch {
+        kind: <K as Kind>::ID,
+        kind_name: K::NAME,
+        origin: None,
+        sender: ReplyTo::NONE,
+        payload: &bytes,
+        count: 1,
+        mail_id: aether_substrate::mail::MailId::NONE,
+        root: aether_substrate::mail::MailId::NONE,
+        parent_mail: None,
+    });
 }
 
 fn wait_for(target: u32, counter: &AtomicU32, budget: Duration) -> bool {


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue references to iamacoffeepot/aether#707 + ADR-0080 phase markers -->

## Summary

PR 2 of 5 for [ADR-0080](docs/adr/0080-substrate-mail-tracing-and-settlement.md) phase 1 (issue iamacoffeepot/aether#707). Implements the **producer → drainer → observer** trace pipeline end-to-end. Settlement gating + chassis sentinel routing + iamacoffeepot/aether#648 helper retirement land in PR 3 / PR 4 / PR 5.

## What's in the box

### Data plumbing
- `aether_data::MailId` gains a hand-rolled `Schema` impl so it can ride inside `BatchedTraceEvents` over postcard.
- `aether_substrate::mail::{Mail, Envelope}` grow `mail_id`, `root`, `parent_mail` fields; `Mail::with_lineage` builder stamps them.
- `MailboxHandler` closure signature collapses 6 positional args into a single `MailDispatch<'_>` struct — bundles the new lineage triple alongside the existing kind/sender/payload metadata. ~30 closure sites updated; tests use `noop_handler()` / `test_dispatch()` helpers that retire the `Arc::new(|_, _, _, _, _, _| {})` shape.
- `NativeCtx` carries `in_flight_mail_id` + `in_flight_root` from the inbound `Envelope`; `NativeBinding::send_mail_with_lineage` reads them via the `Sender` impl and stamps inherited values onto each outbound `Mail`. `send_mail` is the four-arg shorthand that punts lineage to `None` for chassis-side / FFI / log-push call sites that carry no per-handler context.

### Trace pipeline
- `aether_kinds::trace::{Nanos, TraceEvent, BatchedTraceEvents}` ride the substrate-internal trace pipeline. `TRACE_OBSERVER_MAILBOX_NAME` is the well-known `aether.trace` sink.
- `aether_substrate::runtime::trace`: process-global trace queue (`crossbeam_queue::SegQueue`) + monotonic `SUBSTRATE_START` clock + drainer thread (`BATCH_MAX = 256`, `BATCH_INTERVAL = 1ms`). Drainer ships `BatchedTraceEvents` mail when the observer is registered; silently drops batches when not (test-isolation).
- Producer-side hooks: `Sent` in `send_mail_with_lineage`, `Received`/`Finished` around handler dispatch in `dispatch_loop_run` and `DispatcherSlot::dispatch_one`. `MailId::NONE` short-circuits both `Received` and `Finished` — that's the structural recursion break (ADR-0080 §7) since the drainer's outbound `BatchedTraceEvents` push goes bare through `Mailer::push` and inherits the `NONE` default.
- `TraceObserverCapability` (in `aether-capabilities`) folds events into per-root `RootState` + per-mail `MailNode` maps with retention + count-cap eviction (env: `AETHER_TRACE_RETENTION_MS`, `AETHER_TRACE_MAX_ROOTS`). Wired into all four chassis.

## Out of scope (PR 3+)
- `Settled` mail emission + chassis-mail sentinel switch (PR 3).
- `wait_instanced_quiesce` retirement / settlement gate consumers (PR 4).
- iamacoffeepot/aether#648 helper retirement + flake fix (PR 5).
- Wasm trampoline `Received`/`Finished` brackets (PR 4).
- Panic-unwind path bracketing (follow-up).

## Test plan
- [x] `cargo nextest run --workspace --no-fail-fast` — 1044/1044 pass (was 1043/1044 mid-PR; the failure was a test-isolation issue between the global trace queue and the TCP cap's outbound assertions, fixed by the drainer's "skip when observer unregistered" guard).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt` applied.
- [x] 5 unit tests in `aether-capabilities/src/trace.rs::tests` cover `Sent` root creation, child inheritance via `parent_mail`, `Finished` decrement, orphan `Received` drop, `max_roots` eviction, and retention eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)