### PR TITLE
fix(substrate-bundle): gate capture render on pre-mail settlement (issue 860)

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -327,13 +327,38 @@ mod native {
                     }
                 };
 
+            // iamacoffeepot/aether#860: dispatch each pre-mail as a
+            // fresh chassis-rooted chain via `send_envelope_as_root`
+            // and subscribe to its settlement, so the driver can wait
+            // for the full causal chain (component handler → emitted
+            // DrawTriangle → render cap accumulator) to land before
+            // `render_and_capture` runs. Without this gate the cross-
+            // thread chain races the wake-and-render path and an
+            // empty `frame_vertices` falls back to the (empty) cache
+            // → solid-background frame. Same primitive RpcServer uses
+            // for wire-borne Calls (a pre-mail is causally external
+            // from the cap's perspective — triggered by a wire-borne
+            // CaptureFrame, not forwarded from in-flight context).
+            //
+            // If the chassis didn't install a settlement registry
+            // (some test fixtures), the loop still dispatches the
+            // mails but `pre_settlements` stays empty so the driver
+            // renders immediately — preserving the pre-fix behaviour
+            // on those fixtures.
+            let settlement_registry = self.mailer.settlement_registry().cloned();
+            let mut pre_settlements = Vec::with_capacity(pre.len());
             for envelope in pre {
-                self.mailer.push(envelope);
+                let mail_id =
+                    ctx.send_envelope_as_root(envelope.recipient, envelope.kind, &envelope.payload);
+                if let Some(reg) = settlement_registry.as_deref() {
+                    pre_settlements.push(reg.subscribe_settlement(mail_id));
+                }
             }
 
             let pending = PendingCapture {
                 reply_to: sender,
                 after_mails: after,
+                pre_settlements,
             };
             if !backend.queue.request(pending) {
                 backend.outbound.send_reply(

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -210,9 +210,27 @@ fn run_frame(
 
     match capture_queue.take() {
         Some(req) => {
-            let result = match gpu.render_and_capture() {
-                Ok(png) => CaptureFrameResult::Ok { png },
-                Err(error) => CaptureFrameResult::Err { error },
+            // iamacoffeepot/aether#860: wait for pre-mail settlement
+            // before rendering (mirrors the test-bench lib fix). The
+            // standalone bin replies `Err` on stuck-chain rather than
+            // bailing out of the frame loop.
+            let mut pre_failed: Option<String> = None;
+            for rx in req.pre_settlements {
+                if rx.recv_timeout(std::time::Duration::from_secs(5)).is_err() {
+                    pre_failed = Some(
+                        "capture pre-mail chain failed to settle within 5s — \
+                         a downstream cap is wedged"
+                            .to_owned(),
+                    );
+                    break;
+                }
+            }
+            let result = match pre_failed {
+                Some(error) => CaptureFrameResult::Err { error },
+                None => match gpu.render_and_capture() {
+                    Ok(png) => CaptureFrameResult::Ok { png },
+                    Err(error) => CaptureFrameResult::Err { error },
+                },
             };
             for mail in req.after_mails {
                 queue.push(mail);

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -507,9 +507,32 @@ impl ApplicationHandler<UserEvent> for App {
                 if let Some(gpu) = self.gpu.as_mut() {
                     match pending_capture {
                         Some(req) => {
-                            let result = match gpu.render_and_capture() {
-                                Ok(png) => CaptureFrameResult::Ok { png },
-                                Err(error) => CaptureFrameResult::Err { error },
+                            // iamacoffeepot/aether#860: wait for each
+                            // pre-mail's causal chain to settle before
+                            // rendering, mirroring the test-bench fix.
+                            // The desktop driver doesn't have a
+                            // `SettlementTimeout` error to surface, so
+                            // a stuck chain replies the capture with
+                            // an `Err` and continues the frame loop
+                            // (the user can retry without crashing
+                            // the chassis).
+                            let mut pre_failed: Option<String> = None;
+                            for rx in req.pre_settlements {
+                                if rx.recv_timeout(std::time::Duration::from_secs(5)).is_err() {
+                                    pre_failed = Some(
+                                        "capture pre-mail chain failed to settle within 5s — \
+                                         a downstream cap is wedged"
+                                            .to_owned(),
+                                    );
+                                    break;
+                                }
+                            }
+                            let result = match pre_failed {
+                                Some(error) => CaptureFrameResult::Err { error },
+                                None => match gpu.render_and_capture() {
+                                    Ok(png) => CaptureFrameResult::Ok { png },
+                                    Err(error) => CaptureFrameResult::Err { error },
+                                },
                             };
                             for mail in req.after_mails {
                                 self.queue.push(mail);

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -776,6 +776,24 @@ impl TestBench {
 
         match self.capture_queue.take() {
             Some(req) => {
+                // iamacoffeepot/aether#860: wait for each pre-mail's
+                // causal chain to settle before rendering. Matches the
+                // structural settlement gate the Advance path uses for
+                // `Tick` above — without this, the cross-thread chain
+                // pre-mails kick off (component handler → emitted
+                // DrawTriangle → render cap accumulator) races
+                // `render_and_capture` and an empty `frame_vertices`
+                // falls back to the cache. Empty `pre_settlements`
+                // (no pre-mails, or a chassis without trace pipeline)
+                // skips the loop cleanly.
+                for rx in req.pre_settlements {
+                    if rx.recv_timeout(SETTLEMENT_TIMEOUT).is_err() {
+                        return Err(TestBenchError::SettlementTimeout {
+                            recipient: "capture pre-mail chain".to_owned(),
+                            kind_name: "<pre-mail>",
+                        });
+                    }
+                }
                 let result = match self.gpu.render_and_capture() {
                     Ok(png) => CaptureFrameResult::Ok { png },
                     Err(error) => CaptureFrameResult::Err { error },

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -27,6 +27,8 @@
 
 use std::sync::{Arc, Mutex};
 
+use crossbeam_channel::Receiver;
+
 use crate::mail::{Mail, ReplyTo};
 
 /// One pending capture request. Carries the reply handle so the
@@ -34,9 +36,20 @@ use crate::mail::{Mail, ReplyTo};
 /// of `after_mails` the control plane already validated; the
 /// render thread pushes them onto the queue after readback, before
 /// replying.
+///
+/// `pre_settlements` is one settlement receiver per chassis-rooted
+/// pre-mail the render cap pushed before parking this request
+/// (iamacoffeepot/aether#860). The driver waits on each receiver
+/// before rendering so the cross-thread causal chain triggered by
+/// the pre-mails (component handlers → emitted DrawTriangle →
+/// render cap accumulator) has fully landed before readback. Empty
+/// when there were no pre-mails or when the chassis didn't install
+/// a settlement registry (in which case the driver renders
+/// immediately, preserving pre-fix behaviour on test fixtures).
 pub struct PendingCapture {
     pub reply_to: ReplyTo,
     pub after_mails: Vec<Mail>,
+    pub pre_settlements: Vec<Receiver<()>>,
 }
 
 /// Single-slot queue. Cheaply cloneable (wraps an `Arc`), shared
@@ -86,6 +99,7 @@ mod tests {
         PendingCapture {
             reply_to: reply_to(u),
             after_mails: Vec::new(),
+            pre_settlements: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- `RenderCapability::on_capture_frame` now dispatches each `CaptureFrame.pre_mails` via `ctx.send_envelope_as_root` (the existing chassis-root primitive `RpcServer` uses for wire-borne Calls) and subscribes to each root's settlement, stashing the receivers in `PendingCapture.pre_settlements`.
- Driver consumers (`test_bench::bench::run_frame`, `desktop::driver`, `bin/test-bench`) wait on each `pre_settlements` receiver before calling `render_and_capture`. Test-bench surfaces stuck chains as `TestBenchError::SettlementTimeout`; desktop / standalone reply `CaptureFrameResult::Err` and continue the frame loop.
- Empty `pre_settlements` (no pre-mails, or chassis without a trace pipeline) skips the loop cleanly — preserves pre-fix behaviour on test fixtures that don't bring up settlement.

## Why

`capture_with_mails` was racing the cross-thread chain `mailer worker → component handler → render cap accumulator` against `gpu.render_and_capture()`. The Advance path's `Tick` settlement gate (ADR-0080 §6) already gives the structural pattern; this PR applies the same shape to the capture path's pre-mails. Full root-cause writeup + speculation-validation lives at iamacoffeepot/aether#860.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets` clean (pre-existing `unwrap_used` warns untouched)
- `cargo fmt -- --check` clean
- `cargo nextest run -p aether-substrate-bundle --test test_bench_scenario` — 8/8 pass
- Target test in isolation × 100 — 100/100 pass on macOS (full Linux-CI stress is what this PR is for)
- `cargo test --doc` clean

The macOS stress numbers don't capture the contention CI exposes, so the real test is Linux CI green here + on three subsequent main runs after merge.

Closes iamacoffeepot/aether#860
