### PR TITLE
chore(delegate): unlock worktree on agent return

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -21,9 +21,13 @@ Dispatches a `general-purpose` Agent under `isolation: "worktree"` to ship a Git
    >
    > Branch from fresh main as `<type>/<short-slug>` (type matches the Conventional Commit type the fix needs — `fix/`, `feat/`, `refactor/`, `docs/`). Run `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test --workspace`. If the change touches a wasm component, also run `cargo check -p <crate> --target wasm32-unknown-unknown`.
    >
-   > Commit with a Conventional Commits subject (`type(scope): description (issue <NNN>)`, lowercase subject — CI lints PR titles, and main squash-merges the PR title as the commit subject). Push the branch. Open a PR with the same Conventional Commits title and a body including `Closes #<NNN>` (the `#` is required — `Closes issue <NNN>` does NOT trigger GitHub auto-close) plus a 1–3 bullet summary. Hand back the PR URL in the final report.
+   > Commit with a Conventional Commits subject (`type(scope): description (issue <NNN>)`, lowercase subject — CI lints PR titles, and main squash-merges the PR title as the commit subject). Push the branch. Open a PR with the same Conventional Commits title and a body including `Closes #<NNN>` (the `#` is required — `Closes issue <NNN>` does NOT trigger GitHub auto-close) plus a 1–3 bullet summary.
    >
    > {{automerge_clause}}
+   >
+   > Once the PR is open (and any auto-merge is queued), unlock your worktree before returning so `/sweep` doesn't have to fight the framework lock when it cleans up after the PR merges: `git worktree unlock "$(git rev-parse --show-toplevel)"`. Best-effort: if unlock fails (already unlocked, etc.), note in the report and continue.
+   >
+   > Hand back the PR URL in the final report.
    >
    > Constraints: no destructive git ops, no `--no-verify`, no force-push, do not amend an existing commit.
 
@@ -39,6 +43,6 @@ Dispatches a `general-purpose` Agent under `isolation: "worktree"` to ship a Git
 - If the proposed fix in the body looks design-bearing (architectural decisions, new public APIs, ADR-worthy choices), bail and post a triage comment. The skill is for mechanical fixes, not design.
 - One PR per invocation. If the user wants multiple issues delegated, they invoke the skill multiple times.
 - The `automerge` label is the per-issue authorization signal. It is independent of `agent` (and orthogonal to the docs-only self-merge default): without it, the Agent never queues auto-merge regardless of CI state.
-- Use `/sweep` after delegated PRs land to clean up the worktrees + branches the Agent created. The Agent does not delete its own worktree, only the remote branch (via `--delete-branch` when auto-merge is enabled).
+- The Agent unlocks its own worktree before returning (see step 2's unlock line) so `/sweep` can reclaim the worktree + branch refs without contending with the framework lock. Use `/sweep` after delegated PRs land — it removes the worktree directory and local branch ref. The remote branch is deleted via `--delete-branch` when auto-merge is enabled.
 - The Agent will not have access to the live MCP harness (different session). Declarative scenarios (the `aether-scenario` test crate, ADR-0067) run automatically as part of `cargo test --workspace` and exercise the substrate end-to-end inside the worktree. They need a wgpu adapter; on macOS/Windows worktrees they exercise the full chassis, on Linux without `mesa-vulkan-drivers` they skip cleanly. For render- or substrate-touching changes, the Agent should mention in the PR body whether scenarios ran locally — CI has Mesa drivers and pre-builds component wasm so scenarios always exercise on the Linux runner before merge.
 - If the Agent's CI checks fail and the cause isn't obvious, it should push the branch + open the PR anyway with the failure noted in the body — the user reviews and decides whether to retry or take over manually.


### PR DESCRIPTION
## Summary

- Agents now run `git worktree unlock "$(git rev-parse --show-toplevel)"` after the PR is open and any auto-merge is queued.
- Without this, `/sweep` later contends with the framework lock when trying to reclaim the worktree + branch refs.
- Best-effort: if unlock fails (already unlocked, etc.), the agent notes it in the report and continues.

## Test plan

- [ ] Run `/delegate <issue>` against a small mechanical issue, confirm the worktree shows as unlocked in `git worktree list --porcelain` after the agent returns.
- [ ] Run `/sweep` after the PR merges, confirm the worktree is reclaimed without lock errors.