### PR TITLE
feat(hub): add list_active_roots mcp tool

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -687,6 +687,125 @@ mod tests {
         assert!(format!("{err:?}").contains("unknown engine_id"));
     }
 
+    fn list_active_roots_descriptor() -> aether_data::KindDescriptor {
+        use aether_data::Kind as _;
+        aether_data::KindDescriptor {
+            name: aether_kinds::trace::ListActiveRoots::NAME.to_owned(),
+            schema: <aether_kinds::trace::ListActiveRoots as aether_data::Schema>::SCHEMA.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_active_roots_round_trips_observer_reply() {
+        use aether_data::tagged_id::Tag;
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{ListActiveRootsResult, RootSummaryWire};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![list_active_roots_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd003, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        let root_a = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0x111)),
+            correlation_id: 1,
+        };
+        let root_b = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0x222)),
+            correlation_id: 2,
+        };
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = ListActiveRootsResult {
+                roots: vec![
+                    RootSummaryWire {
+                        root: root_b,
+                        kind: aether_data::KindId(with_tag(Tag::Kind, 0xCAFE)),
+                        sender: root_b.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 9)),
+                        t_sent: aether_kinds::trace::Nanos(2_000_000_000),
+                        in_flight: 0,
+                    },
+                    RootSummaryWire {
+                        root: root_a,
+                        kind: aether_data::KindId(with_tag(Tag::Kind, 0xBEEF)),
+                        sender: root_a.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 8)),
+                        t_sent: aether_kinds::trace::Nanos(1_000_000_000),
+                        in_flight: 3,
+                    },
+                ],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.list_active_roots_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let json = hub
+            .list_active_roots(Parameters(args::ListActiveRootsArgs {
+                engine_id: id.0.to_string(),
+                since_ms: Some(60_000),
+                max: Some(50),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+
+        substrate_task.await.expect("stub substrate task");
+
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let roots = raw["roots"].as_array().unwrap();
+        assert_eq!(roots.len(), 2);
+        // Order preserved from the substrate's reply (the substrate
+        // sorts desc by t_sent before encoding).
+        assert_eq!(roots[0]["in_flight"], 0);
+        assert_eq!(roots[1]["in_flight"], 3);
+        // Each typed id renders as its tagged-string form.
+        let r0_sender = roots[0]["sender"].as_str().unwrap();
+        assert!(r0_sender.starts_with("mbx-"), "sender tagged: {r0_sender}");
+        let r0_kind = roots[0]["kind"].as_str().unwrap();
+        assert!(r0_kind.starts_with("knd-"), "kind tagged: {r0_kind}");
+        // Composite root field.
+        assert!(
+            roots[0]["root"]["sender"]
+                .as_str()
+                .unwrap()
+                .starts_with("mbx-"),
+            "root.sender tagged"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_active_roots_unknown_engine_errors() {
+        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(state);
+        let err = hub
+            .list_active_roots(Parameters(args::ListActiveRootsArgs {
+                engine_id: Uuid::from_u128(0xdead).to_string(),
+                since_ms: None,
+                max: None,
+                timeout_ms: Some(1_000),
+            }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("unknown engine_id"));
+    }
+
     #[tokio::test]
     async fn describe_tree_rejects_malformed_sender() {
         let engines = EngineRegistry::new();

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -474,6 +474,27 @@ pub struct MailIdWire {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListActiveRootsArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Filter to roots whose originating `Sent` event was emitted no
+    /// more than this many milliseconds ago. Defaults to 60_000 (1
+    /// minute). Roots older than the window aren't returned even if
+    /// they haven't been evicted yet.
+    #[serde(default)]
+    pub since_ms: Option<u32>,
+    /// Cap the reply length. Defaults to 50; clamped to 1000 by the
+    /// observer. Sorted desc by `t_sent` so the most recent roots
+    /// always land in the truncated head.
+    #[serde(default)]
+    pub max: Option<u32>,
+    /// Maximum time to wait for the substrate's reply, in
+    /// milliseconds. Defaults to 5000. Clamped to 30000.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DescribeTreeArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -16,7 +16,10 @@ use aether_data::tagged_id::{self, Tag};
 use aether_kinds::{
     EnvVar, Spawn as WireSpawn, SpawnResult as WireSpawnResult, Terminate as WireTerminate,
     TerminateResult as WireTerminateResult,
-    trace::{DescribeTree, DescribeTreeResult, TRACE_OBSERVER_MAILBOX_NAME},
+    trace::{
+        DescribeTree, DescribeTreeResult, ListActiveRoots, ListActiveRootsResult,
+        TRACE_OBSERVER_MAILBOX_NAME,
+    },
 };
 use base64::Engine as _;
 use rmcp::{
@@ -36,10 +39,10 @@ use crate::hub::session::SessionHandle;
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
     DescribeKindsArgs, DescribeTreeArgs, EngineInfo, EngineLogEntry, EngineLogsArgs,
-    EngineLogsResponse, LoadComponentArgs, LoadComponentResponse, LoadResultWire, MailSpec,
-    MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs, ReplaceResultWire,
-    SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
-    log_level_to_str,
+    EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs, LoadComponentResponse,
+    LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs,
+    ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult,
+    TerminateSubstrateArgs, log_level_to_str,
 };
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
 use super::{Hub, HubState};
@@ -947,6 +950,85 @@ impl Hub {
         // their human-readable serde branches emit tagged strings for
         // ids and a u64 for `Nanos`, so JSON serialization is a single
         // shot with no manual conversion.
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    #[tool(
+        description = "List recent root mails the substrate's `aether.trace` observer is tracking (issue 718, ADR-0080 Phase 2). Surfaces one summary per active root: `root` (composite `{ sender, correlation_id }`), `kind` (tagged-string id of the root mail's payload kind), `sender` and `recipient` (tagged-string mailbox ids), `t_sent` (nanoseconds since substrate boot), and `in_flight` (count of mails in this chain currently between `Sent` and `Finished`). Sorted desc by `t_sent` so the most recent roots come first. `since_ms` filters by the root's originating send time (default 60_000); `max` caps the reply length (default 50, hard cap 1000). Use this to discover root ids the agent can hand to `describe_tree` for a full subtree view, or to spot-check whether a chain has settled by watching `in_flight` drop to zero. Default timeout 5000ms; clamped to 30000."
+    )]
+    pub(super) async fn list_active_roots(
+        &self,
+        Parameters(args): Parameters<ListActiveRootsArgs>,
+    ) -> Result<String, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        if self.state.engines.get(&id).is_none() {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        }
+
+        // ListActiveRoots's two fields are both `Option<u32>` — the
+        // schema-driven encoder accepts JSON `null` for None and the
+        // raw number for Some, so we serialize the agent's args
+        // straight through.
+        let request_params = serde_json::json!({
+            "since_ms": args.since_ms,
+            "max": args.max,
+        });
+
+        let result_kind = <ListActiveRootsResult as Kind>::NAME.to_owned();
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(result_kind.clone())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a list_active_roots is already in flight on this session; wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        let spec = MailSpec {
+            engine_id: args.engine_id.clone(),
+            recipient_name: TRACE_OBSERVER_MAILBOX_NAME.to_owned(),
+            kind_name: <ListActiveRoots as Kind>::NAME.to_owned(),
+            params: Some(request_params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        let wait = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_REPLY_TIMEOUT))
+            .unwrap_or(DEFAULT_REPLY_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "list_active_roots reply channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for {result_kind}",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        let result: ListActiveRootsResult = postcard::from_bytes(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?;
         serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
     }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 3 (final) of iamacoffeepot/aether#718 — agents can now discover active mail-tree roots without already knowing a `MailId`. Pairs with `describe_tree` from PR 720: `list_active_roots` gives the catalogue, `describe_tree` drills into one.

- New MCP tool `mcp__aether-hub__list_active_roots(engine_id, since_ms?, max?, timeout_ms?)`. Sends `aether.trace.list_active_roots { since_ms, max }` to `aether.trace`, awaits `ListActiveRootsResult` via the same pending-replies mechanism `describe_tree` / `capture_frame` use, returns the result as JSON.
- New `ListActiveRootsArgs` agent-facing type. Defaults: `since_ms = 60_000`, `max = 50`, hard cap `max = 1000` (clamped observer-side per PR 719).
- Each typed id in the reply (`MailId`, `MailboxId`, `KindId`) flows out as its tagged-string form via the existing `is_human_readable` serde branches in `aether-data` — no manual conversion in the tool. The composite `MailId` keeps the structural `{ sender, correlation_id }` JSON shape (same convention as PR 720).
- Two new integration tests: round-trip through a stub substrate (asserting tagged-string ids and that the cap's `t_sent`-desc ordering survives JSON serialization), and the unknown-engine error path.

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle list_active_roots` — 2/2 pass
- [x] `cargo nextest run --workspace --no-fail-fast` — 1064/1064 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes iamacoffeepot/aether#718.
Refs: iamacoffeepot/aether#707

🤖 Generated with [Claude Code](https://claude.com/claude-code)