### PR TITLE
feat(hub): add describe_tree mcp tool

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -539,6 +539,178 @@ mod tests {
         assert!(format!("{err:?}").contains("unknown engine_id"));
     }
 
+    /// Issue 718: descriptor for `aether.trace.describe_tree`.
+    /// Cloned from the kind's `Schema` const so a future schema change
+    /// flows through to the test for free.
+    fn describe_tree_descriptor() -> aether_data::KindDescriptor {
+        use aether_data::Kind as _;
+        aether_data::KindDescriptor {
+            name: aether_kinds::trace::DescribeTree::NAME.to_owned(),
+            schema: <aether_kinds::trace::DescribeTree as aether_data::Schema>::SCHEMA.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn describe_tree_round_trips_observer_reply() {
+        use aether_data::tagged_id::{self, Tag};
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
+
+        // Engine record carries the descriptor for the request kind so
+        // the schema-driven encoder in deliver_one knows how to encode
+        // the agent's params into wire bytes. The reply kind doesn't
+        // need a descriptor — the hub decodes via postcard directly.
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_tree_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd001, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        // Sender mailbox we'll use for the root id; only its tag matters
+        // for the JSON wire form. The root has one extra child node.
+        let sender_raw = with_tag(Tag::Mailbox, 0xABCD);
+        let root = MailId {
+            sender: MailboxId(sender_raw),
+            correlation_id: 7,
+        };
+        let child = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0xCDEF)),
+            correlation_id: 1,
+        };
+
+        // Stub substrate: drain the request the tool sent (we don't
+        // care about its contents for this test — the encode path is
+        // already covered by `encode_schema` tests in aether-codec)
+        // and inject a postcard-encoded `DescribeTreeResult::Ok` reply.
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeTreeResult::Ok {
+                root,
+                in_flight: 1,
+                mails: vec![
+                    MailNodeWire {
+                        mail_id: root,
+                        parent: None,
+                        sender: root.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 1)),
+                        kind: aether_data::KindId(aether_data::with_tag(Tag::Kind, 0xBEEF)),
+                        t_sent: aether_kinds::trace::Nanos(100),
+                        t_received: Some(aether_kinds::trace::Nanos(200)),
+                        t_finished: None,
+                    },
+                    MailNodeWire {
+                        mail_id: child,
+                        parent: Some(root),
+                        sender: child.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 2)),
+                        kind: aether_data::KindId(aether_data::with_tag(Tag::Kind, 0xCAFE)),
+                        t_sent: aether_kinds::trace::Nanos(300),
+                        t_received: None,
+                        t_finished: None,
+                    },
+                ],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_tree_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let json = hub
+            .describe_tree(Parameters(args::DescribeTreeArgs {
+                engine_id: id.0.to_string(),
+                root: args::MailIdWire {
+                    sender: tagged_id::encode(sender_raw).unwrap(),
+                    correlation_id: 7,
+                },
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+
+        substrate_task.await.expect("stub substrate task");
+
+        // The reply enum serializes via serde's external tag — `Ok`
+        // becomes a top-level key. Each typed id flows out as a tagged
+        // string per its human-readable serde branch.
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let ok = &raw["Ok"];
+        assert_eq!(ok["in_flight"], 1);
+        let mails = ok["mails"].as_array().unwrap();
+        assert_eq!(mails.len(), 2);
+        // Root node first; its sender renders as a tagged-string mbx-...
+        let m0 = &mails[0];
+        let s0 = m0["sender"].as_str().unwrap();
+        assert!(s0.starts_with("mbx-"), "sender should be tagged: {s0}");
+        let k0 = m0["kind"].as_str().unwrap();
+        assert!(k0.starts_with("knd-"), "kind should be tagged: {k0}");
+        // root field on the Ok variant: composite `{ sender, correlation_id }`
+        let root_obj = &ok["root"];
+        assert!(
+            root_obj["sender"].as_str().unwrap().starts_with("mbx-"),
+            "root.sender should be tagged"
+        );
+        assert_eq!(root_obj["correlation_id"], 7);
+    }
+
+    #[tokio::test]
+    async fn describe_tree_unknown_engine_errors() {
+        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(state);
+        let err = hub
+            .describe_tree(Parameters(args::DescribeTreeArgs {
+                engine_id: Uuid::from_u128(0xdead).to_string(),
+                root: args::MailIdWire {
+                    sender: aether_data::tagged_id::encode(aether_data::with_tag(
+                        aether_data::tagged_id::Tag::Mailbox,
+                        1,
+                    ))
+                    .unwrap(),
+                    correlation_id: 0,
+                },
+                timeout_ms: Some(1_000),
+            }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("unknown engine_id"));
+    }
+
+    #[tokio::test]
+    async fn describe_tree_rejects_malformed_sender() {
+        let engines = EngineRegistry::new();
+        let (rec, _rx) = record(0xd0c2);
+        let id = rec.id;
+        engines.insert(rec);
+        let hub = Hub::new(test_state(engines, SessionRegistry::new()));
+        let err = hub
+            .describe_tree(Parameters(args::DescribeTreeArgs {
+                engine_id: id.0.to_string(),
+                root: args::MailIdWire {
+                    sender: "not-a-mailbox".into(),
+                    correlation_id: 0,
+                },
+                timeout_ms: Some(1_000),
+            }))
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").to_lowercase().contains("root.sender"),
+            "{err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn describe_component_rejects_malformed_mailbox_id() {
         // ADR-0064: a bare-number mailbox id is no longer valid wire

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -457,3 +457,31 @@ pub struct ReceivedMail {
     /// which has no sending mailbox.
     pub origin: Option<String>,
 }
+
+/// Issue 718: agent-facing JSON shape of `aether_data::MailId`. The
+/// underlying type is a 128-bit composite (`MailboxId` sender + `u64`
+/// correlation) — too wide for the ADR-0064 single-string tagged-id
+/// scheme — so the wire form mirrors the struct, with `sender` carrying
+/// the existing `mbx-XXXX-XXXX-XXXX` tagged form. `correlation_id`
+/// stays a `u64`; for short-running processes it's well under 2^53 and
+/// the agent treats it as opaque (round-trip without arithmetic).
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct MailIdWire {
+    /// Tagged-string mailbox id of the sender that minted the mail.
+    pub sender: String,
+    /// Per-actor correlation counter; opaque to the agent.
+    pub correlation_id: u64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeTreeArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Root mail id to describe. Obtained from a prior
+    /// `list_active_roots` reply or from any observed `MailNodeWire.root`.
+    pub root: MailIdWire,
+    /// Maximum time to wait for the substrate's reply, in
+    /// milliseconds. Defaults to 5000. Clamped to 30000.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -16,6 +16,7 @@ use aether_data::tagged_id::{self, Tag};
 use aether_kinds::{
     EnvVar, Spawn as WireSpawn, SpawnResult as WireSpawnResult, Terminate as WireTerminate,
     TerminateResult as WireTerminateResult,
+    trace::{DescribeTree, DescribeTreeResult, TRACE_OBSERVER_MAILBOX_NAME},
 };
 use base64::Engine as _;
 use rmcp::{
@@ -34,10 +35,11 @@ use crate::hub::session::SessionHandle;
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
-    DescribeKindsArgs, EngineInfo, EngineLogEntry, EngineLogsArgs, EngineLogsResponse,
-    LoadComponentArgs, LoadComponentResponse, LoadResultWire, MailSpec, MailStatus,
-    ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs, ReplaceResultWire, SendMailArgs,
-    SpawnResult, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs, log_level_to_str,
+    DescribeKindsArgs, DescribeTreeArgs, EngineInfo, EngineLogEntry, EngineLogsArgs,
+    EngineLogsResponse, LoadComponentArgs, LoadComponentResponse, LoadResultWire, MailSpec,
+    MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs, ReplaceResultWire,
+    SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
+    log_level_to_str,
 };
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
 use super::{Hub, HubState};
@@ -861,6 +863,91 @@ impl Hub {
             fallback: capabilities.fallback,
         };
         serde_json::to_string(&response).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "Describe the mail tree under one root (issue 718, ADR-0080 Phase 2). The substrate's `aether.trace` observer accumulates a parent → child mail graph keyed by `MailId`; this tool surfaces one root's subtree as JSON: every node's `mail_id`, `parent`, `sender`, `recipient`, `kind`, and `t_sent` / `t_received` / `t_finished` timestamps in nanoseconds-since-substrate-boot, plus the root's current `in_flight` count. `root` is a JSON object `{ sender: \"mbx-XXXX-XXXX-XXXX\", correlation_id: <number> }` — copy a `MailNodeWire.root` from a prior `describe_tree` reply or a `RootSummaryWire.root` from `list_active_roots`. Returns `Err::not_found` (echoing the requested root) when the root has been evicted past retention or never existed. Default timeout 5000ms; clamped to 30000."
+    )]
+    pub(super) async fn describe_tree(
+        &self,
+        Parameters(args): Parameters<DescribeTreeArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        if self.state.engines.get(&id).is_none() {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        }
+        // Validate the tagged-string sender up-front so a malformed
+        // form fails fast with a clear error rather than surfacing as
+        // a downstream encode error from the schema codec.
+        tagged_id::decode_with_tag(&args.root.sender, Tag::Mailbox)
+            .map_err(|e| McpError::invalid_params(format!("root.sender: {e}"), None))?;
+        let root_params = serde_json::json!({
+            "root": {
+                "sender": args.root.sender.clone(),
+                "correlation_id": args.root.correlation_id,
+            },
+        });
+
+        let result_kind = <DescribeTreeResult as Kind>::NAME.to_owned();
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(result_kind.clone())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a describe_tree is already in flight on this session; wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        let spec = MailSpec {
+            engine_id: args.engine_id.clone(),
+            recipient_name: TRACE_OBSERVER_MAILBOX_NAME.to_owned(),
+            kind_name: <DescribeTree as Kind>::NAME.to_owned(),
+            params: Some(root_params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        let wait = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_REPLY_TIMEOUT))
+            .unwrap_or(DEFAULT_REPLY_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "describe_tree reply channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for {result_kind}",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        let result: DescribeTreeResult = postcard::from_bytes(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?;
+        // The cap's reply is already MailId/MailboxId/KindId/Nanos —
+        // their human-readable serde branches emit tagged strings for
+        // ids and a u64 for `Nanos`, so JSON serialization is a single
+        // shot with no manual conversion.
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
     }
 
     #[tool(


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of iamacoffeepot/aether#718 — agents can now ask the substrate's trace observer for the mail tree under one root.

- New MCP tool `mcp__aether-hub__describe_tree(engine_id, root, timeout_ms?)`. Sends `aether.trace.describe_tree { root }` to `aether.trace`, awaits `DescribeTreeResult` via the same pending-replies mechanism `capture_frame` / `load_component` use, returns `DescribeTreeResult` as JSON.
- New `MailIdWire { sender, correlation_id }` agent-facing type (args.rs). MailId is a 128-bit composite — too wide for the single-string ADR-0064 tagged-id scheme — so the JSON shape mirrors the struct, with `sender` carrying the existing `mbx-XXXX-XXXX-XXXX` tagged form. The reply's typed ids (MailId / MailboxId / KindId) all serialize as tagged strings via the existing `is_human_readable` serde branches in `aether-data` — no manual conversion in the tool.
- Up-front validation of `root.sender` so a malformed tagged string fails fast with a clear `root.sender:` error, rather than surfacing as a downstream encode error from the schema codec.
- Three new integration tests: round-trip through a stub substrate (asserts tagged-string ids and structural root shape in the JSON), unknown-engine error path, and malformed-sender rejection.

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle describe_tree` — 3/3 pass
- [x] `cargo nextest run --workspace --no-fail-fast` — 1062/1062 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

PR 3 (`list_active_roots`) follows the same pattern, against the second handler shipped in iamacoffeepot/aether#719.

Refs: iamacoffeepot/aether#718, iamacoffeepot/aether#707

🤖 Generated with [Claude Code](https://claude.com/claude-code)