### PR TITLE
feat(substrate/trace): actor-facing root minting + mail-fired settlement subscription

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -380,6 +380,34 @@ impl NativeBinding {
         parent_mail: Option<MailId>,
         inherited_root: Option<MailId>,
     ) -> u32 {
+        let _ = self.push_envelope_returning_root(
+            recipient,
+            kind,
+            bytes,
+            count,
+            parent_mail,
+            inherited_root,
+        );
+        0
+    }
+
+    /// Like [`Self::send_mail_with_lineage`] but returns the minted
+    /// `MailId` (== the new root when `inherited_root.is_none()`) so the
+    /// caller can subscribe to its settlement via the chassis
+    /// [`crate::chassis::settlement::SettlementRegistry`].
+    ///
+    /// Same semantics as the `u32`-returning variant; the success-path
+    /// `0` was vestigial at this layer (channel-send failures collapse to
+    /// the same scalar).
+    pub fn push_envelope_returning_root(
+        &self,
+        recipient: u64,
+        kind: u64,
+        bytes: &[u8],
+        count: u32,
+        parent_mail: Option<MailId>,
+        inherited_root: Option<MailId>,
+    ) -> MailId {
         let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
         let recipient_id = MailboxId(recipient);
         let reply_to =
@@ -416,7 +444,7 @@ impl NativeBinding {
             pending.insert(correlation, recipient_id);
         }
         self.mailer.push(mail);
-        0
+        mail_id
     }
 
     /// Block this actor's thread until a mail of `expected_kind`

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -339,6 +339,33 @@ impl<'a> NativeCtx<'a> {
                 .send_mail_with_lineage(recipient.0, kind, &bytes, 1, parent, root);
         }
     }
+
+    /// ADR-0080: like [`Sender::send`] but returns the minted `MailId` so
+    /// the caller can subscribe to its settlement via the chassis
+    /// [`crate::chassis::settlement::SettlementRegistry`].
+    ///
+    /// When this ctx represents a chassis-root edge (in-flight `MailId` is
+    /// `NONE`), the returned id is itself the root of a fresh causal chain.
+    /// When this ctx is mid-handler, the returned id is the new mail's id
+    /// inside the inherited root chain — subscribing to it would only fire
+    /// on settlement of *that mail's* descendants, not the whole chain.
+    /// Callers that want chain-root settlement should be at chassis-root
+    /// (typical for capability-init / external-event entry points).
+    pub fn send_envelope_traced<R, K>(&mut self, payload: &K) -> MailId
+    where
+        R: Actor + HandlesKind<K>,
+        K: Kind,
+    {
+        let bytes = payload.encode_into_bytes();
+        self.binding.push_envelope_returning_root(
+            mailbox_id_from_name(R::NAMESPACE).0,
+            K::ID.0,
+            &bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+        )
+    }
 }
 
 impl<'a> Sender for NativeCtx<'a> {

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -282,7 +282,7 @@ impl<'a> NativeCtx<'a> {
     /// ADR-0080 §5: derive the `parent_mail` to stamp on outbound
     /// mail from this ctx's in-flight context. `MailId::NONE` collapses
     /// to `None` (chassis-root or close/init ctx).
-    fn outbound_parent(&self) -> Option<MailId> {
+    pub(crate) fn outbound_parent(&self) -> Option<MailId> {
         if self.in_flight_mail_id == MailId::NONE {
             None
         } else {
@@ -294,7 +294,7 @@ impl<'a> NativeCtx<'a> {
     /// mail from this ctx's in-flight context. `MailId::NONE` collapses
     /// to `None`, in which case `NativeBinding::send_mail_with_lineage`
     /// mints a fresh root from the outbound's own `mail_id`.
-    fn outbound_root(&self) -> Option<MailId> {
+    pub(crate) fn outbound_root(&self) -> Option<MailId> {
         if self.in_flight_root == MailId::NONE {
             None
         } else {
@@ -338,33 +338,6 @@ impl<'a> NativeCtx<'a> {
             self.binding
                 .send_mail_with_lineage(recipient.0, kind, &bytes, 1, parent, root);
         }
-    }
-
-    /// ADR-0080: like [`Sender::send`] but returns the minted `MailId` so
-    /// the caller can subscribe to its settlement via the chassis
-    /// [`crate::chassis::settlement::SettlementRegistry`].
-    ///
-    /// When this ctx represents a chassis-root edge (in-flight `MailId` is
-    /// `NONE`), the returned id is itself the root of a fresh causal chain.
-    /// When this ctx is mid-handler, the returned id is the new mail's id
-    /// inside the inherited root chain — subscribing to it would only fire
-    /// on settlement of *that mail's* descendants, not the whole chain.
-    /// Callers that want chain-root settlement should be at chassis-root
-    /// (typical for capability-init / external-event entry points).
-    pub fn send_envelope_traced<R, K>(&mut self, payload: &K) -> MailId
-    where
-        R: Actor + HandlesKind<K>,
-        K: Kind,
-    {
-        let bytes = payload.encode_into_bytes();
-        self.binding.push_envelope_returning_root(
-            mailbox_id_from_name(R::NAMESPACE).0,
-            K::ID.0,
-            &bytes,
-            1,
-            self.outbound_parent(),
-            self.outbound_root(),
-        )
     }
 }
 

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -16,9 +16,10 @@
 use core::marker::PhantomData;
 
 use aether_actor::{Actor, HandlesKind};
-use aether_data::Kind;
+use aether_data::{Kind, MailId};
 
 use crate::actor::native::binding::NativeBinding;
+use crate::actor::native::ctx::NativeCtx;
 
 /// Phantom-typed receiver-actor handle for native callers. Carries a
 /// borrow of the sender's [`NativeBinding`] so `send` /
@@ -83,5 +84,39 @@ impl<'a, R: Actor> NativeActorMailbox<'a, R> {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         self.binding
             .send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32);
+    }
+
+    /// ADR-0080: like [`Self::send`] but returns the minted `MailId`
+    /// so the caller can subscribe to its settlement via the chassis
+    /// [`crate::chassis::settlement::SettlementRegistry`].
+    ///
+    /// Uses this mailbox's stored per-instance id, so settlement
+    /// subscription works uniformly for singleton actors
+    /// (`ctx.actor::<R>()`) and instanced actors like wasm trampolines
+    /// (`ctx.resolve_actor::<R>(name)`). The compile-time
+    /// `R: HandlesKind<K>` gate is the same as [`Self::send`].
+    ///
+    /// When `ctx` represents a chassis-root edge (in-flight `MailId`
+    /// is `NONE`), the returned id is itself the root of a fresh
+    /// causal chain. When `ctx` is mid-handler, the returned id is
+    /// the new mail's id inside the inherited root chain —
+    /// subscribing to it would only fire on settlement of *that
+    /// mail's* descendants, not the whole chain. Callers that want
+    /// chain-root settlement should be at chassis-root (typical for
+    /// capability-init / external-event entry points).
+    pub fn send_traced<K>(&self, ctx: &NativeCtx<'_>, payload: &K) -> MailId
+    where
+        R: HandlesKind<K>,
+        K: Kind,
+    {
+        let bytes = payload.encode_into_bytes();
+        self.binding.push_envelope_returning_root(
+            self.mailbox,
+            K::ID.0,
+            &bytes,
+            1,
+            ctx.outbound_parent(),
+            ctx.outbound_root(),
+        )
     }
 }

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -1,14 +1,21 @@
 //! ADR-0080 §6 settlement registry — chassis-side gate-notification
 //! map for `Settled { root }` mail.
 //!
-//! Subscribers (lifecycle gates, the per-frame Tick drain, the
-//! `replace_component` drain — landing in PR 4) call
-//! [`SettlementRegistry::subscribe_settlement`] with the root
-//! `MailId` of the causal chain they want to wait on. They get a
-//! `crossbeam_channel::Receiver<()>` that fires when the
-//! [`crate::actor::native`] dispatcher routes a `Settled { root }`
-//! mail addressed to [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`]
-//! through the registry's [`SettlementRegistry::fire_settled`] hook.
+//! Two subscriber shapes share one pending map (keyed on root
+//! [`MailId`]):
+//!
+//! - [`SettlementRegistry::subscribe_settlement`] returns a
+//!   `crossbeam_channel::Receiver<()>` for in-thread waiters
+//!   (chassis-internal code, tests) that can block on `recv` directly.
+//! - [`SettlementRegistry::subscribe_settlement_mail`] pushes a
+//!   notification mail to a target mailbox when the root settles —
+//!   for actors whose thread is committed to its mpsc inbox and
+//!   can't block on a separate channel without per-cid helper threads.
+//!
+//! Both fire when the [`crate::actor::native`] dispatcher routes a
+//! `Settled { root }` mail addressed to
+//! [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`] through the
+//! registry's [`SettlementRegistry::fire_settled`] hook.
 //!
 //! ADR-0080 §6 framing: settlement is eventually-consistent, not
 //! transactional. Two races are handled here:
@@ -51,13 +58,10 @@ struct Inner {
     /// Subscribers waiting on each root's settlement signal. Vec so
     /// multiple gate sites can wait on the same root concurrently
     /// (lifecycle gates + the per-frame drain barrier might both
-    /// listen on the same Tick root).
-    pending: HashMap<MailId, Vec<Sender<()>>>,
-    /// Mail subscriptions. On `fire_settled(root)`, push a mail of
-    /// `kind` to `target` via `mailer`. Coexists with `pending` — a
-    /// root can have both channel and mail subscribers; both fire on
-    /// `fire_settled`.
-    pending_mail: HashMap<MailId, Vec<MailSubscription>>,
+    /// listen on the same Tick root). Channel and mail subscribers
+    /// coexist in the same vec, distinguished by [`SettlementSubscriber`]
+    /// variant — one map, one drain.
+    pending: HashMap<MailId, Vec<SettlementSubscriber>>,
     /// Roots that have already settled at least once. Subscribing to
     /// one pre-fires the receiver. Grows unboundedly within a
     /// chassis lifetime; v1 accepts the bound (chassis tear-down
@@ -65,14 +69,42 @@ struct Inner {
     settled: HashSet<MailId>,
 }
 
-/// One mail subscription parked on a root pending settlement. On
-/// `fire_settled`, the registry pushes a [`crate::mail::Mail`] of
-/// `kind` to `target` via `mailer` with the settled root postcard-
-/// encoded as the payload.
-struct MailSubscription {
-    target: MailboxId,
-    kind: KindId,
-    mailer: Arc<crate::mail::mailer::Mailer>,
+/// One subscriber parked on a root pending settlement. Channel
+/// subscribers are for in-thread waiters (chassis-internal code, tests)
+/// that block on `Receiver<()>`; mail subscribers are for actors whose
+/// thread is committed to its mpsc inbox and can't block on a separate
+/// channel without per-cid helper threads.
+enum SettlementSubscriber {
+    /// Wake an in-thread waiter on a `bounded(1)` channel.
+    Channel(Sender<()>),
+    /// Push a notification mail to `target` via `mailer` with the
+    /// settled root postcard-encoded as the payload.
+    Mail {
+        target: MailboxId,
+        kind: KindId,
+        mailer: Arc<crate::mail::mailer::Mailer>,
+    },
+}
+
+impl SettlementSubscriber {
+    /// Fire this subscriber for the settled `root`. Channel sends are
+    /// non-blocking (`try_send`, so a closed receiver doesn't panic);
+    /// mail sends go through the chassis [`crate::mail::mailer::Mailer`]
+    /// which resolves the recipient inline on the firing thread.
+    fn fire(self, root: MailId) {
+        match self {
+            SettlementSubscriber::Channel(tx) => {
+                let _ = tx.try_send(());
+            }
+            SettlementSubscriber::Mail {
+                target,
+                kind,
+                mailer,
+            } => {
+                push_settlement_notice(&mailer, target, kind, root);
+            }
+        }
+    }
 }
 
 impl SettlementRegistry {
@@ -103,7 +135,11 @@ impl SettlementRegistry {
             // before reading) doesn't panic.
             let _ = tx.try_send(());
         } else {
-            inner.pending.entry(root).or_default().push(tx);
+            inner
+                .pending
+                .entry(root)
+                .or_default()
+                .push(SettlementSubscriber::Channel(tx));
         }
         rx
     }
@@ -131,10 +167,10 @@ impl SettlementRegistry {
             push_settlement_notice(&mailer, target, kind, root);
         } else {
             inner
-                .pending_mail
+                .pending
                 .entry(root)
                 .or_default()
-                .push(MailSubscription {
+                .push(SettlementSubscriber::Mail {
                     target,
                     kind,
                     mailer,
@@ -148,26 +184,26 @@ impl SettlementRegistry {
     /// calls pre-fire. Idempotent: calling twice is the same as
     /// calling once for any waiter that already woke.
     pub fn fire_settled(&self, root: MailId) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.settled.insert(root);
-        if let Some(subs) = inner.pending.remove(&root) {
-            for tx in subs {
-                let _ = tx.try_send(());
-            }
-        }
-        if let Some(subs) = inner.pending_mail.remove(&root) {
-            // Drop the mutex before pushing — `push` may run hot
-            // (resolves the recipient inline on this thread).
-            drop(inner);
+        // Drop the mutex before firing — mail subscribers resolve
+        // the recipient inline on this thread, and channel sends are
+        // cheap but uniformly drop-then-fire keeps the lock window
+        // tight and removes a re-entrancy hazard if a future
+        // subscriber type re-enters the registry.
+        let subs = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.settled.insert(root);
+            inner.pending.remove(&root)
+        };
+        if let Some(subs) = subs {
             for sub in subs {
-                push_settlement_notice(&sub.mailer, sub.target, sub.kind, root);
+                sub.fire(root);
             }
         }
     }
 
-    /// Test introspection: count of pending subscribers across all
-    /// roots. Used by the unit tests in this module; production code
-    /// queries via mail (subscribe + recv).
+    /// Test introspection: count of pending channel subscribers
+    /// across all roots. Used by the unit tests in this module;
+    /// production code queries via mail (subscribe + recv).
     #[cfg(test)]
     fn pending_count(&self) -> usize {
         self.inner
@@ -175,8 +211,9 @@ impl SettlementRegistry {
             .unwrap()
             .pending
             .values()
-            .map(Vec::len)
-            .sum()
+            .flat_map(|v| v.iter())
+            .filter(|s| matches!(s, SettlementSubscriber::Channel(_)))
+            .count()
     }
 
     /// Test introspection: count of roots recorded as already
@@ -193,10 +230,11 @@ impl SettlementRegistry {
         self.inner
             .lock()
             .unwrap()
-            .pending_mail
+            .pending
             .values()
-            .map(Vec::len)
-            .sum()
+            .flat_map(|v| v.iter())
+            .filter(|s| matches!(s, SettlementSubscriber::Mail { .. }))
+            .count()
     }
 }
 

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -32,9 +32,9 @@
 //! memory bounded.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
-use aether_data::MailId;
+use aether_data::{KindId, MailId, MailboxId};
 use crossbeam_channel::{Receiver, Sender, bounded};
 
 /// Chassis-owned settlement notification registry. Owned by the
@@ -53,11 +53,26 @@ struct Inner {
     /// (lifecycle gates + the per-frame drain barrier might both
     /// listen on the same Tick root).
     pending: HashMap<MailId, Vec<Sender<()>>>,
+    /// Mail subscriptions. On `fire_settled(root)`, push a mail of
+    /// `kind` to `target` via `mailer`. Coexists with `pending` — a
+    /// root can have both channel and mail subscribers; both fire on
+    /// `fire_settled`.
+    pending_mail: HashMap<MailId, Vec<MailSubscription>>,
     /// Roots that have already settled at least once. Subscribing to
     /// one pre-fires the receiver. Grows unboundedly within a
     /// chassis lifetime; v1 accepts the bound (chassis tear-down
     /// reclaims).
     settled: HashSet<MailId>,
+}
+
+/// One mail subscription parked on a root pending settlement. On
+/// `fire_settled`, the registry pushes a [`crate::mail::Mail`] of
+/// `kind` to `target` via `mailer` with the settled root postcard-
+/// encoded as the payload.
+struct MailSubscription {
+    target: MailboxId,
+    kind: KindId,
+    mailer: Arc<crate::mail::mailer::Mailer>,
 }
 
 impl SettlementRegistry {
@@ -93,6 +108,40 @@ impl SettlementRegistry {
         rx
     }
 
+    /// Subscribe a mailbox to receive a notification mail when `root`
+    /// settles. The notification is a [`crate::mail::Mail`] with the
+    /// given `kind`, the [`MailId`] of the settled root postcard-encoded
+    /// as payload, and `count = 1`. Pre-fires immediately (synchronously
+    /// pushes the mail) if `root` has already settled at least once.
+    ///
+    /// Coexists with [`Self::subscribe_settlement`] — a root can have
+    /// channel and mail subscribers; both fire on `fire_settled`.
+    pub fn subscribe_settlement_mail(
+        &self,
+        root: MailId,
+        target: MailboxId,
+        kind: KindId,
+        mailer: Arc<crate::mail::mailer::Mailer>,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.settled.contains(&root) {
+            // Drop the mutex before pushing — `push` may run hot
+            // (resolves the recipient inline on this thread).
+            drop(inner);
+            push_settlement_notice(&mailer, target, kind, root);
+        } else {
+            inner
+                .pending_mail
+                .entry(root)
+                .or_default()
+                .push(MailSubscription {
+                    target,
+                    kind,
+                    mailer,
+                });
+        }
+    }
+
     /// Fire the settlement signal for `root`. Wakes every subscriber
     /// currently registered for `root` and records the root in the
     /// `settled` set so subsequent [`Self::subscribe_settlement`]
@@ -104,6 +153,14 @@ impl SettlementRegistry {
         if let Some(subs) = inner.pending.remove(&root) {
             for tx in subs {
                 let _ = tx.try_send(());
+            }
+        }
+        if let Some(subs) = inner.pending_mail.remove(&root) {
+            // Drop the mutex before pushing — `push` may run hot
+            // (resolves the recipient inline on this thread).
+            drop(inner);
+            for sub in subs {
+                push_settlement_notice(&sub.mailer, sub.target, sub.kind, root);
             }
         }
     }
@@ -128,17 +185,93 @@ impl SettlementRegistry {
     fn settled_count(&self) -> usize {
         self.inner.lock().unwrap().settled.len()
     }
+
+    /// Test introspection: count of pending mail subscribers across all
+    /// roots.
+    #[cfg(test)]
+    fn pending_mail_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .pending_mail
+            .values()
+            .map(Vec::len)
+            .sum()
+    }
+}
+
+/// Push a settlement-notice mail to `target` via `mailer`. The payload
+/// is the postcard-encoded settled-root [`MailId`]; on encode failure
+/// the notification is dropped (logged at error) — `MailId` is a small
+/// `repr(C)` postcard-shaped struct, so encode failure here is a "this
+/// should never happen" path rather than a recoverable condition.
+fn push_settlement_notice(
+    mailer: &crate::mail::mailer::Mailer,
+    target: MailboxId,
+    kind: KindId,
+    root: MailId,
+) {
+    let payload = match postcard::to_allocvec(&root) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                target: "aether_substrate::settlement",
+                error = %e,
+                "settlement registry: postcard encode of MailId failed; notification dropped"
+            );
+            return;
+        }
+    };
+    mailer.push(crate::mail::Mail::new(target, kind, payload, 1));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handle_store::HandleStore;
+    use crate::mail::mailer::Mailer;
+    use crate::mail::registry::{MailDispatch, Registry};
+    use std::sync::Mutex as StdMutex;
 
     fn root(sender: u64, cid: u64) -> MailId {
         MailId {
             sender: aether_data::MailboxId(sender),
             correlation_id: cid,
         }
+    }
+
+    /// One captured dispatch — what the test asserts against.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct CapturedDispatch {
+        kind: KindId,
+        payload: Vec<u8>,
+        count: u32,
+    }
+
+    /// Build a fresh `Mailer` backed by a registry + handle store
+    /// pair. Registers a closure-bound sink under `sink_name` that
+    /// captures the dispatched mails into a shared buffer the test
+    /// asserts against. Returns the mailer, the registered sink's
+    /// mailbox id, and the buffer.
+    fn fresh_mailer_with_sink(
+        sink_name: &str,
+    ) -> (Arc<Mailer>, MailboxId, Arc<StdMutex<Vec<CapturedDispatch>>>) {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let captured: Arc<StdMutex<Vec<CapturedDispatch>>> = Arc::new(StdMutex::new(Vec::new()));
+        let captured_clone = Arc::clone(&captured);
+        let target = registry.register_closure(
+            sink_name,
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                captured_clone.lock().unwrap().push(CapturedDispatch {
+                    kind: dispatch.kind,
+                    payload: dispatch.payload.to_vec(),
+                    count: dispatch.count,
+                });
+            }),
+        );
+        (mailer, target, captured)
     }
 
     #[test]
@@ -206,5 +339,151 @@ mod tests {
         assert!(rx2.try_recv().is_err());
         reg.fire_settled(r2);
         rx2.recv().expect("r2 wakes");
+    }
+
+    /// `subscribe_settlement_mail` then `fire_settled`: one mail is
+    /// pushed to the subscribed target with the expected `(kind,
+    /// payload-decodes-to-root)`.
+    #[test]
+    fn subscribe_mail_then_fire_pushes_notification() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.subscribe_fire");
+        let r = root(1, 1);
+        let kind = KindId(0xABCD);
+
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        assert_eq!(reg.pending_mail_count(), 1);
+        reg.fire_settled(r);
+        assert_eq!(reg.pending_mail_count(), 0);
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let mail = &captured[0];
+        assert_eq!(mail.kind, kind);
+        assert_eq!(mail.count, 1);
+        let decoded: MailId = postcard::from_bytes(&mail.payload).expect("decode MailId");
+        assert_eq!(decoded, r);
+    }
+
+    /// `fire_settled` first, then `subscribe_settlement_mail`: the
+    /// notification pre-fires synchronously.
+    #[test]
+    fn fire_then_subscribe_mail_pre_fires() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.fire_subscribe");
+        let r = root(2, 4);
+        let kind = KindId(0x1234);
+
+        reg.fire_settled(r);
+        assert!(captured.lock().unwrap().is_empty());
+
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        // Pre-fire path: no parked entry should remain.
+        assert_eq!(reg.pending_mail_count(), 0);
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].kind, kind);
+        let decoded: MailId = postcard::from_bytes(&captured[0].payload).expect("decode MailId");
+        assert_eq!(decoded, r);
+    }
+
+    /// Three mail subscribers on the same root all receive a
+    /// notification when `fire_settled` runs.
+    #[test]
+    fn multiple_mail_subscribers_all_receive() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.multi");
+        let r = root(3, 9);
+        let kind = KindId(0x5555);
+
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        assert_eq!(reg.pending_mail_count(), 3);
+
+        reg.fire_settled(r);
+        assert_eq!(reg.pending_mail_count(), 0);
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 3);
+        for entry in captured.iter() {
+            assert_eq!(entry.kind, kind);
+            let decoded: MailId = postcard::from_bytes(&entry.payload).expect("decode MailId");
+            assert_eq!(decoded, r);
+        }
+    }
+
+    /// A channel subscriber and a mail subscriber on the same root
+    /// both fire when `fire_settled` runs.
+    #[test]
+    fn channel_and_mail_subscribers_coexist() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.coexist");
+        let r = root(4, 16);
+        let kind = KindId(0x7777);
+
+        let rx = reg.subscribe_settlement(r);
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        assert_eq!(reg.pending_count(), 1);
+        assert_eq!(reg.pending_mail_count(), 1);
+
+        reg.fire_settled(r);
+        assert_eq!(reg.pending_count(), 0);
+        assert_eq!(reg.pending_mail_count(), 0);
+
+        rx.recv().expect("channel subscriber wakes");
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].kind, kind);
+    }
+
+    /// Mail subscribers on distinct roots fire independently — settling
+    /// r1 does not fire r2's mail subscription.
+    #[test]
+    fn distinct_roots_independent_for_mail() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.distinct");
+        let r1 = root(5, 25);
+        let r2 = root(5, 36);
+        let kind = KindId(0x9999);
+
+        reg.subscribe_settlement_mail(r1, target, kind, Arc::clone(&mailer));
+        reg.subscribe_settlement_mail(r2, target, kind, Arc::clone(&mailer));
+        assert_eq!(reg.pending_mail_count(), 2);
+
+        reg.fire_settled(r1);
+        assert_eq!(reg.pending_mail_count(), 1);
+
+        let after_r1 = captured.lock().unwrap().clone();
+        assert_eq!(after_r1.len(), 1);
+        let decoded: MailId = postcard::from_bytes(&after_r1[0].payload).expect("decode MailId");
+        assert_eq!(decoded, r1);
+
+        reg.fire_settled(r2);
+        assert_eq!(reg.pending_mail_count(), 0);
+
+        let after_r2 = captured.lock().unwrap().clone();
+        assert_eq!(after_r2.len(), 2);
+        let decoded: MailId = postcard::from_bytes(&after_r2[1].payload).expect("decode MailId");
+        assert_eq!(decoded, r2);
+    }
+
+    /// The settlement-notice payload postcard-decodes back to the
+    /// subscribed root — direct check of the wire contract.
+    #[test]
+    fn mail_payload_decodes_to_root() {
+        let reg = SettlementRegistry::new();
+        let (mailer, target, captured) = fresh_mailer_with_sink("test.settlement.payload");
+        let r = root(7, 49);
+        let kind = KindId(0x4321);
+
+        reg.subscribe_settlement_mail(r, target, kind, Arc::clone(&mailer));
+        reg.fire_settled(r);
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let decoded: MailId = postcard::from_bytes(&captured[0].payload).expect("decode MailId");
+        assert_eq!(decoded, r);
     }
 }


### PR DESCRIPTION
## Summary

- Add `NativeBinding::push_envelope_returning_root` and refactor `send_mail_with_lineage` to delegate to it; the new method returns the minted `MailId` so callers can subscribe to settlement.
- Add `NativeCtx::send_envelope_traced<R, K>(payload) -> MailId` — like `Sender::send` but returns the minted id, threading lineage from the in-flight ctx.
- Extend `SettlementRegistry` with `subscribe_settlement_mail(root, target, kind, mailer)` — coexists with the channel-based `subscribe_settlement`, pre-fires on already-settled roots, and pushes a postcard-encoded `MailId` payload notification when `fire_settled` runs.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo nextest run --workspace` (1107 tests pass)
- [x] Six new settlement tests pass: `subscribe_mail_then_fire_pushes_notification`, `fire_then_subscribe_mail_pre_fires`, `multiple_mail_subscribers_all_receive`, `channel_and_mail_subscribers_coexist`, `distinct_roots_independent_for_mail`, `mail_payload_decodes_to_root`

Closes iamacoffeepot/aether#751