### PR TITLE
refactor(substrate): rename MailboxEntry variants to describe contract (Inbox + Inline)

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -1034,7 +1034,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(
+            registry.register_inbox(
                 AudioCapability::NAMESPACE,
                 aether_substrate::mail::registry::noop_handler(),
             );

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -929,7 +929,7 @@ mod native {
         fn duplicate_claim_rejects_with_typed_error() {
             let root = scratch_root("collide");
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(
+            registry.register_inbox(
                 FsCapability::NAMESPACE,
                 aether_substrate::mail::registry::noop_handler(),
             );

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -199,7 +199,7 @@ mod native {
             let id = registry
                 .lookup(HandleCapability::NAMESPACE)
                 .expect("mailbox registered");
-            let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry") else {
+            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
                 panic!("expected mailbox entry");
             };
 
@@ -276,7 +276,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (_store, mailer, registry, _rx) = fresh_substrate();
-            registry.register_closure(
+            registry.register_inbox(
                 HandleCapability::NAMESPACE,
                 aether_substrate::mail::registry::noop_handler(),
             );

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -628,7 +628,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(
+            registry.register_inbox(
                 HttpCapability::NAMESPACE,
                 aether_substrate::mail::registry::noop_handler(),
             );

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -203,7 +203,7 @@ mod native {
     /// subscribers if any future driver wants one.
     fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
         match registry.entry(id) {
-            Some(MailboxEntry::Closure(_)) | Some(MailboxEntry::Sink(_)) => Ok(()),
+            Some(MailboxEntry::Inbox(_)) | Some(MailboxEntry::Inline(_)) => Ok(()),
             Some(MailboxEntry::Dropped) => Err(format!("mailbox {:?} already dropped", id)),
             None => Err(format!("unknown mailbox id {:?}", id)),
         }

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -273,7 +273,7 @@ mod native {
             let id = registry
                 .lookup(LogCapability::NAMESPACE)
                 .expect("mailbox registered");
-            let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry") else {
+            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
                 panic!("expected mailbox entry");
             };
 
@@ -300,7 +300,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_closure(
+            registry.register_inbox(
                 LogCapability::NAMESPACE,
                 aether_substrate::mail::registry::noop_handler(),
             );

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -582,7 +582,7 @@ mod native {
 
         fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
             let id = registry.lookup(name).expect("mailbox registered");
-            let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
+            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
                 panic!("expected mailbox entry for {name}");
             };
             handler(aether_substrate::mail::registry::MailDispatch {

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -614,7 +614,7 @@ mod cap_native {
             let id = registry
                 .lookup(cap_namespace)
                 .expect("cap mailbox registered");
-            let MailboxEntry::Closure(handler) = registry.entry(id).expect("cap entry") else {
+            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("cap entry") else {
                 panic!("expected mailbox entry");
             };
             let bytes = postcard::to_allocvec(mail).expect("encode");

--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -127,7 +127,7 @@ fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
 
 fn push_log_batch(registry: &Registry, recipient: &str, payload: &[u8]) {
     let id = registry.lookup(recipient).expect("mailbox registered");
-    let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
+    let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
     handler(aether_substrate::mail::registry::MailDispatch {

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -125,13 +125,13 @@ impl HeadlessChassis {
         // actor dispatch loop behind it, so without the bracket
         // any chain that mails `aether.audio` from the headless
         // chassis leaks `in_flight` and never settles. Same shape
-        // as the AETHER_DIAGNOSTICS sink in `boot.rs::register_sink`.
+        // as the AETHER_DIAGNOSTICS sink in `boot.rs::register_inline`.
         let kind_set_master_gain = boot
             .registry
             .kind_id(SetMasterGain::NAME)
             .expect("SetMasterGain registered");
         let outbound_for_audio_sink = Arc::clone(&boot.outbound);
-        boot.registry.register_sink(
+        boot.registry.register_inline(
             "aether.audio",
             Arc::new(
                 move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -774,7 +774,7 @@ mod tests {
         type CapturedRow = (MailId, MailId, Option<MailId>);
         let captured: Arc<Mutex<Vec<CapturedRow>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
-        let subscriber_mbox = tb.registry.register_closure(
+        let subscriber_mbox = tb.registry.register_inbox(
             "issue_723_test_subscriber",
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 captured_for_handler.lock().unwrap().push((

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -58,10 +58,13 @@ pub use observer::TestBenchObserverConfig;
 /// MCP sessions); with that fan-out retired the observer survives as
 /// a test-bench-private cap whose only job is recording kind names
 /// for `count_observed` assertions. The cap is a real `NativeActor`
-/// (not a `register_closure`) so its handler completes through the
-/// framework's ADR-0080 settlement reporting — the bench's Tick
-/// settlement gate would otherwise wait the full 5 s timeout per
-/// tick when a probe component routes observation mail here.
+/// (not a `register_inline` synchronous handler) so its handler
+/// completes through the framework's ADR-0080 settlement reporting
+/// — the bench's Tick settlement gate would otherwise wait the
+/// full 5 s timeout per tick when a probe component routes
+/// observation mail here. (Post-iamacoffeepot/aether#840 a
+/// `register_inline` sink would also settle correctly; retiring
+/// this actor-shaped workaround is a tracked follow-up.)
 #[aether_actor::bridge(singleton)]
 mod observer {
     use std::sync::{Arc, Mutex};

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -641,7 +641,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<Envelope>();
         // Register a sink so push routes somewhere instead of
         // hitting the unknown-recipient warn.
-        registry.register_closure("test.sink", forward_to_envelope_sender(tx));
+        registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
         let recipient = registry.lookup("test.sink").unwrap();
 
         let transport = NativeBinding::new_for_test(mailer, MailboxId(99));
@@ -721,7 +721,7 @@ mod tests {
     fn cross_class_wait_reply_aborts_when_caller_frame_bound_and_recipient_free_running() {
         let (registry, mailer) = fresh_substrate();
         let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_closure("test.free.running", forward_to_envelope_sender(tx));
+        registry.register_inbox("test.free.running", forward_to_envelope_sender(tx));
         let recipient = registry.lookup("test.free.running").unwrap();
 
         // Empty frame-bound set => recipient classifies as free-running.
@@ -747,7 +747,7 @@ mod tests {
     fn cross_class_wait_reply_does_not_abort_when_recipient_also_frame_bound() {
         let (registry, mailer) = fresh_substrate();
         let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_closure("test.frame.bound", forward_to_envelope_sender(tx));
+        registry.register_inbox("test.frame.bound", forward_to_envelope_sender(tx));
         let recipient = registry.lookup("test.frame.bound").unwrap();
 
         let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
@@ -780,7 +780,7 @@ mod tests {
     fn cross_class_wait_reply_does_not_abort_when_caller_free_running() {
         let (registry, mailer) = fresh_substrate();
         let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_closure("test.any", forward_to_envelope_sender(tx));
+        registry.register_inbox("test.any", forward_to_envelope_sender(tx));
         let recipient = registry.lookup("test.any").unwrap();
 
         // Empty set — recipient is free-running. Caller is also
@@ -806,7 +806,7 @@ mod tests {
     fn wait_reply_prunes_pending_recipient_on_timeout() {
         let (registry, mailer) = fresh_substrate();
         let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_closure("test.prune", forward_to_envelope_sender(tx));
+        registry.register_inbox("test.prune", forward_to_envelope_sender(tx));
         let recipient = registry.lookup("test.prune").unwrap();
 
         let transport = NativeBinding::new_for_test(Arc::clone(&mailer), MailboxId(99));

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -364,9 +364,9 @@ impl Spawner {
 
         // 5-7. Register sink + Live entry + pre-load mail. The actor
         // registry's `insert_live` and the mailbox registry's
-        // `try_register_closure` each take their own write lock; a
+        // `try_register_inbox` each take their own write lock; a
         // collision on either step rolls back. Sequence chosen so the
-        // sink is the gating step (its `try_register_closure` is the
+        // sink is the gating step (its `try_register_inbox` is the
         // only op that can fail with a name collision against a peer
         // singleton claim — the actor_registry slot is keyed on
         // MailboxId which already passed the tombstone check).
@@ -395,7 +395,7 @@ impl Spawner {
         let wake_slot: Arc<crate::chassis::ctx::MailboxWakeSlot> =
             Arc::new(crate::chassis::ctx::MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
-        let registered = self.registry.try_register_closure(
+        let registered = self.registry.try_register_inbox(
             full_name.clone(),
             Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let Some(tx) = weak_for_handler.upgrade() else {

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -358,7 +358,7 @@ mod tests {
     fn register_capture(registry: &Registry, name: &str) -> Arc<Mutex<Vec<CapturedDispatch>>> {
         let captured: Arc<Mutex<Vec<CapturedDispatch>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
-        let _ = registry.try_register_closure(
+        let _ = registry.try_register_inbox(
             name.to_owned(),
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 captured_for_handler.lock().unwrap().push(CapturedDispatch {

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -230,7 +230,7 @@ impl ComponentCtx {
         // downstream dispatch loop records the bracket. See
         // [`MailboxEntry`] docs for the contract.
         match self.registry.entry(recipient) {
-            Some(MailboxEntry::Closure(handler)) => {
+            Some(MailboxEntry::Inbox(handler)) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 // Component-originated mail: the sender is this ctx's
                 // mailbox, so its registry name is the `origin` any
@@ -253,7 +253,7 @@ impl ComponentCtx {
                 });
                 return;
             }
-            Some(MailboxEntry::Sink(handler)) => {
+            Some(MailboxEntry::Inline(handler)) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 let origin = self.registry.mailbox_name(self.sender);
                 let thread_name = std::thread::current().name().map(str::to_owned);
@@ -1133,7 +1133,7 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_closure("client", crate::mail::registry::noop_handler())
+            .try_register_inbox("client", crate::mail::registry::noop_handler())
             .expect("register client mailbox");
 
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
@@ -1175,7 +1175,7 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_closure("client", crate::mail::registry::noop_handler())
+            .try_register_inbox("client", crate::mail::registry::noop_handler())
             .expect("register client mailbox");
 
         let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
@@ -1218,7 +1218,7 @@ mod tests {
 
         let registry = Arc::new(Registry::new());
         let sink_id = registry
-            .try_register_closure(
+            .try_register_inbox(
                 "issue_722_sink",
                 Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                     captured_for_handler.lock().unwrap().push((
@@ -1290,7 +1290,7 @@ mod tests {
 
         let registry = Arc::new(Registry::new());
         let sink_id = registry
-            .try_register_closure(
+            .try_register_inbox(
                 "issue_722_fresh_root_sink",
                 Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
                     captured_for_handler.lock().unwrap().push((

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -24,7 +24,7 @@
 //! through `Builder::with_actor()`. Without this separation, a hub-driven
 //! `load_component` could race ahead of the chassis's main thread
 //! and bind a chassis sink name to a freshly-loaded component before
-//! the chassis's later `register_closure` call, panicking the substrate
+//! the chassis's later `register_inbox` call, panicking the substrate
 //! (issue #262).
 //!
 //! **Env-var reading is the chassis's job.** Per issue 464,
@@ -146,7 +146,7 @@ impl<'a> SubstrateBootBuilder<'a> {
         // (just emits a `tracing::warn!`) — there's no actor
         // dispatch loop behind it, so without the bracket the
         // chain's `in_flight` would leak.
-        registry.register_sink(
+        registry.register_inline(
             AETHER_DIAGNOSTICS,
             Arc::new(|dispatch: crate::mail::registry::MailDispatch<'_>| {
                 let kind_name = dispatch.kind_name;
@@ -219,7 +219,7 @@ mod tests {
         // The boot is alive; chassis sinks can be registered without
         // racing a hub-driven load.
         boot.registry
-            .register_closure("test_chassis_sink", Arc::new(|_dispatch| {}));
+            .register_inbox("test_chassis_sink", Arc::new(|_dispatch| {}));
         // No backend attached → `is_connected()` is false. Chassis
         // crates that want a hub bridge wire `HubClientCapability`
         // themselves through their `Builder`.

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1899,7 +1899,7 @@ mod tests {
         let mailbox_id = registry
             .lookup(<ProbeCap as aether_actor::Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Closure(handler) = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("ProbeCap claim must be a sink entry");
         };
@@ -2074,7 +2074,7 @@ mod tests {
         let mailbox_id = registry
             .lookup(<LocalProbe as aether_actor::Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Closure(handler) = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("LocalProbe claim must be a sink entry");
         };
@@ -2249,7 +2249,7 @@ mod tests {
         let parent_id = registry
             .lookup(<ParentCap as aether_actor::Actor>::NAMESPACE)
             .expect("ParentCap claimed");
-        let MailboxEntry::Closure(handler) = registry.entry(parent_id).expect("sink") else {
+        let MailboxEntry::Inbox(handler) = registry.entry(parent_id).expect("sink") else {
             panic!("expected mailbox entry");
         };
         let bytes = (Hatch { tag: 1 }).encode_into_bytes();
@@ -2373,7 +2373,7 @@ mod tests {
         // registered sink handler. The handler's `ctx.shutdown()`
         // flips the dispatcher's flag; after the handler returns the
         // trampoline drains, runs `unwire`, marks Dead, tombstones.
-        let MailboxEntry::Closure(handler) = registry.entry(id).expect("sink registered") else {
+        let MailboxEntry::Inbox(handler) = registry.entry(id).expect("sink registered") else {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
@@ -2752,7 +2752,7 @@ mod tests {
         // Drive the watcher to register the monitor by pushing a
         // WatchOrder through its sink handler. After this returns
         // the watcher's handle is stored in `self.handle`.
-        let MailboxEntry::Closure(watcher_handler) =
+        let MailboxEntry::Inbox(watcher_handler) =
             registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
@@ -2788,7 +2788,7 @@ mod tests {
         // Fire Quit at the target — its handler self-shuts; the
         // dispatcher's close path runs `close_actor`, which fans out
         // a MonitorNotice mail to watcher_id.
-        let MailboxEntry::Closure(target_handler) =
+        let MailboxEntry::Inbox(target_handler) =
             registry.entry(target_id).expect("target sink registered")
         else {
             panic!("expected mailbox entry for target");
@@ -2981,7 +2981,7 @@ mod tests {
             .expect("spawn watcher");
 
         // Watcher registers monitor against target.
-        let MailboxEntry::Closure(watcher_handler) =
+        let MailboxEntry::Inbox(watcher_handler) =
             registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
@@ -3173,8 +3173,7 @@ mod tests {
         // Close c — Quit it through the sink handler. After close,
         // resolve_actors drops to two and resolve_actor::<Member>("c")
         // returns None.
-        let MailboxEntry::Closure(handler) = registry.entry(id_c).expect("c sink registered")
-        else {
+        let MailboxEntry::Inbox(handler) = registry.entry(id_c).expect("c sink registered") else {
             panic!("expected mailbox entry for c");
         };
         handler(crate::mail::registry::test_dispatch(
@@ -3479,7 +3478,7 @@ mod tests {
             .expect("spawn parent");
 
         // Trigger parent → grandchild spawn.
-        let MailboxEntry::Closure(parent_handler) =
+        let MailboxEntry::Inbox(parent_handler) =
             registry.entry(parent_id).expect("parent sink registered")
         else {
             panic!("expected mailbox entry for parent");

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -227,9 +227,10 @@ pub struct ChassisCtx<'a> {
     /// so its `LogDrainSlot` resolves to the chassis's declared drain
     /// (`Builder::with_log_drain<T>()`).
     ///
-    /// Sink-only registrations (e.g. `AETHER_DIAGNOSTICS`) go through
-    /// `Registry::register_closure` directly and do *not* land here —
-    /// they're not actors and have no `LogDrainSlot` to install.
+    /// Synchronous-handler registrations (e.g. `AETHER_DIAGNOSTICS`)
+    /// go through `Registry::register_inline` directly and do *not*
+    /// land here — they're not actors and have no `LogDrainSlot` to
+    /// install.
     claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
     /// Issue 607 Phase 3b (ADR-0079): the chassis's
     /// [`crate::Spawner`], cloned into every booted actor's
@@ -297,7 +298,7 @@ impl<'a> ChassisCtx<'a> {
     pub fn claim_mailbox_with_override(&mut self, name: &str) -> Result<MailboxClaim, BootError> {
         let (tx, rx) = mpsc::channel::<Envelope>();
         let tx = Arc::new(tx);
-        let id = self.registry.try_register_closure(
+        let id = self.registry.try_register_inbox(
             name.to_owned(),
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 let env = build_envelope(&dispatch);
@@ -351,7 +352,7 @@ impl<'a> ChassisCtx<'a> {
         let weak = Arc::downgrade(&tx);
         let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
-        let id = self.registry.try_register_closure(
+        let id = self.registry.try_register_inbox(
             name.to_owned(),
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 let Some(tx) = weak.upgrade() else {
@@ -421,7 +422,7 @@ impl<'a> ChassisCtx<'a> {
         let pending_for_handler = Arc::clone(&pending);
         let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
-        let id = self.registry.try_register_closure(
+        let id = self.registry.try_register_inbox(
             name.to_owned(),
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 let Some(tx) = weak.upgrade() else {

--- a/crates/aether-substrate/src/chassis/error.rs
+++ b/crates/aether-substrate/src/chassis/error.rs
@@ -20,7 +20,8 @@ use crate::mail::registry::NameConflict;
 pub enum BootError {
     /// The mailbox name is already bound, either to another
     /// capability that claimed it earlier or to a legacy
-    /// `Registry::register_closure` call from `SubstrateBoot::build`.
+    /// `Registry::register_inbox` / `Registry::register_inline`
+    /// call from `SubstrateBoot::build`.
     /// Phase 2-5 expect this during the side-by-side period and
     /// remove the legacy registration in the same diff.
     MailboxAlreadyClaimed { name: String },

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -299,7 +299,7 @@ mod tests {
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         let captured: Arc<StdMutex<Vec<CapturedDispatch>>> = Arc::new(StdMutex::new(Vec::new()));
         let captured_clone = Arc::clone(&captured);
-        let target = registry.register_closure(
+        let target = registry.register_inbox(
             sink_name,
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 captured_clone.lock().unwrap().push(CapturedDispatch {

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -6,7 +6,7 @@
 //
 // Issue 634 Phase 4 retired the wasm-component-specific routing path
 // entirely: every loaded wasm component is now a `WasmTrampoline`
-// `NativeActor` registered as a `MailboxEntry::Closure` like every
+// `NativeActor` registered as a `MailboxEntry::Inbox` like every
 // other actor, so the dedicated `ComponentRouter` slot + `route()`
 // method + `MailboxEntry::Component` variant are gone. PR 2 retired
 // the `drain_all_with_budget` polling barrier in favour of direct
@@ -164,7 +164,7 @@ impl Mailer {
         &self.registry
     }
 
-    /// Hand `mail` to the substrate for dispatch. Closure-bound
+    /// Hand `mail` to the substrate for dispatch. `Inbox`-bound
     /// mailboxes run their handler on the caller thread; dropped /
     /// unknown recipients warn-and-discard (or bubble up to the
     /// hub-substrate when a `HubOutbound` is connected, per ADR-0037).
@@ -262,7 +262,7 @@ impl Mailer {
 }
 
 /// Resolve `mail.recipient` against the registry and dispatch
-/// inline. Closure-bound mailboxes run their handler on the caller
+/// inline. `Inbox`-bound mailboxes forward to an actor's mpsc on the caller
 /// thread (or fan out via the cap's mpsc, depending on the closure).
 /// Dropped / unknown recipients warn-log and drop the mail.
 ///
@@ -353,7 +353,7 @@ fn route_mail(
     let recipient = mail.recipient;
     let inbound_mail_id = mail.mail_id;
     match registry.entry(recipient) {
-        Some(MailboxEntry::Closure(handler)) => {
+        Some(MailboxEntry::Inbox(handler)) => {
             let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
             // Mail reaching a closure-bound mailbox through `push`
             // came from substrate core or a chassis (e.g. the frame
@@ -363,8 +363,8 @@ fn route_mail(
             // and never enter `push`.
             //
             // ADR-0080 §2 producer-hook note (issue 838): no
-            // `Received`/`Finished` bracket fires here. `Closure`
-            // is the actor-inbox-enqueue variant — the closure body
+            // `Received`/`Finished` bracket fires here. `Inbox`
+            // is the actor-enqueue variant — the handler body
             // pushes the envelope onto an mpsc inbox, and the
             // actor's dispatch loop at `actor/native/dispatch.rs`
             // records the bracket downstream when its worker picks
@@ -372,8 +372,8 @@ fn route_mail(
             // double-count `Finished` and fire settlement
             // prematurely (surfaced by
             // `aether-substrate-bundle::rpc_engine_routing` as
-            // ReplyEnd before ReplyEvent). Synchronous sinks live
-            // on the [`MailboxEntry::Sink`] arm below — they get
+            // ReplyEnd before ReplyEvent). Synchronous handlers live
+            // on the [`MailboxEntry::Inline`] arm below — they get
             // the bracket because nothing downstream owns it.
             handler(MailDispatch {
                 kind: mail.kind,
@@ -387,12 +387,12 @@ fn route_mail(
                 parent_mail: mail.parent_mail,
             });
         }
-        Some(MailboxEntry::Sink(handler)) => {
+        Some(MailboxEntry::Inline(handler)) => {
             let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
-            // ADR-0080 §2 producer hook: synchronous sink. Bracket
-            // the inline handler call with `Received`/`Finished`
+            // ADR-0080 §2 producer hook: synchronous handler.
+            // Bracket the inline call with `Received`/`Finished`
             // so the chain's `in_flight` balances and settlement
-            // subscribers wake (issue 838). Distinct from `Closure`
+            // subscribers wake (issue 838). Distinct from `Inbox`
             // above — see that arm's doc for the
             // double-count-prematurely-settle hazard the split
             // avoids.
@@ -647,7 +647,7 @@ mod tests {
             })
             .unwrap();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_closure("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.handler());
 
         let note = Note {
             body: "verbatim".into(),
@@ -681,7 +681,7 @@ mod tests {
             .unwrap();
 
         let sink = CapturingSink::new();
-        let sink_id = registry.register_closure("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.handler());
 
         // Push HeldNote mail with `held = Handle(7)`. Handle 7 is
         // not in the store yet — the mail must park. We construct
@@ -745,7 +745,7 @@ mod tests {
             .unwrap();
 
         let sink = CapturingSink::new();
-        let sink_id = registry.register_closure("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.handler());
 
         // Truncated payload — the walker bails Truncated mid-walk.
         mailer.push(Mail::new(sink_id, kind_id, vec![0u8; 1], 1));
@@ -864,20 +864,20 @@ mod tests {
         );
     }
 
-    /// Issue 838 diff 2: synchronous-sink dispatch via the new `Sink`
+    /// Issue 838 diff 2: synchronous dispatch via the `Inline`
     /// arm runs the handler inline AND emits a `Received`/`Finished`
     /// bracket so the chain's in_flight balances and settlement
     /// subscribers wake. Mirrors what the actor-dispatch loop does
-    /// for `Closure` recipients, but on the pushing thread.
+    /// for `Inbox` recipients, but on the pushing thread.
     #[test]
-    fn sink_arm_brackets_handler_with_received_and_finished() {
+    fn inline_arm_brackets_handler_with_received_and_finished() {
         let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0004_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let (registry, mailer, _store) = make_mailer();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_sink("test.838.sink", sink.handler());
+        let sink_id = registry.register_inline("test.838.sink", sink.handler());
 
         let mail = Mail::new(sink_id, KindId(0xCAFE_BABE), vec![1, 2, 3], 1).with_lineage(
             inbound_mail_id,
@@ -909,9 +909,9 @@ mod tests {
         );
     }
 
-    /// Issue 838 diff 2 regression guard: actor-enqueue closure
-    /// dispatch via `Closure` MUST NOT emit Received/Finished from
-    /// the Mailer side. The actor's dispatch loop at
+    /// Issue 838 diff 2 regression guard: actor-enqueue dispatch
+    /// via `Inbox` MUST NOT emit Received/Finished from the Mailer
+    /// side. The actor's dispatch loop at
     /// `actor/native/dispatch.rs:85` owns the bracket; doubling it
     /// here fires settlement prematurely and breaks
     /// `aether-substrate-bundle::rpc_engine_routing` (ReplyEnd
@@ -919,16 +919,16 @@ mod tests {
     /// future "let's add the bracket for symmetry" refactor fails
     /// loudly.
     #[test]
-    fn closure_arm_does_not_bracket_in_mailer() {
+    fn inbox_arm_does_not_bracket_in_mailer() {
         let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0005_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let (registry, mailer, _store) = make_mailer();
         let sink = CapturingSink::new();
-        // Register as `register_closure` (the actor-enqueue
-        // contract), NOT `register_sink`.
-        let recipient = registry.register_closure("test.838.closure_regression", sink.handler());
+        // Register as `register_inbox` (the actor-enqueue
+        // contract), NOT `register_inline`.
+        let recipient = registry.register_inbox("test.838.closure_regression", sink.handler());
 
         let mail = Mail::new(recipient, KindId(0xCAFE_BABE), vec![4, 5, 6], 1).with_lineage(
             inbound_mail_id,
@@ -950,11 +950,11 @@ mod tests {
         );
         assert!(
             !received_from_mailer,
-            "Closure arm must not emit Received from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
+            "Inbox arm must not emit Received from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
         );
         assert!(
             !finished_from_mailer,
-            "Closure arm must not emit Finished from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
+            "Inbox arm must not emit Finished from Mailer — actor dispatch loop owns it (issue 838 hazard). Got: {events:?}"
         );
     }
 
@@ -996,7 +996,7 @@ mod tests {
             })
             .unwrap();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_sink("test.838.park_defer", sink.handler());
+        let sink_id = registry.register_inline("test.838.park_defer", sink.handler());
 
         // Build a payload that references a handle not yet in the
         // store — the walker returns `Parked`, mail held.
@@ -1076,9 +1076,9 @@ mod tests {
     ///
     /// Both production bugs we shipped on this work would have
     /// failed this test immediately:
-    /// - Original iamacoffeepot/aether#838 leak: `Sink` case would have shown no
+    /// - Original iamacoffeepot/aether#838 leak: `Inline` case would have shown no
     ///   Finished, expected Bracket.
-    /// - iamacoffeepot/aether#839-attempt-1 double-count: `Closure` case would have shown
+    /// - iamacoffeepot/aether#839-attempt-1 double-count: `Inbox` case would have shown
     ///   Finished from the Mailer side, expected NeitherFromMailer.
     #[test]
     fn every_mailer_push_path_produces_correct_lifecycle_events() {
@@ -1088,8 +1088,8 @@ mod tests {
         // and the test loop below. Comment is normative.
         fn dispatch_path_for_entry(entry: &MailboxEntry) -> &'static str {
             match entry {
-                MailboxEntry::Closure(_) => "Closure",
-                MailboxEntry::Sink(_) => "Sink",
+                MailboxEntry::Inbox(_) => "Inbox",
+                MailboxEntry::Inline(_) => "Inline",
                 MailboxEntry::Dropped => "Dropped",
             }
         }
@@ -1109,7 +1109,7 @@ mod tests {
             FinishedOnly,
             /// Held — mail deferred via `HandleStore::park` → neither.
             HeldNeither,
-            /// Actor-enqueue Closure → no bracket from Mailer side
+            /// Actor-enqueue `Inbox` → no bracket from Mailer side
             /// (downstream actor dispatch loop owns it).
             NeitherFromMailer,
         }
@@ -1122,16 +1122,16 @@ mod tests {
         }
 
         let cases: Vec<Case> = vec![
-            // 1. Sink arm — bracket.
+            // 1. Inline arm — bracket.
             Case {
-                name: "Sink",
+                name: "Inline",
                 expect: Expect::Bracket,
                 run: Box::new(|| {
                     let sender = MailboxId(0x8380_DD01_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
                     let sink = CapturingSink::new();
-                    let id = registry.register_sink("test.meta.sink", sink.handler());
+                    let id = registry.register_inline("test.meta.sink", sink.handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
@@ -1139,17 +1139,17 @@ mod tests {
                     mail_id
                 }),
             },
-            // 2. Closure arm — no bracket from Mailer (regression
+            // 2. Inbox arm — no bracket from Mailer (regression
             // guard for actor-enqueue contract).
             Case {
-                name: "Closure (actor-enqueue)",
+                name: "Inbox (actor-enqueue)",
                 expect: Expect::NeitherFromMailer,
                 run: Box::new(|| {
                     let sender = MailboxId(0x8380_DD02_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
                     let sink = CapturingSink::new();
-                    let id = registry.register_closure("test.meta.closure", sink.handler());
+                    let id = registry.register_inbox("test.meta.closure", sink.handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
@@ -1165,7 +1165,7 @@ mod tests {
                     let sender = MailboxId(0x8380_DD03_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
-                    let id = registry.register_closure("test.meta.dropped", Arc::new(|_| {}));
+                    let id = registry.register_inbox("test.meta.dropped", Arc::new(|_| {}));
                     let _ = registry.drop_mailbox(id).expect("drop");
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
@@ -1224,7 +1224,7 @@ mod tests {
                         })
                         .unwrap();
                     let sink = CapturingSink::new();
-                    let id = registry.register_sink("test.meta.refwalk_err", sink.handler());
+                    let id = registry.register_inline("test.meta.refwalk_err", sink.handler());
                     // Truncated payload (1 byte) — walker bails Err.
                     mailer.push(
                         Mail::new(id, kind_id, vec![0u8; 1], 1)
@@ -1254,7 +1254,7 @@ mod tests {
                         })
                         .unwrap();
                     let sink = CapturingSink::new();
-                    let id = registry.register_sink("test.meta.refwalk_parked", sink.handler());
+                    let id = registry.register_inline("test.meta.refwalk_parked", sink.handler());
                     let held = HeldNote {
                         held: Ref::Handle {
                             id: 0x8888_8888_8888_8888,

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -103,39 +103,43 @@ pub type MailboxHandler = Arc<dyn for<'a> Fn(MailDispatch<'a>) + Send + Sync + '
 ///
 /// Issue 634 Phase 4 retired the dedicated `Component` variant —
 /// every loaded wasm component is now a `WasmTrampoline` registered
-/// here as a `Closure` like every other actor.
+/// here as an `Inbox` like every other actor.
 ///
-/// Issue 838: `Closure` and `Sink` are intentionally distinct even
-/// though both wrap a [`MailboxHandler`]. The variant is the
-/// settlement-protocol contract — see each variant's docs and
-/// `Mailer::push`'s route_mail for the bracket semantics.
+/// Issue 838 / iamacoffeepot/aether#841: `Inbox` and `Inline` are
+/// intentionally distinct even though both wrap a [`MailboxHandler`].
+/// The variant *names where the handler runs* — `Inbox` defers the
+/// work to an actor's dispatch thread, `Inline` runs the work on the
+/// pushing thread. That decides who owns the `Received`/`Finished`
+/// lifecycle bracket: the downstream dispatch loop for `Inbox`, the
+/// mailer itself for `Inline`. See each variant's docs and
+/// `Mailer::push`'s `route_mail` for the bracket semantics.
 #[derive(Clone)]
 pub enum MailboxEntry {
-    /// Actor-inbox enqueue closure. The handler body pushes the
-    /// envelope onto an mpsc inbox; an actor's dispatch loop on
-    /// another thread runs the work and records the
-    /// `Received`/`Finished` lifecycle hooks. `Mailer::push` does
-    /// NOT bracket this arm — the downstream dispatch loop owns the
-    /// bracket. Installed by `claim_mailbox` /
-    /// `Spawner::register_closure` (instanced + singleton actors,
-    /// including the wasm trampoline) and by the public
-    /// [`Registry::register_closure`] / [`Registry::try_register_closure`]
-    /// for callers that own a separate dispatcher loop.
-    Closure(MailboxHandler),
-    /// Synchronous sink. The handler body does its work inline on
-    /// the pushing thread; there is no actor dispatch loop behind
-    /// it. `Mailer::push` brackets this arm with `Received` and
-    /// `Finished` so the chain's `in_flight` balances and
-    /// settlement subscribers (`SettlementRegistry`) wake (ADR-0080
-    /// §2, issue 838). Installed by [`Registry::register_sink`] /
-    /// [`Registry::try_register_sink`]. Distinct from `Closure` so
+    /// The handler body forwards the envelope into an actor's mpsc
+    /// inbox; the actor's dispatch loop on another thread runs the
+    /// work and records the `Received`/`Finished` lifecycle hooks.
+    /// `Mailer::push` does NOT bracket this arm — the downstream
+    /// dispatch loop owns the bracket. Installed by
+    /// `claim_mailbox` / `Spawner::register_inbox` (instanced +
+    /// singleton actors, including the wasm trampoline) and by the
+    /// public [`Registry::register_inbox`] /
+    /// [`Registry::try_register_inbox`] for callers that own a
+    /// separate dispatcher loop.
+    Inbox(MailboxHandler),
+    /// The handler body does its work inline on the pushing thread;
+    /// there is no actor dispatch loop behind it. `Mailer::push`
+    /// brackets this arm with `Received` and `Finished` so the
+    /// chain's `in_flight` balances and settlement subscribers
+    /// (`SettlementRegistry`) wake (ADR-0080 §2, issue 838).
+    /// Installed by [`Registry::register_inline`] /
+    /// [`Registry::try_register_inline`]. Distinct from `Inbox` so
     /// the bracket isn't double-counted when the closure was an
     /// actor-enqueue (which would fire settlement prematurely).
-    Sink(MailboxHandler),
+    Inline(MailboxHandler),
     /// Mailbox has been explicitly dropped (ADR-0010). Mail addressed
     /// to a `Dropped` slot is discarded by the scheduler / ctx dispatch
     /// until the same name is re-registered, at which point the slot
-    /// transitions back to `Closure` under the same id (ADR-0029 ids
+    /// transitions back to `Inbox` under the same id (ADR-0029 ids
     /// are a function of name, so they're stable across drop/reload).
     Dropped,
 }
@@ -218,10 +222,10 @@ impl fmt::Display for KindConflict {
 impl std::error::Error for KindConflict {}
 
 /// A runtime mailbox registration lost to name collision. Returned
-/// from `try_register_closure` (ADR-0010) so a runtime caller can
+/// from `try_register_inbox` (ADR-0010) so a runtime caller can
 /// reply with an error instead of panicking. The boot path that
-/// registers hard-coded mailbox names still uses `register_closure`
-/// and panics — collisions there are bugs.
+/// registers hard-coded mailbox names still uses `register_inbox` /
+/// `register_inline` and panics — collisions there are bugs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NameConflict {
     pub name: String,
@@ -274,8 +278,8 @@ impl Registry {
     }
 
     /// Snapshot the inventory and invoke the hook (if installed).
-    /// Called from every successful `register_closure` /
-    /// `try_register_closure`. Snapshot is taken with the inner read
+    /// Called from every successful `register_inbox` /
+    /// `try_register_inbox`. Snapshot is taken with the inner read
     /// lock — separate from the write lock the registration just
     /// released — so a concurrent registration sees a consistent
     /// (post-this-insert) view rather than a torn one.
@@ -318,39 +322,45 @@ impl Registry {
         }
     }
 
-    /// Invalidate a closure-bound mailbox (ADR-0010). Transitions the
-    /// entry to `Dropped` so dispatch-path readers can distinguish an
+    /// Invalidate a live mailbox (ADR-0010). Transitions the entry
+    /// to `Dropped` so dispatch-path readers can distinguish an
     /// intentional drop from an unknown id; the id itself (a function
     /// of the name per ADR-0029) stays addressable and a subsequent
-    /// `try_register_closure` with the same name reuses it. Returns
-    /// the released name on success.
+    /// `try_register_inbox` / `try_register_inline` with the same
+    /// name reuses it. Returns the released name on success.
     ///
     /// Issue 634 Phase 4 retired the dedicated `Component` variant,
-    /// so this now drops any `Closure`-bound mailbox. Production has
-    /// exactly one caller — `WasmTrampoline`'s shutdown path
-    /// transitioning its own slot — chassis-cap mailboxes never
-    /// route here.
+    /// so this now drops any live `Inbox` or `Inline` mailbox.
+    /// Production has exactly one caller — `WasmTrampoline`'s
+    /// shutdown path transitioning its own slot — chassis-cap
+    /// mailboxes never route here.
     pub fn drop_mailbox(&self, id: MailboxId) -> Result<String, DropError> {
         let mut inner = self.inner.write().unwrap();
         let Some(slot) = inner.mailboxes.get_mut(&id) else {
             return Err(DropError::UnknownId(id));
         };
         match slot.entry {
-            MailboxEntry::Closure(_) | MailboxEntry::Sink(_) => {}
+            MailboxEntry::Inbox(_) | MailboxEntry::Inline(_) => {}
             MailboxEntry::Dropped => return Err(DropError::AlreadyDropped(id)),
         }
         slot.entry = MailboxEntry::Dropped;
         Ok(slot.name.clone())
     }
 
-    /// Register a chassis-bound mailbox handled by `handler`. Mail to
-    /// this mailbox runs the closure inline on the delivering thread
-    /// (or on the host-function caller thread if a component sent it).
+    /// Register a mailbox whose handler body forwards the envelope
+    /// into an actor's mpsc inbox. The actor's dispatch loop on its
+    /// own thread runs the work and records the lifecycle
+    /// `Received`/`Finished` bracket — `Mailer::push` does NOT
+    /// bracket this arm. Use this for any registration where a
+    /// dispatch loop downstream owns the per-handler invocation
+    /// (chassis caps via `claim_mailbox*`, instanced + singleton
+    /// actors via the spawner).
+    ///
     /// Panics on a name collision — these are substrate-internal
     /// names, collisions are bugs.
-    pub fn register_closure(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
+    pub fn register_inbox(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
         let name = name.into();
-        match self.insert(name.clone(), MailboxEntry::Closure(handler)) {
+        match self.insert(name.clone(), MailboxEntry::Inbox(handler)) {
             Ok(id) => {
                 self.notify_mailbox_change();
                 id
@@ -359,43 +369,43 @@ impl Registry {
         }
     }
 
-    /// Non-panicking variant of `register_closure`. Returns
+    /// Non-panicking variant of [`Self::register_inbox`]. Returns
     /// `NameConflict` on a collision so callers that legitimately
     /// race (ADR-0070 capability boots, where the side-by-side
-    /// extraction period puts legacy `register_closure` and a new
+    /// extraction period puts legacy registrations and a new
     /// capability claim against the same mailbox during the
     /// transition diff) can surface the collision as a typed error
     /// rather than aborting the chassis.
-    pub fn try_register_closure(
+    pub fn try_register_inbox(
         &self,
         name: impl Into<String>,
         handler: MailboxHandler,
     ) -> Result<MailboxId, NameConflict> {
-        let result = self.insert(name.into(), MailboxEntry::Closure(handler));
+        let result = self.insert(name.into(), MailboxEntry::Inbox(handler));
         if result.is_ok() {
             self.notify_mailbox_change();
         }
         result
     }
 
-    /// Issue 838: register a synchronous-sink mailbox. The handler
-    /// runs inline on `Mailer::push`'s thread; the mailer brackets
-    /// the call with `Received`/`Finished` so the chain's
-    /// `in_flight` balances and settlement subscribers
+    /// Issue 838: register a mailbox whose handler runs inline on
+    /// the pushing thread. `Mailer::push` brackets the call with
+    /// `Received`/`Finished` so the chain's `in_flight` balances
+    /// and settlement subscribers
     /// ([`crate::chassis::settlement::SettlementRegistry`]) wake
     /// (ADR-0080 §2).
     ///
-    /// Distinct from [`Self::register_closure`] which is for
+    /// Distinct from [`Self::register_inbox`] which is for
     /// actor-inbox enqueue closures whose downstream dispatch loop
     /// owns the bracket. Miscategorisation is silent: a synchronous
-    /// sink registered as a `Closure` leaks `in_flight` (chains
-    /// never settle); an actor-enqueue closure registered as a
-    /// `Sink` double-counts `Finished` (settlement fires
+    /// handler registered as an `Inbox` leaks `in_flight` (chains
+    /// never settle); an actor-enqueue closure registered as
+    /// `Inline` double-counts `Finished` (settlement fires
     /// prematurely). Panics on a name collision — these are
     /// substrate-internal names, collisions are bugs.
-    pub fn register_sink(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
+    pub fn register_inline(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
         let name = name.into();
-        match self.insert(name.clone(), MailboxEntry::Sink(handler)) {
+        match self.insert(name.clone(), MailboxEntry::Inline(handler)) {
             Ok(id) => {
                 self.notify_mailbox_change();
                 id
@@ -404,37 +414,37 @@ impl Registry {
         }
     }
 
-    /// Non-panicking variant of [`Self::register_sink`], symmetric
-    /// with [`Self::try_register_closure`].
-    pub fn try_register_sink(
+    /// Non-panicking variant of [`Self::register_inline`], symmetric
+    /// with [`Self::try_register_inbox`].
+    pub fn try_register_inline(
         &self,
         name: impl Into<String>,
         handler: MailboxHandler,
     ) -> Result<MailboxId, NameConflict> {
-        let result = self.insert(name.into(), MailboxEntry::Sink(handler));
+        let result = self.insert(name.into(), MailboxEntry::Inline(handler));
         if result.is_ok() {
             self.notify_mailbox_change();
         }
         result
     }
 
-    /// Issue 607 Phase 7: fully remove a closure-bound mailbox. Used
-    /// in the chassis-boot unwind path when a singleton's `init` fails
-    /// after `try_register_closure` claimed the slot — the partial-boot
-    /// state must not leak into a later cap's namespace lookup.
-    /// Returns `true` if the entry existed and was a `Closure` variant
-    /// (and was removed), `false` if the id is unknown or refers to a
-    /// non-closure entry. Component entries go through
-    /// [`Self::drop_mailbox`] (which transitions to `Dropped` rather
-    /// than removing) — the lifecycle difference is intentional:
-    /// components can re-register the same id after a drop, closure-
-    /// bound mailboxes are torn down on cap teardown and the id can be
-    /// freshly recreated.
+    /// Issue 607 Phase 7: fully remove a registered mailbox. Used in
+    /// the chassis-boot unwind path when a singleton's `init` fails
+    /// after `try_register_inbox` claimed the slot — the partial-
+    /// boot state must not leak into a later cap's namespace lookup.
+    /// Returns `true` if the entry existed and was a live (`Inbox`
+    /// or `Inline`) variant and was removed; `false` if the id is
+    /// unknown or already in `Dropped` state. Component entries go
+    /// through [`Self::drop_mailbox`] (which transitions to
+    /// `Dropped` rather than removing) — the lifecycle difference
+    /// is intentional: components can re-register the same id after
+    /// a drop, chassis-bound mailboxes are torn down on cap
+    /// teardown and the id can be freshly recreated.
     pub(crate) fn remove_closure(&self, id: MailboxId) -> bool {
         let mut inner = self.inner.write().unwrap();
         match inner.mailboxes.get(&id) {
             Some(slot)
-                if matches!(slot.entry, MailboxEntry::Closure(_) | MailboxEntry::Sink(_)) =>
+                if matches!(slot.entry, MailboxEntry::Inbox(_) | MailboxEntry::Inline(_)) =>
             {
                 inner.mailboxes.remove(&id);
                 true
@@ -459,9 +469,9 @@ impl Registry {
     }
 
     /// Fetch the entry for a mailbox id. Returns an owned clone so the
-    /// caller can drop the internal lock before invoking a `Closure`
-    /// handler (avoids holding the registry lock across arbitrary user
-    /// code).
+    /// caller can drop the internal lock before invoking the handler
+    /// (whether `Inbox` or `Inline`) — avoids holding the registry
+    /// lock across arbitrary user code.
     pub fn entry(&self, id: MailboxId) -> Option<MailboxEntry> {
         self.inner
             .read()
@@ -706,10 +716,10 @@ mod tests {
     #[test]
     fn register_and_lookup_closure_mailbox() {
         let r = Registry::new();
-        let id = r.register_closure("physics", noop_handler());
+        let id = r.register_inbox("physics", noop_handler());
         assert_eq!(id, MailboxId::from_name("physics"));
         assert_eq!(r.lookup("physics"), Some(id));
-        assert!(matches!(r.entry(id), Some(MailboxEntry::Closure(_))));
+        assert!(matches!(r.entry(id), Some(MailboxEntry::Inbox(_))));
     }
 
     #[test]
@@ -717,13 +727,13 @@ mod tests {
         let r = Registry::new();
         let counter = Arc::new(AtomicU32::new(0));
         let c2 = Arc::clone(&counter);
-        let id = r.register_closure(
+        let id = r.register_inbox(
             "heartbeat",
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 c2.fetch_add(dispatch.count, Ordering::SeqCst);
             }),
         );
-        let Some(MailboxEntry::Closure(h)) = r.entry(id) else {
+        let Some(MailboxEntry::Inbox(h)) = r.entry(id) else {
             panic!("expected closure entry")
         };
         // Test-side id is irrelevant — the handler ignores it.
@@ -745,9 +755,9 @@ mod tests {
     #[test]
     fn mailbox_ids_are_name_derived() {
         let r = Registry::new();
-        let a = r.register_closure("a", noop_handler());
-        let b = r.register_closure("b", noop_handler());
-        let c = r.register_closure("c", noop_handler());
+        let a = r.register_inbox("a", noop_handler());
+        let b = r.register_inbox("b", noop_handler());
+        let c = r.register_inbox("c", noop_handler());
         assert_eq!(a, MailboxId::from_name("a"));
         assert_eq!(b, MailboxId::from_name("b"));
         assert_eq!(c, MailboxId::from_name("c"));
@@ -762,8 +772,8 @@ mod tests {
     #[should_panic(expected = "mailbox name already registered")]
     fn duplicate_name_panics() {
         let r = Registry::new();
-        r.register_closure("x", noop_handler());
-        r.register_closure("x", noop_handler());
+        r.register_inbox("x", noop_handler());
+        r.register_inbox("x", noop_handler());
     }
 
     #[test]
@@ -776,8 +786,8 @@ mod tests {
     #[test]
     fn mailbox_name_reverse_lookup() {
         let r = Registry::new();
-        let a = r.register_closure("physics", noop_handler());
-        let b = r.register_closure("graphics", noop_handler());
+        let a = r.register_inbox("physics", noop_handler());
+        let b = r.register_inbox("graphics", noop_handler());
         assert_eq!(r.mailbox_name(a).as_deref(), Some("physics"));
         assert_eq!(r.mailbox_name(b).as_deref(), Some("graphics"));
         assert!(r.mailbox_name(MailboxId(999)).is_none());
@@ -975,13 +985,13 @@ mod tests {
     }
 
     #[test]
-    fn try_register_closure_is_non_panicking_on_collision() {
+    fn try_register_inbox_is_non_panicking_on_collision() {
         let r = Registry::new();
         let first = r
-            .try_register_closure("loaded", noop_handler())
+            .try_register_inbox("loaded", noop_handler())
             .expect("fresh name");
         let err = r
-            .try_register_closure("loaded", noop_handler())
+            .try_register_inbox("loaded", noop_handler())
             .expect_err("collision must not panic");
         assert_eq!(err.name, "loaded");
         assert_eq!(r.lookup("loaded"), Some(first));
@@ -995,10 +1005,10 @@ mod tests {
     /// `CHASSIS_MAILBOX_ID` never reaches the registry). Reject at the
     /// registration boundary so the routing path stays unambiguous.
     #[test]
-    fn try_register_closure_rejects_reserved_chassis_name() {
+    fn try_register_inbox_rejects_reserved_chassis_name() {
         let r = Registry::new();
         let err = r
-            .try_register_closure("aether.chassis", noop_handler())
+            .try_register_inbox("aether.chassis", noop_handler())
             .expect_err("reserved name must reject");
         assert_eq!(err.name, "aether.chassis");
         assert_eq!(r.len(), 0);
@@ -1007,7 +1017,7 @@ mod tests {
     #[test]
     fn drop_mailbox_frees_name_and_marks_entry_dropped() {
         let r = Registry::new();
-        let id = r.try_register_closure("loaded", noop_handler()).unwrap();
+        let id = r.try_register_inbox("loaded", noop_handler()).unwrap();
         let name = r.drop_mailbox(id).expect("drop");
         assert_eq!(name, "loaded");
         assert!(r.lookup("loaded").is_none(), "name should be reusable");
@@ -1018,10 +1028,10 @@ mod tests {
         // Under ADR-0029 the id is a function of the name, so a
         // re-register produces the *same* id and flips the entry back
         // to `Component`.
-        let reloaded = r.try_register_closure("loaded", noop_handler()).unwrap();
+        let reloaded = r.try_register_inbox("loaded", noop_handler()).unwrap();
         assert_eq!(reloaded, id);
         assert_eq!(r.lookup("loaded"), Some(reloaded));
-        assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Closure(_))));
+        assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Inbox(_))));
     }
 
     #[test]
@@ -1031,7 +1041,7 @@ mod tests {
             r.drop_mailbox(MailboxId(999)),
             Err(DropError::UnknownId(_))
         ));
-        let c = r.try_register_closure("x", noop_handler()).unwrap();
+        let c = r.try_register_inbox("x", noop_handler()).unwrap();
         r.drop_mailbox(c).unwrap();
         assert!(matches!(
             r.drop_mailbox(c),
@@ -1047,9 +1057,9 @@ mod tests {
     #[test]
     fn list_mailbox_descriptors_snapshots_sorted_with_categories() {
         let r = Registry::new();
-        r.register_closure("aether.input", noop_handler());
-        r.register_closure("aether.component.trampoline:cam", noop_handler());
-        r.register_closure("user_thing", noop_handler());
+        r.register_inbox("aether.input", noop_handler());
+        r.register_inbox("aether.component.trampoline:cam", noop_handler());
+        r.register_inbox("user_thing", noop_handler());
 
         let snap = r.list_mailbox_descriptors();
         // Four entries: 3 registered + 1 synthetic chassis sentinel.
@@ -1098,7 +1108,7 @@ mod tests {
     #[test]
     fn list_mailbox_descriptors_ids_match_name_hashes() {
         let r = Registry::new();
-        let id = r.register_closure("aether.audio", noop_handler());
+        let id = r.register_inbox("aether.audio", noop_handler());
         let entry = r
             .list_mailbox_descriptors()
             .into_iter()
@@ -1109,13 +1119,13 @@ mod tests {
     }
 
     /// Issue iamacoffeepot/aether#742: every successful
-    /// `register_closure` fires the installed change hook with the
+    /// `register_inbox` fires the installed change hook with the
     /// post-registration inventory snapshot. The chassis wires this
     /// hook to push to the hub via `egress_mailboxes_changed` so any
     /// chassis-builder cap that registers post-Hello shows up in the
     /// hub's inventory cache without an explicit publish.
     #[test]
-    fn mailbox_change_hook_fires_on_register_closure() {
+    fn mailbox_change_hook_fires_on_register_inbox() {
         use std::sync::Mutex;
 
         let r = Arc::new(Registry::new());
@@ -1126,14 +1136,14 @@ mod tests {
             snapshots_for_hook.lock().unwrap().push(names);
         }));
 
-        r.register_closure("aether.input", noop_handler());
-        r.register_closure("aether.render", noop_handler());
+        r.register_inbox("aether.input", noop_handler());
+        r.register_inbox("aether.render", noop_handler());
 
         let captured = snapshots.lock().unwrap();
         assert_eq!(
             captured.len(),
             2,
-            "hook should fire once per successful register_closure"
+            "hook should fire once per successful register_inbox"
         );
         // Each snapshot is the FULL inventory at that moment (matches
         // the wire `MailboxesChanged` semantics — full replace, not
@@ -1143,10 +1153,10 @@ mod tests {
         assert!(captured[1].contains(&"aether.render".to_owned()));
     }
 
-    /// Issue 742: `try_register_closure` fires the hook on the Ok
+    /// Issue 742: `try_register_inbox` fires the hook on the Ok
     /// branch and stays silent on `NameConflict`.
     #[test]
-    fn mailbox_change_hook_fires_on_try_register_closure_ok_only() {
+    fn mailbox_change_hook_fires_on_try_register_inbox_ok_only() {
         use std::sync::Mutex;
 
         let r = Arc::new(Registry::new());
@@ -1157,11 +1167,11 @@ mod tests {
         }));
 
         let _ = r
-            .try_register_closure("aether.input", noop_handler())
+            .try_register_inbox("aether.input", noop_handler())
             .expect("first register OK");
         // Second registration with the same name conflicts.
         let _ = r
-            .try_register_closure("aether.input", noop_handler())
+            .try_register_inbox("aether.input", noop_handler())
             .expect_err("second register should NameConflict");
 
         assert_eq!(*count.lock().unwrap(), 1, "hook fires once on Ok only");
@@ -1175,7 +1185,7 @@ mod tests {
         // mailboxes and kinds from a handler that holds an Arc.
         let r = Arc::new(Registry::new());
         let r2 = Arc::clone(&r);
-        let id = r2.register_closure("late", noop_handler());
+        let id = r2.register_inbox("late", noop_handler());
         assert_eq!(r.lookup("late"), Some(id));
         let kind_id = r.register_kind("aether.late");
         assert_eq!(

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -305,7 +305,7 @@ fn ship_batch(
     if !mailer
         .registry()
         .entry(recipient)
-        .map(|e| matches!(e, crate::mail::registry::MailboxEntry::Closure(_)))
+        .map(|e| matches!(e, crate::mail::registry::MailboxEntry::Inbox(_)))
         .unwrap_or(false)
     {
         // Observer not registered (or dropped); silently discard the

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -126,7 +126,7 @@ fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
 fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
     use aether_substrate::mail::registry::MailboxEntry;
     let id: MailboxId = registry.lookup(recipient).expect("mailbox registered");
-    let MailboxEntry::Closure(handler) = registry.entry(id).expect("entry exists") else {
+    let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
     let bytes = payload.encode_into_bytes();


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Renames the `MailboxEntry` variants iamacoffeepot/aether#840 introduced so the names describe **where the handler runs** rather than overloading `Closure` (both variants ARE closures, type-signature-wise) or `Sink` (a term the codebase uses generically for any mailbox handler — `claim_mailbox`'s own doc, `CapturingSink`, `fresh_mailer_with_sink`, etc.).

| Old | New | Contract |
|---|---|---|
| `MailboxEntry::Closure` | `MailboxEntry::Inbox` | Forwards envelope into an actor's mpsc inbox; actor's dispatch loop owns the lifecycle bracket |
| `MailboxEntry::Sink` | `MailboxEntry::Inline` | Runs handler inline on the pushing thread; mailer owns the lifecycle bracket |
| `MailboxEntry::Dropped` | (unchanged) | (unchanged) |

Method renames:
- `register_closure` / `try_register_closure` → `register_inbox` / `try_register_inbox`
- `register_sink` / `try_register_sink` → `register_inline` / `try_register_inline`

`remove_closure` stays as-is (`pub(crate)`, still accurate — it removes any live entry; doc updated to mention both Inbox and Inline).

## Why

The split iamacoffeepot/aether#840 introduced was the right contract; the names were the wrong handle to grab it by. `Inbox` honestly names what the closure body does (deliver to an inbox; deferred dispatch); `Inline` honestly names what the synchronous variant does (run here, right now). Neither name leans on a term that's used colloquially elsewhere.

The contract itself is unchanged: `Inbox` is bracket-free (downstream dispatch loop owns it), `Inline` is bracketed by `Mailer::push` (no one else owns it).

## Scope

Pure rename — no behavior change vs iamacoffeepot/aether#840's main + headless audio sink fix.

- 25 files touched, +225/-211 lines
- All production registrations migrated per the audit table in the issue body
- Test fixtures + meta-test cases renamed to mirror
- Exhaustive lifecycle meta-test (`every_mailer_push_path_produces_correct_lifecycle_events`) is the correctness safety net — any callsite ending up on the wrong variant would have failed it loudly

## Test renames

- `mail::mailer::tests::sink_arm_brackets_handler_with_received_and_finished` → `inline_arm_brackets_handler_with_received_and_finished`
- `mail::mailer::tests::closure_arm_does_not_bracket_in_mailer` → `inbox_arm_does_not_bracket_in_mailer`
- Meta-test case names: `"Sink"` / `"Closure (actor-enqueue)"` → `"Inline"` / `"Inbox (actor-enqueue)"`

## Verification

- `cargo nextest run --workspace --no-fail-fast` — 990/990 passed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `aether-substrate-bundle::rpc_engine_routing::hub_routes_engine_addressed_calls_to_a_real_substrate` — passes (regression guard for the Inbox-no-bracket contract)

## Out of scope (intentional)

- Colloquial `sink` uses in test-helper names (`CapturingSink`, `fresh_mailer_with_sink`, etc.) — flagged in the issue body as a separate cleanup. Worth doing eventually; not load-bearing for this rename.
- Retiring the `TestBenchObserver`-as-actor workaround — the inline-doc reference to it now mentions that `register_inline` would also work post-iamacoffeepot/aether#840, but the actor path is left in place. Separate follow-up.

Closes iamacoffeepot/aether#841
