### PR TITLE
fix(substrate): drain_budget_yields_for_requeue flakes under CPU contention (issue 869)

### DIFF
--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -533,13 +533,24 @@ pub(crate) mod tests {
         }
         slot.state.try_wake();
 
-        let result = run_one_cycle(&slot);
+        // Generous wallclock so only the count budget (`BATCH_MAX_MAILS`)
+        // can trip — this test asserts the exact dispatched count after
+        // the budget trips, so a 200μs wallclock (the `standard()`
+        // default) racing the count under CI CPU contention would
+        // dispatch some `N < BATCH_MAX_MAILS` and flake the assert
+        // (iamacoffeepot/aether#869). Same workaround `drain_empty_returns_idle`
+        // uses for the same reason.
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let result = slot.run_cycle(budget);
         assert_eq!(result, CycleResult::Requeue);
         assert_eq!(slot.dispatched(), BATCH_MAX_MAILS);
         assert_eq!(slot.state.current(), SlotStateLabel::Ready);
 
-        // Second cycle drains the rest.
-        let result = run_one_cycle(&slot);
+        // Second cycle drains the rest. Same wallclock isolation — the
+        // remaining 50 envelopes shouldn't trip the count budget but
+        // could trip the 200μs wallclock under contention.
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let result = slot.run_cycle(budget);
         assert_eq!(result, CycleResult::Idle);
         assert_eq!(slot.dispatched(), BATCH_MAX_MAILS + 50);
         assert_eq!(slot.state.current(), SlotStateLabel::Idle);


### PR DESCRIPTION
## Summary

`drain_budget_yields_for_requeue` was using `BatchBudget::standard()`, which carries a 200μs wallclock budget alongside the 64-mail count. The test asserts the exact dispatched count after the first cycle, which only holds when the *count* budget trips first — under CI CPU contention the wallclock won the race and the assertion flaked.

Fix: both `run_one_cycle` calls in this test now use `BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60))` — generous wallclock so only the count budget can trip. Same pattern the sibling `drain_empty_returns_idle` test already used for the same reason; its doc comment even names this test as "the one that covers the budget invariant," which it does now-without-the-race.

## Verification

- 100/100 isolated runs pass locally on macOS
- `cargo check --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets` clean
- `cargo fmt -- --check` clean

Real validation is Linux CI green here + three subsequent main runs after merge.

Closes iamacoffeepot/aether#869
