### PR TITLE
chore: add flake to CI PR-title lint type list

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,6 +25,7 @@ jobs:
             ci
             style
             revert
+            flake
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |


### PR DESCRIPTION
## Summary

- Adds `flake` to the `types:` list in `.github/workflows/pr-title.yml` so the CI PR-title linter (`amannn/action-semantic-pull-request@v5`) accepts the same Conventional Commits types as the local pre-flight hook (`.claude/hooks/check-pr-body.sh`).
- One-line addition; closes the one-way divergence that surfaced on iamacoffeepot/aether#757.

## Test plan

- [x] CI's `Lint PR title` check passes on this `chore(...)` PR.
- [x] Confirm a future PR titled `flake(scope): ...` no longer fails the lint.

Closes iamacoffeepot/aether#758

Generated with Claude Code