### PR TITLE
feat(capabilities/engine): engines cap with spawn, list, terminate

### DIFF
--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -1,15 +1,18 @@
 //! `aether.engine` — engine-management capability cluster (issue 763).
 //!
-//! P3 (this phase) ships [`proxy::EngineProxy`], the per-engine proxy
-//! actor that wraps one outbound RPC connection to a substrate — the
-//! bridge core of the forward-model architecture. P4 adds the engines
-//! cap (`list` / `spawn` / `terminate`) that supervises a fleet of
-//! these proxies and drives `ForwardEnvelope` at them.
+//! - [`proxy::EngineProxy`] (P3) — the per-engine proxy actor that
+//!   wraps one outbound RPC connection to a substrate; the bridge core
+//!   of the forward-model architecture.
+//! - [`server::EngineServer`] (P4) — the engines cap (`list` / `spawn`
+//!   / `terminate`) that supervises a fleet of proxies, fork+execing
+//!   substrates and connecting a proxy to each.
 //!
 //! See issue 763 for the full design.
 
 pub mod proxy;
+pub mod server;
 
 pub use proxy::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use proxy::EngineProxyConfig;
+pub use server::EngineServer;

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -37,7 +37,7 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
-use aether_kinds::{ForwardEnvelope, RpcInboundReady};
+use aether_kinds::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
 
 // `EngineProxyConfig` carries only wasm-safe types, but it lives inside
 // the bridge mod (which the macro elides on wasm), so the re-export is
@@ -47,8 +47,10 @@ pub use proxy_native::EngineProxyConfig;
 
 #[aether_actor::bridge(instanced)]
 mod proxy_native {
-    use super::{ForwardEnvelope, RpcInboundReady};
-    use crate::rpc::{MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcConnection, WireFrame};
+    use super::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
+    use crate::rpc::{
+        MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, WireFrame,
+    };
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, KindId};
     use aether_substrate::Mail;
@@ -57,16 +59,36 @@ mod proxy_native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{ReplyTarget, ReplyTo};
     use std::collections::HashMap;
+    use std::io::ErrorKind;
+    use std::process::Child;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    /// Total time [`connect_proxy`] keeps retrying a refused dial when
+    /// the proxy just forked the substrate and it may still be coming
+    /// up. Picked to comfortably cover a debug-build headless cold
+    /// start; far longer than a healthy localhost dial needs.
+    const PROXY_CONNECT_RETRY_BUDGET: Duration = Duration::from_secs(5);
+    /// Pause between dial attempts within [`PROXY_CONNECT_RETRY_BUDGET`].
+    const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
     /// Init config for [`EngineProxy`]. `engine_id` is the proxy's
     /// engine identity (also the per-instance subname — full address
     /// `aether.engine.proxy:<engine_id>`); `rpc_addr` is the
     /// substrate's `RpcServerCapability` bind address the proxy dials
     /// at init.
+    ///
+    /// `spawned` is `Some` when the engines cap (`aether.engine`)
+    /// fork+exec'd the substrate and handed its child handle here —
+    /// the proxy then owns that process: it retries the startup dial
+    /// (the substrate may not have bound its port yet), kills it on a
+    /// failed boot, and SIGKILLs + reaps it on `Drop`. `None` for an
+    /// adopted / externally-running substrate, whose lifetime the
+    /// proxy doesn't manage.
     pub struct EngineProxyConfig {
         pub engine_id: EngineId,
         pub rpc_addr: String,
+        pub spawned: Option<Child>,
     }
 
     /// Per-engine proxy: one outbound RPC connection to one substrate,
@@ -86,6 +108,10 @@ mod proxy_native {
         /// opened the call. `ReplyEvent` frames route back here;
         /// `ReplyEnd` clears the entry.
         in_flight: HashMap<u64, ReplyTo>,
+        /// The forked child substrate, when the engines cap spawned it
+        /// (see [`EngineProxyConfig::spawned`]). `Drop` SIGKILLs +
+        /// reaps it; `None` once taken or for an adopted substrate.
+        spawned: Option<Child>,
     }
 
     #[actor]
@@ -93,34 +119,39 @@ mod proxy_native {
         type Config = EngineProxyConfig;
         const NAMESPACE: &'static str = "aether.engine.proxy";
 
-        fn init(config: EngineProxyConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        fn init(
+            mut config: EngineProxyConfig,
+            ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
             let self_mailbox = ctx.self_id();
             let mailer = ctx.mailer();
-
-            // The reader sidecar fires `RpcInboundReady` at this
-            // proxy's own mailbox after every inbound frame so
-            // `on_inbound_ready` drains `conn.inbound` on the
-            // dispatcher thread.
-            let wake_mailer = Arc::clone(&mailer);
             let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
-            let on_frame = move || {
-                wake_mailer.push(Mail::new(self_mailbox, wake_kind, Vec::new(), 1));
-            };
 
-            let conn = RpcClient::connect(
-                &config.rpc_addr,
-                PeerKind::Client {
-                    client_name: "aether.engine.proxy".to_owned(),
-                    client_version: env!("CARGO_PKG_VERSION").to_owned(),
-                },
-                on_frame,
-            )
-            .map_err(|e| BootError::Other(Box::new(e)))?;
+            // A freshly-forked substrate (`spawned.is_some()`) may not
+            // have bound its RPC port yet, so the startup dial retries
+            // briefly. An adopted / externally-running substrate
+            // (`spawned.is_none()`) is dialed once — a refused
+            // connection there is a real error, not a startup race.
+            let retry = config.spawned.is_some();
+            let conn =
+                match connect_proxy(&config.rpc_addr, &mailer, self_mailbox, wake_kind, retry) {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        // The proxy owns the child it was handed — a
+                        // failed boot must not orphan the substrate.
+                        if let Some(mut child) = config.spawned.take() {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
+                        return Err(BootError::Other(Box::new(e)));
+                    }
+                };
 
             tracing::info!(
                 target: "aether_substrate::engine_proxy",
                 engine_id = ?config.engine_id,
                 addr = %config.rpc_addr,
+                spawned = config.spawned.is_some(),
                 "engine proxy connected",
             );
 
@@ -129,6 +160,7 @@ mod proxy_native {
                 mailer,
                 conn,
                 in_flight: HashMap::new(),
+                spawned: config.spawned,
             })
         }
 
@@ -199,6 +231,95 @@ mod proxy_native {
                         );
                     }
                 }
+            }
+        }
+
+        /// Shut this proxy's substrate down.
+        ///
+        /// # Agent
+        /// Sent by the engines cap (`aether.engine`) on a terminate
+        /// request. The proxy self-shuts-down; its `Drop` SIGKILLs and
+        /// reaps the child substrate it forked (if any), and the
+        /// outbound RPC connection closes as the actor drops. The
+        /// `engine_id` field is ignored — a proxy only ever terminates
+        /// its own engine.
+        #[handler]
+        fn on_terminate(&mut self, ctx: &mut NativeCtx<'_>, _mail: TerminateEngine) {
+            tracing::info!(
+                target: "aether_substrate::engine_proxy",
+                engine_id = ?self.engine_id,
+                "engine proxy: terminate requested; shutting down",
+            );
+            ctx.shutdown();
+        }
+    }
+
+    /// Dial the substrate's `RpcServerCapability`, building a fresh
+    /// `on_frame` wake closure per attempt. When `retry` is set, a
+    /// connection-refused / reset error is retried (after a short
+    /// pause) until [`PROXY_CONNECT_RETRY_BUDGET`] elapses — a
+    /// freshly-forked substrate may not have bound its port yet.
+    /// Handshake / frame errors are always terminal: the peer
+    /// answered, just wrongly.
+    fn connect_proxy(
+        addr: &str,
+        mailer: &Arc<Mailer>,
+        self_mailbox: aether_data::MailboxId,
+        wake_kind: KindId,
+        retry: bool,
+    ) -> Result<RpcConnection, RpcClientError> {
+        let deadline = Instant::now() + PROXY_CONNECT_RETRY_BUDGET;
+        loop {
+            // The reader sidecar fires `RpcInboundReady` at the proxy's
+            // own mailbox after every inbound frame so
+            // `on_inbound_ready` drains `conn.inbound` on the
+            // dispatcher thread. `RpcClient::connect` consumes the
+            // closure, so a retry needs a fresh one.
+            let wake_mailer = Arc::clone(mailer);
+            let on_frame = move || {
+                wake_mailer.push(Mail::new(self_mailbox, wake_kind, Vec::new(), 1));
+            };
+            match RpcClient::connect(
+                addr,
+                PeerKind::Client {
+                    client_name: "aether.engine.proxy".to_owned(),
+                    client_version: env!("CARGO_PKG_VERSION").to_owned(),
+                },
+                on_frame,
+            ) {
+                Ok(conn) => return Ok(conn),
+                Err(e) => {
+                    if retry && is_transient_connect_error(&e) && Instant::now() < deadline {
+                        std::thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// `true` for the connection-level errors a still-coming-up
+    /// substrate produces — worth retrying. Handshake / frame errors
+    /// mean the peer answered wrongly: terminal, never retried.
+    fn is_transient_connect_error(e: &RpcClientError) -> bool {
+        matches!(
+            e,
+            RpcClientError::Connect(io)
+                if matches!(io.kind(), ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset)
+        )
+    }
+
+    impl Drop for EngineProxy {
+        /// SIGKILL + reap the child substrate this proxy forked, so a
+        /// terminated proxy (or a chassis teardown) never orphans a
+        /// substrate process. A no-op for an adopted substrate
+        /// (`spawned` is `None`). Graceful SIGTERM is a follow-up;
+        /// v1 is forceful.
+        fn drop(&mut self) {
+            if let Some(mut child) = self.spawned.take() {
+                let _ = child.kill();
+                let _ = child.wait();
             }
         }
     }
@@ -365,6 +486,7 @@ mod tests {
                 EngineProxyConfig {
                     engine_id: EngineId(Uuid::from_u128(1)),
                     rpc_addr: format!("127.0.0.1:{port}"),
+                    spawned: None,
                 },
             )
             .finish()
@@ -435,6 +557,7 @@ mod tests {
                 EngineProxyConfig {
                     engine_id: EngineId(Uuid::from_u128(2)),
                     rpc_addr: format!("127.0.0.1:{port}"),
+                    spawned: None,
                 },
             )
             .finish();

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -1,0 +1,432 @@
+//! `aether.engine` — engines capability (issue 763 P4).
+//!
+//! A `#[bridge(singleton)]` [`NativeActor`] that supervises a fleet of
+//! [`EngineProxy`] actors — the engine-management surface of the
+//! forward-model architecture (issue 763). Three handlers:
+//!
+//! - **`on_spawn`** ([`SpawnEngine`]) picks a free localhost port,
+//!   fork+execs the substrate binary with `AETHER_RPC_PORT` injected,
+//!   then boots an `aether.engine.proxy:<id>` child actor that dials
+//!   it. The proxy owns the forked child from there — startup-dial
+//!   retry, kill-on-failed-boot, kill-on-drop. Reply:
+//!   [`SpawnEngineResult`].
+//! - **`on_list`** ([`ListEngines`]) reports every supervised engine.
+//! - **`on_terminate`** ([`TerminateEngine`]) forwards the kind to the
+//!   engine's proxy (which SIGKILLs its substrate and self-shuts-down)
+//!   and drops the table entry. Reply: [`TerminateEngineResult`].
+//!
+//! ## Scope (issue 763 P4 vs P5)
+//!
+//! P4 is the cap itself: spawn / list / terminate. The hub RPC
+//! server's `engine = Some(_)` routing — which drives `ForwardEnvelope`
+//! at a proxy on behalf of an external RPC client — and the
+//! `describe_kinds` / `describe_component` proxy handlers land in P5
+//! alongside the `aether-mcp` extraction; they only have meaning once
+//! an out-of-process RPC client drives the hub.
+//!
+//! Native-only: the cap fork+execs processes and threads the
+//! `std::process::Child` handle into the proxy. The `#[bridge]` macro
+//! emits the wasm-side marker stub so `aether-capabilities` still
+//! compiles for `wasm32`.
+
+// Handler-signature kinds must be importable at file root — the
+// `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
+// the mod.
+use aether_kinds::{ListEngines, SpawnEngine, TerminateEngine};
+
+#[aether_actor::bridge(singleton)]
+mod server_native {
+    use super::{ListEngines, SpawnEngine, TerminateEngine};
+    use crate::engine::proxy::{EngineProxy, EngineProxyConfig};
+    use aether_actor::{MailCtx, actor};
+    use aether_data::{EngineId, Kind, MailboxId, Uuid};
+    use aether_kinds::{
+        EngineDescriptor, ListEnginesResult, SpawnEngineResult, TerminateEngineResult,
+    };
+    use aether_substrate::Subname;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use std::collections::HashMap;
+    use std::net::TcpListener;
+    use std::process::{Command, Stdio};
+
+    /// One supervised engine in [`EngineServer`]'s table.
+    struct EngineEntry {
+        /// Mailbox of the `aether.engine.proxy:<id>` actor — the
+        /// forward target for [`TerminateEngine`].
+        proxy_mailbox: MailboxId,
+        /// The localhost RPC port the cap assigned this substrate.
+        rpc_port: u16,
+    }
+
+    /// Engines capability: supervises a fleet of [`EngineProxy`]
+    /// actors, one per spawned substrate. Singleton at `aether.engine`.
+    pub struct EngineServer {
+        engines: HashMap<EngineId, EngineEntry>,
+        /// Monotonic source of `EngineId`s. Engine ids only need to be
+        /// unique among the engines this cap currently supervises — a
+        /// process-local counter delivers that without a `uuid` rng
+        /// dependency. Starts at 1 (`Uuid::from_u128(0)` is the nil
+        /// uuid).
+        next_engine_seq: u128,
+    }
+
+    #[actor]
+    impl NativeActor for EngineServer {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.engine";
+
+        fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                engines: HashMap::new(),
+                next_engine_seq: 1,
+            })
+        }
+
+        /// Enumerate every engine the cap currently supervises.
+        ///
+        /// # Agent
+        /// Send `ListEngines` (fieldless). Reply: `ListEnginesResult
+        /// { engines: [{ engine_id, rpc_port }] }`.
+        #[handler]
+        fn on_list(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListEngines) {
+            let engines = self
+                .engines
+                .iter()
+                .map(|(id, entry)| EngineDescriptor {
+                    engine_id: id.0.to_string(),
+                    rpc_port: entry.rpc_port,
+                })
+                .collect();
+            ctx.reply(&ListEnginesResult { engines });
+        }
+
+        /// Fork+exec a substrate binary and connect a proxy to it.
+        ///
+        /// # Agent
+        /// Send `SpawnEngine { binary_path, args }`. The cap assigns a
+        /// free localhost port for the substrate's RPC server, injects
+        /// it as `AETHER_RPC_PORT`, forks the binary, then boots an
+        /// `aether.engine.proxy:<id>` actor that dials it. Reply:
+        /// `SpawnEngineResult::Ok { engine_id, rpc_port }` on success,
+        /// or `Err { error }` if the fork fails or the substrate never
+        /// comes up.
+        #[handler]
+        fn on_spawn(&mut self, ctx: &mut NativeCtx<'_>, mail: SpawnEngine) {
+            let rpc_port = match free_local_port() {
+                Ok(port) => port,
+                Err(e) => {
+                    ctx.reply(&SpawnEngineResult::Err {
+                        error: format!("could not allocate an RPC port: {e}"),
+                    });
+                    return;
+                }
+            };
+
+            let child = match Command::new(&mail.binary_path)
+                .args(&mail.args)
+                .env("AETHER_RPC_PORT", rpc_port.to_string())
+                .stdin(Stdio::null())
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(e) => {
+                    ctx.reply(&SpawnEngineResult::Err {
+                        error: format!("failed to spawn {}: {e}", mail.binary_path),
+                    });
+                    return;
+                }
+            };
+
+            let engine_id = EngineId(Uuid::from_u128(self.next_engine_seq));
+            self.next_engine_seq += 1;
+            let subname = engine_id.0.simple().to_string();
+            let rpc_addr = format!("127.0.0.1:{rpc_port}");
+
+            // `finish()` runs `EngineProxy::init` on this thread: it
+            // dials the substrate (retrying while it comes up) and, on
+            // failure, kills the child it was handed — so a failed
+            // spawn never leaves an orphan for the cap to clean up.
+            let result = ctx
+                .spawn_child::<EngineProxy>(
+                    Subname::Named(&subname),
+                    EngineProxyConfig {
+                        engine_id,
+                        rpc_addr,
+                        spawned: Some(child),
+                    },
+                )
+                .finish();
+
+            match result {
+                Ok(proxy_mailbox) => {
+                    self.engines.insert(
+                        engine_id,
+                        EngineEntry {
+                            proxy_mailbox,
+                            rpc_port,
+                        },
+                    );
+                    ctx.reply(&SpawnEngineResult::Ok {
+                        engine_id: engine_id.0.to_string(),
+                        rpc_port,
+                    });
+                }
+                Err(e) => {
+                    ctx.reply(&SpawnEngineResult::Err {
+                        error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
+                    });
+                }
+            }
+        }
+
+        /// Terminate a supervised engine.
+        ///
+        /// # Agent
+        /// Send `TerminateEngine { engine_id }` (the string from a
+        /// prior `SpawnEngineResult` / `ListEnginesResult`). The cap
+        /// forwards the kind to the engine's proxy — which SIGKILLs
+        /// its substrate and self-shuts-down — and drops its table
+        /// entry. Reply: `TerminateEngineResult::Ok`, or `Err { error }`
+        /// for an `engine_id` that doesn't parse or names no
+        /// supervised engine.
+        #[handler]
+        fn on_terminate(&mut self, ctx: &mut NativeCtx<'_>, mail: TerminateEngine) {
+            let engine_id = match Uuid::parse_str(&mail.engine_id) {
+                Ok(uuid) => EngineId(uuid),
+                Err(e) => {
+                    ctx.reply(&TerminateEngineResult::Err {
+                        error: format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
+                    });
+                    return;
+                }
+            };
+
+            let Some(entry) = self.engines.remove(&engine_id) else {
+                ctx.reply(&TerminateEngineResult::Err {
+                    error: format!("no supervised engine {}", mail.engine_id),
+                });
+                return;
+            };
+
+            // Forward to the proxy: it SIGKILLs its substrate and
+            // self-shuts-down. Fire-and-forget — the proxy doesn't
+            // reply, and the table entry is already gone.
+            let payload = mail.encode_into_bytes();
+            ctx.send_envelope_traced(entry.proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
+            ctx.reply(&TerminateEngineResult::Ok);
+        }
+    }
+
+    /// Bind `127.0.0.1:0`, read the OS-assigned port, drop the
+    /// listener. A tiny TOCTOU window exists before the substrate
+    /// rebinds the port, but on localhost it's negligible — and this
+    /// sidesteps both a wire change to report an ephemeral port back
+    /// from the substrate and an un-recycled incrementing port pool.
+    fn free_local_port() -> std::io::Result<u16> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        Ok(port)
+    }
+}
+
+// The sink's handler-signature kinds must be importable at file root
+// — the `#[bridge]` macro emits `impl HandlesKind<K>` markers as
+// siblings of the `sink` mod.
+#[cfg(test)]
+use aether_kinds::{ListEnginesResult, SpawnEngineResult, TerminateEngineResult};
+
+/// Reply sink: records the latest reply of each engines-cap reply
+/// kind into shared cells so a unit test can drive a handler via
+/// `mailer.push` and observe what it replied. Lives at file root (not
+/// nested in `mod tests`) so the `#[bridge]` macro's marker emission
+/// stays addressable.
+// `pub` (not `pub(crate)`) because it's the `NativeActor::Config` of
+// the test `ReplySink` below, and the `#[actor]` macro's trait impl is
+// fully public — `#[cfg(test)]` keeps it out of the real public API.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub struct ReplyCells {
+    pub list: std::sync::Arc<std::sync::Mutex<Option<ListEnginesResult>>>,
+    pub spawn: std::sync::Arc<std::sync::Mutex<Option<SpawnEngineResult>>>,
+    pub terminate: std::sync::Arc<std::sync::Mutex<Option<TerminateEngineResult>>>,
+}
+
+#[cfg(test)]
+#[aether_actor::bridge(singleton)]
+mod sink {
+    use super::{ListEnginesResult, ReplyCells, SpawnEngineResult, TerminateEngineResult};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct ReplySink {
+        cells: ReplyCells,
+    }
+
+    #[actor]
+    impl NativeActor for ReplySink {
+        type Config = ReplyCells;
+        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+        fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self { cells })
+        }
+
+        #[handler]
+        fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
+            *self.cells.list.lock().unwrap() = Some(reply);
+        }
+
+        #[handler]
+        fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
+            *self.cells.spawn.lock().unwrap() = Some(reply);
+        }
+
+        #[handler]
+        fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
+            *self.cells.terminate.lock().unwrap() = Some(reply);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EngineServer, ReplyCells, ReplySink};
+    use aether_actor::Actor;
+    use aether_data::{Kind, mailbox_id_from_name};
+    use aether_kinds::{
+        ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine, TerminateEngineResult,
+    };
+    use aether_substrate::chassis::Chassis;
+    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::handle_store::HandleStore;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
+    use aether_substrate::mail::registry::Registry;
+    use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    struct TestChassis;
+    impl Chassis for TestChassis {
+        const PROFILE: &'static str = "test";
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        }
+    }
+
+    /// Boot a passive chassis hosting `EngineServer` + the reply sink.
+    /// Returns the chassis (kept alive for its dispatcher threads), the
+    /// mailer to push requests through, and the sink's cells.
+    fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+        let cells = ReplyCells::default();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<EngineServer>(())
+            .with_actor::<ReplySink>(cells.clone())
+            .build_passive()
+            .expect("caps boot");
+        (chassis, mailer, cells)
+    }
+
+    /// Drive one request kind at `aether.engine`, reply-to the sink,
+    /// and block until `probe` sees a recorded reply (or the deadline
+    /// passes).
+    fn drive<K: Kind + serde::Serialize, T>(
+        mailer: &Arc<Mailer>,
+        request: &K,
+        probe: impl Fn() -> Option<T>,
+    ) -> T {
+        let server = mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE);
+        let sink = mailbox_id_from_name(<ReplySink as Actor>::NAMESPACE);
+        mailer.push(
+            Mail::new(server, K::ID, request.encode_into_bytes(), 1)
+                .with_reply_to(ReplyTo::with_correlation(ReplyTarget::Component(sink), 1)),
+        );
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(Instant::now() < deadline, "no reply within deadline");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// `on_list` on a fresh cap replies with an empty engine list.
+    #[test]
+    fn list_on_empty_cap_is_empty() {
+        let (_chassis, mailer, cells) = boot();
+        let result = drive(&mailer, &ListEngines {}, || {
+            cells.list.lock().unwrap().take()
+        });
+        assert!(result.engines.is_empty(), "fresh cap supervises no engines");
+    }
+
+    /// `on_spawn` with a binary path that doesn't exist fails fast at
+    /// the fork — no proxy is spawned, no retry window is entered.
+    #[test]
+    fn spawn_with_missing_binary_replies_err() {
+        let (_chassis, mailer, cells) = boot();
+        let result = drive(
+            &mailer,
+            &SpawnEngine {
+                binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
+                args: vec![],
+            },
+            || cells.spawn.lock().unwrap().take(),
+        );
+        match result {
+            SpawnEngineResult::Err { error } => {
+                assert!(
+                    error.contains("failed to spawn"),
+                    "unexpected error: {error}"
+                );
+            }
+            SpawnEngineResult::Ok { .. } => panic!("a missing binary must not spawn"),
+        }
+    }
+
+    /// `on_terminate` with an `engine_id` that isn't a UUID, and one
+    /// that is well-formed but names no supervised engine, both reply
+    /// `Err` rather than panicking.
+    #[test]
+    fn terminate_unknown_engine_replies_err() {
+        let (_chassis, mailer, cells) = boot();
+
+        let malformed = drive(
+            &mailer,
+            &TerminateEngine {
+                engine_id: "not-a-uuid".to_owned(),
+            },
+            || cells.terminate.lock().unwrap().take(),
+        );
+        assert!(
+            matches!(malformed, TerminateEngineResult::Err { .. }),
+            "a malformed engine_id should be rejected",
+        );
+
+        let unknown = drive(
+            &mailer,
+            &TerminateEngine {
+                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+            },
+            || cells.terminate.lock().unwrap().take(),
+        );
+        assert!(
+            matches!(unknown, TerminateEngineResult::Err { .. }),
+            "a well-formed but unknown engine_id should be rejected",
+        );
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -59,6 +59,7 @@ pub use component::ComponentHostConfig;
 pub use engine::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use engine::EngineProxyConfig;
+pub use engine::EngineServer;
 pub use handle::HandleCapability;
 pub use http::{HttpCapability, HttpConfig};
 pub use input::InputCapability;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -699,6 +699,7 @@ mod rpc {
 }
 
 mod engine {
+    use alloc::string::String;
     use alloc::vec::Vec;
 
     use serde::{Deserialize, Serialize};
@@ -722,6 +723,88 @@ mod engine {
         pub mailbox: aether_data::MailboxId,
         pub kind: aether_data::KindId,
         pub payload: Vec<u8>,
+    }
+
+    /// `aether.engine.list` — ask the engines cap (`aether.engine`) to
+    /// enumerate every engine it currently supervises. Fieldless
+    /// request; the reply is an [`EngineList`]. Issue 763 P4.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.engine.list")]
+    pub struct ListEngines {}
+
+    /// One supervised engine, as reported in an [`EngineList`].
+    ///
+    /// `engine_id` is the plain UUID string the engines cap minted at
+    /// spawn time — `EngineId` itself doesn't implement `Schema`, so
+    /// the wire carries the string form (the same convention the
+    /// `aether.process.*` kinds use). `rpc_port` is the localhost port
+    /// the cap assigned the substrate's `RpcServerCapability`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct EngineDescriptor {
+        pub engine_id: String,
+        pub rpc_port: u16,
+    }
+
+    /// `aether.engine.list_result` — reply to [`ListEngines`]: every
+    /// engine the cap supervises right now. Issue 763 P4.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.list_result")]
+    pub struct ListEnginesResult {
+        pub engines: Vec<EngineDescriptor>,
+    }
+
+    /// `aether.engine.spawn` — ask the engines cap to fork+exec a
+    /// substrate binary and connect a per-engine proxy to it. Issue
+    /// 763 P4.
+    ///
+    /// The cap picks a free localhost port for the substrate's
+    /// `RpcServerCapability`, injects it as `AETHER_RPC_PORT`, forks
+    /// `binary_path` with `args` forwarded verbatim, then boots an
+    /// `aether.engine.proxy:<id>` actor that dials it. Reply:
+    /// [`SpawnResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.spawn")]
+    pub struct SpawnEngine {
+        pub binary_path: String,
+        pub args: Vec<String>,
+    }
+
+    /// Reply to [`SpawnEngine`]. Issue 763 P4.
+    ///
+    /// `Ok` carries the freshly minted `engine_id` (plain UUID string —
+    /// pass it back to [`TerminateEngine`]) and the `rpc_port` the cap
+    /// assigned. `Err` carries a free-form reason — fork failure, or
+    /// the proxy failing to connect within the substrate's startup
+    /// window. On `Err` no child process is left running.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.spawn_result")]
+    pub enum SpawnEngineResult {
+        Ok { engine_id: String, rpc_port: u16 },
+        Err { error: String },
+    }
+
+    /// `aether.engine.terminate` — ask the engines cap to shut down a
+    /// supervised engine. Issue 763 P4.
+    ///
+    /// The cap forwards this kind to the engine's
+    /// `aether.engine.proxy:<id>` actor, which SIGKILLs the child
+    /// substrate it forked and self-shuts-down. `engine_id` is the
+    /// plain UUID string from [`SpawnResult`] / [`EngineList`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.terminate")]
+    pub struct TerminateEngine {
+        pub engine_id: String,
+    }
+
+    /// Reply to [`TerminateEngine`]. Issue 763 P4. `Err` is for an
+    /// `engine_id` that doesn't parse or names no supervised engine.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.terminate_result")]
+    pub enum TerminateEngineResult {
+        Ok,
+        Err { error: String },
     }
 }
 

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
-use aether_capabilities::{BroadcastCapability, trace::TraceObserverCapability};
+use aether_capabilities::{BroadcastCapability, EngineServer, trace::TraceObserverCapability};
 use aether_substrate::Chassis;
 use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
@@ -168,7 +168,13 @@ impl HubChassis {
                 pending,
                 hub_engine_addr: engine_addr,
                 runtime: rt_handle,
-            });
+            })
+            // Issue 763 P4: the forward-model engines cap. Forks
+            // substrates and connects out to them as an RPC client —
+            // independent of the hub's own inbound RPC server, so it
+            // boots unconditionally. Coexists with the legacy
+            // `ProcessCapability` spawn path until P5 collapses the hub.
+            .with_actor::<EngineServer>(());
         if let Some(rpc_addr) = rpc_addr {
             builder = builder.with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: rpc_addr.to_string(),

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -1,0 +1,191 @@
+// End-to-end test for the engines cap (issue 763 P4).
+//
+// Boots a passive chassis hosting `EngineServer`, mails it a
+// `SpawnEngine` pointed at the real `aether-substrate-headless`
+// binary, and asserts the full lifecycle: the substrate forks and
+// binds its RPC port, the per-engine proxy bridges the startup gap
+// and connects, `ListEngines` reflects the live engine, and
+// `TerminateEngine` shuts it down. This is the only test exercising
+// the fork+exec + startup-race-retry + real-process path — the
+// `EngineServer` unit tests cover the error arms in-process.
+
+use aether_actor::Actor;
+use aether_capabilities::EngineServer;
+use aether_data::{Kind, mailbox_id_from_name};
+use aether_kinds::{
+    ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
+    TerminateEngineResult,
+};
+use aether_substrate::chassis::Chassis;
+use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
+use aether_substrate::chassis::error::BootError;
+use aether_substrate::handle_store::HandleStore;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::registry::Registry;
+use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+struct TestChassis;
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("TestChassis is driven by Builder::new directly in this test")
+    }
+}
+
+// Reply sink: records the latest reply of each engines-cap reply kind
+// into shared cells. Lives at module root so the `#[bridge]` macro's
+// marker emission stays addressable.
+#[derive(Clone, Default)]
+pub struct ReplyCells {
+    pub list: Arc<Mutex<Option<ListEnginesResult>>>,
+    pub spawn: Arc<Mutex<Option<SpawnEngineResult>>>,
+    pub terminate: Arc<Mutex<Option<TerminateEngineResult>>>,
+}
+
+#[aether_actor::bridge(singleton)]
+mod sink {
+    use super::{ListEnginesResult, ReplyCells, SpawnEngineResult, TerminateEngineResult};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct ReplySink {
+        cells: ReplyCells,
+    }
+
+    #[actor]
+    impl NativeActor for ReplySink {
+        type Config = ReplyCells;
+        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+        fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self { cells })
+        }
+
+        #[handler]
+        fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
+            *self.cells.list.lock().unwrap() = Some(reply);
+        }
+
+        #[handler]
+        fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
+            *self.cells.spawn.lock().unwrap() = Some(reply);
+        }
+
+        #[handler]
+        fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
+            *self.cells.terminate.lock().unwrap() = Some(reply);
+        }
+    }
+}
+
+// `ReplySink` is re-exported to this module root by the `#[bridge]`
+// macro — no explicit `use sink::ReplySink` needed.
+
+fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
+    let registry = Arc::new(Registry::new());
+    for d in aether_kinds::descriptors::all() {
+        let _ = registry.register_kind_with_descriptor(d);
+    }
+    let (outbound, _rx) = HubOutbound::attached_loopback();
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+    let cells = ReplyCells::default();
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<EngineServer>(())
+        .with_actor::<ReplySink>(cells.clone())
+        .build_passive()
+        .expect("caps boot");
+    (chassis, mailer, cells)
+}
+
+/// Drive one request kind at `aether.engine`, reply-to the sink, and
+/// block until `probe` returns a recorded reply (or `deadline` passes).
+fn drive<K: Kind + serde::Serialize, T>(
+    mailer: &Arc<Mailer>,
+    request: &K,
+    deadline: Duration,
+    probe: impl Fn() -> Option<T>,
+) -> T {
+    let server = mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE);
+    let sink = mailbox_id_from_name(<ReplySink as Actor>::NAMESPACE);
+    mailer.push(
+        Mail::new(server, K::ID, request.encode_into_bytes(), 1)
+            .with_reply_to(ReplyTo::with_correlation(ReplyTarget::Component(sink), 1)),
+    );
+    let until = Instant::now() + deadline;
+    loop {
+        if let Some(value) = probe() {
+            return value;
+        }
+        assert!(Instant::now() < until, "no reply within {deadline:?}");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
+    let (_chassis, mailer, cells) = boot();
+    let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+
+    // Spawn: the cap assigns a port, forks the substrate, and the
+    // proxy retries the dial until the fresh process binds. Generous
+    // deadline — this covers a debug-build chassis cold start.
+    let spawn = drive(
+        &mailer,
+        &SpawnEngine {
+            binary_path: headless.to_owned(),
+            args: vec![],
+        },
+        Duration::from_secs(30),
+        || cells.spawn.lock().unwrap().take(),
+    );
+    let engine_id = match spawn {
+        SpawnEngineResult::Ok {
+            engine_id,
+            rpc_port,
+        } => {
+            assert!(rpc_port != 0, "cap should report the assigned RPC port");
+            engine_id
+        }
+        SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
+    };
+
+    // List: the freshly-spawned engine shows up in the cap's table.
+    let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+        cells.list.lock().unwrap().take()
+    });
+    assert!(
+        list.engines.iter().any(|e| e.engine_id == engine_id),
+        "spawned engine {engine_id} should appear in ListEngines: {list:?}",
+    );
+
+    // Terminate: the cap forwards to the proxy, which SIGKILLs the
+    // substrate and self-shuts-down; the table entry is dropped.
+    let terminate = drive(
+        &mailer,
+        &TerminateEngine {
+            engine_id: engine_id.clone(),
+        },
+        Duration::from_secs(5),
+        || cells.terminate.lock().unwrap().take(),
+    );
+    assert!(
+        matches!(terminate, TerminateEngineResult::Ok),
+        "terminate of a live engine should succeed: {terminate:?}",
+    );
+
+    // After terminate, the engine is gone from the table.
+    let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+        cells.list.lock().unwrap().take()
+    });
+    assert!(
+        !list_after.engines.iter().any(|e| e.engine_id == engine_id),
+        "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
+    );
+}


### PR DESCRIPTION
## Summary

P4 of issue 763's forward-model RPC architecture: **`EngineServer`**, the `aether.engine` singleton that supervises a fleet of per-engine proxies — the engine-management surface of the new model.

- **`aether.engine.*` wire vocab** in `aether-kinds`: `ListEngines` / `SpawnEngine` / `TerminateEngine` and their result kinds. `engine_id` rides as a plain-UUID string (`EngineId` doesn't implement `Schema` — same convention the `aether.process.*` kinds use).
- **`EngineServer`** (`engine/server.rs`): `on_spawn` binds a free localhost port (bind-`:0`-and-drop — no wire change, no un-recycled pool), fork+execs the substrate with `AETHER_RPC_PORT` injected, and spawns an `aether.engine.proxy:<id>` child that dials it; `on_list` reports the table; `on_terminate` forwards to the proxy and drops the entry.
- **`EngineProxy`** gains a `spawned: Option<Child>` it fully owns: `init` retries the startup dial while a freshly-forked substrate is still binding its port (single-shot for adopted substrates), kills the child on a failed boot, and SIGKILLs + reaps it on `Drop`. `on_terminate` self-shuts-down.
- **Hub chassis** wires `EngineServer` in, coexisting with the legacy `ProcessCapability` spawn path until P5.

The startup race (the cap forks a substrate, then the proxy dials it before it has bound its port) is handled by the proxy's bounded retry — gated on `spawned.is_some()` so the adopt path stays single-shot.

Deferred to P5 (they only have meaning once an out-of-process RPC client drives the hub): the hub RPC server's `engine=Some` routing and the `describe_kinds` / `describe_component` proxy handlers.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run --workspace` — 1123 passed
- [x] `cargo check -p aether-capabilities --target wasm32-unknown-unknown` — builds (the `#[bridge]` macro elides the native cap on wasm)
- [x] New integration test `tests/engines_cap.rs` forks the real `aether-substrate-headless` binary through the cap and exercises spawn -> list -> terminate end-to-end
- [x] `EngineServer` unit tests cover the error arms (missing binary, malformed / unknown `engine_id`)

Part of iamacoffeepot/aether#763 (P4) — does not close the umbrella; P5 (`aether-mcp` extraction + hub collapse) does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)