### PR TITLE
feat(substrate-bundle): boot rpc server in desktop + headless chassis

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -11,8 +11,10 @@
 //! the loop so a queued `CaptureQueue` request gets pulled on the
 //! next redraw, even when the window is occluded.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AudioCapability, BroadcastCapability, CaptureBackend, ComponentHostCapability,
     ComponentHostConfig, FsCapability, HandleCapability, HttpCapability, InputCapability,
@@ -75,6 +77,10 @@ pub struct DesktopEnv {
     pub boot_mode: WindowMode,
     pub boot_size: Option<(u32, u32)>,
     pub boot_title: String,
+    /// Issue 763 P2: optional `aether.rpc.server` bind address.
+    /// Populated from `AETHER_RPC_PORT`; `None` (default) skips booting
+    /// `RpcServerCapability` so existing chassis behavior is unchanged.
+    pub rpc_addr: Option<SocketAddr>,
 }
 
 impl DesktopEnv {
@@ -115,6 +121,16 @@ impl DesktopEnv {
         let boot_title =
             std::env::var("AETHER_WINDOW_TITLE").unwrap_or_else(|_| "aether".to_owned());
 
+        // `AETHER_RPC_PORT` has no default — absent means RpcServer
+        // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
+        let rpc_addr = {
+            use std::net::{IpAddr, Ipv4Addr};
+            std::env::var("AETHER_RPC_PORT")
+                .ok()
+                .and_then(|s| s.parse::<u16>().ok())
+                .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
+        };
+
         Ok(DesktopEnv {
             event_loop,
             capture_queue,
@@ -125,6 +141,7 @@ impl DesktopEnv {
             boot_mode,
             boot_size,
             boot_title,
+            rpc_addr,
         })
     }
 }
@@ -150,6 +167,7 @@ impl DesktopChassis {
             boot_mode,
             boot_size,
             boot_title,
+            rpc_addr,
         } = env;
 
         let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION")).build()?;
@@ -224,7 +242,7 @@ impl DesktopChassis {
         // capabilities' boot tracing routes through the log capture;
         // render last so it claims its mailboxes after every other
         // chassis cap.
-        Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
+        let mut builder = Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
             .with_actor::<BroadcastCapability>(())
             .with_actor::<HandleCapability>(())
@@ -237,7 +255,21 @@ impl DesktopChassis {
             .with_actor::<TcpCapability>(())
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
-            .with_actor::<UnsupportedTestBenchCapability>(())
+            .with_actor::<UnsupportedTestBenchCapability>(());
+        // Issue 763 P2: boot the RPC server only when `AETHER_RPC_PORT`
+        // is set, mirroring the hub chassis. The substrate becomes an
+        // RPC server peer that a hub (or any client) connects out to.
+        if let Some(rpc_addr) = rpc_addr {
+            builder = builder.with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: rpc_addr.to_string(),
+                peer_kind: PeerKind::Substrate {
+                    engine_name: "aether-desktop".into(),
+                    engine_version: env!("CARGO_PKG_VERSION").into(),
+                    kinds: vec![],
+                },
+            });
+        }
+        builder
             .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -13,9 +13,11 @@
 //! deleted as a kind in Phase 4 — no replacement, no MCP path until
 //! issue 603 §F2 revives the per-domain shape.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     BroadcastCapability, ComponentHostCapability, ComponentHostConfig, FsCapability,
     HandleCapability, HeadlessRenderCapability, HeadlessWindowCapability, HttpCapability,
@@ -54,6 +56,10 @@ pub struct HeadlessEnv {
     pub namespace_roots: NamespaceRoots,
     pub http: HttpConf,
     pub tick_period: Duration,
+    /// Issue 763 P2: optional `aether.rpc.server` bind address.
+    /// Populated from `AETHER_RPC_PORT`; `None` (default) skips booting
+    /// `RpcServerCapability` so existing chassis behavior is unchanged.
+    pub rpc_addr: Option<SocketAddr>,
 }
 
 impl HeadlessEnv {
@@ -62,16 +68,24 @@ impl HeadlessEnv {
     /// issue 464). Tests bypass this by constructing `HeadlessEnv`
     /// directly.
     pub fn from_env() -> Self {
+        use std::net::{IpAddr, Ipv4Addr};
         let hub_url = std::env::var("AETHER_HUB_URL").ok();
         let http = HttpConf::from_env();
         let namespace_roots = NamespaceRoots::from_env();
         let tick_hz = parse_tick_hz_env();
         let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
+        // `AETHER_RPC_PORT` has no default — absent means RpcServer
+        // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
+        let rpc_addr = std::env::var("AETHER_RPC_PORT")
+            .ok()
+            .and_then(|s| s.parse::<u16>().ok())
+            .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
         HeadlessEnv {
             hub_url,
             namespace_roots,
             http,
             tick_period,
+            rpc_addr,
         }
     }
 }
@@ -90,6 +104,7 @@ impl HeadlessChassis {
             namespace_roots,
             http,
             tick_period,
+            rpc_addr,
         } = env;
 
         let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION")).build()?;
@@ -167,7 +182,7 @@ impl HeadlessChassis {
         // chassis_builder `.with()` chain. Boot order is declaration
         // order — log first so other capabilities' boot tracing routes
         // through the log capture.
-        Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
+        let mut builder = Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
             .with_actor::<BroadcastCapability>(())
             .with_actor::<HandleCapability>(())
@@ -180,7 +195,21 @@ impl HeadlessChassis {
             .with_actor::<TcpCapability>(())
             .with_actor::<HeadlessRenderCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
-            .with_actor::<UnsupportedTestBenchCapability>(())
+            .with_actor::<UnsupportedTestBenchCapability>(());
+        // Issue 763 P2: boot the RPC server only when `AETHER_RPC_PORT`
+        // is set, mirroring the hub chassis. The substrate becomes an
+        // RPC server peer that a hub (or any client) connects out to.
+        if let Some(rpc_addr) = rpc_addr {
+            builder = builder.with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: rpc_addr.to_string(),
+                peer_kind: PeerKind::Substrate {
+                    engine_name: "aether-headless".into(),
+                    engine_version: env!("CARGO_PKG_VERSION").into(),
+                    kinds: vec![],
+                },
+            });
+        }
+        builder
             .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()


### PR DESCRIPTION
## Summary

Second phase of iamacoffeepot/aether#763 — wires `RpcServerCapability` into the desktop and headless chassis builders.

Issue 750 P3 only wired the RPC server into the hub chassis. The forward-model architecture needs every substrate to be an RPC server that a hub (or any client) connects out to, so desktop and headless need it too — and it unblocks P4's spawn path, where the engines cap forks a substrate and dials its RPC port.

Mirrors the hub chassis exactly:
- An optional `rpc_addr: Option<SocketAddr>` on `DesktopEnv` / `HeadlessEnv`, populated from `AETHER_RPC_PORT` (no default — absent means the cap doesn't boot, so existing chassis behavior is unchanged).
- A conditional `.with_actor::<RpcServerCapability>(...)` in each builder chain, with `PeerKind::Substrate { engine_name: "aether-desktop" | "aether-headless", .. }`.

## Test plan

- [x] `cargo nextest run --workspace` — 1117 passed
- [x] `cargo clippy -p aether-substrate-bundle --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Smoke: `AETHER_RPC_PORT=18950 aether-substrate-headless` → logs `rpc server bound addr=127.0.0.1:18950` and the port accepts connections
- [x] Smoke: `aether-substrate-headless` with no env var → no `rpc server bound` line, existing behavior unchanged
- Desktop wiring is byte-identical to headless (verified by compile + clippy); it can't be smoke-run here since it needs a winit event loop, but the path is the same as the headless smoke proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)