### PR TITLE
chore(substrate): replace wildcard match arms over wire enums + promote match_wildcard_for_single_variants to deny (issue 854 phase 1.c.iii)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ unimplemented                       = "warn"  # promote to deny if no hits surfa
 undocumented_unsafe_blocks          = "warn"  # promote to deny in Phase 1.b after 73 SAFETY backfills
 cloned_instead_of_copied            = "warn"  # promote to deny in Phase 1.c.iv
 large_stack_arrays                  = "warn"  # promote to deny in Phase 1.c.iv
-match_wildcard_for_single_variants  = "warn"  # promote to deny in Phase 1.c.iii
+match_wildcard_for_single_variants  = "deny"
 uninlined_format_args               = "warn"  # promote to deny in Phase 1.c.ii
 unreadable_literal                  = "warn"  # promote to deny in Phase 1.c.i
 

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -387,7 +387,7 @@ impl FfiActor for CameraComponent {
         match self.cameras.get_mut(&msg.name) {
             Some(cam) => match &mut cam.mode {
                 ModeState::Orbit(state) => state.apply(&msg.params),
-                other => tracing::warn!(
+                other @ ModeState::Topdown(_) => tracing::warn!(
                     target: "aether_camera",
                     name = %msg.name,
                     actual = %other.name(),
@@ -410,7 +410,7 @@ impl FfiActor for CameraComponent {
         match self.cameras.get_mut(&msg.name) {
             Some(cam) => match &mut cam.mode {
                 ModeState::Topdown(state) => state.apply(&msg.params),
-                other => tracing::warn!(
+                other @ ModeState::Orbit(_) => tracing::warn!(
                     target: "aether_camera",
                     name = %msg.name,
                     actual = %other.name(),

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -751,7 +751,7 @@ mod tests {
                 assert_eq!(id, 42);
                 assert_eq!(kind_id, TestStruct::ID.0);
             }
-            _ => panic!("expected Handle variant"),
+            Ref::Inline(_) => panic!("expected Handle variant"),
         }
     }
 
@@ -764,7 +764,7 @@ mod tests {
         let r = Ref::inline(v.clone());
         match r {
             Ref::Inline(inner) => assert_eq!(inner, v),
-            _ => panic!("expected Inline variant"),
+            Ref::Handle { .. } => panic!("expected Inline variant"),
         }
     }
 

--- a/crates/aether-mesh/src/fixed.rs
+++ b/crates/aether-mesh/src/fixed.rs
@@ -124,7 +124,9 @@ mod tests {
         let too_big = MAX_INPUT_MAGNITUDE + 1.0;
         match f32_to_fixed(too_big).unwrap_err() {
             FixedError::OutOfRange { value } => assert_eq!(value, too_big),
-            other => panic!("expected OutOfRange, got {other:?}"),
+            other @ FixedError::NotFinite { .. } => {
+                panic!("expected OutOfRange, got {other:?}")
+            }
         }
     }
 
@@ -133,7 +135,9 @@ mod tests {
         let too_small = -MAX_INPUT_MAGNITUDE - 1.0;
         match f32_to_fixed(too_small).unwrap_err() {
             FixedError::OutOfRange { value } => assert_eq!(value, too_small),
-            other => panic!("expected OutOfRange, got {other:?}"),
+            other @ FixedError::NotFinite { .. } => {
+                panic!("expected OutOfRange, got {other:?}")
+            }
         }
     }
 
@@ -284,7 +288,9 @@ mod tests {
         );
         match f32_to_fixed(just_above).unwrap_err() {
             FixedError::OutOfRange { value } => assert_eq!(value, just_above),
-            other => panic!("expected OutOfRange, got {other:?}"),
+            other @ FixedError::NotFinite { .. } => {
+                panic!("expected OutOfRange, got {other:?}")
+            }
         }
     }
 

--- a/crates/aether-mesh/src/point.rs
+++ b/crates/aether-mesh/src/point.rs
@@ -152,7 +152,9 @@ mod tests {
         let err = Point3::from_f32(Vec3::new(f32::NAN, f32::INFINITY, 999.0)).unwrap_err();
         match err {
             FixedError::NotFinite { value } => assert!(value.is_nan()),
-            other => panic!("expected NotFinite for x=NaN, got {other:?}"),
+            other @ FixedError::OutOfRange { .. } => {
+                panic!("expected NotFinite for x=NaN, got {other:?}")
+            }
         }
     }
 
@@ -173,7 +175,9 @@ mod tests {
         let err = Point3::from_f32(Vec3::new(0.0, 0.0, f32::INFINITY)).unwrap_err();
         match err {
             FixedError::NotFinite { value } => assert_eq!(value, f32::INFINITY),
-            other => panic!("expected NotFinite for z=Inf, got {other:?}"),
+            other @ FixedError::OutOfRange { .. } => {
+                panic!("expected NotFinite for z=Inf, got {other:?}")
+            }
         }
     }
 

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -382,7 +382,7 @@ impl Gpu {
                 None
             }
             wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => None,
-            other => {
+            other @ wgpu::CurrentSurfaceTexture::Validation => {
                 tracing::warn!(
                     target: "aether_substrate::render",
                     status = ?other,


### PR DESCRIPTION
Part of iamacoffeepot/aether#854 (Phase 1.c.iii).

- Replaced 10 wildcard match arms over wire enums (`FixedError`, `Ref<K>`, `ModeState`, `wgpu::CurrentSurfaceTexture`) with explicit-variant arms so adding a new variant breaks the match at compile time instead of silently falling into the catch-all.
- Promoted `clippy::match_wildcard_for_single_variants` from `warn` to `deny` in the workspace lint block and dropped the Phase 1.c.iii promotion-marker comment.