### PR TITLE
chore(substrate): sweep math intentional-pattern lints (854 phase 2.4)

### DIFF
--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -1,3 +1,7 @@
+// Camera math: bounded tick counts cast to f32 for orbit angle
+// accumulation are domain-correct.
+#![allow(clippy::cast_precision_loss)]
+
 //! Multi-camera runtime. Hosts N named cameras (each in one of two
 //! modes — orbit or orthographic top-down), advances every camera each
 //! tick, and publishes the active camera's `view_proj` to

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -599,6 +599,8 @@ mod native {
         let channels = config.channels;
 
         let (sender, queue) = new_event_channel();
+        // Audio sample rates are bounded well below 2^24 — exact in f32.
+        #[allow(clippy::cast_precision_loss)]
         let mut synth = Synth::new(queue, sample_rate as f32);
 
         let stream = device

--- a/crates/aether-math/src/mat.rs
+++ b/crates/aether-math/src/mat.rs
@@ -1,3 +1,7 @@
+// Matrix math: single-letter names (`a`, `b`, `c`, `d` for matrix
+// elements / rows / columns) are the canonical linear-algebra vocabulary.
+#![allow(clippy::many_single_char_names)]
+
 use core::ops::Mul;
 
 use crate::quat::Quat;

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -1,3 +1,9 @@
+// Coplanar merge: single-letter `a` / `b` for directed-edge twins is
+// the canonical edge-cancellation vocabulary. `cast_lossless` fires on
+// the routine `i32 → i64` widening of integer-grid edge components
+// fed into the exact-arithmetic merge predicates.
+#![allow(clippy::many_single_char_names, clippy::cast_lossless)]
+
 //! Pass 2: coplanar polygon merging — emits boundary loops as n-gons.
 //!
 //! Groups polygons by `(Plane3, color)` and runs a single directed-edge

--- a/crates/aether-mesh/src/cleanup/slivers.rs
+++ b/crates/aether-mesh/src/cleanup/slivers.rs
@@ -1,3 +1,8 @@
+// Integer-grid arithmetic: `i32 → i64 → i128` widenings on snapped
+// fixed-point coordinates feed the exact predicates that classify
+// sliver pairs. The widening is structurally lossless.
+#![allow(clippy::cast_lossless)]
+
 //! Pass 4: sliver-edge removal.
 //!
 //! After T-junction repair, off-axis CSG can still leave polygons with

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -1,3 +1,8 @@
+// Integer-grid arithmetic: `i32 → i64 → i128` widenings on snapped
+// fixed-point coordinates feed the exact predicates that detect
+// T-junctions. The widening is structurally lossless.
+#![allow(clippy::cast_lossless)]
+
 //! Pass 3: T-junction removal.
 //!
 //! After welding + coplanar merging, an edge of one merged region may

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -1,3 +1,15 @@
+// Mesh debug math: bounded counts cast to f32 for averaging, scalar
+// accumulators that don't benefit from FMA, and single-letter names
+// for edge / vertex / face math are canonical. `cast_possible_truncation`
+// fires on the bounded `usize` vertex/face counts cast to `u32` for
+// debug counter formatting.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::suboptimal_flops,
+    clippy::many_single_char_names,
+    clippy::cast_possible_truncation
+)]
+
 //! Debug + invariant-checking tools for the polygon-domain mesh
 //! pipeline (ADR-0057). Used by regression tests and on-demand from
 //! the editor to diagnose topology issues without round-tripping

--- a/crates/aether-mesh/src/fixed.rs
+++ b/crates/aether-mesh/src/fixed.rs
@@ -1,3 +1,10 @@
+// Fixed-point conversion: bounded `i32` snapped grid values cast to
+// f32 are domain-correct at the CSG ↔ float boundary; the
+// truncating casts (`f32 → i32`, `i64 → i32`) in this file are gated
+// by explicit range checks against `MAX_INPUT_MAGNITUDE` / `SCALE`
+// per the module doc.
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
 //! 16:16 binary fixed-point conversion at the CSG boundary.
 //!
 //! Per ADR-0054, all coordinates entering the CSG core are snapped to a

--- a/crates/aether-mesh/src/loop_polygon.rs
+++ b/crates/aether-mesh/src/loop_polygon.rs
@@ -1,3 +1,15 @@
+// Integer-grid arithmetic: `i32 → i64 → i128` widenings move snapped
+// fixed-point coords into the exact predicates that classify points
+// against planes; the truncating `i128 → i32` back-cast after the
+// rounding division is bounded by the ±2^24 fixed-coord budget; the
+// `i128 → u128` sign-loss casts feed the absolute-value magnitude
+// comparison used to pick the dominant axis.
+#![allow(
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
 //! Convex polygon over integer-grid vertices, plus the split-against-plane
 //! routine that drives BSP construction and clipping.
 //!

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -1,3 +1,15 @@
+// Mesh primitives are domain math: bounded integer counts cast to f32,
+// scalar accumulators that don't benefit from FMA, and `a`/`b`/`c`/`d`
+// for triangle vertices and matrix elements are the canonical vocabulary.
+// `cast_lossless` fires on the routine `i32 → i64` widening into the
+// exact-arithmetic integer-grid coord pipeline.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::suboptimal_flops,
+    clippy::many_single_char_names,
+    clippy::cast_lossless
+)]
+
 //! Mesh a typed AST into a triangle list.
 //!
 //! Full v1 vocabulary per ADR-0026 + ADR-0051: primitives `box`,

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -1,3 +1,15 @@
+// Every cast in this file moves an exact integer between explicitly
+// budgeted integer widths (i32 → i64 → i128 → u128) per the magnitude
+// bounds in the module doc. The byte layout is the load-bearing
+// contract; `From::from` / `try_into` would obscure the bit-width
+// reasoning that makes the predicates exact.
+#![allow(
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
 //! Integer-coefficient plane representation: `n · P = d`.
 //!
 //! Computed from three integer points via the cross product. Side tests

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -1,3 +1,7 @@
+// Polygon math: bounded vertex counts cast to f32 for centroid /
+// averaging, scalar accumulators that don't benefit from FMA.
+#![allow(clippy::cast_precision_loss, clippy::suboptimal_flops)]
+
 //! Public n-gon polygon API (ADR-0057).
 //!
 //! `Polygon` is the canonical mesh form for the engine — one `Polygon`

--- a/crates/aether-mesh/src/serialize.rs
+++ b/crates/aether-mesh/src/serialize.rs
@@ -185,7 +185,7 @@ fn kw(s: &str) -> Value {
 }
 
 fn num(f: f32) -> Value {
-    Value::Number(Number::from_f64(f as f64).expect("non-finite float in AST"))
+    Value::Number(Number::from_f64(f64::from(f)).expect("non-finite float in AST"))
 }
 
 fn uint(n: u32) -> Value {

--- a/crates/aether-mesh/src/simplify.rs
+++ b/crates/aether-mesh/src/simplify.rs
@@ -1,3 +1,6 @@
+// Mesh simplification: scalar accumulators that don't benefit from FMA.
+#![allow(clippy::suboptimal_flops)]
+
 //! AST simplification: pure `Node → Node` rewrites that preserve the
 //! mesh result while reducing work the mesher has to do.
 //!

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -1,3 +1,7 @@
+// Tessellation math: bounded vertex counts cast to f32 for fan
+// triangulation indices are domain-correct.
+#![allow(clippy::cast_precision_loss)]
+
 //! Polygon → triangle conversion for the wire `Vec<Triangle>` path.
 //!
 //! Splits cleanly off the `cleanup` module: cleanup's job is to *fix*

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -758,11 +758,15 @@ impl DriverRunning for DesktopDriverRunning {
 
         let total = triangles_rendered.load(Ordering::Relaxed);
         let elapsed = app.started.map(|s| s.elapsed()).unwrap_or_default();
+        // Frame count cast to f64 for FPS report — runs at shutdown,
+        // bounded well below 2^53.
+        #[allow(clippy::cast_precision_loss)]
+        let fps = app.frame as f64 / elapsed.as_secs_f64().max(0.001);
         tracing::info!(
             target: "aether_substrate::shutdown",
             frames = app.frame,
             elapsed_ms = elapsed.as_secs_f64() * 1000.0,
-            fps = app.frame as f64 / elapsed.as_secs_f64().max(0.001),
+            fps = fps,
             triangles = total,
             "frame loop exited",
         );

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -1,3 +1,8 @@
+// Sokoban grid math: bounded `usize` grid coordinates cast to f32 for
+// world-space placement, and single-letter `a` / `b` / `c` for triangle
+// vertices are the canonical vocabulary.
+#![allow(clippy::cast_precision_loss, clippy::many_single_char_names)]
+
 //! Sokoban demo: a grid-based puzzle world. The world owns walls,
 //! boxes, targets, the player's grid position, *and* the player's
 //! visible body — there is no longer a separate player component.


### PR DESCRIPTION
Closes iamacoffeepot/aether#874

Phase 2.4 of iamacoffeepot/aether#854 lint adoption. Sweeps the math intentional-pattern cluster (`cast_precision_loss`, `suboptimal_flops`, `many_single_char_names`, `imprecise_flops`) by adding per-file `#![allow(...)]` declarations with one-line rationale comments. Paired allows for `cast_lossless` / `cast_possible_truncation` / `cast_possible_wrap` / `cast_sign_loss` on the integer-grid CSG predicate files where the widenings are structurally exact.

- Per-file allows: `aether-mesh` mesh.rs, debug.rs, polygon.rs, fixed.rs, simplify.rs, tessellate.rs, cleanup/merge.rs, cleanup/slivers.rs, cleanup/tjunctions.rs, loop_polygon.rs, plane.rs; `aether-math/mat.rs`; `aether-camera/runtime.rs`; `demos/sokoban/lib.rs`.
- Per-site allows: `aether-capabilities/audio.rs` sample-rate cast, `aether-substrate-bundle/desktop/driver.rs` shutdown FPS report.
- `aether-mesh/serialize.rs` swapped `as f64` for `f64::from(f)` (lossless widening, no allow needed).

Verified locally: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (0 hits for the 4 named lints), `cargo fmt -- --check`, `cargo nextest run --workspace` (1001/1001 pass), `cargo test --doc` all green.