### PR TITLE
fix(tcp): block on recv instead of polling under contention

### DIFF
--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -629,16 +629,17 @@ mod cap_native {
             // (the loopback HubOutbound) ships every broadcast over
             // `rx`. We tolerate other egress events (e.g. Tick
             // broadcasts) interleaved.
-            let deadline = Instant::now() + Duration::from_secs(2);
+            let deadline = Instant::now() + Duration::from_secs(5);
             let mut saw_data = false;
             let mut saw_closed = false;
-            while Instant::now() < deadline && (!saw_data || !saw_closed) {
-                let frame = match rx.try_recv() {
+            while !saw_data || !saw_closed {
+                let remaining = match deadline.checked_duration_since(Instant::now()) {
+                    Some(d) => d,
+                    None => break,
+                };
+                let frame = match rx.recv_timeout(remaining) {
                     Ok(f) => f,
-                    Err(_) => {
-                        thread::sleep(Duration::from_millis(5));
-                        continue;
-                    }
+                    Err(_) => break,
                 };
                 let (kind_name, payload) = match frame {
                     EgressEvent::Broadcast {


### PR DESCRIPTION
## Summary

`session_round_trip_data_then_close` was flaking under nextest parallel pressure because its egress-drain loop polled `rx.try_recv()` on a 5ms `thread::sleep` cadence inside a 2s deadline. Under CPU contention the polling cadence could miss the broadcast cap's wake long enough that the deadline elapsed before both `SessionData` and `SessionClosed` arrived.

Switch the loop to a blocking `rx.recv_timeout(remaining)` so the OS wakes the test thread the moment a broadcast lands. The polling cadence is gone from the equation; the existing `assert!(saw_data, ...)` / `assert!(saw_closed, ...)` lines still surface a real timeout as a failure. Bump the outer deadline to 5s for a comfortable safety margin.

Scope is one test function; no production-path changes.

## Test plan

- [x] `cargo nextest run -p aether-capabilities tcp::cap_native::tests::session_round_trip_data_then_close --no-fail-fast` (passed)
- [x] `cargo nextest run --workspace` (1100/1100 passed)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)

Closes iamacoffeepot/aether#713

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)