### PR TITLE
fix(data): give chassis a real tagged mailbox id

### DIFF
--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -152,18 +152,23 @@ impl MailboxId {
     /// real mailbox.
     pub const NONE: MailboxId = MailboxId(0);
 
-    /// ADR-0080 §5 chassis-as-sentinel mailbox id. Aliases
-    /// [`Self::NONE`] — the same reserved-zero id that "no origin"
-    /// already uses. Mail addressed to `CHASSIS_MAILBOX_ID` is
-    /// routed by `Mailer::route_mail` through a chassis-internal
-    /// switch ahead of the registry lookup; today that switch
-    /// handles `Settled { root }` and signals the gate-site
-    /// notification map.
+    /// ADR-0080 §5 chassis-as-mailbox id. Derived from the reserved
+    /// name `"aether.chassis"` so it carries normal `Tag::Mailbox` bits
+    /// and round-trips through the tagged-string wire form like every
+    /// other addressable mailbox (issue iamacoffeepot/aether#725).
+    /// Pre-issue-725 this aliased [`Self::NONE`] (= 0); the dual-use of
+    /// the zero sentinel for both "uninit/absent" and "chassis sender"
+    /// broke the JSON round-trip for chassis-rooted `MailId`s — the
+    /// zero id has reserved tag bits that don't encode.
     ///
-    /// The symbolic name documents the intent at the call site;
-    /// addressing chassis-internal mail by the bare `MailboxId::NONE`
-    /// would read as a bug.
-    pub const CHASSIS_MAILBOX_ID: MailboxId = Self::NONE;
+    /// Mail addressed to `CHASSIS_MAILBOX_ID` is short-circuited by
+    /// `Mailer::route_mail` through a chassis-internal switch ahead of
+    /// the registry lookup; today that switch handles `Settled { root }`
+    /// and signals the gate-site notification map. The chassis is
+    /// **not** registered as a real mailbox — `Registry::insert` rejects
+    /// any name that hashes to this id so the routing path stays
+    /// unambiguous.
+    pub const CHASSIS_MAILBOX_ID: MailboxId = mailbox_id_from_name("aether.chassis");
 
     /// Compute the deterministic id for a mailbox name. Same algorithm
     /// the guest SDK uses on the component side — ids round-trip
@@ -249,5 +254,46 @@ impl Serialize for HandleId {
 impl<'de> Deserialize<'de> for HandleId {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         deserialize_id(d, Tag::Handle).map(HandleId)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue iamacoffeepot/aether#725: CHASSIS_MAILBOX_ID is a real
+    /// `Tag::Mailbox`-tagged id derived from `mailbox_id_from_name(
+    /// "aether.chassis")`, distinct from the zero `NONE` sentinel.
+    /// Verifies the const isn't accidentally aliased back to NONE and
+    /// that it tag-encodes to the standard `mbx-XXXX-XXXX-XXXX` shape
+    /// — the serde human-readable branch routes through this same
+    /// `tagged_id::encode` path, so round-trip correctness on the JSON
+    /// wire follows from this test plus the existing serde tests.
+    #[test]
+    fn chassis_mailbox_id_is_tagged_and_distinct_from_none() {
+        assert_ne!(MailboxId::CHASSIS_MAILBOX_ID, MailboxId::NONE);
+        assert_ne!(MailboxId::CHASSIS_MAILBOX_ID.0, 0);
+        assert_eq!(
+            tagged_id::tag_of(MailboxId::CHASSIS_MAILBOX_ID.0),
+            Some(Tag::Mailbox),
+        );
+        let encoded = tagged_id::encode(MailboxId::CHASSIS_MAILBOX_ID.0)
+            .expect("CHASSIS_MAILBOX_ID must tag-encode");
+        assert!(encoded.starts_with("mbx-"), "expected tagged: {encoded}");
+        let decoded = tagged_id::decode_with_tag(&encoded, Tag::Mailbox)
+            .expect("CHASSIS_MAILBOX_ID must round-trip via decode_with_tag");
+        assert_eq!(decoded, MailboxId::CHASSIS_MAILBOX_ID.0);
+    }
+
+    /// `MailboxId::NONE` keeps its zero-sentinel meaning. Its tag bits
+    /// are reserved so `tagged_id::encode` returns `None` — the serde
+    /// `serialize_id` helper then falls back to `serialize_u64` and
+    /// the wire form is a raw `0`. This is the structural difference
+    /// between "no sender / uninit" and "chassis sender".
+    #[test]
+    fn none_remains_untagged_zero_sentinel() {
+        assert_eq!(MailboxId::NONE.0, 0);
+        assert_eq!(tagged_id::tag_of(MailboxId::NONE.0), None);
+        assert!(tagged_id::encode(MailboxId::NONE.0).is_none());
     }
 }

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -21,9 +21,11 @@ use crate::{EngineId, MailboxId, Schema, SessionToken};
 /// `correlation_id`. Exact-by-construction — no central minter to
 /// contend on, no hash to collide.
 ///
-/// `sender` is `MailboxId::NONE` for chassis-originated mail (the
-/// reserved sentinel for "no actor mailbox"). Per-actor mints use the
-/// owning actor's `MailboxId`.
+/// `sender` is [`MailboxId::CHASSIS_MAILBOX_ID`] for chassis-originated
+/// mail (the reserved name `"aether.chassis"`, issue iamacoffeepot/aether#725).
+/// Per-actor mints use the owning actor's `MailboxId`. The
+/// [`MailId::NONE`] sentinel below carries `MailboxId::NONE` instead —
+/// "no inbound mail" is structurally distinct from "chassis as sender".
 ///
 /// Serde-serializable so PR 2's `TraceEvent` (and its postcard-shaped
 /// `BatchedTraceEvents` envelope) can carry `MailId` over the in-

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -230,10 +230,16 @@ impl Registry {
     /// occupied entry is a collision.
     fn insert(&self, name: String, entry: MailboxEntry) -> Result<MailboxId, NameConflict> {
         let id = MailboxId::from_name(&name);
-        if id == MailboxId::NONE {
-            // Practically impossible at 64 bits, but the sentinel is
-            // reserved and silently shadowing it would break
-            // Option<MailboxId> semantics for the sender path.
+        if id == MailboxId::NONE || id == MailboxId::CHASSIS_MAILBOX_ID {
+            // Sentinel collisions are reserved: NONE shadows the
+            // "absent/uninit" id (Option<MailboxId> semantics break if
+            // a real mailbox claims it), and CHASSIS_MAILBOX_ID is the
+            // chassis-router short-circuit target — registering a real
+            // handler at that name would silently shadow chassis routing
+            // (issue iamacoffeepot/aether#725). Hash collision against
+            // either is practically impossible at 64 bits, but the
+            // CHASSIS check also blocks the obvious footgun: a caller
+            // literally registering "aether.chassis".
             return Err(NameConflict { name });
         }
         let mut inner = self.inner.write().unwrap();
@@ -806,6 +812,21 @@ mod tests {
         assert_eq!(r.lookup("loaded"), Some(first));
         // Entries count unchanged after the failed second attempt.
         assert_eq!(r.len(), 1);
+    }
+
+    /// Issue iamacoffeepot/aether#725: registering a real handler at the
+    /// reserved `"aether.chassis"` name would silently shadow the
+    /// chassis-router short-circuit in `Mailer::route_mail` (mail to
+    /// `CHASSIS_MAILBOX_ID` never reaches the registry). Reject at the
+    /// registration boundary so the routing path stays unambiguous.
+    #[test]
+    fn try_register_closure_rejects_reserved_chassis_name() {
+        let r = Registry::new();
+        let err = r
+            .try_register_closure("aether.chassis", noop_handler())
+            .expect_err("reserved name must reject");
+        assert_eq!(err.name, "aether.chassis");
+        assert_eq!(r.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes iamacoffeepot/aether#725. `CHASSIS_MAILBOX_ID` stops aliasing `MailboxId::NONE` and becomes `mailbox_id_from_name("aether.chassis")` — a normal `Tag::Mailbox`-tagged id that round-trips through the standard tagged-string JSON wire form (`mbx-XXXX-XXXX-XXXX`).

Pre-fix the chassis-rooted `MailId`s emitted by `mcp__aether-hub__list_active_roots` had `sender: 0`, which has reserved tag bits and falls back to a raw `u64` in JSON. `mcp__aether-hub__describe_tree`'s `MailIdWire.sender` expects a string, so the natural `list_active_roots → describe_tree` round-trip was broken specifically for chassis-rooted chains.

- `MailboxId::NONE = MailboxId(0)` — unchanged; remains the "no origin / uninit" reserved zero sentinel.
- `MailboxId::CHASSIS_MAILBOX_ID = mailbox_id_from_name("aether.chassis")` — new value, real tag bits.
- `MailId::NONE.sender` stays `MailboxId::NONE` (it's the structural "no inbound mail" sentinel — distinct from "chassis sender").
- `Registry::insert` grew a parallel rejection arm for names hashing to `CHASSIS_MAILBOX_ID`. The obvious footgun: a literal `"aether.chassis"` registration would silently shadow the `Mailer::route_mail` short-circuit (real mail to that id never reaches the registry — the chassis-router decodes `Settled { root }` ahead of the lookup).

Three new tests:
- `chassis_mailbox_id_is_tagged_and_distinct_from_none` (aether-data)
- `none_remains_untagged_zero_sentinel` (aether-data)
- `try_register_closure_rejects_reserved_chassis_name` (aether-substrate)

## Test plan

- [x] `cargo nextest run -p aether-data` — 44/44 pass
- [x] `cargo nextest run -p aether-substrate registry::tests` — 30/30 pass
- [x] `cargo nextest run --workspace --no-fail-fast` — 1067/1067 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Smoke verification (after merge)

```
list_active_roots(engine_id) → roots[0].root.sender = "mbx-XXXX-XXXX-XXXX"
describe_tree(engine_id, root: roots[0].root) → Ok { ... }
```

Refs: ADR-0080, iamacoffeepot/aether#723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)