### PR TITLE
chore(substrate): backfill SAFETY comments + promote undocumented_unsafe_blocks to deny (issue 854 phase 1.b)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ nursery  = { level = "warn", priority = -1 }
 dbg_macro                           = "warn"  # promote to deny in Phase 1.c.* if any hits exist
 todo                                = "warn"  # promote to deny if no hits surface
 unimplemented                       = "warn"  # promote to deny if no hits surface
-undocumented_unsafe_blocks          = "warn"  # promote to deny in Phase 1.b after 73 SAFETY backfills
+undocumented_unsafe_blocks          = "deny"
 cloned_instead_of_copied            = "deny"
 large_stack_arrays                  = "deny"
 match_wildcard_for_single_variants  = "deny"

--- a/crates/aether-actor/src/actor/slot.rs
+++ b/crates/aether-actor/src/actor/slot.rs
@@ -24,6 +24,12 @@ impl<C> Slot<C> {
     /// exactly once, from within the `init` shim, before any other
     /// access.
     pub unsafe fn set(&self, value: C) {
+        // SAFETY: caller upholds the `# Safety` contract above — no
+        // other live reference to the cell. The single-threaded wasm
+        // guest + serialized FFI shim path means there is no race; the
+        // dereference of the `UnsafeCell` raw pointer is a unique-
+        // access write because the only other caller (`get_mut`) is
+        // gated behind the same caller-side serialization.
         unsafe {
             *self.inner.get() = Some(value);
         }
@@ -39,6 +45,10 @@ impl<C> Slot<C> {
     // lint is designed around.
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn get_mut(&self) -> Option<&mut C> {
+        // SAFETY: caller upholds the `# Safety` contract above — no
+        // other live reference to the cell. The dispatcher serializes
+        // `receive` against `init`/itself, so the `&mut` derived from
+        // the `UnsafeCell` is never aliased.
         unsafe { (*self.inner.get()).as_mut() }
     }
 }
@@ -49,10 +59,11 @@ impl<C> Default for Slot<C> {
     }
 }
 
-// Single-threaded WASM + serialized FFI entry points mean the
+// SAFETY: single-threaded WASM + serialized FFI entry points mean the
 // `UnsafeCell` is only ever touched from one thread at a time. The
 // `Sync` impl unlocks `static SLOT: Slot<MyComponent>` without
-// needing `std::sync` types the `no_std` surface can't provide.
+// needing `std::sync` types the `no_std` surface can't provide. No
+// concurrent access is possible inside a single wasm linear memory.
 unsafe impl<C> Sync for Slot<C> {}
 
 #[cfg(test)]
@@ -62,9 +73,13 @@ mod tests {
     #[test]
     fn slot_set_then_get_mut_returns_value() {
         let slot: Slot<u32> = Slot::new();
+        // SAFETY: test thread holds the only reference to `slot`;
+        // no aliasing access exists.
         unsafe {
             slot.set(42);
         }
+        // SAFETY: `set` has completed and returned; no other reference
+        // to the cell is live on this test thread.
         let got = unsafe { slot.get_mut() };
         assert_eq!(got.copied(), Some(42));
     }
@@ -72,6 +87,8 @@ mod tests {
     #[test]
     fn slot_get_mut_before_set_is_none() {
         let slot: Slot<u32> = Slot::new();
+        // SAFETY: test thread holds the only reference to `slot`;
+        // no aliasing access exists.
         let got = unsafe { slot.get_mut() };
         assert!(got.is_none());
     }

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -35,6 +35,11 @@ impl MailBridge {
     /// host-side failure surfaces.
     #[must_use]
     pub fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
+        // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
+        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+        // derived from the `&[u8]` slice we just received, which the
+        // borrow checker proves is valid for `bytes.len()` bytes for
+        // the duration of the call; the host copies before returning.
         unsafe {
             raw::send_mail(
                 recipient,
@@ -53,6 +58,11 @@ impl MailBridge {
     /// engine mailbox.
     #[must_use]
     pub fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
+        // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
+        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+        // derived from the `&[u8]` slice we just received, which the
+        // borrow checker proves is valid for `bytes.len()` bytes for
+        // the duration of the call; the host copies before returning.
         unsafe {
             raw::reply_mail(
                 sender,
@@ -71,6 +81,11 @@ impl MailBridge {
     /// the inbound's reply correlation.
     #[must_use]
     pub fn prev_correlation(&self) -> u64 {
+        // SAFETY: `raw::prev_correlation` takes no arguments and reads
+        // a host-side scalar set on the most recent `send_mail`; no
+        // ABI invariants to uphold beyond "we are the FFI guest", which
+        // the `#[cfg(target_arch = "wasm32")]` import gate enforces
+        // (the host-target stub panics rather than returning garbage).
         unsafe { raw::prev_correlation() }
     }
 }

--- a/crates/aether-actor/src/ffi/bridge/persist.rs
+++ b/crates/aether-actor/src/ffi/bridge/persist.rs
@@ -34,6 +34,12 @@ impl PersistBridge {
     /// successor).
     #[must_use]
     pub fn save_state(&self, version: u32, bytes: &[u8]) -> u32 {
+        // SAFETY: forwards to `raw::save_state`, whose ABI is documented
+        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+        // derived from the `&[u8]` slice we just received, which the
+        // borrow checker proves is valid for `bytes.len()` bytes for
+        // the duration of the call; the substrate copies the bundle
+        // out of guest memory before returning.
         unsafe { raw::save_state(version, bytes.as_ptr().addr() as u32, bytes.len() as u32) }
     }
 }

--- a/crates/aether-actor/src/ffi/bridge/sync_wait.rs
+++ b/crates/aether-actor/src/ffi/bridge/sync_wait.rs
@@ -39,6 +39,12 @@ impl SyncWaitBridge {
         timeout_ms: u32,
         expected_correlation: u64,
     ) -> i32 {
+        // SAFETY: forwards to `raw::wait_reply`, whose ABI is documented
+        // at the import site in `ffi/raw.rs`. The `(out_ptr, out_cap)`
+        // pair is derived from the `&mut [u8]` we just received, which
+        // the borrow checker proves is valid for `out.len()` bytes for
+        // the duration of the call; the host writes at most `out_cap`
+        // bytes through the pointer (`-2` re-parks rather than spilling).
         unsafe {
             raw::wait_reply(
                 expected_kind,

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -203,6 +203,13 @@ mod native_impl {
                         .expect("TypeId<T> ⇒ RefCell<T>"),
                 )
             };
+            // SAFETY: same justification as `with_mut` above — the
+            // pointer is into a heap-allocated `Box<RefCell<T>>` owned
+            // by `self.by_type`. The outer borrow released so a nested
+            // `with::<U>` can re-enter the map; the box's heap address
+            // is stable across `HashMap` rehashes; we never remove
+            // entries. The `&RefCell<T>` reborrow is unique for the
+            // closure's run.
             let cell = unsafe { &*cell_ptr };
             let borrow = cell.borrow();
             f(&*borrow)

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -181,6 +181,11 @@ impl<'a> Mail<'a> {
             return None;
         }
         let byte_len = core::mem::size_of::<K>();
+        // SAFETY: `self.ptr` / `self.byte_len` originate from the
+        // substrate's receive ABI (`Mail::__from_raw` / `__from_ptr`),
+        // which guarantees the substrate wrote `self.byte_len >=
+        // size_of::<K>()` bytes valid at `self.ptr` for the lifetime
+        // of this `Mail`. `'a` ties the borrow to that lifetime.
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         Some(bytemuck::pod_read_unaligned(bytes))
     }
@@ -198,6 +203,12 @@ impl<'a> Mail<'a> {
             return None;
         }
         let byte_len = core::mem::size_of::<K>() * self.count as usize;
+        // SAFETY: `self.ptr` / `self.byte_len` originate from the
+        // substrate's receive ABI; the substrate guarantees at least
+        // `size_of::<K>() * self.count` bytes valid at `self.ptr` for
+        // the lifetime of this `Mail`. `'a` ties the returned slice
+        // to that lifetime; `try_cast_slice` returns `None` on
+        // alignment mismatch.
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         bytemuck::try_cast_slice(bytes).ok()
     }
@@ -229,6 +240,10 @@ impl<'a> Mail<'a> {
         if self.byte_len as usize != byte_len {
             return None;
         }
+        // SAFETY: `self.ptr` / `self.byte_len` originate from the
+        // substrate's receive ABI; the `byte_len` check above proves
+        // the host promised exactly `size_of::<K>()` bytes valid at
+        // `self.ptr` for this `Mail`'s lifetime.
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         Some(bytemuck::pod_read_unaligned(bytes))
     }
@@ -244,6 +259,11 @@ impl<'a> Mail<'a> {
         if self.byte_len as usize != byte_len {
             return None;
         }
+        // SAFETY: `self.ptr` / `self.byte_len` originate from the
+        // substrate's receive ABI; the `byte_len` check above proves
+        // the host promised `size_of::<K>() * count` bytes valid at
+        // `self.ptr` for this `Mail`'s lifetime. `try_cast_slice`
+        // returns `None` on alignment mismatch.
         let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         bytemuck::try_cast_slice(bytes).ok()
     }
@@ -271,6 +291,12 @@ impl<'a> Mail<'a> {
         if self.kind != K::ID.0 || self.count != 1 {
             return None;
         }
+        // SAFETY: `self.ptr` / `self.byte_len` originate from the
+        // substrate's receive ABI; the substrate guarantees
+        // `self.byte_len` bytes valid at `self.ptr` for this `Mail`'s
+        // lifetime. Bounding the slice by `byte_len` keeps
+        // `K::decode_from_bytes` (cast or postcard) from running past
+        // the substrate-written region into adjacent linear memory.
         let bytes =
             unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
         K::decode_from_bytes(bytes)
@@ -333,6 +359,12 @@ impl<'a> PriorState<'a> {
         if self.len == 0 {
             &[]
         } else {
+            // SAFETY: `self.ptr` / `self.len` originate from the
+            // substrate's `on_rehydrate` ABI (`PriorState::__from_raw`
+            // / `__from_ptr`); the substrate guarantees `self.len`
+            // bytes valid at `self.ptr` for this `PriorState`'s
+            // lifetime. The `len == 0` branch above avoids forming a
+            // slice over a possibly-null pointer.
             unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.len) }
         }
     }
@@ -408,11 +440,24 @@ mod tests {
         ids: alloc::vec::Vec<u32>,
     }
 
+    // SAFETY (test fixtures): each `Mail::__from_ptr` / `__from_raw` /
+    // `PriorState::__from_ptr` / `__from_raw` below substitutes for the
+    // substrate's receive ABI. The host pointer + length pair we pass
+    // is derived from a local stack value or buffer whose lifetime
+    // straddles the resulting `Mail`/`PriorState`, satisfying the
+    // ABI's `(ptr, byte_len)` validity contract for the duration of
+    // the test body. The `count` / `sender` / `version` scalars are
+    // plain values with no aliasing implications. The `0,0,0` no-deref
+    // variants rely on the `bytes()` / `decode*` accessors honouring
+    // the `len == 0` early-return rather than forming a slice over the
+    // null pointer.
+
     #[test]
     fn mail_decode_single_roundtrip() {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&raw const value).addr();
         let byte_len = core::mem::size_of::<FakePod>() as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId::__new(7);
         let out = mail.decode(kind).unwrap();
@@ -424,6 +469,7 @@ mod tests {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&raw const value).addr();
         let byte_len = core::mem::size_of::<FakePod>() as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let wrong: KindId<FakePod> = KindId::__new(8);
         assert!(mail.decode(wrong).is_none());
@@ -434,6 +480,7 @@ mod tests {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId::__new(7);
         // `decode` requires count == 1; use `decode_slice` for batches.
@@ -445,6 +492,7 @@ mod tests {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId::__new(7);
         let out = mail.decode_slice(kind).unwrap();
@@ -453,12 +501,15 @@ mod tests {
 
     #[test]
     fn mail_sender_none_for_sentinel_handle() {
+        // SAFETY: no pointer is dereferenced (`bytes()` and friends
+        // are not called); we only inspect the sentinel `sender`.
         let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.reply_to().is_none());
     }
 
     #[test]
     fn mail_sender_some_for_real_handle() {
+        // SAFETY: no pointer is dereferenced; we only inspect `sender`.
         let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42) };
         let s = mail.reply_to().expect("non-sentinel handle yields Some");
         assert_eq!(s.raw(), 42);
@@ -470,6 +521,8 @@ mod tests {
         // raw 0 ptr with len>0 would be UB if anyone called
         // `from_raw_parts` on it. The `if self.len == 0` branch in
         // `bytes()` is what guarantees this.
+        // SAFETY: `bytes()` returns `&[]` for `len == 0` without
+        // forming a slice over the null pointer.
         let prior = unsafe { PriorState::__from_raw(7, 0, 0) };
         assert_eq!(prior.schema_version(), 7);
         assert_eq!(prior.bytes(), &[] as &[u8]);
@@ -478,6 +531,8 @@ mod tests {
     #[test]
     fn prior_state_nonempty_bytes_roundtrip() {
         let buf: [u8; 4] = [1, 2, 3, 4];
+        // SAFETY: `buf` outlives `prior`; the `(addr, len)` pair is
+        // valid for `buf.len()` bytes for the rest of the test body.
         let prior = unsafe { PriorState::__from_ptr(3, buf.as_ptr().addr(), buf.len()) };
         assert_eq!(prior.schema_version(), 3);
         assert_eq!(prior.bytes(), &buf);
@@ -485,6 +540,7 @@ mod tests {
 
     #[test]
     fn mail_is_typed_matches_kind_id() {
+        // SAFETY: no pointer is dereferenced (`is::<K>` reads `kind`).
         let mail = unsafe { Mail::__from_ptr(FakeKind::ID.0, 0, 0, 0, NO_REPLY_HANDLE) };
         assert!(mail.is::<FakeKind>());
         assert!(!mail.is::<FakePod>());
@@ -495,6 +551,7 @@ mod tests {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&raw const value).addr();
         let byte_len = core::mem::size_of::<FakePod>() as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let out = mail.decode_typed::<FakePod>().unwrap();
@@ -507,6 +564,7 @@ mod tests {
         let ptr_raw = (&raw const value).addr();
         let byte_len = core::mem::size_of::<FakePod>() as u32;
         // Kind id deliberately mismatched (FakeKind instead of FakePod).
+        // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakeKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
@@ -517,6 +575,7 @@ mod tests {
         let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
@@ -527,6 +586,7 @@ mod tests {
         let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (core::mem::size_of::<FakePod>() * 2) as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let out = mail.decode_slice_typed::<FakePod>().unwrap();
@@ -540,6 +600,8 @@ mod tests {
             ids: alloc::vec![1, 2, 3, 4],
         };
         let bytes = postcard::to_allocvec(&value).unwrap();
+        // SAFETY: `bytes` (a `Vec<u8>` from postcard) outlives `mail`;
+        // its `(addr, len)` pair is valid for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
                 FakePostcard::ID.0,
@@ -578,6 +640,7 @@ mod tests {
         let value = FakeCastKind { a: 5, b: 9 };
         let ptr_raw = (&raw const value).addr();
         let byte_len = core::mem::size_of::<FakeCastKind>() as u32;
+        // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakeCastKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let out = mail.decode_kind::<FakeCastKind>().expect("decode");
@@ -591,6 +654,8 @@ mod tests {
             ids: alloc::vec![],
         };
         let bytes = postcard::to_allocvec(&value).unwrap();
+        // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
+        // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
                 FakeKind::ID.0,
@@ -610,6 +675,8 @@ mod tests {
             ids: alloc::vec![],
         };
         let bytes = postcard::to_allocvec(&value).unwrap();
+        // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
+        // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
                 FakePostcard::ID.0,
@@ -632,6 +699,9 @@ mod tests {
         // Pretend the substrate only wrote the first 2 bytes —
         // `decode_from_bytes` (postcard arm) gets the truncated slice
         // and surfaces the parse error as `None`.
+        // SAFETY: `bytes` outlives `mail`; the declared `byte_len=2`
+        // is within the actual allocation so the bounded read is
+        // valid even though it's deliberately a truncation.
         let mail = unsafe {
             Mail::__from_ptr(
                 FakePostcard::ID.0,
@@ -652,6 +722,9 @@ mod tests {
         // Use a real (empty) buffer — `slice::from_raw_parts(NULL, 0)`
         // is UB even when the length is zero.
         let buf: [u8; 1] = [0];
+        // SAFETY: `buf` outlives `mail`; the `(addr, 0)` pair points
+        // into the live `buf` allocation, satisfying the validity
+        // contract trivially for the zero-byte read.
         let mail =
             unsafe { Mail::__from_ptr(FakeKind::ID.0, buf.as_ptr().addr(), 0, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_kind::<FakeKind>().is_none());
@@ -666,6 +739,11 @@ mod tests {
         let value = FakePod { a: 5, b: 9 };
         let ptr_raw = (&raw const value).addr();
         let bogus_byte_len = (core::mem::size_of::<FakePod>() + 4) as u32;
+        // SAFETY: the bogus `byte_len` is intentional; `decode_typed`
+        // detects the size mismatch and returns `None` before reading.
+        // The pointer is still valid for `size_of::<FakePod>()` bytes
+        // (the `value` allocation), so even if decode did read it
+        // would touch only valid memory.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, bogus_byte_len, 1, NO_REPLY_HANDLE) };
         assert!(mail.decode_typed::<FakePod>().is_none());
@@ -706,6 +784,10 @@ mod tests {
     }
 
     fn prior_from(buf: &[u8], version: u32) -> PriorState<'_> {
+        // SAFETY: the returned `PriorState<'_>` borrows `buf` (via the
+        // explicit lifetime); the `(addr, len)` pair derives from a
+        // live slice the caller supplies, so validity holds for the
+        // borrow's lifetime.
         unsafe { PriorState::__from_ptr(version, buf.as_ptr().addr(), buf.len()) }
     }
 
@@ -746,6 +828,9 @@ mod tests {
         // `on_rehydrate` only fires when the predecessor saved
         // something, but a hypothetical zero-length buffer must
         // still fall through cleanly.
+        // SAFETY: `bytes()` returns `&[]` for `len == 0` without
+        // forming a slice over the null pointer; the decode reads
+        // through that empty slice and short-circuits.
         let prior = unsafe { PriorState::__from_raw(0, 0, 0) };
         assert!(prior.as_kind::<StateStruct>().is_none());
     }

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -515,6 +515,13 @@ mod native {
         /// chassis-router isn't installed, so the bare push warn-drops
         /// at the `route_mail` switch — that's fine for state assertions).
         fn boot_observer() -> TraceObserverCapability {
+            // SAFETY: called only from this test thread before any
+            // reader. `AETHER_TRACE_RETENTION_MS` and
+            // `AETHER_TRACE_MAX_ROOTS` are read inside `observer_with`
+            // (the next call on this same thread) and nowhere else in
+            // this test module, so no concurrent reader can race the
+            // write. `std::env::set_var` only requires "no other thread
+            // is reading or writing the environment simultaneously."
             unsafe {
                 std::env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
                 std::env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -272,6 +272,8 @@ mod tests {
             }
         }
         let out = f();
+        // SAFETY: same justification as the prior block — this test
+        // still owns the `AETHER_WORKERS` slot via `ENV_LOCK`.
         unsafe {
             std::env::remove_var("AETHER_WORKERS");
         }

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -93,6 +93,11 @@ impl Drop for DispatchGuard {
 /// restores the prior pointer before the surrounding stack frame
 /// returns, so no `'static` reference escapes.
 pub fn with_actor_dispatch<R>(dispatch: &dyn MailDispatch, f: impl FnOnce() -> R) -> R {
+    // SAFETY: same justification as the `SAFETY` paragraph in the
+    // fn doc — the caller guarantees `dispatch` outlives `f`. The
+    // `'static` reborrow is confined to the surrounding stack frame
+    // by the `DispatchGuard` drop, so no `'static` reference escapes
+    // past `with_actor_dispatch`'s return.
     let static_ref: &'static dyn MailDispatch =
         unsafe { core::mem::transmute::<&dyn MailDispatch, &'static dyn MailDispatch>(dispatch) };
     let _guard = ACTOR_DISPATCH.with(|slot| {


### PR DESCRIPTION
Part of iamacoffeepot/aether#854 (Phase 1.b)

- Backfills `// SAFETY:` comments on every previously-flagged `unsafe` block / `unsafe impl` across `aether-actor`, `aether-capabilities`, `aether-substrate`, and `aether-substrate-bundle` (mail decoders + `Mail::__from_raw`/`__from_ptr`, `PriorState` constructors, `Slot<C>` + `unsafe impl Sync`, `ffi/bridge/{mail,persist,sync_wait}` forwarders, `ActorSlots::with`, `log_install::with_actor_dispatch`, `trace.rs` test env mutation, headless chassis test env helper).
- Promotes `clippy::undocumented_unsafe_blocks` from `warn` to `deny` in the workspace lint block.
- `cargo clippy --workspace --all-targets` reports zero `undocumented_unsafe_blocks` hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
