### PR TITLE
fix(substrate): split MailboxEntry::Closure into Sink + Closure (issue 838 diff 2)

### DIFF
--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -193,15 +193,17 @@ mod native {
     }
 
     /// Shared validation: the mailbox id must name a live (non-dropped)
-    /// closure-bound mailbox. Issue 634 Phase 4 collapsed Component
+    /// dispatchable mailbox. Issue 634 Phase 4 collapsed Component
     /// and chassis-bound mailboxes into a single `Closure` variant —
     /// trampolines and chassis caps both pass this check today.
-    /// Production callers (the input stream fan-out) only address
-    /// trampoline mailboxes here; chassis caps don't subscribe to
-    /// themselves.
+    /// Issue 838 added a `Sink` variant (synchronous-handler
+    /// mailboxes); production callers (the input stream fan-out)
+    /// only address trampoline mailboxes here, but accepting `Sink`
+    /// too keeps the check from rejecting legitimate sync-handler
+    /// subscribers if any future driver wants one.
     fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
         match registry.entry(id) {
-            Some(MailboxEntry::Closure(_)) => Ok(()),
+            Some(MailboxEntry::Closure(_)) | Some(MailboxEntry::Sink(_)) => Ok(()),
             Some(MailboxEntry::Dropped) => Err(format!("mailbox {:?} already dropped", id)),
             None => Err(format!("unknown mailbox id {:?}", id)),
         }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -117,12 +117,21 @@ impl HeadlessChassis {
         // Audio nop sink — NoteOn/NoteOff fall through silently;
         // SetMasterGain replies Err so agents fail fast rather than
         // hang on a chassis with no audio device.
+        //
+        // Issue 838: registered as `Sink` (not `Closure`) so the
+        // `Mailer::push` route brackets the inline handler with
+        // `Received`/`Finished`. The handler does its work
+        // synchronously (calls `send_reply` directly); there's no
+        // actor dispatch loop behind it, so without the bracket
+        // any chain that mails `aether.audio` from the headless
+        // chassis leaks `in_flight` and never settles. Same shape
+        // as the AETHER_DIAGNOSTICS sink in `boot.rs::register_sink`.
         let kind_set_master_gain = boot
             .registry
             .kind_id(SetMasterGain::NAME)
             .expect("SetMasterGain registered");
         let outbound_for_audio_sink = Arc::clone(&boot.outbound);
-        boot.registry.register_closure(
+        boot.registry.register_sink(
             "aether.audio",
             Arc::new(
                 move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -222,28 +222,63 @@ impl ComponentCtx {
             kind,
         );
 
-        if let Some(MailboxEntry::Closure(handler)) = self.registry.entry(recipient) {
-            let kind_name = self.registry.kind_name(kind).unwrap_or_default();
-            // Component-originated mail: the sender is this ctx's
-            // mailbox, so its registry name is the `origin` any
-            // sink cares about (ADR-0011), and the same mailbox id
-            // rides on `reply_to.target` so sink handlers that want
-            // to reply (ADR-0041's io sink is the motivating case)
-            // can route `*Result` back to this component via
-            // `Mailer::send_reply`.
-            let origin = self.registry.mailbox_name(self.sender);
-            handler(crate::mail::registry::MailDispatch {
-                kind,
-                kind_name: &kind_name,
-                origin: origin.as_deref(),
-                sender: reply_to,
-                payload: &payload,
-                count,
-                mail_id,
-                root,
-                parent_mail,
-            });
-            return;
+        // Closure-bound (actor-enqueue) and Sink-bound (synchronous
+        // handler) recipients dispatch inline here, bypassing the
+        // mailer's full route. Issue 838: `Sink` gets a
+        // `Received`/`Finished` bracket so the chain's `in_flight`
+        // balances; `Closure` does NOT because the actor's
+        // downstream dispatch loop records the bracket. See
+        // [`MailboxEntry`] docs for the contract.
+        match self.registry.entry(recipient) {
+            Some(MailboxEntry::Closure(handler)) => {
+                let kind_name = self.registry.kind_name(kind).unwrap_or_default();
+                // Component-originated mail: the sender is this ctx's
+                // mailbox, so its registry name is the `origin` any
+                // sink cares about (ADR-0011), and the same mailbox id
+                // rides on `reply_to.target` so sink handlers that want
+                // to reply (ADR-0041's io sink is the motivating case)
+                // can route `*Result` back to this component via
+                // `Mailer::send_reply`.
+                let origin = self.registry.mailbox_name(self.sender);
+                handler(crate::mail::registry::MailDispatch {
+                    kind,
+                    kind_name: &kind_name,
+                    origin: origin.as_deref(),
+                    sender: reply_to,
+                    payload: &payload,
+                    count,
+                    mail_id,
+                    root,
+                    parent_mail,
+                });
+                return;
+            }
+            Some(MailboxEntry::Sink(handler)) => {
+                let kind_name = self.registry.kind_name(kind).unwrap_or_default();
+                let origin = self.registry.mailbox_name(self.sender);
+                let thread_name = std::thread::current().name().map(str::to_owned);
+                crate::runtime::trace::record_received(mail_id, thread_name);
+                handler(crate::mail::registry::MailDispatch {
+                    kind,
+                    kind_name: &kind_name,
+                    origin: origin.as_deref(),
+                    sender: reply_to,
+                    payload: &payload,
+                    count,
+                    mail_id,
+                    root,
+                    parent_mail,
+                });
+                crate::runtime::trace::record_finished(mail_id);
+                return;
+            }
+            Some(MailboxEntry::Dropped) | None => {
+                // Falls through to the `self.queue.push` path below
+                // — Dropped warn-drops in `route_mail` (with the
+                // Finished bracket from issue 839); unknown bubbles
+                // up via ADR-0037 (also with the local-side
+                // Finished from issue 839).
+            }
         }
 
         // Dropped / unknown both funnel through `Mailer::push`:

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -139,7 +139,14 @@ impl<'a> SubstrateBootBuilder<'a> {
         // today; the sink is structured as a general diagnostic
         // channel so future diagnostic kinds can land here without
         // needing another sink.
-        registry.register_closure(
+        //
+        // Issue 838: registered as `Sink` (not `Closure`) so the
+        // `Mailer::push` route brackets the inline handler with
+        // `Received`/`Finished`. The handler runs synchronously
+        // (just emits a `tracing::warn!`) — there's no actor
+        // dispatch loop behind it, so without the bracket the
+        // chain's `in_flight` would leak.
+        registry.register_sink(
             AETHER_DIAGNOSTICS,
             Arc::new(|dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let kind_name = dispatch.kind_name;

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -363,20 +363,18 @@ fn route_mail(
             // and never enter `push`.
             //
             // ADR-0080 §2 producer-hook note (issue 838): no
-            // `Received`/`Finished` bracket fires here. The
-            // `Closure` arm is overloaded — it serves BOTH
-            // synchronous sinks (which would benefit from a bracket
-            // to balance the producer's `Sent`) AND actor-inbox
-            // enqueue closures registered by `spawn.rs::try_register_closure`
-            // (whose dispatch loop already records `Received`/
-            // `Finished` once the actor's worker picks the envelope
-            // up). Adding a bracket here would double-count
-            // `Finished` for the actor case and fire settlement
-            // prematurely. The structural fix is a new
-            // `MailboxEntry::Sink` variant for synchronous sinks —
-            // tracked as a follow-up; the warn-drop / Dropped /
-            // egress / chassis-router arms below close the other
-            // gaps issue 838 catalogued.
+            // `Received`/`Finished` bracket fires here. `Closure`
+            // is the actor-inbox-enqueue variant — the closure body
+            // pushes the envelope onto an mpsc inbox, and the
+            // actor's dispatch loop at `actor/native/dispatch.rs`
+            // records the bracket downstream when its worker picks
+            // the envelope up. Adding a bracket here would
+            // double-count `Finished` and fire settlement
+            // prematurely (surfaced by
+            // `aether-substrate-bundle::rpc_engine_routing` as
+            // ReplyEnd before ReplyEvent). Synchronous sinks live
+            // on the [`MailboxEntry::Sink`] arm below — they get
+            // the bracket because nothing downstream owns it.
             handler(MailDispatch {
                 kind: mail.kind,
                 kind_name: &kind_name,
@@ -388,6 +386,30 @@ fn route_mail(
                 root: mail.root,
                 parent_mail: mail.parent_mail,
             });
+        }
+        Some(MailboxEntry::Sink(handler)) => {
+            let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
+            // ADR-0080 §2 producer hook: synchronous sink. Bracket
+            // the inline handler call with `Received`/`Finished`
+            // so the chain's `in_flight` balances and settlement
+            // subscribers wake (issue 838). Distinct from `Closure`
+            // above — see that arm's doc for the
+            // double-count-prematurely-settle hazard the split
+            // avoids.
+            let thread_name = std::thread::current().name().map(str::to_owned);
+            crate::runtime::trace::record_received(inbound_mail_id, thread_name);
+            handler(MailDispatch {
+                kind: mail.kind,
+                kind_name: &kind_name,
+                origin: None,
+                sender: mail.reply_to,
+                payload: &mail.payload,
+                count: mail.count,
+                mail_id: mail.mail_id,
+                root: mail.root,
+                parent_mail: mail.parent_mail,
+            });
+            crate::runtime::trace::record_finished(inbound_mail_id);
         }
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
@@ -840,5 +862,486 @@ mod tests {
             finished,
             "expected Finished after egress (per-engine settlement); got {events:?}"
         );
+    }
+
+    /// Issue 838 diff 2: synchronous-sink dispatch via the new `Sink`
+    /// arm runs the handler inline AND emits a `Received`/`Finished`
+    /// bracket so the chain's in_flight balances and settlement
+    /// subscribers wake. Mirrors what the actor-dispatch loop does
+    /// for `Closure` recipients, but on the pushing thread.
+    #[test]
+    fn sink_arm_brackets_handler_with_received_and_finished() {
+        let queue = ensure_trace_queue();
+        let sender = MailboxId(0x8380_0004_0000_0000);
+        let inbound_mail_id = MailId::new(sender, 1);
+
+        let (registry, mailer, _store) = make_mailer();
+        let sink = CapturingSink::new();
+        let sink_id = registry.register_sink("test.838.sink", sink.handler());
+
+        let mail = Mail::new(sink_id, KindId(0xCAFE_BABE), vec![1, 2, 3], 1).with_lineage(
+            inbound_mail_id,
+            inbound_mail_id,
+            None,
+        );
+        mailer.push(mail);
+
+        assert_eq!(
+            sink.delivery_count.load(Ordering::SeqCst),
+            1,
+            "sink handler should have run"
+        );
+
+        let events = drain_events_for(&queue, sender);
+        let received = events.iter().any(
+            |e| matches!(e, TraceEvent::Received { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        let finished = events.iter().any(
+            |e| matches!(e, TraceEvent::Finished { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        assert!(
+            received,
+            "expected Received for sink dispatch; got {events:?}"
+        );
+        assert!(
+            finished,
+            "expected Finished for sink dispatch; got {events:?}"
+        );
+    }
+
+    /// Issue 838 diff 2 regression guard: actor-enqueue closure
+    /// dispatch via `Closure` MUST NOT emit Received/Finished from
+    /// the Mailer side. The actor's dispatch loop at
+    /// `actor/native/dispatch.rs:85` owns the bracket; doubling it
+    /// here fires settlement prematurely and breaks
+    /// `aether-substrate-bundle::rpc_engine_routing` (ReplyEnd
+    /// before ReplyEvent). This test pins the contract so a
+    /// future "let's add the bracket for symmetry" refactor fails
+    /// loudly.
+    #[test]
+    fn closure_arm_does_not_bracket_in_mailer() {
+        let queue = ensure_trace_queue();
+        let sender = MailboxId(0x8380_0005_0000_0000);
+        let inbound_mail_id = MailId::new(sender, 1);
+
+        let (registry, mailer, _store) = make_mailer();
+        let sink = CapturingSink::new();
+        // Register as `register_closure` (the actor-enqueue
+        // contract), NOT `register_sink`.
+        let recipient = registry.register_closure("test.838.closure_regression", sink.handler());
+
+        let mail = Mail::new(recipient, KindId(0xCAFE_BABE), vec![4, 5, 6], 1).with_lineage(
+            inbound_mail_id,
+            inbound_mail_id,
+            None,
+        );
+        mailer.push(mail);
+
+        // Handler still runs — that's how mail reaches the actor's
+        // mpsc inbox in production.
+        assert_eq!(sink.delivery_count.load(Ordering::SeqCst), 1);
+
+        let events = drain_events_for(&queue, sender);
+        let received_from_mailer = events.iter().any(
+            |e| matches!(e, TraceEvent::Received { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        let finished_from_mailer = events.iter().any(
+            |e| matches!(e, TraceEvent::Finished { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        assert!(
+            !received_from_mailer,
+            "Closure arm must not emit Received from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
+        );
+        assert!(
+            !finished_from_mailer,
+            "Closure arm must not emit Finished from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
+        );
+    }
+
+    /// Issue 838 diff 2: mail that parks on a missing handle does
+    /// NOT emit Finished. The chain stays elevated until the
+    /// handle is published and the mail is replayed through
+    /// `Mailer::push`, at which point the now-resolved walk
+    /// reaches a terminal arm (Sink here) and that arm's bracket
+    /// fires. Pins "Parked is not Finished" — semantically
+    /// distinct from Ref-walk Err (which IS terminal and fires
+    /// Finished, covered by the existing
+    /// `malformed_ref_payload_drops_mail` plus the issue 839 Ref-
+    /// walk-Err Finished record).
+    #[test]
+    fn ref_walk_parked_defers_finished_until_handle_publish() {
+        use aether_data::HandleId;
+
+        let queue = ensure_trace_queue();
+        let sender = MailboxId(0x8380_0006_0000_0000);
+        let inbound_mail_id = MailId::new(sender, 1);
+
+        let (registry, mailer, store) = make_mailer();
+        // Register both kinds so the mailer walks the outer schema
+        // and the handle store recognises the inner one. The
+        // registry-derived kind id is what `Ref::Handle.kind_id`
+        // must carry (the walker's debug-assert compares stored
+        // kind_id == wire kind_id) — same pattern as the existing
+        // `handle_ref_parks_then_resolves_through_mailer` test.
+        let outer_kind_id = registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: HeldNote::NAME.into(),
+                schema: held_note_schema(),
+            })
+            .unwrap();
+        let inner_kind_id = registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: Note::NAME.into(),
+                schema: note_schema(),
+            })
+            .unwrap();
+        let sink = CapturingSink::new();
+        let sink_id = registry.register_sink("test.838.park_defer", sink.handler());
+
+        // Build a payload that references a handle not yet in the
+        // store — the walker returns `Parked`, mail held.
+        let handle = HandleId(0x1234_5678_9ABC_DEF0);
+        let held: HeldNote = HeldNote {
+            held: Ref::Handle {
+                id: handle.0,
+                kind_id: inner_kind_id.0,
+            },
+            seq: 7,
+        };
+        let payload = postcard::to_allocvec(&held).unwrap();
+
+        let mail = Mail::new(sink_id, outer_kind_id, payload, 1).with_lineage(
+            inbound_mail_id,
+            inbound_mail_id,
+            None,
+        );
+        mailer.push(mail);
+
+        // Handler hasn't run; mail is parked. NO Finished yet.
+        assert_eq!(
+            sink.delivery_count.load(Ordering::SeqCst),
+            0,
+            "parked mail must not dispatch"
+        );
+        assert_eq!(
+            store.parked_count(handle),
+            1,
+            "mail should be parked under the missing handle"
+        );
+        let events_before_publish = drain_events_for(&queue, sender);
+        let finished_before = events_before_publish.iter().any(
+            |e| matches!(e, TraceEvent::Finished { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        assert!(
+            !finished_before,
+            "Parked mail must NOT emit Finished — the chain stays elevated until publish (issue 838). Got: {events_before_publish:?}"
+        );
+
+        // Publish the handle with matching `Note` bytes; resolve
+        // and replay through the mailer. The walker reruns,
+        // resolves the ref, and the sink's bracket fires.
+        let note = Note {
+            body: "hi".into(),
+            seq: 99,
+        };
+        let note_bytes = postcard::to_allocvec(&note).unwrap();
+        mailer
+            .resolve_handle(handle, inner_kind_id, note_bytes)
+            .expect("resolve_handle");
+
+        assert_eq!(
+            sink.delivery_count.load(Ordering::SeqCst),
+            1,
+            "after publish + replay, sink should have dispatched once"
+        );
+
+        let events_after = drain_events_for(&queue, sender);
+        let finished_after = events_after.iter().any(
+            |e| matches!(e, TraceEvent::Finished { mail_id, .. } if *mail_id == inbound_mail_id),
+        );
+        assert!(
+            finished_after,
+            "after publish, the resumed dispatch should have fired Finished. Got: {events_after:?}"
+        );
+    }
+
+    /// Issue 838 diff 2: exhaustive meta-test asserting every
+    /// `Mailer::push` short-circuit produces the correct ADR-0080
+    /// §2 lifecycle events for stamped (non-NONE) mail. The
+    /// `DispatchPath` enum mirrors the real dispatch surface; the
+    /// match below is exhaustive, so a contributor adding a new
+    /// path (a new `MailboxEntry` variant, a new `route_mail`
+    /// short-circuit) MUST extend this test — that's the
+    /// forcing function for lifecycle-hook coverage.
+    ///
+    /// Both production bugs we shipped on this work would have
+    /// failed this test immediately:
+    /// - Original iamacoffeepot/aether#838 leak: `Sink` case would have shown no
+    ///   Finished, expected Bracket.
+    /// - iamacoffeepot/aether#839-attempt-1 double-count: `Closure` case would have shown
+    ///   Finished from the Mailer side, expected NeitherFromMailer.
+    #[test]
+    fn every_mailer_push_path_produces_correct_lifecycle_events() {
+        // Static link to `MailboxEntry`: a new variant added there
+        // breaks this `match`, which fails to compile, which
+        // forces the contributor to add a case to `DispatchPath`
+        // and the test loop below. Comment is normative.
+        fn dispatch_path_for_entry(entry: &MailboxEntry) -> &'static str {
+            match entry {
+                MailboxEntry::Closure(_) => "Closure",
+                MailboxEntry::Sink(_) => "Sink",
+                MailboxEntry::Dropped => "Dropped",
+            }
+        }
+        // Touch the helper so the compiler considers it live.
+        let _ = dispatch_path_for_entry(&MailboxEntry::Dropped);
+
+        let queue = ensure_trace_queue();
+        // Each case: (case-name, expectation, push-fn that returns
+        // the stamped mail_id to filter on). Cases construct their
+        // own Mailer fixtures so chassis-router / outbound / handle-
+        // store-Parked setups can vary independently.
+        enum Expect {
+            /// Sync handler ran inline → Received + Finished.
+            Bracket,
+            /// Terminal arm (drop / warn / egress / ref-walk-err /
+            /// router-missing) → Finished only.
+            FinishedOnly,
+            /// Held — mail deferred via `HandleStore::park` → neither.
+            HeldNeither,
+            /// Actor-enqueue Closure → no bracket from Mailer side
+            /// (downstream actor dispatch loop owns it).
+            NeitherFromMailer,
+        }
+
+        struct Case {
+            name: &'static str,
+            expect: Expect,
+            // Returns the `MailId` to filter the trace queue on.
+            run: Box<dyn FnOnce() -> MailId>,
+        }
+
+        let cases: Vec<Case> = vec![
+            // 1. Sink arm — bracket.
+            Case {
+                name: "Sink",
+                expect: Expect::Bracket,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD01_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (registry, mailer, _store) = make_mailer();
+                    let sink = CapturingSink::new();
+                    let id = registry.register_sink("test.meta.sink", sink.handler());
+                    mailer.push(
+                        Mail::new(id, KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 2. Closure arm — no bracket from Mailer (regression
+            // guard for actor-enqueue contract).
+            Case {
+                name: "Closure (actor-enqueue)",
+                expect: Expect::NeitherFromMailer,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD02_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (registry, mailer, _store) = make_mailer();
+                    let sink = CapturingSink::new();
+                    let id = registry.register_closure("test.meta.closure", sink.handler());
+                    mailer.push(
+                        Mail::new(id, KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 3. Dropped arm — Finished only.
+            Case {
+                name: "Dropped",
+                expect: Expect::FinishedOnly,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD03_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (registry, mailer, _store) = make_mailer();
+                    let id = registry.register_closure("test.meta.dropped", Arc::new(|_| {}));
+                    let _ = registry.drop_mailbox(id).expect("drop");
+                    mailer.push(
+                        Mail::new(id, KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 4. None warn-drop (no outbound) — Finished only.
+            Case {
+                name: "None warn-drop (no outbound)",
+                expect: Expect::FinishedOnly,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD04_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (_registry, mailer, _store) = make_mailer();
+                    mailer.push(
+                        Mail::new(MailboxId(0xDEAD_BEEF_0001), KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 5. None egress to hub — Finished only (per-engine
+            // settlement; hub settlement is its own domain).
+            Case {
+                name: "None egress (outbound wired)",
+                expect: Expect::FinishedOnly,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD05_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (outbound, _rx) = crate::mail::outbound::HubOutbound::attached_loopback();
+                    let registry = Arc::new(Registry::new());
+                    let store = Arc::new(HandleStore::new(64 * 1024));
+                    let mailer = Mailer::new(registry, store).with_outbound(outbound);
+                    mailer.push(
+                        Mail::new(MailboxId(0xDEAD_BEEF_0002), KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 6. Ref-walk Err (malformed payload, terminal drop) —
+            // Finished only.
+            Case {
+                name: "Ref-walk Err",
+                expect: Expect::FinishedOnly,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD06_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (registry, mailer, _store) = make_mailer();
+                    let kind_id = registry
+                        .register_kind_with_descriptor(KindDescriptor {
+                            name: HeldNote::NAME.into(),
+                            schema: held_note_schema(),
+                        })
+                        .unwrap();
+                    let sink = CapturingSink::new();
+                    let id = registry.register_sink("test.meta.refwalk_err", sink.handler());
+                    // Truncated payload (1 byte) — walker bails Err.
+                    mailer.push(
+                        Mail::new(id, kind_id, vec![0u8; 1], 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 7. Ref-walk Parked (held for handle publish) — neither.
+            Case {
+                name: "Ref-walk Parked",
+                expect: Expect::HeldNeither,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD07_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (registry, mailer, _store) = make_mailer();
+                    let outer_kind_id = registry
+                        .register_kind_with_descriptor(KindDescriptor {
+                            name: HeldNote::NAME.into(),
+                            schema: held_note_schema(),
+                        })
+                        .unwrap();
+                    let inner_kind_id = registry
+                        .register_kind_with_descriptor(KindDescriptor {
+                            name: Note::NAME.into(),
+                            schema: note_schema(),
+                        })
+                        .unwrap();
+                    let sink = CapturingSink::new();
+                    let id = registry.register_sink("test.meta.refwalk_parked", sink.handler());
+                    let held = HeldNote {
+                        held: Ref::Handle {
+                            id: 0x8888_8888_8888_8888,
+                            kind_id: inner_kind_id.0,
+                        },
+                        seq: 1,
+                    };
+                    let payload = postcard::to_allocvec(&held).unwrap();
+                    mailer.push(
+                        Mail::new(id, outer_kind_id, payload, 1)
+                            .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 8. CHASSIS_MAILBOX_ID with router installed — bracket.
+            Case {
+                name: "Chassis router installed",
+                expect: Expect::Bracket,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD08_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (_registry, mailer, _store) = make_mailer();
+                    mailer.install_chassis_router(Box::new(|_| {}));
+                    mailer.push(
+                        Mail::new(
+                            aether_data::MailboxId::CHASSIS_MAILBOX_ID,
+                            KindId(0xFEED),
+                            vec![],
+                            1,
+                        )
+                        .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+            // 9. CHASSIS_MAILBOX_ID with no router — Finished only.
+            Case {
+                name: "Chassis router missing",
+                expect: Expect::FinishedOnly,
+                run: Box::new(|| {
+                    let sender = MailboxId(0x8380_DD09_0000_0000);
+                    let mail_id = MailId::new(sender, 1);
+                    let (_registry, mailer, _store) = make_mailer();
+                    mailer.push(
+                        Mail::new(
+                            aether_data::MailboxId::CHASSIS_MAILBOX_ID,
+                            KindId(0xFEED),
+                            vec![],
+                            1,
+                        )
+                        .with_lineage(mail_id, mail_id, None),
+                    );
+                    mail_id
+                }),
+            },
+        ];
+
+        for case in cases {
+            let name = case.name;
+            let expect = case.expect;
+            let mail_id = (case.run)();
+            let events = drain_events_for(&queue, mail_id.sender);
+            let received = events
+                .iter()
+                .any(|e| matches!(e, TraceEvent::Received { mail_id: m, .. } if *m == mail_id));
+            let finished = events
+                .iter()
+                .any(|e| matches!(e, TraceEvent::Finished { mail_id: m, .. } if *m == mail_id));
+            match expect {
+                Expect::Bracket => assert!(
+                    received && finished,
+                    "{name}: expected Received+Finished bracket; got received={received} finished={finished}; events={events:?}"
+                ),
+                Expect::FinishedOnly => assert!(
+                    !received && finished,
+                    "{name}: expected Finished only (no Received); got received={received} finished={finished}; events={events:?}"
+                ),
+                Expect::HeldNeither => assert!(
+                    !received && !finished,
+                    "{name}: expected neither Received nor Finished (mail held); got received={received} finished={finished}; events={events:?}"
+                ),
+                Expect::NeitherFromMailer => assert!(
+                    !received && !finished,
+                    "{name}: expected neither (actor dispatch owns bracket downstream); got received={received} finished={finished}; events={events:?}"
+                ),
+            }
+        }
     }
 }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -104,13 +104,34 @@ pub type MailboxHandler = Arc<dyn for<'a> Fn(MailDispatch<'a>) + Send + Sync + '
 /// Issue 634 Phase 4 retired the dedicated `Component` variant —
 /// every loaded wasm component is now a `WasmTrampoline` registered
 /// here as a `Closure` like every other actor.
+///
+/// Issue 838: `Closure` and `Sink` are intentionally distinct even
+/// though both wrap a [`MailboxHandler`]. The variant is the
+/// settlement-protocol contract — see each variant's docs and
+/// `Mailer::push`'s route_mail for the bracket semantics.
 #[derive(Clone)]
 pub enum MailboxEntry {
-    /// Mail is handled inline by a substrate-native closure (the
-    /// actor-as-mailbox wrap installed by `claim_mailbox` /
-    /// `register_closure`, including the wasm trampoline's spawn-time
-    /// registration).
+    /// Actor-inbox enqueue closure. The handler body pushes the
+    /// envelope onto an mpsc inbox; an actor's dispatch loop on
+    /// another thread runs the work and records the
+    /// `Received`/`Finished` lifecycle hooks. `Mailer::push` does
+    /// NOT bracket this arm — the downstream dispatch loop owns the
+    /// bracket. Installed by `claim_mailbox` /
+    /// `Spawner::register_closure` (instanced + singleton actors,
+    /// including the wasm trampoline) and by the public
+    /// [`Registry::register_closure`] / [`Registry::try_register_closure`]
+    /// for callers that own a separate dispatcher loop.
     Closure(MailboxHandler),
+    /// Synchronous sink. The handler body does its work inline on
+    /// the pushing thread; there is no actor dispatch loop behind
+    /// it. `Mailer::push` brackets this arm with `Received` and
+    /// `Finished` so the chain's `in_flight` balances and
+    /// settlement subscribers (`SettlementRegistry`) wake (ADR-0080
+    /// §2, issue 838). Installed by [`Registry::register_sink`] /
+    /// [`Registry::try_register_sink`]. Distinct from `Closure` so
+    /// the bracket isn't double-counted when the closure was an
+    /// actor-enqueue (which would fire settlement prematurely).
+    Sink(MailboxHandler),
     /// Mailbox has been explicitly dropped (ADR-0010). Mail addressed
     /// to a `Dropped` slot is discarded by the scheduler / ctx dispatch
     /// until the same name is re-registered, at which point the slot
@@ -315,7 +336,7 @@ impl Registry {
             return Err(DropError::UnknownId(id));
         };
         match slot.entry {
-            MailboxEntry::Closure(_) => {}
+            MailboxEntry::Closure(_) | MailboxEntry::Sink(_) => {}
             MailboxEntry::Dropped => return Err(DropError::AlreadyDropped(id)),
         }
         slot.entry = MailboxEntry::Dropped;
@@ -357,6 +378,46 @@ impl Registry {
         result
     }
 
+    /// Issue 838: register a synchronous-sink mailbox. The handler
+    /// runs inline on `Mailer::push`'s thread; the mailer brackets
+    /// the call with `Received`/`Finished` so the chain's
+    /// `in_flight` balances and settlement subscribers
+    /// ([`crate::chassis::settlement::SettlementRegistry`]) wake
+    /// (ADR-0080 §2).
+    ///
+    /// Distinct from [`Self::register_closure`] which is for
+    /// actor-inbox enqueue closures whose downstream dispatch loop
+    /// owns the bracket. Miscategorisation is silent: a synchronous
+    /// sink registered as a `Closure` leaks `in_flight` (chains
+    /// never settle); an actor-enqueue closure registered as a
+    /// `Sink` double-counts `Finished` (settlement fires
+    /// prematurely). Panics on a name collision — these are
+    /// substrate-internal names, collisions are bugs.
+    pub fn register_sink(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
+        let name = name.into();
+        match self.insert(name.clone(), MailboxEntry::Sink(handler)) {
+            Ok(id) => {
+                self.notify_mailbox_change();
+                id
+            }
+            Err(_) => panic!("mailbox name already registered: {name}"),
+        }
+    }
+
+    /// Non-panicking variant of [`Self::register_sink`], symmetric
+    /// with [`Self::try_register_closure`].
+    pub fn try_register_sink(
+        &self,
+        name: impl Into<String>,
+        handler: MailboxHandler,
+    ) -> Result<MailboxId, NameConflict> {
+        let result = self.insert(name.into(), MailboxEntry::Sink(handler));
+        if result.is_ok() {
+            self.notify_mailbox_change();
+        }
+        result
+    }
+
     /// Issue 607 Phase 7: fully remove a closure-bound mailbox. Used
     /// in the chassis-boot unwind path when a singleton's `init` fails
     /// after `try_register_closure` claimed the slot — the partial-boot
@@ -372,7 +433,9 @@ impl Registry {
     pub(crate) fn remove_closure(&self, id: MailboxId) -> bool {
         let mut inner = self.inner.write().unwrap();
         match inner.mailboxes.get(&id) {
-            Some(slot) if matches!(slot.entry, MailboxEntry::Closure(_)) => {
+            Some(slot)
+                if matches!(slot.entry, MailboxEntry::Closure(_) | MailboxEntry::Sink(_)) =>
+            {
                 inner.mailboxes.remove(&id);
                 true
             }


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Closes the settlement-protocol gap iamacoffeepot/aether#839 left open. Synchronous sinks now register as a distinct `MailboxEntry::Sink` variant; `Mailer::push` (and `WasmComponent::send`'s fast path) bracket Sink dispatch with `Received`/`Finished` so chains whose descendants touch chassis-owned sinks settle and `SettlementRegistry` subscribers wake.

The pre-existing `Closure` variant stays bracket-free — its downstream actor dispatch loop owns the lifecycle hooks. The split is the contract that lets each path do exactly one bracket without double-counting (the rpc_engine_routing failure that forced iamacoffeepot/aether#839 to defer the Closure arm).

## Surface changes

- `MailboxEntry::Sink(MailboxHandler)` variant alongside `Closure` and `Dropped`. Variant choice IS the settlement contract — see the doc on each variant. Miscategorisation is silent (Sink-as-Closure → leak; Closure-as-Sink → premature settle).
- `Registry::register_sink` + `try_register_sink` mirror the `register_closure` / `try_register_closure` shape.
- `Mailer::push`'s `route_mail` adds a Sink arm with the bracket.
- `WasmComponent::send` fast path also adds a Sink arm — guest-originated mail to sync sinks balances the chain.
- `InputCapability::validate_subscriber_mailbox` accepts both Closure and Sink.
- **One production migration**: `boot.rs::AETHER_DIAGNOSTICS` (the only true synchronous sink in production today) moves from `register_closure` to `register_sink`.

## Tests

Three per-arm units + one exhaustive meta-test, all in `mailer::tests`:

1. **`sink_arm_brackets_handler_with_received_and_finished`** — Sink dispatch emits both.
2. **`closure_arm_does_not_bracket_in_mailer`** — regression guard for the rpc_engine_routing contract.
3. **`ref_walk_parked_defers_finished_until_handle_publish`** — pins "Parked is NOT Finished" distinct from Ref-walk Err.
4. **`every_mailer_push_path_produces_correct_lifecycle_events`** — exhaustive table-driven over all 9 `Mailer::push` short-circuits (Sink / Closure / Dropped / None warn-drop / None egress / Ref-walk Err / Ref-walk Parked / Chassis router installed / Chassis router missing). The match is the forcing function: a future contributor adding a new `MailboxEntry` variant or a new `route_mail` short-circuit MUST extend the test (the match goes non-exhaustive and fails to compile). Both production bugs we shipped on this work would have failed this test immediately.

## What this PR does NOT do

- **Doesn't fix iamacoffeepot/aether#834 directly.** That issue's plan migrates `TestBench::send_*` to wait on the now-functional settlement signal; this PR makes the signal correct, that PR makes the consumer use it.
- **Doesn't retire the `TestBenchObserver`-as-actor workaround.** See `test_bench/chassis.rs:55-64` — it was promoted to NativeActor specifically because of the leak we just closed. Could revert to a `register_sink` closure now (saves one thread per TestBench); optional follow-up.

## Verification

- `cargo nextest run --workspace --no-fail-fast` — 990/990 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- 10-run sokoban scenario loop: 9/10. The remaining flake is iamacoffeepot/aether#834 territory (test bench doesn't wait for settlement); this PR doesn't claim to fix that. Acceptance was "RPC roundtrip still passes" (regression guard) — confirmed.

Closes iamacoffeepot/aether#838
