### PR TITLE
feat(trace): resolve mailbox + kind names with type prefixes in trace output

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -913,8 +913,7 @@ mod tests {
         // Filter out the auto-prepended `process_name` metadata
         // events (issue 731 follow-up to silence Perfetto's hashed-pid
         // display) so the assertion stays focused on the slice shape.
-        let slices: Vec<&serde_json::Value> =
-            events.iter().filter(|e| e["ph"] != "M").collect();
+        let slices: Vec<&serde_json::Value> = events.iter().filter(|e| e["ph"] != "M").collect();
         assert_eq!(slices.len(), 1, "one mail -> one X event");
         assert_eq!(slices[0]["ph"], "X");
 
@@ -990,8 +989,7 @@ mod tests {
 
         let trace: serde_json::Value = serde_json::from_str(&response).unwrap();
         let events = trace["traceEvents"].as_array().unwrap();
-        let slices: Vec<&serde_json::Value> =
-            events.iter().filter(|e| e["ph"] != "M").collect();
+        let slices: Vec<&serde_json::Value> = events.iter().filter(|e| e["ph"] != "M").collect();
         assert_eq!(slices.len(), 1);
         assert_eq!(slices[0]["ph"], "X");
     }

--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -910,8 +910,13 @@ mod tests {
         let written = std::fs::read_to_string(&tmp).expect("trace file written");
         let trace: serde_json::Value = serde_json::from_str(&written).unwrap();
         let events = trace["traceEvents"].as_array().unwrap();
-        assert_eq!(events.len(), 1, "one mail -> one X event");
-        assert_eq!(events[0]["ph"], "X");
+        // Filter out the auto-prepended `process_name` metadata
+        // events (issue 731 follow-up to silence Perfetto's hashed-pid
+        // display) so the assertion stays focused on the slice shape.
+        let slices: Vec<&serde_json::Value> =
+            events.iter().filter(|e| e["ph"] != "M").collect();
+        assert_eq!(slices.len(), 1, "one mail -> one X event");
+        assert_eq!(slices[0]["ph"], "X");
 
         std::fs::remove_file(&tmp).ok();
     }
@@ -985,8 +990,10 @@ mod tests {
 
         let trace: serde_json::Value = serde_json::from_str(&response).unwrap();
         let events = trace["traceEvents"].as_array().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0]["ph"], "X");
+        let slices: Vec<&serde_json::Value> =
+            events.iter().filter(|e| e["ph"] != "M").collect();
+        assert_eq!(slices.len(), 1);
+        assert_eq!(slices[0]["ph"], "X");
     }
 
     #[tokio::test]

--- a/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
@@ -3,10 +3,11 @@
 //! iamacoffeepot/aether#728 / ADR-0080 Phase 3.
 //!
 //! Pure function over [`aether_kinds::trace::DescribeTreeResult`] +
-//! a kind-id → name lookup. The MCP `dump_trace_chrome` tool builds
-//! the lookup from the engine's handshake descriptor list, calls
-//! [`render_chrome_trace`], and either returns the JSON inline or
-//! writes it to disk.
+//! a kind-id → name lookup + a mailbox-id → (name, category) lookup
+//! (issue iamacoffeepot/aether#731). The MCP `dump_trace_chrome` tool
+//! builds both lookups from the engine record's `kinds` + `mailboxes`
+//! caches, calls [`render_chrome_trace`], and either returns the JSON
+//! inline or writes it to disk.
 //!
 //! Output format reference:
 //! <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>
@@ -21,25 +22,57 @@
 
 use std::collections::HashMap;
 
-use aether_data::MailId;
+use aether_data::{MailId, MailboxCategory, MailboxId};
 use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
 use serde_json::{Value, json};
+
+/// Per-engine mailbox lookup the chrome renderer uses to swap raw
+/// tagged ids for category-prefixed names (issue
+/// iamacoffeepot/aether#731). Keyed on the raw `MailboxId` u64 so
+/// the call site can pre-strip the tag once instead of per-event.
+/// `None` category means "we know the name but the substrate didn't
+/// classify it" — render the bare name without a prefix so the
+/// failure mode stays visible.
+pub(super) type MailboxLookup = HashMap<u64, (String, Option<MailboxCategory>)>;
 
 /// Render a `DescribeTreeResult` into Chrome trace event format JSON.
 /// Returns the serialized document as a `String`.
 ///
 /// `kind_names` maps the raw `KindId` u64 → human-readable kind name
-/// for the chrome event `name` field. Missing entries fall back to
-/// the tagged-string id (`knd-XXXX-XXXX-XXXX`).
+/// for the chrome event `name` field. Resolved entries render as
+/// `kind:NAME`; missing entries fall back to the tagged-string id
+/// (`knd-XXXX-XXXX-XXXX`) with no prefix so unresolved ids are
+/// visually distinct from resolved-but-empty.
+///
+/// `mailbox_names` (issue iamacoffeepot/aether#731) does the same for
+/// `MailboxId` fields (`pid`, `args.sender`, `args.parent`,
+/// `args.root`). Resolved entries render as `<prefix>:<name>` per the
+/// `MailboxCategory` table:
+///
+/// | Category          | Prefix      |
+/// |-------------------|-------------|
+/// | `Actor`           | `actor:`    |
+/// | `Trampoline`      | `actor:`    |
+/// | `BroadcastSink`   | `sink:`     |
+/// | `ChassisSentinel` | `chassis:`  |
+/// | (None)            | (no prefix) |
+///
+/// Unknown ids fall back to the raw `mbx-XXXX-XXXX-XXXX` tagged form
+/// so the unresolved case stays visible.
 pub(super) fn render_chrome_trace(
     result: &DescribeTreeResult,
     kind_names: &HashMap<u64, String>,
+    mailbox_names: &MailboxLookup,
 ) -> Result<String, serde_json::Error> {
-    let events = build_events(result, kind_names);
+    let events = build_events(result, kind_names, mailbox_names);
     serde_json::to_string_pretty(&json!({ "traceEvents": events }))
 }
 
-fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) -> Vec<Value> {
+fn build_events(
+    result: &DescribeTreeResult,
+    kind_names: &HashMap<u64, String>,
+    mailbox_names: &MailboxLookup,
+) -> Vec<Value> {
     let mails = match result {
         DescribeTreeResult::Ok { mails, .. } => mails,
         DescribeTreeResult::Err { not_found } => {
@@ -47,13 +80,14 @@ fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) 
             // missing root — chrome://tracing surfaces metadata
             // events as a top-level note so the agent sees why the
             // file is empty.
+            let label = format_mail_id(*not_found, mailbox_names);
             return vec![json!({
                 "ph": "M",
                 "name": "process_name",
                 "cat": "metadata",
-                "pid": format_mail_id(*not_found),
+                "pid": label,
                 "args": {
-                    "name": format!("describe_tree returned not_found for {}", format_mail_id(*not_found))
+                    "name": format!("describe_tree returned not_found for {label}")
                 },
             })];
         }
@@ -69,24 +103,20 @@ fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) 
         let (Some(t_received), Some(t_finished)) = (node.t_received, node.t_finished) else {
             continue;
         };
-        let kind_name = kind_names
-            .get(&node.kind.0)
-            .cloned()
-            .unwrap_or_else(|| node.kind.to_string());
         events.push(json!({
             "ph": "X",
-            "name": kind_name,
+            "name": format_kind_label(node.kind.0, kind_names),
             "cat": "mail",
             "ts": ns_to_us(t_received.0),
             "dur": ns_to_us(t_finished.0.saturating_sub(t_received.0)),
-            "pid": node.recipient.to_string(),
+            "pid": format_mailbox_label(node.recipient, mailbox_names),
             "tid": 0,
             "args": {
-                "mail_id": format_mail_id(node.mail_id),
-                "sender": node.sender.to_string(),
-                "parent": node.parent.map(format_mail_id),
-                "root": format_mail_id(root_of(node, &by_id)),
-                "kind_id": node.kind.to_string(),
+                "mail_id": format_mail_id(node.mail_id, mailbox_names),
+                "sender": format_mailbox_label(node.sender, mailbox_names),
+                "parent": node.parent.map(|p| format_mail_id(p, mailbox_names)),
+                "root": format_mail_id(root_of(node, &by_id), mailbox_names),
+                "kind_id": format_kind_label(node.kind.0, kind_names),
             },
         }));
 
@@ -97,14 +127,14 @@ fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) 
             && let Some(parent) = by_id.get(&parent_id)
             && let Some(parent_finished) = parent.t_finished
         {
-            let flow_id = format_mail_id(node.mail_id);
+            let flow_id = format_mail_id(node.mail_id, mailbox_names);
             events.push(json!({
                 "ph": "s",
                 "name": "flow",
                 "cat": "flow",
                 "id": flow_id.clone(),
                 "ts": ns_to_us(parent_finished.0),
-                "pid": parent.recipient.to_string(),
+                "pid": format_mailbox_label(parent.recipient, mailbox_names),
                 "tid": 0,
             }));
             events.push(json!({
@@ -113,7 +143,7 @@ fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) 
                 "cat": "flow",
                 "id": flow_id,
                 "ts": ns_to_us(t_received.0),
-                "pid": node.recipient.to_string(),
+                "pid": format_mailbox_label(node.recipient, mailbox_names),
                 "tid": 0,
                 "bp": "e",
             }));
@@ -122,12 +152,51 @@ fn build_events(result: &DescribeTreeResult, kind_names: &HashMap<u64, String>) 
     events
 }
 
+/// Render a `MailboxId` as `<prefix>:<name>` when the lookup resolves
+/// the id, or as the raw tagged `mbx-XXXX-XXXX-XXXX` form when it
+/// doesn't. Issue iamacoffeepot/aether#731 — keeping the unresolved
+/// case visually distinct from resolved-with-no-prefix lets agents
+/// spot inventory drift at a glance.
+fn format_mailbox_label(id: MailboxId, lookup: &MailboxLookup) -> String {
+    match lookup.get(&id.0) {
+        Some((name, Some(category))) => format!("{}:{}", category_prefix(*category), name),
+        Some((name, None)) => name.clone(),
+        None => id.to_string(),
+    }
+}
+
+/// Mirror of [`format_mailbox_label`] for `KindId` u64 values. Kinds
+/// only have one category, so the prefix is uniformly `kind:`.
+fn format_kind_label(kind_id: u64, kind_names: &HashMap<u64, String>) -> String {
+    match kind_names.get(&kind_id) {
+        Some(name) => format!("kind:{name}"),
+        None => aether_data::KindId(kind_id).to_string(),
+    }
+}
+
+fn category_prefix(c: MailboxCategory) -> &'static str {
+    // Trampoline folds under `actor:` per the issue 731 spec — agents
+    // think of trampolines as just another actor; if they ever need
+    // the distinction the variant survives in the wire and a future
+    // PR can split this into `trampoline:` without churning callers.
+    match c {
+        MailboxCategory::Actor | MailboxCategory::Trampoline => "actor",
+        MailboxCategory::BroadcastSink => "sink",
+        MailboxCategory::ChassisSentinel => "chassis",
+    }
+}
+
 /// MailId composite → compact string for chrome event `id` and `args`
-/// fields. Format: `<sender_tagged_id>:<correlation_id>` (e.g.
-/// `mbx-XXXX-XXXX-XXXX:42`). Stable enough to round-trip and
-/// human-readable enough to spot-check in chrome://tracing.
-fn format_mail_id(id: MailId) -> String {
-    format!("{}:{}", id.sender, id.correlation_id)
+/// fields. Format: `<sender_label>:<correlation_id>` — the sender
+/// component is resolved through [`format_mailbox_label`] (so it
+/// carries a category prefix when known), and the correlation id is
+/// appended verbatim.
+fn format_mail_id(id: MailId, mailbox_names: &MailboxLookup) -> String {
+    format!(
+        "{}:{}",
+        format_mailbox_label(id.sender, mailbox_names),
+        id.correlation_id
+    )
 }
 
 /// Convert a nanosecond value to microseconds for chrome's
@@ -167,7 +236,9 @@ mod tests {
 
     /// Issue 728: the converter emits one complete event per mail
     /// with both timestamps populated, plus one flow pair per
-    /// parent edge.
+    /// parent edge. Issue 731 amendment: with a non-empty mailbox
+    /// lookup, `pid` / `args.sender` / `args.parent` / `args.root`
+    /// + the top-level `name` carry category-prefixed labels.
     #[test]
     fn render_emits_complete_and_flow_events() {
         let root_id = mid(0xAA, 1);
@@ -202,7 +273,21 @@ mod tests {
         let mut kind_names = HashMap::new();
         kind_names.insert(with_tag(Tag::Kind, 0xDEAD), "test.tick".to_owned());
 
-        let json = render_chrome_trace(&result, &kind_names).expect("render");
+        // Two of the three mailbox ids are categorised; the third
+        // (0xEE) is left out so the unresolved fallback path is
+        // exercised on the same render call.
+        let mut mailbox_names: MailboxLookup = HashMap::new();
+        mailbox_names.insert(
+            with_tag(Tag::Mailbox, 0xAA),
+            ("aether.chassis".to_owned(), Some(MailboxCategory::ChassisSentinel)),
+        );
+        mailbox_names.insert(
+            with_tag(Tag::Mailbox, 0xCC),
+            ("aether.input".to_owned(), Some(MailboxCategory::Actor)),
+        );
+
+        let json =
+            render_chrome_trace(&result, &kind_names, &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         // Two complete events + two flow events (s + f for the one
@@ -214,30 +299,56 @@ mod tests {
         assert_eq!(phs.iter().filter(|p| **p == "s").count(), 1);
         assert_eq!(phs.iter().filter(|p| **p == "f").count(), 1);
 
-        // Root event uses the kind name from the lookup; child falls
-        // back to the tagged kind id (not in the lookup).
-        let names: Vec<&str> = events
+        // Root event: kind resolved → `kind:test.tick`; recipient
+        // resolved → `actor:aether.input`; sender resolved →
+        // `chassis:aether.chassis`.
+        let root_complete = events
             .iter()
-            .filter(|e| e["ph"] == "X")
-            .map(|e| e["name"].as_str().unwrap())
-            .collect();
-        assert!(names.contains(&"test.tick"), "names: {names:?}");
+            .find(|e| e["ph"] == "X" && e["name"] == "kind:test.tick")
+            .expect("root complete event with kind: prefix");
+        assert_eq!(root_complete["pid"], "actor:aether.input");
+        assert_eq!(root_complete["args"]["sender"], "chassis:aether.chassis");
+        assert_eq!(root_complete["args"]["parent"], serde_json::Value::Null);
+        // Root's mail_id renders as `<sender_label>:<cid>` =
+        // `chassis:aether.chassis:1`. Same for `root` (root of root
+        // is itself).
+        assert_eq!(root_complete["args"]["mail_id"], "chassis:aether.chassis:1");
+        assert_eq!(root_complete["args"]["root"], "chassis:aether.chassis:1");
+        assert_eq!(root_complete["args"]["kind_id"], "kind:test.tick");
+
+        // Child event: kind NOT in the lookup → falls back to raw
+        // `knd-...` (no `kind:` prefix). Recipient (0xEE) NOT in the
+        // lookup → falls back to raw `mbx-...`. Parent's sender
+        // (0xAA) is resolved → parent renders prefixed.
+        let child_complete = events
+            .iter()
+            .find(|e| e["ph"] == "X" && e["pid"].as_str().unwrap_or("").starts_with("mbx-"))
+            .expect("child complete event with raw mbx- pid");
+        let child_kind_name = child_complete["name"].as_str().unwrap();
         assert!(
-            names.iter().any(|n| n.starts_with("knd-")),
-            "child should fall back to tagged kind id: {names:?}"
+            child_kind_name.starts_with("knd-"),
+            "unresolved kind should fall back to raw tagged id (no kind: prefix): {child_kind_name}"
         );
+        // Child's sender (0xCC) IS resolved → `actor:aether.input`.
+        assert_eq!(child_complete["args"]["sender"], "actor:aether.input");
+        // Parent reference points at root_id, whose sender (0xAA) is
+        // resolved → `chassis:aether.chassis:1`.
+        assert_eq!(child_complete["args"]["parent"], "chassis:aether.chassis:1");
+        // Root walks to root_id again.
+        assert_eq!(child_complete["args"]["root"], "chassis:aether.chassis:1");
 
         // Microsecond conversion: t_received=2000ns → ts=2us,
         // dur=(5000-2000)/1000 = 3us.
-        let root_complete = events
-            .iter()
-            .find(|e| e["ph"] == "X" && e["name"] == "test.tick")
-            .unwrap();
         assert_eq!(root_complete["ts"], 2);
         assert_eq!(root_complete["dur"], 3);
 
-        // Flow pair: child mail_id ties the s/f arrow.
-        let child_mail_str = format_mail_id(child_id);
+        // Flow pair: child mail_id ties the s/f arrow. Same render
+        // path on both sides means the ids match without extra
+        // care.
+        let child_mail_str = format_mail_id(child_id, &mailbox_names);
+        // 0xBB sender is unresolved → raw mbx-... — flow id reflects
+        // that without a prefix, but matches itself, which is all
+        // chrome needs.
         let s = events.iter().find(|e| e["ph"] == "s").unwrap();
         let f = events.iter().find(|e| e["ph"] == "f").unwrap();
         assert_eq!(s["id"], child_mail_str);
@@ -246,6 +357,11 @@ mod tests {
         // child.t_received (6000ns -> 6us).
         assert_eq!(s["ts"], 5);
         assert_eq!(f["ts"], 6);
+        // Flow event pids resolve through the same lookup. s.pid is
+        // parent.recipient (0xCC) → `actor:aether.input`; f.pid is
+        // node.recipient (0xEE) → unresolved raw.
+        assert_eq!(s["pid"], "actor:aether.input");
+        assert!(f["pid"].as_str().unwrap().starts_with("mbx-"));
     }
 
     /// Mails without `t_received` / `t_finished` are skipped (no
@@ -267,7 +383,8 @@ mod tests {
                 t_finished: None,
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new()).expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
+            .expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         assert!(
             parsed["traceEvents"].as_array().unwrap().is_empty(),
@@ -282,7 +399,8 @@ mod tests {
     fn render_not_found_emits_metadata_doc() {
         let missing = mid(0xFF, 99);
         let result = DescribeTreeResult::Err { not_found: missing };
-        let json = render_chrome_trace(&result, &HashMap::new()).expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
+            .expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         assert_eq!(events.len(), 1);
@@ -292,5 +410,41 @@ mod tests {
             arg_name.contains("not_found"),
             "metadata should mention not_found: {arg_name}"
         );
+    }
+
+    /// Issue iamacoffeepot/aether#731: a known-name mailbox with
+    /// `category: None` renders the bare name (no prefix) — that
+    /// signals "we know what it is but the substrate didn't
+    /// classify it" and is a different failure mode from the
+    /// completely-unresolved raw `mbx-...` fallback.
+    #[test]
+    fn render_uncategorised_mailbox_emits_bare_name() {
+        let id = mid(0x77, 5);
+        let mut mailbox_names: MailboxLookup = HashMap::new();
+        mailbox_names.insert(with_tag(Tag::Mailbox, 0x77), ("user_thing".to_owned(), None));
+
+        let result = DescribeTreeResult::Ok {
+            root: id,
+            in_flight: 0,
+            mails: vec![MailNodeWire {
+                mail_id: id,
+                parent: None,
+                sender: MailboxId(with_tag(Tag::Mailbox, 0x77)),
+                recipient: MailboxId(with_tag(Tag::Mailbox, 0x77)),
+                kind: KindId(with_tag(Tag::Kind, 0x44)),
+                t_sent: Nanos(1_000),
+                t_received: Some(Nanos(2_000)),
+                t_finished: Some(Nanos(3_000)),
+            }],
+        };
+        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names)
+            .expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let evt = &parsed["traceEvents"][0];
+        // Bare name, no prefix.
+        assert_eq!(evt["pid"], "user_thing");
+        assert_eq!(evt["args"]["sender"], "user_thing");
+        // Mail id retains the bare-name + correlation_id form.
+        assert_eq!(evt["args"]["mail_id"], "user_thing:5");
     }
 }

--- a/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
@@ -64,8 +64,43 @@ pub(super) fn render_chrome_trace(
     kind_names: &HashMap<u64, String>,
     mailbox_names: &MailboxLookup,
 ) -> Result<String, serde_json::Error> {
-    let events = build_events(result, kind_names, mailbox_names);
-    serde_json::to_string_pretty(&json!({ "traceEvents": events }))
+    let mut events = build_events(result, kind_names, mailbox_names);
+    // Sort by `ts` ascending. Some chrome-trace importers (Perfetto
+    // included) tolerate unsorted streams but emit warnings; sorting
+    // here removes that whole category of noise without callers
+    // noticing.
+    events.sort_by(|a, b| {
+        let a_ts = a.get("ts").and_then(Value::as_f64).unwrap_or(0.0);
+        let b_ts = b.get("ts").and_then(Value::as_f64).unwrap_or(0.0);
+        a_ts.partial_cmp(&b_ts).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    // Prepend one `process_name` metadata event per unique `pid`. The
+    // chrome trace format binds pid → display name through these
+    // metadata events; without them Perfetto treats each pid as an
+    // opaque process and may flag `process_name_unset` / similar
+    // unattributed warnings. Our `pid` strings are already the
+    // human-readable labels, so the metadata args.name just echoes
+    // the pid value.
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for e in &events {
+        if let Some(pid) = e.get("pid").and_then(Value::as_str) {
+            seen.insert(pid.to_owned());
+        }
+    }
+    let mut metadata: Vec<Value> = seen
+        .into_iter()
+        .map(|name| {
+            json!({
+                "ph": "M",
+                "name": "process_name",
+                "cat": "metadata",
+                "pid": name,
+                "args": { "name": name },
+            })
+        })
+        .collect();
+    metadata.extend(events);
+    serde_json::to_string_pretty(&json!({ "traceEvents": metadata }))
 }
 
 fn build_events(
@@ -319,7 +354,10 @@ mod tests {
 
         let json = render_chrome_trace(&result, &kind_names, &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
-        let events = parsed["traceEvents"].as_array().unwrap();
+        let all_events = parsed["traceEvents"].as_array().unwrap();
+        // Filter out the `process_name` metadata auto-prepend so
+        // existing X/s/f assertions stay focused on the trace shape.
+        let events: Vec<&Value> = all_events.iter().filter(|e| e["ph"] != "M").collect();
         // Two complete events + two flow events (s + f for the one
         // parent edge) = 4 total.
         assert_eq!(events.len(), 4, "got: {events:#?}");
@@ -435,9 +473,12 @@ mod tests {
         );
     }
 
-    /// `Err::not_found` produces a trace doc with a single metadata
-    /// event noting the missing root, so chrome://tracing displays
-    /// the diagnostic instead of a blank file.
+    /// `Err::not_found` produces a trace doc with the diagnostic
+    /// metadata event noting the missing root, so chrome://tracing
+    /// displays the diagnostic instead of a blank file. The
+    /// `process_name` auto-prepend (issue 731 follow-up to silence
+    /// Perfetto's hashed-pid display) adds one more metadata event
+    /// for the same pid; both are valid metadata entries.
     #[test]
     fn render_not_found_emits_metadata_doc() {
         let missing = mid(0xFF, 99);
@@ -445,12 +486,87 @@ mod tests {
         let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0]["ph"], "M");
-        let arg_name = events[0]["args"]["name"].as_str().unwrap();
+        // Both events are metadata: the auto-prepended `process_name`
+        // for the missing-root pid, plus the `not_found` diagnostic
+        // M event with the human-readable explanation in args.name.
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|e| e["ph"] == "M"));
+        let diagnostic = events
+            .iter()
+            .find(|e| {
+                e["args"]["name"]
+                    .as_str()
+                    .map(|s| s.contains("not_found"))
+                    .unwrap_or(false)
+            })
+            .expect("diagnostic event present");
+        let arg_name = diagnostic["args"]["name"].as_str().unwrap();
         assert!(
             arg_name.contains("not_found"),
             "metadata should mention not_found: {arg_name}"
+        );
+    }
+
+    /// Issue 731 follow-up: Perfetto auto-hashes string pids and
+    /// shows the lane label as `<pid> <hash>` (e.g.
+    /// `actor:aether.input 7230`) when no `process_name` metadata
+    /// event registers the friendly name. Auto-prepend one
+    /// `process_name` per unique pid so Perfetto uses just the
+    /// configured name.
+    #[test]
+    fn render_prepends_process_name_metadata_per_unique_pid() {
+        let id = mid(0xAA, 1);
+        let mut mailbox_names: MailboxLookup = HashMap::new();
+        mailbox_names.insert(
+            with_tag(Tag::Mailbox, 0xAA),
+            (
+                "aether.chassis".to_owned(),
+                Some(MailboxCategory::ChassisSentinel),
+            ),
+        );
+        mailbox_names.insert(
+            with_tag(Tag::Mailbox, 0xCC),
+            ("aether.input".to_owned(), Some(MailboxCategory::Actor)),
+        );
+        let result = DescribeTreeResult::Ok {
+            root: id,
+            in_flight: 0,
+            mails: vec![MailNodeWire {
+                mail_id: id,
+                parent: None,
+                sender: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+                recipient: MailboxId(with_tag(Tag::Mailbox, 0xCC)),
+                kind: KindId(with_tag(Tag::Kind, 0x99)),
+                t_sent: Nanos(1_000),
+                t_received: Some(Nanos(2_000)),
+                t_finished: Some(Nanos(3_000)),
+            }],
+        };
+        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names).expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let events = parsed["traceEvents"].as_array().unwrap();
+        // Single X event has one unique pid (`actor:aether.input`),
+        // so we expect exactly one process_name metadata + the X
+        // event itself.
+        let metadata: Vec<&Value> = events.iter().filter(|e| e["ph"] == "M").collect();
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0]["name"], "process_name");
+        // The metadata event's `args.name` is just the bare label —
+        // no `#NNN` mail-id leakage. That's what Perfetto binds as
+        // the lane label.
+        assert_eq!(metadata[0]["pid"], "actor:aether.input");
+        assert_eq!(metadata[0]["args"]["name"], "actor:aether.input");
+        // Metadata events come BEFORE slice events in the output —
+        // chrome importers expect process metadata up-front.
+        let first_slice_idx = events
+            .iter()
+            .position(|e| e["ph"] == "X")
+            .expect("X event present");
+        assert!(
+            metadata
+                .iter()
+                .all(|m| events.iter().position(|e| std::ptr::eq(e, *m)).unwrap() < first_slice_idx),
+            "process_name metadata must precede slice events"
         );
     }
 
@@ -479,10 +595,14 @@ mod tests {
                 t_finished: Some(Nanos(2_500)),
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
-            .expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
-        let evt = &parsed["traceEvents"][0];
+        let evt = parsed["traceEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["ph"] == "X")
+            .expect("X event present");
         // dur survives as 0.5us — non-zero, so Perfetto draws the
         // slice.
         assert_eq!(evt["dur"], 0.5);
@@ -519,7 +639,12 @@ mod tests {
         };
         let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
-        let evt = &parsed["traceEvents"][0];
+        let evt = parsed["traceEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["ph"] == "X")
+            .expect("X event present");
         // Bare name, no prefix.
         assert_eq!(evt["pid"], "user_thing");
         assert_eq!(evt["args"]["sender"], "user_thing");

--- a/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
@@ -220,10 +220,17 @@ fn format_mail_id(id: MailId, mailbox_names: &MailboxLookup) -> String {
     )
 }
 
-/// Convert a nanosecond value to microseconds for chrome's
+/// Convert a nanosecond value to fractional microseconds for chrome's
 /// `ts`/`dur` fields (chrome's standard time unit).
-fn ns_to_us(nanos: u64) -> u64 {
-    nanos / 1_000
+///
+/// Returns `f64` so sub-microsecond handlers (the camera component's
+/// per-tick `aether.camera` send takes <1us in release builds) keep
+/// their non-zero duration after the unit conversion. Integer-floored
+/// 0-duration `ph:"X"` events render as invisible slices in Perfetto,
+/// which then makes incoming flow arrows look like they point at
+/// nothing.
+fn ns_to_us(nanos: u64) -> f64 {
+    (nanos as f64) / 1_000.0
 }
 
 /// Walk the parent chain to find the root mail. Falls back to the
@@ -363,10 +370,12 @@ mod tests {
         // Root walks to root_id again.
         assert_eq!(child_complete["args"]["root"], "chassis:aether.chassis#1");
 
-        // Microsecond conversion: t_received=2000ns → ts=2us,
-        // dur=(5000-2000)/1000 = 3us.
-        assert_eq!(root_complete["ts"], 2);
-        assert_eq!(root_complete["dur"], 3);
+        // Microsecond conversion (fractional): t_received=2000ns →
+        // ts=2.0us, dur=(5000-2000)/1000.0 = 3.0us. f64 so
+        // sub-microsecond handlers stay non-zero (and so visible
+        // in Perfetto) after the unit conversion.
+        assert_eq!(root_complete["ts"], 2.0);
+        assert_eq!(root_complete["dur"], 3.0);
 
         // Flow pair: child mail_id ties the s/f arrow. Same render
         // path on both sides means the ids match without extra
@@ -379,13 +388,14 @@ mod tests {
         let f = events.iter().find(|e| e["ph"] == "f").unwrap();
         assert_eq!(s["id"], child_mail_str);
         assert_eq!(f["id"], child_mail_str);
-        // s anchors at child.t_sent (3000ns -> 3us, inside parent's
-        // [2000, 5000) processing slice), f at child.t_received
-        // (6000ns -> 6us, the start of the child's own slice).
-        // Both endpoints sit inside concrete slices so Perfetto's
-        // flow-binder doesn't flag them as flow_invalid_id.
-        assert_eq!(s["ts"], 3);
-        assert_eq!(f["ts"], 6);
+        // s anchors at child.t_sent (3000ns -> 3.0us, inside
+        // parent's [2000, 5000) processing slice), f at
+        // child.t_received (6000ns -> 6.0us, the start of the
+        // child's own slice). Both endpoints sit inside concrete
+        // slices so Perfetto's flow-binder doesn't flag them as
+        // flow_invalid_id.
+        assert_eq!(s["ts"], 3.0);
+        assert_eq!(f["ts"], 6.0);
         // Both endpoints carry `bp: "e"` so the binder uses the
         // enclosing slice instead of searching for a past / future
         // one.
@@ -442,6 +452,41 @@ mod tests {
             arg_name.contains("not_found"),
             "metadata should mention not_found: {arg_name}"
         );
+    }
+
+    /// Sub-microsecond handlers (the camera component's per-tick
+    /// `aether.camera` send takes <1us in release builds) must keep
+    /// their non-zero duration after the ns→us unit conversion.
+    /// Integer-floored 0-duration `ph:"X"` events render as
+    /// invisible slices in Perfetto, which then makes the inbound
+    /// flow arrow look like it points at empty space (the user-
+    /// reported regression on the first #731 smoke).
+    #[test]
+    fn render_preserves_subus_duration_as_fractional() {
+        let id = mid(0xAA, 1);
+        let result = DescribeTreeResult::Ok {
+            root: id,
+            in_flight: 0,
+            mails: vec![MailNodeWire {
+                mail_id: id,
+                parent: None,
+                sender: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+                recipient: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+                kind: KindId(with_tag(Tag::Kind, 0x99)),
+                t_sent: Nanos(1_000),
+                // 500ns handler — under the 1us floor.
+                t_received: Some(Nanos(2_000)),
+                t_finished: Some(Nanos(2_500)),
+            }],
+        };
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
+            .expect("render");
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let evt = &parsed["traceEvents"][0];
+        // dur survives as 0.5us — non-zero, so Perfetto draws the
+        // slice.
+        assert_eq!(evt["dur"], 0.5);
+        assert_eq!(evt["ts"], 2.0);
     }
 
     /// Issue iamacoffeepot/aether#731: a known-name mailbox with

--- a/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/chrome.rs
@@ -120,12 +120,28 @@ fn build_events(
             },
         }));
 
-        // Flow arrow: requires the parent's t_finished and this
-        // node's t_received. The flow id ties the start ("s") and
-        // finish ("f") events into one arrow on chrome://tracing.
+        // Flow arrow: ties the parent's processing slice to this
+        // mail's processing slice via a unique flow id (`s` start +
+        // `f` finish events). Both endpoints carry `bp: "e"` so
+        // Perfetto / chrome://tracing bind them to the *enclosing*
+        // slice on the same pid rather than searching for a future /
+        // past slice — that searching default is what flagged earlier
+        // anchors as `flow_invalid_id` when the s timestamp landed
+        // exactly at the parent slice's `t_finished` boundary
+        // (outside the half-open `[t_received, t_finished)` slice
+        // range, with no future slice to bind to).
+        //
+        // Anchor the `s` at `node.t_sent` — the moment the parent
+        // sent this mail. By construction `t_sent` falls within the
+        // parent's processing window `[t_received, t_finished)`, so
+        // the s event lands inside the parent's slice. The `f` lands
+        // at the child's `t_received`, which is the start of the
+        // child's own slice — inside it by definition. Both pairs of
+        // (pid, ts) now sit inside concrete slices, which is what
+        // Perfetto's flow-binder expects.
         if let Some(parent_id) = node.parent
             && let Some(parent) = by_id.get(&parent_id)
-            && let Some(parent_finished) = parent.t_finished
+            && parent.t_finished.is_some()
         {
             let flow_id = format_mail_id(node.mail_id, mailbox_names);
             events.push(json!({
@@ -133,9 +149,10 @@ fn build_events(
                 "name": "flow",
                 "cat": "flow",
                 "id": flow_id.clone(),
-                "ts": ns_to_us(parent_finished.0),
+                "ts": ns_to_us(node.t_sent.0),
                 "pid": format_mailbox_label(parent.recipient, mailbox_names),
                 "tid": 0,
+                "bp": "e",
             }));
             events.push(json!({
                 "ph": "f",
@@ -187,13 +204,17 @@ fn category_prefix(c: MailboxCategory) -> &'static str {
 }
 
 /// MailId composite → compact string for chrome event `id` and `args`
-/// fields. Format: `<sender_label>:<correlation_id>` — the sender
+/// fields. Format: `<sender_label>#<correlation_id>` — the sender
 /// component is resolved through [`format_mailbox_label`] (so it
 /// carries a category prefix when known), and the correlation id is
-/// appended verbatim.
+/// appended after `#`. The `#` separator (rather than another `:`)
+/// keeps the correlation_id visually distinct from the type-prefix
+/// separator already inside the sender label (e.g.
+/// `actor:aether.input#2489` reads as "actor `aether.input`, mail
+/// 2489" without `:` doing double duty).
 fn format_mail_id(id: MailId, mailbox_names: &MailboxLookup) -> String {
     format!(
-        "{}:{}",
+        "{}#{}",
         format_mailbox_label(id.sender, mailbox_names),
         id.correlation_id
     )
@@ -279,15 +300,17 @@ mod tests {
         let mut mailbox_names: MailboxLookup = HashMap::new();
         mailbox_names.insert(
             with_tag(Tag::Mailbox, 0xAA),
-            ("aether.chassis".to_owned(), Some(MailboxCategory::ChassisSentinel)),
+            (
+                "aether.chassis".to_owned(),
+                Some(MailboxCategory::ChassisSentinel),
+            ),
         );
         mailbox_names.insert(
             with_tag(Tag::Mailbox, 0xCC),
             ("aether.input".to_owned(), Some(MailboxCategory::Actor)),
         );
 
-        let json =
-            render_chrome_trace(&result, &kind_names, &mailbox_names).expect("render");
+        let json = render_chrome_trace(&result, &kind_names, &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         // Two complete events + two flow events (s + f for the one
@@ -309,11 +332,14 @@ mod tests {
         assert_eq!(root_complete["pid"], "actor:aether.input");
         assert_eq!(root_complete["args"]["sender"], "chassis:aether.chassis");
         assert_eq!(root_complete["args"]["parent"], serde_json::Value::Null);
-        // Root's mail_id renders as `<sender_label>:<cid>` =
-        // `chassis:aether.chassis:1`. Same for `root` (root of root
-        // is itself).
-        assert_eq!(root_complete["args"]["mail_id"], "chassis:aether.chassis:1");
-        assert_eq!(root_complete["args"]["root"], "chassis:aether.chassis:1");
+        // Root's mail_id renders as `<sender_label>#<cid>` =
+        // `chassis:aether.chassis#1`. Same for `root` (root of root
+        // is itself). The `#` separator keeps `:` reserved for the
+        // type prefix; reading `chassis:aether.chassis#1` as "the
+        // chassis sentinel's mail 1" stays unambiguous even when
+        // names contain colons (trampolines have a `:NAME` suffix).
+        assert_eq!(root_complete["args"]["mail_id"], "chassis:aether.chassis#1");
+        assert_eq!(root_complete["args"]["root"], "chassis:aether.chassis#1");
         assert_eq!(root_complete["args"]["kind_id"], "kind:test.tick");
 
         // Child event: kind NOT in the lookup → falls back to raw
@@ -332,10 +358,10 @@ mod tests {
         // Child's sender (0xCC) IS resolved → `actor:aether.input`.
         assert_eq!(child_complete["args"]["sender"], "actor:aether.input");
         // Parent reference points at root_id, whose sender (0xAA) is
-        // resolved → `chassis:aether.chassis:1`.
-        assert_eq!(child_complete["args"]["parent"], "chassis:aether.chassis:1");
+        // resolved → `chassis:aether.chassis#1`.
+        assert_eq!(child_complete["args"]["parent"], "chassis:aether.chassis#1");
         // Root walks to root_id again.
-        assert_eq!(child_complete["args"]["root"], "chassis:aether.chassis:1");
+        assert_eq!(child_complete["args"]["root"], "chassis:aether.chassis#1");
 
         // Microsecond conversion: t_received=2000ns → ts=2us,
         // dur=(5000-2000)/1000 = 3us.
@@ -353,10 +379,18 @@ mod tests {
         let f = events.iter().find(|e| e["ph"] == "f").unwrap();
         assert_eq!(s["id"], child_mail_str);
         assert_eq!(f["id"], child_mail_str);
-        // s anchors at parent.t_finished (5000ns -> 5us), f at
-        // child.t_received (6000ns -> 6us).
-        assert_eq!(s["ts"], 5);
+        // s anchors at child.t_sent (3000ns -> 3us, inside parent's
+        // [2000, 5000) processing slice), f at child.t_received
+        // (6000ns -> 6us, the start of the child's own slice).
+        // Both endpoints sit inside concrete slices so Perfetto's
+        // flow-binder doesn't flag them as flow_invalid_id.
+        assert_eq!(s["ts"], 3);
         assert_eq!(f["ts"], 6);
+        // Both endpoints carry `bp: "e"` so the binder uses the
+        // enclosing slice instead of searching for a past / future
+        // one.
+        assert_eq!(s["bp"], "e");
+        assert_eq!(f["bp"], "e");
         // Flow event pids resolve through the same lookup. s.pid is
         // parent.recipient (0xCC) → `actor:aether.input`; f.pid is
         // node.recipient (0xEE) → unresolved raw.
@@ -383,8 +417,7 @@ mod tests {
                 t_finished: None,
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
-            .expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         assert!(
             parsed["traceEvents"].as_array().unwrap().is_empty(),
@@ -399,8 +432,7 @@ mod tests {
     fn render_not_found_emits_metadata_doc() {
         let missing = mid(0xFF, 99);
         let result = DescribeTreeResult::Err { not_found: missing };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new())
-            .expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         assert_eq!(events.len(), 1);
@@ -421,7 +453,10 @@ mod tests {
     fn render_uncategorised_mailbox_emits_bare_name() {
         let id = mid(0x77, 5);
         let mut mailbox_names: MailboxLookup = HashMap::new();
-        mailbox_names.insert(with_tag(Tag::Mailbox, 0x77), ("user_thing".to_owned(), None));
+        mailbox_names.insert(
+            with_tag(Tag::Mailbox, 0x77),
+            ("user_thing".to_owned(), None),
+        );
 
         let result = DescribeTreeResult::Ok {
             root: id,
@@ -437,14 +472,14 @@ mod tests {
                 t_finished: Some(Nanos(3_000)),
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names)
-            .expect("render");
+        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let evt = &parsed["traceEvents"][0];
         // Bare name, no prefix.
         assert_eq!(evt["pid"], "user_thing");
         assert_eq!(evt["args"]["sender"], "user_thing");
-        // Mail id retains the bare-name + correlation_id form.
-        assert_eq!(evt["args"]["mail_id"], "user_thing:5");
+        // Mail id retains the bare-name + correlation_id form,
+        // separated by `#`.
+        assert_eq!(evt["args"]["mail_id"], "user_thing#5");
     }
 }

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -876,30 +876,36 @@ impl Hub {
         &self,
         Parameters(args): Parameters<DumpTraceChromeArgs>,
     ) -> Result<String, McpError> {
-        // Build kind-id → name lookup from the engine's handshake-time
-        // descriptor list. Each chrome event's `name` field uses the
-        // human-readable kind name; missing entries fall back to the
-        // tagged-string kind id.
+        // Build kind-id → name + mailbox-id → (name, category) lookups
+        // from the engine's handshake-time + post-load caches. Chrome
+        // event `name` and id fields use the human-readable forms;
+        // missing entries fall back to the tagged-string id so an
+        // out-of-sync inventory surfaces as visible drift rather than
+        // silent corruption (issue iamacoffeepot/aether#731).
         let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
             McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
         })?;
         let id = EngineId(uuid);
-        let kind_names: std::collections::HashMap<u64, String> = match self.state.engines.get(&id) {
-            Some(record) => record
-                .kinds
-                .iter()
-                .map(|k| {
-                    let kid = aether_data::canonical::kind_id_from_parts(&k.name, &k.schema);
-                    (kid, k.name.clone())
-                })
-                .collect(),
-            None => {
-                return Err(McpError::invalid_params(
-                    format!("unknown engine_id {}", args.engine_id),
-                    None,
-                ));
-            }
+        let Some(record) = self.state.engines.get(&id) else {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
         };
+        let kind_names: std::collections::HashMap<u64, String> = record
+            .kinds
+            .iter()
+            .map(|k| {
+                let kid = aether_data::canonical::kind_id_from_parts(&k.name, &k.schema);
+                (kid, k.name.clone())
+            })
+            .collect();
+        let mailbox_names: super::chrome::MailboxLookup = record
+            .mailboxes
+            .iter()
+            .map(|m| (m.id.0, (m.name.clone(), m.category)))
+            .collect();
+        drop(record);
 
         let describe_args = DescribeTreeArgs {
             engine_id: args.engine_id.clone(),
@@ -907,7 +913,7 @@ impl Hub {
             timeout_ms: args.timeout_ms,
         };
         let result = self.do_describe_tree(describe_args).await?;
-        let chrome_json = render_chrome_trace(&result, &kind_names)
+        let chrome_json = render_chrome_trace(&result, &kind_names, &mailbox_names)
             .map_err(|e| McpError::internal_error(format!("render chrome trace: {e}"), None))?;
 
         match args.output_path {


### PR DESCRIPTION
## Summary

Decorates `dump_trace_chrome` output with category-prefixed labels sourced from the engine record's `mailboxes` + `kinds` caches (the inventory iamacoffeepot/aether#730 plumbed through). Closes iamacoffeepot/aether#731.

| Field | Before | After |
|-------|--------|-------|
| `pid` | `mbx-tede-i3el-covu` | `actor:aether.input` |
| `name` / `args.kind_id` | `aether.tick` / `knd-...` | `kind:aether.tick` |
| `args.sender` | `mbx-rwyb-pgap-gnxm` | `chassis:aether.chassis` |
| `args.parent` / `args.root` | `mbx-...:NNN` | `chassis:aether.chassis:2720` |

Prefix table (per the issue spec):
- `Actor` / `Trampoline` → `actor:`
- `BroadcastSink` → `sink:`
- `ChassisSentinel` → `chassis:`
- (None) → bare name, no prefix
- (unresolved) → raw `mbx-XXXX-XXXX-XXXX` / `knd-XXXX-XXXX-XXXX`

Hub-side decoration only — `describe_tree`'s wire shape is unchanged (out of scope per the issue spec, optional follow-up if useful).

## Verification

- `cargo nextest run --workspace` — 1081/1081 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- New chrome unit tests cover: prefixed-label render, raw fallback when kind/mailbox not in lookup, bare-name render for category=None, flow-event prefixing
- Live smoke: spawned headless, loaded `aether_camera.wasm`, subscribed it to ticks, dumped trace. Every `pid`, `sender`, `parent`, `root`, `kind_id`, `name` field resolved correctly through the prefix table — chassis-rooted ticks, input cap fan-out, trampoline receipt, render emission all visible:

```json
{
  "args": {
    "kind_id": "kind:aether.tick",
    "mail_id": "actor:aether.input:2489",
    "parent": "chassis:aether.chassis:2720",
    "root": "chassis:aether.chassis:2720",
    "sender": "actor:aether.input"
  },
  "name": "kind:aether.tick",
  "pid": "actor:aether.component.trampoline:cam"
}
```

## Test plan

- [x] cargo nextest run --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] live MCP smoke: spawn substrate, load + subscribe camera, dump_trace_chrome, prefixes resolved end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)