### PR TITLE
feat(capabilities/rpc): rpc server cap with TCP listener + dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ name = "aether-capabilities"
 version = "0.2.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-codec",
  "aether-data",
  "aether-kinds",
  "aether-substrate",

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -65,6 +65,7 @@ audio-native = ["audio", "native", "aether-substrate/audio", "dep:cpal", "dep:cr
 # compile fine for `wasm32-unknown-unknown` and carry the markers
 # wasm components rely on.
 aether-actor = { path = "../aether-actor" }
+aether-codec = { path = "../aether-codec" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/aether-capabilities/src/rpc/mod.rs
+++ b/crates/aether-capabilities/src/rpc/mod.rs
@@ -8,8 +8,12 @@
 //!
 //! See issue 750 for the full design.
 
+pub mod server;
 pub mod wire;
 
+pub use server::{RpcServerCapability, rpc_server_mailbox_id};
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::{RpcServerConfig, RpcServerHandle};
 pub use wire::{
     Hello, HelloAck, KindDescriptor, MailEnvelope, MailboxAddress, PeerKind, RpcError,
     WIRE_VERSION, WireFrame,

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -1,0 +1,821 @@
+//! `aether.rpc.server` — generic TCP RPC server capability (issue 750).
+//!
+//! Singleton actor. Binds a `TcpListener` on the configured addr at
+//! init, runs a sidecar accept thread that spawns one reader thread
+//! per accepted connection. Reader threads frame postcard
+//! length-prefix frames via [`aether_codec::frame`] and push them
+//! through an internal mpsc; an `RpcInboundReady` wake mail tells the
+//! cap's dispatcher to drain.
+//!
+//! On `Call`, the cap dispatches the wire-borne envelope via
+//! `NativeCtx::send_envelope_as_root` (fresh causal chain — the wake
+//! mail is causally unrelated to the wire-borne Call) and subscribes
+//! to settlement of the resulting root via
+//! `SettlementRegistry::subscribe_settlement_mail`. Any reply mail
+//! addressed back at this cap with the dispatch's correlation id
+//! gets lifted into a `ReplyEvent` and written to the originating
+//! connection; the settlement notice closes the call with a
+//! `ReplyEnd`.
+
+// Handler-signature kinds need to be importable at file root for the
+// `#[bridge]`-emitted `HandlesKind<K>` markers.
+use aether_kinds::{RpcInboundReady, trace::Settled};
+
+// Re-export the cap's config + handle struct at file root for chassis
+// builders + embedders that read the bound port.
+#[cfg(not(target_arch = "wasm32"))]
+pub use server_native::{RpcServerConfig, RpcServerHandle};
+
+use super::wire::PeerKind;
+
+#[aether_actor::bridge(singleton)]
+mod server_native {
+    use super::{PeerKind, RpcInboundReady, Settled};
+    use crate::rpc::wire::{
+        Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
+    };
+    use aether_actor::actor;
+    use aether_codec::frame::{read_frame, write_frame};
+    use aether_data::{Kind, KindId, MailId, MailboxId};
+    use aether_substrate::Mail;
+    use aether_substrate::actor::native::envelope::Envelope;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::ReplyTarget;
+    use aether_substrate::mail::mailer::Mailer;
+    use std::collections::HashMap;
+    use std::io::{self, BufReader};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    /// Per-connection identifier, monotonic within this cap. Distinct
+    /// from the OS-level peer addr (one peer may reconnect; ids stay
+    /// unique for the cap's lifetime).
+    type ConnId = u64;
+
+    /// Init config for [`RpcServerCapability`].
+    ///
+    /// `bind_addr` is the address to bind on (e.g. `"127.0.0.1:8910"`,
+    /// `"0.0.0.0:0"` to let the OS pick). `peer_kind` identifies this
+    /// server to connecting peers via the `HelloAck` reply; chassis
+    /// builders supply a `PeerKind::Substrate { engine_name, .. }` for
+    /// substrate / hub endpoints.
+    pub struct RpcServerConfig {
+        pub bind_addr: String,
+        pub peer_kind: PeerKind,
+    }
+
+    /// Exported handle bundle published at boot. Reachable from the
+    /// chassis via `PassiveChassis::handle::<RpcServerHandle>()`;
+    /// the load-bearing field is `local_port` so embedders (driver
+    /// threads, tests) can connect to the OS-picked port when
+    /// `bind_addr` requested port 0.
+    #[derive(Clone)]
+    pub struct RpcServerHandle {
+        pub local_port: u16,
+    }
+
+    /// Internal event the accept / reader sidecar threads push to the
+    /// cap dispatcher via an mpsc. The matching wake-mail kind is
+    /// [`RpcInboundReady`] (empty payload) — the dispatcher's
+    /// `on_inbound_ready` handler drains the channel and dispatches
+    /// per item.
+    enum InboundEvent {
+        PeerAccepted { stream: TcpStream, peer: SocketAddr },
+        FrameReceived { conn_id: ConnId, frame: WireFrame },
+        ReaderClosed { conn_id: ConnId, reason: String },
+    }
+
+    /// Per-connection state owned by the cap dispatcher. The reader
+    /// sidecar holds `shutdown` + a clone of `write_half` for the
+    /// reader-side socket (each thread owns one half of the split).
+    struct ConnState {
+        peer: SocketAddr,
+        /// Dispatcher's half — used for inline writes (HelloAck,
+        /// ReplyEvent, ReplyEnd, Pong, Bye).
+        write_half: TcpStream,
+        /// Reader thread's shutdown flag. Cap flips it + shuts down
+        /// the read half to wake the blocked `read()`.
+        shutdown: Arc<AtomicBool>,
+        /// Reader thread handle. Joined in `unwire`.
+        reader_thread: Option<JoinHandle<()>>,
+        hello_received: bool,
+    }
+
+    /// Bookkeeping for one in-flight call (cid passed `Some` on the
+    /// wire). Looked up by the dispatch's auto-minted
+    /// `correlation_id` (== `MailId.correlation_id` of the dispatched
+    /// envelope, which is also the root id since we always dispatch
+    /// as chassis-root via `send_envelope_as_root`).
+    #[derive(Copy, Clone)]
+    struct InFlight {
+        conn_id: ConnId,
+        wire_cid: u64,
+    }
+
+    /// Singleton RPC server cap. Owns one TCP listener + per-
+    /// connection state.
+    pub struct RpcServerCapability {
+        peer_kind: PeerKind,
+        self_mailbox: MailboxId,
+        /// Cached `Arc<Mailer>` so per-handler ctxs (`NativeCtx`,
+        /// which doesn't expose `mailer()`) can fire wake mails into
+        /// the cap from internal helpers — and so the `Call`
+        /// dispatcher can pass the same Arc into
+        /// `subscribe_settlement_mail`. Init grabs it from
+        /// `NativeInitCtx::mailer()`; the cap is single-threaded
+        /// post-ADR-0038 so direct storage is fine.
+        mailer: Arc<Mailer>,
+        listener_port: u16,
+        accept_shutdown: Arc<AtomicBool>,
+        accept_thread: Option<JoinHandle<()>>,
+        inbound_rx: mpsc::Receiver<InboundEvent>,
+        inbound_tx: mpsc::Sender<InboundEvent>,
+        connections: HashMap<ConnId, ConnState>,
+        next_conn_id: ConnId,
+        /// Internal-correlation → connection / wire-cid. Populated on
+        /// `Call { cid: Some(n) }` dispatch; cleared on settlement.
+        in_flight: HashMap<u64, InFlight>,
+    }
+
+    #[actor]
+    impl NativeActor for RpcServerCapability {
+        type Config = RpcServerConfig;
+        const NAMESPACE: &'static str = "aether.rpc.server";
+
+        fn init(config: RpcServerConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let listener =
+                TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
+            let local_addr = listener
+                .local_addr()
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+            let port = local_addr.port();
+            listener
+                .set_nonblocking(false)
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+
+            let accept_shutdown = Arc::new(AtomicBool::new(false));
+            let accept_shutdown_for_thread = Arc::clone(&accept_shutdown);
+
+            let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
+            let inbound_tx_for_thread = inbound_tx.clone();
+
+            let mailer: Arc<Mailer> = ctx.mailer();
+            let self_id = ctx.self_id();
+            let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
+
+            let thread = std::thread::Builder::new()
+                .name(format!("aether-rpc-accept-{port}"))
+                .spawn(move || {
+                    while !accept_shutdown_for_thread.load(Ordering::Acquire) {
+                        match listener.accept() {
+                            Ok((stream, peer)) => {
+                                if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                                    drop(stream);
+                                    break;
+                                }
+                                if inbound_tx_for_thread
+                                    .send(InboundEvent::PeerAccepted { stream, peer })
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                            }
+                            Err(_) => {
+                                if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| BootError::Other(Box::new(e)))?;
+
+            tracing::info!(
+                target: "aether_substrate::rpc",
+                addr = %config.bind_addr,
+                port = port,
+                "rpc server bound",
+            );
+
+            ctx.publish_handle(RpcServerHandle { local_port: port });
+
+            Ok(Self {
+                peer_kind: config.peer_kind,
+                self_mailbox: self_id,
+                mailer: ctx.mailer(),
+                listener_port: port,
+                accept_shutdown,
+                accept_thread: Some(thread),
+                inbound_rx,
+                inbound_tx,
+                connections: HashMap::new(),
+                next_conn_id: 0,
+                in_flight: HashMap::new(),
+            })
+        }
+
+        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+            // Stop the accept thread.
+            self.accept_shutdown.store(true, Ordering::Release);
+            let addr_str = format!("127.0.0.1:{}", self.listener_port);
+            if let Ok(addr) = addr_str.parse::<std::net::SocketAddr>() {
+                let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+            }
+            if let Some(t) = self.accept_thread.take() {
+                let _ = t.join();
+            }
+            // Stop every per-connection reader. Shutting down the read
+            // half wakes the blocked `read()`; the reader sees the
+            // shutdown flag and exits.
+            for (_, conn) in self.connections.iter_mut() {
+                conn.shutdown.store(true, Ordering::Release);
+                let _ = conn.write_half.shutdown(std::net::Shutdown::Read);
+                if let Some(t) = conn.reader_thread.take() {
+                    let _ = t.join();
+                }
+            }
+            tracing::info!(
+                target: "aether_substrate::rpc",
+                port = self.listener_port,
+                "rpc server closed",
+            );
+        }
+
+        /// Sidecar wake. Drain every pending inbound event.
+        ///
+        /// # Agent
+        /// Internal wake mail — not part of the cap's external surface.
+        /// The accept / reader sidecars fire this to wake the
+        /// dispatcher; the handler drains the mpsc and dispatches per
+        /// item.
+        #[handler]
+        fn on_inbound_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: RpcInboundReady) {
+            while let Ok(event) = self.inbound_rx.try_recv() {
+                match event {
+                    InboundEvent::PeerAccepted { stream, peer } => {
+                        self.spawn_reader_for_peer(ctx, stream, peer);
+                    }
+                    InboundEvent::FrameReceived { conn_id, frame } => {
+                        self.dispatch_frame(ctx, conn_id, frame);
+                    }
+                    InboundEvent::ReaderClosed { conn_id, reason } => {
+                        self.close_connection(conn_id, &reason);
+                    }
+                }
+            }
+        }
+
+        /// Settlement notice from the chassis. The root corresponds
+        /// to a `Call` dispatch we subscribed to; close the call by
+        /// writing `ReplyEnd { cid, result: Ok(()) }` and dropping
+        /// the in-flight entry.
+        ///
+        /// # Agent
+        /// Internal — fires from `SettlementRegistry::fire_settled`,
+        /// not from external mail. Subscribers parked in the registry
+        /// receive one of these per settled root.
+        #[handler]
+        fn on_settled(&mut self, _ctx: &mut NativeCtx<'_>, mail: Settled) {
+            let correlation = mail.root.correlation_id;
+            let Some(entry) = self.in_flight.remove(&correlation) else {
+                // No matching in-flight call. Either we never owned
+                // this root or the connection already closed and we
+                // cleared eagerly. Either way: drop silently.
+                return;
+            };
+            self.write_frame_to(
+                entry.conn_id,
+                &WireFrame::ReplyEnd {
+                    cid: entry.wire_cid,
+                    result: Ok(()),
+                },
+            );
+        }
+
+        /// Catch-all. Any mail addressed at this cap that's not one of
+        /// the typed wake / settlement kinds is treated as a reply
+        /// mail from a downstream actor; if its `correlation_id`
+        /// matches an in-flight call, the cap wraps it as a
+        /// `ReplyEvent` and writes to the originating connection.
+        ///
+        /// # Agent
+        /// Not user-callable — this is the cap's reply interception
+        /// path. The wire is mail-shaped (issue 750 §wire), so any
+        /// kind two peers share is reachable; reply correlation goes
+        /// through this fallback.
+        #[fallback]
+        fn on_any(&mut self, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
+            let correlation = env.sender.correlation_id;
+            let Some(entry) = self.in_flight.get(&correlation).copied() else {
+                tracing::debug!(
+                    target: "aether_substrate::rpc",
+                    kind = %env.kind_name,
+                    correlation,
+                    "rpc reply with no matching in-flight call; dropping",
+                );
+                return;
+            };
+            let envelope = MailEnvelope {
+                to: MailboxAddress::local(self.self_mailbox),
+                from: match env.sender.target {
+                    ReplyTarget::Component(id) => Some(MailboxAddress::local(id)),
+                    _ => None,
+                },
+                kind: env.kind,
+                correlation_id: Some(entry.wire_cid),
+                payload: env.payload.clone(),
+            };
+            self.write_frame_to(
+                entry.conn_id,
+                &WireFrame::ReplyEvent {
+                    cid: entry.wire_cid,
+                    envelope,
+                },
+            );
+        }
+    }
+
+    impl RpcServerCapability {
+        /// Allocate a fresh ConnId, store the connection's write half,
+        /// spin a reader thread for the read half.
+        fn spawn_reader_for_peer(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            stream: TcpStream,
+            peer: SocketAddr,
+        ) {
+            let conn_id = self.next_conn_id;
+            self.next_conn_id += 1;
+
+            let read_half = match stream.try_clone() {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::rpc",
+                        peer = %peer,
+                        error = %e,
+                        "rpc conn: try_clone failed; dropping",
+                    );
+                    return;
+                }
+            };
+            let write_half = stream;
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_for_thread = Arc::clone(&shutdown);
+
+            let mailer: Arc<Mailer> = Arc::clone(&self.mailer);
+            let self_id = self.self_mailbox;
+            let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
+            let inbound_tx = self.inbound_tx.clone();
+
+            let thread = match std::thread::Builder::new()
+                .name(format!("aether-rpc-reader-{conn_id}"))
+                .spawn(move || {
+                    let mut reader = BufReader::new(read_half);
+                    loop {
+                        if shutdown_for_thread.load(Ordering::Acquire) {
+                            break;
+                        }
+                        let frame: WireFrame = match read_frame(&mut reader) {
+                            Ok(f) => f,
+                            Err(aether_codec::frame::FrameError::Io(io_err))
+                                if io_err.kind() == io::ErrorKind::UnexpectedEof =>
+                            {
+                                let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                                    conn_id,
+                                    reason: "eof".into(),
+                                });
+                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                                break;
+                            }
+                            Err(e) => {
+                                if shutdown_for_thread.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                                    conn_id,
+                                    reason: format!("read error: {e}"),
+                                });
+                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                                break;
+                            }
+                        };
+                        if inbound_tx
+                            .send(InboundEvent::FrameReceived { conn_id, frame })
+                            .is_err()
+                        {
+                            break;
+                        }
+                        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    }
+                }) {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::rpc",
+                        peer = %peer,
+                        error = %e,
+                        "rpc reader thread spawn failed",
+                    );
+                    return;
+                }
+            };
+
+            self.connections.insert(
+                conn_id,
+                ConnState {
+                    peer,
+                    write_half,
+                    shutdown,
+                    reader_thread: Some(thread),
+                    hello_received: false,
+                },
+            );
+            tracing::debug!(
+                target: "aether_substrate::rpc",
+                conn = conn_id,
+                peer = %peer,
+                "rpc conn accepted",
+            );
+        }
+
+        /// Dispatch one incoming frame.
+        fn dispatch_frame(&mut self, ctx: &mut NativeCtx<'_>, conn_id: ConnId, frame: WireFrame) {
+            match frame {
+                WireFrame::Hello(hello) => self.handle_hello(conn_id, hello),
+                WireFrame::HelloAck(_) => {
+                    // Server doesn't expect HelloAck — only clients do.
+                    tracing::debug!(
+                        target: "aether_substrate::rpc",
+                        conn = conn_id,
+                        "received HelloAck on server side; ignoring",
+                    );
+                }
+                WireFrame::Call { cid, envelope } => self.handle_call(ctx, conn_id, cid, envelope),
+                WireFrame::ReplyEvent { .. } | WireFrame::ReplyEnd { .. } => {
+                    // Server doesn't expect reply frames inbound.
+                    tracing::debug!(
+                        target: "aether_substrate::rpc",
+                        conn = conn_id,
+                        "received reply frame on server side; ignoring",
+                    );
+                }
+                WireFrame::Ping(token) => {
+                    self.write_frame_to(conn_id, &WireFrame::Pong(token));
+                }
+                WireFrame::Pong(_) => {
+                    // Cap doesn't initiate Pings v1; nothing to track.
+                }
+                WireFrame::Bye { reason } => {
+                    self.close_connection(conn_id, &format!("peer bye: {reason}"));
+                }
+            }
+        }
+
+        fn handle_hello(&mut self, conn_id: ConnId, hello: Hello) {
+            if hello.wire_version != WIRE_VERSION {
+                self.write_frame_to(
+                    conn_id,
+                    &WireFrame::Bye {
+                        reason: format!(
+                            "wire_version mismatch: peer={}, server={WIRE_VERSION}",
+                            hello.wire_version,
+                        ),
+                    },
+                );
+                self.close_connection(conn_id, "wire_version mismatch");
+                return;
+            }
+            if let Some(conn) = self.connections.get_mut(&conn_id) {
+                conn.hello_received = true;
+            }
+            self.write_frame_to(
+                conn_id,
+                &WireFrame::HelloAck(HelloAck {
+                    wire_version: WIRE_VERSION,
+                    server: self.peer_kind.clone(),
+                }),
+            );
+        }
+
+        fn handle_call(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            conn_id: ConnId,
+            cid: Option<u64>,
+            envelope: MailEnvelope,
+        ) {
+            // Cross-engine routing isn't in v1. Anything addressed at
+            // a non-local engine surfaces as a ReplyEnd::Err.
+            if envelope.to.engine.is_some() {
+                if let Some(wire_cid) = cid {
+                    self.write_frame_to(
+                        conn_id,
+                        &WireFrame::ReplyEnd {
+                            cid: wire_cid,
+                            result: Err(RpcError::UnsupportedTarget {
+                                reason: "cross-engine routing not in v1".into(),
+                            }),
+                        },
+                    );
+                }
+                return;
+            }
+            // Dispatch the envelope as a fresh chain. The returned
+            // MailId is the new chain's root; if cid is Some, subscribe
+            // to its settlement to know when to write ReplyEnd.
+            let recipient = envelope.to.mailbox;
+            let kind = envelope.kind;
+            let payload = envelope.payload;
+            let mail_id: MailId = ctx.send_envelope_as_root(recipient, kind, &payload);
+
+            let Some(wire_cid) = cid else {
+                // Fire-and-forget at the wire layer. No bookkeeping.
+                return;
+            };
+
+            // Subscribe to settlement of the dispatched chain so we
+            // close the call with a ReplyEnd. Requires the chassis
+            // settlement registry — fail loud if not wired.
+            let Some(reg) = self.mailer.settlement_registry() else {
+                self.write_frame_to(
+                    conn_id,
+                    &WireFrame::ReplyEnd {
+                        cid: wire_cid,
+                        result: Err(RpcError::Other {
+                            reason: "settlement registry unavailable on this chassis".into(),
+                        }),
+                    },
+                );
+                return;
+            };
+            reg.subscribe_settlement_mail(
+                mail_id,
+                self.self_mailbox,
+                <Settled as Kind>::ID,
+                Arc::clone(&self.mailer),
+            );
+            self.in_flight
+                .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
+        }
+
+        fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
+            let Some(mut conn) = self.connections.remove(&conn_id) else {
+                return;
+            };
+            conn.shutdown.store(true, Ordering::Release);
+            let _ = conn.write_half.shutdown(std::net::Shutdown::Both);
+            // Drop reader_thread without joining inline — the
+            // dispatcher must not block on the reader. The thread sees
+            // the shutdown flag (or its own EOF) and exits; the
+            // JoinHandle drop detaches.
+            drop(conn.reader_thread.take());
+            // Clear in-flight entries pinned to this connection so we
+            // don't write ReplyEvents / ReplyEnds to a dead socket.
+            self.in_flight.retain(|_, entry| entry.conn_id != conn_id);
+            tracing::debug!(
+                target: "aether_substrate::rpc",
+                conn = conn_id,
+                peer = %conn.peer,
+                reason,
+                "rpc conn closed",
+            );
+        }
+
+        fn write_frame_to(&mut self, conn_id: ConnId, frame: &WireFrame) {
+            let Some(conn) = self.connections.get_mut(&conn_id) else {
+                return;
+            };
+            if let Err(e) = write_frame(&mut conn.write_half, frame) {
+                let reason = match &e {
+                    aether_codec::frame::FrameError::Io(io_err)
+                        if matches!(
+                            io_err.kind(),
+                            io::ErrorKind::BrokenPipe
+                                | io::ErrorKind::ConnectionReset
+                                | io::ErrorKind::WriteZero
+                        ) =>
+                    {
+                        "peer hung up"
+                    }
+                    aether_codec::frame::FrameError::Io(_) => "write error",
+                    _ => "frame encode error",
+                };
+                tracing::debug!(
+                    target: "aether_substrate::rpc",
+                    conn = conn_id,
+                    error = %e,
+                    "rpc frame write failed",
+                );
+                self.close_connection(conn_id, reason);
+            }
+        }
+    }
+}
+
+/// Address-resolution helper. The cap's mailbox id, derived from its
+/// `NAMESPACE` via the standard name-hash. Convenience for chassis
+/// code that wants to address the cap without round-tripping through
+/// a runtime lookup.
+pub fn rpc_server_mailbox_id() -> aether_data::MailboxId {
+    use aether_actor::Actor;
+    aether_data::mailbox_id_from_name(<RpcServerCapability as Actor>::NAMESPACE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::wire::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
+    use aether_codec::frame::{read_frame, write_frame};
+    use aether_substrate::chassis::Chassis;
+    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::handle_store::HandleStore;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
+    use aether_substrate::mail::registry::Registry;
+    use std::net::TcpStream;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct TestChassis;
+    impl Chassis for TestChassis {
+        const PROFILE: &'static str = "test";
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        }
+    }
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+        (registry, mailer)
+    }
+
+    fn test_peer_kind() -> PeerKind {
+        PeerKind::Substrate {
+            engine_name: "test".into(),
+            engine_version: "0.1.0".into(),
+            kinds: vec![],
+        }
+    }
+
+    /// Boot a `RpcServerCapability` bound to OS-picked port, connect a
+    /// real TCP client, exchange `Hello` for `HelloAck`. Sanity-check
+    /// the wire's framing + handshake path end-to-end.
+    #[test]
+    fn handshake_hello_to_hello_ack_roundtrip() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("rpc server boots");
+
+        let handle = chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published");
+        let port = handle.local_port;
+        assert!(port > 0, "OS-picked port should be non-zero");
+
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+
+        write_frame(
+            &mut stream,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION,
+                peer: PeerKind::Client {
+                    client_name: "test-client".into(),
+                    client_version: "0.0.1".into(),
+                },
+            }),
+        )
+        .expect("write Hello");
+
+        let reply: WireFrame = read_frame(&mut stream).expect("read HelloAck");
+        match reply {
+            WireFrame::HelloAck(HelloAck {
+                wire_version,
+                server,
+            }) => {
+                assert_eq!(wire_version, WIRE_VERSION);
+                match server {
+                    PeerKind::Substrate { engine_name, .. } => {
+                        assert_eq!(engine_name, "test");
+                    }
+                    PeerKind::Client { .. } => panic!("expected Substrate peer kind"),
+                }
+            }
+            other => panic!("expected HelloAck, got {other:?}"),
+        }
+    }
+
+    /// `Ping(token)` round-trips as `Pong(token)`.
+    #[test]
+    fn ping_pong_roundtrip() {
+        let (registry, mailer) = fresh_substrate();
+        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("rpc server boots");
+
+        let port = _chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+
+        // Send a Hello first so the handshake completes, then drain the
+        // HelloAck reply before the Ping/Pong roundtrip.
+        write_frame(
+            &mut stream,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION,
+                peer: PeerKind::Client {
+                    client_name: "test-client".into(),
+                    client_version: "0.0.1".into(),
+                },
+            }),
+        )
+        .unwrap();
+        let _: WireFrame = read_frame(&mut stream).unwrap();
+
+        write_frame(&mut stream, &WireFrame::Ping(0xc0ffee)).expect("write Ping");
+        let reply: WireFrame = read_frame(&mut stream).expect("read Pong");
+        assert_eq!(reply, WireFrame::Pong(0xc0ffee));
+    }
+
+    /// A `Hello` carrying a mismatched `wire_version` triggers a `Bye`
+    /// and connection close on the server side.
+    #[test]
+    fn wire_version_mismatch_kicks_connection() {
+        let (registry, mailer) = fresh_substrate();
+        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("rpc server boots");
+
+        let port = _chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+
+        write_frame(
+            &mut stream,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION + 1,
+                peer: PeerKind::Client {
+                    client_name: "future-client".into(),
+                    client_version: "9.9.9".into(),
+                },
+            }),
+        )
+        .unwrap();
+
+        let reply: WireFrame = read_frame(&mut stream).expect("read Bye");
+        match reply {
+            WireFrame::Bye { reason } => {
+                assert!(
+                    reason.contains("wire_version"),
+                    "Bye reason should mention wire_version: {reason}",
+                );
+            }
+            other => panic!("expected Bye, got {other:?}"),
+        }
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -479,6 +479,7 @@ pub struct MonitorNotice {
 // components anyway).
 
 pub use control_plane::*;
+pub use rpc::*;
 pub use tcp::*;
 
 mod tcp {
@@ -675,6 +676,25 @@ mod tcp {
         pub peer: String,
         pub reason: String,
     }
+}
+
+mod rpc {
+    use serde::{Deserialize, Serialize};
+
+    /// `aether.rpc.inbound_ready` — sidecar accept / read thread →
+    /// `RpcServerCapability` dispatcher wake. Issue 750. Mirrors the
+    /// `ConnectionReady` / `SessionDataReady` pattern for `aether.tcp`:
+    /// the sidecar pushes work over an internal mpsc and fires this
+    /// (empty-payload) mail at the cap's mailbox so the dispatcher
+    /// handler drains the queue. The mpsc carries the live data
+    /// (`TcpStream`, frame bytes, close reason) — a `TcpStream` isn't
+    /// wire-shaped and a frame's payload may be megabytes, so the mail
+    /// is only the wakeup signal.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.rpc.inbound_ready")]
+    pub struct RpcInboundReady {}
 }
 
 mod control_plane {

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -377,6 +377,33 @@ impl<'a> NativeCtx<'a> {
             self.outbound_root(),
         )
     }
+
+    /// Like [`Self::send_envelope_traced`] but always starts a fresh
+    /// causal chain — ignores the ctx's in-flight lineage and passes
+    /// `parent_mail = None, inherited_root = None` to the dispatch
+    /// path. The returned [`MailId`] is the root of the new chain, so
+    /// subscribing to its settlement via
+    /// `SettlementRegistry::subscribe_settlement_mail` fires when the
+    /// dispatch's entire descendant subtree drains.
+    ///
+    /// Use this when the cap is acting on an external event (wire-
+    /// borne RPC call, file watcher, timer) rather than forwarding a
+    /// mail that was already in flight. The RpcServer cap's `Call`
+    /// handler is the motivating case: the inbound that wakes the cap
+    /// is an internal wake mail causally unrelated to the wire-borne
+    /// `Call` — inheriting its chain would attribute the dispatch to
+    /// the wrong root and `subscribe_settlement_mail` would never fire
+    /// (descendants don't settle individually; only the chain root
+    /// does).
+    pub fn send_envelope_as_root(
+        &self,
+        recipient: MailboxId,
+        kind: KindId,
+        bytes: &[u8],
+    ) -> MailId {
+        self.binding
+            .push_envelope_returning_root(recipient.0, kind.0, bytes, 1, None, None)
+    }
 }
 
 impl<'a> Sender for NativeCtx<'a> {

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1180,6 +1180,7 @@ fn boot_passives(
     // the router closure without touching the Mailer's surface.
     let settlement_registry: Arc<crate::chassis::settlement::SettlementRegistry> =
         Arc::new(crate::chassis::settlement::SettlementRegistry::new());
+    mailer.install_settlement_registry(Arc::clone(&settlement_registry));
     let registry_for_router = Arc::clone(&settlement_registry);
     let settled_kind = <aether_kinds::trace::Settled as aether_data::Kind>::ID;
     mailer.install_chassis_router(Box::new(move |mail| {

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -64,6 +64,20 @@ pub struct Mailer {
     /// trace pipeline — chassis-addressed mail is silently dropped
     /// in that case.
     chassis_router: OnceLock<Box<dyn Fn(Mail) + Send + Sync>>,
+    /// ADR-0080 §6 settlement registry handle, exposed so capabilities
+    /// hosting external entry points (RpcServer, future event-source
+    /// caps) can subscribe to settlement of mail they dispatch from
+    /// their handlers. Threaded through the Mailer rather than down
+    /// every `NativeBinding` because settlement is a chassis-wide
+    /// service used at runtime — the cap reaches it via
+    /// `ctx.mailer().settlement_registry()`.
+    ///
+    /// `OnceLock` so the chassis builder installs exactly once at
+    /// boot alongside [`Self::chassis_router`]. `None` on test fixtures
+    /// / chassis that don't bring up the trace pipeline; callers that
+    /// expect to subscribe must check for the presence and surface a
+    /// clear error otherwise.
+    settlement_registry: OnceLock<Arc<crate::chassis::settlement::SettlementRegistry>>,
 }
 
 impl Mailer {
@@ -79,6 +93,7 @@ impl Mailer {
             handle_store,
             outbound: None,
             chassis_router: OnceLock::new(),
+            settlement_registry: OnceLock::new(),
         }
     }
 
@@ -88,6 +103,28 @@ impl Mailer {
     /// calls are no-ops — the router slot is single-claim.
     pub fn install_chassis_router(&self, router: Box<dyn Fn(Mail) + Send + Sync>) {
         let _ = self.chassis_router.set(router);
+    }
+
+    /// ADR-0080 §6 settlement-registry installation. Called once by the
+    /// chassis builder at boot alongside [`Self::install_chassis_router`]
+    /// so capability handlers can reach the registry via
+    /// `ctx.mailer().settlement_registry()`. Single-claim; subsequent
+    /// calls are no-ops.
+    pub fn install_settlement_registry(
+        &self,
+        registry: Arc<crate::chassis::settlement::SettlementRegistry>,
+    ) {
+        let _ = self.settlement_registry.set(registry);
+    }
+
+    /// Borrow the wired [`SettlementRegistry`], or `None` if no
+    /// registry was installed (test fixtures, chassis that don't bring
+    /// up the trace pipeline). Capabilities subscribe via
+    /// [`crate::chassis::settlement::SettlementRegistry::subscribe_settlement_mail`].
+    pub fn settlement_registry(
+        &self,
+    ) -> Option<&Arc<crate::chassis::settlement::SettlementRegistry>> {
+        self.settlement_registry.get()
     }
 
     /// Attach a `HubOutbound` so mail to unknown mailbox ids bubbles


### PR DESCRIPTION
## Summary

Phase 2 of iamacoffeepot/aether#750. Lands the cap that speaks the wire from iamacoffeepot/aether#760.

- `RpcServerCapability` (singleton actor) — binds a `TcpListener` on a configured addr; sidecar accept thread + per-connection reader threads; postcard length-prefix framing via `aether_codec::frame`.
- Handshake (Hello → HelloAck), liveness (Ping → Pong), graceful close (Bye), wire-version mismatch kicks the connection with a Bye carrying the mismatch reason.
- Call dispatch via `NativeCtx::send_envelope_as_root` (fresh chain — the wake mail is causally unrelated to the wire-borne Call), settlement subscription via `SettlementRegistry::subscribe_settlement_mail`, `ReplyEnd` on settlement, `ReplyEvent` on reply mail addressed back with a known correlation (via `#[fallback]` handler).
- `RpcServerHandle { local_port }` published at init; reachable from `PassiveChassis::handle::<RpcServerHandle>()` so embedders + tests pick up the OS-bound port.

## Substrate plumbing in this PR

- `NativeCtx::send_envelope_as_root` — fresh-chain variant of `send_envelope_traced`. Settlement subscribers only fire on chain *roots*; wire-driven dispatch needs its own root rather than inheriting the wake mail's chain.
- `Mailer::settlement_registry()` accessor + `install_settlement_registry` setter, wired by `Builder::boot_passives` so handlers reach the registry via `ctx.mailer().settlement_registry()` without threading through `NativeBinding`.
- `aether_kinds::RpcInboundReady` — wake kind. Mirrors `ConnectionReady` / `SessionDataReady`.

## Test plan

- [x] `cargo nextest run --workspace` — 1110 passed (3 new tests; +3 from baseline).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

New tests exercise real TCP I/O against the bound port:
- `handshake_hello_to_hello_ack_roundtrip`
- `ping_pong_roundtrip`
- `wire_version_mismatch_kicks_connection`

`Call` dispatch / settlement / `ReplyEvent` end-to-end coverage lands in phase 3 alongside chassis wiring — a real receiver actor for the dispatch target is the missing piece, and the natural place to add one is when the substrate / hub chassis pick up the cap.

## Phasing

- Phase 1 (iamacoffeepot/aether#760, merged): wire types + untyped dispatch.
- **Phase 2 (this PR):** the cap itself.
- Phase 3: chassis wiring (substrate / hub boot the cap on an env-configurable port) + `Call` end-to-end integration test.

Refs iamacoffeepot/aether#750