### PR TITLE
feat(hub): add dump_trace_chrome mcp tool

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -31,6 +31,7 @@ use crate::hub::registry::EngineRegistry;
 use crate::hub::session::{QueuedMail, SessionHandle, SessionRegistry};
 
 pub(crate) mod args;
+mod chrome;
 mod codecs;
 mod tools;
 
@@ -828,6 +829,163 @@ mod tests {
             format!("{err:?}").to_lowercase().contains("root.sender"),
             "{err:?}"
         );
+    }
+
+    /// Issue 728: dump_trace_chrome calls the same describe_tree path
+    /// the existing tool uses, then re-shapes the reply as chrome
+    /// trace JSON. The output_path branch writes to disk and returns
+    /// `{"path": ...}`; the inline branch returns the JSON.
+    #[tokio::test]
+    async fn dump_trace_chrome_writes_file_when_path_set() {
+        use aether_data::tagged_id::{self, Tag};
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_tree_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd728, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        let sender_raw = with_tag(Tag::Mailbox, 0xCAFE);
+        let root = MailId {
+            sender: MailboxId(sender_raw),
+            correlation_id: 1,
+        };
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeTreeResult::Ok {
+                root,
+                in_flight: 0,
+                mails: vec![MailNodeWire {
+                    mail_id: root,
+                    parent: None,
+                    sender: root.sender,
+                    recipient: MailboxId(with_tag(Tag::Mailbox, 0xBEEF)),
+                    kind: aether_data::KindId(with_tag(Tag::Kind, 0xDEAD)),
+                    t_sent: aether_kinds::trace::Nanos(1_000),
+                    t_received: Some(aether_kinds::trace::Nanos(2_000)),
+                    t_finished: Some(aether_kinds::trace::Nanos(5_000)),
+                }],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_tree_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let tmp =
+            std::env::temp_dir().join(format!("aether-trace-728-{}.json", std::process::id()));
+        let response = hub
+            .dump_trace_chrome(Parameters(args::DumpTraceChromeArgs {
+                engine_id: id.0.to_string(),
+                root: args::MailIdWire {
+                    sender: tagged_id::encode(sender_raw).unwrap(),
+                    correlation_id: 1,
+                },
+                output_path: Some(tmp.to_string_lossy().into_owned()),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+        substrate_task.await.expect("stub substrate task");
+
+        let parsed: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["path"].as_str().unwrap(), tmp.to_string_lossy());
+
+        let written = std::fs::read_to_string(&tmp).expect("trace file written");
+        let trace: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let events = trace["traceEvents"].as_array().unwrap();
+        assert_eq!(events.len(), 1, "one mail -> one X event");
+        assert_eq!(events[0]["ph"], "X");
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Inline branch: when `output_path` is omitted, the chrome JSON
+    /// flows back as the tool result.
+    #[tokio::test]
+    async fn dump_trace_chrome_returns_inline_when_path_unset() {
+        use aether_data::tagged_id::{self, Tag};
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_tree_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd729, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        let sender_raw = with_tag(Tag::Mailbox, 0xCAFE);
+        let root = MailId {
+            sender: MailboxId(sender_raw),
+            correlation_id: 1,
+        };
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeTreeResult::Ok {
+                root,
+                in_flight: 0,
+                mails: vec![MailNodeWire {
+                    mail_id: root,
+                    parent: None,
+                    sender: root.sender,
+                    recipient: MailboxId(with_tag(Tag::Mailbox, 0xBEEF)),
+                    kind: aether_data::KindId(with_tag(Tag::Kind, 0xDEAD)),
+                    t_sent: aether_kinds::trace::Nanos(1_000),
+                    t_received: Some(aether_kinds::trace::Nanos(2_000)),
+                    t_finished: Some(aether_kinds::trace::Nanos(5_000)),
+                }],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_tree_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let _ = record.replies.try_deliver(&kind, queued);
+        });
+
+        let response = hub
+            .dump_trace_chrome(Parameters(args::DumpTraceChromeArgs {
+                engine_id: id.0.to_string(),
+                root: args::MailIdWire {
+                    sender: tagged_id::encode(sender_raw).unwrap(),
+                    correlation_id: 1,
+                },
+                output_path: None,
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+        substrate_task.await.expect("stub substrate task");
+
+        let trace: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let events = trace["traceEvents"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["ph"], "X");
     }
 
     #[tokio::test]

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -495,6 +495,28 @@ pub struct ListActiveRootsArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct DumpTraceChromeArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Root mail id whose subtree should be exported. Same shape as
+    /// `describe_tree`'s `root` argument — a `MailNodeWire.root` from
+    /// a prior `describe_tree` reply or a `RootSummaryWire.root` from
+    /// `list_active_roots`.
+    pub root: MailIdWire,
+    /// Optional filesystem path to write the chrome trace JSON to.
+    /// Parent directories are created as needed. When omitted, the
+    /// JSON is returned inline as the tool result (fine for small
+    /// subtrees; for busy substrates that generate thousands of
+    /// events the inline path may overflow the agent's context).
+    #[serde(default)]
+    pub output_path: Option<String>,
+    /// Maximum time to wait for the substrate's `DescribeTreeResult`
+    /// reply, in milliseconds. Defaults to 5000. Clamped to 30000.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DescribeTreeArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,

--- a/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
@@ -1,0 +1,296 @@
+//! Chrome trace event format (a.k.a. "trace event format" / "Catapult")
+//! converter for the substrate's `TraceObserverCapability` state. Issue
+//! iamacoffeepot/aether#728 / ADR-0080 Phase 3.
+//!
+//! Pure function over [`aether_kinds::trace::DescribeTreeResult`] +
+//! a kind-id → name lookup. The MCP `dump_trace_chrome` tool builds
+//! the lookup from the engine's handshake descriptor list, calls
+//! [`render_chrome_trace`], and either returns the JSON inline or
+//! writes it to disk.
+//!
+//! Output format reference:
+//! <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>
+//!
+//! Per mail with `t_received` and `t_finished` populated, one
+//! `ph:"X"` (complete) event covering the receive→finish interval on
+//! the recipient's lane. Per mail with a parent (and where both
+//! `parent.t_finished` and `self.t_received` are set), one
+//! `ph:"s"` / `ph:"f"` flow pair so chrome://tracing draws a causal
+//! arrow. Mails missing timestamps (orphan or in-flight at query
+//! time) are skipped — they remain inspectable via `describe_tree`.
+
+use std::collections::HashMap;
+
+use aether_data::MailId;
+use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
+use serde_json::{Value, json};
+
+/// Render a `DescribeTreeResult` into Chrome trace event format JSON.
+/// Returns the serialized document as a `String`.
+///
+/// `kind_names` maps the raw `KindId` u64 → human-readable kind name
+/// for the chrome event `name` field. Missing entries fall back to
+/// the tagged-string id (`knd-XXXX-XXXX-XXXX`).
+pub(super) fn render_chrome_trace(
+    result: &DescribeTreeResult,
+    kind_names: &HashMap<u64, String>,
+) -> Result<String, serde_json::Error> {
+    let events = build_events(result, kind_names);
+    serde_json::to_string_pretty(&json!({ "traceEvents": events }))
+}
+
+fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) -> Vec<Value> {
+    let mails = match result {
+        DescribeTreeResult::Ok { mails, .. } => mails,
+        DescribeTreeResult::Err { not_found } => {
+            // Empty trace doc with a metadata event explaining the
+            // missing root — chrome://tracing surfaces metadata
+            // events as a top-level note so the agent sees why the
+            // file is empty.
+            return vec![json!({
+                "ph": "M",
+                "name": "process_name",
+                "cat": "metadata",
+                "pid": format_mail_id(*not_found),
+                "args": {
+                    "name": format!("describe_tree returned not_found for {}", format_mail_id(*not_found))
+                },
+            })];
+        }
+    };
+
+    // Index for parent-edge lookup.
+    let by_id: HashMap<MailId, &MailNodeWire> = mails.iter().map(|n| (n.mail_id, n)).collect();
+
+    let mut events: Vec<Value> = Vec::with_capacity(mails.len() * 2);
+    for node in mails {
+        // Skip mails missing timestamps (orphan Sent or in-flight at
+        // query time). They stay inspectable via `describe_tree`.
+        let (Some(t_received), Some(t_finished)) = (node.t_received, node.t_finished) else {
+            continue;
+        };
+        let kind_name = kind_names
+            .get(&node.kind.0)
+            .cloned()
+            .unwrap_or_else(|| node.kind.to_string());
+        events.push(json!({
+            "ph": "X",
+            "name": kind_name,
+            "cat": "mail",
+            "ts": ns_to_us(t_received.0),
+            "dur": ns_to_us(t_finished.0.saturating_sub(t_received.0)),
+            "pid": node.recipient.to_string(),
+            "tid": 0,
+            "args": {
+                "mail_id": format_mail_id(node.mail_id),
+                "sender": node.sender.to_string(),
+                "parent": node.parent.map(format_mail_id),
+                "root": format_mail_id(root_of(node, &by_id)),
+                "kind_id": node.kind.to_string(),
+            },
+        }));
+
+        // Flow arrow: requires the parent's t_finished and this
+        // node's t_received. The flow id ties the start ("s") and
+        // finish ("f") events into one arrow on chrome://tracing.
+        if let Some(parent_id) = node.parent
+            && let Some(parent) = by_id.get(&parent_id)
+            && let Some(parent_finished) = parent.t_finished
+        {
+            let flow_id = format_mail_id(node.mail_id);
+            events.push(json!({
+                "ph": "s",
+                "name": "flow",
+                "cat": "flow",
+                "id": flow_id.clone(),
+                "ts": ns_to_us(parent_finished.0),
+                "pid": parent.recipient.to_string(),
+                "tid": 0,
+            }));
+            events.push(json!({
+                "ph": "f",
+                "name": "flow",
+                "cat": "flow",
+                "id": flow_id,
+                "ts": ns_to_us(t_received.0),
+                "pid": node.recipient.to_string(),
+                "tid": 0,
+                "bp": "e",
+            }));
+        }
+    }
+    events
+}
+
+/// MailId composite → compact string for chrome event `id` and `args`
+/// fields. Format: `<sender_tagged_id>:<correlation_id>` (e.g.
+/// `mbx-XXXX-XXXX-XXXX:42`). Stable enough to round-trip and
+/// human-readable enough to spot-check in chrome://tracing.
+fn format_mail_id(id: MailId) -> String {
+    format!("{}:{}", id.sender, id.correlation_id)
+}
+
+/// Convert a nanosecond value to microseconds for chrome's
+/// `ts`/`dur` fields (chrome's standard time unit).
+fn ns_to_us(nanos: u64) -> u64 {
+    nanos / 1_000
+}
+
+/// Walk the parent chain to find the root mail. Falls back to the
+/// node's own `mail_id` if the parent reference is broken (parent
+/// not in the result set — possible if eviction trimmed an
+/// ancestor).
+fn root_of(node: &MailNodeWire, by_id: &HashMap<MailId, &MailNodeWire>) -> MailId {
+    let mut current = node;
+    while let Some(parent_id) = current.parent {
+        match by_id.get(&parent_id) {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+    current.mail_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::tagged_id::Tag;
+    use aether_data::{KindId, MailboxId, with_tag};
+    use aether_kinds::trace::Nanos;
+
+    fn mid(sender_body: u64, cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, sender_body)),
+            correlation_id: cid,
+        }
+    }
+
+    /// Issue 728: the converter emits one complete event per mail
+    /// with both timestamps populated, plus one flow pair per
+    /// parent edge.
+    #[test]
+    fn render_emits_complete_and_flow_events() {
+        let root_id = mid(0xAA, 1);
+        let child_id = mid(0xBB, 2);
+        let result = DescribeTreeResult::Ok {
+            root: root_id,
+            in_flight: 0,
+            mails: vec![
+                MailNodeWire {
+                    mail_id: root_id,
+                    parent: None,
+                    sender: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+                    recipient: MailboxId(with_tag(Tag::Mailbox, 0xCC)),
+                    kind: KindId(with_tag(Tag::Kind, 0xDEAD)),
+                    t_sent: Nanos(1_000),
+                    t_received: Some(Nanos(2_000)),
+                    t_finished: Some(Nanos(5_000)),
+                },
+                MailNodeWire {
+                    mail_id: child_id,
+                    parent: Some(root_id),
+                    sender: MailboxId(with_tag(Tag::Mailbox, 0xCC)),
+                    recipient: MailboxId(with_tag(Tag::Mailbox, 0xEE)),
+                    kind: KindId(with_tag(Tag::Kind, 0xBEEF)),
+                    t_sent: Nanos(3_000),
+                    t_received: Some(Nanos(6_000)),
+                    t_finished: Some(Nanos(9_000)),
+                },
+            ],
+        };
+
+        let mut kind_names = HashMap::new();
+        kind_names.insert(with_tag(Tag::Kind, 0xDEAD), "test.tick".to_owned());
+
+        let json = render_chrome_trace(&result, &kind_names).expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let events = parsed["traceEvents"].as_array().unwrap();
+        // Two complete events + two flow events (s + f for the one
+        // parent edge) = 4 total.
+        assert_eq!(events.len(), 4, "got: {events:#?}");
+
+        let phs: Vec<&str> = events.iter().map(|e| e["ph"].as_str().unwrap()).collect();
+        assert_eq!(phs.iter().filter(|p| **p == "X").count(), 2);
+        assert_eq!(phs.iter().filter(|p| **p == "s").count(), 1);
+        assert_eq!(phs.iter().filter(|p| **p == "f").count(), 1);
+
+        // Root event uses the kind name from the lookup; child falls
+        // back to the tagged kind id (not in the lookup).
+        let names: Vec<&str> = events
+            .iter()
+            .filter(|e| e["ph"] == "X")
+            .map(|e| e["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"test.tick"), "names: {names:?}");
+        assert!(
+            names.iter().any(|n| n.starts_with("knd-")),
+            "child should fall back to tagged kind id: {names:?}"
+        );
+
+        // Microsecond conversion: t_received=2000ns → ts=2us,
+        // dur=(5000-2000)/1000 = 3us.
+        let root_complete = events
+            .iter()
+            .find(|e| e["ph"] == "X" && e["name"] == "test.tick")
+            .unwrap();
+        assert_eq!(root_complete["ts"], 2);
+        assert_eq!(root_complete["dur"], 3);
+
+        // Flow pair: child mail_id ties the s/f arrow.
+        let child_mail_str = format_mail_id(child_id);
+        let s = events.iter().find(|e| e["ph"] == "s").unwrap();
+        let f = events.iter().find(|e| e["ph"] == "f").unwrap();
+        assert_eq!(s["id"], child_mail_str);
+        assert_eq!(f["id"], child_mail_str);
+        // s anchors at parent.t_finished (5000ns -> 5us), f at
+        // child.t_received (6000ns -> 6us).
+        assert_eq!(s["ts"], 5);
+        assert_eq!(f["ts"], 6);
+    }
+
+    /// Mails without `t_received` / `t_finished` are skipped (no
+    /// complete event, no flow). They remain inspectable via
+    /// `describe_tree` for in-flight diagnostics.
+    #[test]
+    fn render_skips_mails_missing_timestamps() {
+        let result = DescribeTreeResult::Ok {
+            root: mid(0xAA, 1),
+            in_flight: 1,
+            mails: vec![MailNodeWire {
+                mail_id: mid(0xAA, 1),
+                parent: None,
+                sender: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+                recipient: MailboxId(with_tag(Tag::Mailbox, 0xCC)),
+                kind: KindId(with_tag(Tag::Kind, 0xDEAD)),
+                t_sent: Nanos(1_000),
+                t_received: None,
+                t_finished: None,
+            }],
+        };
+        let json = render_chrome_trace(&result, &HashMap::new()).expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            parsed["traceEvents"].as_array().unwrap().is_empty(),
+            "in-flight mail must not produce events"
+        );
+    }
+
+    /// `Err::not_found` produces a trace doc with a single metadata
+    /// event noting the missing root, so chrome://tracing displays
+    /// the diagnostic instead of a blank file.
+    #[test]
+    fn render_not_found_emits_metadata_doc() {
+        let missing = mid(0xFF, 99);
+        let result = DescribeTreeResult::Err { not_found: missing };
+        let json = render_chrome_trace(&result, &HashMap::new()).expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let events = parsed["traceEvents"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["ph"], "M");
+        let arg_name = events[0]["args"]["name"].as_str().unwrap();
+        assert!(
+            arg_name.contains("not_found"),
+            "metadata should mention not_found: {arg_name}"
+        );
+    }
+}

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -38,12 +38,13 @@ use crate::hub::session::SessionHandle;
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
-    DescribeKindsArgs, DescribeTreeArgs, EngineInfo, EngineLogEntry, EngineLogsArgs,
-    EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs, LoadComponentResponse,
-    LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs,
-    ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult,
-    TerminateSubstrateArgs, log_level_to_str,
+    DescribeKindsArgs, DescribeTreeArgs, DumpTraceChromeArgs, EngineInfo, EngineLogEntry,
+    EngineLogsArgs, EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs,
+    LoadComponentResponse, LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail,
+    ReplaceComponentArgs, ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs,
+    TerminateResult, TerminateSubstrateArgs, log_level_to_str,
 };
+use super::chrome::render_chrome_trace;
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
 use super::{Hub, HubState};
 use crate::hub::registry::ComponentRecord;
@@ -869,12 +870,90 @@ impl Hub {
     }
 
     #[tool(
+        description = "Export the mail subtree under one root as a Chrome trace event format JSON file (issue iamacoffeepot/aether#728, ADR-0080 Phase 3). Calls the same `describe_tree` substrate path under the hood, then re-shapes each mail into a chrome `ph:\"X\"` (complete) event covering its `t_received → t_finished` interval on the recipient's lane, plus `ph:\"s\"`/`ph:\"f\"` (flow) arrows linking parent.t_finished → child.t_received for causal visualization. Mails without `t_received`/`t_finished` (orphan or in-flight at query time) are skipped. Drop the output JSON into chrome://tracing or perfetto.dev for a flame graph + causal arrows view. When `output_path` is omitted, returns the JSON inline (fine for small subtrees, may overflow agent context for busy substrates). When `output_path` is set, writes to the path (creating parent dirs) and returns a `{path}` confirmation. Default timeout 5000ms; clamped to 30000."
+    )]
+    pub(super) async fn dump_trace_chrome(
+        &self,
+        Parameters(args): Parameters<DumpTraceChromeArgs>,
+    ) -> Result<String, McpError> {
+        // Build kind-id → name lookup from the engine's handshake-time
+        // descriptor list. Each chrome event's `name` field uses the
+        // human-readable kind name; missing entries fall back to the
+        // tagged-string kind id.
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let kind_names: std::collections::HashMap<u64, String> = match self.state.engines.get(&id) {
+            Some(record) => record
+                .kinds
+                .iter()
+                .map(|k| {
+                    let kid = aether_data::canonical::kind_id_from_parts(&k.name, &k.schema);
+                    (kid, k.name.clone())
+                })
+                .collect(),
+            None => {
+                return Err(McpError::invalid_params(
+                    format!("unknown engine_id {}", args.engine_id),
+                    None,
+                ));
+            }
+        };
+
+        let describe_args = DescribeTreeArgs {
+            engine_id: args.engine_id.clone(),
+            root: args.root,
+            timeout_ms: args.timeout_ms,
+        };
+        let result = self.do_describe_tree(describe_args).await?;
+        let chrome_json = render_chrome_trace(&result, &kind_names)
+            .map_err(|e| McpError::internal_error(format!("render chrome trace: {e}"), None))?;
+
+        match args.output_path {
+            Some(path) => {
+                if let Some(parent) = std::path::Path::new(&path).parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                        McpError::internal_error(
+                            format!("create parent dirs for {path}: {e}"),
+                            None,
+                        )
+                    })?;
+                }
+                tokio::fs::write(&path, &chrome_json).await.map_err(|e| {
+                    McpError::internal_error(format!("write trace to {path}: {e}"), None)
+                })?;
+                Ok(serde_json::json!({ "path": path }).to_string())
+            }
+            None => Ok(chrome_json),
+        }
+    }
+
+    #[tool(
         description = "Describe the mail tree under one root (issue 718, ADR-0080 Phase 2). The substrate's `aether.trace` observer accumulates a parent → child mail graph keyed by `MailId`; this tool surfaces one root's subtree as JSON: every node's `mail_id`, `parent`, `sender`, `recipient`, `kind`, and `t_sent` / `t_received` / `t_finished` timestamps in nanoseconds-since-substrate-boot, plus the root's current `in_flight` count. `root` is a JSON object `{ sender: \"mbx-XXXX-XXXX-XXXX\", correlation_id: <number> }` — copy a `MailNodeWire.root` from a prior `describe_tree` reply or a `RootSummaryWire.root` from `list_active_roots`. Returns `Err::not_found` (echoing the requested root) when the root has been evicted past retention or never existed. Default timeout 5000ms; clamped to 30000."
     )]
     pub(super) async fn describe_tree(
         &self,
         Parameters(args): Parameters<DescribeTreeArgs>,
     ) -> Result<String, McpError> {
+        let result = self.do_describe_tree(args).await?;
+        // The cap's reply is already MailId/MailboxId/KindId/Nanos —
+        // their human-readable serde branches emit tagged strings for
+        // ids and a u64 for `Nanos`, so JSON serialization is a single
+        // shot with no manual conversion.
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    /// Shared describe_tree core. The public `describe_tree` tool wraps
+    /// this with JSON serialization; `dump_trace_chrome` reuses it to
+    /// fetch the same observer state and re-shape it as chrome trace
+    /// events (issue iamacoffeepot/aether#728).
+    async fn do_describe_tree(
+        &self,
+        args: DescribeTreeArgs,
+    ) -> Result<DescribeTreeResult, McpError> {
         let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
             McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
         })?;
@@ -944,13 +1023,8 @@ impl Hub {
             }
         };
 
-        let result: DescribeTreeResult = postcard::from_bytes(&queued.payload)
-            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))?;
-        // The cap's reply is already MailId/MailboxId/KindId/Nanos —
-        // their human-readable serde branches emit tagged strings for
-        // ids and a u64 for `Nanos`, so JSON serialization is a single
-        // shot with no manual conversion.
-        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+        postcard::from_bytes(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))
     }
 
     #[tool(


### PR DESCRIPTION
## Summary

Closes iamacoffeepot/aether#728. Phase 3 of ADR-0080. Hub-side converter that fetches the same `DescribeTreeResult` `describe_tree` returns, then re-shapes each mail as chrome trace event format JSON for chrome://tracing or perfetto.dev.

- New MCP tool `mcp__aether-hub__dump_trace_chrome(engine_id, root, output_path?, timeout_ms?)`. Calls a refactored `do_describe_tree` helper internally (no new substrate surface, no wire change).
- Per mail with both `t_received` and `t_finished` populated: one `ph:"X"` (complete) event covering the receive→finish interval on the recipient's lane (microseconds, chrome's standard unit). Skipped for orphan/in-flight mails — they stay inspectable via `describe_tree`.
- Per mail with a parent (and where both `parent.t_finished` and `self.t_received` are set): one `ph:"s"`/`ph:"f"` flow pair so chrome://tracing draws a causal arrow from parent.finish → child.receive. `bp:"e"` snaps the arrow head to the enclosing X event.
- `output_path` set: writes JSON to disk (creating parent dirs) and returns `{path}`. Omitted: returns JSON inline (fine for small subtrees; a busy substrate may overflow agent context).
- `Err::not_found` produces a doc with a single metadata event so the agent sees why the file is empty.

Pure-function `render_chrome_trace` lives in a new `mcp/chrome.rs` module so tests can exercise the conversion without standing up the MCP boundary. Three converter unit tests cover complete + flow events, in-flight skip, and the not_found doc; two integration tests cover the inline and file-write branches.

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle chrome::` — 3/3 pass
- [x] `cargo nextest run -p aether-substrate-bundle dump_trace` — 2/2 pass
- [x] `cargo nextest run --workspace --no-fail-fast` — 1075/1075 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Smoke verification (after merge)

Spawn a headless substrate, load aether-camera, subscribe to ticks, advance a few seconds, then:
```
list_active_roots(engine_id)                       # pick a recent root
dump_trace_chrome(engine_id, root, "/tmp/t.json")  # writes file
```
Open `/tmp/t.json` in chrome://tracing — should show one lane per recipient mailbox (chassis → aether.input → camera trampoline → aether.render), with arrows linking parent finish to child receive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)