### PR TITLE
refactor(mesh): hoist project_2d to plane.rs (issue 800)

### DIFF
--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -68,7 +68,7 @@
 //! tiebreak in the angular pick).
 
 use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
-use crate::plane::Plane3;
+use crate::plane::{Plane3, project_2d};
 use crate::point::Point3;
 use std::collections::HashMap;
 
@@ -604,11 +604,6 @@ fn drop_axis(plane: &Plane3) -> (usize, usize) {
     } else {
         (0, 1)
     }
-}
-
-fn project_2d(p: Point3, axes: (usize, usize)) -> (i64, i64) {
-    let coords = [p.x as i64, p.y as i64, p.z as i64];
-    (coords[axes.0], coords[axes.1])
 }
 
 #[cfg(test)]

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -208,6 +208,18 @@ pub(crate) fn projection_axes(plane: &Plane3) -> (Axis, Axis) {
     }
 }
 
+/// Project a 3D fixed-point point onto a pair of world axes, returning
+/// the two retained coordinates as i64. Used by callers that pick a
+/// containment-plane axis pair (via local `drop_axis` / `containment_axes`
+/// helpers that yield `(usize, usize)`) and need the 2D coordinates for
+/// signed-area, point-in-polygon, or coplanar-merge geometry. Distinct
+/// from [`projection_axes`], which returns the typed [`Axis`] pair used
+/// where CCW-orientation preservation matters.
+pub(crate) fn project_2d(p: Point3, axes: (usize, usize)) -> (i64, i64) {
+    let coords = [p.x as i64, p.y as i64, p.z as i64];
+    (coords[axes.0], coords[axes.1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -37,6 +37,7 @@
 use crate::loop_polygon;
 use crate::mesh::MeshError;
 use crate::plane;
+use crate::plane::project_2d;
 use crate::point::Point3;
 use aether_math::Vec3;
 use std::collections::HashMap;
@@ -206,11 +207,6 @@ fn containment_axes(plane: &plane::Plane3) -> (usize, usize) {
     } else {
         (0, 1)
     }
-}
-
-fn project_2d(p: Point3, axes: (usize, usize)) -> (i64, i64) {
-    let coords = [p.x as i64, p.y as i64, p.z as i64];
-    (coords[axes.0], coords[axes.1])
 }
 
 /// Standard ray-casting point-in-polygon test in 2D fixed-point


### PR DESCRIPTION
Move the 4-line `project_2d` helper from `crates/aether-mesh/src/cleanup/merge.rs` and `crates/aether-mesh/src/polygon.rs` into `crates/aether-mesh/src/plane.rs` as `pub(crate) fn project_2d(p: Point3, axes: (usize, usize)) -> (i64, i64)`. The new home sits adjacent to the `Axis` + `projection_axes` helpers landed by PR 810 (issue 799).

- Both call sites use a `(usize, usize)` axes pair from their local `drop_axis` / `containment_axes` helpers, so the function signature is unchanged.
- Each module gains a `use crate::plane::project_2d` import and drops its private duplicate.
- `cargo check --workspace --all-targets`, `cargo clippy -p aether-mesh --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test -p aether-mesh` all clean.

Closes iamacoffeepot/aether#800
