### PR TITLE
feat(trace): dump_trace_window mcp tool (phase 3)

### DIFF
--- a/crates/aether-substrate-bundle/src/hub/mcp.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp.rs
@@ -1157,6 +1157,168 @@ mod tests {
         assert_eq!(slices[0]["ph"], "X");
     }
 
+    /// Issue 735 phase 3: dump_trace_window calls describe_window then
+    /// renders the resulting flat mail set as Chrome trace JSON. With
+    /// `output_path` set, the trace is written to disk and the tool
+    /// returns `{"path": ...}` — same shape as `dump_trace`. The
+    /// rendered events come straight from the windowed mails (no root
+    /// context); each mail with `t_received`/`t_finished` populated
+    /// becomes one `ph: "X"` slice.
+    #[tokio::test]
+    async fn dump_trace_window_writes_file_when_path_set() {
+        use aether_data::tagged_id::Tag;
+        use aether_data::{MailId, MailboxId, with_tag};
+        use aether_kinds::trace::{DescribeWindowResult, MailNodeWire};
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_window_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd735, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        // Two unrelated mails (different roots) inside the window —
+        // dump_trace_window renders both even though they're in
+        // separate chains.
+        let m_a = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0xAA)),
+            correlation_id: 1,
+        };
+        let m_b = MailId {
+            sender: MailboxId(with_tag(Tag::Mailbox, 0xBB)),
+            correlation_id: 1,
+        };
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeWindowResult::Ok {
+                mails: vec![
+                    MailNodeWire {
+                        mail_id: m_a,
+                        parent: None,
+                        sender: m_a.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 1)),
+                        kind: aether_data::KindId(with_tag(Tag::Kind, 0xCAFE)),
+                        t_sent: aether_kinds::trace::Nanos(1_000),
+                        t_received: Some(aether_kinds::trace::Nanos(2_000)),
+                        t_finished: Some(aether_kinds::trace::Nanos(3_000)),
+                        thread_name: None,
+                    },
+                    MailNodeWire {
+                        mail_id: m_b,
+                        parent: None,
+                        sender: m_b.sender,
+                        recipient: MailboxId(with_tag(Tag::Mailbox, 2)),
+                        kind: aether_data::KindId(with_tag(Tag::Kind, 0xDEAD)),
+                        t_sent: aether_kinds::trace::Nanos(5_000),
+                        t_received: Some(aether_kinds::trace::Nanos(6_000)),
+                        t_finished: Some(aether_kinds::trace::Nanos(8_000)),
+                        thread_name: None,
+                    },
+                ],
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_window_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let tmp =
+            std::env::temp_dir().join(format!("aether-trace-window-{}.json", std::process::id()));
+        let response = hub
+            .dump_trace_window(Parameters(args::DumpTraceWindowArgs {
+                engine_id: id.0.to_string(),
+                window: args::TraceWindowArg::Relative { last_ms: 10_000 },
+                output_path: Some(tmp.to_string_lossy().into_owned()),
+                max_mails: Some(1_000),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .expect("tool should succeed");
+        substrate_task.await.expect("stub substrate task");
+
+        let parsed: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(parsed["path"].as_str().unwrap(), tmp.to_string_lossy());
+
+        let written = std::fs::read_to_string(&tmp).expect("trace file written");
+        let trace: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let events = trace["traceEvents"].as_array().unwrap();
+        let slices: Vec<&serde_json::Value> = events.iter().filter(|e| e["ph"] != "M").collect();
+        assert_eq!(slices.len(), 2, "two mails -> two X events");
+        for s in &slices {
+            assert_eq!(s["ph"], "X");
+        }
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Issue 735 phase 3: when the substrate replies `Err::too_many`
+    /// the hub surfaces it as an `invalid_params` MCP error mentioning
+    /// the matched count, so the agent knows whether to narrow the
+    /// window or raise `max_mails`. No file is written.
+    #[tokio::test]
+    async fn dump_trace_window_too_many_surfaces_error() {
+        use aether_kinds::trace::DescribeWindowResult;
+
+        let engines = EngineRegistry::new();
+        let kinds = vec![describe_window_descriptor()];
+        let (rec, mut rx) = record_with_kinds(0xd736, kinds);
+        let id = rec.id;
+        engines.insert(rec);
+        let state = test_state(engines, SessionRegistry::new());
+        let hub = Hub::new(Arc::clone(&state));
+        let session_token = hub.session.token;
+
+        let sessions_clone = state.sessions.clone();
+        let substrate_task = tokio::spawn(async move {
+            let _req = rx.recv().await.expect("tool should send request");
+            let reply = DescribeWindowResult::Err {
+                too_many: Some(54_321),
+            };
+            let payload = postcard::to_allocvec(&reply).expect("encode reply");
+            let record = sessions_clone.get(&session_token).expect("session");
+            let kind = "aether.trace.describe_window_result".to_owned();
+            let queued = QueuedMail {
+                engine_id: id,
+                kind_name: kind.clone(),
+                payload,
+                broadcast: false,
+                origin: None,
+            };
+            let remainder = record.replies.try_deliver(&kind, queued);
+            assert!(remainder.is_none(), "reply registry should consume mail");
+        });
+
+        let err = hub
+            .dump_trace_window(Parameters(args::DumpTraceWindowArgs {
+                engine_id: id.0.to_string(),
+                window: args::TraceWindowArg::Relative { last_ms: 10_000 },
+                output_path: None,
+                max_mails: Some(5),
+                timeout_ms: Some(2_000),
+            }))
+            .await
+            .unwrap_err();
+        substrate_task.await.expect("stub substrate task");
+
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("54321") && msg.contains("max_mails"),
+            "error should mention matched count + how to fix: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn describe_component_rejects_malformed_mailbox_id() {
         // ADR-0064: a bare-number mailbox id is no longer valid wire

--- a/crates/aether-substrate-bundle/src/hub/mcp/args.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/args.rs
@@ -562,6 +562,33 @@ pub struct DescribeTreeWindowArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct DumpTraceWindowArgs {
+    /// Hub-assigned engine UUID as a string (from `list_engines`).
+    pub engine_id: String,
+    /// Time window selector. Same shape as `describe_tree_window`'s
+    /// `window` arg — `{"last_ms": N}` for relative or
+    /// `{"start_ns": ..., "end_ns": ...}` for absolute. `end_ns`
+    /// optional.
+    pub window: TraceWindowArg,
+    /// Optional filesystem path to write the trace JSON to. Parent
+    /// directories are created as needed. When omitted the JSON is
+    /// returned inline; for any non-trivial window that's likely
+    /// to overflow the agent's context — point this at a file
+    /// instead and load it into Perfetto.
+    #[serde(default)]
+    pub output_path: Option<String>,
+    /// Cap on the number of in-window mails the substrate will return
+    /// before erroring with `Err::too_many`. Substrate defaults
+    /// 10_000; hard cap 100_000. Mirrors `describe_tree_window`.
+    #[serde(default)]
+    pub max_mails: Option<u32>,
+    /// Maximum time to wait for the substrate's `DescribeWindowResult`
+    /// reply, in milliseconds. Defaults to 5000. Clamped to 30000.
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DescribeTreeArgs {
     /// Hub-assigned engine UUID as a string (from `list_engines`).
     pub engine_id: String,

--- a/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/tools.rs
@@ -38,14 +38,15 @@ use crate::hub::session::SessionHandle;
 
 use super::args::{
     CaptureFrameArgs, CaptureFrameResultWire, DescribeComponentArgs, DescribeComponentResponse,
-    DescribeKindsArgs, DescribeTreeArgs, DescribeTreeWindowArgs, DumpTraceArgs, EngineInfo,
-    EngineLogEntry, EngineLogsArgs, EngineLogsResponse, ListActiveRootsArgs, LoadComponentArgs,
-    LoadComponentResponse, LoadResultWire, MailSpec, MailStatus, ReceiveMailArgs, ReceivedMail,
-    ReplaceComponentArgs, ReplaceResultWire, SendMailArgs, SpawnResult, SpawnSubstrateArgs,
-    TerminateResult, TerminateSubstrateArgs, TraceWindowArg, log_level_to_str,
+    DescribeKindsArgs, DescribeTreeArgs, DescribeTreeWindowArgs, DumpTraceArgs,
+    DumpTraceWindowArgs, EngineInfo, EngineLogEntry, EngineLogsArgs, EngineLogsResponse,
+    ListActiveRootsArgs, LoadComponentArgs, LoadComponentResponse, LoadResultWire, MailSpec,
+    MailStatus, ReceiveMailArgs, ReceivedMail, ReplaceComponentArgs, ReplaceResultWire,
+    SendMailArgs, SpawnResult, SpawnSubstrateArgs, TerminateResult, TerminateSubstrateArgs,
+    TraceWindowArg, log_level_to_str,
 };
 use super::codecs::{decode_inbound, deliver_one, encode_capture_bundle};
-use super::trace::render;
+use super::trace::{render, render_mails};
 use super::{Hub, HubState};
 use crate::hub::registry::ComponentRecord;
 
@@ -1032,6 +1033,88 @@ impl Hub {
 
         postcard::from_bytes(&queued.payload)
             .map_err(|e| McpError::internal_error(format!("decode reply: {e}"), None))
+    }
+
+    #[tool(
+        description = "Export every mail whose `t_sent` falls within a time window as a trace JSON file (issue iamacoffeepot/aether#735, ADR-0080 Phase 3). Same Chrome trace event format as `dump_trace`, just collected by overlap rather than by root walk — useful for \"what happened in the last N ms?\" perf investigation. Loads into Perfetto, chrome://tracing, or speedscope. `window` is either `{\"last_ms\": N}` for last-N-milliseconds (resolved against substrate monotonic now) or `{\"start_ns\": ..., \"end_ns\": ...}` for an explicit absolute range. Strict `t_sent` containment — parent edges may dangle to mail outside the window (Perfetto renders these as flow arrows with no destination); drill into a specific root via `dump_trace` for full chain context. `max_mails` caps the substrate's matched set (default 10_000, hard cap 100_000); over-cap windows fail with the matched count so the caller can narrow before retrying. When `output_path` is omitted the JSON is returned inline (likely to overflow agent context for any non-trivial window — point at a file). When set, writes to the path (creating parent dirs) and returns a `{path}` confirmation. Default timeout 5000ms; clamped to 30000."
+    )]
+    pub(super) async fn dump_trace_window(
+        &self,
+        Parameters(args): Parameters<DumpTraceWindowArgs>,
+    ) -> Result<String, McpError> {
+        // Same lookup-build path as `dump_trace`. Resolved entries
+        // give human-readable kind names + category-prefixed mailbox
+        // names in the trace doc; missing entries fall back to the
+        // tagged-string id so an out-of-sync inventory surfaces as
+        // visible drift rather than silent corruption (issue 731).
+        let uuid = Uuid::parse_str(&args.engine_id).map_err(|e| {
+            McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None)
+        })?;
+        let id = EngineId(uuid);
+        let Some(record) = self.state.engines.get(&id) else {
+            return Err(McpError::invalid_params(
+                format!("unknown engine_id {}", args.engine_id),
+                None,
+            ));
+        };
+        let kind_names: std::collections::HashMap<u64, String> = record
+            .kinds
+            .iter()
+            .map(|k| {
+                let kid = aether_data::canonical::kind_id_from_parts(&k.name, &k.schema);
+                (kid, k.name.clone())
+            })
+            .collect();
+        let mailbox_names: super::trace::MailboxLookup = record
+            .mailboxes
+            .iter()
+            .map(|m| (m.id.0, (m.name.clone(), m.category)))
+            .collect();
+        drop(record);
+
+        let describe_args = DescribeTreeWindowArgs {
+            engine_id: args.engine_id.clone(),
+            window: args.window,
+            max_mails: args.max_mails,
+            timeout_ms: args.timeout_ms,
+        };
+        let result = self.do_describe_window(describe_args).await?;
+        let mails = match result {
+            DescribeWindowResult::Ok { mails } => mails,
+            DescribeWindowResult::Err { too_many } => {
+                let count = too_many
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "<unspecified>".to_owned());
+                return Err(McpError::invalid_params(
+                    format!(
+                        "describe_window matched {count} mails (over max_mails); narrow the window or raise max_mails"
+                    ),
+                    None,
+                ));
+            }
+        };
+        let trace_json = render_mails(&mails, &kind_names, &mailbox_names)
+            .map_err(|e| McpError::internal_error(format!("render trace: {e}"), None))?;
+
+        match args.output_path {
+            Some(path) => {
+                if let Some(parent) = std::path::Path::new(&path).parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                        McpError::internal_error(
+                            format!("create parent dirs for {path}: {e}"),
+                            None,
+                        )
+                    })?;
+                }
+                tokio::fs::write(&path, &trace_json).await.map_err(|e| {
+                    McpError::internal_error(format!("write trace to {path}: {e}"), None)
+                })?;
+                Ok(serde_json::json!({ "path": path }).to_string())
+            }
+            None => Ok(trace_json),
+        }
     }
 
     #[tool(

--- a/crates/aether-substrate-bundle/src/hub/mcp/trace.rs
+++ b/crates/aether-substrate-bundle/src/hub/mcp/trace.rs
@@ -80,7 +80,26 @@ pub(super) fn render(
     kind_names: &HashMap<u64, String>,
     mailbox_names: &MailboxLookup,
 ) -> Result<String, serde_json::Error> {
-    let mut events = build_events(result, kind_names, mailbox_names);
+    match result {
+        DescribeTreeResult::Ok { mails, .. } => render_mails(mails, kind_names, mailbox_names),
+        DescribeTreeResult::Err { not_found } => render_not_found(*not_found, mailbox_names),
+    }
+}
+
+/// Issue 735: render a flat list of [`MailNodeWire`]s (the
+/// `dump_trace_window` shape — no `root` / `in_flight` context, just
+/// the mails that fell within the requested window). The body is the
+/// post-`build_events` pipeline lifted out of [`render`] so the
+/// describe-tree path and the describe-window path share the
+/// downstream sort + integer-pid/tid-rewrite + metadata emission
+/// logic without forcing the window-side caller to fabricate an
+/// unused root / in_flight tuple.
+pub(super) fn render_mails(
+    mails: &[MailNodeWire],
+    kind_names: &HashMap<u64, String>,
+    mailbox_names: &MailboxLookup,
+) -> Result<String, serde_json::Error> {
+    let mut events = build_events(mails, kind_names, mailbox_names);
     // Sort by `ts` ascending. Some chrome-trace importers (Perfetto
     // included) tolerate unsorted streams but emit warnings; sorting
     // here removes that whole category of noise without callers
@@ -193,31 +212,48 @@ pub(super) fn render(
     serde_json::to_string_pretty(&json!({ "traceEvents": metadata }))
 }
 
+/// Renders the `not_found` Err arm of [`DescribeTreeResult`] as a
+/// trace doc with a single metadata event explaining the empty
+/// payload. Pulled out of `render` for symmetry with `render_mails` —
+/// the window-side path never produces this shape (Phase 3 surfaces
+/// `Err::too_many` as an MCP error before reaching the renderer at
+/// all).
+fn render_not_found(
+    not_found: MailId,
+    mailbox_names: &MailboxLookup,
+) -> Result<String, serde_json::Error> {
+    let label = format_mail_id(not_found, mailbox_names);
+    // Two-event shape preserved from the pre-refactor pipeline: the
+    // post-build_events resolver auto-emitted one `process_name` M
+    // event per unique pid label, on top of the diagnostic `process_name`
+    // M event itself. Agents that scanned the trace doc for the
+    // `args.name = "...not_found..."` line still find it here.
+    let metadata = vec![
+        json!({
+            "ph": "M",
+            "name": "process_name",
+            "cat": "metadata",
+            "pid": 1,
+            "args": { "name": label.clone() },
+        }),
+        json!({
+            "ph": "M",
+            "name": "process_name",
+            "cat": "metadata",
+            "pid": 1,
+            "args": {
+                "name": format!("describe_tree returned not_found for {label}")
+            },
+        }),
+    ];
+    serde_json::to_string_pretty(&json!({ "traceEvents": metadata }))
+}
+
 fn build_events(
-    result: &DescribeTreeResult,
+    mails: &[MailNodeWire],
     kind_names: &HashMap<u64, String>,
     mailbox_names: &MailboxLookup,
 ) -> Vec<Value> {
-    let mails = match result {
-        DescribeTreeResult::Ok { mails, .. } => mails,
-        DescribeTreeResult::Err { not_found } => {
-            // Empty trace doc with a metadata event explaining the
-            // missing root — chrome://tracing surfaces metadata
-            // events as a top-level note so the agent sees why the
-            // file is empty.
-            let label = format_mail_id(*not_found, mailbox_names);
-            return vec![json!({
-                "ph": "M",
-                "name": "process_name",
-                "cat": "metadata",
-                "pid": label,
-                "args": {
-                    "name": format!("describe_tree returned not_found for {label}")
-                },
-            })];
-        }
-    };
-
     // Index for parent-edge lookup.
     let by_id: HashMap<MailId, &MailNodeWire> = mails.iter().map(|n| (n.mail_id, n)).collect();
 


### PR DESCRIPTION
## Summary

Phase 3 of iamacoffeepot/aether#735 — the agent-facing trace dump for "what happened in the last N ms?" perf investigation. Bundles Phase 2's `do_describe_window` query with a renderer adapted to the windowed flat-mail shape.

- `args.rs`: `DumpTraceWindowArgs { engine_id, window, output_path, max_mails, timeout_ms }`. Same `TraceWindowArg` (untagged: `{"last_ms": N}` or `{"start_ns": ..., "end_ns": ...}`) and same inline-or-file branching as `dump_trace`.
- `tools.rs`: `dump_trace_window` tool fn. Reuses Phase 2's `do_describe_window`; surfaces `Err::too_many` as an `invalid_params` MCP error mentioning the matched count + how to narrow. Renders via `render_mails`.
- `trace.rs`: refactor `render` to extract `render_mails(&[MailNodeWire], ...)` for the windowed path, plus a sibling `render_not_found` for the describe_tree-only `Err::not_found` arm. The pre-extraction `render` was tightly coupled to `DescribeTreeResult`; window-side callers now skip fabricating an unused root/in_flight tuple.

Live smoke (5s headless, `dump_trace_window { window: { last_ms: 1000 } }` → ~60 chains in one Perfetto-loadable file) belongs to a follow-up after the new tool surfaces in restarted hub sessions.

Closes iamacoffeepot/aether#735

## Test plan

- [x] `cargo nextest run -p aether-substrate-bundle 'dump_trace_window'` — 2/2 pass (file write / too_many error)
- [x] `cargo nextest run -p aether-substrate-bundle 'mcp::trace::tests'` — 7/7 pass (existing renderer tests against refactored shape)
- [x] `cargo nextest run --workspace` — 1098/1098 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)