### PR TITLE
feat(aether-mcp): out-of-process MCP coordinator crate + engine-mgmt tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-mcp"
+version = "0.2.0-alpha"
+dependencies = [
+ "aether-actor",
+ "aether-capabilities",
+ "aether-codec",
+ "aether-data",
+ "aether-kinds",
+ "aether-substrate",
+ "anyhow",
+ "axum",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "aether-mesh"
 version = "0.2.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/aether-mesh",
     "crates/aether-camera",
     "crates/aether-capabilities",
+    "crates/aether-mcp",
     "crates/aether-mesh-viewer",
     "crates/aether-test-fixture-probe",
     "demos/sokoban",

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "aether-mcp"
+version.workspace = true
+edition.workspace = true
+
+# The out-of-process MCP coordinator (issue 763 P5). Claude Code points
+# `.mcp.json` at this binary; it owns the `rmcp` HTTP server and the
+# tool surface, and reaches engines purely as an RPC *client* — it dials
+# the hub's `RpcServerCapability` and relays tool calls as wire `Call`s.
+# No `aether-substrate` / wasmtime / wgpu in the dep graph: the MCP
+# coordinator never hosts an actor system, it just speaks the wire.
+#
+# Until the P5d cutover the embedded `aether-substrate-bundle::hub::mcp`
+# server keeps running on its own port — this crate is additive.
+
+[[bin]]
+name = "aether-mcp"
+path = "src/main.rs"
+
+[dependencies]
+# Wire vocabulary + the RPC client primitive. `aether-capabilities`
+# with default features pulls `aether-substrate`; we only need the
+# `rpc::client` types, but the crate isn't split finer than this today
+# so we take the native default. (Trimming this is a P5d follow-up.)
+aether-capabilities = { path = "../aether-capabilities" }
+aether-codec = { path = "../aether-codec" }
+aether-data = { path = "../aether-data" }
+aether-kinds = { path = "../aether-kinds" }
+
+anyhow = "1"
+axum = "0.8"
+rmcp = { version = "0.8", features = [
+    "server",
+    "macros",
+    "transport-streamable-http-server",
+] }
+schemars = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+aether-actor = { path = "../aether-actor" }
+aether-substrate = { path = "../aether-substrate" }

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -1,0 +1,70 @@
+//! Request / response shapes for the `aether-mcp` tool surface
+//! (issue 763 P5b). Pure data — `serde` + `schemars::JsonSchema` so
+//! `rmcp` can derive the JSON Schema it advertises to MCP clients.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// `spawn_substrate` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SpawnSubstrateArgs {
+    /// Absolute path to the substrate binary the hub should fork+exec.
+    /// The hub doesn't resolve or locate binaries — pass a path that
+    /// exists.
+    pub binary_path: String,
+    /// Extra command-line arguments forwarded to the substrate
+    /// verbatim. `AETHER_RPC_PORT` is injected by the hub regardless.
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+/// `terminate_substrate` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TerminateSubstrateArgs {
+    /// Engine UUID, as returned by `spawn_substrate` / `list_engines`.
+    pub engine_id: String,
+}
+
+/// `send_mail` arguments — a best-effort batch.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SendMailArgs {
+    /// One or more mail items. Each is routed independently — a single
+    /// failure doesn't abort the batch; the response carries a
+    /// per-item status.
+    pub mails: Vec<MailSpec>,
+}
+
+/// One item in a `send_mail` batch.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MailSpec {
+    /// Engine UUID the mail targets (from `list_engines`).
+    pub engine_id: String,
+    /// Mailbox name on that engine (e.g. `"aether.fs"`).
+    pub recipient_name: String,
+    /// Kind name (e.g. `"aether.fs.list"`), resolved against the
+    /// substrate kind vocabulary baked into `aether-mcp`.
+    pub kind_name: String,
+    /// Structured params, schema-encoded to wire bytes against the
+    /// kind's descriptor. Omit or `null` for a fieldless kind.
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// One supervised engine, as reported by `list_engines`.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct EngineInfo {
+    /// Engine UUID — pass to `send_mail` / `terminate_substrate`.
+    pub engine_id: String,
+    /// The localhost RPC port the hub assigned this substrate.
+    pub rpc_port: u16,
+}
+
+/// Per-item outcome from a `send_mail` batch.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct MailStatus {
+    /// Index into the `mails` array the caller supplied.
+    pub index: usize,
+    /// `"delivered"` once the call reached the substrate and its
+    /// dispatch chain settled, or `"error: <reason>"` on failure.
+    pub status: String,
+}

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -14,7 +14,6 @@ mod args;
 mod rpc;
 mod tools;
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
@@ -45,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_MCP_PORT);
-    let mcp_addr = SocketAddr::from(([127, 0, 0, 1], mcp_port));
+    let mcp_addr = format!("127.0.0.1:{mcp_port}");
 
     // Dial the hub. The handshake is blocking, so run it on a
     // blocking-pool thread rather than stalling a runtime worker.
@@ -71,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let app = axum::Router::new().nest_service("/mcp", service);
-    let listener = tokio::net::TcpListener::bind(mcp_addr).await?;
+    let listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
     let bound = listener.local_addr()?;
     tracing::info!(target: "aether_mcp", "mcp listener bound on http://{bound}/mcp");
     axum::serve(listener, app).await?;

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -1,0 +1,79 @@
+//! `aether-mcp` — the out-of-process MCP coordinator (issue 763 P5).
+//!
+//! Claude Code points `.mcp.json` at this binary. It owns the `rmcp`
+//! HTTP server and the tool surface, and reaches engines purely as an
+//! RPC *client*: it dials the hub's `RpcServerCapability` once at
+//! startup and relays every tool call as a wire `Call`. There is no
+//! actor system in this process — just the wire.
+//!
+//! Until the P5d cutover the embedded `aether-substrate-bundle::hub::mcp`
+//! server keeps running on its own port; this binary is additive and
+//! defaults to a distinct port so the two coexist.
+
+mod args;
+mod rpc;
+mod tools;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+
+use crate::rpc::RpcSession;
+use crate::tools::Mcp;
+
+/// Default port the MCP HTTP server binds. Distinct from the embedded
+/// hub MCP's 8888 so the two coexist until the P5d cutover.
+/// Overridable via `AETHER_MCP_PORT`.
+const DEFAULT_MCP_PORT: u16 = 8890;
+
+/// Default hub RPC address `aether-mcp` dials. The hub must be launched
+/// with `AETHER_RPC_PORT` set to this port. Overridable via
+/// `AETHER_HUB_RPC_ADDR`.
+const DEFAULT_HUB_RPC_ADDR: &str = "127.0.0.1:8901";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let filter = tracing_subscriber::EnvFilter::try_from_env("AETHER_LOG_FILTER")
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    let hub_addr =
+        std::env::var("AETHER_HUB_RPC_ADDR").unwrap_or_else(|_| DEFAULT_HUB_RPC_ADDR.to_owned());
+    let mcp_port: u16 = std::env::var("AETHER_MCP_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MCP_PORT);
+    let mcp_addr = SocketAddr::from(([127, 0, 0, 1], mcp_port));
+
+    // Dial the hub. The handshake is blocking, so run it on a
+    // blocking-pool thread rather than stalling a runtime worker.
+    tracing::info!(target: "aether_mcp", hub = %hub_addr, "dialing hub rpc server");
+    let session = tokio::task::spawn_blocking({
+        let hub_addr = hub_addr.clone();
+        move || RpcSession::connect(&hub_addr)
+    })
+    .await
+    .expect("connect task panicked")?;
+    let session = Arc::new(session);
+    tracing::info!(
+        target: "aether_mcp",
+        server = ?session.server(),
+        "hub rpc connection established",
+    );
+
+    let factory_session = Arc::clone(&session);
+    let service = StreamableHttpService::new(
+        move || Ok(Mcp::new(Arc::clone(&factory_session))),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+
+    let app = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind(mcp_addr).await?;
+    let bound = listener.local_addr()?;
+    tracing::info!(target: "aether_mcp", "mcp listener bound on http://{bound}/mcp");
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -1,0 +1,169 @@
+//! `RpcSession` — the `aether-mcp` side of one outbound RPC connection
+//! to the hub (issue 763 P5b).
+//!
+//! Wraps [`RpcClient`] / [`RpcConnection`] (issue 763 P1) with the
+//! demultiplexing the MCP tool surface needs: many tool calls share
+//! the one socket, so a router thread drains the connection's single
+//! inbound channel and fans each `ReplyEvent` / `ReplyEnd` to the
+//! [`RpcSession::call`] future waiting on that `cid`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use aether_capabilities::rpc::{
+    MailEnvelope, PeerKind, RpcClient, RpcConnection, RpcReaderHandle, WireFrame,
+};
+use tokio::sync::mpsc;
+
+/// One outbound RPC connection to the hub, shared across every MCP
+/// tool call. Cheap to `Arc`-share into each per-session `Mcp`.
+pub struct RpcSession {
+    /// Write half. Behind a `std::sync::Mutex` so concurrent tool
+    /// calls serialize their `Call` writes — and so a write + the
+    /// matching `pending` registration happen under one lock section,
+    /// closing the race against the router thread.
+    client: Mutex<RpcClient>,
+    /// `cid` → the channel feeding the `call()` future awaiting it.
+    /// The router thread routes inbound frames here; `call()` registers
+    /// an entry before its write is visible and clears it on `ReplyEnd`.
+    pending: Arc<Mutex<HashMap<u64, mpsc::UnboundedSender<WireFrame>>>>,
+    /// The hub's `HelloAck` identity, cached at connect time.
+    server: PeerKind,
+    /// Keeps the connection's reader sidecar alive — its `Drop` tears
+    /// the socket down. Declared before `_router` so it drops first:
+    /// ending the reader closes `inbound`, which ends the router
+    /// thread's blocking `recv()`.
+    _reader: RpcReaderHandle,
+    /// The demux thread. Detached on drop — it exits on its own once
+    /// `_reader`'s teardown closes `inbound`.
+    _router: std::thread::JoinHandle<()>,
+}
+
+impl RpcSession {
+    /// Dial the hub's `RpcServerCapability` at `addr`, run the
+    /// `Hello` / `HelloAck` handshake, and spawn the demux router
+    /// thread. Blocking — call it off the async runtime.
+    pub fn connect(addr: &str) -> anyhow::Result<Self> {
+        let RpcConnection {
+            client,
+            server,
+            inbound,
+            reader,
+        } = RpcClient::connect(
+            addr,
+            PeerKind::Client {
+                client_name: "aether-mcp".to_owned(),
+                client_version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+            // Non-actor consumer: the router thread blocks on
+            // `inbound.recv()` directly, so the wake hook is a no-op.
+            || {},
+        )?;
+
+        let pending: Arc<Mutex<HashMap<u64, mpsc::UnboundedSender<WireFrame>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let router_pending = Arc::clone(&pending);
+        let router = std::thread::Builder::new()
+            .name("aether-mcp-rpc-router".into())
+            .spawn(move || {
+                // `inbound.recv()` ends with `Err` once the reader
+                // sidecar drops its sender (connection torn down).
+                while let Ok(frame) = inbound.recv() {
+                    let cid = match &frame {
+                        WireFrame::ReplyEvent { cid, .. } | WireFrame::ReplyEnd { cid, .. } => *cid,
+                        WireFrame::Bye { reason } => {
+                            tracing::warn!(
+                                target: "aether_mcp::rpc",
+                                reason = %reason,
+                                "hub closed the rpc connection; draining pending calls",
+                            );
+                            // Drop every pending sender so each waiting
+                            // `call()` future sees `None` and errors
+                            // out rather than hanging forever.
+                            router_pending.lock().unwrap().clear();
+                            break;
+                        }
+                        // Hello / HelloAck / Call / Ping / Pong: a
+                        // client-side router never expects these.
+                        _ => continue,
+                    };
+                    if let Some(tx) = router_pending.lock().unwrap().get(&cid) {
+                        // A failed send just means a stray frame for an
+                        // already-finished call — drop it.
+                        let _ = tx.send(frame);
+                    }
+                }
+            })?;
+
+        Ok(Self {
+            client: Mutex::new(client),
+            pending,
+            server,
+            _reader: reader,
+            _router: router,
+        })
+    }
+
+    /// The hub's `HelloAck` identity.
+    pub fn server(&self) -> &PeerKind {
+        &self.server
+    }
+
+    /// Write a `Call` carrying `envelope` and await its terminal
+    /// `ReplyEnd`, collecting every `ReplyEvent` seen in between.
+    ///
+    /// The `pending` registration shares a lock section with the
+    /// socket write, so the router thread can't route this call's
+    /// reply before the entry exists.
+    pub async fn call(&self, envelope: MailEnvelope) -> anyhow::Result<Vec<MailEnvelope>> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let cid = {
+            let mut pending = self.pending.lock().unwrap();
+            let cid = self
+                .client
+                .lock()
+                .unwrap()
+                .call(envelope)
+                .map_err(|e| anyhow::anyhow!("rpc call write failed: {e}"))?;
+            pending.insert(cid, tx);
+            cid
+        };
+
+        let mut events = Vec::new();
+        let outcome = loop {
+            match rx.recv().await {
+                Some(WireFrame::ReplyEvent { envelope, .. }) => events.push(envelope),
+                Some(WireFrame::ReplyEnd { result, .. }) => {
+                    break result.map_err(|e| anyhow::anyhow!("rpc call failed: {e:?}"));
+                }
+                // The router only ever routes ReplyEvent / ReplyEnd to
+                // a pending entry.
+                Some(_) => {}
+                None => {
+                    break Err(anyhow::anyhow!(
+                        "rpc connection closed before the call ended"
+                    ));
+                }
+            }
+        };
+        self.pending.lock().unwrap().remove(&cid);
+        outcome.map(|()| events)
+    }
+
+    /// [`Self::call`], expecting exactly one `ReplyEvent` — the shape
+    /// of the engines-cap result kinds (`ListEnginesResult`, etc.).
+    pub async fn call_one(&self, envelope: MailEnvelope) -> anyhow::Result<MailEnvelope> {
+        let mut events = self.call(envelope).await?;
+        match events.len() {
+            1 => Ok(events.pop().expect("len checked")),
+            n => Err(anyhow::anyhow!("expected exactly one reply event, got {n}")),
+        }
+    }
+
+    /// [`Self::call`], discarding any reply events — for mail whose
+    /// only interesting outcome is "did the call reach the substrate
+    /// and settle". The terminal `ReplyEnd` still gates the result.
+    pub async fn call_settled(&self, envelope: MailEnvelope) -> anyhow::Result<()> {
+        self.call(envelope).await.map(|_events| ())
+    }
+}

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1,0 +1,387 @@
+//! The `aether-mcp` tool surface: the per-session [`Mcp`] service, its
+//! `#[tool_router]` impl, and the `ServerHandler` (issue 763 P5b).
+//!
+//! Each tool translates to one or more RPC `Call`s over the shared
+//! [`RpcSession`]. Engine-management tools (`list_engines`,
+//! `spawn_substrate`, `terminate_substrate`) address the hub's own
+//! `aether.engine` cap (`engine = None`, dispatched locally on the
+//! hub); `send_mail` addresses a specific substrate (`engine = Some`),
+//! which the hub routes through to the matching proxy.
+
+use std::sync::Arc;
+
+use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
+use aether_data::canonical::kind_id_from_parts;
+use aether_data::{EngineId, Kind, KindDescriptor, KindId, Uuid, mailbox_id_from_name};
+use aether_kinds::{
+    ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
+    TerminateEngineResult,
+};
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
+
+use crate::args::{
+    EngineInfo, MailSpec, MailStatus, SendMailArgs, SpawnSubstrateArgs, TerminateSubstrateArgs,
+};
+use crate::rpc::RpcSession;
+
+/// Mailbox name of the hub's engines cap — the `engine = None` target
+/// for the engine-management tools.
+const ENGINE_CAP: &str = "aether.engine";
+
+/// Per-session MCP service. `rmcp` calls the factory once per session
+/// and may clone the result for concurrent tool dispatch — `session`
+/// is an `Arc`, so clones share the one hub connection.
+#[derive(Clone)]
+pub struct Mcp {
+    session: Arc<RpcSession>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl Mcp {
+    /// Construct a per-session service over an established hub
+    /// connection.
+    pub fn new(session: Arc<RpcSession>) -> Self {
+        Self {
+            session,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl Mcp {
+    #[tool(
+        description = "List every engine the hub currently supervises. Each item reports the engine_id (pass it to send_mail / terminate_substrate) and the localhost RPC port the hub assigned its substrate."
+    )]
+    pub async fn list_engines(&self) -> Result<String, McpError> {
+        let reply = self
+            .session
+            .call_one(local_envelope(ENGINE_CAP, &ListEngines {}))
+            .await
+            .map_err(internal)?;
+        let result = ListEnginesResult::decode_from_bytes(&reply.payload)
+            .ok_or_else(|| internal_msg("undecodable ListEnginesResult"))?;
+        let engines: Vec<EngineInfo> = result
+            .engines
+            .into_iter()
+            .map(|e| EngineInfo {
+                engine_id: e.engine_id,
+                rpc_port: e.rpc_port,
+            })
+            .collect();
+        json(&engines)
+    }
+
+    #[tool(
+        description = "Fork+exec a substrate binary as a child of the hub. The hub assigns the substrate a free localhost RPC port, injects it as AETHER_RPC_PORT, forks the binary, and connects a proxy. Returns the engine_id and rpc_port on success."
+    )]
+    pub async fn spawn_substrate(
+        &self,
+        Parameters(args): Parameters<SpawnSubstrateArgs>,
+    ) -> Result<String, McpError> {
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &SpawnEngine {
+                    binary_path: args.binary_path,
+                    args: args.args,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match SpawnEngineResult::decode_from_bytes(&reply.payload) {
+            Some(SpawnEngineResult::Ok {
+                engine_id,
+                rpc_port,
+            }) => json(&EngineInfo {
+                engine_id,
+                rpc_port,
+            }),
+            Some(SpawnEngineResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable SpawnEngineResult")),
+        }
+    }
+
+    #[tool(
+        description = "Terminate a substrate the hub supervises. The hub forwards the request to the engine's proxy, which SIGKILLs the child process and self-shuts-down."
+    )]
+    pub async fn terminate_substrate(
+        &self,
+        Parameters(args): Parameters<TerminateSubstrateArgs>,
+    ) -> Result<String, McpError> {
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &TerminateEngine {
+                    engine_id: args.engine_id,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match TerminateEngineResult::decode_from_bytes(&reply.payload) {
+            Some(TerminateEngineResult::Ok) => json(&serde_json::json!({ "status": "terminated" })),
+            Some(TerminateEngineResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable TerminateEngineResult")),
+        }
+    }
+
+    #[tool(
+        description = "Send one or more mail items to substrate mailboxes. Each item carries structured `params`, schema-encoded against the substrate kind vocabulary. Best-effort batch: per-item status is returned and one failure doesn't abort siblings. 'delivered' means the call reached the substrate and its dispatch chain settled."
+    )]
+    pub async fn send_mail(
+        &self,
+        Parameters(args): Parameters<SendMailArgs>,
+    ) -> Result<String, McpError> {
+        // Snapshot the substrate descriptor inventory once for the
+        // whole batch rather than per item.
+        let descriptors = aether_kinds::descriptors::all();
+        let mut statuses = Vec::with_capacity(args.mails.len());
+        for (index, spec) in args.mails.into_iter().enumerate() {
+            let status = match self.deliver_one(&descriptors, spec).await {
+                Ok(()) => "delivered".to_owned(),
+                Err(e) => format!("error: {e}"),
+            };
+            statuses.push(MailStatus { index, status });
+        }
+        json(&statuses)
+    }
+}
+
+impl Mcp {
+    /// Build one `MailSpec` into an `engine = Some` envelope and route
+    /// it through the hub, awaiting the substrate's terminal settle.
+    async fn deliver_one(
+        &self,
+        descriptors: &[KindDescriptor],
+        spec: MailSpec,
+    ) -> anyhow::Result<()> {
+        let engine = EngineId(
+            Uuid::parse_str(&spec.engine_id)
+                .map_err(|e| anyhow::anyhow!("engine_id is not a valid UUID: {e}"))?,
+        );
+        // Resolve the kind against the substrate vocabulary baked into
+        // `aether-kinds` — the same descriptor set the scenario runner
+        // and the embedded hub encode `send_mail` params against.
+        let desc = descriptors
+            .iter()
+            .find(|d| d.name == spec.kind_name)
+            .ok_or_else(|| anyhow::anyhow!("unknown kind: {}", spec.kind_name))?;
+        let params = spec.params.unwrap_or(serde_json::Value::Null);
+        let payload = aether_codec::encode_schema(&params, &desc.schema)
+            .map_err(|e| anyhow::anyhow!("param encode failed: {e}"))?;
+        let envelope = MailEnvelope {
+            to: MailboxAddress {
+                engine: Some(engine),
+                mailbox: mailbox_id_from_name(&spec.recipient_name),
+            },
+            from: None,
+            kind: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
+            correlation_id: None,
+            payload,
+        };
+        self.session.call_settled(envelope).await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Mcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: "aether-mcp".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+}
+
+/// Build a `MailEnvelope` addressed at a hub-local mailbox
+/// (`engine = None`) carrying a typed kind.
+fn local_envelope<K: Kind + serde::Serialize>(mailbox: &str, kind: &K) -> MailEnvelope {
+    MailEnvelope {
+        to: MailboxAddress::local(mailbox_id_from_name(mailbox)),
+        from: None,
+        kind: K::ID,
+        correlation_id: None,
+        payload: kind.encode_into_bytes(),
+    }
+}
+
+/// Serialize a tool result to the JSON string `rmcp` wraps as text
+/// content.
+fn json<T: serde::Serialize>(value: &T) -> Result<String, McpError> {
+    serde_json::to_string(value).map_err(|e| McpError::internal_error(e.to_string(), None))
+}
+
+fn internal(e: anyhow::Error) -> McpError {
+    McpError::internal_error(e.to_string(), None)
+}
+
+fn internal_msg(msg: &str) -> McpError {
+    McpError::internal_error(msg.to_owned(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::{MailSpec, SendMailArgs, SpawnSubstrateArgs, TerminateSubstrateArgs};
+    use aether_capabilities::EngineServer;
+    use aether_capabilities::rpc::{
+        PeerKind, RpcServerCapability, RpcServerConfig, RpcServerHandle,
+    };
+    use aether_capabilities::trace::TraceObserverCapability;
+    use aether_substrate::chassis::Chassis;
+    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::handle_store::HandleStore;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
+    use aether_substrate::mail::registry::Registry;
+
+    struct TestChassis;
+    impl Chassis for TestChassis {
+        const PROFILE: &'static str = "test";
+        type Driver = NeverDriver;
+        type Env = ();
+        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+        }
+    }
+
+    /// Boot a hub-shaped passive chassis: a forwarding
+    /// `RpcServerCapability` + the engines cap + `TraceObserver` (so
+    /// the RpcServer's local Calls settle and close). Returns the
+    /// chassis (kept alive for its dispatcher threads) and the RPC
+    /// port an `RpcSession` dials.
+    fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
+        let registry = Arc::new(Registry::new());
+        for d in aether_kinds::descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceObserverCapability>(())
+            .with_actor::<EngineServer>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: PeerKind::Substrate {
+                    engine_name: "test-hub".into(),
+                    engine_version: "0.1.0".into(),
+                    kinds: vec![],
+                },
+            })
+            .build_passive()
+            .expect("hub caps boot");
+        let port = chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        (chassis, port)
+    }
+
+    /// Connect an `RpcSession` + wrap it in an `Mcp` against a booted
+    /// hub chassis.
+    fn connect_mcp(port: u16) -> Mcp {
+        let session = RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
+        Mcp::new(Arc::new(session))
+    }
+
+    /// `list_engines` over the RPC round-trip yields an empty array on
+    /// a fresh hub — proves the whole `RpcSession` demux + the
+    /// `engine = None` Call path against the real `aether.engine` cap.
+    #[tokio::test]
+    async fn list_engines_on_empty_hub_is_empty() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let out = mcp.list_engines().await.expect("list_engines ok");
+        assert_eq!(out, "[]", "fresh hub supervises no engines");
+    }
+
+    /// `spawn_substrate` with a binary path that doesn't exist surfaces
+    /// the hub's `SpawnEngineResult::Err` as a tool error.
+    #[tokio::test]
+    async fn spawn_substrate_missing_binary_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .spawn_substrate(Parameters(SpawnSubstrateArgs {
+                binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
+                args: vec![],
+            }))
+            .await;
+        assert!(result.is_err(), "a missing binary should be a tool error");
+    }
+
+    /// `terminate_substrate` with a malformed `engine_id` surfaces the
+    /// hub's `TerminateEngineResult::Err` as a tool error.
+    #[tokio::test]
+    async fn terminate_substrate_bad_engine_id_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .terminate_substrate(Parameters(TerminateSubstrateArgs {
+                engine_id: "not-a-uuid".to_owned(),
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "a malformed engine_id should be a tool error"
+        );
+    }
+
+    /// `send_mail` is a best-effort batch: a bad `kind_name` and a bad
+    /// `engine_id` fail locally in `deliver_one`, while a well-formed
+    /// item addressed at an unknown engine round-trips to the hub and
+    /// comes back a `CallSettled::Err`. Every item reports `error: ...`
+    /// and none aborts its siblings.
+    #[tokio::test]
+    async fn send_mail_reports_per_item_errors() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let out = mcp
+            .send_mail(Parameters(SendMailArgs {
+                mails: vec![
+                    MailSpec {
+                        engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                        recipient_name: "aether.fs".to_owned(),
+                        kind_name: "not.a.real.kind".to_owned(),
+                        params: None,
+                    },
+                    MailSpec {
+                        engine_id: "not-a-uuid".to_owned(),
+                        recipient_name: "aether.fs".to_owned(),
+                        kind_name: "aether.fs.list".to_owned(),
+                        params: None,
+                    },
+                    MailSpec {
+                        engine_id: "00000000-0000-0000-0000-000000000002".to_owned(),
+                        recipient_name: "aether.fs".to_owned(),
+                        kind_name: "aether.fs.list".to_owned(),
+                        params: Some(serde_json::json!({ "namespace": "save", "prefix": "" })),
+                    },
+                ],
+            }))
+            .await
+            .expect("send_mail returns a status array, not a tool error");
+        let statuses: Vec<MailStatus> = serde_json::from_str(&out).expect("status array");
+        assert_eq!(statuses.len(), 3);
+        for status in &statuses {
+            assert!(
+                status.status.starts_with("error: "),
+                "item {} should be an error: {}",
+                status.index,
+                status.status,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

P5b of issue 763's forward-model RPC architecture: a new **`aether-mcp`** binary crate — the out-of-process MCP coordinator. It owns `rmcp` and reaches engines purely as an RPC *client* (it dials the hub's `RpcServerCapability` and relays tool calls as wire `Call`s); there's no `aether-substrate` actor system in the process.

- **`RpcSession`** — wraps the P1 `RpcClient`/`RpcConnection` with the demultiplexing the tool surface needs: one router thread drains the connection's single inbound channel and fans each `ReplyEvent`/`ReplyEnd` to the `call()` future awaiting that `cid`. The `pending` registration shares a lock section with the socket write, so the router can't route a fast reply before the entry exists.
- **Four tools** ported to RPC Calls: `list_engines` / `spawn_substrate` / `terminate_substrate` are `engine = None` Calls to the hub's `aether.engine` cap; `send_mail` is a best-effort batch of `engine = Some` Calls, params schema-encoded against `aether_kinds::descriptors::all()` (the same path the scenario runner uses).
- **`main.rs`** boots an `rmcp` `StreamableHttpService` over axum, dialing the hub at `AETHER_HUB_RPC_ADDR` and serving MCP on `AETHER_MCP_PORT` (default 8890 — distinct from the embedded hub MCP's 8888, so the two coexist).

The embedded `aether-substrate-bundle::hub::mcp` path is untouched and `.mcp.json` is unchanged — this crate is **additive** until the P5d cutover.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run --workspace` — 1128 passed
- [x] 4 new `aether-mcp` tests drive the tool fns over a real RPC socket against an in-process hub chassis: `list_engines` round-trips an empty list, `spawn_substrate` / `terminate_substrate` surface the cap's error replies, and `send_mail` reports per-item status — including a full `engine = Some` round-trip for a well-formed-but-unknown engine.

Part of iamacoffeepot/aether#763 (P5b) — does not close the umbrella. Next: P5c ports the remaining tools (`describe_kinds` / `describe_component`, `load_component` / `replace_component`, `capture_frame`); P5d does the cutover (`.mcp.json` → `aether-mcp`, strip MCP deps from `aether-substrate-bundle`, collapse the hub, closes iamacoffeepot/aether#763).

🤖 Generated with [Claude Code](https://claude.com/claude-code)