### PR TITLE
feat(capabilities/rpc): rpc client primitive

### DIFF
--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -1,0 +1,553 @@
+//! `aether.rpc` client — the outbound counterpart to
+//! [`RpcServerCapability`](crate::rpc::server::RpcServerCapability)
+//! (issue 763 P1).
+//!
+//! [`RpcClient`] is a plain struct, not an actor. It dials an RPC
+//! server, runs the `Hello` / `HelloAck` handshake, and spawns a
+//! reader sidecar thread that frames inbound [`WireFrame`]s onto an
+//! mpsc. It is deliberately actor-agnostic: `aether-mcp` (a plain
+//! binary with no mailbox or `Mailer`) is a consumer too, so readiness
+//! notification is a generic `on_frame` closure rather than a wake-mail
+//! address. Actor-based consumers — the per-engine proxy in issue 763
+//! P3 — capture their `Mailer` + mailbox + wake kind in the closure and
+//! fire wake mail; non-actor consumers pass `|| {}` and block / poll
+//! [`RpcConnection::inbound`] directly.
+//!
+//! The whole module is native-only (gated at the `mod` declaration in
+//! `rpc/mod.rs`) — it owns a `TcpStream` and an OS thread.
+//!
+//! See issue 763 for the forward-model architecture this is the first
+//! piece of.
+
+use crate::rpc::wire::{Hello, HelloAck, MailEnvelope, PeerKind, WIRE_VERSION, WireFrame};
+use aether_codec::frame::{FrameError, read_frame, write_frame};
+use std::fmt;
+use std::io::{self, BufReader};
+use std::net::{Shutdown, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+/// The outbound half of a live RPC connection: the write socket plus a
+/// monotonic call-id counter. `.call()` and `.ping()` write frames;
+/// inbound frames arrive on [`RpcConnection::inbound`] via the reader
+/// sidecar.
+pub struct RpcClient {
+    write_half: TcpStream,
+    next_cid: u64,
+}
+
+/// Everything [`RpcClient::connect`] hands back: the outbound `client`,
+/// the `server` identity lifted from `HelloAck`, the `inbound` frame
+/// channel, and the `reader` sidecar handle (dropping it tears the
+/// connection down).
+pub struct RpcConnection {
+    /// Outbound half — `.call()` / `.ping()`.
+    pub client: RpcClient,
+    /// The server's `HelloAck` identity. For a `PeerKind::Substrate`
+    /// server this carries the kind manifest the per-engine proxy
+    /// (issue 763 P3) caches at connect time.
+    pub server: PeerKind,
+    /// Inbound frames from the reader sidecar. Actor consumers drain
+    /// this from their `on_frame` wake handler; non-actor consumers
+    /// `recv()` it directly.
+    pub inbound: mpsc::Receiver<WireFrame>,
+    /// Reader sidecar handle. Dropping it flags shutdown, shuts the
+    /// socket to wake the blocked read, and joins the thread.
+    pub reader: RpcReaderHandle,
+}
+
+/// Handle to the reader sidecar thread. `Drop` is orderly teardown:
+/// flag shutdown, `shutdown(Both)` the socket to wake the blocked
+/// `read_frame`, then join.
+pub struct RpcReaderHandle {
+    shutdown: Arc<AtomicBool>,
+    /// A clone of the connection's stream, kept solely so `Drop` can
+    /// `shutdown()` it and wake the reader thread's blocked read.
+    wake_handle: TcpStream,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for RpcReaderHandle {
+    fn drop(&mut self) {
+        // Order matters: set the flag first so the reader sees it the
+        // moment the shutdown wakes its blocked read.
+        self.shutdown.store(true, Ordering::Release);
+        let _ = self.wake_handle.shutdown(Shutdown::Both);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// Failure modes for [`RpcClient::connect`] and the frame-writing
+/// methods.
+///
+/// - `Connect` — the TCP dial (or the reader-thread spawn) failed.
+/// - `Handshake` — the server's first frame wasn't a `HelloAck`, was a
+///   `Bye`, or carried a mismatched `wire_version`.
+/// - `Frame` — a codec error reading or writing a frame.
+#[derive(Debug)]
+pub enum RpcClientError {
+    Connect(io::Error),
+    Handshake(String),
+    Frame(FrameError),
+}
+
+impl fmt::Display for RpcClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcClientError::Connect(e) => write!(f, "rpc connect: {e}"),
+            RpcClientError::Handshake(reason) => write!(f, "rpc handshake: {reason}"),
+            RpcClientError::Frame(e) => write!(f, "rpc frame: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RpcClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RpcClientError::Connect(e) => Some(e),
+            RpcClientError::Frame(e) => Some(e),
+            RpcClientError::Handshake(_) => None,
+        }
+    }
+}
+
+impl RpcClient {
+    /// Dial `addr`, run the `Hello` / `HelloAck` handshake identifying
+    /// as `peer`, and spawn the reader sidecar.
+    ///
+    /// `on_frame` is the scheduling kick: the reader calls it after
+    /// pushing each frame onto the inbound channel (and once more after
+    /// the final synthetic `Bye` on EOF / error). Actor consumers
+    /// capture their `Mailer` + mailbox + wake kind in the closure and
+    /// fire wake mail; non-actor consumers pass `|| {}` and block /
+    /// poll [`RpcConnection::inbound`] directly.
+    pub fn connect(
+        addr: &str,
+        peer: PeerKind,
+        on_frame: impl Fn() + Send + 'static,
+    ) -> Result<RpcConnection, RpcClientError> {
+        let stream = TcpStream::connect(addr).map_err(RpcClientError::Connect)?;
+        let mut write_half = stream.try_clone().map_err(RpcClientError::Connect)?;
+        let wake_handle = stream.try_clone().map_err(RpcClientError::Connect)?;
+
+        // Handshake. Write Hello, then read exactly one frame and
+        // require a HelloAck with a matching wire version. The
+        // BufReader is created once over the original stream and moved
+        // into the reader thread afterwards, so any bytes it buffered
+        // past the HelloAck frame are not lost.
+        write_frame(
+            &mut write_half,
+            &WireFrame::Hello(Hello {
+                wire_version: WIRE_VERSION,
+                peer,
+            }),
+        )
+        .map_err(RpcClientError::Frame)?;
+
+        let mut reader = BufReader::new(stream);
+        let first: WireFrame = read_frame(&mut reader).map_err(RpcClientError::Frame)?;
+        let server = match first {
+            WireFrame::HelloAck(HelloAck {
+                wire_version,
+                server,
+            }) => {
+                if wire_version != WIRE_VERSION {
+                    return Err(RpcClientError::Handshake(format!(
+                        "wire_version mismatch: server={wire_version}, client={WIRE_VERSION}"
+                    )));
+                }
+                server
+            }
+            WireFrame::Bye { reason } => {
+                return Err(RpcClientError::Handshake(format!(
+                    "server rejected handshake: {reason}"
+                )));
+            }
+            other => {
+                return Err(RpcClientError::Handshake(format!(
+                    "expected HelloAck, got {other:?}"
+                )));
+            }
+        };
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
+        let (inbound_tx, inbound_rx) = mpsc::channel::<WireFrame>();
+
+        let thread = std::thread::Builder::new()
+            .name("aether-rpc-client-reader".into())
+            .spawn(move || {
+                loop {
+                    if shutdown_for_thread.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let frame: WireFrame = match read_frame(&mut reader) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            // Consumer-initiated teardown: the
+                            // RpcReaderHandle's Drop flips the flag and
+                            // shuts the socket, surfacing here as a
+                            // read error. No synthetic Bye — nobody is
+                            // reading the channel.
+                            if shutdown_for_thread.load(Ordering::Acquire) {
+                                break;
+                            }
+                            // Peer-initiated close (EOF) or a real read
+                            // error: surface it as a Bye so the
+                            // consumer's drain observes the close.
+                            let reason = match &e {
+                                FrameError::Io(io_err)
+                                    if io_err.kind() == io::ErrorKind::UnexpectedEof =>
+                                {
+                                    "eof".to_string()
+                                }
+                                other => format!("read error: {other}"),
+                            };
+                            let _ = inbound_tx.send(WireFrame::Bye { reason });
+                            on_frame();
+                            break;
+                        }
+                    };
+                    if inbound_tx.send(frame).is_err() {
+                        // Receiver dropped — the consumer is gone.
+                        break;
+                    }
+                    on_frame();
+                }
+            })
+            .map_err(RpcClientError::Connect)?;
+
+        Ok(RpcConnection {
+            client: RpcClient {
+                write_half,
+                next_cid: 1,
+            },
+            server,
+            inbound: inbound_rx,
+            reader: RpcReaderHandle {
+                shutdown,
+                wake_handle,
+                thread: Some(thread),
+            },
+        })
+    }
+
+    /// Write a `Call` frame carrying `envelope`, returning the freshly
+    /// minted `cid` the caller correlates replies against. The server
+    /// answers with zero or more `ReplyEvent { cid }` frames followed
+    /// by exactly one `ReplyEnd { cid }`.
+    pub fn call(&mut self, envelope: MailEnvelope) -> Result<u64, RpcClientError> {
+        let cid = self.next_cid;
+        self.next_cid += 1;
+        write_frame(
+            &mut self.write_half,
+            &WireFrame::Call {
+                cid: Some(cid),
+                envelope,
+            },
+        )
+        .map_err(RpcClientError::Frame)?;
+        Ok(cid)
+    }
+
+    /// Write a `Ping(nonce)` liveness probe. The server mirrors it back
+    /// as `Pong(nonce)` on the inbound channel.
+    pub fn ping(&mut self, nonce: u64) -> Result<(), RpcClientError> {
+        write_frame(&mut self.write_half, &WireFrame::Ping(nonce))
+            .map_err(RpcClientError::Frame)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RpcClient, RpcClientError};
+    use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
+    use crate::rpc::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
+    use crate::rpc::wire::{
+        HelloAck, MailEnvelope, MailboxAddress, PeerKind, WIRE_VERSION, WireFrame,
+    };
+    use crate::trace::TraceObserverCapability;
+    use aether_actor::Actor;
+    use aether_codec::frame::{read_frame, write_frame};
+    use aether_data::{Kind, mailbox_id_from_name};
+    use aether_substrate::chassis::Chassis;
+    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::handle_store::HandleStore;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
+    use aether_substrate::mail::registry::Registry;
+    use std::io::BufReader;
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    struct TestChassis;
+    impl Chassis for TestChassis {
+        const PROFILE: &'static str = "test";
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        }
+    }
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+        (registry, mailer)
+    }
+
+    fn substrate_peer_kind() -> PeerKind {
+        PeerKind::Substrate {
+            engine_name: "test".into(),
+            engine_version: "0.1.0".into(),
+            kinds: vec![],
+        }
+    }
+
+    fn client_peer_kind() -> PeerKind {
+        PeerKind::Client {
+            client_name: "rpc-client-test".into(),
+            client_version: "0.0.1".into(),
+        }
+    }
+
+    /// Spin a one-shot fake server on an OS-picked port: bind, hand the
+    /// port back, and on a background thread accept exactly one
+    /// connection and run `handle` against it. Used by the error-path
+    /// tests that need a server behaving in ways the real
+    /// `RpcServerCapability` never would (bad wire version, immediate
+    /// close). Returns the port + the server thread's join handle.
+    fn fake_server(handle: impl FnOnce(TcpStream) + Send + 'static) -> (u16, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+        let port = listener.local_addr().expect("local_addr").port();
+        let thread = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("fake server accept");
+            handle(stream);
+        });
+        (port, thread)
+    }
+
+    /// Full socket round-trip: boot `RpcServerCapability` + the echo
+    /// actor + `TraceObserverCapability`, connect a real `RpcClient`,
+    /// fire a `Call` carrying a `TestEchoRequest`, and drain the inbound
+    /// channel — expect `ReplyEvent { TestEchoReply }` then
+    /// `ReplyEnd { Ok }`. Issue 750's tests dispatched in-process; this
+    /// is the first that exercises the actual TCP path end to end.
+    #[test]
+    fn call_echo_round_trips_over_the_socket() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            // TraceObserver fires `Settled { root }` once a dispatched
+            // chain drains; without it RpcServer's settlement
+            // subscription never wakes and no `ReplyEnd` is written.
+            .with_actor::<TraceObserverCapability>(())
+            .with_actor::<TestEchoActor>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: substrate_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let port = chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+
+        // The on_frame hook bumps a counter — proves the reader fires
+        // it per inbound frame.
+        let frames_seen = Arc::new(AtomicUsize::new(0));
+        let frames_seen_for_hook = Arc::clone(&frames_seen);
+        let mut conn = RpcClient::connect(
+            &format!("127.0.0.1:{port}"),
+            client_peer_kind(),
+            move || {
+                frames_seen_for_hook.fetch_add(1, Ordering::Release);
+            },
+        )
+        .expect("client connects + handshakes");
+
+        // The handshake handed back the server's identity.
+        match &conn.server {
+            PeerKind::Substrate { engine_name, .. } => assert_eq!(engine_name, "test"),
+            PeerKind::Client { .. } => panic!("expected Substrate peer kind from server"),
+        }
+
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 }).unwrap();
+        let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
+        let cid = conn
+            .client
+            .call(MailEnvelope {
+                to: MailboxAddress::local(echo_mailbox),
+                from: None,
+                kind: <TestEchoRequest as Kind>::ID,
+                correlation_id: None,
+                payload: echo_payload,
+            })
+            .expect("call writes");
+
+        // First frame back: ReplyEvent carrying the echoed reply.
+        // recv_timeout so a hung settlement fails the test instead of
+        // blocking forever.
+        let event = conn
+            .inbound
+            .recv_timeout(Duration::from_secs(5))
+            .expect("ReplyEvent within 5s");
+        let envelope = match event {
+            WireFrame::ReplyEvent {
+                cid: ev_cid,
+                envelope,
+            } => {
+                assert_eq!(ev_cid, cid);
+                envelope
+            }
+            other => panic!("expected ReplyEvent, got {other:?}"),
+        };
+        assert_eq!(envelope.kind, <TestEchoReply as Kind>::ID);
+        let decoded: TestEchoReply = postcard::from_bytes(&envelope.payload).expect("decode reply");
+        assert_eq!(decoded.value, 42);
+
+        // Then ReplyEnd closes the call.
+        let end = conn
+            .inbound
+            .recv_timeout(Duration::from_secs(5))
+            .expect("ReplyEnd within 5s");
+        match end {
+            WireFrame::ReplyEnd {
+                cid: end_cid,
+                result,
+            } => {
+                assert_eq!(end_cid, cid);
+                result.expect("ReplyEnd result Ok");
+            }
+            other => panic!("expected ReplyEnd, got {other:?}"),
+        }
+
+        assert!(
+            frames_seen.load(Ordering::Acquire) >= 2,
+            "on_frame should fire at least once per inbound frame",
+        );
+    }
+
+    /// `Ping(nonce)` round-trips as `Pong(nonce)` over the socket.
+    #[test]
+    fn ping_pongs_over_the_socket() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: substrate_peer_kind(),
+            })
+            .build_passive()
+            .expect("rpc server boots");
+
+        let port = chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+
+        let mut conn = RpcClient::connect(&format!("127.0.0.1:{port}"), client_peer_kind(), || {})
+            .expect("client connects");
+
+        conn.client.ping(0xc0ffee).expect("ping writes");
+        let pong = conn
+            .inbound
+            .recv_timeout(Duration::from_secs(2))
+            .expect("Pong within 2s");
+        assert_eq!(pong, WireFrame::Pong(0xc0ffee));
+    }
+
+    /// A peer that completes the handshake then closes surfaces as a
+    /// synthetic `Bye { reason: "eof" }` on the inbound channel — the
+    /// reader sidecar's EOF path.
+    #[test]
+    fn peer_close_surfaces_eof_bye_on_inbound() {
+        let (port, server) = fake_server(|mut stream| {
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let _hello: WireFrame = read_frame(&mut reader).expect("read Hello");
+            write_frame(
+                &mut stream,
+                &WireFrame::HelloAck(HelloAck {
+                    wire_version: WIRE_VERSION,
+                    server: substrate_peer_kind(),
+                }),
+            )
+            .expect("write HelloAck");
+            // Return — drops the stream, closing the peer side.
+        });
+
+        let conn = RpcClient::connect(&format!("127.0.0.1:{port}"), client_peer_kind(), || {})
+            .expect("client connects");
+        server.join().expect("fake server thread");
+
+        let frame = conn
+            .inbound
+            .recv_timeout(Duration::from_secs(2))
+            .expect("Bye within 2s");
+        match frame {
+            WireFrame::Bye { reason } => assert_eq!(reason, "eof"),
+            other => panic!("expected Bye, got {other:?}"),
+        }
+    }
+
+    /// A server that answers with a mismatched `wire_version` is
+    /// rejected at connect time as `RpcClientError::Handshake`, not a
+    /// silent hang.
+    #[test]
+    fn wire_version_mismatch_surfaces_as_handshake_error() {
+        let (port, server) = fake_server(|mut stream| {
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let _hello: WireFrame = read_frame(&mut reader).expect("read Hello");
+            write_frame(
+                &mut stream,
+                &WireFrame::HelloAck(HelloAck {
+                    wire_version: WIRE_VERSION + 1,
+                    server: substrate_peer_kind(),
+                }),
+            )
+            .expect("write HelloAck");
+        });
+
+        let result = RpcClient::connect(&format!("127.0.0.1:{port}"), client_peer_kind(), || {});
+        server.join().expect("fake server thread");
+
+        match result {
+            Err(RpcClientError::Handshake(reason)) => assert!(
+                reason.contains("wire_version"),
+                "handshake error should mention wire_version: {reason}",
+            ),
+            Err(other) => panic!("expected Handshake error, got {other:?}"),
+            Ok(_) => panic!("mismatched wire_version should not yield a connection"),
+        }
+    }
+
+    /// Dialing a closed port is an `RpcClientError::Connect`. Bind an
+    /// OS-picked port, drop the listener, then dial it — the port is
+    /// free for the microseconds between drop and connect.
+    #[test]
+    fn connect_to_closed_port_is_connect_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        drop(listener);
+
+        match RpcClient::connect(&format!("127.0.0.1:{port}"), client_peer_kind(), || {}) {
+            Err(RpcClientError::Connect(_)) => {}
+            Err(other) => panic!("expected Connect error, got {other:?}"),
+            Ok(_) => panic!("dialing a closed port should not yield a connection"),
+        }
+    }
+}

--- a/crates/aether-capabilities/src/rpc/mod.rs
+++ b/crates/aether-capabilities/src/rpc/mod.rs
@@ -1,16 +1,31 @@
-//! `aether.rpc` — generic TCP RPC capability (issue 750).
+//! `aether.rpc` — generic TCP RPC transport (issues 750, 763).
 //!
-//! Phase 1 (this module): wire vocabulary and the untyped envelope
-//! dispatch surface on `NativeCtx::send_envelope_traced`. The
-//! `RpcServerCapability` actor itself lands in phase 2, alongside
-//! the accept-thread + per-connection reader machinery. Phase 3
-//! wires it into the hub / substrate chassis on a configurable port.
+//! - [`wire`] — the type-erased wire vocabulary: length-prefix postcard
+//!   [`WireFrame`]s carrying mail envelopes. Endpoints are mail kinds,
+//!   not request enums, so any kind two peers share is reachable
+//!   without a wire change.
+//! - [`server`] — [`RpcServerCapability`], the singleton actor that
+//!   binds a TCP listener, accepts connections, and dispatches inbound
+//!   `Call` envelopes into the local actor system (issue 750).
+//! - [`client`] — [`RpcClient`], the outbound counterpart: dials an RPC
+//!   server, runs the handshake, and frames inbound `WireFrame`s onto
+//!   an mpsc (issue 763 P1). Native-only.
 //!
-//! See issue 750 for the full design.
+//! See issues 750 and 763 for the full design.
 
 pub mod server;
 pub mod wire;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub mod client;
+
+// Shared round-trip test scaffolding (echo actor + its kinds), used by
+// both the `server` and `client` test modules.
+#[cfg(test)]
+mod test_echo;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use client::{RpcClient, RpcClientError, RpcConnection, RpcReaderHandle};
 pub use server::{RpcServerCapability, rpc_server_mailbox_id};
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{RpcServerConfig, RpcServerHandle};

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -630,81 +630,6 @@ pub fn rpc_server_mailbox_id() -> aether_data::MailboxId {
 }
 
 #[cfg(test)]
-use serde::{Deserialize, Serialize};
-
-/// Test-only kinds for the call-roundtrip test. Need to live at file
-/// root (not in `mod tests`) because the `Kind` derive's inventory
-/// submission relies on items being addressable from a path the
-/// linker keeps. The `Kind` derive also registers the kind in
-/// `aether_kinds::descriptors::all()` so `fresh_substrate()`'s
-/// registry walk picks them up.
-#[cfg(test)]
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    aether_data::Kind,
-    aether_data::Schema,
-)]
-#[kind(name = "aether.rpc.test.echo_request")]
-pub struct TestEchoRequest {
-    pub value: u64,
-}
-
-#[cfg(test)]
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    aether_data::Kind,
-    aether_data::Schema,
-)]
-#[kind(name = "aether.rpc.test.echo_reply")]
-pub struct TestEchoReply {
-    pub value: u64,
-}
-
-/// Test-only echo actor: handles [`TestEchoRequest`] and replies with
-/// a matching [`TestEchoReply`]. The minimum viable receiver for
-/// exercising RpcServer's `Call → ReplyEvent → ReplyEnd` path
-/// without coupling the test to a production cap's semantics.
-#[cfg(test)]
-#[aether_actor::bridge(singleton)]
-mod test_echo_actor {
-    use super::{TestEchoReply, TestEchoRequest};
-    use aether_actor::{actor, actor::ctx::OutboundReply};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-
-    pub struct TestEchoActor;
-
-    #[actor]
-    impl NativeActor for TestEchoActor {
-        type Config = ();
-        const NAMESPACE: &'static str = "aether.rpc.test.echo";
-
-        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self)
-        }
-
-        #[handler]
-        fn on_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) {
-            ctx.reply(&TestEchoReply { value: mail.value });
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::rpc::wire::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
@@ -855,7 +780,7 @@ mod tests {
     /// phase 2.
     #[test]
     fn call_echo_round_trip_event_then_end() {
-        use crate::rpc::server::test_echo_actor::TestEchoActor;
+        use crate::rpc::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
         use crate::rpc::wire::{MailEnvelope, MailboxAddress};
         use crate::trace::TraceObserverCapability;
         use aether_actor::Actor;
@@ -954,7 +879,7 @@ mod tests {
     /// no stale ReplyEvent / ReplyEnd frames are in the way.
     #[test]
     fn call_without_cid_is_fire_and_forget() {
-        use crate::rpc::server::test_echo_actor::TestEchoActor;
+        use crate::rpc::test_echo::{TestEchoActor, TestEchoRequest};
         use crate::rpc::wire::{MailEnvelope, MailboxAddress};
         use aether_actor::Actor;
         use aether_data::{Kind, mailbox_id_from_name};

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -1,0 +1,82 @@
+//! Shared test-support: a minimal echo actor plus its request / reply
+//! kinds, used by both the `rpc::server` and `rpc::client` round-trip
+//! tests.
+//!
+//! The kinds live at this module's root (not nested in a `mod tests`)
+//! so the `Kind` derive's inventory submission stays addressable from a
+//! path the linker keeps — and so the derive registers them in
+//! `aether_kinds::descriptors::all()` for the test substrate's registry
+//! walk. The whole module is `#[cfg(test)]` (gated at the `mod`
+//! declaration in `rpc/mod.rs`): it is test scaffolding, not part of
+//! the cap's shipped surface.
+
+use serde::{Deserialize, Serialize};
+
+/// Echo request kind — the test driver sends one of these; the echo
+/// actor replies with a [`TestEchoReply`] carrying the same `value`.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.echo_request")]
+pub struct TestEchoRequest {
+    pub value: u64,
+}
+
+/// Echo reply kind — the echo actor's response to a [`TestEchoRequest`].
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.echo_reply")]
+pub struct TestEchoReply {
+    pub value: u64,
+}
+
+/// Test-only echo actor: handles [`TestEchoRequest`] and replies with a
+/// matching [`TestEchoReply`]. The minimum viable receiver for
+/// exercising the RPC `Call → ReplyEvent → ReplyEnd` path without
+/// coupling a test to a production cap's semantics.
+#[aether_actor::bridge(singleton)]
+mod test_echo_actor {
+    use super::{TestEchoReply, TestEchoRequest};
+    use aether_actor::{actor, actor::ctx::OutboundReply};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestEchoActor;
+
+    #[actor]
+    impl NativeActor for TestEchoActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.rpc.test.echo";
+
+        fn init(_: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        #[handler]
+        fn on_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) {
+            ctx.reply(&TestEchoReply { value: mail.value });
+        }
+    }
+}
+
+// `TestEchoActor` is re-exported at this module's root by the
+// `#[bridge]` macro itself — no explicit `pub use` needed.


### PR DESCRIPTION
## Summary

First phase of iamacoffeepot/aether#763 — the RPC client primitive.

- `RpcClient` (`rpc/client.rs`): the outbound counterpart to `RpcServerCapability`. Dials an RPC server, runs the `Hello` / `HelloAck` handshake, spawns a reader sidecar that frames inbound `WireFrame`s onto an mpsc. `.call()` mints + writes a `Call` cid; `.ping()` writes a liveness probe; `RpcReaderHandle`'s `Drop` tears the connection down cleanly.
- Deliberately actor-agnostic: readiness notification is a generic `on_frame` closure, not a wake-mail address. Actor consumers (the per-engine proxy in P3) capture their `Mailer` + mailbox + wake kind; non-actor consumers (`aether-mcp`, P5) pass `|| {}` and poll `RpcConnection::inbound` directly. Native-only — gated at the `mod` declaration.
- Promotes the `TestEcho*` round-trip scaffolding out of `server.rs` into a shared `#[cfg(test)] rpc::test_echo` module so both the server and client test modules use it.

This is the first test coverage that round-trips the actual TCP socket — issue 750's tests all dispatched in-process.

## Test plan

- [x] `cargo nextest run --workspace` — 1117 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features` — `client` correctly elided from the wasm marker build
- [x] New `rpc::client` tests: full Call echo round-trip over the socket, Ping/Pong, peer-close → synthetic `Bye`, wire-version mismatch → `Handshake` error, closed-port dial → `Connect` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)