### PR TITLE
fix(substrate-bundle): testBench send_mail / send_bytes block on settlement (issue 834)

### DIFF
--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -87,22 +87,21 @@ fn load_viewer(bench: &mut TestBench, wasm_path: &std::path::Path) {
 }
 
 /// Direct `aether.tick` to the loaded viewer so the next `capture`
-/// sees fresh render-sink emissions.
-///
 /// Background: `TestBench::capture` runs its frame with
 /// `dispatch_tick=false` (capture is a state snapshot, not a tick
-/// advance). The render sink's vert buffer is consumed-and-replaced
-/// every frame, so a component that emits geometry only on `on_tick`
-/// paints nothing during the capture frame even though the previous
-/// `advance` ticked it. Sending `Tick` directly to the component's
-/// mailbox right before `capture` queues a tick that drains alongside
-/// the capture request, populating the buffer before the offscreen
-/// render reads it.
+/// advance). The render cap's vert accumulator drains on every
+/// `record_frame` (`std::mem::replace` on `frame_vertices`), so a
+/// viewer that emits geometry only on `on_tick` has nothing in the
+/// accumulator by the time capture's render reads it. Sending
+/// `Tick` directly to the component's mailbox right before
+/// `capture` populates the accumulator for the upcoming capture
+/// frame.
+///
+/// Pre-iamacoffeepot/aether#834 this was a band-aid that flaked
+/// because the bare `send_bytes` push didn't subscribe to the
+/// chain's settlement. iamacoffeepot/aether#834 made `send_bytes`
+/// synchronous on settlement, so this now reliably pre-populates.
 fn nudge_tick(bench: &mut TestBench) {
-    // `Tick` is a unit struct on the cast wire shape (no Serialize),
-    // so it can't go through `send_mail::<K>` (postcard-only). Use
-    // the bytes path with the kind's own `encode_into_bytes` helper,
-    // which the derive emits per-shape.
     bench
         .send_bytes(&component_address(), Tick::ID, Tick.encode_into_bytes())
         .expect("send tick");

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -56,7 +56,12 @@ pub const DEFAULT_HEIGHT: u32 = 600;
 /// decode failures (rare — implies a kind shape mismatch); `Timeout`
 /// covers replies that never arrive (chassis hung or wrong target);
 /// `Advance` and `Capture` pass through `Err` variants from the
-/// substrate's reply.
+/// substrate's reply. `SettlementTimeout` surfaces when a
+/// `send_mail` / `send_bytes` chain didn't drain within
+/// [`SETTLEMENT_TIMEOUT`] — issue 834: the bench waits on each
+/// pushed chain's `Settled { root }` so the next observation
+/// (`capture()`, the next typed send, an assertion) is causally
+/// after the producer's full descendant tree dispatched.
 #[derive(Debug)]
 pub enum TestBenchError {
     Boot(String),
@@ -68,6 +73,10 @@ pub enum TestBenchError {
     Advance(String),
     Capture(String),
     UnknownMailbox(String),
+    SettlementTimeout {
+        recipient: String,
+        kind_name: &'static str,
+    },
 }
 
 impl fmt::Display for TestBenchError {
@@ -85,9 +94,22 @@ impl fmt::Display for TestBenchError {
             Self::Advance(e) => write!(f, "advance failed: {e}"),
             Self::Capture(e) => write!(f, "capture failed: {e}"),
             Self::UnknownMailbox(name) => write!(f, "unknown mailbox: {name}"),
+            Self::SettlementTimeout {
+                recipient,
+                kind_name,
+            } => write!(
+                f,
+                "send to {recipient:?} ({kind_name}) did not settle within {} s — chain likely has an in_flight leak; check `engine_logs` for stuck mail",
+                SETTLEMENT_TIMEOUT.as_secs(),
+            ),
         }
     }
 }
+
+/// Per-send settlement timeout. Mirrors the `run_frame` tick wait at
+/// `bench.rs::run_frame`; long enough to absorb wasm compile + cap
+/// dispatcher wake under nextest CPU contention.
+const SETTLEMENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl std::error::Error for TestBenchError {}
 
@@ -333,10 +355,21 @@ impl TestBench {
         self.observed_kinds.lock().unwrap().clone()
     }
 
-    /// Push a fire-and-forget mail into the queue. Recipient is
-    /// resolved by name against the registry; kind ids are pulled
-    /// from `K::ID` so the caller doesn't need to look anything up.
-    /// No reply awaited.
+    /// Push a typed mail and block until the dispatched chain
+    /// settles (ADR-0080 §6). Recipient is resolved by name against
+    /// the registry; kind ids are pulled from `K::ID` so the caller
+    /// doesn't need to look anything up.
+    ///
+    /// Issue 834: this is synchronous-on-settle. The mail is minted
+    /// as a chassis-root via [`push_chassis_root_mail`] so the trace
+    /// pipeline tracks the chain; the bench then subscribes to
+    /// `Settled { root }` and waits up to [`SETTLEMENT_TIMEOUT`] for
+    /// the chain (the recipient's handler + every descendant mail
+    /// it spawned) to drain. By the time this returns, any
+    /// subsequent observation (`capture()`, the next send, an
+    /// assertion) is causally after the producer's full chain —
+    /// no more nudge_tick-style band-aids needed for render-flush
+    /// races.
     pub fn send_mail<K>(&self, recipient_name: &str, mail: &K) -> Result<(), TestBenchError>
     where
         K: Kind + serde::Serialize,
@@ -346,8 +379,7 @@ impl TestBench {
             .lookup(recipient_name)
             .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
         let payload = encode_struct(mail);
-        self.queue.push(Mail::new(mailbox, K::ID, payload, 1));
-        Ok(())
+        self.push_and_settle(recipient_name, K::NAME, mailbox, K::ID, payload)
     }
 
     /// Bytes-level send for callers that resolve kind+payload at
@@ -355,6 +387,9 @@ impl TestBench {
     /// recipient lookup as `send_mail` but takes a pre-encoded
     /// `(kind, bytes)` tuple — the typed `send_mail<K>` is the
     /// preferred path when `K` is known statically.
+    ///
+    /// Issue 834: synchronous-on-settle, same semantics as
+    /// [`Self::send_mail`].
     pub fn send_bytes(
         &self,
         recipient_name: &str,
@@ -365,8 +400,33 @@ impl TestBench {
             .registry
             .lookup(recipient_name)
             .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
-        self.queue.push(Mail::new(mailbox, kind, bytes, 1));
-        Ok(())
+        self.push_and_settle(recipient_name, "<bytes>", mailbox, kind, bytes)
+    }
+
+    /// Shared body of [`Self::send_mail`] / [`Self::send_bytes`]:
+    /// push as a chassis-root mail (so the trace pipeline tracks
+    /// the chain) and block on `Settled { root }`. Returns
+    /// `SettlementTimeout` if the chain doesn't drain within
+    /// [`SETTLEMENT_TIMEOUT`].
+    fn push_and_settle(
+        &self,
+        recipient_name: &str,
+        kind_name: &'static str,
+        mailbox: aether_data::MailboxId,
+        kind: KindId,
+        payload: Vec<u8>,
+    ) -> Result<(), TestBenchError> {
+        let cid = self.fresh_correlation_id();
+        let registry = self._passive.settlement_registry();
+        let root = push_chassis_root_mail(&self.queue, cid, mailbox, kind, payload, 1);
+        let rx = registry.subscribe_settlement(root);
+        match rx.recv_timeout(SETTLEMENT_TIMEOUT) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(TestBenchError::SettlementTimeout {
+                recipient: recipient_name.to_owned(),
+                kind_name,
+            }),
+        }
     }
 
     /// Issue 607 Phase 3: spawn an instanced actor onto the bench's

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -76,17 +76,21 @@ fn load_sokoban(bench: &mut TestBench, wasm_path: &std::path::Path) {
 ///
 /// Background: `TestBench::capture` runs its frame with
 /// `dispatch_tick=false` (capture is a state snapshot, not a tick
-/// advance). The render sink's vert buffer is consumed-and-replaced
-/// every frame, so a component that emits geometry only on `on_tick`
-/// paints nothing during the capture frame even though the previous
-/// `advance` ticked it. Sending `Tick` directly to the component's
-/// mailbox right before `capture` queues a tick that drains alongside
-/// the capture request, populating the buffer before the offscreen
-/// render reads it.
+/// advance). The render cap's vert accumulator drains on every
+/// `record_frame` (`std::mem::replace` on `frame_vertices`), so a
+/// component that emits geometry only on `on_tick` has nothing in
+/// the accumulator by the time capture's render reads it. Sending
+/// `Tick` directly to the component's mailbox right before
+/// `capture` populates the accumulator for the upcoming capture
+/// frame.
+///
+/// Pre-iamacoffeepot/aether#834 this was a band-aid that flaked
+/// because the bare `send_bytes` push didn't subscribe to the
+/// chain's settlement — capture could race ahead before sokoban's
+/// DrawTriangle landed in render's accumulator. iamacoffeepot/aether#834 made
+/// `send_bytes` synchronous on settlement, so nudge_tick now
+/// reliably pre-populates the accumulator before returning.
 fn nudge_tick(bench: &mut TestBench) {
-    // `Tick` is a unit struct on the cast wire shape (no Serialize);
-    // can't go through `send_mail::<K>` (postcard-only). Same applies
-    // to `Key` below.
     bench
         .send_bytes(&component_address(), Tick::ID, Tick.encode_into_bytes())
         .expect("send tick");
@@ -102,10 +106,12 @@ fn assert_draw_triangle_observed(bench: &TestBench) {
 }
 
 /// Default-level rendering smoke test. Loads the wasm, advances a
-/// few ticks so init + tick can flush, fires one more tick before
-/// capture (so render-sink verts populate), and asserts both that
-/// `DrawTriangle` mail flows and that the captured frame contains
-/// pixels diverging from the chassis clear color.
+/// few ticks so init can flush, fires one more `Tick` via
+/// `nudge_tick` to populate render's accumulator (consumed during
+/// each advance's render — see `nudge_tick` docs), captures, and
+/// asserts both that `DrawTriangle` mail flowed and that the
+/// captured frame contains pixels diverging from the chassis clear
+/// color.
 #[test]
 fn default_level_renders_grid_and_player() {
     let Some(wasm_path) = require_runtime("aether_demo_sokoban") else {
@@ -140,7 +146,10 @@ fn key_press_keeps_render_path_alive() {
     bench.advance(2).expect("pre-key advance");
 
     // Press D — sokoban steps the player east; the WASD/arrow mapping
-    // lives in `step_delta` inside the demo's lib.rs.
+    // lives in `step_delta` inside the demo's lib.rs. `send_bytes`
+    // is synchronous-on-settle (iamacoffeepot/aether#834), so the
+    // post-key advance below picks up the new player position
+    // structurally.
     let key = Key {
         code: keycode::KEY_D,
     };


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Closes the long-standing render-flush flake by making `TestBench::send_mail` and `TestBench::send_bytes` synchronous on chain settlement.

Pre-fix: both methods pushed bare `Mail::new(...)` (no lineage). The trace observer's `record_received` / `record_finished` short-circuit on `MailId::NONE`, so chains rooted at these sends were invisible to the settlement protocol. Sokoban's `nudge_tick` band-aid raced: capture could read render's empty accumulator before the producer's chain landed.

Post-fix: both methods mint a fresh chassis-root via `push_chassis_root_mail`, subscribe to `Settled { root }`, and block up to `SETTLEMENT_TIMEOUT` (5 s) for the chain to drain. By the time they return, the recipient's handler + every descendant mail it spawned have dispatched. `nudge_tick` is now structurally reliable instead of racy.

## Why nudge_tick still exists

`nudge_tick`'s purpose is structural, not racy. `TestBench::capture` runs its frame with `dispatch_tick=false` (capture is a state snapshot, not an advance). Render's vert accumulator drains on every `record_frame` via `std::mem::replace` on `frame_vertices` (`render.rs:415-418`), so after `advance(N)`'s last frame consumes the accumulator, capture's render reads an empty buffer unless a fresh `Tick` populates it first.

`nudge_tick` does exactly that. Pre-iamacoffeepot/aether#834, its `send_bytes` push didn't subscribe to settlement, so it raced. Now `send_bytes` blocks on the chain — `nudge_tick` returns only after sokoban's `Tick → DrawTriangle → render.handler` chain has fully dispatched, accumulator populated, ready for capture.

## Surface changes

- `TestBench::send_mail<K>` and `TestBench::send_bytes` route through a new shared `push_and_settle` helper. Same signatures, but now synchronous-on-settlement instead of fire-and-forget.
- `TestBenchError::SettlementTimeout { recipient, kind_name }` variant — surfaces when a chain doesn't drain within `SETTLEMENT_TIMEOUT`. Actionable failure mode for future in_flight leaks; pre-fix the silent fire-and-forget could mask them.
- `SETTLEMENT_TIMEOUT: Duration = 5s` constant, matching `run_frame`'s tick wait.

`send_and_await_reply` is unchanged — its reply pump already provides the structural ack for reply-bearing kinds.

## What this depended on

iamacoffeepot/aether#834 sat unfinished until the substrate-side settlement protocol was actually correct end-to-end. That took:

- iamacoffeepot/aether#838 + iamacoffeepot/aether#840 — closed `Mailer::push` terminal-arm leaks (Dropped, Closure-now-Inbox/Sink-now-Inline split, None/warn-drop, None/egress, ref-walk Err, chassis-router)
- iamacoffeepot/aether#842 — renamed `MailboxEntry::Closure` → `Inbox` and `Sink` → `Inline` so the contract is honest
- iamacoffeepot/aether#843 — retired the TestBenchObserver-as-actor workaround now that synchronous handlers settle correctly

Without those, this PR's `recv_timeout(SETTLEMENT_TIMEOUT)` would have either hung (waiting for a chain that couldn't structurally settle) or surfaced `SettlementTimeout` on every send. With them, settlement reliably fires within milliseconds.

## Verification

- **30-run loop on sokoban scenarios at `-j 16`: 30/30** (pre-fix was 48/50 = ~96% pass rate; the flake reappeared on every other batch of 10 runs).
- `cargo nextest run --workspace --no-fail-fast` — 990/990 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

## Out of scope

- Fixing `run_frame`'s silent `let _ = rx.recv_timeout(...)` swallow at `bench.rs::run_frame`. That swallow was a workaround for the pre-iamacoffeepot/aether#840 settlement leaks; now that settlement is correct, it's silent-but-harmless (recv returns `Ok(())` quickly). Could be promoted to strict propagation as a follow-up, but it's not load-bearing for closing this issue.
- Render's `consumed-on-record_frame` accumulator semantic — see "Why nudge_tick still exists" above. A future PR could explore whether capture should implicitly tick, but that changes scenario semantics (capture would advance state) and isn't required here.

Closes iamacoffeepot/aether#834
