### PR TITLE
chore: lint issue titles and auto-apply type/crate labels

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   enforce:
-    name: Require type and crate (or design)
+    name: Lint title and auto-apply type/crate labels
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -18,18 +18,82 @@ jobs:
             const issue = context.payload.issue;
             const labels = issue.labels.map(l => l.name);
 
-            const hasType = labels.some(n => n.startsWith('type:'));
-            const hasCrate = labels.some(n => n.startsWith('crate:'));
-            const hasDesign = labels.includes('design');
+            // Allowed types match the existing `type:*` label set.
+            const TYPES = ['feat', 'fix', 'chore', 'docs', 'perf', 'refactor', 'flake'];
 
-            const missing = [];
-            if (!hasType) {
-              missing.push('a `type:*` label (`type:fix`, `type:feat`, `type:refactor`, `type:chore`, `type:docs`, `type:perf`)');
-            }
-            if (!hasCrate && !hasDesign) {
-              missing.push('a `crate:*` label (or `design` for cross-cutting / architectural issues)');
+            // {type}({crate}): <subject>  OR  {type}({crate}/{subfeat}): <subject>
+            const titleRegex = new RegExp(
+              '^(' + TYPES.join('|') + ')\\(([a-z0-9-]+)(?:/[a-z0-9-]+)?\\): .+$'
+            );
+            const m = issue.title.match(titleRegex);
+
+            const messages = [];
+            const labelsToAdd = [];
+            const labelsToRemove = [];
+
+            if (!m) {
+              messages.push(
+                'Title must match `{type}({crate}): <subject>` ' +
+                '(subfeatures allowed via `{type}({crate}/{subfeat}): <subject>`).'
+              );
+              messages.push('Allowed types: ' + TYPES.join(', ') + '.');
+              if (!labels.includes('invalid-title')) {
+                labelsToAdd.push('invalid-title');
+              }
+            } else {
+              const typeFromTitle = m[1];
+              const crateFromTitle = m[2];
+
+              const allRepoLabels = await github.paginate(
+                github.rest.issues.listLabelsForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 100,
+                }
+              );
+              const validCrates = allRepoLabels
+                .filter(l => l.name.startsWith('crate:'))
+                .map(l => l.name.slice('crate:'.length))
+                .sort();
+
+              if (!validCrates.includes(crateFromTitle)) {
+                messages.push(
+                  'Scope `' + crateFromTitle + '` is not a known crate. ' +
+                  'Valid: ' + validCrates.join(', ') + '.'
+                );
+                if (!labels.includes('invalid-title')) {
+                  labelsToAdd.push('invalid-title');
+                }
+              } else {
+                const wantType = 'type:' + typeFromTitle;
+                const wantCrate = 'crate:' + crateFromTitle;
+                if (!labels.includes(wantType)) labelsToAdd.push(wantType);
+                if (!labels.includes(wantCrate)) labelsToAdd.push(wantCrate);
+                if (labels.includes('invalid-title')) {
+                  labelsToRemove.push('invalid-title');
+                }
+              }
             }
 
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: labelsToAdd,
+              });
+            }
+            for (const name of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name,
+              });
+            }
+
+            // Comment management — single rolling comment marker.
             const marker = '<!-- issue-label-bot -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -38,7 +102,7 @@ jobs:
             });
             const existing = comments.find(c => c.body && c.body.includes(marker));
 
-            if (missing.length === 0) {
+            if (messages.length === 0) {
               if (existing) {
                 await github.rest.issues.deleteComment({
                   owner: context.repo.owner,
@@ -51,9 +115,9 @@ jobs:
 
             const body = [
               marker,
-              'This issue is missing ' + missing.join(' and ') + '.',
+              ...messages,
               '',
-              'Add via the labels sidebar — this comment auto-resolves once the labels are present.',
+              'This comment auto-resolves once the title matches the convention.',
             ].join('\n');
 
             if (existing) {


### PR DESCRIPTION
## Summary

- Extends `.github/workflows/issue-labels.yml` to parse issue titles against the `{type}({crate}): <subject>` convention (subfeatures via `{type}({crate}/{subfeat}): <subject>`).
- On a conformant title, auto-applies `type:<type>` + `crate:<crate>` labels and clears the `invalid-title` label / explainer comment.
- On a non-conformant title (bad shape, unknown type, or scope that isn't a registered `crate:*` label), adds `invalid-title` and posts a rolling explainer comment that auto-resolves when the title is fixed.

PR title rules and the optional-scope policy on PRs (`pr-title.yml`) are intentionally untouched — that workflow still uses `amannn/action-semantic-pull-request` with `requireScope: false`. Issues are stricter than PRs because each issue should be focused on one crate.

## Test plan

- [ ] Open a test issue titled `feat(substrate): test` — workflow adds `type:feat` + `crate:substrate`, no comment.
- [ ] Open a test issue titled `wat:` — workflow adds `invalid-title` + posts explainer comment.
- [ ] Open a test issue titled `feat(notacrate): test` — workflow adds `invalid-title` + posts explainer listing valid crates.
- [ ] Edit a non-conformant test issue's title to a valid form — `invalid-title` removed, comment deleted, type/crate labels applied.