### PR TITLE
chore: gitignore traces/ for dump_trace JSON dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ spikes/*/target/
 # not part of the source tree; issues filed from them link back to
 # the source instead.
 /audits/
+# Trace dumps from `dump_trace` (issue #730 / ADR-0080). Per-run
+# JSON, not part of the source tree — keep them out of /tmp so
+# they survive shell sessions and land somewhere predictable. The
+# directory itself is tracked via `.gitkeep` so the path is
+# discoverable; everything else under it is ignored.
+/traces/*
+!/traces/.gitkeep


### PR DESCRIPTION
## Summary

- Adds `/traces/*` with `!/traces/.gitkeep` to `.gitignore` so the directory is tracked but per-run trace JSON dumps are ignored
- Gives `dump_trace` a predictable repo-local path instead of `/tmp` (where files get fished out across shell sessions)
- Mirrors the `/audits/` precedent for per-run agent artifacts

## Test plan

- [x] `git check-ignore -v traces/foo.json` matches `/traces/*`
- [x] `traces/.gitkeep` stays tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)