### PR TITLE
feat(trace): describe_tree_window mcp tool (phase 2)

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -691,6 +691,165 @@ mod tests {
         assert!(format!("{err:?}").contains("unknown engine_id"));
     }
 
+    /// Issue 735: descriptor for `aether.trace.describe_window`.
+    fn describe_window_descriptor() -> aether_data::KindDescriptor {
+        use aether_data::Kind as _;
+        aether_data::KindDescriptor {
+            name: aether_kinds::trace::DescribeWindow::NAME.to_owned(),
+            schema: <aether_kinds::trace::DescribeWindow as aether_data::Schema>::SCHEMA.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn describe_tree_window_round_trips_observer_reply() {
+        use aether_data::tagged_id::Tag;
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{DescribeWindowResult, MailNodeWire};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_window_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd010, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        let m_in = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0xAA01)),
+            correlation_id: 1,
+        };
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeWindowResult::Ok {
+                mails: vec![MailNodeWire {
+                    mail_id: m_in,
+                    parent: None,
+                    sender: m_in.sender,
+                    recipient: MailboxId(with_tag(Tag::Mailbox, 0xAA02)),
+                    kind: aether_data::KindId(aether_data::with_tag(Tag::Kind, 0xCAFE)),
+                    t_sent: aether_kinds::trace::Nanos(500),
+                    t_received: Some(aether_kinds::trace::Nanos(600)),
+                    t_finished: Some(aether_kinds::trace::Nanos(700)),
+                    thread_name: Some("aether-worker-3".to_owned()),
+                }],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_window_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let json = hub
+            .describe_tree_window(Parameters(args::DescribeTreeWindowArgs {
+                engine_id: id.0.to_string(),
+                window: args::TraceWindowArg::Relative { last_ms: 1_000 },
+                max_mails: Some(100),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+
+        substrate_task.await.expect("stub substrate task");
+
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let ok = &raw["Ok"];
+        let mails = ok["mails"].as_array().unwrap();
+        assert_eq!(mails.len(), 1);
+        let m = &mails[0];
+        assert!(
+            m["sender"].as_str().unwrap().starts_with("mbx-"),
+            "sender should be tagged"
+        );
+        assert!(
+            m["kind"].as_str().unwrap().starts_with("knd-"),
+            "kind should be tagged"
+        );
+        assert_eq!(m["t_sent"], 500);
+        assert_eq!(m["thread_name"], "aether-worker-3");
+    }
+
+    #[tokio::test]
+    async fn describe_tree_window_too_many_surfaces_err() {
+        use aether_kinds::trace::DescribeWindowResult;
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_window_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd011, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        // Stub substrate replies with Err::too_many — the hub should
+        // pass it through as the externally-tagged JSON envelope so
+        // the agent can read the matched count.
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeWindowResult::Err {
+                too_many: Some(12_345),
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_window_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let json = hub
+            .describe_tree_window(Parameters(args::DescribeTreeWindowArgs {
+                engine_id: id.0.to_string(),
+                window: args::TraceWindowArg::Absolute {
+                    start_ns: 0,
+                    end_ns: Some(1_000_000_000_000),
+                },
+                max_mails: Some(5),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+
+        substrate_task.await.expect("stub substrate task");
+
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["Err"]["too_many"], 12_345);
+    }
+
+    #[tokio::test]
+    async fn describe_tree_window_unknown_engine_errors() {
+        let state = test_state(EngineRegistry::new(), SessionRegistry::new());
+        let hub = Hub::new(state);
+        let err = hub
+            .describe_tree_window(Parameters(args::DescribeTreeWindowArgs {
+                engine_id: Uuid::from_u128(0xdead_beef).to_string(),
+                window: args::TraceWindowArg::Relative { last_ms: 100 },
+                max_mails: None,
+                timeout_ms: Some(1_000),
+            }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("unknown engine_id"));
+    }
+
     fn list_active_roots_descriptor() -> aether_data::KindDescriptor {
         use aether_data::Kind as _;
         aether_data::KindDescriptor {

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -516,6 +516,51 @@ pub struct DumpTraceArgs {
     pub timeout_ms: Option<u32>,
 }
 
+/// Issue 735: agent-facing window selector for the time-window trace
+/// queries. Untagged so the JSON discriminates by field presence —
+/// `{"last_ms": N}` is `Relative`, `{"start_ns": X, "end_ns": Y?}` is
+/// `Absolute`. The two field-name sets don't overlap, so deserialize
+/// is unambiguous. Mirrors `aether_kinds::trace::TraceWindow`; kept
+/// hub-side because `aether-kinds` is `no_std + alloc` and doesn't
+/// depend on `schemars`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum TraceWindowArg {
+    /// Explicit absolute range in nanoseconds-since-substrate-boot.
+    /// `end_ns: None` means "open-ended through now" (resolved by the
+    /// observer at handler entry).
+    Absolute {
+        start_ns: u64,
+        #[serde(default)]
+        end_ns: Option<u64>,
+    },
+    /// Last N milliseconds, relative to the substrate's monotonic now
+    /// at handler entry. Equivalent to `{ start_ns: now - last_ms, end_ns: None }`.
+    Relative { last_ms: u64 },
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeTreeWindowArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Time window selector. Either `{"last_ms": N}` for "last N
+    /// milliseconds" (resolved against substrate monotonic now) or
+    /// `{"start_ns": ..., "end_ns": ...}` for an explicit absolute
+    /// range. `end_ns` is optional; omitting it means "open-ended
+    /// through now."
+    pub window: TraceWindowArg,
+    /// Cap on the number of in-window mails returned. Substrate
+    /// defaults 10_000; hard cap 100_000. Over-cap windows reply
+    /// `Err::too_many` with the matched count so you can narrow the
+    /// window or raise this. Strict containment of `t_sent`.
+    #[serde(default)]
+    pub max_mails: Option<u32>,
+    /// Maximum time to wait for the substrate's reply, in
+    /// milliseconds. Defaults to 5000. Clamped to 30000.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DescribeTreeArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -17,8 +17,8 @@ use aether_kinds::{
     EnvVar, Spawn as WireSpawn, SpawnResult as WireSpawnResult, Terminate as WireTerminate,
     TerminateResult as WireTerminateResult,
     trace::{
-        DescribeTree, DescribeTreeResult, ListActiveRoots, ListActiveRootsResult,
-        TRACE_OBSERVER_MAILBOX_NAME,
+        DescribeTree, DescribeTreeResult, DescribeWindow, DescribeWindowResult, ListActiveRoots,
+        ListActiveRootsResult, TRACE_OBSERVER_MAILBOX_NAME, TraceWindow,
     },
 };
 use base64::Engine as _;
@@ -38,11 +38,11 @@ use crate::hub::session::SessionHandle;
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
-    DescribeKindsArgs, DescribeTreeArgs, DumpTraceArgs, EngineInfo, EngineLogEntry, EngineLogsArgs,
-    EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs, LoadComponentResponse,
-    LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs,
-    ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult,
-    TerminateSubstrateArgs, log_level_to_str,
+    DescribeKindsArgs, DescribeTreeArgs, DescribeTreeWindowArgs, DumpTraceArgs, EngineInfo,
+    EngineLogEntry, EngineLogsArgs, EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs,
+    LoadComponentResponse, LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail,
+    ReplaceComponentArgs, ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs,
+    TerminateResult, TerminateSubstrateArgs, TraceWindowArg, log_level_to_str,
 };
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
 use super::trace::render;
@@ -1016,6 +1016,111 @@ impl Hub {
             Ok(Err(_)) => {
                 return Err(McpError::internal_error(
                     "describe_tree reply channel closed before reply arrived".to_owned(),
+                    None,
+                ));
+            }
+            Err(_) => {
+                return Err(McpError::internal_error(
+                    format!(
+                        "timed out after {}ms waiting for {result_kind}",
+                        wait.as_millis()
+                    ),
+                    None,
+                ));
+            }
+        };
+
+        postcard::from_bytes(&queued.payload)
+            .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))
+    }
+
+    #[tool(
+        description = "Describe every mail whose `t_sent` falls within a time window (issue iamacoffeepot/aether#735). Same observer state as `describe_tree`, just collected by overlap rather than by root walk — useful for perf investigation when you want \"what happened in the last N ms?\" rather than drilling into one specific chain. `window` is either `{\"last_ms\": N}` for last-N-milliseconds (resolved against the substrate's monotonic now) or `{\"start_ns\": ..., \"end_ns\": ...}` for an explicit absolute range (`end_ns` optional, defaults to \"now\"). Strict `t_sent` containment — parent edges may dangle to mail outside the window; drill into a specific root via `describe_tree` for full chain context. `max_mails` caps the reply (default 10_000, substrate hard cap 100_000); over-cap windows reply `{\"Err\": {\"too_many\": <matched_count>}}` instead of truncating, so the caller can narrow before retrying. Default timeout 5000ms; clamped to 30000."
+    )]
+    pub(super) async fn describe_tree_window(
+        &self,
+        Parameters(args): Parameters<DescribeTreeWindowArgs>,
+    ) -> Result<String, McpError> {
+        let result = self.do_describe_window(args).await?;
+        // `DescribeWindowResult`'s serde branches emit tagged strings
+        // for ids and a u64 for `Nanos` on human-readable serializers,
+        // so JSON serialization is a single shot. The externally-
+        // tagged `Ok` / `Err` shape mirrors `describe_tree`'s reply.
+        serde_json::to_string(&result).map_err(|e| McpError::internal_error(e.to_string(), None))
+    }
+
+    /// Shared describe_tree_window core. The public tool wraps this
+    /// with JSON serialization; `dump_trace_window` (Phase 3) reuses
+    /// it to fetch the same observer state and re-shape it as trace
+    /// events.
+    pub(super) async fn do_describe_window(
+        &self,
+        args: DescribeTreeWindowArgs,
+    ) -> Result<DescribeWindowResult, McpError> {
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        if self.state.engines.get(&id).is_none() {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        }
+
+        // Convert the agent's untagged `TraceWindowArg` to the
+        // substrate-side externally-tagged `TraceWindow`, then
+        // serialize the whole `DescribeWindow` request through serde.
+        // The schema codec expects externally-tagged enum JSON
+        // (`{"Absolute": {...}}` / `{"Relative": {...}}`), which is
+        // exactly what serde's default impl emits for `TraceWindow`.
+        let window_kind = match args.window {
+            TraceWindowArg::Absolute { start_ns, end_ns } => {
+                TraceWindow::Absolute { start_ns, end_ns }
+            }
+            TraceWindowArg::Relative { last_ms } => TraceWindow::Relative { last_ms },
+        };
+        let request = DescribeWindow {
+            window: window_kind,
+            max_mails: args.max_mails,
+        };
+        let request_params = serde_json::to_value(request).map_err(|e| {
+            McpError::internal_error(format!("encode describe_window request: {e}"), None)
+        })?;
+
+        let result_kind = <DescribeWindowResult as Kind>::NAME.to_owned();
+        let (_guard, rx) = self
+            .session
+            .replies
+            .register(result_kind.clone())
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "a describe_tree_window is already in flight on this session; wait for it to complete"
+                        .to_owned(),
+                    None,
+                )
+            })?;
+
+        let spec = MailSpec {
+            engine_id: args.engine_id.clone(),
+            recipient_name: TRACE_OBSERVER_MAILBOX_NAME.to_owned(),
+            kind_name: <DescribeWindow as Kind>::NAME.to_owned(),
+            params: Some(request_params),
+            count: 1,
+        };
+        deliver_one(spec, &self.state.engines, self.session.token)
+            .await
+            .map_err(|e| McpError::internal_error(format!("send failed: {e}"), None))?;
+
+        let wait = args
+            .timeout_ms
+            .map(|ms| Duration::from_millis(ms as u64).min(MAX_REPLY_TIMEOUT))
+            .unwrap_or(DEFAULT_REPLY_TIMEOUT);
+        let queued = match timeout(wait, rx).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) => {
+                return Err(McpError::internal_error(
+                    "describe_tree_window reply channel closed before reply arrived".to_owned(),
                     None,
                 ));
             }


### PR DESCRIPTION
## Summary

Phase 2 of iamacoffeepot/aether#735 — exposes the substrate's `aether.trace.describe_window` handler (shipped in iamacoffeepot/aether#739) over MCP.

- `args.rs`: `TraceWindowArg` (untagged enum: agent picks `{"last_ms": N}` for relative or `{"start_ns": ..., "end_ns": ...}` for absolute), `DescribeTreeWindowArgs { engine_id, window, max_mails, timeout_ms }`.
- `tools.rs`: `describe_tree_window` tool fn + extracted `do_describe_window` core (Phase 3's `dump_trace_window` will reuse it). Converts the agent-facing untagged window to the substrate-side externally-tagged `TraceWindow`, encodes the `DescribeWindow` request via serde, awaits the postcard reply through the existing pending-replies mechanism, returns the JSON envelope verbatim (`{"Ok": {"mails": [...]}}` / `{"Err": {"too_many": <count>}}`) for symmetry with `describe_tree`.

Phase 3 (`dump_trace_window`) bundles this with the existing renderer and ships the live smoke.

Refs iamacoffeepot/aether#735

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle 'mcp::tests::describe_tree_window'` — 3/3 pass (round-trip / too_many / unknown-engine)
- [x] `cargo nextest run --workspace` — 1096/1096 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)