### PR TITLE
refactor(substrate): migrate MailboxEntry to typed Inbox/Inline traits (iamacoffeepot/aether#848 PR 2)

### DIFF
--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -208,12 +208,12 @@ mod native {
                 bytes: vec![1, 2, 3, 4, 5],
             };
             let bytes = postcard::to_allocvec(&req).unwrap();
-            handler(aether_substrate::mail::registry::MailDispatch {
+            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
                 kind: <HandlePublish as Kind>::ID,
-                kind_name: "aether.handle.publish",
+                kind_name: "aether.handle.publish".to_owned(),
                 origin: None,
                 sender: session_reply_to(),
-                payload: &bytes,
+                payload: bytes,
                 count: 1,
                 mail_id: aether_substrate::mail::MailId::NONE,
                 root: aether_substrate::mail::MailId::NONE,

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -281,12 +281,12 @@ mod native {
                 entries: vec![event(3, "parse failed: missing close paren")],
             };
             let bytes = postcard::to_allocvec(&batch).expect("encode");
-            handler(aether_substrate::mail::registry::MailDispatch {
+            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
                 kind: <LogBatch as Kind>::ID,
-                kind_name: "aether.log",
+                kind_name: "aether.log".to_owned(),
                 origin: None,
                 sender: aether_substrate::mail::ReplyTo::NONE,
-                payload: &bytes,
+                payload: bytes,
                 count: 1,
                 mail_id: aether_substrate::mail::MailId::NONE,
                 root: aether_substrate::mail::MailId::NONE,

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -585,12 +585,12 @@ mod native {
             let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
                 panic!("expected mailbox entry for {name}");
             };
-            handler(aether_substrate::mail::registry::MailDispatch {
+            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
                 kind,
-                kind_name: "test.kind",
+                kind_name: "test.kind".to_owned(),
                 origin: None,
                 sender: ReplyTo::NONE,
-                payload,
+                payload: payload.to_vec(),
                 count: 1,
                 mail_id: aether_substrate::mail::MailId::NONE,
                 root: aether_substrate::mail::MailId::NONE,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -618,12 +618,12 @@ mod cap_native {
                 panic!("expected mailbox entry");
             };
             let bytes = postcard::to_allocvec(mail).expect("encode");
-            handler(aether_substrate::mail::registry::MailDispatch {
+            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
                 kind: K::ID,
-                kind_name: K::NAME,
+                kind_name: K::NAME.to_owned(),
                 origin: None,
                 sender: session_reply(),
-                payload: &bytes,
+                payload: bytes,
                 count: 1,
                 mail_id: aether_substrate::mail::MailId::NONE,
                 root: aether_substrate::mail::MailId::NONE,

--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -130,12 +130,12 @@ fn push_log_batch(registry: &Registry, recipient: &str, payload: &[u8]) {
     let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
-    handler(aether_substrate::mail::registry::MailDispatch {
+    handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
         kind: <LogBatch as Kind>::ID,
-        kind_name: LogBatch::NAME,
+        kind_name: LogBatch::NAME.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
-        payload,
+        payload: payload.to_vec(),
         count: 1,
         mail_id: aether_substrate::mail::MailId::NONE,
         root: aether_substrate::mail::MailId::NONE,

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -617,14 +617,21 @@ mod tests {
     /// observing — or just not warn-dropping — the mail.
     fn forward_to_envelope_sender(
         tx: mpsc::Sender<Envelope>,
-    ) -> crate::mail::registry::MailboxHandler {
-        Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+    ) -> Arc<dyn crate::mail::registry::InboxHandler> {
+        // iamacoffeepot/aether#848 PR 2: the test helper takes
+        // `OwnedDispatch` directly so the payload + kind_name move
+        // into the forwarded `Envelope` rather than being cloned via
+        // `to_vec()` / `to_owned()`. The legacy borrowed-dispatch
+        // shape stays accessible through `legacy_inbox_handler` for
+        // cap closures still mid-migration; this test helper is
+        // greenfield enough to skip the adapter.
+        Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
             let _ = tx.send(Envelope {
                 kind: dispatch.kind,
-                kind_name: dispatch.kind_name.to_owned(),
-                origin: dispatch.origin.map(str::to_owned),
+                kind_name: dispatch.kind_name,
+                origin: dispatch.origin,
                 sender: dispatch.sender,
-                payload: dispatch.payload.to_vec(),
+                payload: dispatch.payload,
                 count: dispatch.count,
                 mail_id: dispatch.mail_id,
                 root: dispatch.root,

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -397,45 +397,47 @@ impl Spawner {
         let wake_for_handler = Arc::clone(&wake_slot);
         let registered = self.registry.try_register_inbox(
             full_name.clone(),
-            Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
-                let Some(tx) = weak_for_handler.upgrade() else {
-                    tracing::warn!(
-                        target: "aether_substrate::spawn",
-                        kind = dispatch.kind_name,
-                        "instanced actor sender dropped — mail discarded"
-                    );
-                    return;
-                };
-                let env = Envelope {
-                    kind: dispatch.kind,
-                    kind_name: dispatch.kind_name.to_owned(),
-                    origin: dispatch.origin.map(str::to_owned),
-                    sender: dispatch.sender,
-                    payload: dispatch.payload.to_vec(),
-                    count: dispatch.count,
-                    mail_id: dispatch.mail_id,
-                    root: dispatch.root,
-                    parent_mail: dispatch.parent_mail,
-                };
-                pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                if tx.send(env).is_err() {
-                    // Receiver disconnected before we could deliver;
-                    // un-account for the increment so the counter
-                    // stays accurate (a future post-PR-4 cleanup may
-                    // drop the counter entirely now that
-                    // `wait_instanced_quiesce` retired).
-                    pending_for_handler.fetch_sub(1, Ordering::AcqRel);
-                    tracing::warn!(
-                        target: "aether_substrate::spawn",
-                        kind = dispatch.kind_name,
-                        "instanced actor receiver dropped — mail discarded"
-                    );
-                    return;
-                }
-                if let Some(wake) = wake_for_handler.get() {
-                    wake();
-                }
-            }),
+            crate::mail::registry::legacy_inbox_handler(
+                move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                    let Some(tx) = weak_for_handler.upgrade() else {
+                        tracing::warn!(
+                            target: "aether_substrate::spawn",
+                            kind = dispatch.kind_name,
+                            "instanced actor sender dropped — mail discarded"
+                        );
+                        return;
+                    };
+                    let env = Envelope {
+                        kind: dispatch.kind,
+                        kind_name: dispatch.kind_name.to_owned(),
+                        origin: dispatch.origin.map(str::to_owned),
+                        sender: dispatch.sender,
+                        payload: dispatch.payload.to_vec(),
+                        count: dispatch.count,
+                        mail_id: dispatch.mail_id,
+                        root: dispatch.root,
+                        parent_mail: dispatch.parent_mail,
+                    };
+                    pending_for_handler.fetch_add(1, Ordering::AcqRel);
+                    if tx.send(env).is_err() {
+                        // Receiver disconnected before we could deliver;
+                        // un-account for the increment so the counter
+                        // stays accurate (a future post-PR-4 cleanup may
+                        // drop the counter entirely now that
+                        // `wait_instanced_quiesce` retired).
+                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
+                        tracing::warn!(
+                            target: "aether_substrate::spawn",
+                            kind = dispatch.kind_name,
+                            "instanced actor receiver dropped — mail discarded"
+                        );
+                        return;
+                    }
+                    if let Some(wake) = wake_for_handler.get() {
+                        wake();
+                    }
+                },
+            ),
         );
         let _ = sender_for_init; // Phase 3 doesn't stamp pre-load mail with the spawner; envelopes are pre-built by SpawnBuilder.
         match registered {

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -360,7 +360,7 @@ mod tests {
         let captured_for_handler = Arc::clone(&captured);
         let _ = registry.try_register_inbox(
             name.to_owned(),
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
                 captured_for_handler.lock().unwrap().push(CapturedDispatch {
                     mail_id: dispatch.mail_id,
                     root: dispatch.root,

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -239,13 +239,20 @@ impl ComponentCtx {
                 // to reply (ADR-0041's io sink is the motivating case)
                 // can route `*Result` back to this component via
                 // `Mailer::send_reply`.
+                //
+                // iamacoffeepot/aether#848 PR 2: handler is now
+                // `Arc<dyn InboxHandler>`; build an [`OwnedDispatch`]
+                // and move payload + kind_name into it. The bytes
+                // flow straight into the downstream cap's mpsc
+                // envelope without a `to_vec()` clone (once the cap
+                // migrates off `legacy_inbox_handler` in PR 3).
                 let origin = self.registry.mailbox_name(self.sender);
-                handler(crate::mail::registry::MailDispatch {
+                handler.enqueue(crate::mail::registry::OwnedDispatch {
                     kind,
-                    kind_name: &kind_name,
-                    origin: origin.as_deref(),
+                    kind_name,
+                    origin,
                     sender: reply_to,
-                    payload: &payload,
+                    payload,
                     count,
                     mail_id,
                     root,
@@ -258,7 +265,7 @@ impl ComponentCtx {
                 let origin = self.registry.mailbox_name(self.sender);
                 let thread_name = std::thread::current().name().map(str::to_owned);
                 crate::runtime::trace::record_received(mail_id, thread_name);
-                handler(crate::mail::registry::MailDispatch {
+                handler.dispatch(crate::mail::registry::MailDispatch {
                     kind,
                     kind_name: &kind_name,
                     origin: origin.as_deref(),
@@ -1220,7 +1227,7 @@ mod tests {
         let sink_id = registry
             .try_register_inbox(
                 "issue_722_sink",
-                Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                     captured_for_handler.lock().unwrap().push((
                         dispatch.mail_id,
                         dispatch.root,
@@ -1292,7 +1299,7 @@ mod tests {
         let sink_id = registry
             .try_register_inbox(
                 "issue_722_fresh_root_sink",
-                Arc::new(move |dispatch: crate::mail::registry::MailDispatch<'_>| {
+                Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                     captured_for_handler.lock().unwrap().push((
                         dispatch.mail_id,
                         dispatch.root,

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1906,7 +1906,7 @@ mod tests {
 
         let payload = Ping { tag: 0xDEAD_BEEF };
         let bytes = payload.encode_into_bytes();
-        handler(crate::mail::registry::test_dispatch(
+        handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Ping as Kind>::ID,
             Ping::NAME,
             &bytes,
@@ -2086,7 +2086,7 @@ mod tests {
         for seq in 0..3 {
             let payload = Tick { seq };
             let bytes = payload.encode_into_bytes();
-            handler(crate::mail::registry::test_dispatch(
+            handler.enqueue(crate::mail::registry::test_owned_dispatch(
                 <Tick as Kind>::ID,
                 Tick::NAME,
                 &bytes,
@@ -2253,7 +2253,7 @@ mod tests {
             panic!("expected mailbox entry");
         };
         let bytes = (Hatch { tag: 1 }).encode_into_bytes();
-        handler(crate::mail::registry::test_dispatch(
+        handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
             &bytes,
@@ -2377,7 +2377,7 @@ mod tests {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
-        handler(crate::mail::registry::test_dispatch(
+        handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &bytes,
@@ -2760,7 +2760,7 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler(crate::mail::registry::test_dispatch(
+        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
             &order.encode_into_bytes(),
@@ -2793,7 +2793,7 @@ mod tests {
         else {
             panic!("expected mailbox entry for target");
         };
-        target_handler(crate::mail::registry::test_dispatch(
+        target_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -2989,7 +2989,7 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler(crate::mail::registry::test_dispatch(
+        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
             &order.encode_into_bytes(),
@@ -3007,7 +3007,7 @@ mod tests {
 
         // Quit watcher — its close path walks `monitoring[watcher]` and
         // prunes watcher from `monitors_of[target]`.
-        watcher_handler(crate::mail::registry::test_dispatch(
+        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -3176,7 +3176,7 @@ mod tests {
         let MailboxEntry::Inbox(handler) = registry.entry(id_c).expect("c sink registered") else {
             panic!("expected mailbox entry for c");
         };
-        handler(crate::mail::registry::test_dispatch(
+        handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -3483,7 +3483,7 @@ mod tests {
         else {
             panic!("expected mailbox entry for parent");
         };
-        parent_handler(crate::mail::registry::test_dispatch(
+        parent_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
             &(Hatch { tag: 1 }).encode_into_bytes(),
@@ -3533,7 +3533,7 @@ mod tests {
         // Closing the parent does NOT cascade-close the grandchild.
         // Parent-child shutdown coupling is opt-in via monitor; without
         // it, the grandchild keeps running.
-        parent_handler(crate::mail::registry::test_dispatch(
+        parent_handler.enqueue(crate::mail::registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -300,7 +300,7 @@ impl<'a> ChassisCtx<'a> {
         let tx = Arc::new(tx);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
                 let env = build_envelope(&dispatch);
                 if tx.send(env).is_err() {
                     tracing::warn!(
@@ -354,7 +354,7 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",
@@ -424,7 +424,7 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -301,7 +301,7 @@ mod tests {
         let captured_clone = Arc::clone(&captured);
         let target = registry.register_inbox(
             sink_name,
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
                 captured_clone.lock().unwrap().push(CapturedDispatch {
                     kind: dispatch.kind,
                     payload: dispatch.payload.to_vec(),

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::outbound::HubOutbound;
-use crate::mail::registry::{MailDispatch, MailboxEntry, Registry};
+use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use aether_data::{HandleId, KindId};
 use std::sync::OnceLock;
@@ -375,12 +375,22 @@ fn route_mail(
             // ReplyEnd before ReplyEvent). Synchronous handlers live
             // on the [`MailboxEntry::Inline`] arm below — they get
             // the bracket because nothing downstream owns it.
-            handler(MailDispatch {
+            //
+            // iamacoffeepot/aether#848 PR 2: payload + kind_name
+            // move into [`OwnedDispatch`] rather than being borrowed.
+            // The handler is now `Arc<dyn InboxHandler>` whose
+            // `enqueue` takes owned bytes — caps that migrate to
+            // `Fn(OwnedDispatch)` in PR 3 send the envelope
+            // downstream with zero payload-bytes copies; legacy cap
+            // closures still wrapped in `legacy_inbox_handler`
+            // re-borrow once back into `MailDispatch<'_>` for the
+            // unchanged body, cost-neutral with today's path.
+            handler.enqueue(OwnedDispatch {
                 kind: mail.kind,
-                kind_name: &kind_name,
+                kind_name,
                 origin: None,
                 sender: mail.reply_to,
-                payload: &mail.payload,
+                payload: mail.payload,
                 count: mail.count,
                 mail_id: mail.mail_id,
                 root: mail.root,
@@ -398,7 +408,7 @@ fn route_mail(
             // avoids.
             let thread_name = std::thread::current().name().map(str::to_owned);
             crate::runtime::trace::record_received(inbound_mail_id, thread_name);
-            handler(MailDispatch {
+            handler.dispatch(MailDispatch {
                 kind: mail.kind,
                 kind_name: &kind_name,
                 origin: None,
@@ -490,7 +500,6 @@ mod tests {
     use crate::handle_store::HandleStore;
     use crate::mail::MailboxId;
     use crate::mail::outbound::EgressEvent;
-    use crate::mail::registry::MailboxHandler;
     use aether_data::{Kind, Ref};
     use aether_data::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
 
@@ -618,11 +627,30 @@ mod tests {
                 delivery_count: Arc::new(AtomicUsize::new(0)),
             }
         }
-        fn handler(&self) -> MailboxHandler {
+        /// Inline-variant handler: synchronous capture body. Used by
+        /// the `register_inline` test sites; mailer brackets the
+        /// call so settlement balances.
+        fn inline_handler(&self) -> Arc<dyn crate::mail::registry::InlineHandler> {
             let captured = Arc::clone(&self.captured);
             let count = Arc::clone(&self.delivery_count);
             Arc::new(move |dispatch: MailDispatch<'_>| {
                 captured.write().unwrap().push(dispatch.payload.to_vec());
+                count.fetch_add(1, Ordering::SeqCst);
+            })
+        }
+
+        /// Inbox-variant handler: receives [`OwnedDispatch`] and
+        /// moves the payload into the captured Vec (no `to_vec()`
+        /// clone). Used by `register_inbox` test sites that exercise
+        /// the actor-enqueue dispatch path. Bracket owned downstream
+        /// — these tests don't subscribe to settlement so the
+        /// "downstream never finishes" path is intentional and
+        /// harmless.
+        fn inbox_handler(&self) -> Arc<dyn crate::mail::registry::InboxHandler> {
+            let captured = Arc::clone(&self.captured);
+            let count = Arc::clone(&self.delivery_count);
+            Arc::new(move |dispatch: OwnedDispatch| {
+                captured.write().unwrap().push(dispatch.payload);
                 count.fetch_add(1, Ordering::SeqCst);
             })
         }
@@ -647,7 +675,7 @@ mod tests {
             })
             .unwrap();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_inbox("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
 
         let note = Note {
             body: "verbatim".into(),
@@ -681,7 +709,7 @@ mod tests {
             .unwrap();
 
         let sink = CapturingSink::new();
-        let sink_id = registry.register_inbox("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
 
         // Push HeldNote mail with `held = Handle(7)`. Handle 7 is
         // not in the store yet — the mail must park. We construct
@@ -745,7 +773,7 @@ mod tests {
             .unwrap();
 
         let sink = CapturingSink::new();
-        let sink_id = registry.register_inbox("test.sink", sink.handler());
+        let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
 
         // Truncated payload — the walker bails Truncated mid-walk.
         mailer.push(Mail::new(sink_id, kind_id, vec![0u8; 1], 1));
@@ -877,7 +905,7 @@ mod tests {
 
         let (registry, mailer, _store) = make_mailer();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_inline("test.838.sink", sink.handler());
+        let sink_id = registry.register_inline("test.838.sink", sink.inline_handler());
 
         let mail = Mail::new(sink_id, KindId(0xCAFE_BABE), vec![1, 2, 3], 1).with_lineage(
             inbound_mail_id,
@@ -928,7 +956,8 @@ mod tests {
         let sink = CapturingSink::new();
         // Register as `register_inbox` (the actor-enqueue
         // contract), NOT `register_inline`.
-        let recipient = registry.register_inbox("test.838.closure_regression", sink.handler());
+        let recipient =
+            registry.register_inbox("test.838.closure_regression", sink.inbox_handler());
 
         let mail = Mail::new(recipient, KindId(0xCAFE_BABE), vec![4, 5, 6], 1).with_lineage(
             inbound_mail_id,
@@ -996,7 +1025,7 @@ mod tests {
             })
             .unwrap();
         let sink = CapturingSink::new();
-        let sink_id = registry.register_inline("test.838.park_defer", sink.handler());
+        let sink_id = registry.register_inline("test.838.park_defer", sink.inline_handler());
 
         // Build a payload that references a handle not yet in the
         // store — the walker returns `Parked`, mail held.
@@ -1131,7 +1160,7 @@ mod tests {
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
                     let sink = CapturingSink::new();
-                    let id = registry.register_inline("test.meta.sink", sink.handler());
+                    let id = registry.register_inline("test.meta.sink", sink.inline_handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
@@ -1149,7 +1178,7 @@ mod tests {
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
                     let sink = CapturingSink::new();
-                    let id = registry.register_inbox("test.meta.closure", sink.handler());
+                    let id = registry.register_inbox("test.meta.closure", sink.inbox_handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
@@ -1224,7 +1253,8 @@ mod tests {
                         })
                         .unwrap();
                     let sink = CapturingSink::new();
-                    let id = registry.register_inline("test.meta.refwalk_err", sink.handler());
+                    let id =
+                        registry.register_inline("test.meta.refwalk_err", sink.inline_handler());
                     // Truncated payload (1 byte) — walker bails Err.
                     mailer.push(
                         Mail::new(id, kind_id, vec![0u8; 1], 1)
@@ -1254,7 +1284,8 @@ mod tests {
                         })
                         .unwrap();
                     let sink = CapturingSink::new();
-                    let id = registry.register_inline("test.meta.refwalk_parked", sink.handler());
+                    let id =
+                        registry.register_inline("test.meta.refwalk_parked", sink.inline_handler());
                     let held = HeldNote {
                         held: Ref::Handle {
                             id: 0x8888_8888_8888_8888,

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -41,12 +41,88 @@ pub(crate) fn test_dispatch<'a>(
     }
 }
 
-/// No-op [`MailboxHandler`] for tests that just need a registered
+/// Test-only owned mirror of [`test_dispatch`]. Used by tests that
+/// poke an `Inbox` handler directly through
+/// [`InboxHandler::enqueue`] — the trait's owned-dispatch contract
+/// makes the borrowed [`test_dispatch`] unsuitable. Same defaults
+/// (empty origin, `ReplyTo::NONE`, `MailId::NONE`).
+///
+/// Issue iamacoffeepot/aether#848 PR 2: added alongside the
+/// [`OwnedDispatch`] migration so cap-side dispatcher tests stay
+/// terse without each rebuilding the full struct literal.
+#[cfg(test)]
+pub(crate) fn test_owned_dispatch(
+    kind: KindId,
+    kind_name: &str,
+    payload: &[u8],
+    count: u32,
+) -> OwnedDispatch {
+    OwnedDispatch {
+        kind,
+        kind_name: kind_name.to_owned(),
+        origin: None,
+        sender: ReplyTo::NONE,
+        payload: payload.to_vec(),
+        count,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
+        parent_mail: None,
+    }
+}
+
+/// No-op [`InboxHandler`] for tests that just need a registered
 /// mailbox to route to *somewhere* without observing the mail. The
-/// explicit named helper documents intent at the call site and keeps
-/// the closure shape (post-ADR-0080 `MailDispatch`-based) hidden.
-pub fn noop_handler() -> MailboxHandler {
-    Arc::new(|_dispatch: MailDispatch<'_>| {})
+/// explicit named helper documents intent at the call site.
+///
+/// Defaults to the Inbox variant because every current caller pairs
+/// it with `register_inbox` / `try_register_inbox`. Tests that need
+/// the Inline variant (e.g. asserting bracket recording paths)
+/// build their own `Arc::new(|_d: MailDispatch<'_>| {}) as
+/// Arc<dyn InlineHandler>`.
+pub fn noop_handler() -> Arc<dyn InboxHandler> {
+    Arc::new(|_dispatch: OwnedDispatch| {})
+}
+
+/// Issue iamacoffeepot/aether#848 PR 2 adapter: wrap a legacy
+/// `Fn(MailDispatch<'_>)` closure (the pre-PR-2 cap shape) into an
+/// `Arc<dyn InboxHandler>` so existing cap closures keep compiling
+/// through the staged migration. The adapter re-borrows the inbound
+/// [`OwnedDispatch`] back into a [`MailDispatch<'_>`] for the legacy
+/// body. Cost-neutral with today's path (the borrow itself is free;
+/// the legacy body's `to_vec()` / `to_owned()` clones inside the
+/// closure are unchanged), so PR 2 doesn't introduce a perf
+/// regression on the cap dispatch hot path.
+///
+/// Each production cap that's still wrapped here migrates in PR 3
+/// to take `Fn(OwnedDispatch)` directly — moving payload + kind_name
+/// rather than cloning them, which is where iamacoffeepot/aether#848's
+/// documented hot-path win materializes. PR 5 retires this helper
+/// once every wrap is gone.
+pub fn legacy_inbox_handler<F>(closure: F) -> Arc<dyn InboxHandler>
+where
+    F: for<'a> Fn(MailDispatch<'a>) + Send + Sync + 'static,
+{
+    struct LegacyAdapter<F>(F);
+    impl<F> InboxHandler for LegacyAdapter<F>
+    where
+        F: for<'a> Fn(MailDispatch<'a>) + Send + Sync + 'static,
+    {
+        fn enqueue(&self, dispatch: OwnedDispatch) {
+            let borrowed = MailDispatch {
+                kind: dispatch.kind,
+                kind_name: &dispatch.kind_name,
+                origin: dispatch.origin.as_deref(),
+                sender: dispatch.sender,
+                payload: &dispatch.payload,
+                count: dispatch.count,
+                mail_id: dispatch.mail_id,
+                root: dispatch.root,
+                parent_mail: dispatch.parent_mail,
+            };
+            (self.0)(borrowed);
+        }
+    }
+    Arc::new(LegacyAdapter(closure))
 }
 use aether_data::canonical::{canonical_kind_bytes, kind_id_from_parts};
 use aether_data::{KindDescriptor, MailboxCategory, MailboxDescriptor, SchemaType};
@@ -247,7 +323,17 @@ pub enum MailboxEntry {
     /// public [`Registry::register_inbox`] /
     /// [`Registry::try_register_inbox`] for callers that own a
     /// separate dispatcher loop.
-    Inbox(MailboxHandler),
+    ///
+    /// Issue iamacoffeepot/aether#848 PR 2: the variant now wraps
+    /// `Arc<dyn InboxHandler>` (was `MailboxHandler`). Handler
+    /// bodies receive [`OwnedDispatch`] so payload bytes move into
+    /// the downstream envelope rather than being cloned via
+    /// `to_vec()` — the hot-path perf win documented in iamacoffeepot/aether#848.
+    /// Legacy `Fn(MailDispatch<'_>)` cap closures bridge via
+    /// [`legacy_inbox_handler`] during the staged migration; PR 3
+    /// rewrites each cap to take `OwnedDispatch` directly and the
+    /// adapter retires in PR 5.
+    Inbox(Arc<dyn InboxHandler>),
     /// The handler body does its work inline on the pushing thread;
     /// there is no actor dispatch loop behind it. `Mailer::push`
     /// brackets this arm with `Received` and `Finished` so the
@@ -257,7 +343,13 @@ pub enum MailboxEntry {
     /// [`Registry::try_register_inline`]. Distinct from `Inbox` so
     /// the bracket isn't double-counted when the closure was an
     /// actor-enqueue (which would fire settlement prematurely).
-    Inline(MailboxHandler),
+    ///
+    /// Issue iamacoffeepot/aether#848 PR 2: the variant now wraps
+    /// `Arc<dyn InlineHandler>` (was `MailboxHandler`). The handler
+    /// body shape — `Fn(MailDispatch<'_>)` — is unchanged; the
+    /// blanket impl on the `InlineHandler` trait makes existing
+    /// closures coerce into `Arc<dyn InlineHandler>` automatically.
+    Inline(Arc<dyn InlineHandler>),
     /// Mailbox has been explicitly dropped (ADR-0010). Mail addressed
     /// to a `Dropped` slot is discarded by the scheduler / ctx dispatch
     /// until the same name is re-registered, at which point the slot
@@ -480,7 +572,11 @@ impl Registry {
     ///
     /// Panics on a name collision — these are substrate-internal
     /// names, collisions are bugs.
-    pub fn register_inbox(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
+    pub fn register_inbox(
+        &self,
+        name: impl Into<String>,
+        handler: Arc<dyn InboxHandler>,
+    ) -> MailboxId {
         let name = name.into();
         match self.insert(name.clone(), MailboxEntry::Inbox(handler)) {
             Ok(id) => {
@@ -501,7 +597,7 @@ impl Registry {
     pub fn try_register_inbox(
         &self,
         name: impl Into<String>,
-        handler: MailboxHandler,
+        handler: Arc<dyn InboxHandler>,
     ) -> Result<MailboxId, NameConflict> {
         let result = self.insert(name.into(), MailboxEntry::Inbox(handler));
         if result.is_ok() {
@@ -525,7 +621,11 @@ impl Registry {
     /// `Inline` double-counts `Finished` (settlement fires
     /// prematurely). Panics on a name collision — these are
     /// substrate-internal names, collisions are bugs.
-    pub fn register_inline(&self, name: impl Into<String>, handler: MailboxHandler) -> MailboxId {
+    pub fn register_inline(
+        &self,
+        name: impl Into<String>,
+        handler: Arc<dyn InlineHandler>,
+    ) -> MailboxId {
         let name = name.into();
         match self.insert(name.clone(), MailboxEntry::Inline(handler)) {
             Ok(id) => {
@@ -541,7 +641,7 @@ impl Registry {
     pub fn try_register_inline(
         &self,
         name: impl Into<String>,
-        handler: MailboxHandler,
+        handler: Arc<dyn InlineHandler>,
     ) -> Result<MailboxId, NameConflict> {
         let result = self.insert(name.into(), MailboxEntry::Inline(handler));
         if result.is_ok() {
@@ -851,7 +951,7 @@ mod tests {
         let c2 = Arc::clone(&counter);
         let id = r.register_inbox(
             "heartbeat",
-            Arc::new(move |dispatch: MailDispatch<'_>| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 c2.fetch_add(dispatch.count, Ordering::SeqCst);
             }),
         );
@@ -859,13 +959,13 @@ mod tests {
             panic!("expected closure entry")
         };
         // Test-side id is irrelevant — the handler ignores it.
-        h(test_dispatch(KindId(0), "aether.tick", &[], 7));
-        h(MailDispatch {
+        h.enqueue(test_owned_dispatch(KindId(0), "aether.tick", &[], 7));
+        h.enqueue(OwnedDispatch {
             kind: KindId(0),
-            kind_name: "aether.tick",
-            origin: Some("physics"),
+            kind_name: "aether.tick".to_owned(),
+            origin: Some("physics".to_owned()),
             sender: ReplyTo::NONE,
-            payload: &[],
+            payload: Vec::new(),
             count: 3,
             mail_id: MailId::NONE,
             root: MailId::NONE,

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -130,12 +130,12 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
         panic!("expected mailbox entry under {recipient}");
     };
     let bytes = payload.encode_into_bytes();
-    handler(aether_substrate::mail::registry::MailDispatch {
+    handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
         kind: <K as Kind>::ID,
-        kind_name: K::NAME,
+        kind_name: K::NAME.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
-        payload: &bytes,
+        payload: bytes,
         count: 1,
         mail_id: aether_substrate::mail::MailId::NONE,
         root: aether_substrate::mail::MailId::NONE,


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue/PR refs -->

## Summary

PR 2 of iamacoffeepot/aether#848's 5-PR plan. The variant + signature migration that consumes PR 1's additive types and cascades through every call site that builds or unwraps a `MailboxEntry::{Inbox, Inline}` handler.

The Inbox arm now moves `mail.payload` + `kind_name` into [`OwnedDispatch`] (eliminating the borrowed-then-cloned shape the legacy `Fn(MailDispatch<'_>)` closures used). Inline keeps borrowed `MailDispatch<'_>` — byte-for-byte identical to today. Compile errors flagged every call site that needed updating; this PR fixes them.

## Mechanical changes

### Type plumbing

- `MailboxEntry::Inbox(MailboxHandler)` → `Inbox(Arc<dyn InboxHandler>)`
- `MailboxEntry::Inline(MailboxHandler)` → `Inline(Arc<dyn InlineHandler>)`
- `register_inbox` / `try_register_inbox` take `Arc<dyn InboxHandler>`
- `register_inline` / `try_register_inline` take `Arc<dyn InlineHandler>`
- `noop_handler()` now returns `Arc<dyn InboxHandler>` (matches every current caller's pairing with `register_inbox`)
- New `legacy_inbox_handler<F>()` adapter wraps `Fn(MailDispatch<'_>)` cap closures into `Arc<dyn InboxHandler>` by re-borrowing `OwnedDispatch` back to `MailDispatch<'_>`. Cost-neutral; self-deletes as caps migrate to `Fn(OwnedDispatch)` in PR 3.

### `Mailer::push` arms

```rust
Some(MailboxEntry::Inbox(handler)) => {
    let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
    handler.enqueue(OwnedDispatch {
        kind: mail.kind,
        kind_name,                // moved
        origin: None,
        sender: mail.reply_to,
        payload: mail.payload,    // moved
        count: mail.count,
        mail_id: mail.mail_id,
        root: mail.root,
        parent_mail: mail.parent_mail,
    });
}
Some(MailboxEntry::Inline(handler)) => {
    let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
    let thread_name = std::thread::current().name().map(str::to_owned);
    crate::runtime::trace::record_received(inbound_mail_id, thread_name);
    handler.dispatch(MailDispatch {
        kind: mail.kind,
        kind_name: &kind_name,
        ..  // borrowed everywhere
    });
    crate::runtime::trace::record_finished(inbound_mail_id);
}
```

### Call-site migrations

Production cap closures that build envelopes from the dispatch (`chassis/ctx.rs::claim_mailbox*`, `actor/native/spawn.rs`, `chassis/settlement.rs`, the warn-drop test in `actor/wasm/component.rs`) wrap with `legacy_inbox_handler`. **Minimum diff for PR 2** — PR 3 will rewrite each cap closure body to `Fn(OwnedDispatch)` directly, dropping one payload `to_vec()` + one kind_name `to_owned()` per Inbox dispatch (the iamacoffeepot/aether#848 perf win materializes there).

Test helpers and synthetic-payload sites migrate directly:
- `actor/native/binding.rs::forward_to_envelope_sender` — moves payload + kind_name into the forwarded `Envelope` (no `to_vec()` / `to_owned()`).
- `actor/wasm/component.rs::ComponentCtx::send` Inbox + Inline inline-dispatch arms — `handler.enqueue` / `handler.dispatch` route the right shape.
- `actor/native/spawn_thread.rs` test sink wraps via the adapter; lineage-capturing sinks in `actor/wasm/component.rs` migrate to `Fn(OwnedDispatch)` directly.
- `chassis/builder.rs` (11 sites): `handler(test_dispatch(...))` → `handler.enqueue(test_owned_dispatch(...))`.
- `aether-capabilities` dispatcher tests (log, handle, render, tcp, log_pool_stress) construct `OwnedDispatch{...}` literals with owned fields.

### Test fixtures

- `test_owned_dispatch(kind, kind_name, payload, count)` — pub(crate) helper mirroring `test_dispatch` for the owned dispatch shape.
- `CapturingSink::handler()` splits into `inbox_handler()` + `inline_handler()`. The Inbox variant moves payload (no `to_vec()`); the Inline variant keeps the borrowed path. Each test site picks the variant matching its `register_inbox` / `register_inline` call.
- `closure_handler_runs_on_call` test in registry.rs migrates to the new dispatch shape.

## Performance

**Zero new allocations** while the legacy adapter still wraps production caps — the OwnedDispatch construction in the mailer is balanced by the legacy adapter's re-borrow into MailDispatch for the unchanged cap body. PR 3 swaps cap closures to `Fn(OwnedDispatch)` directly, dropping the cap-side `to_vec()` + `to_owned()` clones; that's where the documented hot-path win lands.

## Surface scope

| Area | Files | Note |
|---|---|---|
| Core types | `mail/registry.rs`, `mail/mailer.rs` | Variant + signature + Mailer arms |
| Cap dispatch via FFI | `actor/wasm/component.rs::ComponentCtx::send` | Inbox + Inline arms migrated |
| Production caps (wrapped) | `chassis/ctx.rs`, `actor/native/spawn.rs`, `chassis/settlement.rs` | 4 sites via `legacy_inbox_handler` |
| Test fixtures | `actor/native/binding.rs::forward_to_envelope_sender`, `actor/native/spawn_thread.rs`, `mail/mailer.rs` test sinks | Direct migration where greenfield |
| Test call sites | `chassis/builder.rs` (×11), `tests/native_actor_macro.rs`, `aether-capabilities/{src,tests}/*.rs` (×5) | Mechanical handler call updates |

15 files, +266 / -119.

## Verification

- `cargo nextest run --workspace --no-fail-fast` — **993/993 passed**.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- `cargo check -p aether-demo-sokoban -p aether-mesh-viewer -p aether-camera --target wasm32-unknown-unknown` — clean.

## Plan reference

5-PR ladder per iamacoffeepot/aether#848:

1. iamacoffeepot/aether#849 (merged) — types + blanket impls + smoke tests.
2. **This PR** — variant + signature migration + cascading call-site updates.
3. **PR 3** — rewrite production cap closures (`chassis/ctx.rs`, `actor/native/spawn.rs`, etc.) to `Fn(OwnedDispatch)` directly. Retires the `legacy_inbox_handler` adapter for those sites. **Perf win materializes here.**
4. **PR 4** — remaining test call sites that still use `legacy_inbox_handler`.
5. **PR 5** — retire `MailboxHandler` alias + retire `legacy_inbox_handler` + doc-tighten + optional `cargo asm` bench to confirm the predicted hot-path win.