### PR TITLE
refactor(mesh): extract shared fn pt test helper

### DIFF
--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -614,17 +614,8 @@ fn project_2d(p: Point3, axes: (usize, usize)) -> (i64, i64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
     use crate::loop_polygon::Polygon;
-    use crate::point::Point3;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     fn weld_then_merge(polys: Vec<Polygon>) -> Vec<Polygon> {
         IndexedMesh::weld(polys).merge_coplanar().into_polygons()

--- a/crates/aether-mesh/src/cleanup/provenance.rs
+++ b/crates/aether-mesh/src/cleanup/provenance.rs
@@ -164,16 +164,7 @@ fn find_polygon_with_edge(polygons: &[IndexedPolygon], a: VertexId, b: VertexId)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
-    use crate::point::Point3;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     #[test]
     fn watertight_mesh_has_no_provenance_records() {

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -184,18 +184,10 @@ pub(super) fn is_strictly_between(p: Point3, a: Point3, b: Point3) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
     use crate::plane::Plane3;
+    use crate::test_helpers::pt;
 
     use super::super::mesh::IndexedPolygon;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
 
     fn xy_plane() -> Plane3 {
         Plane3 {

--- a/crates/aether-mesh/src/cleanup/weld.rs
+++ b/crates/aether-mesh/src/cleanup/weld.rs
@@ -144,16 +144,8 @@ fn lookup_or_insert(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
     use crate::plane::Plane3;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     #[test]
     fn empty_input_produces_empty_mesh() {

--- a/crates/aether-mesh/src/lib.rs
+++ b/crates/aether-mesh/src/lib.rs
@@ -25,6 +25,9 @@ pub mod serialize;
 pub mod simplify;
 pub mod tessellate;
 
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
 pub use ast::{Axis, Node};
 pub use mesh::{MeshError, Triangle, mesh};
 pub use obj::to_obj;

--- a/crates/aether-mesh/src/loop_polygon.rs
+++ b/crates/aether-mesh/src/loop_polygon.rs
@@ -201,15 +201,7 @@ fn round_div(numer: i128, denom: i128) -> i128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     #[test]
     fn degenerate_triangle_returns_none() {

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -226,15 +226,7 @@ fn triangulate_indexed(mesh: IndexedMesh) -> Vec<Polygon> {
 mod tests {
     use super::cleanup::mesh::IndexedPolygon;
     use super::*;
-    use crate::fixed::f32_to_fixed;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     fn xy_plane() -> Plane3 {
         Plane3 {

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -268,15 +268,7 @@ pub(in crate::tessellate) fn signed_area2_2d(loop2d: &[Point2]) -> i128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixed::f32_to_fixed;
-
-    fn pt(x: f32, y: f32, z: f32) -> Point3 {
-        Point3 {
-            x: f32_to_fixed(x).unwrap(),
-            y: f32_to_fixed(y).unwrap(),
-            z: f32_to_fixed(z).unwrap(),
-        }
-    }
+    use crate::test_helpers::pt;
 
     fn xy_plane() -> Plane3 {
         Plane3 {

--- a/crates/aether-mesh/src/test_helpers.rs
+++ b/crates/aether-mesh/src/test_helpers.rs
@@ -1,0 +1,16 @@
+//! Shared fixtures for `aether-mesh` unit tests.
+//!
+//! `pt(x, y, z)` constructs a `Point3` from `f32` literals, encoding each
+//! coordinate through `f32_to_fixed` and unwrapping. Inline-construction
+//! convenience for tests; not part of the public API.
+
+use crate::fixed::f32_to_fixed;
+use crate::point::Point3;
+
+pub(crate) fn pt(x: f32, y: f32, z: f32) -> Point3 {
+    Point3 {
+        x: f32_to_fixed(x).unwrap(),
+        y: f32_to_fixed(y).unwrap(),
+        z: f32_to_fixed(z).unwrap(),
+    }
+}


### PR DESCRIPTION
Closes iamacoffeepot/aether#787

- Move the `fn pt(x: f32, y: f32, z: f32) -> Point3` test fixture (7 byte-identical copies) into `crates/aether-mesh/src/test_helpers.rs` behind `#[cfg(test)] pub(crate) mod test_helpers;`.
- Each test module now `use crate::test_helpers::pt;` and drops its private copy plus the now-unused `crate::fixed::f32_to_fixed` / `crate::point::Point3` imports where they were only there to feed `pt`.
- No production code changed; `cargo nextest run -p aether-mesh` is green (326 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)