### PR TITLE
feat(capabilities): subscribe/unsubscribe helpers on InputMailboxExt + migrate call sites (issue 828)

### DIFF
--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -36,9 +36,10 @@
 use std::collections::HashMap;
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::{InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{Camera, SubscribeInput, Tick, WindowSize};
+use aether_kinds::{Camera, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
 
 use crate::{
@@ -274,14 +275,8 @@ impl FfiActor for CameraComponent {
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
         let me = MailboxId(ctx.mailbox_id());
         let input = ctx.actor::<InputCapability>();
-        input.send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: me,
-        });
-        input.send(&SubscribeInput {
-            kind: WindowSize::ID,
-            mailbox: me,
-        });
+        input.subscribe(Tick::ID, me);
+        input.subscribe(WindowSize::ID, me);
     }
 
     /// Advance every camera's per-mode state, then publish the active

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -17,15 +17,88 @@
 //! domain so the chassis-internal component-host cap (`aether.component`,
 //! formerly `aether.control`) only carries component-lifecycle concerns.
 
+use aether_actor::FfiActorMailbox;
+use aether_data::{KindId, MailboxId};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::SubscribeInputResult;
 use aether_kinds::{
     Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, Tick, UnsubscribeAll,
     UnsubscribeInput, WindowSize,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use aether_substrate::actor::native::NativeActorMailbox;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::InputConfig;
+
+/// Sender-side facade for callers addressing [`InputCapability`] via
+/// `ctx.actor::<InputCapability>()`.
+///
+/// Lifts the cap-shaped operations (`subscribe(kind, mailbox)`,
+/// `unsubscribe(kind, mailbox)`, `unsubscribe_all(mailbox)`) one
+/// indirection above the raw `.send(&SubscribeInput { .. })` so
+/// component code stops reconstructing the kind struct at every call
+/// site. Same shape and rationale as [`crate::fs::FsMailboxExt`]
+/// (issue 580) and [`crate::component::ComponentHostFfiExt`] (issue
+/// 654) — the cap module owns receive-side ([`InputCapability`]) AND
+/// send-side ([`InputMailboxExt`]) so future kind additions land both
+/// surfaces in one place.
+///
+/// Impl'd for both transports `ctx.actor::<InputCapability>()` can
+/// return:
+///
+/// - [`FfiActorMailbox<InputCapability>`] — always-on, for
+///   wasm-component callers.
+/// - [`NativeActorMailbox<'_, InputCapability>`] — native cap-to-cap
+///   sends, gated on `#[cfg(not(target_arch = "wasm32"))]`.
+///
+/// All methods are fire-and-forget. `subscribe` / `unsubscribe` reply
+/// via `aether.input.subscribe_result`; reply handling stays on the
+/// caller. `unsubscribe_all` has no reply (issued by the trampoline on
+/// drop, when nobody's listening).
+///
+/// The generic escape hatch is unaffected: `mailbox.send(&SubscribeInput { .. })`
+/// still works for any `K` the cap declares via `HandlesKind<K>`,
+/// since `send` is an inherent method on the underlying mailbox type.
+pub trait InputMailboxExt {
+    /// Mail `aether.input.subscribe { kind, mailbox }` to the cap.
+    /// Add `mailbox` to the subscriber set for `kind`. Idempotent.
+    fn subscribe(&self, kind: KindId, mailbox: MailboxId);
+
+    /// Mail `aether.input.unsubscribe { kind, mailbox }` to the cap.
+    /// Remove `mailbox` from the subscriber set for `kind`. Idempotent.
+    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId);
+
+    /// Mail `aether.input.unsubscribe_all { mailbox }` to the cap.
+    /// Remove `mailbox` from every input stream's subscriber set;
+    /// used by the trampoline on drop. Idempotent; fire-and-forget.
+    fn unsubscribe_all(&self, mailbox: MailboxId);
+}
+
+impl InputMailboxExt for FfiActorMailbox<InputCapability> {
+    fn subscribe(&self, kind: KindId, mailbox: MailboxId) {
+        self.send(&SubscribeInput { kind, mailbox });
+    }
+    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId) {
+        self.send(&UnsubscribeInput { kind, mailbox });
+    }
+    fn unsubscribe_all(&self, mailbox: MailboxId) {
+        self.send(&UnsubscribeAll { mailbox });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a> InputMailboxExt for NativeActorMailbox<'a, InputCapability> {
+    fn subscribe(&self, kind: KindId, mailbox: MailboxId) {
+        self.send(&SubscribeInput { kind, mailbox });
+    }
+    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId) {
+        self.send(&UnsubscribeInput { kind, mailbox });
+    }
+    fn unsubscribe_all(&self, mailbox: MailboxId) {
+        self.send(&UnsubscribeAll { mailbox });
+    }
+}
 
 #[aether_actor::bridge(singleton)]
 mod native {

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -33,9 +33,10 @@
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::fs::FsMailboxExt;
+use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::{FsCapability, InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, ReadResult, SubscribeInput, Tick, Vertex};
+use aether_kinds::{DrawTriangle, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
@@ -89,10 +90,8 @@ impl FfiActor for MeshViewer {
     /// per frame. Lives in `wire` (post-init, mail-allowed); `init`
     /// itself is `Resolver`-only.
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: MailboxId(ctx.mailbox_id()),
-        });
+        ctx.actor::<InputCapability>()
+            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
     }
 
     /// Re-emits every cached triangle to the render sink.

--- a/crates/aether-test-fixture-probe/src/lib.rs
+++ b/crates/aether-test-fixture-probe/src/lib.rs
@@ -25,9 +25,10 @@
 //!   captured PNG.
 
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
+use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::{InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, SubscribeInput, Tick, Vertex};
+use aether_kinds::{DrawTriangle, Tick, Vertex};
 use bytemuck::{Pod, Zeroable};
 
 /// Mirror of `aether_substrate_bundle::test_bench::TEST_BENCH_OBSERVER_MAILBOX_NAME`.
@@ -84,10 +85,8 @@ impl FfiActor for Probe {
     /// Issue 640: explicit subscribe in `wire`; init is `Resolver`-only
     /// post-issue-703 and can't mail.
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: MailboxId(ctx.mailbox_id()),
-        });
+        ctx.actor::<InputCapability>()
+            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional Closes #828 auto-close keyword -->

## Summary

- Adds InputMailboxExt to aether-capabilities/src/input.rs with subscribe / unsubscribe / unsubscribe_all helpers; impls for both FfiActorMailbox InputCapability (always-on) and NativeActorMailbox InputCapability (gated on not-wasm32), mirroring the FsMailboxExt / ComponentHostFfiExt shape from iamacoffeepot/aether#580 and iamacoffeepot/aether#654.
- Migrates the three existing call sites (aether-mesh-viewer, aether-camera, aether-test-fixture-probe) so they call input.subscribe(Tick::ID, me) instead of constructing SubscribeInput at the use site.
- Verified clean: cargo check --workspace --all-targets, cargo clippy --all-targets -- -D warnings, cargo fmt -- --check, cargo nextest run --workspace --no-fail-fast (993 passed), and cargo check -p aether-capabilities --target wasm32-unknown-unknown --no-default-features.

Closes #828
