### PR TITLE
refactor(substrate): cap closures take OwnedDispatch directly (iamacoffeepot/aether#848 PR 3)

### DIFF
--- a/crates/aether-substrate/src/actor/native/envelope.rs
+++ b/crates/aether-substrate/src/actor/native/envelope.rs
@@ -2,6 +2,7 @@
 //! mpsc inbox. Sinks today take borrowed args (`&str`, `&[u8]`); routing
 //! across an mpsc channel forces ownership.
 
+use crate::mail::registry::OwnedDispatch;
 use crate::mail::{KindId, MailId, ReplyTo};
 
 /// One mail delivered to a capability through its mpsc receiver.
@@ -28,4 +29,27 @@ pub struct Envelope {
     pub mail_id: MailId,
     pub root: MailId,
     pub parent_mail: Option<MailId>,
+}
+
+/// Issue iamacoffeepot/aether#848 PR 3: move every field out of
+/// the inbound [`OwnedDispatch`] into a fresh [`Envelope`]. No
+/// allocations — payload + kind_name + origin all transfer
+/// ownership. Replaces the legacy `build_envelope(&MailDispatch)`
+/// path inside production cap registration closures, which paid
+/// `Vec<u8>` + `String` clones per dispatch.
+impl From<OwnedDispatch> for Envelope {
+    #[inline]
+    fn from(dispatch: OwnedDispatch) -> Self {
+        Self {
+            kind: dispatch.kind,
+            kind_name: dispatch.kind_name,
+            origin: dispatch.origin,
+            sender: dispatch.sender,
+            payload: dispatch.payload,
+            count: dispatch.count,
+            mail_id: dispatch.mail_id,
+            root: dispatch.root,
+            parent_mail: dispatch.parent_mail,
+        }
+    }
 }

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -395,49 +395,44 @@ impl Spawner {
         let wake_slot: Arc<crate::chassis::ctx::MailboxWakeSlot> =
             Arc::new(crate::chassis::ctx::MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
+        // iamacoffeepot/aether#848 PR 3: closure takes `OwnedDispatch`
+        // directly. Payload + kind_name + origin all move into the
+        // forwarded `Envelope` via `From`; no clones on the
+        // instanced-actor hot path. The pre-send increment + on-fail
+        // decrement bracket the `tx.send` exactly as before; the
+        // failure branch reads `env.kind_name` out of `SendError`
+        // since `dispatch` was already moved into `env`.
         let registered = self.registry.try_register_inbox(
             full_name.clone(),
-            crate::mail::registry::legacy_inbox_handler(
-                move |dispatch: crate::mail::registry::MailDispatch<'_>| {
-                    let Some(tx) = weak_for_handler.upgrade() else {
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            kind = dispatch.kind_name,
-                            "instanced actor sender dropped — mail discarded"
-                        );
-                        return;
-                    };
-                    let env = Envelope {
-                        kind: dispatch.kind,
-                        kind_name: dispatch.kind_name.to_owned(),
-                        origin: dispatch.origin.map(str::to_owned),
-                        sender: dispatch.sender,
-                        payload: dispatch.payload.to_vec(),
-                        count: dispatch.count,
-                        mail_id: dispatch.mail_id,
-                        root: dispatch.root,
-                        parent_mail: dispatch.parent_mail,
-                    };
-                    pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                    if tx.send(env).is_err() {
-                        // Receiver disconnected before we could deliver;
-                        // un-account for the increment so the counter
-                        // stays accurate (a future post-PR-4 cleanup may
-                        // drop the counter entirely now that
-                        // `wait_instanced_quiesce` retired).
-                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
-                        tracing::warn!(
-                            target: "aether_substrate::spawn",
-                            kind = dispatch.kind_name,
-                            "instanced actor receiver dropped — mail discarded"
-                        );
-                        return;
-                    }
-                    if let Some(wake) = wake_for_handler.get() {
-                        wake();
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+                let Some(tx) = weak_for_handler.upgrade() else {
+                    tracing::warn!(
+                        target: "aether_substrate::spawn",
+                        kind = %dispatch.kind_name,
+                        "instanced actor sender dropped — mail discarded"
+                    );
+                    return;
+                };
+                let env = Envelope::from(dispatch);
+                pending_for_handler.fetch_add(1, Ordering::AcqRel);
+                if let Err(mpsc::SendError(env)) = tx.send(env) {
+                    // Receiver disconnected before we could deliver;
+                    // un-account for the increment so the counter
+                    // stays accurate (a future post-PR-4 cleanup may
+                    // drop the counter entirely now that
+                    // `wait_instanced_quiesce` retired).
+                    pending_for_handler.fetch_sub(1, Ordering::AcqRel);
+                    tracing::warn!(
+                        target: "aether_substrate::spawn",
+                        kind = %env.kind_name,
+                        "instanced actor receiver dropped — mail discarded"
+                    );
+                    return;
+                }
+                if let Some(wake) = wake_for_handler.get() {
+                    wake();
+                }
+            }),
         );
         let _ = sender_for_init; // Phase 3 doesn't stamp pre-load mail with the spawner; envelopes are pre-built by SpawnBuilder.
         match registered {

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -325,7 +325,7 @@ mod tests {
     use aether_data::{KindId, MailboxId};
 
     use crate::handle_store::HandleStore;
-    use crate::mail::registry::{MailDispatch, Registry};
+    use crate::mail::registry::Registry;
     use crate::mail::{Mail, Mailer};
 
     /// Stub actor used as the `A` phantom marker on [`InheritCtx`] /
@@ -358,9 +358,13 @@ mod tests {
     fn register_capture(registry: &Registry, name: &str) -> Arc<Mutex<Vec<CapturedDispatch>>> {
         let captured: Arc<Mutex<Vec<CapturedDispatch>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
+        // iamacoffeepot/aether#848 PR 3: synchronous lineage-only
+        // capture; take `OwnedDispatch` directly (no envelope build,
+        // no `to_vec()` clone on the lineage fields which are all
+        // Copy).
         let _ = registry.try_register_inbox(
             name.to_owned(),
-            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                 captured_for_handler.lock().unwrap().push(CapturedDispatch {
                     mail_id: dispatch.mail_id,
                     root: dispatch.root,

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -17,27 +17,15 @@ use crate::actor::native::envelope::Envelope;
 use crate::chassis::error::BootError;
 use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
-use crate::mail::registry::{MailDispatch, Registry};
+use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::FatalAborter;
 
-/// Materialise an owned [`Envelope`] from a borrowed [`MailDispatch`].
-/// Used by every `claim_mailbox*` variant's registry closure to copy the
-/// dispatch's borrowed `kind_name` / `origin` / `payload` into owned
-/// fields before the envelope crosses the mpsc boundary into the
-/// capability's dispatcher thread.
-fn build_envelope(dispatch: &MailDispatch<'_>) -> Envelope {
-    Envelope {
-        kind: dispatch.kind,
-        kind_name: dispatch.kind_name.to_owned(),
-        origin: dispatch.origin.map(str::to_owned),
-        sender: dispatch.sender,
-        payload: dispatch.payload.to_vec(),
-        count: dispatch.count,
-        mail_id: dispatch.mail_id,
-        root: dispatch.root,
-        parent_mail: dispatch.parent_mail,
-    }
-}
+// iamacoffeepot/aether#848 PR 3: the `build_envelope(&MailDispatch)`
+// helper retired. Production cap registration closures now take
+// `OwnedDispatch` directly and call `Envelope::from(dispatch)` —
+// payload + kind_name + origin all move rather than clone. The
+// borrowed-dispatch shape is still available through the
+// `MailboxEntry::Inline` path elsewhere.
 
 /// Result returned from [`ChassisCtx::claim_mailbox`].
 ///
@@ -300,12 +288,22 @@ impl<'a> ChassisCtx<'a> {
         let tx = Arc::new(tx);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
-                let env = build_envelope(&dispatch);
-                if tx.send(env).is_err() {
+            // iamacoffeepot/aether#848 PR 3: closure now takes
+            // `OwnedDispatch` directly and moves it into `Envelope`
+            // via `From`. Drops the `legacy_inbox_handler` adapter
+            // (PR 2's transitional wrap) and the prior
+            // `build_envelope(&dispatch)` clone — one `Vec<u8>` +
+            // one `String` saved per Inbox dispatch through this
+            // claim path. `SendError` returns the envelope on
+            // failure so the warn-log reads `env.kind_name` (the
+            // owned String) without needing to clone ahead of the
+            // send.
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+                let env = Envelope::from(dispatch);
+                if let Err(mpsc::SendError(env)) = tx.send(env) {
                     tracing::warn!(
                         target: "aether_substrate::capability",
-                        kind = dispatch.kind_name,
+                        kind = %env.kind_name,
                         "capability mailbox receiver dropped — mail discarded"
                     );
                 }
@@ -354,20 +352,25 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
+            // iamacoffeepot/aether#848 PR 3: see `claim_mailbox_with_override`
+            // for the rationale. The pre-send `weak.upgrade()` check
+            // logs `dispatch.kind_name` (still owned by the closure
+            // at that point); the post-send fail branch reads
+            // `env.kind_name` out of the `SendError` payload.
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",
-                        kind = dispatch.kind_name,
+                        kind = %dispatch.kind_name,
                         "capability mailbox sender dropped — mail discarded"
                     );
                     return;
                 };
-                let env = build_envelope(&dispatch);
-                if tx.send(env).is_err() {
+                let env = Envelope::from(dispatch);
+                if let Err(mpsc::SendError(env)) = tx.send(env) {
                     tracing::warn!(
                         target: "aether_substrate::capability",
-                        kind = dispatch.kind_name,
+                        kind = %env.kind_name,
                         "capability mailbox receiver dropped — mail discarded"
                     );
                     return;
@@ -424,16 +427,22 @@ impl<'a> ChassisCtx<'a> {
         let wake_for_handler = Arc::clone(&wake_slot);
         let id = self.registry.try_register_inbox(
             name.to_owned(),
-            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
+            // iamacoffeepot/aether#848 PR 3: see `claim_mailbox_with_override`
+            // for the rationale. Pre-send increment + post-fail
+            // decrement bracket the `tx.send` exactly as before;
+            // the only change is that `dispatch` is `OwnedDispatch`
+            // (moved into `env` via `From`) and the failure branch
+            // reads `env.kind_name` out of the `SendError`.
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",
-                        kind = dispatch.kind_name,
+                        kind = %dispatch.kind_name,
                         "frame-bound capability sender dropped — mail discarded"
                     );
                     return;
                 };
-                let env = build_envelope(&dispatch);
+                let env = Envelope::from(dispatch);
                 // Increment before send so the dispatcher's
                 // matching decrement-after-dispatch sees a count
                 // > 0 by the time it tries to decrement. If the
@@ -441,11 +450,11 @@ impl<'a> ChassisCtx<'a> {
                 // upgrade and the send — shutdown race), undo
                 // the increment so the counter doesn't drift up.
                 pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                if tx.send(env).is_err() {
+                if let Err(mpsc::SendError(env)) = tx.send(env) {
                     pending_for_handler.fetch_sub(1, Ordering::AcqRel);
                     tracing::warn!(
                         target: "aether_substrate::capability",
-                        kind = dispatch.kind_name,
+                        kind = %env.kind_name,
                         "frame-bound capability receiver dropped — mail discarded"
                     );
                     return;

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -268,7 +268,7 @@ mod tests {
     use super::*;
     use crate::handle_store::HandleStore;
     use crate::mail::mailer::Mailer;
-    use crate::mail::registry::{MailDispatch, Registry};
+    use crate::mail::registry::Registry;
     use std::sync::Mutex as StdMutex;
 
     fn root(sender: u64, cid: u64) -> MailId {
@@ -301,10 +301,14 @@ mod tests {
         let captured_clone = Arc::clone(&captured);
         let target = registry.register_inbox(
             sink_name,
-            crate::mail::registry::legacy_inbox_handler(move |dispatch: MailDispatch<'_>| {
+            // iamacoffeepot/aether#848 PR 3: take `OwnedDispatch`
+            // directly and move payload into the captured row
+            // (was: `payload.to_vec()` clone via the legacy
+            // borrowed-dispatch shape).
+            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
                 captured_clone.lock().unwrap().push(CapturedDispatch {
                     kind: dispatch.kind,
-                    payload: dispatch.payload.to_vec(),
+                    payload: dispatch.payload,
                     count: dispatch.count,
                 });
             }),


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue/PR refs -->

## Summary

PR 3 of iamacoffeepot/aether#848's 5-PR plan. Rewrites every production cap registration closure to take `Fn(OwnedDispatch)` directly, dropping the `legacy_inbox_handler` wrap PR 2 used for minimum diff. **This is where the documented hot-path perf win materializes** — payload + kind_name + origin all move into the forwarded `Envelope` via `From<OwnedDispatch>` rather than being cloned via `to_vec()` / `to_owned()`.

Stacked on iamacoffeepot/aether#850 (PR 2).

## Per-Inbox-dispatch cost on the production cap path

| Allocation | Pre-PR-3 | Post-PR-3 |
|---|---|---|
| `String` clone (kind_name into Envelope) | 1 | 0 |
| `Vec<u8>` clone (payload via `to_vec()`) | 1 | 0 |
| `Option<String>` clone (origin) | 0 or 1 | 0 |

The `OwnedDispatch` fields flow `mail.payload` → `OwnedDispatch.payload` → `Envelope::from(dispatch)` → `tx.send(env)` without ever being copied. Per cap-side closure invocation, that's one `Vec<u8>` allocation + memcpy saved on every Inbox dispatch through the cap registration path — log, handle, audio, http, fs, render, the trampoline, every `with_actor` chain.

## Surface changes

### `From<OwnedDispatch> for Envelope` (`actor/native/envelope.rs`)

Move-only conversion. No allocations. Replaces the legacy `build_envelope(&MailDispatch)` clone path.

### `chassis/ctx.rs::claim_mailbox*` (3 sites)

The common cap-registration paths used by every `with_actor` chain. Closures now take `OwnedDispatch`, call `Envelope::from(dispatch)`, and extract the envelope from `mpsc::SendError` on the warn-discard path so `env.kind_name` is readable after the send (which moved `dispatch`):

```rust
Arc::new(move |dispatch: OwnedDispatch| {
    let env = Envelope::from(dispatch);
    if let Err(mpsc::SendError(env)) = tx.send(env) {
        tracing::warn!(
            target: "aether_substrate::capability",
            kind = %env.kind_name,
            "capability mailbox receiver dropped — mail discarded"
        );
    }
})
```

The `weak.upgrade()` paths log `dispatch.kind_name` directly (still owned at that point); the pre-send increment / post-fail decrement bracket on the frame-bound variant is unchanged.

### `actor/native/spawn.rs` (instanced actor sink)

Same shape as the chassis cap closures. Pending counter increment + decrement bracket unchanged; `env.kind_name` from `SendError` for the warn-discard.

### Test sinks (`chassis/settlement.rs`, `actor/native/spawn_thread.rs`)

Direct migration to `Fn(OwnedDispatch)`; legacy adapter wrap dropped. Payload moves into the captured Vec instead of cloning.

### `chassis/ctx.rs::build_envelope` retired

Dead code post-migration. `Envelope::from(OwnedDispatch)` replaces it. `MailDispatch` import in ctx.rs / settlement.rs / spawn_thread.rs goes with it.

## What's left for PR 4 / 5

`legacy_inbox_handler` has no callers post-PR-3. It stays through PR 5 alongside the `MailboxHandler` type alias for cross-crate compatibility; both retire in the final cleanup PR. PR 4's original "migrate test call sites" scope was already covered by PR 2's cascading variant migration — that task collapses into PR 5.

## Verification

- `cargo nextest run --workspace --no-fail-fast` — **993/993 passed**.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- `cargo check -p aether-demo-sokoban -p aether-mesh-viewer -p aether-camera --target wasm32-unknown-unknown` — clean.

## Plan reference

5-PR ladder per iamacoffeepot/aether#848:

1. iamacoffeepot/aether#849 (merged) — types + blanket impls + smoke tests.
2. iamacoffeepot/aether#850 (auto-merging) — variant + signature migration + cascading call-site updates.
3. **This PR** — production cap closure migration. Perf win materializes here.
4. *Absorbed into PR 2* — test call site migration was completed in iamacoffeepot/aether#850's cascade.
5. **PR 5** — retire `legacy_inbox_handler` + `MailboxHandler` alias + doc-tighten + optional `cargo asm` bench to confirm the predicted hot-path win.