### PR TITLE
fix(capabilities): delete bogus frames_seen assertion in call_echo rpc test (issue 835)

### DIFF
--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -280,7 +280,6 @@ mod tests {
     use std::io::BufReader;
     use std::net::{TcpListener, TcpStream};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::JoinHandle;
     use std::time::Duration;
 
@@ -342,18 +341,17 @@ mod tests {
             .expect("RpcServerHandle published")
             .local_port;
 
-        // The on_frame hook bumps a counter — proves the reader fires
-        // it per inbound frame.
-        let frames_seen = Arc::new(AtomicUsize::new(0));
-        let frames_seen_for_hook = Arc::clone(&frames_seen);
-        let mut conn = RpcClient::connect(
-            &format!("127.0.0.1:{port}"),
-            client_peer_kind(),
-            move || {
-                frames_seen_for_hook.fetch_add(1, Ordering::Release);
-            },
-        )
-        .expect("client connects + handshakes");
+        // No on_frame work needed — `recv_timeout` returning is the
+        // observable signal we care about. iamacoffeepot/aether#835:
+        // a prior version asserted `frames_seen >= 2` against an
+        // AtomicUsize bumped inside the hook, but the hook is a
+        // post-enqueue scheduling kick by design (see `connect`'s
+        // doc) — the test thread can wake from `recv_timeout` before
+        // the reader thread reaches `on_frame()`, racing the
+        // assertion. End-to-end correctness here is the two
+        // `recv_timeout` returns below: ReplyEvent then ReplyEnd.
+        let mut conn = RpcClient::connect(&format!("127.0.0.1:{port}"), client_peer_kind(), || {})
+            .expect("client connects + handshakes");
 
         // The handshake handed back the server's identity.
         match &conn.server {
@@ -410,11 +408,6 @@ mod tests {
             }
             other => panic!("expected ReplyEnd, got {other:?}"),
         }
-
-        assert!(
-            frames_seen.load(Ordering::Acquire) >= 2,
-            "on_frame should fire at least once per inbound frame",
-        );
     }
 
     /// `Ping(nonce)` round-trips as `Pong(nonce)` over the socket.


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Closes iamacoffeepot/aether#835 by deleting the bogus `frames_seen >= 2` assertion in `rpc::client::tests::call_echo_round_trips_over_the_socket` — the assertion checked an implementation-internal counter that has no stable contract observable from the test thread.

## Root cause

The assertion was racing the reader-thread:

```rust
// crates/aether-capabilities/src/rpc/client.rs:215-219 (unchanged)
if inbound_tx.send(frame).is_err() {
    break;
}
on_frame();
```

The frame is enqueued onto `inbound_tx` (which unblocks the test thread's `recv_timeout`) **before** `on_frame()` runs. The `connect` doc even codifies this as intentional:

> `on_frame` is the scheduling kick: the reader calls it after pushing each frame onto the inbound channel…

Between `inbound_tx.send` returning and the reader's next instruction firing `on_frame()`, the test thread could race ahead, recv both frames, and reach the assertion before the second `on_frame()` had fired. The hook's purpose is "wake the consumer post-enqueue" — useful for actor consumers that select on the wake mail. It is **not** an observable counter for the test thread.

End-to-end correctness is already structurally guaranteed by the two `recv_timeout` returns earlier in the test: `ReplyEvent` then `ReplyEnd`. Both arriving means the call completed; the counter assertion added no signal worth flaking on.

## Fix

Three small deletions:

- Remove the `frames_seen: Arc<AtomicUsize>` + `frames_seen_for_hook` clone.
- Pass `|| {}` for `on_frame` (same as `ping_pongs_over_the_socket` and the other tests in this file).
- Delete the trailing `assert!(frames_seen.load(...) >= 2, ...)`.
- Drop the now-unused `use std::sync::atomic::{AtomicUsize, Ordering}` from the test module.

Net diff: +11 / -18.

## Explicitly NOT doing

- **No `Notify` / `AtomicWaker` introduction** — inventing a new wait primitive to make a useless assertion observable is the wrong shape (and was rejected in iamacoffeepot/aether#835's body).
- **No `crossbeam_channel` swap** — bigger refactor for no real bug.
- **No bounded spin / `wait_until`** — same flake-masking objection.
- **No reordering `on_frame` to pre-send** — would break the actor-wake contract the hook exists to serve.

If we ever need to test the actor-side wake path, the right test is an actor consumer that wakes on the kick and drains the channel — separate test, not a band-aid here.

## Verification

- 50-run loop on `call_echo_round_trips_over_the_socket` under nextest with CI-equivalent parallelism: **50/50** (was flaking ~10–20% pre-fix per iamacoffeepot/aether#835's catalogue).
- `cargo nextest run --workspace --no-fail-fast` — 990/990 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

Closes iamacoffeepot/aether#835
