### PR TITLE
refactor(mcp): extract shared TestChassis test fixture (issue 802)

### DIFF
--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -12,6 +12,8 @@
 
 mod args;
 mod rpc;
+#[cfg(test)]
+mod test_chassis;
 mod tools;
 
 use std::sync::Arc;

--- a/crates/aether-mcp/src/test_chassis.rs
+++ b/crates/aether-mcp/src/test_chassis.rs
@@ -1,0 +1,31 @@
+//! Shared `TestChassis` fixture for unit tests inside `aether-mcp`.
+//!
+//! `tools.rs`'s `#[cfg(test)] mod tests` boots a hub-shaped passive
+//! chassis through [`Builder`](aether_substrate::chassis::builder::Builder)
+//! against a no-op chassis declaration. This module hosts the single
+//! canonical declaration so test modules `use crate::test_chassis::TestChassis;`
+//! instead of inlining the same 8-line `impl Chassis for TestChassis` block.
+//!
+//! Filed by issue 802. Local sibling to `aether-capabilities`'s
+//! `test_chassis` module (issue 785); the cap-side copy is
+//! `#[cfg(test)] pub(crate)` and not reachable cross-crate, so each
+//! workspace consumer that needs the fixture keeps its own one-line
+//! declaration close at hand.
+
+use aether_substrate::chassis::Chassis;
+use aether_substrate::chassis::builder::{BuiltChassis, NeverDriver};
+use aether_substrate::chassis::error::BootError;
+
+/// Canonical test chassis. `build()` is unreachable — every consumer
+/// drives the chassis through `Builder::<TestChassis>::new(...)` directly
+/// rather than going through `TestChassis::build(())`.
+pub struct TestChassis;
+
+impl Chassis for TestChassis {
+    const PROFILE: &'static str = "test";
+    type Driver = NeverDriver;
+    type Env = ();
+    fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
+        unreachable!("TestChassis is driven by Builder::new directly in unit tests")
+    }
+}

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -491,23 +491,13 @@ mod tests {
         PeerKind, RpcServerCapability, RpcServerConfig, RpcServerHandle,
     };
     use aether_capabilities::trace::TraceObserverCapability;
-    use aether_substrate::chassis::Chassis;
-    use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
-    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
 
-    struct TestChassis;
-    impl Chassis for TestChassis {
-        const PROFILE: &'static str = "test";
-        type Driver = NeverDriver;
-        type Env = ();
-        fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-            unreachable!("TestChassis is driven by Builder::new directly in unit tests")
-        }
-    }
+    use crate::test_chassis::TestChassis;
 
     /// Boot a hub-shaped passive chassis: a forwarding
     /// `RpcServerCapability` + the engines cap + `TraceObserver` (so


### PR DESCRIPTION
Hoists the inline `impl Chassis for TestChassis` block out of `crates/aether-mcp/src/tools.rs`'s `#[cfg(test)] mod tests` into a sibling `#[cfg(test)] mod test_chassis;` so the canonical 8-line declaration lives in one place.

- Mirrors the F2 extraction in `aether-capabilities` (issue 785 / PR 806); cross-crate reuse was rejected because that module is `#[cfg(test)] pub(crate)` and not reachable from a sibling crate.
- `cargo nextest run --workspace` 992/992 pass; clippy + fmt clean.

Closes iamacoffeepot/aether#802

🤖 Generated with [Claude Code](https://claude.com/claude-code)