### PR TITLE
feat(substrate,capabilities): chassis sentinel + Settled emission

### DIFF
--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -24,11 +24,15 @@ mod native {
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
+    use std::sync::Arc;
+
     use aether_actor::actor;
     use aether_data::{KindId, MailId, MailboxId};
-    use aether_kinds::trace::{Nanos, TraceEvent};
+    use aether_kinds::trace::{Nanos, Settled, TraceEvent};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::Mail;
+    use aether_substrate::mail::mailer::Mailer;
 
     /// ADR-0080 §11 retention defaults. Override via env vars.
     /// `AETHER_TRACE_RETENTION_MS` — drop roots older than this many
@@ -66,12 +70,25 @@ mod native {
     }
 
     /// `aether.trace` mailbox cap. Folds [`BatchedTraceEvents`] into
-    /// per-root counters and a parent → mail graph.
+    /// per-root counters and a parent → mail graph; emits `Settled`
+    /// to [`MailboxId::CHASSIS_MAILBOX_ID`] when a root's `in_flight`
+    /// count transitions to zero (ADR-0080 §6).
     pub struct TraceObserverCapability {
         roots: HashMap<MailId, RootState>,
         mails: HashMap<MailId, MailNode>,
         retention: Duration,
         max_roots: usize,
+        /// Mailer handle stashed at init so `Settled` mail can be
+        /// pushed bare via [`Mailer::push`] — bypassing
+        /// `NativeBinding::send_mail_with_lineage` so the outbound
+        /// doesn't generate a `TraceEvent::Sent` (which would mint
+        /// a fresh mail_id chain whose `Finished` never fires —
+        /// chassis-router-routed mail doesn't trip the dispatcher's
+        /// Received/Finished hooks).
+        mailer: Arc<Mailer>,
+        /// Cached `Settled` kind id; computed once at init to avoid
+        /// re-resolving for every settlement event.
+        settled_kind: KindId,
     }
 
     impl TraceObserverCapability {
@@ -138,13 +155,42 @@ mod native {
                         if let Some(state) = self.roots.get_mut(&root) {
                             state.in_flight = state.in_flight.saturating_sub(1);
                             state.last_event_at = Instant::now();
-                            // PR 3 fires `Settled { root }` here when
-                            // `state.in_flight` hits zero. PR 2 just
-                            // observes the transition.
+                            // ADR-0080 §6: settlement fires when the
+                            // chain's in-flight count transitions to
+                            // zero. We push `Settled { root }` to
+                            // `CHASSIS_MAILBOX_ID` via the bare mailer
+                            // so the outbound doesn't generate trace
+                            // events; the chassis-router decodes the
+                            // payload and signals every gate-site
+                            // subscriber waiting on this root.
+                            if state.in_flight == 0 {
+                                self.fire_settled(root);
+                            }
                         }
                     }
                 }
             }
+        }
+
+        fn fire_settled(&self, root: MailId) {
+            let payload = match postcard::to_allocvec(&Settled { root }) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(
+                        target: "aether_capabilities::trace",
+                        root = ?root,
+                        error = %e,
+                        "Settled encode failed; chassis subscribers not notified",
+                    );
+                    return;
+                }
+            };
+            self.mailer.push(Mail::new(
+                MailboxId::CHASSIS_MAILBOX_ID,
+                self.settled_kind,
+                payload,
+                1,
+            ));
         }
 
         fn evict(&mut self) {
@@ -196,7 +242,7 @@ mod native {
         // be a literal here for the `#[actor]` macro's expansion.
         const NAMESPACE: &'static str = "aether.trace";
 
-        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        fn init(_: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let retention_ms = parse_env_u64("AETHER_TRACE_RETENTION_MS", RETENTION_MS_DEFAULT);
             let max_roots = parse_env_usize("AETHER_TRACE_MAX_ROOTS", MAX_ROOTS_DEFAULT);
             Ok(Self {
@@ -204,6 +250,8 @@ mod native {
                 mails: HashMap::new(),
                 retention: Duration::from_millis(retention_ms),
                 max_roots,
+                mailer: ctx.mailer(),
+                settled_kind: <Settled as aether_data::Kind>::ID,
             })
         }
 
@@ -231,21 +279,32 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::registry::Registry;
 
+        /// Construct an observer for state-fold tests. Stash a fresh
+        /// `Mailer` so `fire_settled` has somewhere to push (the
+        /// chassis-router isn't installed, so the bare push warn-drops
+        /// at the route_mail switch — that's fine for state assertions).
         fn boot_observer() -> TraceObserverCapability {
-            // Use deterministic-friendly knobs so the eviction tests
-            // don't have to wait on real time.
             unsafe {
                 std::env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
                 std::env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");
             }
-            // Construct directly via init's logic (no chassis needed
-            // for these state-fold tests).
+            observer_with(Duration::from_millis(60_000), 1000)
+        }
+
+        fn observer_with(retention: Duration, max_roots: usize) -> TraceObserverCapability {
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let mailer = Arc::new(Mailer::new(registry, store));
             TraceObserverCapability {
                 roots: HashMap::new(),
                 mails: HashMap::new(),
-                retention: Duration::from_millis(60_000),
-                max_roots: 1000,
+                retention,
+                max_roots,
+                mailer,
+                settled_kind: <Settled as aether_data::Kind>::ID,
             }
         }
 
@@ -344,12 +403,7 @@ mod native {
 
         #[test]
         fn max_roots_evicts_oldest() {
-            let mut obs = TraceObserverCapability {
-                roots: HashMap::new(),
-                mails: HashMap::new(),
-                retention: Duration::from_secs(3600),
-                max_roots: 3,
-            };
+            let mut obs = observer_with(Duration::from_secs(3600), 3);
             for cid in 1..=5 {
                 let m = mail(1, cid);
                 obs.apply_event(TraceEvent::Sent {
@@ -374,13 +428,60 @@ mod native {
         }
 
         #[test]
-        fn retention_evicts_stale() {
+        fn finished_to_zero_fires_settled() {
+            use std::sync::Mutex;
+
+            // Build a Mailer with a chassis-router that records every
+            // chassis-addressed mail. The observer's `fire_settled`
+            // pushes through the Mailer; the router intercepts.
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let mailer = Arc::new(Mailer::new(registry, store));
+            let captured: Arc<Mutex<Vec<Settled>>> = Arc::new(Mutex::new(Vec::new()));
+            let captured_for_router = Arc::clone(&captured);
+            let settled_kind = <Settled as aether_data::Kind>::ID;
+            mailer.install_chassis_router(Box::new(move |mail| {
+                if mail.kind == settled_kind
+                    && let Ok(notice) = postcard::from_bytes::<Settled>(&mail.payload)
+                {
+                    captured_for_router.lock().unwrap().push(notice);
+                }
+            }));
+
             let mut obs = TraceObserverCapability {
                 roots: HashMap::new(),
                 mails: HashMap::new(),
-                retention: Duration::from_millis(50),
+                retention: Duration::from_secs(60),
                 max_roots: 1000,
+                mailer: Arc::clone(&mailer),
+                settled_kind,
             };
+
+            let root = mail(1, 1);
+            obs.apply_event(TraceEvent::Sent {
+                mail_id: root,
+                root,
+                parent_mail: None,
+                sender: MailboxId(1),
+                recipient: MailboxId(2),
+                kind: KindId(0xABCD),
+                t: Nanos(100),
+            });
+            // No Settled yet — in_flight is 1.
+            assert!(captured.lock().unwrap().is_empty());
+            obs.apply_event(TraceEvent::Finished {
+                mail_id: root,
+                t: Nanos(200),
+            });
+            // Settled fired; chassis-router decoded the mail.
+            let captured = captured.lock().unwrap();
+            assert_eq!(captured.len(), 1);
+            assert_eq!(captured[0].root, root);
+        }
+
+        #[test]
+        fn retention_evicts_stale() {
+            let mut obs = observer_with(Duration::from_millis(50), 1000);
             let m = mail(1, 1);
             obs.apply_event(TraceEvent::Sent {
                 mail_id: m,

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -152,6 +152,19 @@ impl MailboxId {
     /// real mailbox.
     pub const NONE: MailboxId = MailboxId(0);
 
+    /// ADR-0080 §5 chassis-as-sentinel mailbox id. Aliases
+    /// [`Self::NONE`] — the same reserved-zero id that "no origin"
+    /// already uses. Mail addressed to `CHASSIS_MAILBOX_ID` is
+    /// routed by `Mailer::route_mail` through a chassis-internal
+    /// switch ahead of the registry lookup; today that switch
+    /// handles `Settled { root }` and signals the gate-site
+    /// notification map.
+    ///
+    /// The symbolic name documents the intent at the call site;
+    /// addressing chassis-internal mail by the bare `MailboxId::NONE`
+    /// would read as a bug.
+    pub const CHASSIS_MAILBOX_ID: MailboxId = Self::NONE;
+
     /// Compute the deterministic id for a mailbox name. Same algorithm
     /// the guest SDK uses on the component side — ids round-trip
     /// verbatim across the FFI.

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -106,3 +106,36 @@ pub enum TraceEvent {
 pub struct BatchedTraceEvents {
     pub events: Vec<TraceEvent>,
 }
+
+/// ADR-0080 §6 settlement notification. Emitted by
+/// [`crate::trace::BatchedTraceEvents`]'s consumer
+/// (`TraceObserverCapability`) when a causal chain's `in_flight`
+/// counter hits zero, addressed to
+/// [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`]. The chassis-side
+/// dispatcher switch routes this kind into the gate-site
+/// notification map and signals every subscriber waiting on `root`.
+///
+/// **Settlement is a hint, not a guarantee.** Per ADR-0080 §6,
+/// consumers MUST be idempotent — duplicate `Settled { root }` mail
+/// for the same root is a no-op for any waiter that already woke.
+/// The observer's eviction may also lose late `Finished` events, in
+/// which case settlement is reported earlier than strictly correct;
+/// the gate-site contract is "settles eventually," not "settles only
+/// once every dependency is provably done."
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.trace.settled")]
+pub struct Settled {
+    pub root: aether_data::MailId,
+}

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1067,6 +1067,13 @@ struct BootedPassives {
     /// `TraceObserver` mailbox — that's acceptable: the observer cap
     /// drained its inbox during its own dispatcher's phase-2 drain.
     _trace_drainer: crate::runtime::trace::TraceDrainerHandle,
+    /// ADR-0080 §6 settlement registry. Cloned into the Mailer's
+    /// chassis-router closure (which decodes `Settled { root }`
+    /// mail addressed to `CHASSIS_MAILBOX_ID` and signals
+    /// subscribers); reachable from `BootedPassives`-holders via
+    /// [`Self::settlement_registry`] for PR 4 gate-site
+    /// `subscribe_settlement` calls.
+    settlement_registry: Arc<crate::chassis::settlement::SettlementRegistry>,
 }
 
 /// Issue #601: dispatch a `ConfigureLogDrain { mailbox: drain }` mail
@@ -1100,6 +1107,14 @@ fn dispatch_configure_log_drain(
 }
 
 impl BootedPassives {
+    /// ADR-0080 §6: borrow the chassis-owned settlement registry.
+    /// PR 4 gate-site code (lifecycle drains, the per-frame Tick
+    /// barrier, `replace_component` drain) reaches for this to call
+    /// `subscribe_settlement(root)` and wait on the returned receiver.
+    pub fn settlement_registry(&self) -> &Arc<crate::chassis::settlement::SettlementRegistry> {
+        &self.settlement_registry
+    }
+
     fn shutdown_in_place(&mut self) {
         // Issue 685: spawned-instanced actors close BEFORE the
         // singleton shutdowns walk. Two reasons: (1) their close
@@ -1155,6 +1170,36 @@ fn boot_passives(
     crate::runtime::trace::install_trace_queue(Arc::clone(&trace_queue));
     let trace_drainer =
         crate::runtime::trace::start_drainer(Arc::clone(&trace_queue), Arc::clone(mailer));
+
+    // ADR-0080 §6 settlement registry + chassis-mail router. The
+    // registry owns the gate-site notification map; the router
+    // closure decodes `Settled { root }` mail addressed to
+    // `CHASSIS_MAILBOX_ID` and signals the matching subscribers.
+    // Other chassis-internal kinds (none today; future debugger /
+    // describe_tree replies could land here) add matching arms inside
+    // the router closure without touching the Mailer's surface.
+    let settlement_registry: Arc<crate::chassis::settlement::SettlementRegistry> =
+        Arc::new(crate::chassis::settlement::SettlementRegistry::new());
+    let registry_for_router = Arc::clone(&settlement_registry);
+    let settled_kind = <aether_kinds::trace::Settled as aether_data::Kind>::ID;
+    mailer.install_chassis_router(Box::new(move |mail| {
+        if mail.kind == settled_kind {
+            match postcard::from_bytes::<aether_kinds::trace::Settled>(&mail.payload) {
+                Ok(notice) => registry_for_router.fire_settled(notice.root),
+                Err(e) => tracing::warn!(
+                    target: "aether_substrate::chassis::settlement",
+                    error = %e,
+                    "Settled mail decode failed; subscribers not woken",
+                ),
+            }
+        } else {
+            tracing::warn!(
+                target: "aether_substrate::chassis",
+                kind = %mail.kind,
+                "unhandled chassis-addressed kind",
+            );
+        }
+    }));
     let spawner: Arc<crate::Spawner> = Arc::new(crate::Spawner::new(
         Arc::clone(registry),
         Arc::clone(&actor_registry),
@@ -1328,6 +1373,7 @@ fn boot_passives(
         spawner,
         _pool: pool,
         _trace_drainer: trace_drainer,
+        settlement_registry,
     })
 }
 
@@ -1485,6 +1531,15 @@ impl<C: Chassis> PassiveChassis<C> {
     /// type.
     pub fn handle<H: std::any::Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
         self.booted.handles.get::<H>()
+    }
+
+    /// ADR-0080 §6: borrow the chassis-owned settlement registry.
+    /// PR 4 lifecycle / frame / `replace_component` gate sites reach
+    /// for this to call `subscribe_settlement(root)`; PR 3 surfaces
+    /// the accessor for tests that pump synthetic events through the
+    /// trace pipeline and wait on the resulting `Settled` signal.
+    pub fn settlement_registry(&self) -> &Arc<crate::chassis::settlement::SettlementRegistry> {
+        self.booted.settlement_registry()
     }
 
     /// Snapshot of every frame-bound mailbox's pending counter

--- a/crates/aether-substrate/src/chassis/mod.rs
+++ b/crates/aether-substrate/src/chassis/mod.rs
@@ -23,6 +23,7 @@ pub mod ctx;
 pub mod error;
 pub mod frame_loop;
 pub mod helpers;
+pub mod settlement;
 
 use crate::chassis::builder::{BuiltChassis, DriverCapability};
 use crate::chassis::error::BootError;

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -1,0 +1,210 @@
+//! ADR-0080 §6 settlement registry — chassis-side gate-notification
+//! map for `Settled { root }` mail.
+//!
+//! Subscribers (lifecycle gates, the per-frame Tick drain, the
+//! `replace_component` drain — landing in PR 4) call
+//! [`SettlementRegistry::subscribe_settlement`] with the root
+//! `MailId` of the causal chain they want to wait on. They get a
+//! `crossbeam_channel::Receiver<()>` that fires when the
+//! [`crate::actor::native`] dispatcher routes a `Settled { root }`
+//! mail addressed to [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`]
+//! through the registry's [`SettlementRegistry::fire_settled`] hook.
+//!
+//! ADR-0080 §6 framing: settlement is eventually-consistent, not
+//! transactional. Two races are handled here:
+//!
+//! - **Subscribe-after-fire.** A gate may subscribe to a root that
+//!   already settled (the `Finished` event landed before the gate
+//!   site got around to subscribing). The registry tracks
+//!   already-fired roots in a small `HashSet`; subscribing to one
+//!   pre-fires the receiver immediately so the gate doesn't hang.
+//! - **Duplicate `fire_settled`.** Per ADR §6, settlement is a hint
+//!   — a root may report settled multiple times under retries or
+//!   late-arriving `Finished` events. The registry's `fire_settled`
+//!   is idempotent: subsequent calls for the same root after the
+//!   subscribers have drained are no-ops (the `HashSet` hit short-
+//!   circuits).
+//!
+//! The `settled` HashSet grows unboundedly within a chassis lifetime
+//! today. PR 5 (or a later cleanup) wires retention against the
+//! observer's eviction policy. For v1 — a chassis runs for a session,
+//! not forever — the cap-by-count plus per-process tear-down keeps
+//! memory bounded.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use aether_data::MailId;
+use crossbeam_channel::{Receiver, Sender, bounded};
+
+/// Chassis-owned settlement notification registry. Owned by the
+/// chassis (one per substrate); cloned via `Arc` into the
+/// [`crate::mail::Mailer`]'s chassis-router closure so the
+/// dispatcher's `Settled` switch can fire.
+#[derive(Default)]
+pub struct SettlementRegistry {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Subscribers waiting on each root's settlement signal. Vec so
+    /// multiple gate sites can wait on the same root concurrently
+    /// (lifecycle gates + the per-frame drain barrier might both
+    /// listen on the same Tick root).
+    pending: HashMap<MailId, Vec<Sender<()>>>,
+    /// Roots that have already settled at least once. Subscribing to
+    /// one pre-fires the receiver. Grows unboundedly within a
+    /// chassis lifetime; v1 accepts the bound (chassis tear-down
+    /// reclaims).
+    settled: HashSet<MailId>,
+}
+
+impl SettlementRegistry {
+    /// Construct an empty registry. Production chassis builders wrap
+    /// the result in `Arc<SettlementRegistry>` and clone into both
+    /// the chassis context (subscribers reach for it) and the
+    /// `Mailer` chassis-router closure (the `Settled` mail dispatch
+    /// fires it).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Subscribe a gate site to `root`'s settlement signal. Returns
+    /// a [`Receiver<()>`] that wakes when [`Self::fire_settled`] is
+    /// called for the same root. Pre-fires immediately if `root` has
+    /// already settled at least once.
+    ///
+    /// The receiver carries a single `()` value; subsequent receive
+    /// attempts return [`crossbeam_channel::TryRecvError::Empty`] /
+    /// `Disconnected` per the bounded(1) channel contract. Gate
+    /// sites typically `recv_timeout` once and discard the receiver.
+    pub fn subscribe_settlement(&self, root: MailId) -> Receiver<()> {
+        let (tx, rx) = bounded::<()>(1);
+        let mut inner = self.inner.lock().unwrap();
+        if inner.settled.contains(&root) {
+            // Pre-fire — root already settled. `try_send` rather
+            // than `send` so a closed receiver (caller dropped it
+            // before reading) doesn't panic.
+            let _ = tx.try_send(());
+        } else {
+            inner.pending.entry(root).or_default().push(tx);
+        }
+        rx
+    }
+
+    /// Fire the settlement signal for `root`. Wakes every subscriber
+    /// currently registered for `root` and records the root in the
+    /// `settled` set so subsequent [`Self::subscribe_settlement`]
+    /// calls pre-fire. Idempotent: calling twice is the same as
+    /// calling once for any waiter that already woke.
+    pub fn fire_settled(&self, root: MailId) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.settled.insert(root);
+        if let Some(subs) = inner.pending.remove(&root) {
+            for tx in subs {
+                let _ = tx.try_send(());
+            }
+        }
+    }
+
+    /// Test introspection: count of pending subscribers across all
+    /// roots. Used by the unit tests in this module; production code
+    /// queries via mail (subscribe + recv).
+    #[cfg(test)]
+    fn pending_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .pending
+            .values()
+            .map(Vec::len)
+            .sum()
+    }
+
+    /// Test introspection: count of roots recorded as already
+    /// settled.
+    #[cfg(test)]
+    fn settled_count(&self) -> usize {
+        self.inner.lock().unwrap().settled.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root(sender: u64, cid: u64) -> MailId {
+        MailId {
+            sender: aether_data::MailboxId(sender),
+            correlation_id: cid,
+        }
+    }
+
+    #[test]
+    fn subscribe_then_fire_wakes_receiver() {
+        let reg = SettlementRegistry::new();
+        let r = root(1, 1);
+        let rx = reg.subscribe_settlement(r);
+        assert_eq!(reg.pending_count(), 1);
+        reg.fire_settled(r);
+        assert_eq!(reg.pending_count(), 0);
+        assert_eq!(reg.settled_count(), 1);
+        rx.recv().expect("settlement signal");
+    }
+
+    #[test]
+    fn fire_then_subscribe_pre_fires_receiver() {
+        let reg = SettlementRegistry::new();
+        let r = root(1, 1);
+        reg.fire_settled(r);
+        assert_eq!(reg.settled_count(), 1);
+        let rx = reg.subscribe_settlement(r);
+        // Subscriber landed in the settled-set fast path — no
+        // pending entry was added.
+        assert_eq!(reg.pending_count(), 0);
+        rx.recv().expect("pre-fired signal");
+    }
+
+    #[test]
+    fn multiple_subscribers_all_wake() {
+        let reg = SettlementRegistry::new();
+        let r = root(1, 1);
+        let rx1 = reg.subscribe_settlement(r);
+        let rx2 = reg.subscribe_settlement(r);
+        let rx3 = reg.subscribe_settlement(r);
+        assert_eq!(reg.pending_count(), 3);
+        reg.fire_settled(r);
+        rx1.recv().expect("subscriber 1 wakes");
+        rx2.recv().expect("subscriber 2 wakes");
+        rx3.recv().expect("subscriber 3 wakes");
+    }
+
+    #[test]
+    fn fire_twice_is_idempotent() {
+        let reg = SettlementRegistry::new();
+        let r = root(1, 1);
+        let rx = reg.subscribe_settlement(r);
+        reg.fire_settled(r);
+        reg.fire_settled(r);
+        // First fire wakes the subscriber; second is a no-op for the
+        // already-drained pending entry.
+        rx.recv().expect("first fire wakes");
+        assert_eq!(reg.settled_count(), 1);
+    }
+
+    #[test]
+    fn distinct_roots_are_independent() {
+        let reg = SettlementRegistry::new();
+        let r1 = root(1, 1);
+        let r2 = root(1, 2);
+        let rx1 = reg.subscribe_settlement(r1);
+        let rx2 = reg.subscribe_settlement(r2);
+        reg.fire_settled(r1);
+        rx1.recv().expect("r1 wakes");
+        // r2's subscriber stays parked.
+        assert!(rx2.try_recv().is_err());
+        reg.fire_settled(r2);
+        rx2.recv().expect("r2 wakes");
+    }
+}

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -24,6 +24,7 @@ use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use aether_data::{HandleId, KindId};
+use std::sync::OnceLock;
 
 pub struct Mailer {
     /// Registry handle for resolving recipients on `push`. Owned for
@@ -50,6 +51,19 @@ pub struct Mailer {
     /// post-construction via `wire_outbound`; the constructor +
     /// `with_outbound` pair below replaces that.
     outbound: Option<Arc<HubOutbound>>,
+    /// ADR-0080 §5 chassis-mail router. When mail is addressed to
+    /// [`MailboxId::CHASSIS_MAILBOX_ID`], `route_mail` short-circuits
+    /// the registry lookup and invokes this closure instead. Today
+    /// the chassis installs a router that decodes `Settled { root }`
+    /// and signals the [`crate::chassis::settlement::SettlementRegistry`]
+    /// — keeping the Mailer ignorant of trace kinds while still
+    /// providing the dispatch surface those kinds need.
+    ///
+    /// `OnceLock` so the chassis builder installs exactly once at
+    /// boot. `None` for tests / chassis that don't bring up the
+    /// trace pipeline — chassis-addressed mail is silently dropped
+    /// in that case.
+    chassis_router: OnceLock<Box<dyn Fn(Mail) + Send + Sync>>,
 }
 
 impl Mailer {
@@ -64,7 +78,16 @@ impl Mailer {
             registry,
             handle_store,
             outbound: None,
+            chassis_router: OnceLock::new(),
         }
+    }
+
+    /// ADR-0080 §5 chassis-mail router installation. Called once by
+    /// the chassis builder at boot to wire the closure that handles
+    /// mail addressed to [`MailboxId::CHASSIS_MAILBOX_ID`]. Subsequent
+    /// calls are no-ops — the router slot is single-claim.
+    pub fn install_chassis_router(&self, router: Box<dyn Fn(Mail) + Send + Sync>) {
+        let _ = self.chassis_router.set(router);
     }
 
     /// Attach a `HubOutbound` so mail to unknown mailbox ids bubbles
@@ -115,6 +138,7 @@ impl Mailer {
             &self.registry,
             self.outbound.as_ref(),
             &self.handle_store,
+            self.chassis_router.get().map(|b| &**b),
         );
     }
 
@@ -139,8 +163,15 @@ impl Mailer {
         self.handle_store.put(handle, kind, bytes)?;
         let parked = self.handle_store.take_parked(handle);
         let outbound = self.outbound.as_ref();
+        let chassis_router = self.chassis_router.get().map(|b| &**b);
         for mail in parked {
-            route_mail(mail, &self.registry, outbound, &self.handle_store);
+            route_mail(
+                mail,
+                &self.registry,
+                outbound,
+                &self.handle_store,
+                chassis_router,
+            );
         }
         Ok(())
     }
@@ -210,7 +241,27 @@ fn route_mail(
     registry: &Registry,
     outbound: Option<&Arc<HubOutbound>>,
     store: &Arc<HandleStore>,
+    chassis_router: Option<&(dyn Fn(Mail) + Send + Sync)>,
 ) {
+    // ADR-0080 §5 chassis-mail switch — routed ahead of the registry
+    // lookup so mail to `CHASSIS_MAILBOX_ID` reaches the chassis-
+    // installed router without bubbling up as `UnresolvedMail`. Today
+    // the router decodes `Settled { root }` and signals the
+    // `SettlementRegistry`; future chassis-internal kinds add
+    // matching arms inside the router closure.
+    if mail.recipient == aether_data::MailboxId::CHASSIS_MAILBOX_ID {
+        if let Some(router) = chassis_router {
+            router(mail);
+        } else {
+            tracing::warn!(
+                target: "aether_substrate::queue",
+                kind = %mail.kind,
+                "chassis-addressed mail dropped — no chassis router installed",
+            );
+        }
+        return;
+    }
+
     if let Some(descriptor) = registry.kind_descriptor(mail.kind)
         && handle_store::schema_contains_ref(&descriptor.schema)
     {


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue references to iamacoffeepot/aether#707 / iamacoffeepot/aether#648 -->

## Summary

PR 3 of 5 for [ADR-0080](docs/adr/0080-substrate-mail-tracing-and-settlement.md) phase 1 (issue iamacoffeepot/aether#707). Settlement signal lands end-to-end: `TraceObserverCapability` fires `Settled { root }` when a chain's `in_flight` hits zero, the chassis-mail dispatcher routes it to a chassis-internal handler, and the `SettlementRegistry` wakes every subscriber waiting on that root. PR 4 will replace `wait_instanced_quiesce` and the per-frame Tick gate with `subscribe_settlement(root).recv_timeout`.

## Pieces

- `aether_data::MailboxId::CHASSIS_MAILBOX_ID` aliases `MailboxId::NONE` — symbolic name for the chassis-as-mail-endpoint sentinel (ADR-0080 §5).
- `aether_kinds::trace::Settled { root: MailId }` is the wire kind.
- `aether_substrate::chassis::settlement::SettlementRegistry` owns the gate-notification map: `subscribe_settlement(root)` returns a `crossbeam_channel::Receiver<()>`; `fire_settled(root)` wakes every pending subscriber + records the root as settled (so subscribe-after-fire pre-fires the receiver immediately, no race-window hangs).
- `Mailer::install_chassis_router` lets the chassis builder register a closure that handles mail addressed to `CHASSIS_MAILBOX_ID`. `route_mail` short-circuits the registry lookup ahead of the regular path so chassis-internal mail doesn't bubble up as `UnresolvedMail`.
- `TraceObserverCapability::apply_event` now calls `fire_settled(root)` on the `in_flight == 0` transition; the cap posts a `Settled` mail bare via `Mailer::push` (no producer hook → no recursion).
- `PassiveChassis::settlement_registry()` exposes the registry to embedders / tests; PR 4 lifecycle and frame-loop gate sites reach for it via the same accessor on `BuiltChassis`.

## Out of scope

- Settlement gate consumers (PR 4): `wait_instanced_quiesce` retirement + per-frame Tick gate + `replace_component` drain replacement.
- iamacoffeepot/aether#648 helper retirement + `replace_component_*` flake structural fix (PR 5).
- Thread-spawn primitives (`InheritCtx<A>`, `RootCtx<A>`, `spawn_inherit`, `spawn_detached`) — split out per scope decision; ships as a follow-up after phase 1.

## Test plan

- [x] 5 unit tests in `chassis/settlement.rs::tests` cover subscribe-then-fire, fire-then-subscribe (pre-fire), multi-subscriber wake, idempotent fire, distinct-root isolation.
- [x] 1 new test in `trace::native::tests::finished_to_zero_fires_settled` installs a chassis-router that records `Settled` decodes; pumps a `Sent` + `Finished` pair through the observer; asserts the router sees exactly one `Settled` with the right root.
- [x] `cargo nextest run --workspace --no-fail-fast` — 1049/1050. The 1 failure (`drop_component_silences_tick_echoes`) is the pre-existing load-then-tick race ADR-0080 settlement gating retires structurally in PR 4; passes 5/5 in isolation. Same flake class as the camera scenarios called out in PR 1 / PR 2.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)