### PR TITLE
feat(capabilities/rpc): route engine-addressed Calls through to substrates

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -49,10 +49,12 @@ pub use proxy_native::EngineProxyConfig;
 mod proxy_native {
     use super::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
     use crate::rpc::{
-        MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, WireFrame,
+        MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, RpcError,
+        WireFrame,
     };
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, KindId};
+    use aether_kinds::CallSettled;
     use aether_substrate::Mail;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -206,9 +208,7 @@ mod proxy_native {
             while let Ok(frame) = self.conn.inbound.try_recv() {
                 match frame {
                     WireFrame::ReplyEvent { cid, envelope } => self.route_reply(cid, envelope),
-                    WireFrame::ReplyEnd { cid, .. } => {
-                        self.in_flight.remove(&cid);
-                    }
+                    WireFrame::ReplyEnd { cid, result } => self.route_settled(cid, result),
                     WireFrame::Bye { reason } => {
                         tracing::info!(
                             target: "aether_substrate::engine_proxy",
@@ -352,6 +352,47 @@ mod proxy_native {
                 Mail::new(target, envelope.kind, envelope.payload, 1).with_reply_to(
                     ReplyTo::with_correlation(ReplyTarget::None, reply_to.correlation_id),
                 ),
+            );
+        }
+
+        /// Lift the substrate's terminal `ReplyEnd` for `cid` into a
+        /// [`CallSettled`] mail back to whoever opened the call, then
+        /// clear the in-flight entry. Mirrors [`Self::route_reply`]'s
+        /// correlation handling — a forwarded call has no local chain
+        /// to settle, so this explicit terminal signal is how the
+        /// originating `RpcServerCapability` learns to close its wire
+        /// call. The wire `RpcError` is rendered to a string; the
+        /// `aether-kinds` layer can't carry the structured variant.
+        fn route_settled(&mut self, cid: u64, result: Result<(), RpcError>) {
+            let Some(reply_to) = self.in_flight.remove(&cid) else {
+                tracing::debug!(
+                    target: "aether_substrate::engine_proxy",
+                    engine_id = ?self.engine_id,
+                    cid,
+                    "engine proxy: ReplyEnd with no matching in-flight forward; dropping",
+                );
+                return;
+            };
+            let ReplyTarget::Component(target) = reply_to.target else {
+                return;
+            };
+            let settled = match result {
+                Ok(()) => CallSettled::Ok,
+                Err(e) => CallSettled::Err {
+                    error: format!("{e:?}"),
+                },
+            };
+            self.mailer.push(
+                Mail::new(
+                    target,
+                    <CallSettled as Kind>::ID,
+                    settled.encode_into_bytes(),
+                    1,
+                )
+                .with_reply_to(ReplyTo::with_correlation(
+                    ReplyTarget::None,
+                    reply_to.correlation_id,
+                )),
             );
         }
     }

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -32,23 +32,28 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
-use aether_kinds::{ListEngines, SpawnEngine, TerminateEngine};
+use aether_kinds::{ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine};
 
 #[aether_actor::bridge(singleton)]
 mod server_native {
-    use super::{ListEngines, SpawnEngine, TerminateEngine};
+    use super::{ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine};
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig};
     use aether_actor::{MailCtx, actor};
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
-        EngineDescriptor, ListEnginesResult, SpawnEngineResult, TerminateEngineResult,
+        CallSettled, EngineDescriptor, ForwardEnvelope, ListEnginesResult, SpawnEngineResult,
+        TerminateEngineResult,
     };
+    use aether_substrate::Mail;
     use aether_substrate::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::{ReplyTarget, ReplyTo};
     use std::collections::HashMap;
     use std::net::TcpListener;
     use std::process::{Command, Stdio};
+    use std::sync::Arc;
 
     /// One supervised engine in [`EngineServer`]'s table.
     struct EngineEntry {
@@ -69,6 +74,11 @@ mod server_native {
         /// dependency. Starts at 1 (`Uuid::from_u128(0)` is the nil
         /// uuid).
         next_engine_seq: u128,
+        /// Cached so `on_route` can push a `ForwardEnvelope` at a proxy
+        /// while *propagating the inbound reply-to* — `NativeCtx`'s
+        /// sends stamp the cap as sender, but a routed call's reply
+        /// must reach the originating `RpcServerCapability`, not here.
+        mailer: Arc<Mailer>,
     }
 
     #[actor]
@@ -76,10 +86,11 @@ mod server_native {
         type Config = ();
         const NAMESPACE: &'static str = "aether.engine";
 
-        fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             Ok(Self {
                 engines: HashMap::new(),
                 next_engine_seq: 1,
+                mailer: ctx.mailer(),
             })
         }
 
@@ -216,6 +227,94 @@ mod server_native {
             ctx.send_envelope_traced(entry.proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
             ctx.reply(&TerminateEngineResult::Ok);
         }
+
+        /// Relay one mail to a specific engine's substrate.
+        ///
+        /// # Agent
+        /// Not a user-facing tool — the hub's `RpcServerCapability`
+        /// sends this when an RPC client addresses a `Call` at
+        /// `engine = Some(_)`. The cap looks the engine up in its
+        /// table and re-emits a `ForwardEnvelope` at the matching
+        /// `aether.engine.proxy:<id>`, propagating the inbound
+        /// reply-to verbatim so the substrate's reply (and the proxy's
+        /// terminal `CallSettled`) stream straight back to that
+        /// `RpcServerCapability`. An unknown / unparseable `engine_id`
+        /// is answered with `CallSettled::Err` so the originating wire
+        /// call closes instead of hanging.
+        #[handler]
+        fn on_route(&mut self, ctx: &mut NativeCtx<'_>, mail: RouteEnvelope) {
+            let reply_to = ctx.reply_target();
+            let ReplyTarget::Component(reply_target) = reply_to.target else {
+                // A routed call always carries a Component reply-to
+                // (the originating RpcServerCapability). Without one
+                // there's nowhere to stream the reply or the
+                // CallSettled — drop rather than guess.
+                tracing::warn!(
+                    target: "aether_substrate::engine_server",
+                    engine_id = %mail.engine_id,
+                    "engine route: no Component reply-to; dropping",
+                );
+                return;
+            };
+            let correlation = reply_to.correlation_id;
+
+            let engine_id = match Uuid::parse_str(&mail.engine_id) {
+                Ok(uuid) => EngineId(uuid),
+                Err(e) => {
+                    settle_err(
+                        &self.mailer,
+                        reply_target,
+                        correlation,
+                        format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
+                    );
+                    return;
+                }
+            };
+            let Some(entry) = self.engines.get(&engine_id) else {
+                settle_err(
+                    &self.mailer,
+                    reply_target,
+                    correlation,
+                    format!("no supervised engine {}", mail.engine_id),
+                );
+                return;
+            };
+
+            // Re-emit as a ForwardEnvelope at the proxy, carrying the
+            // inbound reply-to verbatim so the substrate's reply — and
+            // the proxy's CallSettled — route straight back to the
+            // originating RpcServerCapability.
+            let forward = ForwardEnvelope {
+                mailbox: mail.mailbox,
+                kind: mail.kind,
+                payload: mail.payload,
+            };
+            self.mailer.push(
+                Mail::new(
+                    entry.proxy_mailbox,
+                    <ForwardEnvelope as Kind>::ID,
+                    forward.encode_into_bytes(),
+                    1,
+                )
+                .with_reply_to(reply_to),
+            );
+        }
+    }
+
+    /// Push a `CallSettled::Err` back to `target` (correlation
+    /// preserved) so a routed call that the cap can't satisfy — bad
+    /// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
+    /// instead of leaving the RPC client hanging.
+    fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
+        mailer.push(
+            Mail::new(
+                target,
+                <CallSettled as Kind>::ID,
+                CallSettled::Err { error }.encode_into_bytes(),
+                1,
+            )
+            .with_reply_to(ReplyTo::with_correlation(ReplyTarget::None, correlation)),
+        );
     }
 
     /// Bind `127.0.0.1:0`, read the OS-assigned port, drop the

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -36,7 +36,8 @@ mod server_native {
     };
     use aether_actor::actor;
     use aether_codec::frame::{read_frame, write_frame};
-    use aether_data::{Kind, KindId, MailId, MailboxId};
+    use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+    use aether_kinds::{CallSettled, RouteEnvelope};
     use aether_substrate::Mail;
     use aether_substrate::actor::native::envelope::Envelope;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
@@ -322,6 +323,31 @@ mod server_native {
                 );
                 return;
             };
+
+            // A forwarded engine call (issue 763 P5a) closes when its
+            // proxy lifts the substrate's terminal `ReplyEnd` into a
+            // `CallSettled` — there's no local chain for `on_settled`
+            // to catch. Recognize it here, write the wire `ReplyEnd`,
+            // and clear the in-flight entry.
+            if env.kind == <CallSettled as Kind>::ID {
+                let result = match CallSettled::decode_from_bytes(&env.payload) {
+                    Some(CallSettled::Ok) => Ok(()),
+                    Some(CallSettled::Err { error }) => Err(RpcError::Other { reason: error }),
+                    None => Err(RpcError::Other {
+                        reason: "malformed CallSettled payload".into(),
+                    }),
+                };
+                self.write_frame_to(
+                    entry.conn_id,
+                    &WireFrame::ReplyEnd {
+                        cid: entry.wire_cid,
+                        result,
+                    },
+                );
+                self.in_flight.remove(&correlation);
+                return;
+            }
+
             let envelope = MailEnvelope {
                 to: MailboxAddress::local(self.self_mailbox),
                 from: match env.sender.target {
@@ -512,19 +538,41 @@ mod server_native {
             cid: Option<u64>,
             envelope: MailEnvelope,
         ) {
-            // Cross-engine routing isn't in v1. Anything addressed at
-            // a non-local engine surfaces as a ReplyEnd::Err.
-            if envelope.to.engine.is_some() {
+            // Engine-addressed Calls (issue 763 P5a): relay to the
+            // engines cap (`aether.engine`), which owns the
+            // `EngineId -> proxy` table and re-emits a `ForwardEnvelope`
+            // at the right proxy. The substrate's reply streams back
+            // here as a normal reply mail (handled by `on_any` as a
+            // `ReplyEvent`); its terminal `ReplyEnd` arrives — via the
+            // proxy — as a `CallSettled` (also handled by `on_any`).
+            //
+            // Crucially this path does NOT subscribe to settlement: the
+            // local `RouteEnvelope` chain settles almost immediately,
+            // long before the remote substrate replies, so settlement
+            // would close the wire call prematurely. The terminal close
+            // comes from `CallSettled` instead.
+            //
+            // On a chassis with no engines cap the `RouteEnvelope`
+            // warn-drops and the call never closes — only the hub
+            // chassis wires `aether.engine`, and only the hub fields
+            // engine-addressed Calls.
+            if let Some(engine_id) = envelope.to.engine {
+                let route = RouteEnvelope {
+                    engine_id: engine_id.0.to_string(),
+                    mailbox: envelope.to.mailbox,
+                    kind: envelope.kind,
+                    payload: envelope.payload,
+                };
+                // `mailbox_id_from_name` of `EngineServer::NAMESPACE`.
+                let engine_cap = mailbox_id_from_name("aether.engine");
+                let mail_id = ctx.send_envelope_as_root(
+                    engine_cap,
+                    <RouteEnvelope as Kind>::ID,
+                    &route.encode_into_bytes(),
+                );
                 if let Some(wire_cid) = cid {
-                    self.write_frame_to(
-                        conn_id,
-                        &WireFrame::ReplyEnd {
-                            cid: wire_cid,
-                            result: Err(RpcError::UnsupportedTarget {
-                                reason: "cross-engine routing not in v1".into(),
-                            }),
-                        },
-                    );
+                    self.in_flight
+                        .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
                 }
                 return;
             }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -806,6 +806,49 @@ mod engine {
         Ok,
         Err { error: String },
     }
+
+    /// `aether.engine.route` — ask the engines cap (`aether.engine`) to
+    /// relay one mail to a *specific* engine's substrate. Issue 763 P5a.
+    ///
+    /// The engine-addressed sibling of [`ForwardEnvelope`]: where
+    /// `ForwardEnvelope` already names a proxy and only needs the
+    /// substrate-local `mailbox` + `kind` + `payload`, `RouteEnvelope`
+    /// also carries the `engine_id`, because the sender (the hub's
+    /// `RpcServerCapability`, relaying an `engine = Some(_)` wire
+    /// `Call`) doesn't know which proxy hosts that engine. The engines
+    /// cap looks the engine up in its table and re-emits a
+    /// `ForwardEnvelope` at the right `aether.engine.proxy:<id>`,
+    /// propagating the original reply-to so the substrate's reply
+    /// streams back to the originating `RpcServerCapability`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.route")]
+    pub struct RouteEnvelope {
+        pub engine_id: String,
+        pub mailbox: aether_data::MailboxId,
+        pub kind: aether_data::KindId,
+        pub payload: Vec<u8>,
+    }
+
+    /// `aether.engine.call_settled` — a per-engine proxy's signal that
+    /// a forwarded RPC call has run to completion. Issue 763 P5a.
+    ///
+    /// When the proxy relays a [`ForwardEnvelope`] as an RPC `Call`,
+    /// the substrate eventually answers with a wire `ReplyEnd`. The
+    /// proxy lifts that terminal frame into this kind and pushes it
+    /// back to whoever opened the call (correlation preserved) — the
+    /// hub's `RpcServerCapability` matches it to the in-flight wire
+    /// call and writes its own `ReplyEnd` to the RPC client. (Local,
+    /// non-forwarded calls close on chassis settlement instead; a
+    /// forwarded call has no local chain to settle, so it needs this
+    /// explicit terminal signal.) `Err` carries the wire `RpcError`
+    /// rendered as a string — the structured variant doesn't survive
+    /// the `aether-kinds` layer, which can't depend on the RPC crate.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.call_settled")]
+    pub enum CallSettled {
+        Ok,
+        Err { error: String },
+    }
 }
 
 mod control_plane {

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -1,0 +1,215 @@
+// End-to-end test for the hub's `engine = Some(_)` RPC routing
+// (issue 763 P5a).
+//
+// Boots a "hub" chassis (forwarding `RpcServerCapability` + the
+// `aether.engine` engines cap), connects a raw RPC client to it, and
+// drives the whole forward model through that one socket — exactly
+// the shape the out-of-process `aether-mcp` binary will take in P5d:
+//
+//   1. An `engine = None` Call spawns a real `aether-substrate-headless`
+//      via the engines cap and yields its `engine_id`.
+//   2. An `engine = Some(engine_id)` Call is *routed* — hub RpcServer
+//      -> `aether.engine` -> proxy -> (RPC) -> substrate -> back — and
+//      the substrate's reply streams home as `ReplyEvent` + `ReplyEnd`.
+//   3. An `engine = None` `TerminateEngine` Call cleans the engine up.
+//
+// Step 2 is the P5a proof: before this phase, `engine = Some` Calls
+// were rejected with `RpcError::UnsupportedTarget`.
+
+use aether_capabilities::EngineServer;
+use aether_capabilities::rpc::{
+    Hello, HelloAck, MailEnvelope, MailboxAddress, PeerKind, RpcServerCapability, RpcServerConfig,
+    WIRE_VERSION, WireFrame,
+};
+use aether_capabilities::trace::TraceObserverCapability;
+use aether_codec::frame::{read_frame, write_frame};
+use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
+use aether_kinds::{List, ListResult, SpawnEngine, SpawnEngineResult, TerminateEngine};
+use aether_substrate::chassis::Chassis;
+use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
+use aether_substrate::chassis::error::BootError;
+use aether_substrate::handle_store::HandleStore;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::registry::Registry;
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::time::Duration;
+
+struct TestChassis;
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("TestChassis is driven by Builder::new directly in this test")
+    }
+}
+
+/// Boot a hub-shaped passive chassis: a forwarding `RpcServerCapability`
+/// (engine-addressed Calls route through `aether.engine`), the engines
+/// cap, and `TraceObserverCapability` so the RpcServer's local Calls
+/// (`spawn`, `terminate`) settle and close.
+fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
+    let registry = Arc::new(Registry::new());
+    for d in aether_kinds::descriptors::all() {
+        let _ = registry.register_kind_with_descriptor(d);
+    }
+    let (outbound, _rx) = HubOutbound::attached_loopback();
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<EngineServer>(())
+        .with_actor::<RpcServerCapability>(RpcServerConfig {
+            bind_addr: "127.0.0.1:0".into(),
+            peer_kind: PeerKind::Substrate {
+                engine_name: "test-hub".into(),
+                engine_version: "0.1.0".into(),
+                kinds: vec![],
+            },
+        })
+        .build_passive()
+        .expect("hub caps boot");
+    let port = chassis
+        .handle::<aether_capabilities::rpc::RpcServerHandle>()
+        .expect("RpcServerHandle published")
+        .local_port;
+    (chassis, port)
+}
+
+/// Fire one `Call` and read frames until its `ReplyEnd` arrives,
+/// returning the `(kind, payload)` of the single `ReplyEvent` seen in
+/// between (these calls each yield exactly one event then end). Panics
+/// on a `ReplyEnd::Err` or a missing event.
+fn call_round_trip<K: Kind + serde::Serialize>(
+    stream: &mut TcpStream,
+    cid: u64,
+    engine: Option<EngineId>,
+    mailbox_name: &str,
+    request: &K,
+) -> (aether_data::KindId, Vec<u8>) {
+    write_frame(
+        stream,
+        &WireFrame::Call {
+            cid: Some(cid),
+            envelope: MailEnvelope {
+                to: MailboxAddress {
+                    engine,
+                    mailbox: mailbox_id_from_name(mailbox_name),
+                },
+                from: None,
+                kind: K::ID,
+                correlation_id: None,
+                payload: request.encode_into_bytes(),
+            },
+        },
+    )
+    .expect("write Call");
+
+    let mut event: Option<(aether_data::KindId, Vec<u8>)> = None;
+    loop {
+        match read_frame(stream).expect("read reply frame") {
+            WireFrame::ReplyEvent {
+                cid: got_cid,
+                envelope,
+            } => {
+                assert_eq!(got_cid, cid, "ReplyEvent cid mismatch");
+                event = Some((envelope.kind, envelope.payload));
+            }
+            WireFrame::ReplyEnd {
+                cid: got_cid,
+                result,
+            } => {
+                assert_eq!(got_cid, cid, "ReplyEnd cid mismatch");
+                result.unwrap_or_else(|e| panic!("call {cid} ended with error: {e:?}"));
+                return event.unwrap_or_else(|| panic!("call {cid} ended with no ReplyEvent"));
+            }
+            other => panic!("unexpected frame for call {cid}: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn hub_routes_engine_addressed_calls_to_a_real_substrate() {
+    let (_chassis, hub_port) = boot_hub();
+    let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{hub_port}")).expect("connect to hub");
+    // Generous: a forwarded call's first step is forking a real
+    // substrate and waiting for it to bind its RPC port.
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+
+    // Handshake.
+    write_frame(
+        &mut stream,
+        &WireFrame::Hello(Hello {
+            wire_version: WIRE_VERSION,
+            peer: PeerKind::Client {
+                client_name: "rpc-engine-routing-test".into(),
+                client_version: "0.0.1".into(),
+            },
+        }),
+    )
+    .expect("write Hello");
+    match read_frame(&mut stream).expect("read HelloAck") {
+        WireFrame::HelloAck(HelloAck { wire_version, .. }) => {
+            assert_eq!(wire_version, WIRE_VERSION);
+        }
+        other => panic!("expected HelloAck, got {other:?}"),
+    }
+
+    // 1. engine = None: spawn a real headless substrate via the
+    //    hub-local engines cap. Dispatches locally on the hub.
+    let (spawn_kind, spawn_payload) = call_round_trip(
+        &mut stream,
+        1,
+        None,
+        "aether.engine",
+        &SpawnEngine {
+            binary_path: headless.to_owned(),
+            args: vec![],
+        },
+    );
+    assert_eq!(spawn_kind, <SpawnEngineResult as Kind>::ID);
+    let engine_id = match SpawnEngineResult::decode_from_bytes(&spawn_payload) {
+        Some(SpawnEngineResult::Ok { engine_id, .. }) => engine_id,
+        Some(SpawnEngineResult::Err { error }) => panic!("spawn failed: {error}"),
+        None => panic!("undecodable SpawnEngineResult"),
+    };
+    let engine_id = EngineId(Uuid::parse_str(&engine_id).expect("engine_id parses"));
+
+    // 2. engine = Some(_): a ROUTED call. The hub forwards it through
+    //    aether.engine -> proxy -> (RPC) -> the substrate's aether.fs
+    //    -> back. This is the P5a proof.
+    let (routed_kind, _routed_payload) = call_round_trip(
+        &mut stream,
+        2,
+        Some(engine_id),
+        "aether.fs",
+        &List {
+            namespace: "save".to_owned(),
+            prefix: String::new(),
+        },
+    );
+    assert_eq!(
+        routed_kind,
+        <ListResult as Kind>::ID,
+        "routed call should return the substrate's aether.fs ListResult",
+    );
+
+    // 3. engine = None: terminate the engine — proxy SIGKILLs + reaps
+    //    the child, so the test leaves no orphaned substrate.
+    let (term_kind, _term_payload) = call_round_trip(
+        &mut stream,
+        3,
+        None,
+        "aether.engine",
+        &TerminateEngine {
+            engine_id: engine_id.0.to_string(),
+        },
+    );
+    assert_eq!(term_kind, <aether_kinds::TerminateEngineResult as Kind>::ID);
+}


### PR DESCRIPTION
## Summary

P5a of issue 763's forward-model RPC architecture: the hub's `RpcServerCapability` now **routes `engine = Some(_)` Calls through to the right substrate** instead of rejecting them with `UnsupportedTarget`. This is the foundational piece that makes the hub a real forwarder — the prerequisite for the out-of-process `aether-mcp` extraction (P5b–d).

- **Two kinds in `aether-kinds`:** `RouteEnvelope` (the `RpcServer → EngineServer` hop — the engine-addressed sibling of `ForwardEnvelope`) and `CallSettled` (the `proxy → RpcServer` terminal signal).
- **`RpcServerCapability::handle_call`:** `engine = Some` Calls are dispatched as a `RouteEnvelope` at `aether.engine`. This path deliberately does **not** subscribe to chassis settlement — the local `RouteEnvelope` hop settles long before the remote substrate replies — so the wire call is closed by `CallSettled`, recognized in the `on_any` fallback.
- **`EngineServer::on_route`:** looks the engine up in its table and re-emits a `ForwardEnvelope` at the matching `aether.engine.proxy:<id>`, propagating the inbound reply-to so the substrate's reply routes home. An unknown / unparseable `engine_id` answers `CallSettled::Err` so the call closes instead of hanging.
- **`EngineProxy`:** lifts the substrate's terminal `ReplyEnd` into a `CallSettled` (P3/P4 dropped it) so the originating `RpcServer` learns to close its wire call.

**Layering:** the generic `RpcServerCapability` routes *through* the `aether.engine` cap rather than hardcoding the `aether.engine.proxy:<id>` naming convention — the engines cap owns its `EngineId → proxy` table.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run --workspace` — 1124 passed
- [x] `cargo check -p aether-capabilities --target wasm32-unknown-unknown` — builds
- [x] New integration test `tests/rpc_engine_routing.rs` drives the whole forward model through one RPC socket: an `engine = None` Call spawns a real `aether-substrate-headless`, an `engine = Some` Call is routed through to its `aether.fs` and the reply streams back as `ReplyEvent` + `ReplyEnd`, an `engine = None` Call terminates it.

Part of iamacoffeepot/aether#763 (P5a) — does not close the umbrella. Next sub-phases: P5b (the `aether-mcp` crate skeleton + engine-management tools over RPC), P5c (remaining tools), P5d (cutover + strip MCP deps from `aether-substrate-bundle`, closes iamacoffeepot/aether#763).

🤖 Generated with [Claude Code](https://claude.com/claude-code)