### PR TITLE
feat(aether-mcp): port the per-engine + describe tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "aether-substrate",
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "rmcp",
  "schemars",
  "serde",

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -29,6 +29,7 @@ aether-kinds = { path = "../aether-kinds" }
 
 anyhow = "1"
 axum = "0.8"
+base64 = "0.22"
 rmcp = { version = "0.8", features = [
     "server",
     "macros",
@@ -37,7 +38,7 @@ rmcp = { version = "0.8", features = [
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -68,3 +68,74 @@ pub struct MailStatus {
     /// dispatch chain settled, or `"error: <reason>"` on failure.
     pub status: String,
 }
+
+/// `load_component` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LoadComponentArgs {
+    /// Engine UUID the component loads into (from `list_engines`).
+    pub engine_id: String,
+    /// Absolute path to the component's `.wasm`. `aether-mcp` reads
+    /// the bytes and forwards them to the substrate — agents never
+    /// inline wasm through the tool call.
+    pub binary_path: String,
+    /// Optional human-readable name. The substrate defaults one from
+    /// the wasm if omitted; the reply echoes the resolved name.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// `replace_component` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReplaceComponentArgs {
+    /// Engine UUID hosting the component (from `list_engines`).
+    pub engine_id: String,
+    /// Tagged mailbox id (`mbx-…`) of the component to replace, as
+    /// returned by `load_component`.
+    pub mailbox_id: String,
+    /// Absolute path to the replacement `.wasm`.
+    pub binary_path: String,
+    /// Accepted for wire compatibility; currently ignored by the
+    /// substrate (post-ADR-0038 the splice is structural).
+    #[serde(default)]
+    pub drain_timeout_ms: Option<u32>,
+}
+
+/// `describe_component` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeComponentArgs {
+    /// Engine UUID hosting the component (from `list_engines`).
+    pub engine_id: String,
+    /// Tagged mailbox id (`mbx-…`) of the loaded component.
+    pub mailbox_id: String,
+}
+
+/// One mail in a `capture_frame` bundle. Like [`MailSpec`] but without
+/// `engine_id` — every bundle entry is dispatched on the engine being
+/// captured, so the engine is already fixed by `CaptureFrameArgs`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureMailSpec {
+    /// Mailbox name on the captured engine (e.g. `"aether.render"`).
+    pub recipient_name: String,
+    /// Kind name, resolved against the substrate kind vocabulary.
+    pub kind_name: String,
+    /// Structured params, schema-encoded to wire bytes. Omit or
+    /// `null` for a fieldless kind.
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// `capture_frame` arguments.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureFrameArgs {
+    /// Engine UUID to capture (from `list_engines`).
+    pub engine_id: String,
+    /// Mail dispatched *before* the frame is read back — state changes
+    /// whose effects should appear in the image. Resolved atomically:
+    /// any bad entry aborts the whole capture.
+    #[serde(default)]
+    pub mails: Vec<CaptureMailSpec>,
+    /// Mail dispatched *after* readback — cleanup such as restoring a
+    /// flag the caller flipped for the capture.
+    #[serde(default)]
+    pub after_mails: Vec<CaptureMailSpec>,
+}

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -20,7 +20,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
 use crate::rpc::RpcSession;
-use crate::tools::Mcp;
+use crate::tools::{ComponentCache, Mcp};
 
 /// Default port the MCP HTTP server binds. Distinct from the embedded
 /// hub MCP's 8888 so the two coexist until the P5d cutover.
@@ -62,9 +62,20 @@ async fn main() -> anyhow::Result<()> {
         "hub rpc connection established",
     );
 
+    // Process-wide component-capability cache, shared into every
+    // per-session `Mcp` — `load_component` / `replace_component`
+    // populate it, `describe_component` reads it.
+    let components: Arc<ComponentCache> = Arc::new(ComponentCache::default());
+
     let factory_session = Arc::clone(&session);
+    let factory_components = Arc::clone(&components);
     let service = StreamableHttpService::new(
-        move || Ok(Mcp::new(Arc::clone(&factory_session))),
+        move || {
+            Ok(Mcp::new(
+                Arc::clone(&factory_session),
+                Arc::clone(&factory_components),
+            ))
+        },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),
     );

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1,51 +1,75 @@
 //! The `aether-mcp` tool surface: the per-session [`Mcp`] service, its
-//! `#[tool_router]` impl, and the `ServerHandler` (issue 763 P5b).
+//! `#[tool_router]` impl, and the `ServerHandler` (issue 763 P5b/P5c).
 //!
-//! Each tool translates to one or more RPC `Call`s over the shared
-//! [`RpcSession`]. Engine-management tools (`list_engines`,
-//! `spawn_substrate`, `terminate_substrate`) address the hub's own
-//! `aether.engine` cap (`engine = None`, dispatched locally on the
-//! hub); `send_mail` addresses a specific substrate (`engine = Some`),
-//! which the hub routes through to the matching proxy.
+//! Each tool translates to RPC `Call`s over the shared [`RpcSession`].
+//! Engine-management tools (`list_engines`, `spawn_substrate`,
+//! `terminate_substrate`) address the hub's own `aether.engine` cap
+//! (`engine = None`, dispatched locally on the hub); the per-engine
+//! tools (`send_mail`, `load_component`, `replace_component`,
+//! `capture_frame`) address a specific substrate (`engine = Some`),
+//! which the hub routes through to the matching proxy. `describe_kinds`
+//! and `describe_component` answer locally — from the substrate kind
+//! inventory baked into `aether-kinds` and from a component-capability
+//! cache populated by `load_component` / `replace_component`.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
 use aether_data::canonical::kind_id_from_parts;
-use aether_data::{EngineId, Kind, KindDescriptor, KindId, Uuid, mailbox_id_from_name};
-use aether_kinds::{
-    ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
-    TerminateEngineResult,
+use aether_data::{
+    EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name, tagged_id,
 };
+use aether_kinds::{
+    CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines, ListEnginesResult,
+    LoadComponent, LoadResult, ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult,
+    TerminateEngine, TerminateEngineResult,
+};
+use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 
 use crate::args::{
-    EngineInfo, MailSpec, MailStatus, SendMailArgs, SpawnSubstrateArgs, TerminateSubstrateArgs,
+    CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, EngineInfo, LoadComponentArgs,
+    MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs, SpawnSubstrateArgs,
+    TerminateSubstrateArgs,
 };
 use crate::rpc::RpcSession;
 
 /// Mailbox name of the hub's engines cap — the `engine = None` target
 /// for the engine-management tools.
 const ENGINE_CAP: &str = "aether.engine";
+/// Mailbox name of a substrate's component-host cap.
+const COMPONENT_CAP: &str = "aether.component";
+/// Mailbox name of a substrate's render cap.
+const RENDER_CAP: &str = "aether.render";
+
+/// Component receive-side capabilities, keyed by `(engine, mailbox)`.
+/// Populated from `load_component` / `replace_component` replies and
+/// read by `describe_component` — the forward-model stand-in for the
+/// embedded hub's component registry.
+pub type ComponentCache = Mutex<HashMap<(EngineId, MailboxId), ComponentCapabilities>>;
 
 /// Per-session MCP service. `rmcp` calls the factory once per session
 /// and may clone the result for concurrent tool dispatch — `session`
-/// is an `Arc`, so clones share the one hub connection.
+/// and `components` are `Arc`s, so clones share the one hub connection
+/// and one component cache.
 #[derive(Clone)]
 pub struct Mcp {
     session: Arc<RpcSession>,
+    components: Arc<ComponentCache>,
     tool_router: ToolRouter<Self>,
 }
 
 impl Mcp {
     /// Construct a per-session service over an established hub
-    /// connection.
-    pub fn new(session: Arc<RpcSession>) -> Self {
+    /// connection + the process-wide component cache.
+    pub fn new(session: Arc<RpcSession>, components: Arc<ComponentCache>) -> Self {
         Self {
             session,
+            components,
             tool_router: Self::tool_router(),
         }
     }
@@ -150,6 +174,168 @@ impl Mcp {
         }
         json(&statuses)
     }
+
+    #[tool(
+        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section."
+    )]
+    pub async fn load_component(
+        &self,
+        Parameters(args): Parameters<LoadComponentArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let wasm = tokio::fs::read(&args.binary_path).await.map_err(|e| {
+            McpError::invalid_params(
+                format!("reading binary_path {:?}: {e}", args.binary_path),
+                None,
+            )
+        })?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(
+                engine,
+                COMPONENT_CAP,
+                &LoadComponent {
+                    wasm,
+                    name: args.name,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match LoadResult::decode_from_bytes(&reply.payload) {
+            Some(LoadResult::Ok {
+                mailbox_id,
+                name,
+                capabilities,
+            }) => {
+                self.components
+                    .lock()
+                    .unwrap()
+                    .insert((engine, mailbox_id), capabilities.clone());
+                json(&serde_json::json!({
+                    "mailbox_id": mailbox_id,
+                    "name": name,
+                    "capabilities": capabilities,
+                }))
+            }
+            Some(LoadResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable LoadResult")),
+        }
+    }
+
+    #[tool(
+        description = "Atomically replace a live component's WASM with a new binary loaded from a filesystem path (ADR-0022 structural splice). aether-mcp reads the binary and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities."
+    )]
+    pub async fn replace_component(
+        &self,
+        Parameters(args): Parameters<ReplaceComponentArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let mailbox_id = parse_mailbox_id(&args.mailbox_id)?;
+        let wasm = tokio::fs::read(&args.binary_path).await.map_err(|e| {
+            McpError::invalid_params(
+                format!("reading binary_path {:?}: {e}", args.binary_path),
+                None,
+            )
+        })?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(
+                engine,
+                COMPONENT_CAP,
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm,
+                    drain_timeout_ms: args.drain_timeout_ms,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match ReplaceResult::decode_from_bytes(&reply.payload) {
+            Some(ReplaceResult::Ok { capabilities }) => {
+                self.components
+                    .lock()
+                    .unwrap()
+                    .insert((engine, mailbox_id), capabilities.clone());
+                json(&capabilities)
+            }
+            Some(ReplaceResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable ReplaceResult")),
+        }
+    }
+
+    #[tool(
+        description = "Capture an engine's current frame as a PNG, returned inline as image content. Optionally carries two mail bundles dispatched atomically around the capture: `mails` fires before readback (state changes that should appear in the image), `after_mails` fires after (cleanup). A bad bundle entry aborts the whole capture before any mail moves."
+    )]
+    pub async fn capture_frame(
+        &self,
+        Parameters(args): Parameters<CaptureFrameArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        // Encode both bundles before sending — a bad entry produces a
+        // clean invalid-params error and never touches the wire.
+        let descriptors = aether_kinds::descriptors::all();
+        let mails = encode_capture_bundle(&descriptors, &args.mails).map_err(|e| {
+            McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
+        })?;
+        let after_mails = encode_capture_bundle(&descriptors, &args.after_mails).map_err(|e| {
+            McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
+        })?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(
+                engine,
+                RENDER_CAP,
+                &CaptureFrame { mails, after_mails },
+            ))
+            .await
+            .map_err(internal)?;
+        match CaptureFrameResult::decode_from_bytes(&reply.payload) {
+            Some(CaptureFrameResult::Ok { png }) => {
+                let encoded = base64::engine::general_purpose::STANDARD.encode(&png);
+                Ok(CallToolResult::success(vec![Content::image(
+                    encoded,
+                    "image/png",
+                )]))
+            }
+            Some(CaptureFrameResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable CaptureFrameResult")),
+        }
+    }
+
+    #[tool(
+        description = "List the substrate kind vocabulary — every aether.* kind with its full schema, enough to build send_mail params. This is the static vocabulary aether-mcp ships with, not a per-engine query; component-defined kinds aren't included (use describe_component for a loaded component's handlers)."
+    )]
+    pub async fn describe_kinds(&self) -> Result<String, McpError> {
+        json(&aether_kinds::descriptors::all())
+    }
+
+    #[tool(
+        description = "Describe a loaded component's receive-side capabilities (ADR-0033): the kinds it typed-handles with per-handler docs, whether it has a fallback catchall, and its top-level doc. Reads aether-mcp's component cache, populated by load_component / replace_component — describing a component aether-mcp didn't load (or after an aether-mcp restart) returns an error."
+    )]
+    pub async fn describe_component(
+        &self,
+        Parameters(args): Parameters<DescribeComponentArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let mailbox_id = parse_mailbox_id(&args.mailbox_id)?;
+        let caps = self
+            .components
+            .lock()
+            .unwrap()
+            .get(&(engine, mailbox_id))
+            .cloned();
+        match caps {
+            Some(caps) => json(&caps),
+            None => Err(McpError::invalid_params(
+                format!(
+                    "no component cached at {} on engine {} — load_component / replace_component \
+                     populate this cache",
+                    args.mailbox_id, args.engine_id
+                ),
+                None,
+            )),
+        }
+    }
 }
 
 impl Mcp {
@@ -215,6 +401,70 @@ fn local_envelope<K: Kind + serde::Serialize>(mailbox: &str, kind: &K) -> MailEn
     }
 }
 
+/// Build a `MailEnvelope` addressed at a mailbox on a specific
+/// substrate (`engine = Some`) carrying a typed kind — the hub routes
+/// it through to that engine's proxy.
+fn engine_envelope<K: Kind + serde::Serialize>(
+    engine: EngineId,
+    mailbox: &str,
+    kind: &K,
+) -> MailEnvelope {
+    MailEnvelope {
+        to: MailboxAddress {
+            engine: Some(engine),
+            mailbox: mailbox_id_from_name(mailbox),
+        },
+        from: None,
+        kind: K::ID,
+        correlation_id: None,
+        payload: kind.encode_into_bytes(),
+    }
+}
+
+/// Parse a UUID-string `engine_id` (from `list_engines` /
+/// `spawn_substrate`) into an `EngineId`.
+fn parse_engine_id(s: &str) -> Result<EngineId, McpError> {
+    Uuid::parse_str(s)
+        .map(EngineId)
+        .map_err(|e| McpError::invalid_params(format!("engine_id is not a valid UUID: {e}"), None))
+}
+
+/// Parse a tagged mailbox-id string (`mbx-…`, ADR-0064) into a
+/// `MailboxId`.
+fn parse_mailbox_id(s: &str) -> Result<MailboxId, McpError> {
+    tagged_id::decode_with_tag(s, Tag::Mailbox)
+        .map(MailboxId)
+        .map_err(|e| McpError::invalid_params(format!("mailbox_id: {e}"), None))
+}
+
+/// Encode a `capture_frame` mail bundle: resolve each spec's kind
+/// against the substrate descriptor inventory, schema-encode its
+/// params, and wrap into the substrate-side `aether_kinds::MailEnvelope`
+/// shape (name-level addressing + pre-encoded payload).
+fn encode_capture_bundle(
+    descriptors: &[KindDescriptor],
+    specs: &[CaptureMailSpec],
+) -> anyhow::Result<Vec<aether_kinds::MailEnvelope>> {
+    specs
+        .iter()
+        .map(|spec| {
+            let desc = descriptors
+                .iter()
+                .find(|d| d.name == spec.kind_name)
+                .ok_or_else(|| anyhow::anyhow!("unknown kind: {}", spec.kind_name))?;
+            let params = spec.params.clone().unwrap_or(serde_json::Value::Null);
+            let payload = aether_codec::encode_schema(&params, &desc.schema)
+                .map_err(|e| anyhow::anyhow!("param encode failed for {}: {e}", spec.kind_name))?;
+            Ok(aether_kinds::MailEnvelope {
+                recipient_name: spec.recipient_name.clone(),
+                kind_name: spec.kind_name.clone(),
+                payload,
+                count: 1,
+            })
+        })
+        .collect()
+}
+
 /// Serialize a tool result to the JSON string `rmcp` wraps as text
 /// content.
 fn json<T: serde::Serialize>(value: &T) -> Result<String, McpError> {
@@ -232,7 +482,10 @@ fn internal_msg(msg: &str) -> McpError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::args::{MailSpec, SendMailArgs, SpawnSubstrateArgs, TerminateSubstrateArgs};
+    use crate::args::{
+        CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, LoadComponentArgs, MailSpec,
+        ReplaceComponentArgs, SendMailArgs, SpawnSubstrateArgs, TerminateSubstrateArgs,
+    };
     use aether_capabilities::EngineServer;
     use aether_capabilities::rpc::{
         PeerKind, RpcServerCapability, RpcServerConfig, RpcServerHandle,
@@ -290,10 +543,10 @@ mod tests {
     }
 
     /// Connect an `RpcSession` + wrap it in an `Mcp` against a booted
-    /// hub chassis.
+    /// hub chassis, with a fresh component cache.
     fn connect_mcp(port: u16) -> Mcp {
         let session = RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
-        Mcp::new(Arc::new(session))
+        Mcp::new(Arc::new(session), Arc::new(ComponentCache::default()))
     }
 
     /// `list_engines` over the RPC round-trip yields an empty array on
@@ -383,5 +636,120 @@ mod tests {
                 status.status,
             );
         }
+    }
+
+    /// `describe_kinds` is fully local — it renders the substrate kind
+    /// inventory baked into `aether-kinds`, no hub round-trip. The
+    /// result is a non-empty JSON array.
+    #[tokio::test]
+    async fn describe_kinds_returns_the_substrate_inventory() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let out = mcp.describe_kinds().await.expect("describe_kinds ok");
+        let kinds: serde_json::Value = serde_json::from_str(&out).expect("json array");
+        assert!(
+            kinds.as_array().is_some_and(|a| !a.is_empty()),
+            "describe_kinds should list the substrate vocabulary",
+        );
+    }
+
+    /// `load_component` with a binary path that doesn't exist fails at
+    /// the file read, before any RPC.
+    #[tokio::test]
+    async fn load_component_missing_binary_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .load_component(Parameters(LoadComponentArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                binary_path: "/nonexistent/does-not-exist.wasm".to_owned(),
+                name: None,
+            }))
+            .await;
+        assert!(result.is_err(), "a missing binary should be a tool error");
+    }
+
+    /// `replace_component` with a malformed tagged mailbox id is
+    /// rejected before any RPC.
+    #[tokio::test]
+    async fn replace_component_bad_mailbox_id_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .replace_component(Parameters(ReplaceComponentArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                mailbox_id: "not-a-tagged-id".to_owned(),
+                binary_path: "/tmp/whatever.wasm".to_owned(),
+                drain_timeout_ms: None,
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "a malformed mailbox_id should be a tool error"
+        );
+    }
+
+    /// `capture_frame` with an unknown kind in the mails bundle is
+    /// rejected up front — the bundle is encoded before any RPC.
+    #[tokio::test]
+    async fn capture_frame_bad_bundle_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .capture_frame(Parameters(CaptureFrameArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                mails: vec![CaptureMailSpec {
+                    recipient_name: "aether.render".to_owned(),
+                    kind_name: "not.a.real.kind".to_owned(),
+                    params: None,
+                }],
+                after_mails: vec![],
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "an unknown kind in the bundle should be a tool error",
+        );
+    }
+
+    /// `describe_component` reads the component cache: an empty cache
+    /// errors, a seeded entry round-trips.
+    #[tokio::test]
+    async fn describe_component_reads_the_cache() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let engine_id = "00000000-0000-0000-0000-000000000001";
+        // A real, taggable mailbox id (arbitrary u64s don't carry the
+        // mailbox-domain bits `tagged_id::encode` needs).
+        let mailbox = mailbox_id_from_name("aether.test.fake_component");
+        let tagged = tagged_id::encode(mailbox.0).expect("mailbox id is taggable");
+
+        // Empty cache → error.
+        let miss = mcp
+            .describe_component(Parameters(DescribeComponentArgs {
+                engine_id: engine_id.to_owned(),
+                mailbox_id: tagged.clone(),
+            }))
+            .await;
+        assert!(
+            miss.is_err(),
+            "an uncached component should be a tool error"
+        );
+
+        // Seed the cache, then it round-trips.
+        let engine = EngineId(Uuid::parse_str(engine_id).unwrap());
+        mcp.components
+            .lock()
+            .unwrap()
+            .insert((engine, mailbox), ComponentCapabilities::default());
+        let hit = mcp
+            .describe_component(Parameters(DescribeComponentArgs {
+                engine_id: engine_id.to_owned(),
+                mailbox_id: tagged,
+            }))
+            .await
+            .expect("cached component describes");
+        let caps: serde_json::Value = serde_json::from_str(&hit).expect("json");
+        assert!(caps.get("handlers").is_some(), "capabilities shape: {hit}");
     }
 }


### PR DESCRIPTION
## Summary

P5c of issue 763's forward-model RPC architecture: the five remaining MCP tools, completing the `aether-mcp` tool surface.

- **`load_component` / `replace_component`** — read the wasm from disk, build the `LoadComponent` / `ReplaceComponent` kind, `engine = Some` Call to the substrate's `aether.component` mailbox via `call_one`, decode the typed `LoadResult` / `ReplaceResult`.
- **`capture_frame`** — schema-encode the `mails` / `after_mails` bundles into `aether_kinds::MailEnvelope`, `engine = Some` Call to `aether.render`, decode `CaptureFrameResult`, return the PNG as base64 image content (`Result<CallToolResult, _>`).
- **`describe_kinds` / `describe_component`** answer **locally** rather than forwarding — the proxy's `HelloAck` manifest is `{id, name}`-only, too thin to be the "proxy handler" the issue sketched:
  - `describe_kinds` renders the static `aether_kinds::descriptors::all()` inventory (substrate vocab + full schemas, no round-trip). Loses per-engine fidelity and component-defined kinds vs the embedded tool — acceptable, since `send_mail` already encodes params against this same set.
  - `describe_component` reads a process-wide component-capability cache (keyed by `engine + mailbox`), populated from `load_component` / `replace_component` replies — the forward-model stand-in for the embedded hub's component registry.

The embedded `aether-substrate-bundle::hub::mcp` path is still untouched and `.mcp.json` unchanged — the cutover is P5d.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run --workspace --retries 2` — 1133 passed (two pre-existing timing flakes in `aether-substrate` / `aether-capabilities` — crates this PR doesn't touch — pass on retry)
- [x] 5 new `aether-mcp` tests against an in-process hub chassis: the forwarded-call tools surface their error arms (missing binary, malformed mailbox id, bad capture bundle), `describe_kinds` renders the inventory, `describe_component` round-trips a seeded cache entry.

Part of iamacoffeepot/aether#763 (P5c) — does not close the umbrella. Next: P5d — point `.mcp.json` at `aether-mcp`, strip the `rmcp` / `axum` deps from `aether-substrate-bundle`, collapse the hub, and close iamacoffeepot/aether#763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)