### PR TITLE
fix(workspace): annotate as _ force-linkage imports flagged as unused

### DIFF
--- a/crates/aether-camera/tests/scenario.rs
+++ b/crates/aether-camera/tests/scenario.rs
@@ -26,6 +26,7 @@ use aether_substrate_bundle::test_bench::TestBench;
 // the linker strips inventory submits for kinds the test code doesn't
 // statically reference. Without this anchor, `Step::SendMail` for
 // `aether.camera.*` kinds fails with "unknown kind".
+#[allow(unused_imports)]
 use aether_camera as _;
 
 #[test]

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -33,6 +33,7 @@ use aether_substrate_bundle::test_bench::TestBench;
 // kinds the test code doesn't statically reference. Without this
 // anchor, `Step::SendMail` for `aether.mesh.load` fails with
 // "unknown kind".
+#[allow(unused_imports)]
 use aether_mesh_viewer as _;
 
 /// User-facing component name passed to `LoadComponent`.

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -40,6 +40,7 @@ use aether_test_fixture_probe::SetRender;
 // entries are present in this test binary. Without the reference, the
 // host-target rlib's descriptor symbols can be stripped by the linker
 // and `aether_kinds::descriptors::all()` won't see fixture kinds.
+#[allow(unused_imports)]
 use aether_test_fixture_probe as _;
 
 /// Caller-supplied component name passed to `LoadComponent`.

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -25,6 +25,7 @@ use aether_substrate_bundle::test_bench::TestBench;
 // `Step::SendMail` for `demo.sokoban.*` kinds fails with "unknown
 // kind". Same fix as PR 432 / PR 434 used for the trunk-rlib
 // pattern.
+#[allow(unused_imports)]
 use aether_demo_sokoban as _;
 
 /// User-facing component name passed to `LoadComponent`.


### PR DESCRIPTION
Add an allow(unused_imports) attribute above each of the four use-crate-as-underscore force-linkage anchors so RustRover's unused-import inspection stops flagging them.

- Touches four integration-test files: aether-camera, aether-mesh-viewer, aether-substrate-bundle, demos/sokoban.
- Preserves the linker-side-effect intent that pulls each crate's inventory submit KindDescriptor entries into the test binary.
- cargo check --workspace --all-targets, cargo clippy --all-targets -- -D warnings, and cargo fmt -- --check all clean; the two RPC test flakes observed in cargo test reproduce on baseline main, unrelated to this change.

Closes iamacoffeepot/aether#784