### PR TITLE
chore(substrate/scheduler): loop drain_empty_returns_idle until idle

### DIFF
--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -513,7 +513,20 @@ pub(crate) mod tests {
         slot.push(2);
         slot.state.try_wake();
 
-        assert_eq!(run_one_cycle(&slot), CycleResult::Idle);
+        // Both Idle and Requeue are legitimate per-cycle results under
+        // nextest CPU contention (see PR 747). The invariant is that both
+        // envelopes get dispatched and the slot eventually reaches Idle.
+        for _ in 0..8 {
+            match run_one_cycle(&slot) {
+                CycleResult::Idle | CycleResult::Requeue => {}
+                CycleResult::Closed => panic!("slot closed unexpectedly"),
+            }
+            if slot.dispatched() == 2 {
+                break;
+            }
+            slot.state.try_wake();
+        }
+
         assert_eq!(slot.dispatched(), 2);
         assert_eq!(slot.state.current(), SlotStateLabel::Idle);
     }


### PR DESCRIPTION
## Summary

- Extend the eventual-drain pattern from PR 747 to `drain_empty_returns_idle`: loop `run_one_cycle` (up to 8 iterations) treating both `Idle` and `Requeue` as legitimate per-cycle results, asserting only the invariant that both envelopes dispatch and the slot reaches Idle.
- Pure test edit; no production code touched. Mirrors the sibling fix in PR 747.
- 50-iteration stress run: 50/50 pass.

Closes iamacoffeepot/aether#756