### PR TITLE
feat(skills): add /audit skill — symbolic per-crate code-quality scan

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -89,34 +89,36 @@ If `<type>` or `<crate>` is missing or unknown, stop and surface the gap — don
 
 Each procedure starts with the RustRover tools it relies on and the symbolic queries it issues. None of them grep for type shapes — text search appears only where the question is literally about text (e.g. is a name mentioned in a comment).
 
-### `unused` — unused fields, methods, pub items
+### `unused` — unused fields, methods, items
 
-**Tools**: `mcp__rustrover__get_file_problems` (primary), `mcp__rustrover__search_symbol`, `mcp__rustrover__get_symbol_info`.
+**Tools**: `mcp__rustrover__get_file_problems`.
 
-Two passes:
+For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. The tool returns problems as `{ severity, description, lineContent, line, column }` — there's no structured category tag, so filtering happens on the description string. Keep problems whose `description` matches a case-insensitive `Unused | Dead | Never used | does nothing | unreachable | redundant import | never read` substring. Each surviving problem becomes a `U<n>` finding. Severity mapping: `WARNING` and above → high, `WEAK WARNING` → medium, `INFORMATION` → low (the resolver is symbolic — false positives here are rare and almost always intentional `#[allow]` candidates).
 
-1. **IDE inspections per file.** For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. Filter to inspection categories whose name carries `Unused` / `Dead` / `NoEffect` (e.g. `RsDeadCode`, `RsUnusedImport`, `RsUnusedVariable`, `RsUnusedFunction`, `RsUnusedField`). Each surviving problem becomes a `U<n>` finding; severity high (the resolver is symbolic — false positives here are rare and almost always intentional `#[allow]` candidates).
+The report's Architecture Observed section lists the crate's module + pub surface (just by reading `src/lib.rs` and `src/*.rs` headers — no symbolic enumeration needed) so the reader sees the denominator before reading findings.
 
-2. **Pub-but-unimported scan.** `search_symbol` over `<crate>/**/src/**/*.rs` with the crate's name as a `q` seed isn't useful directly — instead, enumerate pub items by issuing `search_symbol` for the crate's module names (the entry points the IDE knows about), then walk each returned symbol via `get_symbol_info` to read its visibility + check the IDE's resolved reference list. A pub item with zero external resolved references → `U<n>` finding (severity: medium — pub items may be intended for future external API or `#[cfg(test)]` consumers; the finding body has to call out the ambiguity).
-
-The report's Architecture Observed section lists the crate's pub surface (counts by item kind, derived from `search_symbol`) so the reader sees what "pub" means for this crate before reading findings.
+**Deferred from v1 — cross-crate pub-but-unimported pass.** RustRover's built-in "Unused declaration" inspection conservatively skips `pub` items (since `pub` declares external API intent), so an item that's pub and only used within the same crate doesn't surface in `get_file_problems`. Properly finding cross-crate unused pubs requires either a workspace-PSI walk via `run_inspection_kts` (expensive per-name; needs verification that the API exposes reference lookup) or a textual `use <crate>::` reconciliation (drops the symbolic guarantee). Surfaced during the skill's first smoke against `aether-codec`; deferred to a future PR rather than shipped with a shaky implementation.
 
 Commit type when filing: `refactor` (or `chore` for pure deletion of dead code with no behavioural surface).
 
 ### `concurrency` — concurrency primitive smells
 
-**Tools**: `mcp__rustrover__search_symbol` (primary entry point), `mcp__rustrover__get_symbol_info` (resolution + type-shape inspection), `mcp__rustrover__run_inspection_kts` (for patterns that need PSI walking).
+**Tools**: `mcp__rustrover__run_inspection_kts` (primary — PSI + resolver walks per pattern), `mcp__rustrover__generate_inspection_kts_api` + `generate_inspection_kts_examples` (consulted when writing or revising a pattern's kts script).
+
+The patterns in this category ask questions of the form "find every struct field whose resolved type tree matches X" — that's field-type enumeration over PSI, not name-fragment lookup. `search_symbol` returns hits by name; it can't be inverted to "give me all fields of resolved type Y". So the primary path is a per-pattern kts script the audit runs via `run_inspection_kts` against each file in `<crate>/src`.
 
 The pattern catalogue lives in `patterns/concurrency.md` (sibling of this file); load it and apply each pattern in order. Each pattern entry specifies:
 - The **symbolic question** it asks (e.g. "find every field whose resolved type is `Arc<Mutex<Option<T>>>` for any `T`").
-- The **primary tool** + the symbolic query (e.g. `search_symbol q: "Mutex"`, then for each hit `get_symbol_info` and inspect the resolved generic args).
-- An **optional kts script** path under `patterns/kts/` for patterns that need real PSI walking; the procedure runs it via `run_inspection_kts` per file in `<crate>/src`.
+- The **kts script** path under `patterns/kts/<pattern-id>.kts` — the script does the PSI walk + resolver query.
+- An **expected output shape** so the aggregator can convert per-file results into clustered findings.
 
-Each hit becomes a `C<n>` finding; per-pattern severity + suggested-fix text live in the catalogue.
+Each surviving hit becomes a `C<n>` finding; per-pattern severity + suggested-fix text live in the catalogue.
 
-Architecture Observed for `concurrency` enumerates the crate's sync primitives in use (Mutex / RwLock / Atomic / Condvar / channel kinds), thread-creation sites, and channel-creation sites with their bounds (or unbounded) — all gathered through `search_symbol` for `Mutex`, `RwLock`, `spawn`, `channel`, etc., then `get_symbol_info` to confirm the resolved source (`std::sync::Mutex` vs a local alias).
+Architecture Observed for `concurrency` is itself generated by a small inventory kts script (`patterns/kts/inventory.kts`) that walks struct fields + function calls and emits a per-crate primitive census (Mutex count, RwLock count, channel-creation sites with bounds, thread-spawn sites). The findings paragraph then references the inventory.
 
-If a pattern's symbolic query proves infeasible (the inspection API can't express what we need), the catalogue entry is flagged `status: deferred — kts unsupported` rather than degrading to a regex fallback. Better to under-report than to silently switch off the symbolic guarantee.
+**Honest limitation**: the kts scripts haven't been verified against Rust PSI yet. The first run of `/audit concurrency <crate>` is the verification — `run_inspection_kts` returns compilation errors if a script can't reach the Rust PSI types it needs. If a pattern's script fails to compile, that pattern is flagged `status: deferred — kts unsupported` in the catalogue rather than degrading to a regex fallback; better to under-report than to silently switch off the symbolic guarantee.
+
+Until a `/audit concurrency <crate>` run successfully populates findings end-to-end, treat the concurrency category as v1-pending and skip it for routine use. The simpler `unused` and `dup` categories are unblocked today via `get_file_problems`.
 
 Commit type when filing: `refactor`.
 
@@ -139,17 +141,15 @@ Commit type when filing: `refactor` for magic-string findings, `chore` for stale
 
 ### `dup` — duplicated code
 
-**Tools**: `mcp__rustrover__run_inspection_kts` (primary; PSI-subtree hashing), with `mcp__rustrover__generate_inspection_kts_api` + `generate_inspection_kts_examples` consulted when writing or revising the duplicate-detection script.
+**Tools**: `mcp__rustrover__get_file_problems` (primary), `mcp__rustrover__get_symbol_info` (used when aggregating clusters across files).
 
-Function-body duplicate detection within `<crate>/src` + `<crate>/tests`. Cross-crate dup is out of scope for v1 (forcing function deferred).
+Verified during the skill's first smoke (against `aether-codec`): RustRover's built-in Duplicates inspection runs as part of `get_file_problems` and returns symbolic findings of the form `"Duplicated code fragment (<N> lines long)"`. No custom kts script needed for v1 — the IDE's PSI-driven dup detector already does the work the audit was going to script by hand.
 
-1. The dup detection script lives at `patterns/kts/duplicate-bodies.kts` (sibling of this file). It walks function PSI subtrees, normalizes ident names to placeholders, hashes per-statement, and flags clusters of size ≥ 2. The script is the symbolic engine here — no regex sliding-window approximation.
-2. For each file under `<crate>/src` and `<crate>/tests`, call `run_inspection_kts` with the script as `inspectionKtsCode` and the file as `contextPath`. Aggregate the per-file results into clusters across the crate.
-3. Each cluster of size ≥ 2 across distinct functions becomes a `D<n>` finding. Severity: high if 100% normalized match across all sites, medium if 80–99% match, low if 70–80% (skip <70%).
+1. For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. Filter problems whose `description` matches `Duplicated code fragment`. Each problem carries the file + the starting line of one duplicate; aggregate across files into clusters by parsing the `(<N> lines long)` length and locating the matching block in the second file via `search_symbol` for the leading identifier on the duplicated lines.
+2. Each cluster of size ≥ 2 across distinct functions becomes a `D<n>` finding. Severity heuristic: the IDE inspection reports `WEAK WARNING` for every dup it finds — promote to medium if the cluster spans ≥ 15 lines, medium-low otherwise. (The dup-finding shape doesn't currently carry confidence — RustRover's inspection either matches or doesn't.)
+3. Architecture Observed for `dup` lists the crate's function inventory (counts by module) so the reader sees the denominator.
 
-Architecture Observed for `dup` lists the crate's function inventory (counts by module) so the reader sees the denominator.
-
-**Honest limitation**: this depends on whether `run_inspection_kts` exposes Rust PSI access via the inspection.kts API. The first run of `/audit dup <crate>` is the verification — if the script fails to compile because the Rust PSI types aren't reachable, the failure surface is loud (the tool returns compilation errors), and the skill's procedure documents that we'd revisit the duplicates inspection or fall back to invoking RustRover's built-in "Locate Duplicates" action via a different MCP path. Until verified, treat `dup` as the highest-risk category in this skill.
+For dup clusters that need richer detection — semantically-equivalent functions written with different variable names, or cross-crate dup — promote to a custom kts script under `patterns/kts/duplicates-deep.kts` and ride `run_inspection_kts`. Deferred until v1's built-in pass proves insufficient.
 
 Commit type when filing: `refactor`.
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -145,11 +145,12 @@ Commit type when filing: `refactor` for magic-string findings, `chore` for stale
 
 Verified during the skill's first smoke (against `aether-codec`): RustRover's built-in Duplicates inspection runs as part of `get_file_problems` and returns symbolic findings of the form `"Duplicated code fragment (<N> lines long)"`. No custom kts script needed for v1 — the IDE's PSI-driven dup detector already does the work the audit was going to script by hand.
 
-1. For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. Filter problems whose `description` matches `Duplicated code fragment`. Each problem carries the file + the starting line of one duplicate; aggregate across files into clusters by parsing the `(<N> lines long)` length and locating the matching block in the second file via `search_symbol` for the leading identifier on the duplicated lines.
-2. Each cluster of size ≥ 2 across distinct functions becomes a `D<n>` finding. Severity heuristic: the IDE inspection reports `WEAK WARNING` for every dup it finds — promote to medium if the cluster spans ≥ 15 lines, medium-low otherwise. (The dup-finding shape doesn't currently carry confidence — RustRover's inspection either matches or doesn't.)
-3. Architecture Observed for `dup` lists the crate's function inventory (counts by module) so the reader sees the denominator.
+1. For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. Filter problems whose `description` matches `Duplicated code fragment` — the format is `Duplicated code fragment (<N> lines long)`.
+2. Each surviving problem becomes a `D<n>` finding. **Honest limitation**: `get_file_problems` returns each dup site standalone — it doesn't carry the partner location. RustRover's UI shows the partner in its tooltip and via Find Usages, but the MCP tool doesn't expose that link directly. The skill's per-finding body therefore includes the dup's line + length + leading line content, and notes that the partner is locatable by opening the file in RustRover or by string-matching the leading line against sibling files in the same crate.
+3. The skill DOES attempt an inferred-cluster pass as a hint: group findings whose `(leading_line, length)` tuple matches across files. Findings in the same inferred cluster get the same `D<n>` ID with sub-letters (`D1a`, `D1b`); findings the inference can't pair stay standalone. Severity heuristic: medium if length ≥ 15 lines, medium-low otherwise.
+4. Architecture Observed for `dup` lists the crate's function inventory (counts by module) so the reader sees the denominator.
 
-For dup clusters that need richer detection — semantically-equivalent functions written with different variable names, or cross-crate dup — promote to a custom kts script under `patterns/kts/duplicates-deep.kts` and ride `run_inspection_kts`. Deferred until v1's built-in pass proves insufficient.
+For dup clusters that need richer detection — semantically-equivalent functions written with different variable names, cross-crate dup, or the partner-location info the built-in inspection withholds — promote to a custom kts script under `patterns/kts/duplicates-deep.kts` and ride `run_inspection_kts`. Deferred until v1's built-in pass proves insufficient.
 
 Commit type when filing: `refactor`.
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: audit
+description: Run a code-quality scan on a single workspace crate and write a narrative audit report under `/audits/`. Invoke as `/audit <type> <crate>` where <type> ∈ {dup, unused, concurrency, stale} and <crate> is a workspace member (e.g. `/audit concurrency aether-substrate`). After the report writes, prompts which findings to file as GitHub issues. Use when a crate has grown enough to accrete smells worth a thoughtful read.
+---
+
+# Audit skill
+
+Category-driven code-quality scan over a single workspace crate. Each type targets a different class of smell — duplicated code, unused symbols, concurrency primitive misuse, stale comments + magic-string duplication — and produces a narrative audit report under `/audits/`. After the report lands, the user picks which findings warrant GitHub issues.
+
+The report shape matches the prior hand-written audits already in `/audits/`: executive summary, architecture observed for the area, then detailed findings with stable IDs that issue-filing can reference.
+
+**Symbolic only — no regex pattern matching.** Findings come from RustRover's symbol resolver, not text grep. The IDE knows when `Slot<T>` aliases to `Arc<Mutex<Option<T>>>`; a regex doesn't. Every category's procedure leans on `mcp__rustrover__*` symbol/PSI tools as the primary path; textual search appears only when the question is genuinely textual (e.g. "is this name mentioned in a comment?").
+
+## Arguments
+
+`<type>` — one of: `dup` | `unused` | `concurrency` | `stale`.
+`<crate>` — a workspace member name (e.g. `aether-substrate`, `aether-capabilities`); must resolve via `cargo metadata --no-deps`.
+
+Example: `/audit concurrency aether-capabilities`
+
+If `<type>` or `<crate>` is missing or unknown, stop and surface the gap — don't guess.
+
+## Procedure
+
+1. **Validate inputs.** Check `<type>` against the four known categories. Resolve `<crate>` via `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "<crate>") | .manifest_path'`. If either fails, surface what's wrong and stop. Verify `mcp__rustrover__*` tools are available in the session; if not, stop with "RustRover MCP plugin must be enabled — bring up RustRover with the project open and retry." The skill cannot degrade to grep-only; the symbolic engine is load-bearing.
+
+2. **Resolve crate root.** Strip `/Cargo.toml` from the manifest path. The scan walks `src/` for every type, plus `tests/` for `dup` and `unused` (dead test code matters).
+
+3. **Run the type-specific scan** (see per-type procedures below). Each scan emits a list of findings with stable per-type IDs — `D<n>` (dup), `U<n>` (unused), `C<n>` (concurrency), `S<n>` (stale) — assigned in file:line order so re-running the scan produces stable references unless the source moved.
+
+4. **Write the narrative report.** Target path: `audits/<CRATE_UPPER>_<TYPE_UPPER>_AUDIT_<YYYYMMDD_HHMMSS>.md`. The `<CRATE_UPPER>` is the crate name uppercased with hyphens → underscores (`aether-substrate` → `AETHER_SUBSTRATE`). `<TYPE_UPPER>` is one of `DUP` / `UNUSED` / `CONCURRENCY` / `STALE`. The timestamp is local time.
+
+   Section layout (mirrors the existing `/audits/CODE_*_AUDIT_*.md` reports):
+
+   ```markdown
+   # <Type human name> Audit — <crate>
+
+   Audit timestamp: <YYYY-MM-DD HH:MM:SS Zone>
+   Repository: `aether`
+   Crate scope: `crates/<crate>` (or `demos/<crate>`)
+   Git head: `<short-sha>` (or `<short-sha>-dirty` if working tree is dirty)
+   Tooling: RustRover MCP — list of `mcp__rustrover__*` tools actually called this run.
+
+   ## Scope
+
+   Two or three sentences describing what this audit type catches and what it does NOT cover. Explicit about FP risk for the `stale` type.
+
+   ## Executive Summary
+
+   <n> findings; <n_high> high-severity, <n_medium> medium, <n_low> needs-review.
+
+   One paragraph naming the dominant pattern across findings (e.g. "Three of four findings cluster around `Arc<Mutex<...>>` cap state — a retrofit pattern from issue 629 that ADR-0038 was supposed to retire").
+
+   ## Architecture Observed
+
+   Two to four short subsections walking the crate's relevant structure for the audit type. For `concurrency`: synchronization primitives in use, thread model, channel boundaries (built from `search_symbol` enumerations). For `dup`: module layout + which areas grew copy-paste fastest. For `unused`: pub surface inventory (from `search_symbol` filtered to `pub`). For `stale`: any ADR-superseded module names still present. Cite files inline (`file:line`).
+
+   ## Findings
+
+   ### <ID> — <one-line summary>
+
+   - **Severity**: high | medium | low
+   - **Location**: `<file>:<line>` (clickable file path)
+   - **How surfaced**: which RustRover tool + which inspection / query returned this finding (e.g. "`get_file_problems` → `RsDeadCode`", or "`search_symbol` for `Mutex` filtered by `get_symbol_info` resolving to `std::sync::Mutex<Option<…>>`").
+
+   Two or three paragraphs of context: what the code does, what the pattern catches, why it's flagged. Quote 3–8 lines of source when the shape isn't obvious from a one-line summary.
+
+   **Suggested action**: one paragraph; either a concrete fix or "needs human read because <reason>".
+
+   ### <ID> — ...
+   ```
+
+   `audits/` is gitignored — reports live on disk locally. Issues filed from them link to source files (not the report path).
+
+5. **Prompt for issue filing.** Print the report path and a short summary (number of findings per severity), then use `AskUserQuestion` with a multiSelect listing each finding by `<ID> — <one-line summary>`. AskUserQuestion caps at 4 options per question; for >4 findings, batch via multiple AskUserQuestion calls or fall back to "reply with a space-separated ID list (e.g. `C1 C3 C7`)".
+
+   For each chosen finding:
+   - **Title**: `<commit-type>(<crate>): <finding summary>` where `<commit-type>` per category is `refactor` (dup, unused, concurrency, stale-magic-string) or `chore` (stale-comments, pure deletion).
+   - **Body**: paste the finding's report section verbatim, then a footer:
+     ```
+     ---
+     Surfaced by `/audit <type> <crate>`. Local report:
+     `<audits/...>` (not committed; report lives in the gitignored `/audits/` dir).
+     ```
+   - **Labels**: `triage`, `crate:<crate-short-name>` (matches the CI auto-labeler's convention), and `audit:<type>`.
+   - **Cross-issue refs**: use the cross-repo `iamacoffeepot/aether#NNN` form per the project's pr-body hook (memory `feedback_close_keyword_hook_strips_hash`).
+
+## Per-type procedures
+
+Each procedure starts with the RustRover tools it relies on and the symbolic queries it issues. None of them grep for type shapes — text search appears only where the question is literally about text (e.g. is a name mentioned in a comment).
+
+### `unused` — unused fields, methods, pub items
+
+**Tools**: `mcp__rustrover__get_file_problems` (primary), `mcp__rustrover__search_symbol`, `mcp__rustrover__get_symbol_info`.
+
+Two passes:
+
+1. **IDE inspections per file.** For each file under `<crate>/src` and `<crate>/tests`, call `get_file_problems` with `errorsOnly: false`. Filter to inspection categories whose name carries `Unused` / `Dead` / `NoEffect` (e.g. `RsDeadCode`, `RsUnusedImport`, `RsUnusedVariable`, `RsUnusedFunction`, `RsUnusedField`). Each surviving problem becomes a `U<n>` finding; severity high (the resolver is symbolic — false positives here are rare and almost always intentional `#[allow]` candidates).
+
+2. **Pub-but-unimported scan.** `search_symbol` over `<crate>/**/src/**/*.rs` with the crate's name as a `q` seed isn't useful directly — instead, enumerate pub items by issuing `search_symbol` for the crate's module names (the entry points the IDE knows about), then walk each returned symbol via `get_symbol_info` to read its visibility + check the IDE's resolved reference list. A pub item with zero external resolved references → `U<n>` finding (severity: medium — pub items may be intended for future external API or `#[cfg(test)]` consumers; the finding body has to call out the ambiguity).
+
+The report's Architecture Observed section lists the crate's pub surface (counts by item kind, derived from `search_symbol`) so the reader sees what "pub" means for this crate before reading findings.
+
+Commit type when filing: `refactor` (or `chore` for pure deletion of dead code with no behavioural surface).
+
+### `concurrency` — concurrency primitive smells
+
+**Tools**: `mcp__rustrover__search_symbol` (primary entry point), `mcp__rustrover__get_symbol_info` (resolution + type-shape inspection), `mcp__rustrover__run_inspection_kts` (for patterns that need PSI walking).
+
+The pattern catalogue lives in `patterns/concurrency.md` (sibling of this file); load it and apply each pattern in order. Each pattern entry specifies:
+- The **symbolic question** it asks (e.g. "find every field whose resolved type is `Arc<Mutex<Option<T>>>` for any `T`").
+- The **primary tool** + the symbolic query (e.g. `search_symbol q: "Mutex"`, then for each hit `get_symbol_info` and inspect the resolved generic args).
+- An **optional kts script** path under `patterns/kts/` for patterns that need real PSI walking; the procedure runs it via `run_inspection_kts` per file in `<crate>/src`.
+
+Each hit becomes a `C<n>` finding; per-pattern severity + suggested-fix text live in the catalogue.
+
+Architecture Observed for `concurrency` enumerates the crate's sync primitives in use (Mutex / RwLock / Atomic / Condvar / channel kinds), thread-creation sites, and channel-creation sites with their bounds (or unbounded) — all gathered through `search_symbol` for `Mutex`, `RwLock`, `spawn`, `channel`, etc., then `get_symbol_info` to confirm the resolved source (`std::sync::Mutex` vs a local alias).
+
+If a pattern's symbolic query proves infeasible (the inspection API can't express what we need), the catalogue entry is flagged `status: deferred — kts unsupported` rather than degrading to a regex fallback. Better to under-report than to silently switch off the symbolic guarantee.
+
+Commit type when filing: `refactor`.
+
+### `stale` — stale comments + magic-string duplication
+
+**Tools**: `mcp__rustrover__search_symbol` (resolves whether a name is still a live symbol), `mcp__rustrover__search_in_files_by_text` (only for the genuinely textual question "does this name appear in a comment").
+
+Two passes:
+
+1. **Retired-symbol references.** Pattern list at `patterns/stale-symbols.md` — symbols that retired or renamed, with their retirement PR/issue and successor. For each entry:
+   - Call `search_symbol` for `<symbol>` scoped to `<crate>/**`. If the symbolic resolver returns a hit, the symbol is still alive in this crate — that's a `S<n>` finding (someone reintroduced or never removed an identifier the catalogue marks as retired). Severity: high.
+   - If the symbolic resolver returns no hit, fall through to `search_in_files_by_text` for the name. Hits that aren't inside an annotated history marker (`// historical:`, `// pre-#NNN`, `// ADR-NNNN superseded by`) become `S<n>` findings — the name only appears in comments/strings. Severity: medium.
+   - The finding body cites the retirement PR + successor.
+
+2. **Magic-string mailbox names.** For each `<Cap>` cap available in the crate (enumerated via `search_symbol` for symbols ending in `Capability`), call `get_symbol_info` on the cap to read its `NAMESPACE` const. Then `search_in_files_by_text` for that exact string literal under `<crate>/src`. Hits inside files that import the cap but use the literal instead of `mailbox_id_from_name(<Cap>::NAMESPACE)` → `S<n>` finding (severity: medium). Hits inside files that don't import the cap are surfaced as needs-review (severity: low — verify intentional literal).
+
+The `stale` type has the highest FP rate among the four. The report's Scope section calls this out explicitly so the reader applies extra skepticism, and the AskUserQuestion prompt at the end defaults severity-low findings to unchecked.
+
+Commit type when filing: `refactor` for magic-string findings, `chore` for stale-comment cleanup.
+
+### `dup` — duplicated code
+
+**Tools**: `mcp__rustrover__run_inspection_kts` (primary; PSI-subtree hashing), with `mcp__rustrover__generate_inspection_kts_api` + `generate_inspection_kts_examples` consulted when writing or revising the duplicate-detection script.
+
+Function-body duplicate detection within `<crate>/src` + `<crate>/tests`. Cross-crate dup is out of scope for v1 (forcing function deferred).
+
+1. The dup detection script lives at `patterns/kts/duplicate-bodies.kts` (sibling of this file). It walks function PSI subtrees, normalizes ident names to placeholders, hashes per-statement, and flags clusters of size ≥ 2. The script is the symbolic engine here — no regex sliding-window approximation.
+2. For each file under `<crate>/src` and `<crate>/tests`, call `run_inspection_kts` with the script as `inspectionKtsCode` and the file as `contextPath`. Aggregate the per-file results into clusters across the crate.
+3. Each cluster of size ≥ 2 across distinct functions becomes a `D<n>` finding. Severity: high if 100% normalized match across all sites, medium if 80–99% match, low if 70–80% (skip <70%).
+
+Architecture Observed for `dup` lists the crate's function inventory (counts by module) so the reader sees the denominator.
+
+**Honest limitation**: this depends on whether `run_inspection_kts` exposes Rust PSI access via the inspection.kts API. The first run of `/audit dup <crate>` is the verification — if the script fails to compile because the Rust PSI types aren't reachable, the failure surface is loud (the tool returns compilation errors), and the skill's procedure documents that we'd revisit the duplicates inspection or fall back to invoking RustRover's built-in "Locate Duplicates" action via a different MCP path. Until verified, treat `dup` as the highest-risk category in this skill.
+
+Commit type when filing: `refactor`.
+
+## Constraints and notes
+
+- The skill is per-crate by design. Workspace-wide scans cost too much per-run and lose narrative coherence; if a smell pattern truly needs cross-crate visibility, a follow-up issue can capture it without forcing this skill to grow that mode.
+- RustRover MCP tools are required. If the session doesn't have `mcp__rustrover__*` available, the skill fails fast in step 1 — no silent grep fallback. The IDE inspections + symbol resolver are load-bearing; the whole skill's value over a `rg`/`cargo` script is the symbolic precision.
+- `get_file_problems` default timeout is 60 seconds, which can time out on large files (e.g. `crates/aether-substrate/src/lib.rs`). The per-type procedures should pass an explicit `timeout: 120000` for any file ≥ 500 lines and retry once at `300000` before giving up. A timed-out file becomes a skipped-file note in the report's Tooling line, not a finding.
+- Pattern files (`patterns/concurrency.md`, `patterns/stale-symbols.md`) and inspection scripts (`patterns/kts/*.kts`) are append-only — adding patterns or refining a kts script extends the skill without procedure changes. Mark deprecated patterns inline (`status: deprecated — <reason>`) rather than deleting; the history matters for re-running old reports.
+- The report path lives under `/audits/` which is gitignored — reports are local artifacts. Issues filed from a report link to source files, not the report path.
+- Don't auto-file findings. Every issue created from an audit goes through the user's explicit selection step, even when severity is high — false positives in any category cost more than the friction of confirming.
+- For findings whose suggested action is design-bearing (touches an ADR-load-bearing primitive, breaks a public API), the filed issue body should say "design decision required — not `agent`-eligible" rather than presenting a mechanical fix. The `delegate` skill explicitly bails on design-bearing issues; the `audit` skill should not feed it any.
+- After filing, the report stays on disk. If you re-run the same audit type against the same crate later, IDs reset (assignment is per-run) — issues filed from the prior run reference the prior report path in their footer, which still works to find the local file.
+- Pattern catalogue maintenance is manual today. When retiring a symbol or shipping a new concurrency anti-pattern, append to the relevant `patterns/*.md` file in the same PR. A future `/audit-update-patterns` companion that scrapes recent merge commits is parked until the manual cadence hurts.

--- a/.claude/skills/audit/patterns/concurrency.md
+++ b/.claude/skills/audit/patterns/concurrency.md
@@ -1,0 +1,83 @@
+# Concurrency smell patterns
+
+Catalogue used by `/audit concurrency <crate>`. Each entry is a symbolic question the skill asks via RustRover MCP tools, not a regex. The IDE knows when `Slot<T>` aliases to `Arc<Mutex<Option<T>>>` and when a use of `Mutex` actually resolves to `parking_lot::Mutex` instead of `std::sync::Mutex` — leaning on the resolver catches both cases that regex would miss.
+
+**Append-only.** Mark deprecated patterns inline with `status: deprecated — <reason>` rather than deleting; the history matters for reproducing older reports.
+
+Entry shape:
+
+```
+## <stable-id> — <one-line summary>
+
+- **Symbolic question**: <plain-English description of what the audit is asking>
+- **Primary tool**: <mcp__rustrover__... + the query>
+- **Confirmation tool**: <follow-up call to confirm the match isn't an alias false-positive>
+- **kts script** (optional): `patterns/kts/<name>.kts` for patterns that need PSI walking
+- **Severity**: high | medium | low
+- **Suggested action**: <one or two sentences>
+
+<one paragraph rationale, citing memories or ADRs that motivate the pattern>
+```
+
+---
+
+## P-Arc-Mutex-Option — `Arc<Mutex<Option<...>>>` in cap state
+
+- **Symbolic question**: which fields in this crate have a resolved type of `Arc<Mutex<Option<T>>>` for any `T`, including through type aliases?
+- **Primary tool**: `mcp__rustrover__search_symbol` with `q: "Arc"` scoped to `<crate>/**/src/**/*.rs` to enumerate every `Arc` usage site. (RustRover returns symbol coordinates for type references, not just declarations.)
+- **Confirmation tool**: for each hit, `mcp__rustrover__get_symbol_info` at the coords; inspect the resolved generic args. Only count the hit if the resolved type tree matches `Arc<Mutex<Option<*>>>` (any inner type). This filters out plain `Arc<T>` / `Arc<Mutex<T>>` and catches aliased `Slot<T>` forms because the resolver follows aliases.
+- **kts script**: `patterns/kts/arc-mutex-option.kts` — walks PSI for struct fields, asks the resolver for the resolved type, matches the three-deep generic shape. Use the kts route when the per-symbol roundtrip from primary + confirmation is too slow on a large crate.
+- **Severity**: high
+- **Suggested action**: refactor to a bare field; if the slot truly needs to be reset at runtime, use `RefCell<Option<T>>` (actor is single-threaded post-ADR-0038).
+
+Symptomatic of issue-629-era cap state retrofitted from the pre-actor model. Per memory `feedback_actor_state_no_locks`, actor state is plain fields — Mutex / RwLock / Atomic in cap fields signals legacy. Per memory `feedback_existing_primitive_smell`, the first `WasmTrampoline` draft had this exact shape and collapsed to a bare `Sender` field with no synchronization once the design realized `NativeTransport` already had it. -1000 lines.
+
+## P-Mutex-Atomic-coexist — Mutex + Atomic in the same struct
+
+- **Symbolic question**: which structs in this crate have at least one field whose resolved type contains `std::sync::Mutex` and at least one other field whose resolved type contains `core::sync::atomic::Atomic*`?
+- **Primary tool**: `mcp__rustrover__run_inspection_kts` with `patterns/kts/mutex-atomic-coexist.kts` — a per-file PSI walker that enumerates struct decls, asks the resolver for each field's type, and emits a problem when both primitive families appear in the same struct.
+- **Confirmation tool**: not needed; the kts script confirms symbolically.
+- **Severity**: medium
+- **Suggested action**: pick one sync primitive. If the Mutex and the Atomic protect related state, the Atomic is usually redundant (the Mutex already orders access). If they protect independent state, name them so the audit reads them as separate concerns.
+
+Two primitives in one struct often means a writer picked an Atomic for one field, hit a needs-more-than-CAS scenario for another, added a Mutex, and never collapsed. Per the WasmTrampoline collapse in memory `feedback_existing_primitive_smell`, layered primitives usually unwind to one once the design is understood.
+
+## P-loop-sleep — bare polling loop without a channel signal
+
+- **Symbolic question**: which functions in this crate contain a `loop {}` block whose body calls `thread::sleep` (or any function whose resolved fully-qualified path ends in `::sleep`), with no concurrent `select!` / `recv_timeout` / `Condvar::wait_timeout` in the same loop scope?
+- **Primary tool**: `mcp__rustrover__run_inspection_kts` with `patterns/kts/loop-sleep-without-channel.kts` — walks function bodies, finds `loop` PSI nodes, asks the resolver to confirm the inner call resolves to a `sleep` API, then scans the loop body's PSI for any channel-receive call. Reports the loop site only when no channel-receive is present.
+- **Confirmation tool**: not needed; the kts script's resolver query distinguishes `std::thread::sleep` from `tokio::time::sleep` from `cpal::*::sleep` — each is reported separately so the suggested-action paragraph can call out the right replacement (sync vs async).
+- **Severity**: medium
+- **Suggested action**: replace the sleep with a `select!` (sync-channel + shutdown channel) or a `Condvar::wait_timeout` keyed on the actual state being polled.
+
+Per memory `feedback_dont_conflate_failfast_with_sync`: polling barriers often carry two invariants (fail-fast AND implicit per-frame sync); deleting one breaks the other silently. Per memory `feedback_pool_worker_holds_own_sender`: even pool workers that "should" terminate via channel disconnect can polling-loop forever if the channel never closes. A channel-signal makes intent explicit.
+
+## P-hand-rolled-Actor — hand-rolled trait impl bypassing `#[actor]`
+
+- **Symbolic question**: which `impl` blocks in this crate implement `NativeActor` / `FfiActor` / `InstancedNativeActor` / `Actor`, and which of those `impl` blocks are NOT inside an expansion of the `#[actor]` proc-macro?
+- **Primary tool**: `mcp__rustrover__search_symbol` with `q: "NativeActor"` (and once per other trait name) to find all impl sites in the crate. The resolver returns each impl's coords.
+- **Confirmation tool**: `mcp__rustrover__get_symbol_info` on the impl site; inspect whether the IDE's metadata shows the impl was emitted by a proc-macro expansion. Manually-written impls land in the source tree directly; macro expansions are flagged as such by RustRover's resolver.
+- **Severity**: medium (high if the impl is in `src/` outside a `tests` or `examples` subdir)
+- **Suggested action**: convert to `#[actor]` macro form. If the impl is a test fixture, annotate it with `// hand-rolled: test fixture` so the audit can skip it on re-runs (the skill checks for that exact comment marker on the line above the impl).
+
+Per memory `feedback_trait_default_audit_hand_rolled_impls`: production caps inherit via the `#[actor]` macro and pick up trait defaults from the macro expansion (e.g. `Actor::SCHEDULING`). Hand-rolled `impl Trait` blocks silently take the bare trait default — a different default. PR C learned this with `Actor::SCHEDULING` on the way through Phase 3. Test fixtures legitimately hand-roll; production caps should not.
+
+## P-introspection-Arc — `Arc<A>` peering at sibling actor state
+
+- **Symbolic question**: which call sites in this crate invoke `ctx.peer::<A>()`, `ctx.actor::<A>()`, `ctx.resolve_actor::<A>()`, or `chassis.actor::<A>()`, and which of those sites sit inside a method whose surrounding `impl` is annotated with `#[handler]` (i.e. runtime path, not init)?
+- **Primary tool**: `mcp__rustrover__search_symbol` for each of the four method names (one search each — they're distinct symbols, the resolver returns the right call sites).
+- **Confirmation tool**: `mcp__rustrover__get_symbol_info` at each call site; the IDE returns enough context to identify the enclosing function and its annotations. Init-time sites (inside `init` / `wire` of a supervisor cap) are skipped; handler-time sites become findings.
+- **Severity**: high if called inside a `#[handler]`, medium if init-time on a non-supervisor cap.
+- **Suggested action**: if init-time on a supervisor cap, keep — that's the legit bootstrap path. If runtime / handler-time, switch to mail (`ctx.send_to_named`); peering at sibling state violates the actor model.
+
+Per memory `feedback_introspection_shape_constraints`: runtime cap handlers communicate via mail, never via `Arc<A>`. Per memory `feedback_actor_lookup_bootstrap_only`: `actor::<A>()` lookup is bootstrap-only, never on per-handler `NativeCtx`/`WasmCtx`/`WasmInitCtx`. PR 627 closed runtime paths; PR 630 closed init `peer<A>` + chassis `.actor::<X>()`. Cap supervisors hold cap-local children, don't walk the chassis registry.
+
+## P-unbounded-channel — unbounded mpsc on a hot path
+
+- **Symbolic question**: which call sites in this crate invoke `mpsc::channel` / `mpsc::unbounded_channel` / `crossbeam::channel::unbounded` and resolve to an unbounded variant?
+- **Primary tool**: `mcp__rustrover__search_symbol` for `channel`, then `mpsc`, then `unbounded_channel` — each returns the relevant call sites.
+- **Confirmation tool**: `mcp__rustrover__get_symbol_info` at each call site to read the resolved signature; flag the site only when the resolved API has no bound argument (e.g. `std::sync::mpsc::channel()` vs `std::sync::mpsc::sync_channel(N)`).
+- **Severity**: low
+- **Suggested action**: assess whether the channel can ever fill faster than it drains. If yes (component inboxes, hub outbound), specify a bound. If no (one-shot reply paths), keep unbounded but annotate `// intentionally unbounded: <reason>`.
+
+Surfaced by the prior CODE_CONCURRENCY_AUDIT (2026-04-29). Memory growth under slow consumers is a tail risk; the audit catches it but the fix usually wants a domain read. False-positive friendly because much of the codebase rightly uses unbounded for short-lived correlation flows.

--- a/.claude/skills/audit/patterns/stale-symbols.md
+++ b/.claude/skills/audit/patterns/stale-symbols.md
@@ -1,0 +1,67 @@
+# Stale symbol catalogue
+
+Identifiers that retired or renamed and shouldn't appear as live references anymore. Used by `/audit stale <crate>`. The audit asks the resolver first (`search_symbol`) — a hit there means someone reintroduced the identifier and the finding is high-severity. Only when the resolver returns nothing does the audit fall through to a text search for in-comment / in-string mentions (medium-severity stale comment).
+
+**Append-only.** When you retire a new symbol, add an entry here in the same PR. Mark deprecated entries inline with `status: removed-from-catalogue — <reason>` rather than deleting (older audit reports may still cite the entry).
+
+Entry shape:
+
+```
+- `<symbol>` | <retirement PR / issue> | <successor or `removed`> | <optional severity override>
+```
+
+`<symbol>` is the bare identifier the resolver / text search looks for. `<retirement PR>` is the cross-repo form (`iamacoffeepot/aether#NNN`) so the finding body can link back. `<successor>` is the kind name, type, or const that replaced it (or the literal word `removed` if nothing replaced it). The optional severity column overrides the default mapping (live ref = high, comment-only = medium).
+
+---
+
+## Retired in 2026
+
+### Crates / modules
+
+- `aether-id` | iamacoffeepot/aether#444 | `aether-data` typed-id newtypes
+- `aether-mail` | iamacoffeepot/aether#444 | split between `aether-component` (SDK) and `aether-substrate` (dispatcher)
+- `aether-params-codec` | iamacoffeepot/aether#444 | `aether-codec`
+- `aether-hub-protocol` | iamacoffeepot/aether#444 | `aether-substrate-bundle::hub::wire`
+- `aether-substrate-core` | ADR-0073 | `aether-substrate`
+- `aether-substrate-desktop` | ADR-0073 | `aether-substrate-bundle` `desktop` submodule
+- `aether-substrate-headless` | ADR-0073 | `aether-substrate-bundle` `headless` submodule
+- `aether-substrate-hub` | ADR-0073 | `aether-substrate-bundle` `hub` submodule (the binary name `aether-substrate-hub` is preserved as the binary entry point)
+- `aether-substrate-test-bench` | ADR-0073 | `aether-substrate-bundle` `test_bench` submodule
+- `aether-demo-tic-tac-toe` | iamacoffeepot/aether#782 | `removed`
+- `aether-demo-tic-tac-toe-server` | iamacoffeepot/aether#782 | `removed`
+- `aether-demo-tic-tac-toe-client` | iamacoffeepot/aether#782 | `removed`
+
+### Caps + types
+
+- `BroadcastCapability` | iamacoffeepot/aether#778 | `removed`
+- `HubClient` | iamacoffeepot/aether#777 | `removed` (substrate-side; out-of-process `aether-mcp` dials the hub RPC server directly)
+- `connect_hub_client` | iamacoffeepot/aether#777 | `removed`
+- `ProcessCapability` | iamacoffeepot/aether#773 | `removed`
+
+### Kinds + mailbox names
+
+- `HUB_BROADCAST_MAILBOX_NAME` | iamacoffeepot/aether#778 | `removed`
+- `aether.observation.frame_stats` | iamacoffeepot/aether#778 | `removed`
+- `aether.observation.component_died` | iamacoffeepot/aether#778 | `removed`
+- `aether.observation.substrate_dying` | iamacoffeepot/aether#778 | `removed`
+- `aether.observation.monitor_notice` | iamacoffeepot/aether#780 | `aether.actor.monitor_notice`
+- `aether.sink.` (any kind name with this prefix) | ADR-0074 Phase 5 | `aether.<name>` (e.g. `aether.sink.audio` → `aether.audio`)
+- `tic_tac_toe.play_move` | iamacoffeepot/aether#782 | `removed`
+- `tic_tac_toe.reset` | iamacoffeepot/aether#782 | `removed`
+- `tic_tac_toe.game_state` | iamacoffeepot/aether#782 | `removed`
+- `tic_tac_toe.move_result` | iamacoffeepot/aether#782 | `removed`
+
+### APIs / FFI
+
+- `resolve_kind_p32` | ADR-0030 Phase 2 | `Kind::ID` compile-time const
+- `resolve_mailbox_p32` | ADR-0029 | `mailbox_id_from_name(<Cap>::NAMESPACE)` compile-time const
+- `Component::receive` (typelist dispatch) | ADR-0033 | `#[handlers]` macro + per-kind `#[handler] fn ...`
+- `type Kinds = ...` (in `Component` impls) | ADR-0033 | retired — handlers are the source of truth
+- `mailboxes::*` typed registry module | iamacoffeepot/aether#613 | inline `mailbox_id_from_name(<Cap>::NAMESPACE)` at use sites
+- `attach_component_for_test` | issue 648 | route through real load + advance via `TestBench`
+- `ComponentHostCapability::for_test` | issue 648 | same
+- `EngineToHub` (engine-side listener) | iamacoffeepot/aether#773 | the hub is now a thin chassis hosting `RpcServerCapability` + `EngineServer` directly
+
+## Format extensions
+
+If a future entry needs more structured metadata (e.g. "warn even in comments because the retirement is sensitive"), extend the shape additively rather than re-encoding existing entries. The audit's parsing tolerates extra `|`-separated columns.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ spikes/*/target/
 .claude/scheduled_tasks.lock
 .claude/skills/*
 !.claude/skills/adr/
+!.claude/skills/audit/
 !.claude/skills/delegate/
 !.claude/skills/sweep/
 # Agent audit artifacts — runs of an audit workflow that examines


### PR DESCRIPTION
## Why

Systematizes the per-crate code-quality reads that have been done by
hand in `/audits/` over the past few months (CODE_CONCURRENCY_AUDIT,
CODE_QUALITY_DEDUP_AUDIT, etc.). Hand-driven audits drift in shape +
depth between runs; this skill locks in a procedure that uses
RustRover's symbolic resolver (not regex) as the primary signal.

## What

`/audit <type> <crate>` where `<type>` ∈ {dup, unused, concurrency,
stale} and `<crate>` is a workspace member. Writes a narrative
report under `/audits/` matching the existing report shape
(executive summary + architecture observed + per-finding sections
with stable IDs), then prompts via AskUserQuestion which findings
to file as GitHub issues.

Symbolic only — every category leans on `mcp__rustrover__*`
symbol/PSI tools. Filtering happens on the IDE inspection output,
not on grepped patterns. The skill fails fast if the RustRover
MCP plugin isn't reachable rather than degrading to grep-only.

Two pattern catalogues land alongside `SKILL.md`:

- `patterns/concurrency.md` — six anti-pattern entries (Arc<Mutex<
  Option<…>>>, Mutex+Atomic coexistence, loop+sleep without channel
  signal, hand-rolled Actor impls bypassing `#[actor]`, runtime
  `Arc<A>` introspection, unbounded mpsc on hot paths), each phrased
  as a symbolic question + tool path.
- `patterns/stale-symbols.md` — append-only catalogue of retired
  identifiers spanning every retirement from issues 444 / 613 / 648
  / 773 / 777 / 778 / 780 / 782 plus the ADR-0029 / 0030 / 0033 /
  0073 / 0074 supersessions. The audit asks `search_symbol` first;
  a retired identifier that still resolves is a high-severity hit.

## Per-category v1 status

| Type | Status | Tool path |
|---|---|---|
| `unused` | verified | `get_file_problems` filtered by description-substring |
| `dup` | verified | `get_file_problems` (built-in PSI Duplicates inspection), with inferred-cluster pass |
| `concurrency` | v1-pending verification | `run_inspection_kts` with per-pattern kts scripts; first kts run is the validation |
| `stale` | v1-pending verification | `search_symbol` for retired idents, then `search_in_files_by_text` fallback for comment-only mentions |

## Verified during development

Three smoke runs against `aether-codec` forced four substantive design
corrections before the skill was trustworthy. All landed in the iteration
commits:

1. `get_file_problems` returns flat `{ severity, description, lineContent,
   line, column }` — no structured category tag. Filtering happens by
   description-substring.
2. The IDE's built-in Duplicates inspection IS PSI-driven and ships in
   `get_file_problems` — `dup` doesn't need a custom kts script for v1.
3. `search_symbol` returns hits by name (decls + type-references), not
   find-references-to-a-specific-symbol. The pub-but-unimported pass as
   originally designed can't run cleanly; deferred from v1 with an
   explicit note rather than shipped fragile.
4. `get_file_problems` returns each dup site standalone — no partner
   location. The `dup` aggregation uses a `(leading_line, length)`
   heuristic and is honest about ambiguous cases.

Two smoke reports landed under `/audits/` during development (gitignored,
not in the diff):

- `AETHER_CODEC_UNUSED_AUDIT_20260515_200829.md` — 0 findings (aether-codec
  is symbolically clean for `unused`).
- `AETHER_CODEC_DUP_AUDIT_20260515_201034.md` — 5 inferred clusters.
  Strongest finding: `fn align_of_primitive` byte-identical across
  `decode.rs:260` and `encode.rs:746` — single-PR refactor candidate.

## Plumbing

- `.claude/skills/audit/` is opted into the repo via `.gitignore`
  negation, following the same pattern as `/adr`, `/delegate`, and
  `/sweep`. Project-process skill per the `feedback_skills_local_only`
  rule.
- Report path is `audits/<CRATE_UPPER>_<TYPE_UPPER>_AUDIT_<TS>.md`;
  `/audits/` is gitignored so reports stay local. Issues filed from a
  report link to source files, not the report path.

## Follow-up work

- Verify the `concurrency` path by writing + running the first kts
  script (`patterns/kts/arc-mutex-option.kts`) against
  `aether-substrate`. If `run_inspection_kts` can express Rust PSI
  matchers, the v1-pending flag drops; if not, the catalogue entries
  get `status: deferred — kts unsupported`.
- Verify the `stale` path by running `/audit stale aether-capabilities`
  (most likely crate to expose retirement-fallout hits).
- Pub-but-unimported pass for `unused` — needs either a workspace-PSI
  walk via `run_inspection_kts` or a textual `use <crate>::`
  reconciliation; design call deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)