### PR TITLE
chore(substrate-bundle): retire TestBenchObserver actor; correct mpsc-fed-sink docs (842 follow-up)

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -33,91 +33,29 @@ use super::events::{ChassisEvent, EventSender};
 /// hub-protocol wire for compatibility).
 pub const WORKERS: usize = 2;
 
-/// Test-bench observability mailbox. Scenarios that want to assert on
-/// component-emitted kinds (the probe's `aether.test_fixture.tick_observed`,
-/// for example) target this name with `ctx.send_to_named`; the
-/// test-bench chassis registers [`TestBenchObserverCapability`] under
-/// this namespace and the cap's fallback handler records each kind
-/// name in `TestBenchEnv::observed_kinds`. Only booted when
-/// `observed_kinds` is `Some` (binaries pass `None` for zero
-/// overhead).
+/// Test-bench observability mailbox. Scenarios that want to assert
+/// on component-emitted kinds (the probe's
+/// `aether.test_fixture.tick_observed`, for example) target this
+/// name with `ctx.send_to_named`; the test-bench chassis registers
+/// a synchronous-handler closure under this namespace via
+/// `Registry::register_inline` (see `build_passive`) and the
+/// closure records each kind name in `TestBenchEnv::observed_kinds`.
+/// Only registered when `observed_kinds` is `Some` (binaries pass
+/// `None` for zero overhead — mail to this mailbox warn-drops in
+/// that mode).
 ///
-/// Mirrored inline as the `NativeActor::NAMESPACE` literal inside
-/// the observer module (the bridge macro can't see this const from
-/// the lifted-impl scope); keep them in lockstep.
-pub const TEST_BENCH_OBSERVER_MAILBOX_NAME: &str = "aether.test_bench.observer";
-
-// `TestBenchObserverCapability` re-exports via the `#[bridge]` macro;
-// `TestBenchObserverConfig` lives inside the `observer` mod and is
-// surfaced for chassis builder calls.
-pub use observer::TestBenchObserverConfig;
-
-/// Catch-all observer cap that records every kind name addressed at
-/// `aether.test_bench.observer`. Pre-issue-775 the same role lived on
-/// `BroadcastCapability` (which also fanned the mail out to attached
-/// MCP sessions); with that fan-out retired the observer survives as
-/// a test-bench-private cap whose only job is recording kind names
-/// for `count_observed` assertions. The cap is a real `NativeActor`
-/// (not a `register_inline` synchronous handler) so its handler
-/// completes through the framework's ADR-0080 settlement reporting
+/// Pre-iamacoffeepot/aether#838 this rode a full `NativeActor`
+/// (TestBenchObserverCapability) specifically because synchronous
+/// closures leaked `in_flight` and prevented chains from settling
 /// — the bench's Tick settlement gate would otherwise wait the
-/// full 5 s timeout per tick when a probe component routes
-/// observation mail here. (Post-iamacoffeepot/aether#840 a
-/// `register_inline` sink would also settle correctly; retiring
-/// this actor-shaped workaround is a tracked follow-up.)
-#[aether_actor::bridge(singleton)]
-mod observer {
-    use std::sync::{Arc, Mutex};
-
-    use aether_actor::actor;
-    use aether_substrate::actor::native::envelope::Envelope;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-
-    /// Config passed in via [`super::TestBenchEnv::observed_kinds`].
-    /// The cap captures the `Arc<Mutex<Vec<String>>>` and pushes each
-    /// handled mail's kind name into it.
-    pub struct TestBenchObserverConfig {
-        pub observed_kinds: Arc<Mutex<Vec<String>>>,
-    }
-
-    pub struct TestBenchObserverCapability {
-        observed_kinds: Arc<Mutex<Vec<String>>>,
-    }
-
-    #[actor]
-    impl NativeActor for TestBenchObserverCapability {
-        type Config = TestBenchObserverConfig;
-        // Mirror of `super::TEST_BENCH_OBSERVER_MAILBOX_NAME` (the
-        // bridge macro lifts the impl outside the mod, so a `super::`
-        // path no longer resolves in the rewritten location).
-        const NAMESPACE: &'static str = "aether.test_bench.observer";
-
-        fn init(
-            cfg: TestBenchObserverConfig,
-            _ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            Ok(Self {
-                observed_kinds: cfg.observed_kinds,
-            })
-        }
-
-        /// Catch-all: every kind sent to this mailbox records its
-        /// name. The macro auto-emits a blanket `HandlesKind<K>` impl
-        /// so callers using `ctx.send_to_named` against an arbitrary
-        /// kind compile against the cap.
-        #[fallback]
-        fn on_any(&self, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
-            if env.kind_name.is_empty() {
-                return;
-            }
-            self.observed_kinds
-                .lock()
-                .unwrap()
-                .push(env.kind_name.clone());
-        }
-    }
-}
+/// full 5 s timeout per tick when a probe component routed
+/// observation mail here. iamacoffeepot/aether#840 added the
+/// `MailboxEntry::Inline` variant (renamed `MailboxEntry::Sink` ->
+/// `Inline` in iamacoffeepot/aether#842) which brackets sync
+/// handlers with `Received`/`Finished`, closing the gap and
+/// letting us retire the actor-shaped workaround — one fewer
+/// thread per TestBench.
+pub const TEST_BENCH_OBSERVER_MAILBOX_NAME: &str = "aether.test_bench.observer";
 
 /// ADR-0071 marker type for the test-bench chassis. Carries no
 /// fields — the chassis instance is the [`PassiveChassis<TestBenchChassis>`]
@@ -303,6 +241,40 @@ impl TestBenchChassis {
             None => None,
         };
 
+        // Issue 775: scenarios that want to assert on component-
+        // emitted kinds register a synchronous catch-all observer
+        // closure under `aether.test_bench.observer`. The closure
+        // body records each inbound mail's kind name into the shared
+        // `observed_kinds` vec; the binary (`bin/test-bench.rs`)
+        // passes `observed_kinds: None` and skips registration —
+        // mail to the observer mailbox warn-drops in that mode.
+        //
+        // Registered via `register_inline` (issue 840 + iamacoffeepot/aether#841
+        // follow-up): the closure runs inline on the pushing thread
+        // and the mailer brackets it with `Received`/`Finished` so
+        // chains touching this mailbox settle. Pre-iamacoffeepot/aether#840
+        // this rode a full NativeActor specifically because closure
+        // arms leaked settlement; now that `Inline` participates in
+        // ADR-0080 §6 we get the same correctness with one fewer
+        // thread per TestBench.
+        if let Some(sink) = observed_kinds.clone() {
+            let observed_for_handler = sink;
+            boot.registry.register_inline(
+                TEST_BENCH_OBSERVER_MAILBOX_NAME,
+                Arc::new(
+                    move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {
+                        if dispatch.kind_name.is_empty() {
+                            return;
+                        }
+                        observed_for_handler
+                            .lock()
+                            .unwrap()
+                            .push(dispatch.kind_name.to_owned());
+                    },
+                ),
+            );
+        }
+
         let mut builder =
             Builder::<TestBenchChassis>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
                 .with_actor::<HandleCapability>(())
@@ -314,16 +286,6 @@ impl TestBenchChassis {
                 .with_actor::<RenderCapability>(render_config)
                 .with_actor::<HeadlessWindowCapability>(())
                 .with_actor::<TestBenchCapability>(test_bench_cap_config);
-        // Issue 775: scenarios that want to assert on component-emitted
-        // kinds boot the catch-all observer cap. The binary
-        // (`bin/test-bench.rs`) passes `observed_kinds: None` and skips
-        // the cap entirely; mail to the observer mailbox warn-drops in
-        // that mode.
-        if let Some(sink) = observed_kinds.clone() {
-            builder = builder.with_actor::<TestBenchObserverCapability>(TestBenchObserverConfig {
-                observed_kinds: sink,
-            });
-        }
         if let Some(roots) = io_roots {
             builder = builder.with_actor::<FsCapability>(roots);
         }

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -271,10 +271,10 @@ impl<'a> ChassisCtx<'a> {
         }
     }
 
-    /// Register an mpsc-fed sink under `C::NAMESPACE` and return both
-    /// its derived [`MailboxId`] (ADR-0029 hash) and the receiver.
-    /// The capability's own type is the single source of truth for
-    /// the recipient name (issue 525 Phase 1).
+    /// Register a `MailboxEntry::Inbox` under `C::NAMESPACE` and
+    /// return both its derived [`MailboxId`] (ADR-0029 hash) and
+    /// the receiver. The capability's own type is the single source
+    /// of truth for the recipient name (issue 525 Phase 1).
     ///
     /// Tests that need a parameterized name (one fixture, many
     /// claims) reach for [`Self::claim_mailbox_with_override`].
@@ -282,11 +282,11 @@ impl<'a> ChassisCtx<'a> {
         self.claim_mailbox_with_override(C::NAMESPACE)
     }
 
-    /// Register an mpsc-fed sink under `name` and return both its
-    /// derived [`MailboxId`] (ADR-0029 hash) and the receiver.
-    /// Escape hatch for tests with parameterized names; production
-    /// caps go through [`Self::claim_mailbox`] so the cap's own
-    /// `NAMESPACE` is authoritative.
+    /// Register a `MailboxEntry::Inbox` under `name` and return
+    /// both its derived [`MailboxId`] (ADR-0029 hash) and the
+    /// receiver. Escape hatch for tests with parameterized names;
+    /// production caps go through [`Self::claim_mailbox`] so the
+    /// cap's own `NAMESPACE` is authoritative.
     ///
     /// The closure registered with the registry forwards every
     /// delivery into the sender side of the mpsc pair, so the


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Two follow-ups falling out of the iamacoffeepot/aether#841 → iamacoffeepot/aether#842 naming work.

### 1. Retire the TestBenchObserver-as-actor workaround

The TestBenchObserver cap was promoted to a full `NativeActor` pre-iamacoffeepot/aether#838 specifically because synchronous closure-bound mailboxes leaked `in_flight` and blocked ADR-0080 §6 settlement. The relevant note in source said as much (now removed):

> The cap is a real `NativeActor` (not a `register_inline` synchronous handler) so its handler completes through the framework's ADR-0080 settlement reporting — the bench's Tick settlement gate would otherwise wait the full 5 s timeout per tick…

iamacoffeepot/aether#840's `MailboxEntry::Sink` variant (renamed `MailboxEntry::Inline` in iamacoffeepot/aether#842) closed that gap. This PR replaces the actor with a `register_inline` closure registered directly at chassis boot:

- Drops the entire `#[bridge(singleton)] mod observer { ... }` block — no more `TestBenchObserverCapability`, `TestBenchObserverConfig`, or `with_actor::<TestBenchObserverCapability>` registration.
- Registers an inline closure that records each inbound mail's kind name into the shared `observed_kinds` `Vec<String>`, guarded by the same `observed_kinds: Some(_)` check.
- Saves **one OS thread per TestBench** (the actor's dispatch thread).
- `TEST_BENCH_OBSERVER_MAILBOX_NAME` const + the `TestBench::count_observed` surface unchanged.

### 2. Correct misleading `mpsc-fed sink` docs in `chassis/ctx.rs`

`claim_mailbox` and `claim_mailbox_with_override` documented themselves as registering an "mpsc-fed sink" — language that conflicted with the iamacoffeepot/aether#841 / iamacoffeepot/aether#842 naming: these calls register `MailboxEntry::Inbox` (an actor-enqueue closure that forwards to the cap's mpsc inbox and dispatcher loop), not `MailboxEntry::Inline` (a synchronous handler). Updated to say "Register a `MailboxEntry::Inbox`" so the doc matches the actual variant.

## Verification

- `cargo nextest run --workspace --no-fail-fast` — 990/990 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- The exhaustive lifecycle meta-test from iamacoffeepot/aether#840 (`every_mailer_push_path_produces_correct_lifecycle_events`) is the correctness safety net — the observer's now-inline closure goes through the same Inline-arm bracket the meta-test pins.

## Out of scope

- Renaming `CapturingSink` / `fresh_mailer_with_sink` test helpers. After the iamacoffeepot/aether#841 / iamacoffeepot/aether#842 split, `sink` as a generic English noun ("a thing that absorbs dispatched mail") no longer collides with a variant name — the colloquial use is fine and renaming would just churn test fixtures with no clarity gain.

Follow-up to iamacoffeepot/aether#841 / iamacoffeepot/aether#842 — no issue to close; this is the optional cleanup mentioned in both PR bodies.
