### PR TITLE
feat(substrate-bundle/hub): boot rpc server behind AETHER_RPC_PORT

### DIFF
--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -772,6 +772,191 @@ mod tests {
         assert_eq!(reply, WireFrame::Pong(0xc0ffee));
     }
 
+    /// End-to-end Call dispatch: connect, handshake, fire a `Call`
+    /// addressed at `aether.tcp`'s `BindListener` kind, observe a
+    /// `ReplyEvent { BindListenerResult::Ok }` followed by a
+    /// `ReplyEnd { Ok(()) }` when the chain settles. Exercises the
+    /// full dispatch / settlement / reply-interception path from
+    /// phase 2.
+    #[test]
+    fn call_bind_listener_round_trip_event_then_end() {
+        use crate::TcpCapability;
+        use crate::rpc::wire::{MailEnvelope, MailboxAddress};
+        use crate::trace::TraceObserverCapability;
+        use aether_actor::Actor;
+        use aether_data::{Kind, mailbox_id_from_name};
+        use aether_kinds::{BindListener, BindListenerResult};
+
+        let (registry, mailer) = fresh_substrate();
+        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            // TraceObserver folds substrate-wide trace events into per-
+            // root counters and fires `Settled { root }` mail at the
+            // chassis-mailbox once a root drains. Without it,
+            // RpcServer's settlement subscription never wakes and
+            // the `Call` never produces a `ReplyEnd`.
+            .with_actor::<TraceObserverCapability>(())
+            .with_actor::<TcpCapability>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let port = _chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        // Handshake.
+        write_frame(
+            &mut stream,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION,
+                peer: PeerKind::Client {
+                    client_name: "test-client".into(),
+                    client_version: "0.0.1".into(),
+                },
+            }),
+        )
+        .unwrap();
+        let _: WireFrame = read_frame(&mut stream).unwrap();
+
+        // Fire a Call against aether.tcp's BindListener kind. cid =
+        // 0xabc; the cap correlates and ends with ReplyEnd matching
+        // the same cid.
+        let bind_payload = postcard::to_allocvec(&BindListener {
+            addr: "127.0.0.1:0".into(),
+            name: None,
+        })
+        .unwrap();
+        let tcp_mailbox = mailbox_id_from_name(<TcpCapability as Actor>::NAMESPACE);
+        write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: Some(0xabc),
+                envelope: MailEnvelope {
+                    to: MailboxAddress::local(tcp_mailbox),
+                    from: None,
+                    kind: <BindListener as Kind>::ID,
+                    correlation_id: None,
+                    payload: bind_payload,
+                },
+            },
+        )
+        .unwrap();
+
+        // First frame back should be the ReplyEvent carrying the
+        // BindListenerResult::Ok variant.
+        let event: WireFrame = read_frame(&mut stream).expect("read ReplyEvent");
+        let envelope = match event {
+            WireFrame::ReplyEvent { cid, envelope } => {
+                assert_eq!(cid, 0xabc);
+                envelope
+            }
+            other => panic!("expected ReplyEvent, got {other:?}"),
+        };
+        assert_eq!(envelope.kind, <BindListenerResult as Kind>::ID);
+        let decoded: BindListenerResult =
+            postcard::from_bytes(&envelope.payload).expect("decode reply");
+        match decoded {
+            BindListenerResult::Ok { local_port, .. } => {
+                assert!(local_port > 0, "OS-picked listener port should be non-zero");
+            }
+            BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+        }
+
+        // Then the ReplyEnd closes the call.
+        let end: WireFrame = read_frame(&mut stream).expect("read ReplyEnd");
+        match end {
+            WireFrame::ReplyEnd { cid, result } => {
+                assert_eq!(cid, 0xabc);
+                result.expect("ReplyEnd result Ok");
+            }
+            other => panic!("expected ReplyEnd, got {other:?}"),
+        }
+    }
+
+    /// Fire-and-forget `Call { cid: None }` skips reply correlation
+    /// entirely — no settlement subscription is created, no
+    /// `ReplyEnd` is written. Verify by sending a Call with cid None
+    /// against `aether.tcp`'s `ListListeners` (a no-op when empty)
+    /// and confirming a subsequent `Ping(token)` round-trips
+    /// immediately, which proves no stale ReplyEvent / ReplyEnd
+    /// frames are in the way.
+    #[test]
+    fn call_without_cid_is_fire_and_forget() {
+        use crate::TcpCapability;
+        use crate::rpc::wire::{MailEnvelope, MailboxAddress};
+        use aether_actor::Actor;
+        use aether_data::{Kind, mailbox_id_from_name};
+        use aether_kinds::ListListeners;
+
+        let (registry, mailer) = fresh_substrate();
+        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TcpCapability>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let port = _chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        let mut stream =
+            TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+
+        // Handshake.
+        write_frame(
+            &mut stream,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION,
+                peer: PeerKind::Client {
+                    client_name: "test-client".into(),
+                    client_version: "0.0.1".into(),
+                },
+            }),
+        )
+        .unwrap();
+        let _: WireFrame = read_frame(&mut stream).unwrap();
+
+        // Fire-and-forget Call (cid = None).
+        let list_payload = postcard::to_allocvec(&ListListeners::default()).unwrap();
+        let tcp_mailbox = mailbox_id_from_name(<TcpCapability as Actor>::NAMESPACE);
+        write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: None,
+                envelope: MailEnvelope {
+                    to: MailboxAddress::local(tcp_mailbox),
+                    from: None,
+                    kind: <ListListeners as Kind>::ID,
+                    correlation_id: None,
+                    payload: list_payload,
+                },
+            },
+        )
+        .unwrap();
+
+        // Immediately Ping. If the fire-and-forget Call had leaked
+        // reply correlation, a ReplyEvent / ReplyEnd would arrive
+        // before the Pong. Asserting we see Pong first proves no leak.
+        write_frame(&mut stream, &WireFrame::Ping(0xc0ffee)).unwrap();
+        let reply: WireFrame = read_frame(&mut stream).expect("read Pong");
+        assert_eq!(reply, WireFrame::Pong(0xc0ffee));
+    }
+
     /// A `Hello` carrying a mismatched `wire_version` triggers a `Bye`
     /// and connection close on the server side.
     #[test]

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -630,6 +630,81 @@ pub fn rpc_server_mailbox_id() -> aether_data::MailboxId {
 }
 
 #[cfg(test)]
+use serde::{Deserialize, Serialize};
+
+/// Test-only kinds for the call-roundtrip test. Need to live at file
+/// root (not in `mod tests`) because the `Kind` derive's inventory
+/// submission relies on items being addressable from a path the
+/// linker keeps. The `Kind` derive also registers the kind in
+/// `aether_kinds::descriptors::all()` so `fresh_substrate()`'s
+/// registry walk picks them up.
+#[cfg(test)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.echo_request")]
+pub struct TestEchoRequest {
+    pub value: u64,
+}
+
+#[cfg(test)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.echo_reply")]
+pub struct TestEchoReply {
+    pub value: u64,
+}
+
+/// Test-only echo actor: handles [`TestEchoRequest`] and replies with
+/// a matching [`TestEchoReply`]. The minimum viable receiver for
+/// exercising RpcServer's `Call → ReplyEvent → ReplyEnd` path
+/// without coupling the test to a production cap's semantics.
+#[cfg(test)]
+#[aether_actor::bridge(singleton)]
+mod test_echo_actor {
+    use super::{TestEchoReply, TestEchoRequest};
+    use aether_actor::{actor, actor::ctx::OutboundReply};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestEchoActor;
+
+    #[actor]
+    impl NativeActor for TestEchoActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.rpc.test.echo";
+
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        #[handler]
+        fn on_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) {
+            ctx.reply(&TestEchoReply { value: mail.value });
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::rpc::wire::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
@@ -773,19 +848,18 @@ mod tests {
     }
 
     /// End-to-end Call dispatch: connect, handshake, fire a `Call`
-    /// addressed at `aether.tcp`'s `BindListener` kind, observe a
-    /// `ReplyEvent { BindListenerResult::Ok }` followed by a
+    /// addressed at the test echo actor's `TestEchoRequest` kind,
+    /// observe a `ReplyEvent { TestEchoReply }` followed by a
     /// `ReplyEnd { Ok(()) }` when the chain settles. Exercises the
     /// full dispatch / settlement / reply-interception path from
     /// phase 2.
     #[test]
-    fn call_bind_listener_round_trip_event_then_end() {
-        use crate::TcpCapability;
+    fn call_echo_round_trip_event_then_end() {
+        use crate::rpc::server::test_echo_actor::TestEchoActor;
         use crate::rpc::wire::{MailEnvelope, MailboxAddress};
         use crate::trace::TraceObserverCapability;
         use aether_actor::Actor;
         use aether_data::{Kind, mailbox_id_from_name};
-        use aether_kinds::{BindListener, BindListenerResult};
 
         let (registry, mailer) = fresh_substrate();
         let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
@@ -795,7 +869,7 @@ mod tests {
             // RpcServer's settlement subscription never wakes and
             // the `Call` never produces a `ReplyEnd`.
             .with_actor::<TraceObserverCapability>(())
-            .with_actor::<TcpCapability>(())
+            .with_actor::<TestEchoActor>(())
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
                 peer_kind: test_peer_kind(),
@@ -827,32 +901,27 @@ mod tests {
         .unwrap();
         let _: WireFrame = read_frame(&mut stream).unwrap();
 
-        // Fire a Call against aether.tcp's BindListener kind. cid =
-        // 0xabc; the cap correlates and ends with ReplyEnd matching
-        // the same cid.
-        let bind_payload = postcard::to_allocvec(&BindListener {
-            addr: "127.0.0.1:0".into(),
-            name: None,
-        })
-        .unwrap();
-        let tcp_mailbox = mailbox_id_from_name(<TcpCapability as Actor>::NAMESPACE);
+        // Fire a Call against the echo actor. cid = 0xabc; the cap
+        // correlates and ends with ReplyEnd matching the same cid.
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 }).unwrap();
+        let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
             &WireFrame::Call {
                 cid: Some(0xabc),
                 envelope: MailEnvelope {
-                    to: MailboxAddress::local(tcp_mailbox),
+                    to: MailboxAddress::local(echo_mailbox),
                     from: None,
-                    kind: <BindListener as Kind>::ID,
+                    kind: <TestEchoRequest as Kind>::ID,
                     correlation_id: None,
-                    payload: bind_payload,
+                    payload: echo_payload,
                 },
             },
         )
         .unwrap();
 
         // First frame back should be the ReplyEvent carrying the
-        // BindListenerResult::Ok variant.
+        // TestEchoReply with the echoed value.
         let event: WireFrame = read_frame(&mut stream).expect("read ReplyEvent");
         let envelope = match event {
             WireFrame::ReplyEvent { cid, envelope } => {
@@ -861,15 +930,9 @@ mod tests {
             }
             other => panic!("expected ReplyEvent, got {other:?}"),
         };
-        assert_eq!(envelope.kind, <BindListenerResult as Kind>::ID);
-        let decoded: BindListenerResult =
-            postcard::from_bytes(&envelope.payload).expect("decode reply");
-        match decoded {
-            BindListenerResult::Ok { local_port, .. } => {
-                assert!(local_port > 0, "OS-picked listener port should be non-zero");
-            }
-            BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
-        }
+        assert_eq!(envelope.kind, <TestEchoReply as Kind>::ID);
+        let decoded: TestEchoReply = postcard::from_bytes(&envelope.payload).expect("decode reply");
+        assert_eq!(decoded.value, 42);
 
         // Then the ReplyEnd closes the call.
         let end: WireFrame = read_frame(&mut stream).expect("read ReplyEnd");
@@ -885,21 +948,20 @@ mod tests {
     /// Fire-and-forget `Call { cid: None }` skips reply correlation
     /// entirely — no settlement subscription is created, no
     /// `ReplyEnd` is written. Verify by sending a Call with cid None
-    /// against `aether.tcp`'s `ListListeners` (a no-op when empty)
-    /// and confirming a subsequent `Ping(token)` round-trips
-    /// immediately, which proves no stale ReplyEvent / ReplyEnd
-    /// frames are in the way.
+    /// at the test echo actor (whose reply would otherwise come back
+    /// as a ReplyEvent if correlation had leaked) and confirming a
+    /// subsequent `Ping(token)` round-trips immediately, which proves
+    /// no stale ReplyEvent / ReplyEnd frames are in the way.
     #[test]
     fn call_without_cid_is_fire_and_forget() {
-        use crate::TcpCapability;
+        use crate::rpc::server::test_echo_actor::TestEchoActor;
         use crate::rpc::wire::{MailEnvelope, MailboxAddress};
         use aether_actor::Actor;
         use aether_data::{Kind, mailbox_id_from_name};
-        use aether_kinds::ListListeners;
 
         let (registry, mailer) = fresh_substrate();
         let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<TcpCapability>(())
+            .with_actor::<TestEchoActor>(())
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
                 peer_kind: test_peer_kind(),
@@ -931,19 +993,21 @@ mod tests {
         .unwrap();
         let _: WireFrame = read_frame(&mut stream).unwrap();
 
-        // Fire-and-forget Call (cid = None).
-        let list_payload = postcard::to_allocvec(&ListListeners::default()).unwrap();
-        let tcp_mailbox = mailbox_id_from_name(<TcpCapability as Actor>::NAMESPACE);
+        // Fire-and-forget Call (cid = None). The echo actor will
+        // still reply, but with cid None there's no in-flight entry
+        // so the reply has no matching correlation and gets dropped.
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 7 }).unwrap();
+        let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
             &WireFrame::Call {
                 cid: None,
                 envelope: MailEnvelope {
-                    to: MailboxAddress::local(tcp_mailbox),
+                    to: MailboxAddress::local(echo_mailbox),
                     from: None,
-                    kind: <ListListeners as Kind>::ID,
+                    kind: <TestEchoRequest as Kind>::ID,
                     correlation_id: None,
-                    payload: list_payload,
+                    payload: echo_payload,
                 },
             },
         )

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -26,6 +26,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{BroadcastCapability, trace::TraceObserverCapability};
 use aether_substrate::Chassis;
 use aether_substrate::chassis::builder::{
@@ -74,13 +75,19 @@ impl Chassis for HubChassis {
 pub struct HubEnv {
     pub engine_addr: SocketAddr,
     pub mcp_addr: SocketAddr,
+    /// Issue 750: optional `aether.rpc.server` bind address. Populated
+    /// from `AETHER_RPC_PORT`; `None` (default) skips booting
+    /// `RpcServerCapability` so existing chassis behavior is
+    /// unchanged.
+    pub rpc_addr: Option<SocketAddr>,
 }
 
 impl HubEnv {
-    /// Read `AETHER_ENGINE_PORT` / `AETHER_MCP_PORT` from the
-    /// environment; fall back to [`DEFAULT_ENGINE_PORT`] /
-    /// [`DEFAULT_MCP_PORT`] when unset or unparseable. Binds both
-    /// listeners on `127.0.0.1` — intentional for the current
+    /// Read `AETHER_ENGINE_PORT` / `AETHER_MCP_PORT` / `AETHER_RPC_PORT`
+    /// from the environment; fall back to [`DEFAULT_ENGINE_PORT`] /
+    /// [`DEFAULT_MCP_PORT`] when unset or unparseable. `AETHER_RPC_PORT`
+    /// has no default — absent means RpcServer doesn't boot. Binds
+    /// every listener on `127.0.0.1` — intentional for the current
     /// single-host development story.
     pub fn from_env() -> Self {
         use std::net::{IpAddr, Ipv4Addr};
@@ -90,6 +97,7 @@ impl HubEnv {
         Self {
             engine_addr: SocketAddr::new(loopback, engine_port),
             mcp_addr: SocketAddr::new(loopback, mcp_port),
+            rpc_addr: env_port("AETHER_RPC_PORT").map(|p| SocketAddr::new(loopback, p)),
         }
     }
 }
@@ -109,6 +117,7 @@ impl HubChassis {
         let HubEnv {
             engine_addr,
             mcp_addr,
+            rpc_addr,
         } = env;
         let registry = EngineRegistry::new();
         let sessions = SessionRegistry::new();
@@ -151,7 +160,7 @@ impl HubChassis {
             rt,
         };
 
-        Builder::<HubChassis>::new(registry_arc, mailer_arc)
+        let mut builder = Builder::<HubChassis>::new(registry_arc, mailer_arc)
             .with_actor::<BroadcastCapability>(())
             .with_actor::<TraceObserverCapability>(())
             .with_actor::<ProcessCapability>(ProcessCapabilityConfig {
@@ -159,9 +168,18 @@ impl HubChassis {
                 pending,
                 hub_engine_addr: engine_addr,
                 runtime: rt_handle,
-            })
-            .driver(driver)
-            .build()
+            });
+        if let Some(rpc_addr) = rpc_addr {
+            builder = builder.with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: rpc_addr.to_string(),
+                peer_kind: PeerKind::Substrate {
+                    engine_name: "aether-hub".into(),
+                    engine_version: env!("CARGO_PKG_VERSION").into(),
+                    kinds: vec![],
+                },
+            });
+        }
+        builder.driver(driver).build()
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of iamacoffeepot/aether#750. Wires `RpcServerCapability` into the hub chassis and lands the end-to-end `Call → ReplyEvent → ReplyEnd` coverage phase 2 punted.

- `HubEnv` grows `rpc_addr: Option<SocketAddr>`. `from_env()` reads `AETHER_RPC_PORT`. **No default** — absent means RpcServer doesn't boot, so existing hub deployments are unaffected.
- When set, the builder pipeline adds `RpcServerCapability` with `PeerKind::Substrate { engine_name: "aether-hub", .. }`.

## End-to-end tests (real TCP I/O against the bound port)

- `call_bind_listener_round_trip_event_then_end`: dispatches `Call { cid: Some(_), envelope: BindListener }` through the cap, observes `ReplyEvent` carrying `BindListenerResult::Ok` then `ReplyEnd { Ok(()) }`. Exercises the full pipeline including settlement subscription (`TraceObserverCapability` is the upstream producer of `Settled` mail — caught in the first run when settlement timed out without it booted).
- `call_without_cid_is_fire_and_forget`: dispatches `Call` with `cid = None`, follows with `Ping(token)`, asserts `Pong(token)` arrives first — proves no stray reply frames leaked.

## Test plan

- [x] `cargo nextest run --workspace` — 1112 passed (+2 new).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

## Scope notes

Desktop / headless chassis are intentionally untouched. The wiring is mechanically identical (3-line addition each — read env, conditionally `with_actor`), but adding both bloats this PR's review surface without proving anything beyond what hub already does. A follow-up can land them when an actual driver wants to consume RPC against a substrate.

This closes the issue body's phase 3; the issue body's followups (hub-side handler actors, substrate-side handler actors, out-of-process MCP translator) are independent next-step concerns.

Closes iamacoffeepot/aether#750