### PR TITLE
refactor(substrate-bundle): hoist AETHER_RPC_PORT parsing to shared helper

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -123,9 +123,7 @@ impl DesktopEnv {
         // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
         let rpc_addr = {
             use std::net::{IpAddr, Ipv4Addr};
-            std::env::var("AETHER_RPC_PORT")
-                .ok()
-                .and_then(|s| s.parse::<u16>().ok())
+            crate::hub::rpc_port_from_env()
                 .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
         };
 

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -74,9 +74,7 @@ impl HeadlessEnv {
         let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
         // `AETHER_RPC_PORT` has no default — absent means RpcServer
         // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
-        let rpc_addr = std::env::var("AETHER_RPC_PORT")
-            .ok()
-            .and_then(|s| s.parse::<u16>().ok())
+        let rpc_addr = crate::hub::rpc_port_from_env()
             .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
         HeadlessEnv {
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -54,10 +54,7 @@ impl HubEnv {
     /// development story.
     pub fn from_env() -> Self {
         use std::net::{IpAddr, Ipv4Addr};
-        let rpc_port = std::env::var("AETHER_RPC_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(DEFAULT_RPC_PORT);
+        let rpc_port = super::rpc_port_from_env().unwrap_or(DEFAULT_RPC_PORT);
         Self {
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port),
         }

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -24,3 +24,14 @@ pub use chassis::{HubChassis, HubEnv, HubServerDriverCapability, HubServerDriver
 /// out-of-process `aether-mcp` coordinator dials (matching that
 /// crate's `DEFAULT_HUB_RPC_ADDR`). `AETHER_RPC_PORT` overrides.
 pub const DEFAULT_RPC_PORT: u16 = 8901;
+
+/// Parse the `AETHER_RPC_PORT` env var into an optional port number
+/// (issue 792). `None` when unset or unparseable. The hub chassis
+/// substitutes [`DEFAULT_RPC_PORT`] when this returns `None`; the
+/// desktop and headless chassis treat `None` as "don't boot the RPC
+/// server" instead.
+pub fn rpc_port_from_env() -> Option<u16> {
+    std::env::var("AETHER_RPC_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+}


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #792 needs the bare hash for GitHub auto-close -->
Closes #792

- Add `pub fn rpc_port_from_env() -> Option<u16>` to `aether-substrate-bundle::hub`, parsing `AETHER_RPC_PORT` once.
- Desktop and headless `from_env()` builders call the helper and `.map` it onto `127.0.0.1`; `None` continues to mean "skip booting `RpcServerCapability`".
- Hub `from_env()` calls the helper and applies `.unwrap_or(DEFAULT_RPC_PORT)`, preserving the unconditional-boot contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)