### PR TITLE
chore(trace): rename dump_trace_chrome MCP tool + chrome module to trace

### DIFF
--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -65,8 +65,8 @@ mod native {
     /// after the originating `Sent`. Issue 734: `thread_name` patches
     /// from the `Received` event the same way `t_received` does — the
     /// dispatcher captures `std::thread::current().name()` so the
-    /// chrome trace renderer can give each actor its own per-thread
-    /// row.
+    /// trace renderer (`hub::mcp::trace`) can give each actor its
+    /// own per-thread row.
     #[derive(Debug, Clone)]
     pub struct MailNode {
         pub root: MailId,

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -80,9 +80,9 @@ pub enum TraceEvent {
         /// Issue 734: OS thread name captured at the dispatcher's
         /// receive hook (`std::thread::current().name()`). The
         /// substrate's default `Pooled` scheduler (post-issue-635)
-        /// names worker threads `aether-worker-N`, so the chrome
-        /// trace renderer can distinguish per-thread rows even when
-        /// one OS thread serves multiple actors. Actors that opt into
+        /// names worker threads `aether-worker-N`, so the trace
+        /// renderer (`hub::mcp::trace`) can distinguish per-thread
+        /// rows even when one OS thread serves multiple actors. Actors that opt into
         /// the `Thread` scheduler get `aether-instanced-<full_name>` /
         /// `aether-root-<NAMESPACE>` from `actor::native::spawn` and
         /// `spawn_thread`. `None` when the OS thread has no name

--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -31,9 +31,9 @@ use crate::hub::registry::EngineRegistry;
 use crate::hub::session::{QueuedMail, SessionHandle, SessionRegistry};
 
 pub(crate) mod args;
-mod chrome;
 mod codecs;
 mod tools;
+mod trace;
 
 // Bring args types and commonly-referenced protocol types into mcp's
 // namespace so the tests module below can reach them via `use
@@ -834,12 +834,12 @@ mod tests {
         );
     }
 
-    /// Issue 728: dump_trace_chrome calls the same describe_tree path
-    /// the existing tool uses, then re-shapes the reply as chrome
-    /// trace JSON. The output_path branch writes to disk and returns
+    /// Issue 728: dump_trace calls the same describe_tree path the
+    /// existing tool uses, then re-shapes the reply as trace JSON.
+    /// The output_path branch writes to disk and returns
     /// `{"path": ...}`; the inline branch returns the JSON.
     #[tokio::test]
-    async fn dump_trace_chrome_writes_file_when_path_set() {
+    async fn dump_trace_writes_file_when_path_set() {
         use aether_data::tagged_id::{self, Tag};
         use aether_data::{MailId, MailboxId, with_tag};
         use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
@@ -894,7 +894,7 @@ mod tests {
         let tmp =
             std::env::temp_dir().join(format!("aether-trace-728-{}.json", std::process::id()));
         let response = hub
-            .dump_trace_chrome(Parameters(args::DumpTraceChromeArgs {
+            .dump_trace(Parameters(args::DumpTraceArgs {
                 engine_id: id.0.to_string(),
                 root: args::MailIdWire {
                     sender: tagged_id::encode(sender_raw).unwrap(),
@@ -923,10 +923,10 @@ mod tests {
         std::fs::remove_file(&tmp).ok();
     }
 
-    /// Inline branch: when `output_path` is omitted, the chrome JSON
+    /// Inline branch: when `output_path` is omitted, the trace JSON
     /// flows back as the tool result.
     #[tokio::test]
-    async fn dump_trace_chrome_returns_inline_when_path_unset() {
+    async fn dump_trace_returns_inline_when_path_unset() {
         use aether_data::tagged_id::{self, Tag};
         use aether_data::{MailId, MailboxId, with_tag};
         use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
@@ -978,7 +978,7 @@ mod tests {
         });
 
         let response = hub
-            .dump_trace_chrome(Parameters(args::DumpTraceChromeArgs {
+            .dump_trace(Parameters(args::DumpTraceArgs {
                 engine_id: id.0.to_string(),
                 root: args::MailIdWire {
                     sender: tagged_id::encode(sender_raw).unwrap(),

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -495,7 +495,7 @@ pub struct ListActiveRootsArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct DumpTraceChromeArgs {
+pub struct DumpTraceArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,
     /// Root mail id whose subtree should be exported. Same shape as
@@ -503,11 +503,11 @@ pub struct DumpTraceChromeArgs {
     /// a prior `describe_tree` reply or a `RootSummaryWire.root` from
     /// `list_active_roots`.
     pub root: MailIdWire,
-    /// Optional filesystem path to write the chrome trace JSON to.
-    /// Parent directories are created as needed. When omitted, the
-    /// JSON is returned inline as the tool result (fine for small
-    /// subtrees; for busy substrates that generate thousands of
-    /// events the inline path may overflow the agent's context).
+    /// Optional filesystem path to write the trace JSON to. Parent
+    /// directories are created as needed. When omitted, the JSON is
+    /// returned inline as the tool result (fine for small subtrees;
+    /// for busy substrates that generate thousands of events the
+    /// inline path may overflow the agent's context).
     #[serde(default)]
     pub output_path: Option<String>,
     /// Maximum time to wait for the substrate's `DescribeTreeResult`

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -38,14 +38,14 @@ use crate::hub::session::SessionHandle;
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
-    DescribeKindsArgs, DescribeTreeArgs, DumpTraceChromeArgs, EngineInfo, EngineLogEntry,
-    EngineLogsArgs, EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs,
-    LoadComponentResponse, LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail,
-    ReplaceComponentArgs, ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs,
-    TerminateResult, TerminateSubstrateArgs, log_level_to_str,
+    DescribeKindsArgs, DescribeTreeArgs, DumpTraceArgs, EngineInfo, EngineLogEntry, EngineLogsArgs,
+    EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs, LoadComponentResponse,
+    LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs,
+    ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult,
+    TerminateSubstrateArgs, log_level_to_str,
 };
-use super::chrome::render_chrome_trace;
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
+use super::trace::render;
 use super::{Hub, HubState};
 use crate::hub::registry::ComponentRecord;
 
@@ -870,18 +870,19 @@ impl Hub {
     }
 
     #[tool(
-        description = "Export the mail subtree under one root as a Chrome trace event format JSON file (issue iamacoffeepot/aether#728, ADR-0080 Phase 3). Calls the same `describe_tree` substrate path under the hood, then re-shapes each mail into a chrome `ph:\"X\"` (complete) event covering its `t_received → t_finished` interval on the recipient's lane, plus `ph:\"s\"`/`ph:\"f\"` (flow) arrows linking parent.t_finished → child.t_received for causal visualization. Mails without `t_received`/`t_finished` (orphan or in-flight at query time) are skipped. Drop the output JSON into chrome://tracing or perfetto.dev for a flame graph + causal arrows view. When `output_path` is omitted, returns the JSON inline (fine for small subtrees, may overflow agent context for busy substrates). When `output_path` is set, writes to the path (creating parent dirs) and returns a `{path}` confirmation. Default timeout 5000ms; clamped to 30000."
+        description = "Export the mail subtree under one root as a trace JSON file (issue iamacoffeepot/aether#728, ADR-0080 Phase 3). Output is the Chrome trace event format, which Perfetto, chrome://tracing, and speedscope all read natively — drop the file into perfetto.dev for a flame graph + causal arrows view. Calls the same `describe_tree` substrate path under the hood, then re-shapes each mail into one `ph:\"X\"` (complete) event covering its `t_received → t_finished` interval on the recipient's lane, plus `ph:\"s\"`/`ph:\"f\"` (flow) arrows linking parent.t_finished → child.t_received for causal visualization. Mails without `t_received`/`t_finished` (orphan or in-flight at query time) are skipped. When `output_path` is omitted, returns the JSON inline (fine for small subtrees, may overflow agent context for busy substrates). When `output_path` is set, writes to the path (creating parent dirs) and returns a `{path}` confirmation. Default timeout 5000ms; clamped to 30000."
     )]
-    pub(super) async fn dump_trace_chrome(
+    pub(super) async fn dump_trace(
         &self,
-        Parameters(args): Parameters<DumpTraceChromeArgs>,
+        Parameters(args): Parameters<DumpTraceArgs>,
     ) -> Result<String, McpError> {
         // Build kind-id → name + mailbox-id → (name, category) lookups
-        // from the engine's handshake-time + post-load caches. Chrome
-        // event `name` and id fields use the human-readable forms;
-        // missing entries fall back to the tagged-string id so an
-        // out-of-sync inventory surfaces as visible drift rather than
-        // silent corruption (issue iamacoffeepot/aether#731).
+        // from the engine's handshake-time + post-load caches. The
+        // renderer uses the human-readable forms in event `name` /
+        // id fields; missing entries fall back to the tagged-string
+        // id so an out-of-sync inventory surfaces as visible drift
+        // rather than silent corruption (issue
+        // iamacoffeepot/aether#731).
         let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
             McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
         })?;
@@ -900,7 +901,7 @@ impl Hub {
                 (kid, k.name.clone())
             })
             .collect();
-        let mailbox_names: super::chrome::MailboxLookup = record
+        let mailbox_names: super::trace::MailboxLookup = record
             .mailboxes
             .iter()
             .map(|m| (m.id.0, (m.name.clone(), m.category)))
@@ -913,8 +914,8 @@ impl Hub {
             timeout_ms: args.timeout_ms,
         };
         let result = self.do_describe_tree(describe_args).await?;
-        let chrome_json = render_chrome_trace(&result, &kind_names, &mailbox_names)
-            .map_err(|e| McpError::internal_error(format!("render chrome trace: {e}"), None))?;
+        let trace_json = render(&result, &kind_names, &mailbox_names)
+            .map_err(|e| McpError::internal_error(format!("render trace: {e}"), None))?;
 
         match args.output_path {
             Some(path) => {
@@ -928,12 +929,12 @@ impl Hub {
                         )
                     })?;
                 }
-                tokio::fs::write(&path, &chrome_json).await.map_err(|e| {
+                tokio::fs::write(&path, &trace_json).await.map_err(|e| {
                     McpError::internal_error(format!("write trace to {path}: {e}"), None)
                 })?;
                 Ok(serde_json::json!({ "path": path }).to_string())
             }
-            None => Ok(chrome_json),
+            None => Ok(trace_json),
         }
     }
 
@@ -953,9 +954,9 @@ impl Hub {
     }
 
     /// Shared describe_tree core. The public `describe_tree` tool wraps
-    /// this with JSON serialization; `dump_trace_chrome` reuses it to
-    /// fetch the same observer state and re-shape it as chrome trace
-    /// events (issue iamacoffeepot/aether#728).
+    /// this with JSON serialization; `dump_trace` reuses it to fetch
+    /// the same observer state and re-shape it as trace events (issue
+    /// iamacoffeepot/aether#728).
     async fn do_describe_tree(
         &self,
         args: DescribeTreeArgs,

--- a/crates/aether-substrate-bundle/src/hub/mcp/trace.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/trace.rs
@@ -1,36 +1,41 @@
-//! Chrome trace event format (a.k.a. "trace event format" / "Catapult")
-//! converter for the substrate's `TraceObserverCapability` state. Issue
-//! iamacoffeepot/aether#728 / ADR-0080 Phase 3.
+//! Trace renderer for the substrate's `TraceObserverCapability` state.
+//! Issue iamacoffeepot/aether#728 / ADR-0080 Phase 3. The MCP
+//! `dump_trace` tool ([`super::tools`]) is the only consumer.
+//!
+//! Output format today is the Chrome trace event format (a.k.a.
+//! "trace event format" / "Catapult"), which Perfetto, chrome://tracing,
+//! and speedscope all read natively — see
+//! <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>.
+//! The module name is intentionally generic so a future renderer
+//! (pprof, perfetto-protobuf, …) can land as a sibling without
+//! re-shuffling the path; the `dump_trace` tool would gain a `format`
+//! param and dispatch.
 //!
 //! Pure function over [`aether_kinds::trace::DescribeTreeResult`] +
 //! a kind-id → name lookup + a mailbox-id → (name, category) lookup
-//! (issue iamacoffeepot/aether#731). The MCP `dump_trace_chrome` tool
-//! builds both lookups from the engine record's `kinds` + `mailboxes`
-//! caches, calls [`render_chrome_trace`], and either returns the JSON
-//! inline or writes it to disk.
-//!
-//! Output format reference:
-//! <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>
+//! (issue iamacoffeepot/aether#731). The tool builds both lookups
+//! from the engine record's `kinds` + `mailboxes` caches, calls
+//! [`render`], and either returns the JSON inline or writes it to
+//! disk.
 //!
 //! Per mail with `t_received` and `t_finished` populated, one
 //! `ph:"X"` (complete) event covering the receive→finish interval on
 //! the recipient's lane. Per mail with a parent (and where both
 //! `parent.t_finished` and `self.t_received` are set), one
-//! `ph:"s"` / `ph:"f"` flow pair so chrome://tracing draws a causal
+//! `ph:"s"` / `ph:"f"` flow pair so the trace viewer draws a causal
 //! arrow. Mails missing timestamps (orphan or in-flight at query
 //! time) are skipped — they remain inspectable via `describe_tree`.
 //!
 //! Issue iamacoffeepot/aether#734: pids and tids are emitted as
-//! integers, not strings — Perfetto's chrome-trace importer auto-
-//! hashes string pids (showing `<label> <hashed_pid>` decoration in
-//! lane headers); integers go through the `process_name` /
-//! `thread_name` metadata events as the only display-name binding.
-//! `process_name` events bind each integer pid to the resolved actor
-//! label; `thread_name` events bind each integer tid to the OS thread
-//! name captured at the dispatcher's receive hook (per ADR-0038
-//! every dispatcher thread is named `aether-instanced-<full_name>` /
-//! `aether-root-<NAMESPACE>`, so the per-actor row labels read
-//! directly).
+//! integers, not strings — Perfetto's importer auto-hashes string
+//! pids (showing `<label> <hashed_pid>` decoration in lane headers);
+//! integers go through the `process_name` / `thread_name` metadata
+//! events as the only display-name binding. `process_name` events
+//! bind each integer pid to the resolved actor label; `thread_name`
+//! events bind each integer tid to the OS thread name captured at
+//! the dispatcher's receive hook. Tids start past the pid range so
+//! Perfetto's "tid==pid means main-thread" Linux heuristic never
+//! fires.
 
 use std::collections::HashMap;
 
@@ -38,20 +43,19 @@ use aether_data::{MailId, MailboxCategory, MailboxId};
 use aether_kinds::trace::{DescribeTreeResult, MailNodeWire};
 use serde_json::{Value, json};
 
-/// Per-engine mailbox lookup the chrome renderer uses to swap raw
-/// tagged ids for category-prefixed names (issue
-/// iamacoffeepot/aether#731). Keyed on the raw `MailboxId` u64 so
-/// the call site can pre-strip the tag once instead of per-event.
-/// `None` category means "we know the name but the substrate didn't
-/// classify it" — render the bare name without a prefix so the
-/// failure mode stays visible.
+/// Per-engine mailbox lookup the renderer uses to swap raw tagged
+/// ids for category-prefixed names (issue iamacoffeepot/aether#731).
+/// Keyed on the raw `MailboxId` u64 so the call site can pre-strip
+/// the tag once instead of per-event. `None` category means "we know
+/// the name but the substrate didn't classify it" — render the bare
+/// name without a prefix so the failure mode stays visible.
 pub(super) type MailboxLookup = HashMap<u64, (String, Option<MailboxCategory>)>;
 
 /// Render a `DescribeTreeResult` into Chrome trace event format JSON.
 /// Returns the serialized document as a `String`.
 ///
 /// `kind_names` maps the raw `KindId` u64 → human-readable kind name
-/// for the chrome event `name` field. Resolved entries render as
+/// for the event `name` field. Resolved entries render as
 /// `kind:NAME`; missing entries fall back to the tagged-string id
 /// (`knd-XXXX-XXXX-XXXX`) with no prefix so unresolved ids are
 /// visually distinct from resolved-but-empty.
@@ -71,7 +75,7 @@ pub(super) type MailboxLookup = HashMap<u64, (String, Option<MailboxCategory>)>;
 ///
 /// Unknown ids fall back to the raw `mbx-XXXX-XXXX-XXXX` tagged form
 /// so the unresolved case stays visible.
-pub(super) fn render_chrome_trace(
+pub(super) fn render(
     result: &DescribeTreeResult,
     kind_names: &HashMap<u64, String>,
     mailbox_names: &MailboxLookup,
@@ -233,7 +237,7 @@ fn build_events(
             "pid": format_mailbox_label(node.recipient, mailbox_names),
             "tid": 0,
             // Issue 734: stash the thread name captured at the
-            // dispatcher's receive hook. `render_chrome_trace` rewrites
+            // dispatcher's receive hook. `render` rewrites
             // `pid` to an integer + assigns a per-thread tid + emits
             // the matching `process_name` / `thread_name` M events,
             // then strips this field. Underscore prefix marks it as
@@ -458,7 +462,7 @@ mod tests {
             ("aether.input".to_owned(), Some(MailboxCategory::Actor)),
         );
 
-        let json = render_chrome_trace(&result, &kind_names, &mailbox_names).expect("render");
+        let json = render(&result, &kind_names, &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let all_events = parsed["traceEvents"].as_array().unwrap();
         // Filter out the `process_name` / `thread_name` metadata
@@ -638,7 +642,7 @@ mod tests {
                 thread_name: None,
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
+        let json = render(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         assert!(
             parsed["traceEvents"].as_array().unwrap().is_empty(),
@@ -656,7 +660,7 @@ mod tests {
     fn render_not_found_emits_metadata_doc() {
         let missing = mid(0xFF, 99);
         let result = DescribeTreeResult::Err { not_found: missing };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
+        let json = render(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         // Both events are metadata: the auto-prepended `process_name`
@@ -716,7 +720,7 @@ mod tests {
                 thread_name: Some("aether-root-aether.input".to_owned()),
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names).expect("render");
+        let json = render(&result, &HashMap::new(), &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         // Single X event has one unique pid (`actor:aether.input`)
@@ -783,7 +787,7 @@ mod tests {
                 thread_name: None,
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
+        let json = render(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let evt = parsed["traceEvents"]
             .as_array()
@@ -838,7 +842,7 @@ mod tests {
                 },
             ],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &HashMap::new()).expect("render");
+        let json = render(&result, &HashMap::new(), &HashMap::new()).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let events = parsed["traceEvents"].as_array().unwrap();
         let max_pid = events
@@ -893,7 +897,7 @@ mod tests {
                 thread_name: None,
             }],
         };
-        let json = render_chrome_trace(&result, &HashMap::new(), &mailbox_names).expect("render");
+        let json = render(&result, &HashMap::new(), &mailbox_names).expect("render");
         let parsed: Value = serde_json::from_str(&json).unwrap();
         let all_events = parsed["traceEvents"].as_array().unwrap();
         let evt = all_events

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -76,11 +76,11 @@ pub(crate) fn dispatch_loop_run<A>(
         };
         let inbound_mail_id = env.mail_id;
         // ADR-0080 §2 producer hook: `Received` at handler entry.
-        // Issue 734: capture the OS thread name so the chrome trace
-        // renderer can stamp per-thread tids + emit thread_name M
-        // events. With the default `Pooled` scheduler (issue 635)
-        // this surfaces as `aether-worker-N` shared across actors;
-        // `Thread`-scheduled actors get per-actor names.
+        // Issue 734: capture the OS thread name so the trace renderer
+        // can stamp per-thread tids + emit thread_name M events. With
+        // the default `Pooled` scheduler (issue 635) this surfaces as
+        // `aether-worker-N` shared across actors; `Thread`-scheduled
+        // actors get per-actor names.
         let thread_name = std::thread::current().name().map(str::to_owned);
         crate::runtime::trace::record_received(inbound_mail_id, thread_name);
         aether_actor::local::with_stamped(slots, || {

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -165,8 +165,8 @@ where
     fn dispatch_one(&self, actor: &mut Box<A>, env: crate::actor::native::Envelope) {
         let inbound_mail_id = env.mail_id;
         // Issue 734: capture the OS thread name at the dispatcher's
-        // receive hook so the chrome trace renderer can stamp each
-        // event with a per-thread tid + thread_name M event. With the
+        // receive hook so the trace renderer can stamp each event
+        // with a per-thread tid + thread_name M event. With the
         // `Pooled` default scheduler (issue 635) this is the worker's
         // `aether-worker-N` name (shared across actors); `Thread`-
         // scheduled actors land on a per-actor name.

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -128,8 +128,8 @@ pub fn record_sent(
 /// generating events that would re-feed the drainer.
 ///
 /// Issue 734: dispatchers pass `std::thread::current().name()
-/// .map(str::to_owned)` as `thread_name` so the chrome trace renderer
-/// can stamp each event with a per-thread row in Perfetto. The
+/// .map(str::to_owned)` as `thread_name` so the trace renderer
+/// (`hub::mcp::trace`) can stamp each event with a per-thread row. The
 /// default `Pooled` scheduler (post-issue-635) names worker threads
 /// `aether-worker-N`, so one tid commonly serves multiple actors;
 /// actors on the `Thread` scheduler get the per-actor names from


### PR DESCRIPTION
## Summary

- Drop the `chrome` qualifier from the caller-facing tool + module so the surface stays neutral if/when a second renderer (pprof, perfetto-protobuf, speedscope) lands as a sibling.
- Output today is unchanged — still Chrome trace event format JSON, which Perfetto and chrome://tracing both read natively. Internal mentions of the format spec are kept where they're technically accurate (chrome://tracing as a viewer, chrome event spec, etc).

## Renames

- MCP tool: `dump_trace_chrome` → `dump_trace`
- Args type: `DumpTraceChromeArgs` → `DumpTraceArgs`
- Module: `hub::mcp::chrome` → `hub::mcp::trace`
- Function: `render_chrome_trace` → `render` (module name carries `trace` context now)
- Test fns updated; substrate-side comments now point at `hub::mcp::trace` rather than "the chrome trace renderer"

## Test plan

- [x] cargo nextest run -p aether-substrate-bundle (137/137)
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt -- --check
- [ ] Smoke via MCP after merge — purely cosmetic but worth a final eyeball.

Generated with [Claude Code](https://claude.com/claude-code)