### PR TITLE
feat(capabilities): per-cap sender facade traits (issue 580)

### DIFF
--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -20,7 +20,10 @@ use std::sync::Arc;
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
+use aether_actor::FfiActorMailbox;
 use aether_kinds::{Delete, FsError, List, Read, Write};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_substrate::actor::native::NativeActorMailbox;
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `FsError` map directly onto ADR-0041 §1's reply enums, so the
@@ -250,6 +253,111 @@ impl NamespaceRoots {
         self.assets.canonicalize()?;
         self.config.canonicalize()?;
         Ok(())
+    }
+}
+
+/// Sender-side facade for actors addressed via
+/// `ctx.actor::<FsCapability>()`.
+///
+/// Lifts the cap-shaped methods (`read(ns, path)`, `write(ns, path,
+/// bytes)`, ...) one indirection above the raw
+/// `.send(&Read { ns, path })` so component code stops reconstructing
+/// the kind struct (and the `.into()` conversions on every field) at
+/// every call site. The cap module owns receive-side
+/// ([`FsCapability`]) AND send-side ([`FsMailboxExt`]) so future
+/// kind additions land both surfaces in one place.
+///
+/// Impl'd for both transports `ctx.actor::<FsCapability>()` can
+/// return:
+///
+/// - [`FfiActorMailbox<FsCapability>`] — always-on, for wasm-component
+///   callers.
+/// - [`NativeActorMailbox<'_, FsCapability>`] — native cap-to-cap
+///   sends, gated on `#[cfg(not(target_arch = "wasm32"))]`.
+///
+/// All methods are fire-and-forget. Replies arrive as
+/// `aether.fs.read_result` / `aether.fs.write_result` /
+/// `aether.fs.delete_result` / `aether.fs.list_result`, correlated
+/// by the echoed `namespace` + `path` (or `prefix`) per ADR-0041.
+/// Synchronous `read_sync` / `write_sync` wrappers were on the
+/// original issue 580 sketch — parked as a follow-up so this PR
+/// stays mechanical.
+///
+/// The generic escape hatch is unaffected: `mailbox.send(&CustomKind { .. })`
+/// still works for any `K` the cap declares via `HandlesKind<K>`,
+/// since `send` is an inherent method on the underlying mailbox type.
+pub trait FsMailboxExt {
+    /// Mail `aether.fs.read { namespace, path }` to the cap.
+    fn read(&self, namespace: &str, path: &str);
+
+    /// Mail `aether.fs.write { namespace, path, bytes }` to the cap.
+    /// The reply echoes `namespace` + `path` only (bytes are omitted
+    /// from the echo so a megabyte write doesn't produce a megabyte
+    /// reply).
+    fn write(&self, namespace: &str, path: &str, bytes: &[u8]);
+
+    /// Mail `aether.fs.delete { namespace, path }` to the cap.
+    fn delete(&self, namespace: &str, path: &str);
+
+    /// Mail `aether.fs.list { namespace, prefix }` to the cap. The
+    /// reply enumerates entries under the prefix.
+    fn list(&self, namespace: &str, prefix: &str);
+}
+
+impl FsMailboxExt for FfiActorMailbox<FsCapability> {
+    fn read(&self, namespace: &str, path: &str) {
+        self.send(&Read {
+            namespace: namespace.into(),
+            path: path.into(),
+        });
+    }
+    fn write(&self, namespace: &str, path: &str, bytes: &[u8]) {
+        self.send(&Write {
+            namespace: namespace.into(),
+            path: path.into(),
+            bytes: bytes.to_vec(),
+        });
+    }
+    fn delete(&self, namespace: &str, path: &str) {
+        self.send(&Delete {
+            namespace: namespace.into(),
+            path: path.into(),
+        });
+    }
+    fn list(&self, namespace: &str, prefix: &str) {
+        self.send(&List {
+            namespace: namespace.into(),
+            prefix: prefix.into(),
+        });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a> FsMailboxExt for NativeActorMailbox<'a, FsCapability> {
+    fn read(&self, namespace: &str, path: &str) {
+        self.send(&Read {
+            namespace: namespace.into(),
+            path: path.into(),
+        });
+    }
+    fn write(&self, namespace: &str, path: &str, bytes: &[u8]) {
+        self.send(&Write {
+            namespace: namespace.into(),
+            path: path.into(),
+            bytes: bytes.to_vec(),
+        });
+    }
+    fn delete(&self, namespace: &str, path: &str) {
+        self.send(&Delete {
+            namespace: namespace.into(),
+            path: path.into(),
+        });
+    }
+    fn list(&self, namespace: &str, prefix: &str) {
+        self.send(&List {
+            namespace: namespace.into(),
+            prefix: prefix.into(),
+        });
     }
 }
 

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -18,7 +18,10 @@ use std::time::Duration;
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
+use aether_actor::FfiActorMailbox;
 use aether_kinds::{Fetch, HttpError, HttpHeader, HttpMethod};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_substrate::actor::native::NativeActorMailbox;
 
 /// Default response-body cap when `AETHER_HTTP_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -159,6 +162,85 @@ fn parse_default_timeout_env() -> Duration {
         .and_then(|s| s.parse::<u32>().ok())
         .unwrap_or(DEFAULT_TIMEOUT_MS);
     Duration::from_millis(ms as u64)
+}
+
+/// Sender-side facade for actors addressed via
+/// `ctx.actor::<HttpCapability>()`.
+///
+/// Lifts the two most common HTTP verbs to a typed method so callers
+/// stop reconstructing `Fetch { method: HttpMethod::Get, headers:
+/// vec![], body: vec![], timeout_ms: None, .. }` for a basic
+/// request. Same shape and rationale as [`crate::fs::FsMailboxExt`].
+///
+/// All methods are fire-and-forget. Replies arrive as
+/// `aether.http.fetch_result`, correlated by the echoed `url`
+/// (ADR-0043).
+///
+/// For requests that need custom headers, body, method, or a
+/// per-request timeout, the generic escape hatch is unchanged:
+/// `mailbox.send(&Fetch { ... })` still works because the cap
+/// declares `HandlesKind<Fetch>`. The facade only exists for the
+/// no-options cases that don't benefit from spelling out a five-
+/// field struct.
+///
+/// Impl'd for both transports `ctx.actor::<HttpCapability>()` can
+/// return:
+///
+/// - [`FfiActorMailbox<HttpCapability>`] — always-on, for
+///   wasm-component callers.
+/// - [`NativeActorMailbox<'_, HttpCapability>`] — native cap-to-cap
+///   sends, gated on `#[cfg(not(target_arch = "wasm32"))]`.
+pub trait HttpMailboxExt {
+    /// Mail `aether.http.fetch { url, method: Get, headers: [], body: [], timeout_ms: None }`
+    /// to the cap. Uses the chassis default timeout.
+    fn get(&self, url: &str);
+
+    /// Mail `aether.http.fetch { url, method: Post, headers: [], body, timeout_ms: None }`
+    /// to the cap. Uses the chassis default timeout.
+    fn post(&self, url: &str, body: &[u8]);
+}
+
+impl HttpMailboxExt for FfiActorMailbox<HttpCapability> {
+    fn get(&self, url: &str) {
+        self.send(&Fetch {
+            url: url.into(),
+            method: HttpMethod::Get,
+            headers: Vec::new(),
+            body: Vec::new(),
+            timeout_ms: None,
+        });
+    }
+    fn post(&self, url: &str, body: &[u8]) {
+        self.send(&Fetch {
+            url: url.into(),
+            method: HttpMethod::Post,
+            headers: Vec::new(),
+            body: body.to_vec(),
+            timeout_ms: None,
+        });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a> HttpMailboxExt for NativeActorMailbox<'a, HttpCapability> {
+    fn get(&self, url: &str) {
+        self.send(&Fetch {
+            url: url.into(),
+            method: HttpMethod::Get,
+            headers: Vec::new(),
+            body: Vec::new(),
+            timeout_ms: None,
+        });
+    }
+    fn post(&self, url: &str, body: &[u8]) {
+        self.send(&Fetch {
+            url: url.into(),
+            method: HttpMethod::Post,
+            headers: Vec::new(),
+            body: body.to_vec(),
+            timeout_ms: None,
+        });
+    }
 }
 
 #[aether_actor::bridge(singleton)]

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -32,9 +32,10 @@
 //!    `"aether.render"`.
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::{FsCapability, InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, Read, ReadResult, SubscribeInput, Tick, Vertex};
+use aether_kinds::{DrawTriangle, ReadResult, SubscribeInput, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
@@ -123,10 +124,7 @@ impl FfiActor for MeshViewer {
             path = %msg.path,
             "load requested; issuing read",
         );
-        ctx.actor::<FsCapability>().send(&Read {
-            namespace: msg.namespace,
-            path: msg.path,
-        });
+        ctx.actor::<FsCapability>().read(&msg.namespace, &msg.path);
     }
 
     /// Consumes the substrate's I/O reply. Dispatches on the echoed


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

Adds the per-cap sender-side facade trait pattern from issue 580. The cap module owns receive-side (the `#[actor] impl`) AND send-side (the facade trait) so future kind additions land both surfaces in one place. Generic escape hatch is unaffected — `mailbox.send(&CustomKind { .. })` still works against the underlying inherent `send` on the mailbox.

Closes iamacoffeepot/aether#580.

## What this PR does

### `FsMailboxExt` (`aether-capabilities/src/fs.rs`)

```rust
pub trait FsMailboxExt {
    fn read(&self, namespace: &str, path: &str);
    fn write(&self, namespace: &str, path: &str, bytes: &[u8]);
    fn delete(&self, namespace: &str, path: &str);
    fn list(&self, namespace: &str, prefix: &str);
}
```

Impl'd for both transports `ctx.actor::<FsCapability>()` can return:

- `FfiActorMailbox<FsCapability>` — always-on, for wasm-component callers
- `NativeActorMailbox<'_, FsCapability>` — gated on `#[cfg(not(target_arch = "wasm32"))]`, for native cap-to-cap sends

Bodies are the obvious one-liners that build the kind struct from the `&str` / `&[u8]` args.

### `HttpMailboxExt` (`aether-capabilities/src/http.rs`)

```rust
pub trait HttpMailboxExt {
    fn get(&self, url: &str);
    fn post(&self, url: &str, body: &[u8]);
}
```

Same per-transport impl pair. Only the two most common verbs are exposed; anything with custom headers, methods, or per-request timeouts goes through the generic `mailbox.send(&Fetch { .. })`. The issue called out that there's no in-tree consumer of `HttpCapability` yet, so the facade just lands the pattern alongside fs without speculating on API surface for missing callers.

### Out of scope (deliberate)

- **Tcp** — its kind names (`bind_listener`, `session_write`, `session_close`) are already verb-shaped enough. The issue called it out as a "consider."
- **`_sync` wrappers** (`read_sync` / `write_sync` / `fetch_sync`) — extra design surface (timeout, error type, decode wiring). Parked as a follow-up; this PR stays mechanical.
- **`ctx.fs()` / `ctx.http()` ctx-level shortcut traits** — the issue noted this as a follow-up once the facade pattern proved out. Same impl underneath, saves the turbofish.

### Migration

The only in-tree call site that benefits is `aether-mesh-viewer/src/runtime.rs`:

```rust
// before
ctx.actor::<FsCapability>().send(&Read {
    namespace: msg.namespace,
    path: msg.path,
});

// after
ctx.actor::<FsCapability>().read(&msg.namespace, &msg.path);
```

The `Read` kind import dropped from the file along with it.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace --no-fail-fast` — **984/984 passed** (no new tests; this is a refactor)
- `cargo test --doc --workspace` — clean
- `cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features` — clean (wasm-component build path)
- `cargo check -p aether-mesh-viewer --target wasm32-unknown-unknown` — clean

## Follow-up: issue 654

Issue 654's remaining open question — `ctx.send_to_named("aether.component.trampoline:NAME", &mail)` ergonomics — is the same shape as this PR's facade traits, just for peer-component addressing rather than cap addressing. Will rescope iamacoffeepot/aether#654 to ride this pattern in a follow-up note.
