### PR TITLE
fix(spawn): channel-signal shutdown_instanced instead of polling

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -114,6 +114,15 @@ where
     /// Static label for tracing / fairness logs. Today this is the
     /// actor's `NAMESPACE`.
     label: &'static str,
+    /// Issue 714: one-shot completion sender installed by
+    /// [`crate::actor::native::spawn::Spawner::shutdown_instanced`].
+    /// Fired exactly once after the `Closed` branch of [`Self::run_cycle`]
+    /// finishes its `unwire` + registry-close + `actor_guard.take()`
+    /// sequence. The Spawner waits on the matching receiver via
+    /// `recv_timeout` so chassis teardown settles deterministically
+    /// without a 2 ms polling loop. `Mutex<Option<_>>` so the slot can
+    /// take + send without holding the lock across the actor mutex.
+    close_done_tx: Mutex<Option<crossbeam_channel::Sender<()>>>,
 }
 
 impl<A> DispatcherSlot<A>
@@ -154,7 +163,27 @@ where
             mailer,
             self_id,
             label: A::NAMESPACE,
+            close_done_tx: Mutex::new(None),
         })
+    }
+
+    /// Issue 714: fire the installed one-shot completion sender if any.
+    /// Called once from the `Closed` branch of [`Self::run_cycle`] after
+    /// `unwire` + registry close + `actor_guard.take()` have run. Take +
+    /// `try_send`: bounded(1) guarantees the receiver only sees the
+    /// first send; subsequent calls (idempotent — there should never be
+    /// any) are no-ops. Done outside the actor mutex.
+    fn fire_close_done(&self) {
+        let tx = self
+            .close_done_tx
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take();
+        if let Some(tx) = tx {
+            // Receiver may have hung up if the wait already timed out.
+            // Either way, the channel goes away after this call.
+            let _ = tx.try_send(());
+        }
     }
 
     /// Per-envelope dispatch matching
@@ -266,7 +295,11 @@ where
             Some(a) => a,
             None => {
                 // Slot already finalized. Nothing to do.
+                drop(actor_guard);
                 self.state.mark_idle();
+                // Issue 714: a wait that came in after the close cycle
+                // already ran needs the signal too.
+                self.fire_close_done();
                 return CycleResult::Closed;
             }
         };
@@ -305,7 +338,16 @@ where
             // Phase 4: registry close + monitor fan-out.
             self.finalize_registry();
             actor_guard.take();
+            // Drop the actor mutex before signalling so the waiter (the
+            // chassis-teardown thread in `Spawner::shutdown_instanced`)
+            // wakes onto an unlocked slot.
+            drop(actor_guard);
             self.state.mark_idle();
+            // Issue 714: signal chassis teardown that this slot's
+            // close cycle finished. `is_closed()` would return `true`
+            // from this point onward; the channel signal lets the
+            // waiter wake immediately instead of polling.
+            self.fire_close_done();
             return CycleResult::Closed;
         }
 
@@ -359,14 +401,47 @@ where
     /// Issue 685: chassis-teardown wait predicate. The Closed branch
     /// of [`Self::run_cycle`] takes the actor out of the `Mutex<Option<Box<A>>>`
     /// guard, so `actor_guard.is_none()` is equivalent to "close cycle
-    /// has run." Spawner polls this with a bounded timeout while
-    /// waiting for spawned actors to wind down before the pool drops.
+    /// has run." Issue 714 retired the polling caller in favour of a
+    /// channel signal (see [`Self::set_close_done_tx`]), but the
+    /// predicate stays available for diagnostics + the fast-path
+    /// already-closed check inside `set_close_done_tx`.
     fn is_closed(&self) -> bool {
         let guard = self
             .actor
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         guard.is_none()
+    }
+
+    /// Issue 714: install the chassis-teardown completion sender.
+    /// Stash it in the slot; the close cycle's `fire_close_done` will
+    /// fire it on the way out. Fast path: if the slot already finished
+    /// its close cycle (actor mutex empty), fire immediately so a late
+    /// waiter doesn't park forever waiting for a signal that already
+    /// passed.
+    fn set_close_done_tx(&self, tx: crossbeam_channel::Sender<()>) {
+        // Fast-path: already closed. Signal directly without stashing.
+        if self.is_closed() {
+            let _ = tx.try_send(());
+            return;
+        }
+        let prior = self
+            .close_done_tx
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .replace(tx);
+        // Defensive: if a prior sender was installed (shouldn't happen
+        // — `shutdown_instanced` runs once per chassis), drop it. The
+        // bounded(1) channel goes away with it; that waiter will see
+        // a Disconnected, not a Timeout.
+        drop(prior);
+        // Re-check: the close cycle may have run between the
+        // `is_closed` fast-path check and the stash. If so, fire the
+        // sender we just stashed manually — it isn't going to be picked
+        // up by another `fire_close_done` call.
+        if self.is_closed() {
+            self.fire_close_done();
+        }
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -156,8 +156,9 @@ impl Spawner {
     /// Issue 685: walk every spawned instanced slot, signal shutdown
     /// on its binding, fire one wake so a pool worker picks it up and
     /// runs the close path (drain residual → `unwire` → registry
-    /// close + monitor fan-out), then poll [`crate::scheduler::Drainable::is_closed`]
-    /// until every slot has finished or `timeout` elapses.
+    /// close + monitor fan-out), then wait per-slot on a one-shot
+    /// completion channel until every slot has finished or `timeout`
+    /// elapses.
     ///
     /// Called from [`crate::chassis::builder::BootedPassives::shutdown_in_place`]
     /// before the singleton shutdowns walk. The ordering matters:
@@ -167,6 +168,16 @@ impl Spawner {
     /// `_pool: PoolHandle` field on `BootedPassives` which has a later
     /// drop order than the explicit `shutdown_in_place` call), so
     /// workers can drain the close cycles we just queued.
+    ///
+    /// Issue 714: the original implementation polled
+    /// [`crate::scheduler::Drainable::is_closed`] every 2 ms with a
+    /// `timeout`-bounded loop. Under nextest contention the worker that
+    /// observed the wake could be scheduled out long enough that the
+    /// 2 s deadline elapsed before the close cycle ran, surfacing as
+    /// the chassis_teardown_runs_unwire flake. The waker now installs a
+    /// one-shot `crossbeam_channel::bounded(1)` per entry; the slot's
+    /// close cycle fires it after `unwire` + registry close land, so
+    /// teardown wakes the instant the cycle settles instead of polling.
     ///
     /// On timeout: logs at warn level and returns. The slot Arcs we
     /// drained out of `instanced_slots` will then drop, and any actor
@@ -180,27 +191,50 @@ impl Spawner {
         if entries.is_empty() {
             return;
         }
+        // Wire one (tx, rx) per entry up-front. Installing the tx on
+        // the slot before signalling shutdown ensures the close cycle
+        // sees the sender to fire — even if the worker enters the
+        // close path before `signal_shutdown` returns control. The
+        // slot's `set_close_done_tx` fast-paths an already-closed slot
+        // by firing immediately, so there's no race window where the
+        // close cycle ran without seeing the tx.
+        let mut waiters: Vec<crossbeam_channel::Receiver<()>> = Vec::with_capacity(entries.len());
         for entry in &entries {
+            let (tx, rx) = crossbeam_channel::bounded::<()>(1);
+            entry.slot.set_close_done_tx(tx);
+            waiters.push(rx);
             entry.slot.signal_shutdown();
             entry.wake.wake();
         }
         let deadline = std::time::Instant::now() + timeout;
-        loop {
-            let all_closed = entries.iter().all(|e| e.slot.is_closed());
-            if all_closed {
-                return;
+        let mut stuck = 0usize;
+        for rx in &waiters {
+            let now = std::time::Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            // `remaining == 0` means the deadline has passed; pass
+            // `Duration::ZERO` to `recv_timeout` and treat as a
+            // timeout. crossbeam channels return Timeout for the
+            // zero-duration call when the channel has nothing to
+            // recv, which is exactly what we want.
+            match rx.recv_timeout(remaining) {
+                Ok(()) => {}
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                    stuck += 1;
+                }
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                    // Slot dropped its sender without firing — treat
+                    // the same as a timeout (close cycle didn't run).
+                    stuck += 1;
+                }
             }
-            if std::time::Instant::now() >= deadline {
-                let stuck = entries.iter().filter(|e| !e.slot.is_closed()).count();
-                tracing::warn!(
-                    target: "aether_substrate::spawner",
-                    stuck_count = stuck,
-                    total = entries.len(),
-                    "shutdown_instanced timed out waiting for spawned actors to run close path",
-                );
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        if stuck > 0 {
+            tracing::warn!(
+                target: "aether_substrate::spawner",
+                stuck_count = stuck,
+                total = entries.len(),
+                "shutdown_instanced timed out waiting for spawned actors to run close path",
+            );
         }
     }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -2504,6 +2504,81 @@ mod tests {
         let _ = id;
     }
 
+    /// Issue 714: stress version of the chassis-teardown contract.
+    /// Spawn N=64 instanced actors and assert all N close_observed
+    /// counters tick to exactly 1 after `drop(chassis)`. Pre-714 the
+    /// polling-based `shutdown_instanced` could lose individual wakes
+    /// under contention; the channel-signal rewrite is deterministic
+    /// — even one missed `unwire` here fails the test.
+    #[test]
+    fn chassis_teardown_runs_unwire_for_many_pooled_actors() {
+        use crate::actor::native::spawn::Subname;
+        use aether_actor::Instanced;
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        struct Quiet {
+            close_observed: Arc<AtomicU32>,
+        }
+        impl aether_actor::Actor for Quiet {
+            const NAMESPACE: &'static str = "test.teardown.quiet_many";
+        }
+        impl Instanced for Quiet {}
+        impl crate::actor::native::NativeActor for Quiet {
+            type Config = Arc<AtomicU32>;
+            fn init(
+                config: Self::Config,
+                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
+            ) -> Result<Self, BootError> {
+                Ok(Self {
+                    close_observed: config,
+                })
+            }
+            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
+        impl crate::actor::native::NativeDispatch for Quiet {
+            fn __aether_dispatch_envelope(
+                &mut self,
+                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
+                _kind: crate::mail::KindId,
+                _payload: &[u8],
+            ) -> Option<()> {
+                None
+            }
+        }
+
+        const N: usize = 64;
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .build_passive()
+            .expect("empty chassis boots");
+
+        let counters: Vec<Arc<AtomicU32>> = (0..N).map(|_| Arc::new(AtomicU32::new(0))).collect();
+        for (i, counter) in counters.iter().enumerate() {
+            let name = format!("inst-{i}");
+            chassis
+                .spawn_actor::<Quiet>(Subname::Named(&name), Arc::clone(counter))
+                .finish()
+                .expect("spawn instanced actor");
+        }
+
+        for counter in &counters {
+            assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+        }
+
+        drop(chassis);
+
+        for (i, counter) in counters.iter().enumerate() {
+            assert_eq!(
+                counter.load(AtomicOrdering::SeqCst),
+                1,
+                "actor {i} must have run unwire exactly once",
+            );
+        }
+    }
+
     /// Issue 607 Phase 4b verify: a `ctx.monitor(target)` registration
     /// fires exactly one `MonitorNotice` at the watcher when the
     /// target self-shuts. Two-actor scenario: Watcher (instanced)

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -261,6 +261,19 @@ pub trait Drainable: Send + Sync + 'static {
         true
     }
 
+    /// Issue 714: install a one-shot completion sender the slot fires
+    /// when its [`CycleResult::Closed`] cycle finishes — i.e. after
+    /// `unwire` + registry close ran and the actor box was taken out.
+    /// [`crate::actor::native::spawn::Spawner::shutdown_instanced`]
+    /// uses this to settle on each spawned slot via `recv_timeout`
+    /// instead of polling [`Self::is_closed`] in a 2 ms loop, which
+    /// flaked under nextest contention.
+    ///
+    /// Default no-op: mock fixtures don't have a real close cycle so
+    /// they never need to signal. Idempotent — the slot only fires the
+    /// first installed sender once; a re-install after close is a no-op.
+    fn set_close_done_tx(&self, _tx: crossbeam_channel::Sender<()>) {}
+
     /// Upcast helper for downcasting in tests. Production code doesn't
     /// reach for this.
     fn as_any(&self) -> &dyn Any;


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

- Replace `Spawner::shutdown_instanced`'s 2 ms polling loop with per-slot one-shot `crossbeam_channel::bounded(1)` completion signals — the slot's close cycle (`unwire` + registry close + `actor_guard.take()`) fires the sender on its way out, teardown waits via `recv_timeout(remaining_budget)`.
- Adds `Drainable::set_close_done_tx` (default no-op for mock fixtures) and the `DispatcherSlot` impl that stashes/fires the sender. Includes the fast-path-already-closed signal + post-stash recheck so a slot that finishes between the install steps still wakes the waiter.
- Adds `chassis_teardown_runs_unwire_for_many_pooled_actors` (N=64) to exercise the path under load.

## Why

Under nextest contention either the wake racing with the worker observing the close signal (issue iamacoffeepot/aether#685's failure class) or the coarse 2 ms polling cadence let the 2 s deadline elapse before the worker ran the close path. Channel-signalling makes teardown wake the moment the cycle settles instead of polling for a flag.

`signal_shutdown` already uses `Release` ordering paired with `should_shutdown`'s `Acquire`, so the wake-handle ordering called out in iamacoffeepot/aether#685 remains correct under the new wait shape.

## Test plan

- [x] `cargo nextest run -p aether-substrate chassis::builder::tests::chassis_teardown_runs_unwire --no-fail-fast` 20/20 passes in a shell loop:
      ```
      for i in $(seq 1 20); do cargo nextest run -p aether-substrate chassis::builder::tests::chassis_teardown_runs_unwire --no-fail-fast || echo "FAIL on iteration $i"; done
      ```
- [x] `cargo nextest run --workspace --no-fail-fast` — 1101/1101 pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes iamacoffeepot/aether#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)