### PR TITLE
chore(substrate): wire workspace clippy lint set + drop -D warnings (issue 854 phase 1.a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Install ALSA dev headers (cpal Linux backend)
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      # TODO(iamacoffeepot/aether#854): restore `-D warnings` after the warn-prune passes land.
+      - run: cargo clippy --workspace --all-targets
 
   # Workspace-wide tests run on linux only. Non-chassis crates
   # (aether-kinds, aether-data, aether-actor, aether-actor-derive,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,32 @@ exclude = ["spikes/*"]
 [workspace.package]
 version = "0.2.0-alpha"
 edition = "2024"
+
+[workspace.lints.clippy]
+# Baseline — both groups as warn, then opt out of the idiom-fight bucket below.
+pedantic = { level = "warn", priority = -1 }
+nursery  = { level = "warn", priority = -1 }
+
+# Deny picks — INITIALLY AT WARN until per-pick cleanup PRs land (iamacoffeepot/aether#854 Phase 1.b-1.c.iv).
+# Each follow-up PR fixes its hits and promotes its lint to deny in the same diff.
+dbg_macro                           = "warn"  # promote to deny in Phase 1.c.* if any hits exist
+todo                                = "warn"  # promote to deny if no hits surface
+unimplemented                       = "warn"  # promote to deny if no hits surface
+undocumented_unsafe_blocks          = "warn"  # promote to deny in Phase 1.b after 73 SAFETY backfills
+cloned_instead_of_copied            = "warn"  # promote to deny in Phase 1.c.iv
+large_stack_arrays                  = "warn"  # promote to deny in Phase 1.c.iv
+match_wildcard_for_single_variants  = "warn"  # promote to deny in Phase 1.c.iii
+uninlined_format_args               = "warn"  # promote to deny in Phase 1.c.ii
+unreadable_literal                  = "warn"  # promote to deny in Phase 1.c.i
+
+# Warn picks — cherry-picked from restriction + style (not covered by pedantic/nursery baseline).
+unwrap_used                         = "warn"
+print_stdout                        = "warn"
+print_stderr                        = "warn"
+
+# Disable — idiom fight / dispatcher contract / doc-burden. Rationale in iamacoffeepot/aether#854.
+float_cmp                    = "allow"
+missing_const_for_fn         = "allow"
+missing_errors_doc           = "allow"
+needless_pass_by_ref_mut     = "allow"
+too_long_first_doc_paragraph = "allow"

--- a/crates/aether-actor-derive/Cargo.toml
+++ b/crates/aether-actor-derive/Cargo.toml
@@ -17,3 +17,6 @@ bytemuck = { version = "1.19", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 inventory = "0.3"
 aether-actor = { path = "../aether-actor" }
+
+[lints]
+workspace = true

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1,3 +1,9 @@
+// Derive codegen builds deeply-nested `quote!` trees from `if let Some(...)` branches;
+// `map_or_else` would obscure the control flow. Allow at the crate root because cargo
+// doesn't permit `[lints.clippy]` overrides alongside `lints.workspace = true` in the
+// manifest (iamacoffeepot/aether#854 Phase 1.a).
+#![allow(clippy::option_if_let_else)]
+
 //! Proc-macro home for `#[derive(Kind)]` and `#[derive(Schema)]` per
 //! ADR-0019 / ADR-0031 / ADR-0032. Kept separate from `aether-data`
 //! because Rust requires proc-macro crates to opt into

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -85,3 +85,6 @@ crate-type = ["cdylib"]
 [[example]]
 name = "hello"
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/crates/aether-camera/Cargo.toml
+++ b/crates/aether-camera/Cargo.toml
@@ -60,3 +60,6 @@ inventory = "0.3"
 # and discovered at runtime under `target/wasm32-unknown-unknown/{debug,release}/`.
 [dev-dependencies]
 aether-substrate-bundle = { path = "../aether-substrate-bundle" }
+
+[lints]
+workspace = true

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -93,3 +93,6 @@ crossbeam-queue = { version = "0.3", optional = true }
 [dev-dependencies]
 aether-data = { path = "../aether-data", features = ["derive"] }
 bytemuck = { version = "1.19", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/aether-codec/Cargo.toml
+++ b/crates/aether-codec/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = "1"
 aether-kinds = { path = "../aether-kinds" }
 aether-data = { path = "../aether-data", features = ["derive"] }
 bytemuck = { version = "1.19", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/aether-data/Cargo.toml
+++ b/crates/aether-data/Cargo.toml
@@ -33,3 +33,6 @@ uuid = { version = "1", default-features = false, features = ["serde"] }
 # the wasm-side collection mechanism; this is the native mirror.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 inventory = "0.3"
+
+[lints]
+workspace = true

--- a/crates/aether-kinds/Cargo.toml
+++ b/crates/aether-kinds/Cargo.toml
@@ -24,3 +24,6 @@ postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 # derive's `cfg(not(target_arch = "wasm32"))` gate skips emission).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 inventory = "0.3"
+
+[lints]
+workspace = true

--- a/crates/aether-math/Cargo.toml
+++ b/crates/aether-math/Cargo.toml
@@ -5,3 +5,6 @@ edition.workspace = true
 
 [dependencies]
 libm = "0.2"
+
+[lints]
+workspace = true

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -45,3 +45,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 aether-actor = { path = "../aether-actor" }
 aether-substrate = { path = "../aether-substrate" }
+
+[lints]
+workspace = true

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -59,3 +59,6 @@ inventory = "0.3"
 # and discovered at runtime under `target/wasm32-unknown-unknown/{debug,release}/`.
 [dev-dependencies]
 aether-substrate-bundle = { path = "../aether-substrate-bundle" }
+
+[lints]
+workspace = true

--- a/crates/aether-mesh/Cargo.toml
+++ b/crates/aether-mesh/Cargo.toml
@@ -12,3 +12,6 @@ tracing = "0.1"
 [dev-dependencies]
 pretty_assertions = "1"
 tracing-subscriber = "0.3"
+
+[lints]
+workspace = true

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -85,3 +85,6 @@ wat = "1"
 # module through `crate::test_bench::{visual, test_helpers}` directly
 # (post-issue-821, formerly via `aether-scenario`).
 aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }
+
+[lints]
+workspace = true

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -80,3 +80,6 @@ wat = "1"
 # in for non-test builds.
 aether-data = { path = "../aether-data", features = ["derive"] }
 bytemuck = { version = "1.19", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/aether-test-fixture-probe/Cargo.toml
+++ b/crates/aether-test-fixture-probe/Cargo.toml
@@ -22,3 +22,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 # actor-aware subscriber installed by `export!()` buffers + drains it
 # to LogCapability.
 tracing = { version = "0.1", default-features = false }
+
+[lints]
+workspace = true

--- a/demos/sokoban/Cargo.toml
+++ b/demos/sokoban/Cargo.toml
@@ -33,3 +33,6 @@ bytemuck = { version = "1", default-features = false, features = ["derive"] }
 # `target/wasm32-unknown-unknown/{debug,release}/`.
 [dev-dependencies]
 aether-substrate-bundle = { path = "../../crates/aether-substrate-bundle" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Part of iamacoffeepot/aether#854 (Phase 1.a).

The smallest landable unit of the phased lint adoption. This PR is purely additive: it wires the curated `[workspace.lints.clippy]` block and relaxes CI so the warn backlog is visible without gating merges. The 9 originally-deny picks land AT WARN with promotion markers; each follow-up PR (Phase 1.b through 1.c.iv) will fix its lint's hits and promote it to deny in the same diff.

## What this PR does

- Adds `[workspace.lints.clippy]` to root `Cargo.toml` (pedantic + nursery as `warn` baseline, 9 deny picks at `warn` with promotion markers, 3 warn picks, 5 explicit allows).
- Adds `[lints] workspace = true` to every workspace member (`crates/*` and `demos/*`; spike crates are standalone workspaces and untouched).
- Drops `-D warnings` from the CI clippy invocation with a TODO referencing iamacoffeepot/aether#854.
- Per-crate scope for `option_if_let_else = "allow"` in `aether-actor-derive` (the derive's `quote!` codegen leans on `if let Some(...)` for control-flow clarity).

## Warning count

`cargo clippy --workspace --all-targets` produces roughly 2.7k raw warning lines (5k+ as the issue body cites, depending on dedupe / format-short). This is expected and intended — the phased plan in iamacoffeepot/aether#854 walks the backlog down across Phase 1.b through 1.c.iv. The clippy run still exits 0 because `-D warnings` is off; CI does not fail on the warn flood.

## Deviation from the issue text

The issue's "Proposed fix" sketched the `option_if_let_else` allow as a `[lints.clippy]` block in `aether-actor-derive/Cargo.toml` after `[lints] workspace = true`. Cargo rejects that combination ("cannot override `workspace.lints` in `lints`"). The equivalent crate-scoped allow lands as `#![allow(clippy::option_if_let_else)]` at the top of `crates/aether-actor-derive/src/lib.rs` with a comment explaining the constraint. Same effect, cargo-supported shape.

## Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets` (no `-D warnings`) — exits 0, surfaces the warn backlog.
- `cargo fmt --all -- --check` — clean.
- `cargo nextest run --workspace` — all 1001 tests pass. (The first run flaked `scheduler::slot::tests::drain_budget_yields_for_requeue` under heavy CPU contention from the parallel test load; the test passes in isolation and on re-run. The lint changes are pure metadata and cannot affect runtime behavior.)
- `cargo test --doc --workspace` — clean.

## Follow-ups (tracked under iamacoffeepot/aether#854)

- Phase 1.b — backfill 73 SAFETY comments, promote `undocumented_unsafe_blocks` to deny.
- Phase 1.c.i — fix `unreadable_literal` (85 hits), promote to deny.
- Phase 1.c.ii — fix `uninlined_format_args` (57 hits), promote to deny.
- Phase 1.c.iii — fix `match_wildcard_for_single_variants` (13 hits), promote to deny.
- Phase 1.c.iv — fix `cloned_instead_of_copied` (1) + `large_stack_arrays` (2) + the small bucket (`dbg_macro`, `todo`, `unimplemented`), promote each.
