### PR TITLE
refactor(capabilities): extract shared TestChassis test fixture (issue 785)

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -876,22 +876,12 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
-
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -444,13 +444,12 @@ mod tests {
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
     use crate::rpc::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::rpc::wire::PeerKind;
+    use crate::test_chassis::TestChassis;
     use crate::trace::TraceObserverCapability;
     use aether_actor::Actor;
     use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
     use aether_substrate::Subname;
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
-    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::chassis::builder::Builder;
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -458,16 +457,6 @@ mod tests {
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-        }
-    }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -393,14 +393,13 @@ mod sink {
 #[cfg(test)]
 mod tests {
     use super::{EngineServer, ReplyCells, ReplySink};
+    use crate::test_chassis::TestChassis;
     use aether_actor::Actor;
     use aether_data::{Kind, mailbox_id_from_name};
     use aether_kinds::{
         ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine, TerminateEngineResult,
     };
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
-    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -408,16 +407,6 @@ mod tests {
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
-
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-        }
-    }
 
     /// Boot a passive chassis hosting `EngineServer` + the reply sink.
     /// Returns the chassis (kept alive for its dispatcher threads), the

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -500,22 +500,13 @@ mod native {
         use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
 
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
+        use crate::test_chassis::TestChassis;
 
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -152,22 +152,12 @@ mod native {
         use super::{
             Arc, BootError, HandleCapability, HandlePublish, HandlePublishResult, HandleStore,
         };
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use crate::test_chassis::TestChassis;
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::EgressEvent;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
-
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
 
         fn fresh_substrate() -> (
             Arc<HandleStore>,

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -452,22 +452,13 @@ mod native {
         use aether_data::{Kind, MailboxId};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
 
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
+        use crate::test_chassis::TestChassis;
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -39,6 +39,8 @@ pub mod render;
 pub mod rpc;
 pub mod tcp;
 pub mod test_bench;
+#[cfg(test)]
+pub(crate) mod test_chassis;
 pub mod trace;
 pub mod window;
 

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -118,23 +118,13 @@ mod native {
         use std::time::Duration;
 
         use super::{BootError, LogBatch, LogCapability};
+        use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
         use aether_data::Kind;
         use aether_kinds::LogEvent;
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
-
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             {

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -548,23 +548,12 @@ mod native {
         use std::time::Duration;
 
         use super::*;
+        use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
-        use aether_substrate::chassis::error::BootError;
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{KindId, ReplyTo};
-
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -271,13 +271,12 @@ mod tests {
     use crate::rpc::wire::{
         HelloAck, MailEnvelope, MailboxAddress, PeerKind, WIRE_VERSION, WireFrame,
     };
+    use crate::test_chassis::TestChassis;
     use crate::trace::TraceObserverCapability;
     use aether_actor::Actor;
     use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{Kind, mailbox_id_from_name};
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
-    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::chassis::builder::Builder;
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -288,16 +287,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::JoinHandle;
     use std::time::Duration;
-
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-        }
-    }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -681,10 +681,9 @@ pub fn rpc_server_mailbox_id() -> aether_data::MailboxId {
 mod tests {
     use super::*;
     use crate::rpc::wire::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
+    use crate::test_chassis::TestChassis;
     use aether_codec::frame::{read_frame, write_frame};
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
-    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::chassis::builder::Builder;
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -692,16 +691,6 @@ mod tests {
     use std::net::TcpStream;
     use std::sync::Arc;
     use std::time::Duration;
-
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-        }
-    }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -336,25 +336,14 @@ mod cap_native {
             BindListener, BindListenerResult, ListListeners, ListListenersResult, TcpCapability,
             UnbindListener, UnbindListenerResult,
         };
+        use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
         use aether_data::{Kind, SessionToken, Uuid};
-        use aether_substrate::chassis::Chassis;
-        use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver};
-        use aether_substrate::chassis::error::BootError;
+        use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
-
-        struct TestChassis;
-        impl Chassis for TestChassis {
-            const PROFILE: &'static str = "test";
-            type Driver = NeverDriver;
-            type Env = ();
-            fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-                unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-            }
-        }
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
             let registry = Arc::new(Registry::new());

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -1,0 +1,29 @@
+//! Shared `TestChassis` fixture for unit tests across `aether-capabilities`.
+//!
+//! Every cap's `#[cfg(test)] mod tests` exercises its `init` / handlers
+//! by booting a real [`Builder`](aether_substrate::chassis::builder::Builder)
+//! against a no-op chassis declaration. Pre-extraction every site copied
+//! the same 8-line `impl Chassis for TestChassis` block; this module is
+//! the single canonical declaration so test modules just
+//! `use crate::test_chassis::TestChassis;` and address it by the typename
+//! the builder expects.
+//!
+//! Filed by issue 785.
+
+use aether_substrate::chassis::Chassis;
+use aether_substrate::chassis::builder::{BuiltChassis, NeverDriver};
+use aether_substrate::chassis::error::BootError;
+
+/// Canonical test chassis. `build()` is unreachable — every consumer
+/// drives the chassis through `Builder::<TestChassis>::new(...)` directly
+/// rather than going through `TestChassis::build(())`.
+pub struct TestChassis;
+
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+    }
+}


### PR DESCRIPTION
Closes iamacoffeepot/aether#785

- Adds crates/aether-capabilities/src/test_chassis.rs behind #[cfg(test)] as the single canonical declaration of TestChassis + its Chassis impl.
- Replaces the 11 byte-identical struct TestChassis; impl Chassis for TestChassis { ... } blocks (audio, fs, handle, http, log, render, engine/{proxy,server}, rpc/{client,server}, tcp) with use crate::test_chassis::TestChassis;, dropping the now-unused Chassis / BuiltChassis / NeverDriver (and where applicable BootError) imports.
- No behavior change — same chassis declaration, same Builder::<TestChassis>::new(...) boot path; the 992-test suite passes unchanged.