### PR TITLE
feat(substrate,bundle): settlement-gate Tick + retire #648 helpers + wait_instanced_quiesce

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -37,6 +37,7 @@ use aether_substrate::{
     capture::CaptureQueue,
     chassis::frame_loop,
     mail::{Mail, MailboxId},
+    runtime::trace::push_chassis_root_mail,
 };
 
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
@@ -653,33 +654,40 @@ impl TestBench {
 
     fn run_frame(&mut self, dispatch_tick: bool) {
         if dispatch_tick {
-            self.queue.push(Mail::new(
+            // ADR-0080 §6 settlement gating: push the Tick mail with a
+            // chassis-minted `MailId` so the trace pipeline tracks
+            // the chain, subscribe to its settlement before pushing,
+            // and wait on the receiver after. The chain rooted at
+            // this Tick's `MailId` covers everything the Tick
+            // triggers — input fanout, subscriber handlers, the
+            // tick_observed broadcasts that those subscribers emit,
+            // the broadcast cap's egress to outbound. When the
+            // chain settles, all derived work is done.
+            //
+            // Replaces the pre-PR-4 `wait_instanced_quiesce` poll
+            // loop (issue #707): the polling deadline guessed at
+            // when broadcasts had landed; settlement knows
+            // structurally.
+            let registry = self._passive.settlement_registry();
+            let tick_root = push_chassis_root_mail(
+                &self.queue,
+                self.fresh_correlation_id(),
                 self.input_mailbox,
                 self.kind_tick,
                 encode_empty::<Tick>(),
                 1,
-            ));
+            );
+            let rx = registry.subscribe_settlement(tick_root);
+            let _ = rx.recv_timeout(std::time::Duration::from_secs(5));
         }
-        // Wait for instanced actors (today: wasm trampolines) to
-        // process the just-pushed Tick before draining frame-bound
-        // caps. Without this, broadcasts the trampoline emits in
-        // response to the Tick land in the broadcast cap's inbox
-        // *after* `drain_frame_bound_or_abort` returns, and
-        // `pump_until_reply` sees `AdvanceResult` before the
-        // tick_observed broadcasts make the loopback round-trip.
-        // Production drivers don't share this wait — they let
-        // trampolines run free at their own cadence. Generous
-        // 5 s deadline matches the pre-Phase-4 implicit drain budget
-        // for slow CI; a never-quiescing actor surfaces as a test
-        // timeout, not a substrate abort (wedge detection waits on
-        // a future epoch-deadline ADR, symmetric with native).
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        let _ = self._passive.wait_instanced_quiesce(deadline);
         // ADR-0074 §Decision 5: render's inbox must quiesce before
         // submit so any DrawTriangle / aether.camera mail this frame
-        // is integrated into the recorded pass. (The pre-Phase-4
-        // component drain barrier is retired; trampoline traps
-        // fail-fast directly via `NativeBinding::fatal_abort`.)
+        // is integrated into the recorded pass. Settlement above
+        // covers the causal-chain invariant; this preserves the
+        // separate per-frame ordering invariant for frame-bound caps.
+        // (The pre-Phase-4 component drain barrier is retired;
+        // trampoline traps fail-fast directly via
+        // `NativeBinding::fatal_abort`.)
         frame_loop::drain_frame_bound_or_abort(&self.frame_bound_pending, &self.outbound);
 
         match self.capture_queue.take() {
@@ -700,16 +708,29 @@ impl TestBench {
 
         if self.frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
             let triangles = self.triangles_rendered.load(Ordering::Relaxed);
-            frame_loop::emit_frame_stats(&self.queue, self.kind_frame_stats, self.frame, triangles);
-            // Issue 576: pre-cap-promotion the broadcast sink ran inline on
-            // the caller thread, so `emit_frame_stats` synchronously
-            // produced an `EngineToHub::Mail` on outbound. Post-576
-            // broadcast is `BroadcastCapability` with its own dispatcher
-            // thread (FRAME_BARRIER, so the chassis tracks its pending
-            // counter). Without this drain, `pump_until_reply` would see
-            // `AdvanceResult` first and return before the broadcast
-            // dispatcher's `egress_broadcast` reached outbound, dropping
-            // `aether.observation.frame_stats` from `observed_kinds`.
+            // ADR-0080 settlement-gate the FrameStats broadcast.
+            // Pre-PR-4 the helper pushed bare and the `drain_frame_bound_or_abort`
+            // below was the synchronisation point; with settlement we
+            // push as a chassis-root chain and wait for the broadcast
+            // cap's egress to outbound to complete.
+            let registry = self._passive.settlement_registry();
+            let stats_root = push_chassis_root_mail(
+                &self.queue,
+                self.fresh_correlation_id(),
+                aether_data::mailbox_id_from_name(aether_kinds::HUB_BROADCAST_MAILBOX_NAME),
+                self.kind_frame_stats,
+                aether_data::encode(&aether_kinds::FrameStats {
+                    frame: self.frame,
+                    triangles,
+                }),
+                1,
+            );
+            let rx = registry.subscribe_settlement(stats_root);
+            let _ = rx.recv_timeout(std::time::Duration::from_secs(5));
+            // Belt-and-suspenders: keep the frame-bound drain so the
+            // ADR-0074 §Decision 5 ordering invariant for frame-bound
+            // caps still holds. Settlement covers the causal chain;
+            // this covers the per-frame ordering.
             frame_loop::drain_frame_bound_or_abort(&self.frame_bound_pending, &self.outbound);
             let elapsed = self.started.elapsed().as_secs_f64().max(0.001);
             tracing::info!(

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -15,9 +15,9 @@
 use std::path::Path;
 
 use aether_actor::Actor;
-use aether_capabilities::{ComponentHostCapability, InputCapability};
+use aether_capabilities::ComponentHostCapability;
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{LoadComponent, LoadResult, SubscribeInput, SubscribeInputResult, Tick};
+use aether_kinds::{LoadComponent, LoadResult};
 use aether_scenario::test_helpers::require_runtime;
 use aether_substrate_bundle::test_bench::TestBench;
 use aether_test_fixture_probe::TickObserved;
@@ -41,41 +41,6 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
     }
 }
 
-/// The probe self-subscribes to `Tick` from its `wire` handler via
-/// fire-and-forget mail; `LoadResult` returns before that mail has
-/// necessarily been drained by `InputCapability`'s actor. Mailing a
-/// redundant `SubscribeInput` from the test side and awaiting its
-/// reply gives a deterministic happens-before: `InputCapability` is
-/// single-threaded mpsc-FIFO, so once our reply arrives the probe's
-/// prior wire-time subscribe has been processed too. The set is a
-/// `BTreeSet` so the duplicate insert is a no-op.
-fn await_tick_subscribed(bench: &mut TestBench, mailbox: MailboxId) {
-    let r: SubscribeInputResult = bench
-        .send_and_await_reply(
-            InputCapability::NAMESPACE,
-            &SubscribeInput {
-                kind: Tick::ID,
-                mailbox,
-            },
-        )
-        .expect("await redundant subscribe reply");
-    match r {
-        SubscribeInputResult::Ok => {}
-        SubscribeInputResult::Err { error } => panic!("redundant subscribe failed: {error}"),
-    }
-}
-
-/// Run one no-tick `capture()` after a measurement window so the
-/// last advanced frame's trampoline broadcast (which can still be
-/// in `BroadcastCapability`'s inbox if `wait_instanced_quiesce`
-/// gave up early under heavy parallel-test CPU pressure) lands in
-/// `observed_kinds` before we read the count. Capture runs a full
-/// frame with `dispatch_tick = false`, so no new `tick_observed`
-/// is produced — the count delta stays at exactly N.
-fn settle_observations(bench: &mut TestBench) {
-    let _png = bench.capture().expect("settle capture");
-}
-
 /// Tick fanout reaches a freshly-loaded wasm component, the
 /// component's `ctx.actor::<BroadcastCapability>().send(...)` host
 /// call lands a kind-tagged broadcast on the bench's loopback, and
@@ -88,12 +53,10 @@ fn tick_roundtrip_component_to_sink() {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    let mbox = load_probe(&mut bench, &wasm_path);
-    await_tick_subscribed(&mut bench, mbox);
+    let _mbox = load_probe(&mut bench, &wasm_path);
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(3).expect("advance 3");
-    settle_observations(&mut bench);
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -118,12 +81,10 @@ fn batched_ticks_preserve_per_mailbox_count() {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    let mbox = load_probe(&mut bench, &wasm_path);
-    await_tick_subscribed(&mut bench, mbox);
+    let _mbox = load_probe(&mut bench, &wasm_path);
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(N).expect("advance N");
-    settle_observations(&mut bench);
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -13,8 +13,8 @@ use aether_actor::Actor;
 use aether_capabilities::{ComponentHostCapability, InputCapability};
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::{
-    DropComponent, DropResult, LoadComponent, LoadResult, SubscribeInput, SubscribeInputResult,
-    Tick, UnsubscribeInput,
+    DropComponent, DropResult, LoadComponent, LoadResult, SubscribeInputResult, Tick,
+    UnsubscribeInput,
 };
 use aether_scenario::test_helpers::require_runtime;
 use aether_substrate_bundle::test_bench::TestBench;
@@ -63,41 +63,6 @@ fn drop_component(bench: &mut TestBench, mailbox_id: MailboxId) {
     }
 }
 
-/// The probe self-subscribes to `Tick` from its `wire` handler via
-/// fire-and-forget mail; `LoadResult` returns before that mail has
-/// necessarily been drained by `InputCapability`'s actor. Mailing a
-/// redundant `SubscribeInput` from the test side and awaiting its
-/// reply gives a deterministic happens-before: `InputCapability` is
-/// single-threaded mpsc-FIFO, so once our reply arrives the probe's
-/// prior wire-time subscribe has been processed too. The set is a
-/// `BTreeSet` so the duplicate insert is a no-op.
-fn await_tick_subscribed(bench: &mut TestBench, mailbox: MailboxId) {
-    let r: SubscribeInputResult = bench
-        .send_and_await_reply(
-            InputCapability::NAMESPACE,
-            &SubscribeInput {
-                kind: Tick::ID,
-                mailbox,
-            },
-        )
-        .expect("await redundant subscribe reply");
-    match r {
-        SubscribeInputResult::Ok => {}
-        SubscribeInputResult::Err { error } => panic!("redundant subscribe failed: {error}"),
-    }
-}
-
-/// Run one no-tick `capture()` after a measurement window so the
-/// last advanced frame's trampoline broadcast (which can still be
-/// in `BroadcastCapability`'s inbox if `wait_instanced_quiesce`
-/// gave up early under heavy parallel-test CPU pressure) lands in
-/// `observed_kinds` before we read the count. Capture runs a full
-/// frame with `dispatch_tick = false`, so no new `tick_observed`
-/// is produced.
-fn settle_observations(bench: &mut TestBench) {
-    let _png = bench.capture().expect("settle capture");
-}
-
 /// No probes loaded ⇒ no Tick subscribers ⇒ advance generates zero
 /// `tick_observed` broadcasts. Confirms the input fanout is gated on
 /// the subscriber set rather than firing unconditionally.
@@ -108,7 +73,6 @@ fn empty_subscribers_means_no_delivery() {
     }
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     bench.advance(2).expect("advance 2");
-    settle_observations(&mut bench);
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         0,
@@ -124,12 +88,10 @@ fn subscribed_component_receives_published_ticks() {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
-    await_tick_subscribed(&mut bench, mbox);
+    let _mbox = load_probe_named(&mut bench, &wasm_path, "listener");
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(3).expect("advance 3");
-    settle_observations(&mut bench);
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -148,14 +110,11 @@ fn two_subscribers_each_receive_every_tick() {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    let mbox_a = load_probe_named(&mut bench, &wasm_path, "a");
-    let mbox_b = load_probe_named(&mut bench, &wasm_path, "b");
-    await_tick_subscribed(&mut bench, mbox_a);
-    await_tick_subscribed(&mut bench, mbox_b);
+    let _mbox_a = load_probe_named(&mut bench, &wasm_path, "a");
+    let _mbox_b = load_probe_named(&mut bench, &wasm_path, "b");
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(2).expect("advance 2");
-    settle_observations(&mut bench);
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -175,11 +134,9 @@ fn unsubscribe_stops_delivery() {
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
-    await_tick_subscribed(&mut bench, mbox);
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(1).expect("pre-unsubscribe advance");
-    settle_observations(&mut bench);
     assert_eq!(
         bench.count_observed(TickObserved::NAME) - baseline,
         1,
@@ -190,7 +147,6 @@ fn unsubscribe_stops_delivery() {
 
     unsubscribe(&mut bench, Tick::ID, mbox);
     bench.advance(2).expect("post-unsubscribe advance");
-    settle_observations(&mut bench);
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         pre_unsub,
@@ -210,11 +166,9 @@ fn drop_clears_subscriptions() {
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let mbox = load_probe_named(&mut bench, &wasm_path, "victim");
-    await_tick_subscribed(&mut bench, mbox);
     let baseline = bench.count_observed(TickObserved::NAME);
 
     bench.advance(1).expect("pre-drop advance");
-    settle_observations(&mut bench);
     assert_eq!(
         bench.count_observed(TickObserved::NAME) - baseline,
         1,
@@ -225,7 +179,6 @@ fn drop_clears_subscriptions() {
 
     drop_component(&mut bench, mbox);
     bench.advance(2).expect("post-drop advance");
-    settle_observations(&mut bench);
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         pre_drop,

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -51,7 +51,9 @@ use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
 /// `pending` is decremented after every dispatched envelope when
 /// `Some` — singletons pass it for `FRAME_BARRIER` caps (the chassis
 /// frame-loop drain barrier reads it); instanced actors pass their
-/// per-actor counter (`Spawner::wait_instanced_quiesce` reads it).
+/// per-actor counter (no live consumer post-PR-4: `wait_instanced_quiesce`
+/// retired in favour of ADR-0080 settlement gating, but the counter
+/// stays plumbed for the trampoline's `tx.send` accounting).
 pub(crate) fn dispatch_loop_run<A>(
     binding: &Arc<NativeBinding>,
     actor: &mut Box<A>,

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -93,15 +93,6 @@ pub struct Spawner {
     /// Monotonic counter for [`Subname::Counter`]. Per-Spawner so each
     /// chassis runs its own sequence; not shared across substrates.
     counter: AtomicU64,
-    /// Per-instanced-actor inbox-pending counters. Each spawn registers
-    /// one here; the sink handler increments on push, the dispatcher
-    /// loop decrements after dispatching. Used by the test bench's
-    /// `advance` loop to wait for trampolines to drain before
-    /// declaring a frame done — production drivers (desktop, headless)
-    /// don't read this. Wedge detection (CPU-loop wasm) waits on a
-    /// future epoch-deadline ADR; this counter is for synchronization,
-    /// not fail-fast.
-    instanced_pending: RwLock<Vec<(MailboxId, Arc<AtomicU64>)>>,
     /// Issue 635 PR C: chassis worker pool's ready-queue sender.
     /// Cloned into [`crate::scheduler::WakeHandle`]s when the
     /// Pooled spawn branch lands a slot.
@@ -148,7 +139,6 @@ impl Spawner {
             frame_bound_set,
             aborter,
             counter: AtomicU64::new(0),
-            instanced_pending: RwLock::new(Vec::new()),
             pool_ready_tx,
             instanced_slots: Mutex::new(HashMap::new()),
         }
@@ -211,32 +201,6 @@ impl Spawner {
                 return;
             }
             std::thread::sleep(std::time::Duration::from_millis(2));
-        }
-    }
-
-    /// Wait for every spawned instanced actor's inbox to quiesce
-    /// (`pending == 0`), polling until either every counter is zero or
-    /// `deadline` passes. Returns `true` on quiesce, `false` on
-    /// timeout. Test-bench-only — production drivers don't poll this;
-    /// trampolines are free-running by design and a slow tick handler
-    /// stalls only the next frame's render, not the chassis.
-    ///
-    /// Wedge detection (a CPU-loop wasm guest) waits on a future
-    /// epoch-deadline ADR; this is a passive wait, not an abort
-    /// barrier.
-    pub fn wait_instanced_quiesce(&self, deadline: std::time::Instant) -> bool {
-        loop {
-            let still_pending = {
-                let counters = self.instanced_pending.read().unwrap();
-                counters.iter().any(|(_, c)| c.load(Ordering::Acquire) > 0)
-            };
-            if !still_pending {
-                return true;
-            }
-            if std::time::Instant::now() >= deadline {
-                return false;
-            }
-            std::thread::sleep(std::time::Duration::from_micros(50));
         }
     }
 
@@ -381,9 +345,13 @@ impl Spawner {
         let strong_sender: Arc<mpsc::Sender<Envelope>> = Arc::new(tx.clone());
         let weak_for_handler = Arc::downgrade(&strong_sender);
         // Per-actor inbox-pending counter. Sink handler ++ on push;
-        // dispatcher loop -- after handling. Used by the test bench's
-        // `wait_instanced_quiesce` to wait for the actor to drain
-        // between ticks. Production drivers don't read this.
+        // dispatcher loop -- after handling. Pre-PR-4 the test bench's
+        // `wait_instanced_quiesce` queried this through
+        // `Spawner::instanced_pending`; ADR-0080 settlement gating
+        // retires that polling path. The counter survives because
+        // `dispatch_loop_run` still threads it as the optional
+        // `pending` arg, but nothing queries the value today —
+        // a future cleanup PR can drop it entirely.
         let pending = Arc::new(AtomicU64::new(0));
         let pending_for_handler = Arc::clone(&pending);
         // Issue 635 PR C: optional pool wake hook for `Pooled` actors.
@@ -419,8 +387,9 @@ impl Spawner {
                 if tx.send(env).is_err() {
                     // Receiver disconnected before we could deliver;
                     // un-account for the increment so the counter
-                    // stays accurate (otherwise `wait_instanced_quiesce`
-                    // would never see zero).
+                    // stays accurate (a future post-PR-4 cleanup may
+                    // drop the counter entirely now that
+                    // `wait_instanced_quiesce` retired).
                     pending_for_handler.fetch_sub(1, Ordering::AcqRel);
                     tracing::warn!(
                         target: "aether_substrate::spawn",
@@ -504,9 +473,9 @@ impl Spawner {
 
         // Pre-load bootstrap mail. tx is alive (rx is held by the
         // transport; nobody's polling yet), so these sends always
-        // succeed. Each pre-load increments the pending counter so
-        // `wait_instanced_quiesce` can see it before the actor's
-        // dispatcher consumes it.
+        // succeed. The per-actor `pending` counter increments here
+        // for symmetry with the sink-handler path; the value is no
+        // longer queried (PR 4 retired `wait_instanced_quiesce`).
         for env in after_init_mail {
             pending.fetch_add(1, Ordering::AcqRel);
             // mpsc::Sender::send only fails when the receiver
@@ -514,14 +483,6 @@ impl Spawner {
             // theoretical impossibility.
             let _ = tx.send(env);
         }
-
-        // Register the pending counter for `wait_instanced_quiesce`
-        // *after* pre-load so the test bench observing this list sees
-        // a populated inbox at boot, not a phantom-empty one.
-        self.instanced_pending
-            .write()
-            .unwrap()
-            .push((id, Arc::clone(&pending)));
 
         // 8. Spawn dispatcher (or pool-register) per `A::SCHEDULING`.
         // The local strong Arc was the populator for the Weak handler

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1619,18 +1619,6 @@ impl<C: Chassis> PassiveChassis<C> {
     pub fn actor_registry(&self) -> &Arc<crate::ActorRegistry> {
         &self.booted.actor_registry
     }
-
-    /// Wait for every spawned instanced actor's inbox to drain
-    /// (`pending == 0`), polling until quiet or `deadline` passes.
-    /// Returns `true` on quiesce, `false` on timeout. Test-bench-only:
-    /// production drivers don't poll this; trampolines are
-    /// free-running by design and a slow tick handler stalls only
-    /// the next frame's render, not the chassis. Wedge detection
-    /// (CPU-loop wasm) waits on a future epoch-deadline ADR — this
-    /// is a passive wait, not an abort barrier.
-    pub fn wait_instanced_quiesce(&self, deadline: std::time::Instant) -> bool {
-        self.booted.spawner.wait_instanced_quiesce(deadline)
-    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -155,6 +155,42 @@ pub fn record_finished(mail_id: MailId) {
     });
 }
 
+/// ADR-0080 chassis-root push helper. Combines `MailId` minting,
+/// the `Sent` trace event emission, and the `Mailer::push` into one
+/// call so chassis-side mail (Tick fanout from the frame loop, hub-
+/// bridged inbound, MCP-bridged) gets observable lineage without
+/// duplicating the producer-side hook in `NativeBinding::send_mail_with_lineage`.
+///
+/// Returns the freshly minted `MailId` so the caller can subscribe
+/// to its settlement via the chassis [`crate::chassis::settlement::SettlementRegistry`]
+/// before waiting on the chain.
+///
+/// `correlation_id` is allocated by the caller (the chassis owns its
+/// own `AtomicU64` counter, symmetric with each per-actor `NativeBinding`'s
+/// counter). Pre-PR 4 the test bench / hub minters were the only
+/// chassis-side counters; this helper shapes them as ADR-0080 §1
+/// chassis-root MailIds.
+pub fn push_chassis_root_mail(
+    mailer: &Mailer,
+    correlation_id: u64,
+    recipient: MailboxId,
+    kind: KindId,
+    payload: Vec<u8>,
+    count: u32,
+) -> MailId {
+    let mail_id = MailId::new(MailboxId::CHASSIS_MAILBOX_ID, correlation_id);
+    record_sent(
+        mail_id,
+        mail_id,
+        None,
+        MailboxId::CHASSIS_MAILBOX_ID,
+        recipient,
+        kind,
+    );
+    mailer.push(Mail::new(recipient, kind, payload, count).with_lineage(mail_id, mail_id, None));
+    mail_id
+}
+
 /// ADR-0080 §3 batch parameters: drain at most this many events per
 /// drainer cycle. Picked to amortise observer dispatch (~1k observer
 /// mails/sec at the busy-scene baseline of ~33k events/sec).


### PR DESCRIPTION
<!-- pr-body-ok: b — closes iamacoffeepot/aether#707; cross-issue refs to #648 / #685 -->

## Summary

PR 4 of 4 for [ADR-0080](docs/adr/0080-substrate-mail-tracing-and-settlement.md) phase 1. **Closes iamacoffeepot/aether#707.** The PR 5 originally planned for thread-spawn primitives was split out per the user-chosen scope and becomes a follow-up; phase 1's structural settlement work completes here.

## Settlement-gated frame loop

- New `aether_substrate::runtime::trace::push_chassis_root_mail` helper combines `MailId` minting, `Sent` trace event emission, and bare `Mailer::push` so chassis-side mail (Tick fanout from the frame loop, hub-bridged inbound, MCP-bridged) gets observable lineage. Returns the freshly minted root `MailId` so the caller can subscribe to its settlement before waiting on the chain.
- `TestBench::run_frame` now uses this helper for both the per-frame `Tick` push and the periodic `FrameStats` broadcast. The pre-existing `wait_instanced_quiesce` poll loop retires; the gate becomes `subscribe_settlement(root).recv_timeout(5s)`.

## #648 helper retirement

Drops `await_tick_subscribed` and `settle_observations` from `crates/aether-substrate-bundle/tests/{end_to_end,input_subscriptions}.rs`. The probe's `wire`-time `SubscribeInput` is now part of the load chain that the next `bench.advance()` waits on; the post-window `capture()` is no longer needed because the broadcast cap's inbox drains as part of each Tick chain's settlement.

## Dead-code retirement

- `Spawner::wait_instanced_quiesce` — gone.
- `Spawner::instanced_pending` — gone.
- `BuiltChassis::wait_instanced_quiesce` wrapper — gone.
- The per-spawn `pending` counter survives (still threaded through `dispatch_loop_run` for the trampoline's `tx.send` accounting), but no live consumer queries the value. A future cleanup PR can drop the per-spawn counter entirely if desired.

## Production drivers

Desktop and headless drivers are unchanged. They push Tick via bare `Mailer::push` (mail_id = NONE, no trace events emitted, no settlement chain), which is correct: production drivers don't have a test-side observer waiting on per-frame settlement, and the ADR-0074 §Decision 5 frame-bound drain barrier still runs for the ordering invariant.

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle` — 119/119 pass 5/5 consecutive runs.
- [x] `cargo nextest run -p aether-substrate-bundle --test test_bench_scenario` — 9/9 pass 10/10 consecutive runs. The `drop_component_silences_tick_echoes`, `replace_component_preserves_mailbox_identity`, `camera_destroy_main_keeps_substrate_alive`, and `input_subscription_yields_one_tick_observed_per_advance` flakes retire structurally.
- [x] `cargo nextest run --workspace --no-fail-fast` — 1050/1050 / 1050/1050 / 1048/1050. The two run-3 failures are unrelated pre-existing flakes:
  - `aether-capabilities tcp::cap_native::tests::session_round_trip_data_then_close` — TCP loopback socket race; passes 5/5 in isolation.
  - `aether-substrate chassis::builder::tests::chassis_teardown_runs_unwire_for_pooled_spawned_actors` — pooled-scheduling teardown race (iamacoffeepot/aether#685 area); passes 5/5 in isolation.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt` applied.

## Out of scope (follow-up after phase 1)

- Thread-spawn primitives (`InheritCtx<A>`, `RootCtx<A>`, `spawn_inherit`, `spawn_detached`, `spawn_root_worker`) — split out per the user-chosen scope; ships as a separate PR.
- Per-spawn `pending` counter cleanup (it's now dead but cheap; survives for diff minimisation).
- Production-driver settlement gating (desktop / headless) — unnecessary today; revisit if a use case forces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)