### PR TITLE
feat(aether-mcp): point .mcp.json at aether-mcp; hub RPC server on by default

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "aether-hub": {
       "type": "http",
-      "url": "http://127.0.0.1:8888/mcp"
+      "url": "http://127.0.0.1:8890/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,11 @@ The chassis layer consolidated in May 2026 (ADR-0073). All four chassis live in 
 
 ## MCP harness
 
-Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. Starting `cargo run -p aether-substrate-bundle --bin aether-substrate-hub` (and either letting the hub spawn substrates via `spawn_substrate`, or running `AETHER_HUB_URL=127.0.0.1:8889 cargo run -p aether-substrate-bundle --bin aether-substrate` by hand — `--bin aether-substrate-headless` for workloads that don't need a window or GPU, ADR-0035) exposes eleven tools to a Claude Code session pointed at the project-scoped `.mcp.json`:
+Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision.
+
+**Issue 763 P5 — the harness is moving out-of-process (migration in progress).** The MCP coordinator now lives in the standalone `aether-mcp` crate — an RPC client that dials the hub, not an embedded server. The dev workflow is two processes: start the hub (`cargo run -p aether-substrate-bundle --bin aether-substrate-hub`; it now boots its RPC server on `127.0.0.1:8901` by default), then start `cargo run -p aether-mcp` (it dials the hub there and serves MCP on `127.0.0.1:8890`, where `.mcp.json` points). Get a substrate with `spawn_substrate` — `aether-mcp` tracks the engines the hub forks via the `aether.engine` cap. `aether-mcp` exposes nine of the eleven tools below; `receive_mail` is dropped (broadcast retires) and `engine_logs` is deferred (substrate-side pull migration). The embedded hub MCP server (`:8888`) still compiles but is unwired from `.mcp.json` — it and this section's full rewrite retire in P5e.
+
+The tool surface a Claude Code session sees:
 
 - `mcp__aether-hub__list_engines` — connected engines (UUID + name/pid/version + `spawned` flag: `true` if the hub launched the process, `false` if it connected externally).
 - `mcp__aether-hub__describe_kinds(engine_id)` — the kind vocabulary the engine declared at handshake, with enough structural detail to build params.

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -41,8 +41,8 @@ use crate::hub::loopback::{
     LoopbackEngine, LoopbackHandle, run_inbound_drainer, spawn_outbound_drainer,
 };
 use crate::hub::{
-    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, EngineRegistry, HubState, LogStore, PendingSpawns,
-    SessionRegistry, run_engine_listener, run_mcp_server,
+    DEFAULT_ENGINE_PORT, DEFAULT_MCP_PORT, DEFAULT_RPC_PORT, EngineRegistry, HubState, LogStore,
+    PendingSpawns, SessionRegistry, run_engine_listener, run_mcp_server,
 };
 
 /// Grace window per child when the hub shuts down. Shorter than
@@ -75,29 +75,32 @@ impl Chassis for HubChassis {
 pub struct HubEnv {
     pub engine_addr: SocketAddr,
     pub mcp_addr: SocketAddr,
-    /// Issue 750: optional `aether.rpc.server` bind address. Populated
-    /// from `AETHER_RPC_PORT`; `None` (default) skips booting
-    /// `RpcServerCapability` so existing chassis behavior is
-    /// unchanged.
+    /// `aether.rpc.server` bind address. Issue 763 P5d: the hub now
+    /// boots its RPC server unconditionally — it's the target the
+    /// out-of-process `aether-mcp` coordinator dials — so
+    /// [`HubEnv::from_env`] always populates this (`AETHER_RPC_PORT`
+    /// overrides the port). The field stays `Option` so embedders
+    /// constructing `HubEnv` directly (tests) can still opt out with
+    /// `None`.
     pub rpc_addr: Option<SocketAddr>,
 }
 
 impl HubEnv {
     /// Read `AETHER_ENGINE_PORT` / `AETHER_MCP_PORT` / `AETHER_RPC_PORT`
     /// from the environment; fall back to [`DEFAULT_ENGINE_PORT`] /
-    /// [`DEFAULT_MCP_PORT`] when unset or unparseable. `AETHER_RPC_PORT`
-    /// has no default — absent means RpcServer doesn't boot. Binds
-    /// every listener on `127.0.0.1` — intentional for the current
-    /// single-host development story.
+    /// [`DEFAULT_MCP_PORT`] / [`DEFAULT_RPC_PORT`] when unset or
+    /// unparseable. Binds every listener on `127.0.0.1` — intentional
+    /// for the current single-host development story.
     pub fn from_env() -> Self {
         use std::net::{IpAddr, Ipv4Addr};
         let engine_port = env_port("AETHER_ENGINE_PORT").unwrap_or(DEFAULT_ENGINE_PORT);
         let mcp_port = env_port("AETHER_MCP_PORT").unwrap_or(DEFAULT_MCP_PORT);
+        let rpc_port = env_port("AETHER_RPC_PORT").unwrap_or(DEFAULT_RPC_PORT);
         let loopback = IpAddr::V4(Ipv4Addr::LOCALHOST);
         Self {
             engine_addr: SocketAddr::new(loopback, engine_port),
             mcp_addr: SocketAddr::new(loopback, mcp_port),
-            rpc_addr: env_port("AETHER_RPC_PORT").map(|p| SocketAddr::new(loopback, p)),
+            rpc_addr: Some(SocketAddr::new(loopback, rpc_port)),
         }
     }
 }

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -93,6 +93,12 @@ pub use spawn::{
 /// fixes this; `AETHER_ENGINE_PORT` overrides.
 pub const DEFAULT_ENGINE_PORT: u16 = 8889;
 
+/// Default port the hub binds its `aether.rpc.server` on (issue 763).
+/// The hub now boots its RPC server unconditionally — it's the target
+/// the out-of-process `aether-mcp` coordinator dials (matching that
+/// crate's `DEFAULT_HUB_RPC_ADDR`). `AETHER_RPC_PORT` overrides.
+pub const DEFAULT_RPC_PORT: u16 = 8901;
+
 /// Run the engine listener loop on `addr`, dispatching each accepted
 /// connection to a per-connection task. Returns on listener error
 /// only; individual connection failures are logged and isolated.


### PR DESCRIPTION
## Summary

The **validatable half of the MCP cutover** (issue 763 P5d): Claude Code now drives engines through the out-of-process `aether-mcp` coordinator instead of the hub's embedded MCP server.

- **`.mcp.json`** points at `aether-mcp`'s port (8890) instead of the embedded hub MCP (8888).
- **The hub chassis boots its `RpcServerCapability` unconditionally** — `HubEnv::from_env` defaults `rpc_addr` to `127.0.0.1:8901` (`aether-mcp`'s `DEFAULT_HUB_RPC_ADDR`) when `AETHER_RPC_PORT` is unset, so the two-process dev workflow needs no env var. The field stays `Option` so embedders / tests can still opt out.
- **CLAUDE.md** gets a focused migration note on the new two-process workflow; the full harness-section rewrite lands with P5e.

**Deliberately reversible.** The embedded `hub/mcp/` server still compiles and the old engine-listener model is untouched — nothing is deleted. This is the safe step the split was chosen for: `aether-mcp` can now be driven by a real Claude Code session and shake out bugs before P5e demolishes the old model.

### Dev workflow after this PR

```
cargo run -p aether-substrate-bundle --bin aether-substrate-hub   # RPC server on :8901
cargo run -p aether-mcp                                           # dials :8901, serves MCP on :8890
```

`.mcp.json` points Claude Code at `:8890`. `aether-mcp` exposes 9 of the 11 tools (`receive_mail` dropped, `engine_logs` deferred).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run --workspace --retries 2` — 1133 passed (nothing deleted, nothing broken)
- [ ] Real validation is the point of the split: drive `aether-mcp` from a live Claude Code session before P5e.

Part of iamacoffeepot/aether#763 (P5d) — does not close the umbrella. P5e demolishes the old hub model (embedded MCP + engine listener + sessions + loopback drainers + `ProcessCapability`), strips the `rmcp` / `axum` deps, collapses the chassis, rewrites the harness docs, and closes iamacoffeepot/aether#763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)