### PR TITLE
feat(trace): wire chassis tick driver and input fanout lineage

### DIFF
--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -35,12 +35,11 @@ mod native {
     };
     use aether_actor::actor;
     use aether_actor::actor::ctx::OutboundReply;
-    use aether_data::{Kind, KindId, encode};
+    use aether_data::{Kind, KindId};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::MailboxId;
     use aether_substrate::mail::registry::{MailboxEntry, Registry};
-    use aether_substrate::mail::{Mail, MailboxId};
     use std::collections::{BTreeSet, HashMap};
     use std::sync::Arc;
 
@@ -69,7 +68,6 @@ mod native {
     /// runs on the cap's dispatcher thread.
     pub struct InputCapability {
         registry: Arc<Registry>,
-        mailer: Arc<Mailer>,
         subscribers: HashMap<KindId, BTreeSet<MailboxId>>,
     }
 
@@ -79,11 +77,9 @@ mod native {
         const NAMESPACE: &'static str = "aether.input";
 
         fn init(_config: InputConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let mailer = ctx.mailer();
-            let registry = Arc::clone(mailer.registry());
+            let registry = Arc::clone(ctx.mailer().registry());
             Ok(Self {
                 registry,
-                mailer,
                 subscribers: HashMap::new(),
             })
         }
@@ -145,59 +141,54 @@ mod native {
 
         /// Per-frame tick fan-out (ADR-0021). Empty payload.
         #[handler]
-        fn on_tick(&mut self, _ctx: &mut NativeCtx<'_>, payload: Tick) {
-            self.fanout(Tick::ID, &payload);
+        fn on_tick(&mut self, ctx: &mut NativeCtx<'_>, payload: Tick) {
+            self.fanout(ctx, &payload);
         }
 
         /// Key-press fan-out.
         #[handler]
-        fn on_key(&mut self, _ctx: &mut NativeCtx<'_>, payload: Key) {
-            self.fanout(Key::ID, &payload);
+        fn on_key(&mut self, ctx: &mut NativeCtx<'_>, payload: Key) {
+            self.fanout(ctx, &payload);
         }
 
         /// Key-release fan-out (paired with [`Key`] for hold-to-act
         /// semantics).
         #[handler]
-        fn on_key_release(&mut self, _ctx: &mut NativeCtx<'_>, payload: KeyRelease) {
-            self.fanout(KeyRelease::ID, &payload);
+        fn on_key_release(&mut self, ctx: &mut NativeCtx<'_>, payload: KeyRelease) {
+            self.fanout(ctx, &payload);
         }
 
         /// Cursor-move fan-out.
         #[handler]
-        fn on_mouse_move(&mut self, _ctx: &mut NativeCtx<'_>, payload: MouseMove) {
-            self.fanout(MouseMove::ID, &payload);
+        fn on_mouse_move(&mut self, ctx: &mut NativeCtx<'_>, payload: MouseMove) {
+            self.fanout(ctx, &payload);
         }
 
         /// Mouse-press fan-out. Empty payload.
         #[handler]
-        fn on_mouse_button(&mut self, _ctx: &mut NativeCtx<'_>, payload: MouseButton) {
-            self.fanout(MouseButton::ID, &payload);
+        fn on_mouse_button(&mut self, ctx: &mut NativeCtx<'_>, payload: MouseButton) {
+            self.fanout(ctx, &payload);
         }
 
         /// Window-resize fan-out.
         #[handler]
-        fn on_window_size(&mut self, _ctx: &mut NativeCtx<'_>, payload: WindowSize) {
-            self.fanout(WindowSize::ID, &payload);
+        fn on_window_size(&mut self, ctx: &mut NativeCtx<'_>, payload: WindowSize) {
+            self.fanout(ctx, &payload);
         }
     }
 
     impl InputCapability {
-        /// Push one mail per subscriber for `kind`. Re-encodes
-        /// `payload` once and clones the `Vec<u8>` per recipient — the
-        /// payloads are tiny (cast-shaped, ≤ 8 bytes) so per-subscriber
-        /// allocation churn is negligible at 60Hz tick / 1kHz mouse
-        /// move cadence.
-        fn fanout<K: Kind + bytemuck::NoUninit>(&self, kind: KindId, payload: &K) {
-            let Some(subs) = self.subscribers.get(&kind) else {
+        /// Push one mail per subscriber for `K`. Routes through
+        /// [`NativeCtx::fanout`] so each subscriber-bound copy carries
+        /// the inbound `(mail_id, root)` as `parent_mail` +
+        /// `inherited_root` — the trace observer sees N children
+        /// fanning out under the same parent edge (ADR-0080 §6,
+        /// issue iamacoffeepot/aether#723).
+        fn fanout<K: Kind>(&self, ctx: &mut NativeCtx<'_>, payload: &K) {
+            let Some(subs) = self.subscribers.get(&K::ID) else {
                 return;
             };
-            if subs.is_empty() {
-                return;
-            }
-            let bytes = encode(payload);
-            for mbox in subs {
-                self.mailer.push(Mail::new(*mbox, kind, bytes.clone(), 1));
-            }
+            ctx.fanout(subs.iter().copied(), payload);
         }
     }
 

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -20,9 +20,7 @@ use aether_actor::Actor;
 use aether_capabilities::InputCapability;
 use aether_data::{encode_empty, mailbox_id_from_name};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
-use aether_substrate::{
-    Chassis, capture::CaptureQueue, chassis::frame_loop, mail::Mail, mail::MailboxId,
-};
+use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId};
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
@@ -138,6 +136,11 @@ fn drive_events_loop(
     let frame_bound_pending = passive.frame_bound_pending();
     let started = Instant::now();
     let mut frame: u64 = 0;
+    // ADR-0080 §6 chassis-root correlation counter (issue
+    // iamacoffeepot/aether#723). Threaded through `run_frame` so the
+    // tick + frame-stats pushes here carry observable lineage like
+    // the desktop and headless drivers do.
+    let chassis_correlation = std::sync::atomic::AtomicU64::new(1);
 
     while let Ok(event) = events_rx.recv() {
         match event {
@@ -157,6 +160,7 @@ fn drive_events_loop(
                         &render_handles,
                         &frame_bound_pending,
                         &mut gpu,
+                        &chassis_correlation,
                     );
                 }
                 outbound.send_reply(
@@ -181,6 +185,7 @@ fn drive_events_loop(
                     &render_handles,
                     &frame_bound_pending,
                     &mut gpu,
+                    &chassis_correlation,
                 );
             }
         }
@@ -213,14 +218,26 @@ fn run_frame(
         Arc<std::sync::atomic::AtomicU64>,
     )],
     gpu: &mut Gpu,
+    chassis_correlation: &std::sync::atomic::AtomicU64,
 ) {
+    let next_correlation = || -> u64 {
+        let id = chassis_correlation.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if id == 0 {
+            chassis_correlation.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        } else {
+            id
+        }
+    };
+
     if dispatch_tick {
-        queue.push(Mail::new(
+        aether_substrate::runtime::trace::push_chassis_root_mail(
+            queue,
+            next_correlation(),
             input_mailbox,
             kind_tick,
             encode_empty::<Tick>(),
             1,
-        ));
+        );
     }
     // ADR-0074 §Decision 5: render's inbox must quiesce before
     // submit so any DrawTriangle / aether.camera mail this frame is
@@ -247,7 +264,13 @@ fn run_frame(
 
     if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
         let triangles = render_handles.triangles_rendered.load(Ordering::Relaxed);
-        frame_loop::emit_frame_stats(queue, kind_frame_stats, frame, triangles);
+        frame_loop::emit_frame_stats(
+            queue,
+            kind_frame_stats,
+            frame,
+            triangles,
+            next_correlation(),
+        );
         let elapsed = started.elapsed().as_secs_f64().max(0.001);
         tracing::info!(
             target: "aether_substrate::frame_loop",

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -35,9 +35,8 @@ use aether_substrate::actor::native::envelope::Envelope;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
-    HubOutbound, Mailer, SubstrateBoot,
-    chassis::frame_loop,
-    mail::{Mail, MailboxId},
+    HubOutbound, Mailer, SubstrateBoot, chassis::frame_loop, mail::MailboxId,
+    runtime::trace::push_chassis_root_mail,
 };
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
@@ -125,6 +124,12 @@ pub struct App {
     window_inbox: std::sync::mpsc::Receiver<Envelope>,
     kind_set_window_mode: aether_data::KindId,
     kind_set_window_title: aether_data::KindId,
+    /// ADR-0080 §6 chassis-root correlation counter (issue
+    /// iamacoffeepot/aether#723). Bumped per chassis-source push so
+    /// every input/window/frame-stats emission carries a fresh
+    /// `MailId` for the trace observer to root a tree on. Symmetric
+    /// with the per-actor counter on `NativeBinding`.
+    chassis_correlation: AtomicU64,
 }
 
 /// Translate a winit `KeyCode` into the engine's stable named-key u32
@@ -288,6 +293,24 @@ fn resolve_fullscreen(
 }
 
 impl App {
+    /// ADR-0080 §6 chassis-source push helper (issue
+    /// iamacoffeepot/aether#723). Mints a fresh correlation, calls
+    /// `push_chassis_root_mail` so the trace observer sees a `Sent`
+    /// event for every input/window/frame-stats emission.
+    fn push_chassis_root(
+        &self,
+        recipient: MailboxId,
+        kind: aether_data::KindId,
+        payload: Vec<u8>,
+        count: u32,
+    ) {
+        let mut correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+        if correlation == 0 {
+            correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+        }
+        push_chassis_root_mail(&self.queue, correlation, recipient, kind, payload, count);
+    }
+
     fn apply_window_mode(
         &mut self,
         mode: WindowMode,
@@ -386,12 +409,7 @@ impl App {
 
     fn publish_window_size(&self, width: u32, height: u32) {
         let payload = encode(&WindowSize { width, height });
-        self.queue.push(Mail::new(
-            self.input_mailbox,
-            self.kind_window_size,
-            payload,
-            1,
-        ));
+        self.push_chassis_root(self.input_mailbox, self.kind_window_size, payload, 1);
     }
 
     fn set_occluded(&mut self, occluded: bool, event_loop: &ActiveEventLoop) {
@@ -478,12 +496,12 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
-                self.queue.push(Mail::new(
+                self.push_chassis_root(
                     self.input_mailbox,
                     self.kind_tick,
                     encode_empty::<Tick>(),
                     1,
-                ));
+                );
                 if let Some(window) = &self.window {
                     let size = window.inner_size();
                     if size.width != 0 && size.height != 0 {
@@ -530,11 +548,16 @@ impl ApplicationHandler<UserEvent> for App {
                         triangles,
                         "frame stats",
                     );
+                    let mut correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+                    if correlation == 0 {
+                        correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+                    }
                     frame_loop::emit_frame_stats(
                         &self.queue,
                         self.kind_frame_stats,
                         self.frame,
                         triangles,
+                        correlation,
                     );
                 }
                 if !self.occluded
@@ -554,20 +577,20 @@ impl ApplicationHandler<UserEvent> for App {
                 };
                 match key_event.state {
                     ElementState::Pressed => {
-                        self.queue.push(Mail::new(
+                        self.push_chassis_root(
                             self.input_mailbox,
                             self.kind_key,
                             encode(&Key { code }),
                             1,
-                        ));
+                        );
                     }
                     ElementState::Released => {
-                        self.queue.push(Mail::new(
+                        self.push_chassis_root(
                             self.input_mailbox,
                             self.kind_key_release,
                             encode(&KeyRelease { code }),
                             1,
-                        ));
+                        );
                     }
                 }
             }
@@ -575,24 +598,19 @@ impl ApplicationHandler<UserEvent> for App {
                 state: ElementState::Pressed,
                 ..
             } => {
-                self.queue.push(Mail::new(
+                self.push_chassis_root(
                     self.input_mailbox,
                     self.kind_mouse_button,
                     encode_empty::<MouseButton>(),
                     1,
-                ));
+                );
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let payload = encode(&MouseMove {
                     x: position.x as f32,
                     y: position.y as f32,
                 });
-                self.queue.push(Mail::new(
-                    self.input_mailbox,
-                    self.kind_mouse_move,
-                    payload,
-                    1,
-                ));
+                self.push_chassis_root(self.input_mailbox, self.kind_mouse_move, payload, 1);
             }
             _ => {}
         }
@@ -725,6 +743,9 @@ impl DriverCapability for DesktopDriverCapability {
             window_inbox: window_claim.receiver,
             kind_set_window_mode,
             kind_set_window_title,
+            // 0 is the "no correlation" sentinel; mirror NativeBinding's
+            // start-at-1 convention.
+            chassis_correlation: AtomicU64::new(1),
         };
 
         Ok(DesktopDriverRunning {

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -15,6 +15,7 @@
 //! Builder→BuiltChassis→run path applies all the same).
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -26,9 +27,8 @@ use aether_kinds::Tick;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
-    Mailer, SubstrateBoot,
-    chassis::frame_loop,
-    mail::{Mail, MailboxId},
+    Mailer, SubstrateBoot, chassis::frame_loop, mail::MailboxId,
+    runtime::trace::push_chassis_root_mail,
 };
 
 /// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
@@ -125,6 +125,20 @@ impl DriverRunning for HeadlessTimerRunning {
             _hub,
         } = *self;
 
+        // ADR-0080 §6 chassis-root correlation counter (issue
+        // iamacoffeepot/aether#723). One per driver, symmetric with the
+        // per-actor counter on `NativeBinding`. Skipping 0 keeps the
+        // sentinel slot reserved.
+        let chassis_correlation = AtomicU64::new(1);
+        let next_correlation = || -> u64 {
+            let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
+            if id == 0 {
+                chassis_correlation.fetch_add(1, Ordering::Relaxed)
+            } else {
+                id
+            }
+        };
+
         let started = Instant::now();
         let mut frame: u64 = 0;
         let mut next_deadline = Instant::now() + tick_period;
@@ -141,14 +155,22 @@ impl DriverRunning for HeadlessTimerRunning {
             next_deadline = Instant::now() + tick_period;
 
             frame += 1;
-            queue.push(Mail::new(
+            push_chassis_root_mail(
+                &queue,
+                next_correlation(),
                 input_mailbox,
                 kind_tick,
                 encode_empty::<Tick>(),
                 1,
-            ));
+            );
             if frame.is_multiple_of(frame_loop::LOG_EVERY_FRAMES) {
-                frame_loop::emit_frame_stats(&queue, kind_frame_stats, frame, 0);
+                frame_loop::emit_frame_stats(
+                    &queue,
+                    kind_frame_stats,
+                    frame,
+                    0,
+                    next_correlation(),
+                );
                 let elapsed = started.elapsed().as_secs_f64().max(0.001);
                 tracing::info!(
                     target: "aether_substrate::frame_loop",

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -793,6 +793,93 @@ mod tests {
         );
     }
 
+    /// Issue iamacoffeepot/aether#723: chassis-source ticks are minted
+    /// via `push_chassis_root_mail`, and the input cap fanout
+    /// propagates `(root, parent_mail)` from the inbound through
+    /// `NativeCtx::fanout` so each subscriber-bound copy lands in the
+    /// same causal chain. Verified by registering a closure-bound
+    /// mailbox, subscribing it to ticks, advancing one tick, and
+    /// asserting the captured `MailDispatch` carries non-default root +
+    /// parent.
+    #[test]
+    fn tick_fanout_propagates_chassis_root_lineage() {
+        use aether_data::{Kind as DataKind, MailId};
+        use aether_kinds::SubscribeInput;
+        use aether_substrate::mail::registry::MailDispatch;
+        use std::sync::Mutex;
+
+        let mut tb = match TestBench::start_with_size(64, 48) {
+            Ok(tb) => tb,
+            Err(e) => {
+                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                return;
+            }
+        };
+
+        // Register a closure mailbox that captures the lineage of every
+        // mail it receives. The Closure variant is what the input cap's
+        // `validate_subscriber_mailbox` accepts.
+        type CapturedRow = (MailId, MailId, Option<MailId>);
+        let captured: Arc<Mutex<Vec<CapturedRow>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_handler = Arc::clone(&captured);
+        let subscriber_mbox = tb.registry.register_closure(
+            "issue_723_test_subscriber",
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                captured_for_handler.lock().unwrap().push((
+                    dispatch.mail_id,
+                    dispatch.root,
+                    dispatch.parent_mail,
+                ));
+            }),
+        );
+
+        // Subscribe the closure mailbox to Tick. Goes through the input
+        // cap's on_subscribe handler.
+        tb.send_mail(
+            "aether.input",
+            &SubscribeInput {
+                kind: aether_kinds::Tick::ID,
+                mailbox: subscriber_mbox,
+            },
+        )
+        .expect("subscribe");
+
+        // Advance one tick. This calls `push_chassis_root_mail` for the
+        // tick (issue 723), which mints a fresh chassis-root MailId and
+        // fires `Sent`. The input cap's `on_tick` reads `ctx.in_flight_*`
+        // and threads them through `ctx.fanout` to every subscriber.
+        let _ = tb.advance(1).expect("advance");
+
+        let captured = captured.lock().unwrap();
+        assert!(
+            !captured.is_empty(),
+            "subscriber received no mail — fanout never reached it",
+        );
+        let (mail_id, root, parent) = captured[0];
+        // Issue 723 fix: each fanned-out copy gets its own MailId, but
+        // the root is inherited from the chassis-root tick and the
+        // parent_mail points at it. Pre-fix both would be MailId::NONE
+        // (orphaned: ctx.in_flight was NONE because the tick used
+        // bare push, AND the fanout used bare push too).
+        assert_ne!(
+            root,
+            MailId::NONE,
+            "fanned-out copy should inherit a non-default root"
+        );
+        assert!(
+            parent.is_some_and(|p| p != MailId::NONE),
+            "fanned-out copy should carry a non-default parent_mail (got {:?})",
+            parent,
+        );
+        // The fanned-out copy's own mail_id must be distinct from its
+        // parent — it's a child node in the trace tree.
+        assert_ne!(
+            mail_id,
+            parent.unwrap(),
+            "fanned-out mail_id should differ from parent (each fanout copy gets a fresh id)"
+        );
+    }
+
     /// Issue 607 Phase 3 verify: spawn an instanced actor through
     /// `TestBench::spawn_actor`, exercise `Subname::Counter` +
     /// `Subname::Named`, assert returned `MailboxId` matches the

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -26,7 +26,7 @@ use aether_actor::mail::sync::WaitError;
 use aether_actor::{Actor, HandlesKind, MailCtx, Sender, Singleton};
 
 use crate::actor::native::mailbox::NativeActorMailbox;
-use aether_data::{Kind, MailId, mailbox_id_from_name};
+use aether_data::{Kind, MailId, MailboxId, mailbox_id_from_name};
 
 use crate::actor::monitor::MonitorHandle;
 use crate::actor::native::binding::NativeBinding;
@@ -299,6 +299,44 @@ impl<'a> NativeCtx<'a> {
             None
         } else {
             Some(self.in_flight_root)
+        }
+    }
+}
+
+impl<'a> NativeCtx<'a> {
+    /// Lineage-aware multicast: encode `payload` once, then push one copy
+    /// to every `recipient`. The inbound `(mail_id, root)` from this ctx
+    /// propagate as `parent_mail` + `inherited_root`, so each fanned-out
+    /// copy lands in the same causal chain as the inbound that triggered
+    /// the fanout — every subscriber-bound copy gets its own fresh
+    /// `MailId` keyed under the same parent edge.
+    ///
+    /// Recipients aren't known to share a receiver type at compile site
+    /// (subscribers register at runtime by mailbox id), so this takes
+    /// mailbox ids directly rather than the typed
+    /// `R: Actor + HandlesKind<K>` shape of [`Sender::send`]. The empty
+    /// recipient set is a fast no-op — encoding only runs when there's at
+    /// least one consumer.
+    ///
+    /// Issue iamacoffeepot/aether#723.
+    pub fn fanout<K: Kind>(
+        &mut self,
+        recipients: impl IntoIterator<Item = MailboxId>,
+        payload: &K,
+    ) {
+        let mut recipients = recipients.into_iter();
+        let Some(first) = recipients.next() else {
+            return;
+        };
+        let bytes = payload.encode_into_bytes();
+        let parent = self.outbound_parent();
+        let root = self.outbound_root();
+        let kind = K::ID.0;
+        self.binding
+            .send_mail_with_lineage(first.0, kind, &bytes, 1, parent, root);
+        for recipient in recipients {
+            self.binding
+                .send_mail_with_lineage(recipient.0, kind, &bytes, 1, parent, root);
         }
     }
 }

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -34,9 +34,9 @@ use std::time::{Duration, Instant};
 use aether_data::encode;
 use aether_kinds::FrameStats;
 
+use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
 use crate::mail::outbound::HubOutbound;
-use crate::mail::{Mail, MailboxId};
 use crate::runtime::lifecycle;
 
 /// Frame-stats emission cadence. Hardcoded for v1; an env knob is
@@ -122,16 +122,23 @@ pub fn emit_frame_stats(
     kind_frame_stats: aether_data::KindId,
     frame: u64,
     triangles: u64,
+    correlation_id: u64,
 ) {
     if !frame.is_multiple_of(LOG_EVERY_FRAMES) {
         return;
     }
-    queue.push(Mail::new(
+    // ADR-0080 §6: emit through the chassis-root helper so the broadcast
+    // carries observable lineage (issue iamacoffeepot/aether#723). The
+    // caller mints `correlation_id` from its own counter — symmetric with
+    // `push_chassis_root_mail`'s contract.
+    crate::runtime::trace::push_chassis_root_mail(
+        queue,
+        correlation_id,
         aether_data::mailbox_id_from_name(aether_kinds::HUB_BROADCAST_MAILBOX_NAME),
         kind_frame_stats,
         encode(&FrameStats { frame, triangles }),
         1,
-    ));
+    );
 }
 
 #[cfg(test)]
@@ -166,8 +173,8 @@ mod tests {
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
         let kind_id = FrameStats::ID;
-        emit_frame_stats(&mailer, kind_id, 1, 0);
-        emit_frame_stats(&mailer, kind_id, 119, 0);
+        emit_frame_stats(&mailer, kind_id, 1, 0, 1);
+        emit_frame_stats(&mailer, kind_id, 119, 0, 2);
         assert!(captured.read().unwrap().is_empty());
     }
 
@@ -191,7 +198,7 @@ mod tests {
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
-        emit_frame_stats(&mailer, FrameStats::ID, LOG_EVERY_FRAMES, 42);
+        emit_frame_stats(&mailer, FrameStats::ID, LOG_EVERY_FRAMES, 42, 1);
         let frames = captured.read().unwrap();
         assert_eq!(frames.len(), 1, "one delivery on the boundary");
         let stats: FrameStats = aether_data::decode(&frames[0]).expect("decode FrameStats");


### PR DESCRIPTION
## Summary

Closes iamacoffeepot/aether#723. Chassis-source push paths and `InputCapability::fanout` now propagate `MailId` lineage so every tick / key / mouse / window-size event becomes visible to the `TraceObserverCapability`.

- Headless tick driver, desktop driver (tick + key/mouse/window-size + frame stats), and test-bench bin all mint chassis-root `MailId`s via `push_chassis_root_mail` instead of bare `Mailer::push`. Each driver owns its own `AtomicU64` correlation counter, symmetric with the per-actor counter on `NativeBinding`.
- `frame_loop::emit_frame_stats` grew a `correlation_id` parameter and routes through `push_chassis_root_mail` internally.
- New `NativeCtx::fanout<K>(recipients, payload)` helper: encodes `payload` once, then mints a fresh `MailId` per recipient with `parent_mail = ctx.in_flight_mail_id()` and `inherited_root = ctx.in_flight_root()`. Empty recipient set is a fast no-op.
- `InputCapability::fanout` reshaped to take `&mut NativeCtx<'_>` and route through `ctx.fanout(subs.iter().copied(), payload)`. The cap's stale `mailer: Arc<Mailer>` field retired alongside (it was only used by the old bare-push path).
- Bytes-level escape hatches were not added — recipients live behind a typed `K`, encoding stays inside the substrate, and the encode-once / push-many shape is preserved through the typed multicast helper instead of a bytes API.

## Test

New `tick_fanout_propagates_chassis_root_lineage` integration test in `test_bench::bench`: registers a closure-bound mailbox, subscribes it to ticks via `aether.input.subscribe`, advances one tick, asserts the captured `MailDispatch` carries non-default `root` + `parent_mail`. Pre-fix both were `MailId::NONE` (orphaned: chassis-source was bare push, AND the input-cap fanout was bare push).

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle test_bench::bench::tests::tick_fanout` — 1/1 pass
- [x] `cargo nextest run --workspace --no-fail-fast` — 1065/1065 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Wasm-guest send lineage (iamacoffeepot/aether#722) is the remaining producer-side gap; once that lands the full mail tree under a chassis tick will be observable end-to-end via `mcp__aether-hub__describe_tree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)