### PR TITLE
refactor(capabilities): extract shared fresh_substrate test helper

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -876,24 +876,10 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::test_chassis::TestChassis;
+        use crate::test_chassis::{TestChassis, fresh_substrate};
         use aether_actor::Actor;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::registry::Registry;
-
-        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-            let registry = Arc::new(Registry::new());
-            for d in aether_kinds::descriptors::all() {
-                let _ = registry.register_kind_with_descriptor(d);
-            }
-            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-            (registry, mailer)
-        }
 
         #[test]
         fn builtin_registry_covers_five_patches() {

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -444,30 +444,15 @@ mod tests {
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
     use crate::rpc::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::rpc::wire::PeerKind;
-    use crate::test_chassis::TestChassis;
+    use crate::test_chassis::{TestChassis, fresh_substrate};
     use crate::trace::TraceObserverCapability;
     use aether_actor::Actor;
     use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
     use aether_substrate::Subname;
     use aether_substrate::chassis::builder::Builder;
-    use aether_substrate::handle_store::HandleStore;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::outbound::HubOutbound;
-    use aether_substrate::mail::registry::Registry;
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
-        }
-        let (outbound, _rx) = HubOutbound::attached_loopback();
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
-        (registry, mailer)
-    }
 
     fn substrate_peer_kind() -> PeerKind {
         PeerKind::Substrate {

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -506,7 +506,7 @@ mod native {
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::Registry;
 
-        use crate::test_chassis::TestChassis;
+        use crate::test_chassis::{TestChassis, fresh_substrate};
 
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.
@@ -552,18 +552,6 @@ mod native {
 
         fn cleanup(path: &Path) {
             let _ = std::fs::remove_dir_all(path);
-        }
-
-        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-            let registry = Arc::new(Registry::new());
-            for d in aether_kinds::descriptors::all() {
-                let _ = registry.register_kind_with_descriptor(d);
-            }
-            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-            (registry, mailer)
         }
 
         fn roots_under(root: &Path) -> NamespaceRoots {

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -456,21 +456,8 @@ mod native {
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::registry::Registry;
 
-        use crate::test_chassis::TestChassis;
-
-        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-            let registry = Arc::new(Registry::new());
-            for d in aether_kinds::descriptors::all() {
-                let _ = registry.register_kind_with_descriptor(d);
-            }
-            let store = ::std::sync::Arc::new(::aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-            (registry, mailer)
-        }
+        use crate::test_chassis::{TestChassis, fresh_substrate};
 
         struct StubAdapter {
             response: Mutex<Option<Result<FetchResponse, HttpError>>>,

--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -271,33 +271,18 @@ mod tests {
     use crate::rpc::wire::{
         HelloAck, MailEnvelope, MailboxAddress, PeerKind, WIRE_VERSION, WireFrame,
     };
-    use crate::test_chassis::TestChassis;
+    use crate::test_chassis::{TestChassis, fresh_substrate};
     use crate::trace::TraceObserverCapability;
     use aether_actor::Actor;
     use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{Kind, mailbox_id_from_name};
     use aether_substrate::chassis::builder::Builder;
-    use aether_substrate::handle_store::HandleStore;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::outbound::HubOutbound;
-    use aether_substrate::mail::registry::Registry;
     use std::io::BufReader;
     use std::net::{TcpListener, TcpStream};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::JoinHandle;
     use std::time::Duration;
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
-        }
-        let (outbound, _rx) = HubOutbound::attached_loopback();
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
-        (registry, mailer)
-    }
 
     fn substrate_peer_kind() -> PeerKind {
         PeerKind::Substrate {

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -681,27 +681,12 @@ pub fn rpc_server_mailbox_id() -> aether_data::MailboxId {
 mod tests {
     use super::*;
     use crate::rpc::wire::{Hello, HelloAck, PeerKind, WIRE_VERSION, WireFrame};
-    use crate::test_chassis::TestChassis;
+    use crate::test_chassis::{TestChassis, fresh_substrate};
     use aether_codec::frame::{read_frame, write_frame};
     use aether_substrate::chassis::builder::Builder;
-    use aether_substrate::handle_store::HandleStore;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::outbound::HubOutbound;
-    use aether_substrate::mail::registry::Registry;
     use std::net::TcpStream;
     use std::sync::Arc;
     use std::time::Duration;
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
-            let _ = registry.register_kind_with_descriptor(d);
-        }
-        let (outbound, _rx) = HubOutbound::attached_loopback();
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
-        (registry, mailer)
-    }
 
     fn test_peer_kind() -> PeerKind {
         PeerKind::Substrate {

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -8,11 +8,19 @@
 //! `use crate::test_chassis::TestChassis;` and address it by the typename
 //! the builder expects.
 //!
-//! Filed by issue 785.
+//! Filed by issue 785. The `fresh_substrate` helper extracted by issue
+//! 786 lives here too — same six sites all wanted the same
+//! `(Arc<Registry>, Arc<Mailer>)` seed for `Builder::new`.
+
+use std::sync::Arc;
 
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{BuiltChassis, NeverDriver};
 use aether_substrate::chassis::error::BootError;
+use aether_substrate::handle_store::HandleStore;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::registry::Registry;
 
 /// Canonical test chassis. `build()` is unreachable — every consumer
 /// drives the chassis through `Builder::<TestChassis>::new(...)` directly
@@ -26,4 +34,23 @@ impl Chassis for TestChassis {
     fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
         unreachable!("TestChassis is driven by Builder::new directly in unit tests")
     }
+}
+
+/// Build the `(Arc<Registry>, Arc<Mailer>)` seed every cap test feeds to
+/// `Builder::<TestChassis>::new`. The registry is pre-populated with the
+/// substrate kind descriptors so tests can address built-in kinds by id
+/// without re-registering; the mailer carries a loopback `HubOutbound`
+/// (rx dropped) so the unknown-mailbox bubble-up path (ADR-0037) is
+/// wired but inert — tests that never hit it (audio, fs, http handler
+/// paths) see no behavioural difference, and tests that do hit it
+/// (rpc, engine proxy) get the connected backend they need.
+pub(crate) fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+    let registry = Arc::new(Registry::new());
+    for d in aether_kinds::descriptors::all() {
+        let _ = registry.register_kind_with_descriptor(d);
+    }
+    let (outbound, _rx) = HubOutbound::attached_loopback();
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+    (registry, mailer)
 }


### PR DESCRIPTION
Collapses six copies of the same fresh_substrate test helper (returning (Arc<Registry>, Arc<Mailer>)) across the aether-capabilities test modules into one canonical pub(crate) in test_chassis — the same module that issue 785 / PR 806 used for the shared TestChassis fixture.

- Three sites (audio, fs, http) had no HubOutbound attached; three (engine/proxy, rpc/client, rpc/server) attached a loopback. The shared helper ships the loopback variant; for the three cap-internal sites the bubble-up path stays inert (rx dropped, the tests never hit unknown-mailbox routing anyway).
- Net -57 lines across the six sites; cargo nextest run -p aether-capabilities keeps all 84 tests green and full cargo nextest run --workspace keeps all 992 green.

Closes iamacoffeepot/aether#786