### PR TITLE
refactor(codec): hoist align_of_primitive to shared cast module (issue 789)

### DIFF
--- a/crates/aether-codec/src/cast.rs
+++ b/crates/aether-codec/src/cast.rs
@@ -1,0 +1,20 @@
+// Cast-shape helpers shared between the encode and decode paths.
+//
+// Both `encode_schema` and `decode_schema` walk the same `#[repr(C)]`
+// byte layout for `Struct { repr_c: true }` schemas and need an
+// alignment lookup for primitive scalars to pad / skip between fields.
+// The function is byte-identical on both sides, so it lives here.
+
+use aether_data::Primitive;
+
+/// Byte alignment of a `Primitive` scalar in its cast-shape (`#[repr(C)]`)
+/// layout. Mirrors the alignment Rust would pick for the corresponding
+/// scalar type.
+pub(crate) fn align_of_primitive(p: Primitive) -> usize {
+    match p {
+        Primitive::U8 | Primitive::I8 => 1,
+        Primitive::U16 | Primitive::I16 => 2,
+        Primitive::U32 | Primitive::I32 | Primitive::F32 => 4,
+        Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
+    }
+}

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -23,6 +23,8 @@ use std::fmt;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::{Map, Value};
 
+use crate::cast::align_of_primitive;
+
 #[derive(Debug)]
 pub enum DecodeError {
     Truncated {
@@ -254,15 +256,6 @@ fn alignment_of_schema(ty: &SchemaType) -> Result<usize, DecodeError> {
         _ => Err(DecodeError::UnsupportedSchema(
             "alignment query on non-cast schema",
         )),
-    }
-}
-
-fn align_of_primitive(p: Primitive) -> usize {
-    match p {
-        Primitive::U8 | Primitive::I8 => 1,
-        Primitive::U16 | Primitive::I16 => 2,
-        Primitive::U32 | Primitive::I32 | Primitive::F32 => 4,
-        Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
     }
 }
 

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -35,6 +35,8 @@ use aether_data::tagged_id;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::Value;
 
+use crate::cast::align_of_primitive;
+
 #[derive(Debug)]
 pub enum EncodeError {
     NotAnObject,
@@ -740,15 +742,6 @@ fn alignment_of_schema(ty: &SchemaType) -> Result<usize, EncodeError> {
         _ => Err(EncodeError::UnsupportedSchema(
             "alignment query on non-cast schema",
         )),
-    }
-}
-
-fn align_of_primitive(p: Primitive) -> usize {
-    match p {
-        Primitive::U8 | Primitive::I8 => 1,
-        Primitive::U16 | Primitive::I16 => 2,
-        Primitive::U32 | Primitive::I32 | Primitive::F32 => 4,
-        Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
     }
 }
 

--- a/crates/aether-codec/src/lib.rs
+++ b/crates/aether-codec/src/lib.rs
@@ -22,6 +22,7 @@
 //! sibling modules. Future framing variants subdivide [`frame`] under
 //! `frame::postcard` / `frame::protobuf`.
 
+mod cast;
 mod decode;
 mod encode;
 pub mod frame;


### PR DESCRIPTION
Hoists the byte-identical `align_of_primitive(Primitive) -> usize` helper out of `crates/aether-codec/src/decode.rs` and `crates/aether-codec/src/encode.rs` into a new `crates/aether-codec/src/cast.rs` as `pub(crate) fn`. Both callers now `use crate::cast::align_of_primitive;`.

- No wire-shape change — same `usize` return at every call site.
- Single source of truth for cast-shape primitive alignment, ready to host any sibling cast-layout helpers identified in the F7 audit follow-up.

Closes iamacoffeepot/aether#789

🤖 Generated with [Claude Code](https://claude.com/claude-code)