### PR TITLE
feat(substrate): wire AETHER_WORKERS env var to override pool size

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -29,7 +29,7 @@ use aether_substrate::{Chassis, SubstrateBoot, capture::CaptureQueue};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 
-use super::driver::{DesktopDriverCapability, WORKERS, parse_window_mode_env};
+use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 
 /// Event the event-loop thread consumes from the desktop chassis.
 /// Just one variant today: a wake-up so the loop picks up a queued
@@ -80,6 +80,10 @@ pub struct DesktopEnv {
     /// Populated from `AETHER_RPC_PORT`; `None` (default) skips booting
     /// `RpcServerCapability` so existing chassis behavior is unchanged.
     pub rpc_addr: Option<SocketAddr>,
+    /// Issue 745: optional worker-pool size override. Populated from
+    /// `AETHER_WORKERS`; `None` keeps `PoolConfig::default()` behavior
+    /// (`available_parallelism() - 1`, min 1).
+    pub workers: Option<usize>,
 }
 
 impl DesktopEnv {
@@ -129,6 +133,8 @@ impl DesktopEnv {
                 .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
         };
 
+        let workers = parse_workers_env();
+
         Ok(DesktopEnv {
             event_loop,
             capture_queue,
@@ -139,7 +145,36 @@ impl DesktopEnv {
             boot_size,
             boot_title,
             rpc_addr,
+            workers,
         })
+    }
+}
+
+/// Parse `AETHER_WORKERS`. Unset → `None` (chassis falls back to
+/// [`aether_substrate::scheduler::PoolConfig::default`]); positive →
+/// `Some(n)`; `0` → `Some(1)` with a warn (the pool requires at least
+/// one worker); unparseable → `None` with a warn. Issue 745.
+fn parse_workers_env() -> Option<usize> {
+    let raw = std::env::var("AETHER_WORKERS").ok()?;
+    match raw.trim().parse::<usize>() {
+        Ok(0) => {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                "AETHER_WORKERS=0 — clamping to 1",
+            );
+            Some(1)
+        }
+        Ok(n) => Some(n),
+        Err(e) => {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                error = %e,
+                "AETHER_WORKERS unparseable — falling back to PoolConfig::default",
+            );
+            None
+        }
     }
 }
 
@@ -163,10 +198,10 @@ impl DesktopChassis {
             boot_size,
             boot_title,
             rpc_addr,
+            workers,
         } = env;
 
         let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION")).build()?;
-        let _ = WORKERS;
 
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),
@@ -193,7 +228,7 @@ impl DesktopChassis {
 
         tracing::info!(
             target: "aether_substrate::boot",
-            workers = WORKERS,
+            workers_override = ?workers,
             "componentless boot — close window to exit; load a component via aether.component.load",
         );
 
@@ -229,6 +264,7 @@ impl DesktopChassis {
         // chassis cap.
         let mut builder = Builder::<DesktopChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
+            .with_workers(workers)
             .with_actor::<HandleCapability>(())
             .with_actor::<LogCapability>(())
             .with_actor::<TraceObserverCapability>(())

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -47,14 +47,6 @@ use winit::window::{Fullscreen, Window, WindowId};
 use super::chassis::UserEvent;
 use super::render::Gpu;
 
-/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
-/// component, the scheduler doesn't read this — it's retained on the
-/// hub-protocol wire for compatibility). Stays chassis-side because
-/// it's declarative for `aether.control.platform_info`, not loop
-/// policy. The shared frame-loop policy (drain budget, frame-stats
-/// cadence) lives in `aether_substrate::frame_loop`.
-pub const WORKERS: usize = 2;
-
 pub struct App {
     queue: Arc<Mailer>,
     /// `aether.input` mailbox id, cached at driver boot. Each platform

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -30,7 +30,7 @@ use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use super::driver::{HeadlessTimerCapability, WORKERS, parse_tick_hz_env};
+use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 
 /// Marker type for the headless chassis. Carries no fields — the
 /// chassis instance is the [`BuiltChassis<HeadlessChassis>`] returned
@@ -59,6 +59,10 @@ pub struct HeadlessEnv {
     /// Populated from `AETHER_RPC_PORT`; `None` (default) skips booting
     /// `RpcServerCapability` so existing chassis behavior is unchanged.
     pub rpc_addr: Option<SocketAddr>,
+    /// Issue 745: optional worker-pool size override. Populated from
+    /// `AETHER_WORKERS`; `None` keeps `PoolConfig::default()` behavior
+    /// (`available_parallelism() - 1`, min 1).
+    pub workers: Option<usize>,
 }
 
 impl HeadlessEnv {
@@ -78,11 +82,41 @@ impl HeadlessEnv {
             .ok()
             .and_then(|s| s.parse::<u16>().ok())
             .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
+        let workers = parse_workers_env();
         HeadlessEnv {
             namespace_roots,
             http,
             tick_period,
             rpc_addr,
+            workers,
+        }
+    }
+}
+
+/// Parse `AETHER_WORKERS`. Unset → `None` (chassis falls back to
+/// [`aether_substrate::scheduler::PoolConfig::default`]); positive →
+/// `Some(n)`; `0` → `Some(1)` with a warn (the pool requires at least
+/// one worker); unparseable → `None` with a warn. Issue 745.
+fn parse_workers_env() -> Option<usize> {
+    let raw = std::env::var("AETHER_WORKERS").ok()?;
+    match raw.trim().parse::<usize>() {
+        Ok(0) => {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                "AETHER_WORKERS=0 — clamping to 1",
+            );
+            Some(1)
+        }
+        Ok(n) => Some(n),
+        Err(e) => {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                error = %e,
+                "AETHER_WORKERS unparseable — falling back to PoolConfig::default",
+            );
+            None
         }
     }
 }
@@ -101,10 +135,10 @@ impl HeadlessChassis {
             http,
             tick_period,
             rpc_addr,
+            workers,
         } = env;
 
         let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION")).build()?;
-        let _ = WORKERS;
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),
@@ -151,7 +185,7 @@ impl HeadlessChassis {
         let tick_hz = (Duration::from_secs(1).as_nanos() / tick_period.as_nanos().max(1)) as u32;
         tracing::info!(
             target: "aether_substrate::boot",
-            workers = WORKERS,
+            workers_override = ?workers,
             tick_hz = tick_hz,
             "componentless boot — load a component via aether.component.load",
         );
@@ -179,6 +213,7 @@ impl HeadlessChassis {
         // through the log capture.
         let mut builder = Builder::<HeadlessChassis>::new(registry, Arc::clone(&mailer))
             .with_aborter(aborter)
+            .with_workers(workers)
             .with_actor::<HandleCapability>(())
             .with_actor::<LogCapability>(())
             .with_actor::<TraceObserverCapability>(())
@@ -207,5 +242,62 @@ impl HeadlessChassis {
             .with_log_drain::<LogCapability>()
             .driver(driver)
             .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_workers_env;
+    use std::sync::Mutex;
+
+    /// Process-wide guard around `AETHER_WORKERS` env mutation —
+    /// `cargo test` parallelises within a binary, so each parser test
+    /// has to serialise its set/remove pair. Shared with the desktop
+    /// chassis test would require a crate-level module; one per chassis
+    /// is fine given there are four tests total.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: this test owns the AETHER_WORKERS slot for the
+        // duration of the closure via ENV_LOCK; no other thread inside
+        // the same test binary mutates it concurrently. Edition-2024
+        // marked the env mutators unsafe due to non-test signal-handler
+        // races that don't apply here.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("AETHER_WORKERS", v),
+                None => std::env::remove_var("AETHER_WORKERS"),
+            }
+        }
+        let out = f();
+        unsafe {
+            std::env::remove_var("AETHER_WORKERS");
+        }
+        out
+    }
+
+    #[test]
+    fn parse_workers_unset_returns_none() {
+        let parsed = with_env(None, parse_workers_env);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn parse_workers_positive_returns_some() {
+        let parsed = with_env(Some("4"), parse_workers_env);
+        assert_eq!(parsed, Some(4));
+    }
+
+    #[test]
+    fn parse_workers_zero_clamps_to_one() {
+        let parsed = with_env(Some("0"), parse_workers_env);
+        assert_eq!(parsed, Some(1));
+    }
+
+    #[test]
+    fn parse_workers_unparseable_returns_none() {
+        let parsed = with_env(Some("abc"), parse_workers_env);
+        assert_eq!(parsed, None);
     }
 }

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -29,12 +29,6 @@ use aether_substrate::{
     Mailer, SubstrateBoot, mail::MailboxId, runtime::trace::push_chassis_root_mail,
 };
 
-/// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
-/// component, the scheduler doesn't read this — it's retained on the
-/// hub-protocol wire for compatibility). The shared frame-loop
-/// policy (drain budget, frame-stats cadence) lives in
-/// `aether_substrate::frame_loop`.
-pub const WORKERS: usize = 2;
 pub const DEFAULT_TICK_HZ: u32 = 60;
 
 /// Parse `AETHER_TICK_HZ`. Unset → [`DEFAULT_TICK_HZ`]; non-positive

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -804,6 +804,11 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     /// `LogDrainSlot`s, set the same way every actor's slot is set:
     /// via mail.
     log_drain: Option<MailboxId>,
+    /// Issue 745: override [`PoolConfig::workers`]. `None` means
+    /// [`PoolConfig::default`] (`available_parallelism() - 1`, min 1);
+    /// `Some(n)` plumbs `n` into the pool at boot. Production chassis
+    /// mains populate this from `AETHER_WORKERS`.
+    workers: Option<usize>,
     _chassis: PhantomData<fn() -> C>,
     _state: PhantomData<fn() -> S>,
 }
@@ -822,6 +827,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             driver: None,
             aborter: Arc::new(PanicAborter),
             log_drain: None,
+            workers: None,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -834,6 +840,16 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// second invocation overwrites the prior aborter.
     pub fn with_aborter(mut self, aborter: Arc<dyn FatalAborter>) -> Self {
         self.aborter = aborter;
+        self
+    }
+
+    /// Issue 745: override the worker pool size. `None` keeps
+    /// [`PoolConfig::default`] (`available_parallelism() - 1`, min 1);
+    /// `Some(n)` plumbs `n` into the pool at boot. `Some(0)` is
+    /// clamped to 1 since the pool requires at least one worker. The
+    /// override can be applied either before or after `.driver(_)`.
+    pub fn with_workers(mut self, workers: Option<usize>) -> Self {
+        self.workers = workers.map(|n| n.max(1));
         self
     }
 
@@ -900,6 +916,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             driver: self.driver,
             aborter: self.aborter,
             log_drain: self.log_drain,
+            workers: self.workers,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -909,7 +926,13 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// and returns a [`PassiveChassis`] whose embedder is responsible
     /// for driving the loop manually (TestBench).
     pub fn build_passive(self) -> Result<PassiveChassis<C>, BootError> {
-        let booted = boot_passives(&self.registry, &self.mailer, &self.aborter, self.passives)?;
+        let booted = boot_passives(
+            &self.registry,
+            &self.mailer,
+            &self.aborter,
+            self.workers,
+            self.passives,
+        )?;
         // Issue #601: push `ConfigureLogDrain` to every booted actor
         // and to `aether.component` so every per-actor `LogDrainSlot`
         // (auto-emitted handler) plus the `ComponentHostCapability`'s
@@ -961,6 +984,13 @@ impl<C: Chassis> Builder<C, HasDriver> {
         self
     }
 
+    /// Mirror of [`Builder::with_workers`][Builder<C, NoDriver>::with_workers]
+    /// for the post-driver state. Issue 745.
+    pub fn with_workers(mut self, workers: Option<usize>) -> Self {
+        self.workers = workers.map(|n| n.max(1));
+        self
+    }
+
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via
@@ -972,11 +1002,12 @@ impl<C: Chassis> Builder<C, HasDriver> {
             passives,
             driver,
             aborter,
+            workers,
             ..
         } = self;
         let driver_boot = driver.expect("HasDriver state implies driver was supplied");
 
-        let mut booted = boot_passives(&registry, &mailer, &aborter, passives)?;
+        let mut booted = boot_passives(&registry, &mailer, &aborter, workers, passives)?;
         // Issue #601: push `ConfigureLogDrain` to every booted actor
         // and to `aether.component` so the runtime load path picks up
         // the chassis-declared drain through the same mail every
@@ -1141,6 +1172,7 @@ fn boot_passives(
     registry: &Arc<Registry>,
     mailer: &Arc<Mailer>,
     aborter: &Arc<dyn FatalAborter>,
+    workers: Option<usize>,
     passives: Vec<Box<dyn PassiveBoot>>,
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
@@ -1156,7 +1188,20 @@ fn boot_passives(
     // caps). Today every cap is Dedicated so the pool sits idle, but
     // booting it here means PR D / Phase 2 can flip a cap to Pooled
     // without re-plumbing the boot order.
-    let pool = Pool::start(PoolConfig::default(), Arc::clone(aborter));
+    //
+    // Issue 745: `workers` is the `AETHER_WORKERS` override threaded
+    // through `Builder::with_workers`. `None` keeps `PoolConfig::default`
+    // (`available_parallelism() - 1`, min 1); `Some(n)` swaps the
+    // worker count while preserving every other default field
+    // (`budget_template`, etc.).
+    let pool_config = match workers {
+        Some(n) => PoolConfig {
+            workers: n,
+            ..PoolConfig::default()
+        },
+        None => PoolConfig::default(),
+    };
+    let pool = Pool::start(pool_config, Arc::clone(aborter));
 
     // ADR-0080 §3 trace pipeline. `init_substrate_start` pins the
     // monotonic-since-boot reference; `install_trace_queue` makes the
@@ -3824,5 +3869,47 @@ mod tests {
 
         drop(chassis);
         let _ = id;
+    }
+
+    /// Issue 745: `Builder::with_workers(None)` leaves the override
+    /// field unset so `boot_passives` falls back to
+    /// `PoolConfig::default()`.
+    #[test]
+    fn with_workers_none_leaves_field_unset() {
+        let (registry, mailer) = fresh_substrate();
+        let builder = Builder::<TestChassis>::new(registry, mailer).with_workers(None);
+        assert_eq!(builder.workers, None);
+    }
+
+    /// Issue 745: a positive worker count plumbs through verbatim.
+    #[test]
+    fn with_workers_some_passes_through() {
+        let (registry, mailer) = fresh_substrate();
+        let builder = Builder::<TestChassis>::new(registry, mailer).with_workers(Some(7));
+        assert_eq!(builder.workers, Some(7));
+    }
+
+    /// Issue 745: `Some(0)` clamps to 1 since the pool requires at
+    /// least one worker.
+    #[test]
+    fn with_workers_some_zero_clamps_to_one() {
+        let (registry, mailer) = fresh_substrate();
+        let builder = Builder::<TestChassis>::new(registry, mailer).with_workers(Some(0));
+        assert_eq!(builder.workers, Some(1));
+    }
+
+    /// Issue 745: the override survives the type-state transition into
+    /// [`HasDriver`] so chassis mains can call `.with_workers(...)`
+    /// either before or after `.driver(_)`.
+    #[test]
+    fn with_workers_survives_driver_transition() {
+        let (registry, mailer) = fresh_substrate();
+        let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let builder = Builder::<DrivenTestChassis<RanDriver>>::new(registry, mailer)
+            .with_workers(Some(3))
+            .driver(RanDriver {
+                ran: Arc::clone(&ran),
+            });
+        assert_eq!(builder.workers, Some(3));
     }
 }


### PR DESCRIPTION
Plumbs the long-pending AETHER_WORKERS env var through the chassis builder so deployments can size the worker pool without editing source.

- New Builder::with_workers(Option<usize>) on both NoDriver and HasDriver impls; None keeps PoolConfig::default(), Some(0) clamps to 1.
- HeadlessEnv / DesktopEnv gain a workers: Option<usize> field populated by a parse_workers_env() helper (warns on 0 and on unparseable strings).
- Retires the vestigial pub const WORKERS: usize = 2 in desktop/driver.rs + headless/driver.rs and the let _ = WORKERS placeholders; test_bench/chassis.rs WORKERS stays (wire-stable per its docstring).

Closes iamacoffeepot/aether#745

Verification: cargo check --workspace --all-targets, cargo clippy --all-targets -- -D warnings, cargo fmt -- --check, cargo nextest run --workspace all clean (1001/1001).