### PR TITLE
refactor(capabilities): render swap-cache retires nudge_tick (issue 847)

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -175,9 +175,20 @@ mod native {
         /// `RenderConfig`; init only sets up the in-process buffers and
         /// the wgpu `OnceLock` (the driver fills it in `resumed` /
         /// post-`build_passive`).
+        ///
+        /// `last_submitted` mirrors `frame_vertices`'s capacity so the
+        /// swap inside `record_frame` (iamacoffeepot/aether#847) lands
+        /// a full-capacity buffer back into the live slot — without the
+        /// pre-allocation, the first frame's swap would leave the live
+        /// accumulator at `last_submitted`'s starting capacity (zero)
+        /// and the next tick's `on_draw_triangle` would reallocate
+        /// from scratch.
         fn init(config: RenderConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let handles = RenderHandles {
                 frame_vertices: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
+                    config.vertex_buffer_bytes,
+                ))),
+                last_submitted: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
                     config.vertex_buffer_bytes,
                 ))),
                 triangles_rendered: Arc::new(AtomicU64::new(0)),
@@ -354,7 +365,21 @@ mod native {
     /// drops are independent.
     #[derive(Clone)]
     pub struct RenderHandles {
+        /// Per-frame accumulator. `on_draw_triangle` appends bytes
+        /// here; `record_frame` consumes by swapping with
+        /// `last_submitted` and clearing.
         pub frame_vertices: Arc<Mutex<Vec<u8>>>,
+        /// Most-recently-rendered geometry, kept across frames
+        /// (iamacoffeepot/aether#847). When `record_frame` runs with
+        /// an empty `frame_vertices` — typically a `TestBench::capture`
+        /// that didn't dispatch a `Tick` — the GPU draw replays this
+        /// buffer so the captured frame matches "what the user would
+        /// see right now" instead of clear-color.
+        ///
+        /// Lock ordering: `frame_vertices` first, then `last_submitted`
+        /// when both are held. Today only `record_frame` holds both;
+        /// callers reading `last_submitted` in isolation are fine.
+        pub last_submitted: Arc<Mutex<Vec<u8>>>,
         pub triangles_rendered: Arc<AtomicU64>,
         pub camera_state: Arc<Mutex<[f32; 16]>>,
         /// wgpu state, installed post-cap-construction by the driver via
@@ -398,32 +423,78 @@ mod native {
             )
         }
 
-        /// Drain the current frame's accumulated vertices, read the
-        /// latest camera view-proj, and record the main render pass into
-        /// `encoder`. Each call consumes the accumulator (subsequent
-        /// inbound mail builds the next frame). `extra_pipelines` are
-        /// drawn after the main pipeline inside the same render pass —
-        /// desktop passes a wireframe overlay pipeline here when
-        /// `AETHER_WIREFRAME=overlay`; test-bench passes `&[]`.
+        /// Read the latest camera view-proj and record the main render
+        /// pass into `encoder` against the current frame's geometry.
+        /// `extra_pipelines` are drawn after the main pipeline inside
+        /// the same render pass — desktop passes a wireframe overlay
+        /// pipeline here when `AETHER_WIREFRAME=overlay`; test-bench
+        /// passes `&[]`.
+        ///
+        /// ## Cache semantics (iamacoffeepot/aether#847)
+        ///
+        /// If `frame_vertices` holds new emissions from this tick's
+        /// `on_draw_triangle` calls, swap them into `last_submitted`
+        /// and clear the live accumulator (the swapped-out buffer,
+        /// now in `live`, becomes the next tick's staging area). The
+        /// render pass then draws from `last_submitted`.
+        ///
+        /// If `frame_vertices` is empty, `replay_cache_when_idle`
+        /// picks the behaviour:
+        ///
+        /// - `false` — **commit-current**: clear `last_submitted` so
+        ///   the next frame reflects "the producer chose not to
+        ///   emit," and render an empty draw list (clear-color
+        ///   frame). Used by desktop's per-frame draw and by the
+        ///   test-bench's advance path. Matches a game's normal
+        ///   semantic: if the producer stops drawing, the screen
+        ///   goes to clear color.
+        /// - `true` — **replay-cache**: leave `last_submitted`
+        ///   untouched and render its current contents. Used by
+        ///   `TestBench::capture` when it didn't dispatch a `Tick`
+        ///   of its own — the cache holds whatever the last advance
+        ///   committed, which is the right "what would the user
+        ///   see right now" answer. Retires the historical
+        ///   `nudge_tick` boilerplate.
+        ///
+        /// Lock ordering: `frame_vertices` first, then
+        /// `last_submitted`. Today only this function holds both.
         pub fn record_frame(
             &self,
             encoder: &mut wgpu::CommandEncoder,
             extra_pipelines: &[&wgpu::RenderPipeline],
+            replay_cache_when_idle: bool,
         ) -> Result<(), RenderError> {
             let gpu = self.expect_gpu();
-            let cap = self.frame_vertices.lock().unwrap().capacity();
-            let vertices = std::mem::replace(
-                &mut *self.frame_vertices.lock().unwrap(),
-                Vec::with_capacity(cap),
-            );
+            {
+                let mut live = self.frame_vertices.lock().unwrap();
+                let mut last = self.last_submitted.lock().unwrap();
+                if !live.is_empty() {
+                    // Producer emitted: swap into cache.
+                    std::mem::swap(&mut *live, &mut *last);
+                    // Post-swap, `live` holds what `last` held before
+                    // — stale geometry from however many frames ago.
+                    // Clear (preserves capacity) so the next tick's
+                    // `on_draw_triangle` appends into an empty buffer
+                    // without reallocating.
+                    live.clear();
+                } else if !replay_cache_when_idle {
+                    // Commit-current: producer chose not to emit
+                    // this frame, so the cache should reflect that
+                    // for any subsequent replay-cache caller.
+                    last.clear();
+                }
+                // else: replay-cache + empty live — leave cache
+                // alone, render its current contents.
+            }
             let view_proj = *self.camera_state.lock().unwrap();
+            let last = self.last_submitted.lock().unwrap();
             let targets = gpu.targets.lock().unwrap();
             record_main_pass(
                 &gpu.queue,
                 encoder,
                 &gpu.pipeline,
                 &targets,
-                &vertices,
+                &last,
                 &view_proj,
                 extra_pipelines,
             )

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -20,8 +20,7 @@
 //! `TestBench::builder().namespace_roots(...)` rather than env-var
 //! mutation.
 
-use aether_data::Kind;
-use aether_kinds::{LoadComponent, LoadResult, Tick};
+use aether_kinds::{LoadComponent, LoadResult};
 use aether_mesh_viewer::LoadMesh;
 use aether_substrate_bundle::test_bench::{
     TestBench,
@@ -86,27 +85,6 @@ fn load_viewer(bench: &mut TestBench, wasm_path: &std::path::Path) {
     }
 }
 
-/// Direct `aether.tick` to the loaded viewer so the next `capture`
-/// Background: `TestBench::capture` runs its frame with
-/// `dispatch_tick=false` (capture is a state snapshot, not a tick
-/// advance). The render cap's vert accumulator drains on every
-/// `record_frame` (`std::mem::replace` on `frame_vertices`), so a
-/// viewer that emits geometry only on `on_tick` has nothing in the
-/// accumulator by the time capture's render reads it. Sending
-/// `Tick` directly to the component's mailbox right before
-/// `capture` populates the accumulator for the upcoming capture
-/// frame.
-///
-/// Pre-iamacoffeepot/aether#834 this was a band-aid that flaked
-/// because the bare `send_bytes` push didn't subscribe to the
-/// chain's settlement. iamacoffeepot/aether#834 made `send_bytes`
-/// synchronous on settlement, so this now reliably pre-populates.
-fn nudge_tick(bench: &mut TestBench) {
-    bench
-        .send_bytes(&component_address(), Tick::ID, Tick.encode_into_bytes())
-        .expect("send tick");
-}
-
 /// Assert that `aether.draw_triangle` was observed at least once.
 /// Surfaces the observed-kinds list on failure so a typo or missing
 /// subscription is debuggable.
@@ -153,7 +131,6 @@ fn dsl_box_loads_and_renders() {
         )
         .expect("send mesh.load");
     bench.advance(5).expect("post-load advance");
-    nudge_tick(&mut bench);
 
     let png = bench.capture().expect("capture");
     let img = decode_png(&png).expect("decode capture png");
@@ -191,7 +168,6 @@ fn obj_quad_loads_and_renders() {
         )
         .expect("send mesh.load");
     bench.advance(5).expect("post-load advance");
-    nudge_tick(&mut bench);
 
     let png = bench.capture().expect("capture");
     let img = decode_png(&png).expect("decode capture png");
@@ -247,7 +223,6 @@ fn parse_failure_keeps_prior_mesh() {
         )
         .expect("send bad mesh.load");
     bench.advance(5).expect("post-bad-load advance");
-    nudge_tick(&mut bench);
 
     // The cached triangle list should be intact — the captured frame
     // still has non-clear-color geometry.

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -306,9 +306,12 @@ impl Gpu {
             }
             None => &[],
         };
+        // Desktop renders every frame from current producer state —
+        // commit-current semantic (false). The replay-cache mode is
+        // reserved for `TestBench::capture` (iamacoffeepot/aether#847).
         match self
             .render_handles
-            .record_frame(&mut encoder, extra_pipelines)
+            .record_frame(&mut encoder, extra_pipelines, false)
         {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return None,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -511,6 +511,17 @@ impl TestBench {
     /// PNG bytes. Capture observes the current state — it does not
     /// dispatch `Tick`. Pair with `advance` if the world needs to
     /// advance before the capture.
+    ///
+    /// Post-iamacoffeepot/aether#847 the render cap caches the
+    /// most-recently-submitted geometry across frames: the capture's
+    /// `record_frame` sees an empty `frame_vertices` (no producer
+    /// emit this microsecond) and replays the cache instead of
+    /// drawing into a clear-color buffer. Callers no longer need to
+    /// poke the loaded component with a `Tick` before each capture
+    /// — what the test sees is the geometry the producer last
+    /// rendered, which matches "what the user would see right now"
+    /// in the same way wgpu / D3D / Vulkan swapchain front buffers
+    /// behave.
     pub fn capture(&mut self) -> Result<Vec<u8>, TestBenchError> {
         self.capture_with_mails(Vec::new(), Vec::new())
     }

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -82,14 +82,20 @@ impl Gpu {
     /// Draw the current accumulator's vertices into the offscreen
     /// target with the latest camera view-proj. No presentation step
     /// — desktop's swapchain blit is omitted because there's no
-    /// surface.
+    /// surface. Drives the test-bench's advance path; commits the
+    /// current frame to the render cap's `last_submitted` cache so
+    /// any subsequent `capture` observes the freshly-rendered state
+    /// (or an empty cache, if the producer chose not to emit).
     pub fn render(&mut self) {
         let device = self.render_handles.device();
         let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
-        match self.render_handles.record_frame(&mut encoder, &[]) {
+        // Advance path: commit-current (false). Empty live clears
+        // the cache so a producer that stopped emitting flushes
+        // cleanly to the next capture.
+        match self.render_handles.record_frame(&mut encoder, &[], false) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return,
         }
@@ -100,13 +106,24 @@ impl Gpu {
     /// into a readback buffer, maps it, and returns an encoded PNG.
     /// On any capture-path failure, returns `Err(reason)`; the frame
     /// still rendered to the offscreen — capture is a side channel.
+    ///
+    /// Drives the test-bench's `TestBench::capture` path with
+    /// `dispatch_tick=false`. The render cap's `replay_cache_when_idle`
+    /// flag is set so an empty live accumulator (no producer
+    /// emitted, because no `Tick` was dispatched for this frame)
+    /// replays the cache from the last committed advance —
+    /// iamacoffeepot/aether#847 retired the historical `nudge_tick`
+    /// boilerplate that worked around the prior consume-and-discard
+    /// behaviour.
     pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
         let device = self.render_handles.device();
         let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
-        match self.render_handles.record_frame(&mut encoder, &[]) {
+        // Capture path: replay-cache (true). Empty live → render
+        // whatever the last advance committed.
+        match self.render_handles.record_frame(&mut encoder, &[], true) {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => {
                 return Err("vertex buffer overflow — capture skipped".to_owned());

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -16,7 +16,7 @@
 //! (issues 460 + 821).
 
 use aether_data::Kind;
-use aether_kinds::{Key, LoadComponent, LoadResult, Tick, keycode};
+use aether_kinds::{Key, LoadComponent, LoadResult, keycode};
 use aether_substrate_bundle::test_bench::{
     TestBench,
     test_helpers::require_runtime,
@@ -71,31 +71,6 @@ fn load_sokoban(bench: &mut TestBench, wasm_path: &std::path::Path) {
     }
 }
 
-/// Direct `aether.tick` to the loaded component so the next `capture`
-/// sees fresh render-sink emissions.
-///
-/// Background: `TestBench::capture` runs its frame with
-/// `dispatch_tick=false` (capture is a state snapshot, not a tick
-/// advance). The render cap's vert accumulator drains on every
-/// `record_frame` (`std::mem::replace` on `frame_vertices`), so a
-/// component that emits geometry only on `on_tick` has nothing in
-/// the accumulator by the time capture's render reads it. Sending
-/// `Tick` directly to the component's mailbox right before
-/// `capture` populates the accumulator for the upcoming capture
-/// frame.
-///
-/// Pre-iamacoffeepot/aether#834 this was a band-aid that flaked
-/// because the bare `send_bytes` push didn't subscribe to the
-/// chain's settlement — capture could race ahead before sokoban's
-/// DrawTriangle landed in render's accumulator. iamacoffeepot/aether#834 made
-/// `send_bytes` synchronous on settlement, so nudge_tick now
-/// reliably pre-populates the accumulator before returning.
-fn nudge_tick(bench: &mut TestBench) {
-    bench
-        .send_bytes(&component_address(), Tick::ID, Tick.encode_into_bytes())
-        .expect("send tick");
-}
-
 fn assert_draw_triangle_observed(bench: &TestBench) {
     let observed = bench.count_observed("aether.draw_triangle");
     assert!(
@@ -106,12 +81,18 @@ fn assert_draw_triangle_observed(bench: &TestBench) {
 }
 
 /// Default-level rendering smoke test. Loads the wasm, advances a
-/// few ticks so init can flush, fires one more `Tick` via
-/// `nudge_tick` to populate render's accumulator (consumed during
-/// each advance's render — see `nudge_tick` docs), captures, and
-/// asserts both that `DrawTriangle` mail flowed and that the
-/// captured frame contains pixels diverging from the chassis clear
-/// color.
+/// few ticks so the cap's accumulator + the render cap's
+/// `last_submitted` cache populate, captures, and asserts both
+/// that `DrawTriangle` mail flowed and that the captured frame
+/// contains pixels diverging from the chassis clear color.
+///
+/// Pre-iamacoffeepot/aether#847 this required an explicit
+/// `nudge_tick` after the advance: `capture` runs `record_frame`
+/// with `dispatch_tick=false`, the live `frame_vertices` was
+/// drained by the last `advance` render, and capture saw an empty
+/// buffer. iamacoffeepot/aether#847 made `record_frame` swap-not-
+/// replace into `last_submitted`, so capture replays the last
+/// rendered geometry and no nudge is needed.
 #[test]
 fn default_level_renders_grid_and_player() {
     let Some(wasm_path) = require_runtime("aether_demo_sokoban") else {
@@ -122,7 +103,6 @@ fn default_level_renders_grid_and_player() {
     load_sokoban(&mut bench, &wasm_path);
 
     bench.advance(3).expect("advance");
-    nudge_tick(&mut bench);
 
     let png = bench.capture().expect("capture");
     let img = decode_png(&png).expect("decode capture png");
@@ -158,7 +138,6 @@ fn key_press_keeps_render_path_alive() {
         .expect("send key");
 
     bench.advance(2).expect("post-key advance");
-    nudge_tick(&mut bench);
 
     let png = bench.capture().expect("capture");
     let img = decode_png(&png).expect("decode capture png");

--- a/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md
+++ b/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md
@@ -137,6 +137,13 @@ Render becomes one actor with one mailbox. The `aether.camera` kind addresses re
 
 This collapses render's two-thread structure to one thread (consistent with decision 4) and removes the implementation-detail second mailbox name from the public substrate vocabulary.
 
+**Amendment (iamacoffeepot/aether#847).** Render's `record_frame` keeps a per-cap `last_submitted` cache alongside the live `frame_vertices` accumulator. The cache holds whatever geometry was last drawn; `record_frame` swaps live into the cache when the producer emitted this frame, and the GPU pass always draws from the cache. The caller picks the empty-live policy via a `replay_cache_when_idle` flag:
+
+- **Commit-current** (`false`) — used by desktop's per-frame draw and the test-bench's advance path. Empty live clears the cache so the next frame reflects "the producer chose not to emit." Matches a game's normal semantic: stop drawing, screen goes to clear color.
+- **Replay-cache** (`true`) — used by `TestBench::capture` when it didn't dispatch a `Tick`. Empty live replays the cache from the last committed advance. Retires the historical `nudge_tick` boilerplate that every render-using scenario test carried — "what would the user see right now" is the cache contents, not an empty buffer.
+
+The cache is a render-cap implementation detail; producers see no contract change. Future render-architecture work (slot-tree, two-tier-intents) operates above the render cap and is unaffected.
+
 ### 8. Sinks retire (concept and name)
 
 The "sink" concept — synchronous-on-caller dispatch as a special-case path — disappears. Every recipient is an actor with an mpsc inbox. Every send is async at the dispatch layer. Per-frame consistency that sinks used to provide is recovered structurally by the frame barrier (decision 5) plus FIFO ordering inside each actor's inbox.


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional cross-issue refs -->

## Summary

Closes iamacoffeepot/aether#847. Retires the `nudge_tick` boilerplate that every render-using scenario test carried as a workaround for `TestBench::capture`'s consume-and-discard semantic. Render's `record_frame` now keeps a per-cap `last_submitted` cache and the caller picks the empty-live policy via a new flag.

## What I tried first

The issue rough-recommended option C ("render keeps a last-frame cache; capture falls back to it") with my initial framing as a one-line `std::mem::swap` shift. That landed cleanly for the nudge_tick case — but broke `capture_frame_round_trip_runs_pre_and_after_mails`. The test sets `visible=0` in an after-mail, advances, and asserts the next capture sees clear color. A blanket cache replays the pre-cleanup geometry forever because "the producer stopped emitting" looks the same as "the producer didn't tick" to the cache.

## What actually shipped

The cache + a `replay_cache_when_idle: bool` flag on `record_frame`. The flag picks the empty-live behaviour per call site:

- **`false` (commit-current)** — desktop's per-frame draw + the test-bench's advance path. Empty live clears the cache so the next frame reflects "the producer chose not to emit." Matches a game's normal semantic: stop drawing, screen goes clear. Lets the `visible=0` cleanup propagate.
- **`true` (replay-cache)** — `TestBench::capture` when no `Tick` was dispatched. Empty live replays the cache from the last committed advance. Retires the `nudge_tick` boilerplate. The "what would the user see right now" answer.

When live IS non-empty (the always-emitting hot path), live + cache swap and the swapped-out `Vec` becomes the next tick's staging area — no clones. Cost is one extra `Vec<u8>` lying around between frames (mirrors `vertex_buffer_bytes` capacity, ~tens of KB for typical scenes).

## Call sites

| File | Flag | Why |
|---|---|---|
| `desktop/render.rs` | `false` | Per-frame current state; no cache replay needed |
| `test_bench/render.rs::Gpu::render` | `false` | Advance commits current |
| `test_bench/render.rs::Gpu::render_and_capture` | `true` | Capture replays cache |

## Retirements

- `demos/sokoban/tests/scenario.rs::nudge_tick` — deleted; 2 call sites + the helper + `Tick` import gone.
- `crates/aether-mesh-viewer/tests/scenario.rs::nudge_tick` — deleted; 3 call sites + the helper + `Tick`+`Kind` imports gone.

## Docs

- `TestBench::capture` doc updated with the new semantic + wgpu/D3D/Vulkan front-buffer analogy.
- `record_frame` doc spells out the cache semantics for both flag values.
- `RenderHandles::last_submitted` doc + lock-ordering note added.
- ADR-0074 §Decision 7 amended with the cache + policy-flag contract; called out as a render-cap implementation detail invisible to producers and to future slot-tree / two-tier-intents work.

## Why the flag and not blanket caching

The `capture_frame_round_trip_runs_pre_and_after_mails` test exists specifically to assert that after-mail cleanup actually propagates. A blanket cache breaks that contract because "producer stopped" can't be distinguished from "no tick dispatched." The flag lets advance commit "empty draw" to the cache (cleanup propagates) while capture reads it as "what was last fully rendered" (nudge_tick retires). Both invariants hold.

## Verification

- `cargo nextest run --workspace --no-fail-fast` — **993/993 passed**.
- Sokoban + mesh-viewer scenarios looped **5× = 55/55 passed** (the historical flake surface for the nudge_tick path).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

## Diff

+140 / −77 across 7 files. Most of the removed lines are the deleted `nudge_tick` helpers + call sites; the added lines are the doc tightening + the flag plumbing.

Closes #847.