### PR TITLE
refactor(codec): consolidate non-cast SchemaType rejection arm (issue 790)

### DIFF
--- a/crates/aether-codec/src/cast.rs
+++ b/crates/aether-codec/src/cast.rs
@@ -18,3 +18,10 @@ pub(crate) fn align_of_primitive(p: Primitive) -> usize {
         Primitive::U64 | Primitive::I64 | Primitive::F64 => 8,
     }
 }
+
+/// Error message reported when a non-cast `SchemaType` variant
+/// (`Bool` / `String` / `Bytes` / `Option` / `Vec` / `Enum` / `Unit` /
+/// `Ref` / `Map`) appears inside a `#[repr(C)]` cast-shaped struct.
+/// Used by both the encode and decode paths so the diagnostic string
+/// stays byte-identical across the two sides.
+pub(crate) const NON_CAST_VARIANTS_MSG: &str = "non-cast field inside cast-shaped struct";

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::{Map, Value};
 
-use crate::cast::align_of_primitive;
+use crate::cast::{NON_CAST_VARIANTS_MSG, align_of_primitive};
 
 #[derive(Debug)]
 pub enum DecodeError {
@@ -194,9 +194,7 @@ fn decode_cast_field(
         | SchemaType::Enum { .. }
         | SchemaType::Unit
         | SchemaType::Ref(_)
-        | SchemaType::Map { .. } => Err(DecodeError::UnsupportedSchema(
-            "non-cast field inside cast-shaped struct",
-        )),
+        | SchemaType::Map { .. } => Err(DecodeError::UnsupportedSchema(NON_CAST_VARIANTS_MSG)),
     }
 }
 

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -35,7 +35,7 @@ use aether_data::tagged_id;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::Value;
 
-use crate::cast::align_of_primitive;
+use crate::cast::{NON_CAST_VARIANTS_MSG, align_of_primitive};
 
 #[derive(Debug)]
 pub enum EncodeError {
@@ -715,9 +715,7 @@ fn encode_field_value(
         | SchemaType::Enum { .. }
         | SchemaType::Unit
         | SchemaType::Ref(_)
-        | SchemaType::Map { .. } => Err(EncodeError::UnsupportedSchema(
-            "non-cast field inside cast-shaped struct",
-        )),
+        | SchemaType::Map { .. } => Err(EncodeError::UnsupportedSchema(NON_CAST_VARIANTS_MSG)),
     }
 }
 


### PR DESCRIPTION
Extract the duplicated 'non-cast field inside cast-shaped struct' error message into a single `NON_CAST_VARIANTS_MSG` const in `aether-codec::cast`.

- Both `decode_cast_field` (decode.rs:197) and `encode_field_value` (encode.rs:718) now reference the shared const; error types (`DecodeError` / `EncodeError`) stay in their own modules.
- The 9-variant match arm list stays explicit in each callsite so the compiler still flags new `SchemaType` variants instead of letting them silently fall into a catch-all.
- Lives next to `align_of_primitive` in `cast.rs` (the shared module added by issue 789 / PR 808).

Closes iamacoffeepot/aether#790
