### PR TITLE
refactor(mesh): extract projection_axes helper shared by polygon + cdt (issue 799)

### DIFF
--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -162,6 +162,52 @@ impl Plane3 {
     }
 }
 
+/// A world-space coordinate axis. Used by [`projection_axes`] to name
+/// the pair of axes a 3D point projects onto for 2D operations
+/// (signed-area, point-in-polygon, CDT). Distinct from
+/// [`crate::ast::Axis`], which carries DSL semantics (symbol parsing,
+/// orientation enums) the projection helpers don't need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+/// Pick the ordered pair of world axes to project a 3D point onto for
+/// 2D operations on a polygon lying in `plane`. Drops the axis with
+/// the largest absolute normal component (keeps the projection
+/// non-degenerate) and orders the remaining two so the projection
+/// preserves CCW winding around `plane.normal` — flipping the pair
+/// when the dropped component is negative cancels the reflection that
+/// would otherwise reverse orientation.
+///
+/// Shared by `polygon::projected_signed_area` and
+/// `tessellate::cdt::triangulate` so both domains agree on the
+/// orientation convention.
+pub(crate) fn projection_axes(plane: &Plane3) -> (Axis, Axis) {
+    let ax = plane.n_x.unsigned_abs();
+    let ay = plane.n_y.unsigned_abs();
+    let az = plane.n_z.unsigned_abs();
+    if ax >= ay && ax >= az {
+        if plane.n_x >= 0 {
+            (Axis::Y, Axis::Z)
+        } else {
+            (Axis::Z, Axis::Y)
+        }
+    } else if ay >= az {
+        if plane.n_y >= 0 {
+            (Axis::Z, Axis::X)
+        } else {
+            (Axis::X, Axis::Z)
+        }
+    } else if plane.n_z >= 0 {
+        (Axis::X, Axis::Y)
+    } else {
+        (Axis::Y, Axis::X)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -263,7 +263,7 @@ fn unit_normal(plane: &plane::Plane3) -> Vec3 {
 /// Signed doubled area of `vertices` projected onto the plane's
 /// dominant axes. Positive = CCW around `plane.normal`, negative = CW.
 fn projected_signed_area(vertices: &[Point3], plane: &plane::Plane3) -> i128 {
-    let (axis_a, axis_b) = projection_axes(plane);
+    let (axis_a, axis_b) = plane::projection_axes(plane);
     let mut sum: i128 = 0;
     let n = vertices.len();
     for i in 0..n {
@@ -277,41 +277,11 @@ fn projected_signed_area(vertices: &[Point3], plane: &plane::Plane3) -> i128 {
     sum
 }
 
-#[derive(Debug, Clone, Copy)]
-enum Axis {
-    X,
-    Y,
-    Z,
-}
-
-fn pick(p: Point3, a: Axis) -> i32 {
+fn pick(p: Point3, a: plane::Axis) -> i32 {
     match a {
-        Axis::X => p.x,
-        Axis::Y => p.y,
-        Axis::Z => p.z,
-    }
-}
-
-fn projection_axes(plane: &plane::Plane3) -> (Axis, Axis) {
-    let ax = plane.n_x.unsigned_abs();
-    let ay = plane.n_y.unsigned_abs();
-    let az = plane.n_z.unsigned_abs();
-    if ax >= ay && ax >= az {
-        if plane.n_x >= 0 {
-            (Axis::Y, Axis::Z)
-        } else {
-            (Axis::Z, Axis::Y)
-        }
-    } else if ay >= az {
-        if plane.n_y >= 0 {
-            (Axis::Z, Axis::X)
-        } else {
-            (Axis::X, Axis::Z)
-        }
-    } else if plane.n_z >= 0 {
-        (Axis::X, Axis::Y)
-    } else {
-        (Axis::Y, Axis::X)
+        plane::Axis::X => p.x,
+        plane::Axis::Y => p.y,
+        plane::Axis::Z => p.z,
     }
 }
 

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -17,38 +17,8 @@ use super::predicates::Point2;
 #[cfg(test)]
 use super::predicates::orient2d;
 use crate::cleanup::mesh::VertexId;
-use crate::plane::Plane3;
+use crate::plane::{Axis, Plane3, projection_axes};
 use crate::point::Point3;
-
-#[derive(Debug, Clone, Copy)]
-enum Axis {
-    X,
-    Y,
-    Z,
-}
-
-fn projection_axes(plane: &Plane3) -> (Axis, Axis) {
-    let ax = plane.n_x.unsigned_abs();
-    let ay = plane.n_y.unsigned_abs();
-    let az = plane.n_z.unsigned_abs();
-    if ax >= ay && ax >= az {
-        if plane.n_x >= 0 {
-            (Axis::Y, Axis::Z)
-        } else {
-            (Axis::Z, Axis::Y)
-        }
-    } else if ay >= az {
-        if plane.n_y >= 0 {
-            (Axis::Z, Axis::X)
-        } else {
-            (Axis::X, Axis::Z)
-        }
-    } else if plane.n_z >= 0 {
-        (Axis::X, Axis::Y)
-    } else {
-        (Axis::Y, Axis::X)
-    }
-}
 
 fn project_point(p: Point3, axis_a: Axis, axis_b: Axis) -> Point2 {
     let pick = |a: Axis| -> i64 {


### PR DESCRIPTION
Lifts the 17-line dominant-axis pick into `crate::plane` as `pub(crate) Axis` + `projection_axes(plane: &Plane3) -> (Axis, Axis)`.

- `polygon::projected_signed_area` and `tessellate::cdt::triangulate::triangulate` now share the helper instead of maintaining structurally identical copies; net 14 lines removed and the orientation convention (axis pair flipped when the dropped normal component is negative) now lives in one place.
- Per-file local helpers stay (polygon's `pick` returning `i32`, triangulate's `project_point` returning `Point2`) since their return shapes differ — only the axis-selection block was duplicated.

Closes iamacoffeepot/aether#799

🤖 Generated with [Claude Code](https://claude.com/claude-code)