### PR TITLE
chore(substrate): sweep clippy::missing_panics_doc (issue 854 phase 2.5)

### DIFF
--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -168,6 +168,10 @@ impl FfiCtx<'_> {
     /// substrate-side `fatal_abort` path. Symmetric to
     /// `aether_substrate::actor::native::NativeCtx::fatal_abort` so
     /// trap-escalation reads the same on both sides.
+    ///
+    /// # Panics
+    /// Always panics — that's the point. The trap propagates to the
+    /// substrate's ADR-0063 fail-fast escalation path.
     pub fn fatal_abort(&self, reason: alloc::string::String) -> ! {
         panic!("aether-actor: fatal_abort: {reason}")
     }
@@ -314,6 +318,12 @@ impl FfiDropCtx<'_> {
     }
 
     /// Deposit a migration bundle. Mirrors [`Persistence::save_state`].
+    ///
+    /// # Panics
+    /// Panics if the host `save_state` import returns non-zero — fail-fast
+    /// per ADR-0063: the persistence bridge is part of the substrate
+    /// contract and a failure here means the runtime is in an
+    /// unrecoverable state.
     pub fn save_state(&mut self, version: u32, bytes: &[u8]) {
         let status = PERSIST_BRIDGE.save_state(version, bytes);
         assert!(

--- a/crates/aether-actor/src/ffi/raw.rs
+++ b/crates/aether-actor/src/ffi/raw.rs
@@ -65,36 +65,60 @@ unsafe extern "C" {
     pub fn init_failed(ptr: u32, len: u32);
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::send_mail` import. Always
 /// panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub unsafe fn send_mail(_recipient: u64, _kind: u64, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-actor: send_mail called outside the FFI guest");
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::reply_mail` import. Always
 /// panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub unsafe fn reply_mail(_sender: u32, _kind: u64, _ptr: u32, _len: u32, _count: u32) -> u32 {
     panic!("aether-actor: reply_mail called outside the FFI guest");
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::save_state` import. Always
 /// panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub unsafe fn save_state(_version: u32, _ptr: u32, _len: u32) -> u32 {
     panic!("aether-actor: save_state called outside the FFI guest");
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::wait_reply` import. Always
 /// panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub unsafe fn wait_reply(
@@ -107,18 +131,30 @@ pub unsafe fn wait_reply(
     panic!("aether-actor: wait_reply called outside the FFI guest");
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::prev_correlation` import.
 /// Always panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub unsafe fn prev_correlation() -> u64 {
     panic!("aether-actor: prev_correlation called outside the FFI guest");
 }
 
-/// # Safety
 /// Host-side stub for the FFI `aether::init_failed` import.
 /// Always panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
 #[cfg(not(target_arch = "wasm32"))]
 pub unsafe fn init_failed(_ptr: u32, _len: u32) {
     panic!("aether-actor: init_failed called outside the FFI guest");

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -424,9 +424,13 @@ mod native {
         /// The driver constructs [`RenderGpu`] once it has a device +
         /// queue — for desktop that's inside `resumed` after winit hands
         /// back a window and surface; for test-bench it's right after
-        /// `build_passive` returns. Calling twice panics: install is the
-        /// chassis's promise that wgpu state is now ready and stable for
-        /// the chassis lifetime.
+        /// `build_passive` returns.
+        ///
+        /// # Panics
+        /// Panics if called more than once — fail-fast per ADR-0063:
+        /// install is the chassis's promise that wgpu state is now
+        /// ready and stable for the chassis lifetime; a double install
+        /// indicates a chassis-wiring bug.
         pub fn install_gpu(&self, gpu: RenderGpu) {
             self.gpu
                 .set(gpu)
@@ -485,6 +489,12 @@ mod native {
         ///
         /// Lock ordering: `frame_vertices` first, then
         /// `last_submitted`. Today only this function holds both.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called, or if any of the
+        /// internal mutexes (frame vertices, last submitted, camera
+        /// state, targets) are poisoned — fail-fast per ADR-0063: both
+        /// indicate a substrate-level invariant violation.
         pub fn record_frame(
             &self,
             encoder: &mut wgpu::CommandEncoder,
@@ -532,6 +542,10 @@ mod native {
         /// readback buffer is reallocated on size mismatch with the
         /// current offscreen, so any sequence of resize → `record_frame` →
         /// `record_capture_copy` → submit → `finish_capture` works.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
             let gpu = self.expect_gpu();
             let mut targets = gpu.targets.lock().unwrap();
@@ -541,6 +555,10 @@ mod native {
         /// Map the readback buffer prepared by [`Self::record_capture_copy`]
         /// and return the encoded PNG. Call after the encoder containing
         /// the matching `record_capture_copy` has been submitted.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
             let gpu = self.expect_gpu();
             let targets = gpu.targets.lock().unwrap();
@@ -549,6 +567,10 @@ mod native {
 
         /// Resize the offscreen color + depth targets. Idempotent on
         /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn resize(&self, width: u32, height: u32) {
             let gpu = self.expect_gpu();
             let mut targets = gpu.targets.lock().unwrap();
@@ -583,6 +605,10 @@ mod native {
 
         /// Current offscreen color target dimensions. Drivers reading
         /// after a `resize` see the new dimensions immediately.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
         #[must_use]
         pub fn color_size(&self) -> (u32, u32) {
             let targets = self.expect_gpu().targets.lock().unwrap();
@@ -594,6 +620,10 @@ mod native {
         /// mutex, so any encoder commands recorded inside are sequenced
         /// against any concurrent resize. Test-bench reaches the
         /// offscreen via the capture path and doesn't need this.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn with_color_texture<F, R>(&self, f: F) -> R
         where
             F: FnOnce(&wgpu::Texture) -> R,

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -70,6 +70,12 @@ impl From<postcard::Error> for FrameError {
 /// Encode a message into its framed wire representation (4-byte LE
 /// length prefix + postcard body). Infallible — postcard encoding
 /// of `alloc::Vec` is infallible for the types this is used with.
+///
+/// # Panics
+/// Panics if postcard encoding of `msg` fails — fail-fast per ADR-0063:
+/// `postcard::to_allocvec` into a growable `Vec` cannot fail for the
+/// `Serialize` types this is used with, so a failure indicates the
+/// caller passed a type whose serializer is observably broken.
 pub fn encode_frame<T: Serialize>(msg: &T) -> Vec<u8> {
     let body = postcard::to_allocvec(msg).expect("postcard encode to Vec is infallible");
     let mut out = Vec::with_capacity(4 + body.len());

--- a/crates/aether-data/src/canonical/labels.rs
+++ b/crates/aether-data/src/canonical/labels.rs
@@ -127,6 +127,12 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
 }
 
 /// Serialize `labels` into `N` bytes of canonical postcard form.
+///
+/// # Panics
+/// Panics if `N` does not match the byte length the size pass
+/// (`canonical_serialize_labels_len`) reports for `labels` — fail-fast
+/// per ADR-0063: callers pair the two passes via the same `const`
+/// inputs, so a mismatch is a bug in the serializer or its caller.
 #[must_use]
 pub const fn canonical_serialize_labels<const N: usize>(labels: &KindLabels) -> [u8; N] {
     let mut out = [0u8; N];

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -90,6 +90,14 @@ pub const fn varint_u32_len(val: u32) -> usize {
     }
 }
 
+/// Byte count of `val` in postcard's unsigned-varint encoding, after
+/// narrowing `usize` to `u32`. Used by `const` size passes that walk
+/// schema arrays whose lengths fit in `u32` by construction.
+///
+/// # Panics
+/// Panics if `val > u32::MAX` — fail-fast per ADR-0063: callers
+/// guarantee the input fits in `u32` by walking bounded `const`
+/// structures, so an overflow indicates a bug in the caller.
 #[must_use]
 pub const fn varint_usize_len(val: usize) -> usize {
     assert!(

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -130,6 +130,12 @@ const fn canonical_len_variant(variant: &EnumVariant) -> usize {
 
 /// Serialize `schema` into `N` bytes of canonical postcard form.
 /// Caller passes `N = canonical_len_schema(schema)`.
+///
+/// # Panics
+/// Panics if `N` does not match the byte length the size pass
+/// (`canonical_len_schema`) reports for `schema` — fail-fast per
+/// ADR-0063: callers pair the two passes via the same `const` inputs,
+/// so a mismatch is a bug in the serializer or its caller.
 #[must_use]
 pub const fn canonical_serialize_schema<const N: usize>(schema: &SchemaType) -> [u8; N] {
     let mut out = [0u8; N];
@@ -151,6 +157,12 @@ pub const fn canonical_len_kind(name: &str, schema: &SchemaType) -> usize {
 /// Serialize `(name, schema)` into `N` bytes of a canonical postcard
 /// record. These are the bytes that populate `aether.kinds` (one
 /// record per `#[derive(Kind)]` type) and that `Kind::ID` hashes over.
+///
+/// # Panics
+/// Panics if `N` does not match the byte length the size pass
+/// (`canonical_len_kind`) reports for `(name, schema)` — fail-fast per
+/// ADR-0063: callers pair the two passes via the same `const` inputs,
+/// so a mismatch is a bug in the serializer or its caller.
 #[must_use]
 pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &SchemaType) -> [u8; N] {
     let mut out = [0u8; N];
@@ -176,6 +188,11 @@ pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &Schem
 /// const serializer also drops, so the two paths produce
 /// byte-identical output. Pinned by the `canonical_kind_bytes_runtime_
 /// matches_const` test below.
+///
+/// # Panics
+/// Panics if postcard encoding of the `KindShape` fails — fail-fast
+/// per ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot
+/// fail for `KindShape`, so a failure indicates a serializer bug.
 #[must_use]
 pub fn canonical_kind_bytes(name: &str, schema: &SchemaType) -> alloc::vec::Vec<u8> {
     let shape = crate::schema::KindShape {
@@ -271,6 +288,11 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 /// `postcard(KindShape)`, so we postcard the shape directly without a
 /// `SchemaShape → SchemaType` detour. Used by `kind_manifest` to key
 /// labels records by id after decoding both sections off the wasm.
+///
+/// # Panics
+/// Panics if postcard encoding of `shape` fails — fail-fast per
+/// ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot fail
+/// for `KindShape`, so a failure indicates a serializer bug.
 #[must_use]
 pub fn kind_id_from_shape(shape: &crate::schema::KindShape) -> u64 {
     let bytes =

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -613,6 +613,12 @@ pub fn decode_slice<T: Kind + bytemuck::AnyBitPattern>(bytes: &[u8]) -> Result<&
 }
 
 /// Encode a structural value via postcard.
+///
+/// # Panics
+/// Panics if postcard encoding of `value` fails — fail-fast per ADR-0063:
+/// `postcard::to_allocvec` into a growable `Vec` cannot fail for the
+/// `Serialize` types this is used with, so a failure indicates the
+/// caller passed a type whose serializer is observably broken.
 pub fn encode_struct<T: Kind + serde::Serialize>(value: &T) -> Vec<u8> {
     postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
 }

--- a/crates/aether-math/src/aabb.rs
+++ b/crates/aether-math/src/aabb.rs
@@ -225,7 +225,11 @@ impl Aabb {
 
     /// Mirror across the plane `axis_index = 0` (`0 = X, 1 = Y, 2 = Z`).
     /// The bounds along that axis flip sign and swap; the others are
-    /// unchanged. Panics if `axis_index > 2`.
+    /// unchanged.
+    ///
+    /// # Panics
+    /// Panics if `axis_index > 2` — the only valid values are `0`, `1`,
+    /// or `2`.
     #[must_use]
     pub fn mirror(&self, axis_index: usize) -> Self {
         assert!(axis_index < 3, "axis_index must be 0, 1, or 2");

--- a/crates/aether-mesh/src/serialize.rs
+++ b/crates/aether-mesh/src/serialize.rs
@@ -8,6 +8,13 @@ use lexpr::{Cons, Number, Value};
 use crate::ast::Node;
 use aether_math::Vec3;
 
+/// Serialize a typed mesh AST to its canonical Lisp s-expression form.
+///
+/// # Panics
+/// Panics if writing to the in-memory `Vec` buffer fails or if `lexpr`
+/// emits non-UTF-8 bytes — fail-fast per ADR-0063: both conditions are
+/// structurally impossible (Vec writes never fail; lexpr emits UTF-8),
+/// so a failure indicates an upstream bug.
 #[must_use]
 pub fn serialize(node: &Node) -> String {
     let value = node_to_value(node);

--- a/crates/aether-mesh/src/simplify.rs
+++ b/crates/aether-mesh/src/simplify.rs
@@ -21,6 +21,13 @@ use aether_math::Vec3;
 
 /// Recursively simplify `node`. Pure transformation: input + output
 /// always describe the same mesh.
+///
+/// # Panics
+/// Panics if internal invariants are violated — fail-fast per
+/// ADR-0063: the single-child `composition` unwrap proves the vector
+/// has one element via `simplified.len() == 1` before the `unwrap`,
+/// so an unwrap failure would indicate a mid-iter mutation that
+/// cannot occur in safe code.
 pub fn simplify(node: &Node) -> Node {
     match node {
         Node::Box { .. }

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -93,6 +93,15 @@ impl WireframeMode {
 }
 
 impl Gpu {
+    /// Construct the desktop chassis's wgpu state: instance, surface,
+    /// adapter, device, queue, pipeline, and the shared `RenderHandles`
+    /// install. Called once during desktop boot from inside winit's
+    /// `resumed` handler.
+    ///
+    /// # Panics
+    /// Panics if surface creation, adapter selection, or device
+    /// acquisition fail — fail-fast per ADR-0063: the desktop chassis
+    /// can't proceed without a usable GPU pipeline.
     pub fn new(window: Arc<Window>, render_handles: RenderHandles) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -342,6 +342,11 @@ impl TestBench {
     /// / session-zero frames that arrived on the loopback. Mail to
     /// other sinks and direct component-to-component flows are not
     /// observed (v1).
+    ///
+    /// # Panics
+    /// Panics if the `observed_kinds` mutex is poisoned — fail-fast
+    /// per ADR-0063: a poisoned mutex means a prior holder panicked
+    /// under the guard.
     pub fn count_observed(&self, kind_name: &str) -> usize {
         self.observed_kinds
             .lock()
@@ -354,6 +359,11 @@ impl TestBench {
     /// Snapshot every kind name currently observed, oldest first.
     /// Cheap clone — used for scenario diagnostics when an assert
     /// trips, so the failure message can list "what we did see."
+    ///
+    /// # Panics
+    /// Panics if the `observed_kinds` mutex is poisoned — fail-fast
+    /// per ADR-0063: a poisoned mutex means a prior holder panicked
+    /// under the guard.
     pub fn observed_kinds(&self) -> Vec<String> {
         self.observed_kinds.lock().unwrap().clone()
     }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -165,6 +165,13 @@ impl TestBenchChassis {
     /// further capability adds (io with whatever failure semantics
     /// it wants), GPU creation, egress-backend attach, and driving
     /// the event loop.
+    ///
+    /// # Panics
+    /// Panics if the `Tick` kind isn't registered in the substrate boot
+    /// — fail-fast per ADR-0063: `Tick` is part of the always-on kind
+    /// vocabulary the substrate registers from
+    /// `aether_kinds::descriptors::all()`, so a missing entry indicates
+    /// a substrate-build bug.
     pub fn build_passive(env: TestBenchEnv) -> anyhow::Result<TestBenchBuild> {
         let TestBenchEnv {
             name,

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -33,6 +33,13 @@ impl Gpu {
     /// `render_running` so encoder methods on the running can read
     /// them. `width` and `height` size the offscreen color + depth
     /// targets — the dimensions every captured frame will report.
+    ///
+    /// # Panics
+    /// Panics if adapter selection or device acquisition fail —
+    /// fail-fast per ADR-0063: the test bench can't proceed without a
+    /// usable offscreen wgpu pipeline, and driverless dev boxes are
+    /// expected to skip the test entirely (handled at the scenario
+    /// runner layer per ADR-0067).
     #[must_use]
     pub fn new(width: u32, height: u32, render_handles: RenderHandles) -> Self {
         let instance =

--- a/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
@@ -80,6 +80,12 @@ pub fn has_wgpu_adapter() -> bool {
 /// `CARGO_MANIFEST_DIR` is irrelevant because the wasm artifacts live
 /// under the shared workspace target dir, which is the same for every
 /// caller.
+///
+/// # Panics
+/// Panics if `CARGO_MANIFEST_DIR` does not have two ancestor
+/// directories — fail-fast per ADR-0063: this helper only runs from
+/// integration-test binaries (`crates/<crate>/tests/...`), so the
+/// workspace root is always two levels up.
 #[must_use]
 pub fn locate_component_wasm(crate_name: &str) -> Option<PathBuf> {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -106,6 +112,12 @@ pub fn locate_component_wasm(crate_name: &str) -> Option<PathBuf> {
 /// CI catches a forgotten pre-build entry instead of passing a 30 ms
 /// vacuous test. CI sets this; local devs leave it unset and keep the
 /// existing skip behavior.
+///
+/// # Panics
+/// Panics in strict (`AETHER_REQUIRE_RUNTIME=1`) mode if either no
+/// wgpu adapter is available or the named crate's wasm artifact is
+/// not pre-built — fail-fast per ADR-0063: CI relies on the strict
+/// mode to catch missing pre-build entries.
 #[must_use]
 pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
     let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
@@ -144,6 +156,10 @@ pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
 /// like `"mesh-viewer"` or `"test-bench-io"`. Each integration test
 /// binary is its own process, so the label is only ever set once per
 /// process and collisions across binaries don't arise.
+///
+/// # Panics
+/// Panics if the tempdir can't be created — fail-fast per ADR-0063:
+/// a test that can't reserve its sandbox can't proceed.
 pub fn init_save_sandbox(label: &str) -> &'static Path {
     TEST_SAVE_DIR.get_or_init(|| {
         let dir = std::env::temp_dir().join(format!(
@@ -178,9 +194,12 @@ pub fn test_namespace_roots(save_dir: &Path) -> NamespaceRoots {
 /// namespace root, so callers pass this as the `path` field of
 /// `aether.fs.read` / `aether.mesh.load` / etc.
 ///
-/// Panics if `init_save_sandbox` was never called in this process —
-/// the helper resolves the dir from the same `OnceLock` that
-/// `init_save_sandbox` populates.
+/// # Panics
+/// Panics if [`init_save_sandbox`] was never called in this process,
+/// or if the file write fails — fail-fast per ADR-0063: the helper
+/// resolves the dir from the same `OnceLock` that
+/// `init_save_sandbox` populates, and a failed fixture write means
+/// the test can't proceed.
 pub fn write_fixture(name: &str, bytes: &[u8]) -> String {
     let dir = TEST_SAVE_DIR
         .get()

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -223,6 +223,11 @@ impl NativeBinding {
     /// `wait_reply` has somewhere to pull from. Called once per
     /// transport, before any `wait_reply` invocation. Subsequent
     /// calls panic — the slot is single-claim by construction.
+    ///
+    /// # Panics
+    /// Panics if called more than once — fail-fast per ADR-0063: the
+    /// inbox slot is single-claim, so a second install indicates a
+    /// chassis-wiring bug.
     pub fn install_inbox(&self, inbox: Receiver<Envelope>) {
         self.inbox
             .set(Mutex::new(inbox))
@@ -297,6 +302,11 @@ impl NativeBinding {
     /// `(kind, correlation)` and returns when a *specific* reply
     /// arrives — `recv_blocking` is for the dispatcher's "next
     /// thing, whatever it is" main loop.
+    ///
+    /// # Panics
+    /// Panics if the inbox mutex is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked inside the
+    /// guard, which is itself a substrate-level invariant violation.
     pub fn recv_blocking(&self) -> Option<Envelope> {
         let inbox = self.inbox.get()?;
         // The mutex guard stays held across `recv()`. Dispatcher
@@ -309,6 +319,11 @@ impl NativeBinding {
     /// `None` for "no envelope available right now" or "channel
     /// disconnected" or "no inbox installed". A capability that
     /// needs to distinguish drains via repeated calls until `None`.
+    ///
+    /// # Panics
+    /// Panics if the inbox mutex is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked inside the
+    /// guard, which is itself a substrate-level invariant violation.
     pub fn try_recv(&self) -> Option<Envelope> {
         let inbox = self.inbox.get()?;
         inbox.lock().unwrap().try_recv().ok()
@@ -400,6 +415,12 @@ impl NativeBinding {
     /// Same semantics as the `u32`-returning variant; the success-path
     /// `0` was vestigial at this layer (channel-send failures collapse to
     /// the same scalar).
+    ///
+    /// # Panics
+    /// Panics if the `pending_recipients` mutex is poisoned — fail-fast
+    /// per ADR-0063: a poisoned mutex means a prior holder panicked
+    /// inside the guard, which is itself a substrate-level invariant
+    /// violation.
     pub fn push_envelope_returning_root(
         &self,
         recipient: u64,
@@ -458,6 +479,13 @@ impl NativeBinding {
     /// larger than `out` (mail re-parked for retry), `-3` = the host
     /// tore the actor down mid-wait. Any other negative is a
     /// transport-specific sentinel (e.g. `-100` no-inbox).
+    ///
+    /// # Panics
+    /// Panics if any of the internal mutexes (overflow, pending
+    /// recipients, frame-bound set) are poisoned, or if the cross-class
+    /// guard fires (ADR-0074 §Decision 5: a frame-bound caller blocking
+    /// on a free-running recipient triggers `fatal_abort`) — both are
+    /// fail-fast per ADR-0063.
     pub fn wait_reply(
         &self,
         expected_kind: u64,

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -236,9 +236,11 @@ impl<'a> NativeCtx<'a> {
     /// them so monitoring a singleton works the same way. Until then,
     /// monitor only addresses instanced actors.
     ///
+    /// # Panics
     /// Panics if the transport was constructed via
     /// [`NativeBinding::new_for_test`] (no spawner / actor registry
-    /// wired). Production transports always carry both.
+    /// wired) — fail-fast per ADR-0063: production transports always
+    /// carry both, so handler code never reaches the panic.
     pub fn monitor(&self, target: aether_data::MailboxId) -> Result<MonitorHandle, MonitorError> {
         let spawner = self
             .binding
@@ -260,10 +262,11 @@ impl<'a> NativeCtx<'a> {
     /// `PassiveChassis::spawn_actor` / `BuiltChassis::spawn_actor`
     /// shape; both flow through the same [`crate::Spawner`].
     ///
+    /// # Panics
     /// Panics if the transport was constructed via
     /// [`NativeBinding::new_for_test`] (which doesn't wire a
-    /// spawner). Production transports always carry one, so handler
-    /// code never reaches the panic.
+    /// spawner) — fail-fast per ADR-0063: production transports always
+    /// carry one, so handler code never reaches the panic.
     pub fn spawn_child<'b, A>(
         &'b self,
         subname: super::spawn::Subname<'b>,

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -684,6 +684,13 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
     /// Consume the builder and run the spawn lifecycle. Returns the
     /// new actor's [`MailboxId`] on success, or a typed [`SpawnError`]
     /// describing which lifecycle step failed.
+    ///
+    /// # Panics
+    /// Panics if `finish` is called more than once on the same builder
+    /// (the `Config` slot is taken on first call) — fail-fast per
+    /// ADR-0063: `SpawnBuilder` is a single-use type, the typestate is
+    /// enforced by the move into `finish`, and a double-finish would
+    /// require an unsafe API misuse.
     pub fn finish(self) -> Result<MailboxId, SpawnError> {
         let SpawnBuilder {
             spawner,

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -140,6 +140,11 @@ impl ActorRegistry {
     /// distinguish via this path, by design (ADR-0079: `Dead` is opaque
     /// to lookup; spawn-time retirement check goes through
     /// [`Self::is_tombstoned`]).
+    ///
+    /// # Panics
+    /// Panics if the `actors` `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior writer panicked under
+    /// the guard, a substrate-level invariant violation.
     pub fn is_live(&self, id: MailboxId) -> bool {
         let actors = self.actors.read().unwrap();
         matches!(actors.get(&id), Some(ActorEntry::Live { .. }))
@@ -149,6 +154,11 @@ impl ActorRegistry {
     /// `Sender` is cloned out of the registry's `Arc<Sender>` so the
     /// caller can push mail directly into the actor's inbox without
     /// holding the registry lock or affecting the Arc's strong count.
+    ///
+    /// # Panics
+    /// Panics if the `actors` `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior writer panicked under
+    /// the guard, a substrate-level invariant violation.
     pub fn live_sender(&self, id: MailboxId) -> Option<Sender<Envelope>> {
         let actors = self.actors.read().unwrap();
         match actors.get(&id) {
@@ -160,6 +170,11 @@ impl ActorRegistry {
     /// `TypeId` of the actor occupying the slot at `id`, or `None` if
     /// the slot is `Dead` or missing. The downcast-safety counterpart
     /// to [`Self::is_live`].
+    ///
+    /// # Panics
+    /// Panics if the `actors` `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior writer panicked under
+    /// the guard, a substrate-level invariant violation.
     pub fn type_id_at(&self, id: MailboxId) -> Option<TypeId> {
         let actors = self.actors.read().unwrap();
         match actors.get(&id) {
@@ -170,12 +185,22 @@ impl ActorRegistry {
 
     /// Has this id been tombstoned (its actor closed)? `spawn_child`
     /// uses this in Phase 3 to reject reuse of retired full names.
+    ///
+    /// # Panics
+    /// Panics if the `tombstones` `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior writer panicked under
+    /// the guard, a substrate-level invariant violation.
     pub fn is_tombstoned(&self, id: MailboxId) -> bool {
         self.tombstones.read().unwrap().contains(&id)
     }
 
     /// `TypeId` that owns the given namespace, if any. Populated at
     /// chassis-build (singletons) and first spawn (instanced).
+    ///
+    /// # Panics
+    /// Panics if the `name_owners` `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior writer panicked under
+    /// the guard, a substrate-level invariant violation.
     pub fn namespace_owner(&self, namespace: &'static str) -> Option<TypeId> {
         self.name_owners.read().unwrap().get(namespace).copied()
     }

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -635,6 +635,11 @@ impl Component {
     /// accessor: the production mail path writes at `MAIL_OFFSET`
     /// and the guest interprets the bytes — nothing in non-test
     /// code reads guest memory directly.
+    ///
+    /// # Panics
+    /// Panics if the memory read fails — fail-fast per ADR-0063:
+    /// tests construct the offset/length pair directly, so an
+    /// out-of-bounds read is a test bug.
     #[cfg(test)]
     pub fn read_u32(&mut self, offset: usize) -> u32 {
         let mut buf = [0u8; 4];
@@ -647,6 +652,11 @@ impl Component {
     /// Read `len` bytes from guest linear memory starting at `offset`.
     /// Test-only accessor for verifying that a rehydrate hook copied
     /// bytes to a known marker offset.
+    ///
+    /// # Panics
+    /// Panics if the memory read fails — fail-fast per ADR-0063:
+    /// tests construct the offset/length pair directly, so an
+    /// out-of-bounds read is a test bug.
     #[cfg(test)]
     pub fn read_bytes(&mut self, offset: usize, len: usize) -> Vec<u8> {
         let mut buf = vec![0u8; len];

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -111,6 +111,13 @@ impl<'a> SubstrateBootBuilder<'a> {
     /// chassis main using the fields exposed on [`SubstrateBoot`].
     /// Does NOT dial the hub — chassis mains compose
     /// `aether_hub::HubClientCapability` themselves (issue #262).
+    ///
+    /// # Panics
+    /// Panics if `aether_kinds::descriptors::all()` contains a
+    /// duplicate kind id, or if any of the substrate's internal
+    /// locks are poisoned during the boot sequence — fail-fast per
+    /// ADR-0063: both conditions indicate a substrate-level invariant
+    /// violation discovered before any user code runs.
     pub fn build(self) -> wasmtime::Result<SubstrateBoot> {
         // Issue #321: route panics through tracing so dispatcher-thread
         // crashes surface in `engine_logs` instead of vanishing to

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -69,6 +69,10 @@ impl CaptureQueue {
     /// if the slot was empty and the request is now pending; `false`
     /// if a capture is already in flight. The caller wakes the event
     /// loop on success — `CaptureQueue` itself stays chassis-agnostic.
+    ///
+    /// # Panics
+    /// Panics if the slot `Mutex` is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked under the guard.
     #[must_use]
     pub fn request(&self, pending: PendingCapture) -> bool {
         let mut slot = self.slot.lock().unwrap();
@@ -82,6 +86,10 @@ impl CaptureQueue {
     /// Take the pending capture if one is set. Called by the render
     /// thread at the start of a frame; leaves the slot empty so the
     /// next capture request can land before this one completes.
+    ///
+    /// # Panics
+    /// Panics if the slot `Mutex` is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked under the guard.
     #[must_use]
     pub fn take(&self) -> Option<PendingCapture> {
         self.slot.lock().unwrap().take()

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1007,6 +1007,11 @@ impl<C: Chassis> Builder<C, HasDriver> {
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via
     /// [`BootedPassives::Drop`]) before propagating the error.
+    ///
+    /// # Panics
+    /// Panics if the `HasDriver` typestate is reached without a driver
+    /// installed — fail-fast per ADR-0063: the typestate guarantees
+    /// `with_driver` has run, so a missing driver is a builder API bug.
     pub fn build(self) -> Result<BuiltChassis<C>, BootError> {
         let Builder {
             registry,

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -411,6 +411,11 @@ impl<'a> ChassisCtx<'a> {
     /// wait for it to hit zero before render submit. Pair this with
     /// `FRAME_BARRIER = true` on the [`Actor`] impl. See
     /// `aether_capabilities::RenderCapability` for the reference shape.
+    ///
+    /// # Panics
+    /// Panics if the `frame_bound_set` `RwLock` is poisoned — fail-fast
+    /// per ADR-0063: a poisoned lock means a prior writer panicked
+    /// under the guard, a substrate-level invariant violation.
     pub fn claim_frame_bound_mailbox_with_override(
         &mut self,
         name: &str,
@@ -496,6 +501,11 @@ impl<'a> ChassisCtx<'a> {
     /// against its namespace and a stuck counter in
     /// `frame_bound_pending` that the chassis frame loop would wait
     /// for forever.
+    ///
+    /// # Panics
+    /// Panics if the `frame_bound_set` `RwLock` is poisoned — fail-fast
+    /// per ADR-0063: a poisoned lock means a prior writer panicked
+    /// under the guard, a substrate-level invariant violation.
     pub fn unclaim_mailbox(&mut self, id: MailboxId) {
         self.registry.remove_closure(id);
         self.frame_bound_pending.retain(|(i, _)| *i != id);

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -127,6 +127,10 @@ impl SettlementRegistry {
     /// attempts return [`crossbeam_channel::TryRecvError::Empty`] /
     /// `Disconnected` per the bounded(1) channel contract. Gate
     /// sites typically `recv_timeout` once and discard the receiver.
+    ///
+    /// # Panics
+    /// Panics if the inner `Mutex` is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked under the guard.
     pub fn subscribe_settlement(&self, root: MailId) -> Receiver<()> {
         let (tx, rx) = bounded::<()>(1);
         let mut inner = self.inner.lock().unwrap();
@@ -153,6 +157,10 @@ impl SettlementRegistry {
     ///
     /// Coexists with [`Self::subscribe_settlement`] — a root can have
     /// channel and mail subscribers; both fire on `fire_settled`.
+    ///
+    /// # Panics
+    /// Panics if the inner `Mutex` is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked under the guard.
     pub fn subscribe_settlement_mail(
         &self,
         root: MailId,
@@ -184,6 +192,10 @@ impl SettlementRegistry {
     /// `settled` set so subsequent [`Self::subscribe_settlement`]
     /// calls pre-fire. Idempotent: calling twice is the same as
     /// calling once for any waiter that already woke.
+    ///
+    /// # Panics
+    /// Panics if the inner `Mutex` is poisoned — fail-fast per ADR-0063:
+    /// a poisoned mutex means a prior holder panicked under the guard.
     pub fn fire_settled(&self, root: MailId) {
         // Drop the mutex before firing — mail subscribers resolve
         // the recipient inline on this thread, and channel sends are

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -173,6 +173,11 @@ impl HandleStore {
     /// are bit-distinguishable from mailbox / kind ids. The counter
     /// occupies the low 60 bits — at one mint per nanosecond it
     /// wraps in ~37 years, well past any single substrate lifetime.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn next_ephemeral(&self) -> HandleId {
         let mut inner = self.inner.write().unwrap();
         let counter = inner.next_ephemeral;
@@ -188,6 +193,11 @@ impl HandleStore {
     /// existing entry is a `KindMismatch` error. Refcount and pinned
     /// state survive a same-kind re-put — the publisher updating
     /// bytes shouldn't silently break references held by other code.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned, or if the eviction
+    /// pass underflows the byte accounting — fail-fast per ADR-0063:
+    /// both indicate a substrate-level invariant violation.
     pub fn put(&self, id: HandleId, kind: KindId, bytes: Vec<u8>) -> Result<(), PutError> {
         let mut inner = self.inner.write().unwrap();
         let (prior_size, refcount, pinned) = match inner.entries.get(&id) {
@@ -229,6 +239,11 @@ impl HandleStore {
     /// Mark `id` as pinned: it won't be evicted under memory pressure
     /// regardless of `refcount`. Returns `false` if the id isn't in
     /// the store.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn pin(&self, id: HandleId) -> bool {
         let mut inner = self.inner.write().unwrap();
         if let Some(entry) = inner.entries.get_mut(&id) {
@@ -241,6 +256,11 @@ impl HandleStore {
 
     /// Clear the pinned flag on `id`. Doesn't drop the entry; only
     /// makes it eligible for LRU eviction once `refcount == 0`.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn unpin(&self, id: HandleId) -> bool {
         let mut inner = self.inner.write().unwrap();
         if let Some(entry) = inner.entries.get_mut(&id) {
@@ -251,6 +271,14 @@ impl HandleStore {
         }
     }
 
+    /// Increment the refcount on `id`. Returns `false` if the id isn't
+    /// in the store. Saturating: held references past `u32::MAX` clamp
+    /// rather than wrap, so the `dec_ref` underflow guard never trips.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn inc_ref(&self, id: HandleId) -> bool {
         let mut inner = self.inner.write().unwrap();
         if let Some(entry) = inner.entries.get_mut(&id) {
@@ -261,6 +289,14 @@ impl HandleStore {
         }
     }
 
+    /// Decrement the refcount on `id`. Returns `false` if the id isn't
+    /// in the store. Saturating at zero: a double-drop doesn't
+    /// underflow.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn dec_ref(&self, id: HandleId) -> bool {
         let mut inner = self.inner.write().unwrap();
         if let Some(entry) = inner.entries.get_mut(&id) {
@@ -275,6 +311,11 @@ impl HandleStore {
     /// caller can drop the lock before extending its output buffer.
     /// Bumps `last_access` so dispatch usage protects an entry from
     /// LRU eviction.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn get(&self, id: HandleId) -> Option<(KindId, Vec<u8>)> {
         let mut inner = self.inner.write().unwrap();
         let access = bump_clock(&mut inner);
@@ -286,6 +327,11 @@ impl HandleStore {
     /// Park a `Mail` under `handle_id`. The mailer calls this when
     /// `walk_and_resolve` returns `Parked`. The mail stays in the
     /// queue until a matching `put` or until the engine shuts down.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn park(&self, handle_id: HandleId, mail: Mail) {
         let mut inner = self.inner.write().unwrap();
         inner.parked.entry(handle_id).or_default().push_back(mail);
@@ -298,6 +344,11 @@ impl HandleStore {
     /// resolved). Returns the drained mails in FIFO order; the
     /// HashMap entry itself is removed so a subsequent `parked_count`
     /// returns 0.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn take_parked(&self, id: HandleId) -> Vec<Mail> {
         let mut inner = self.inner.write().unwrap();
         match inner.parked.remove(&id) {
@@ -306,14 +357,32 @@ impl HandleStore {
         }
     }
 
+    /// Sum of `bytes.len()` across every entry in the store.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn total_bytes(&self) -> usize {
         self.inner.read().unwrap().total_bytes
     }
 
+    /// Count of stored entries (parked-mail queues not included).
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn entry_count(&self) -> usize {
         self.inner.read().unwrap().entries.len()
     }
 
+    /// Number of mails currently parked under `id`.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn parked_count(&self, id: HandleId) -> usize {
         self.inner
             .read()
@@ -324,10 +393,18 @@ impl HandleStore {
             .unwrap_or(0)
     }
 
+    /// Configured byte cap; eviction kicks in once `total_bytes`
+    /// would exceed this value.
     pub fn max_bytes(&self) -> usize {
         self.max_bytes
     }
 
+    /// `true` if `id` is currently stored.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn contains(&self, id: HandleId) -> bool {
         self.inner.read().unwrap().entries.contains_key(&id)
     }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -435,6 +435,11 @@ impl Registry {
     /// (chassis-builder `.with_actor::<...>` chain, runtime
     /// `load_component`, etc.). Subsequent calls overwrite the
     /// previous hook.
+    ///
+    /// # Panics
+    /// Panics if the `on_mailbox_change` `RwLock` is poisoned —
+    /// fail-fast per ADR-0063: a poisoned lock means a prior holder
+    /// panicked under the guard.
     pub fn set_on_mailbox_change(&self, hook: MailboxChangeHook) {
         *self.on_mailbox_change.write().unwrap() = Some(hook);
     }
@@ -496,6 +501,11 @@ impl Registry {
     /// Production has exactly one caller — `WasmTrampoline`'s
     /// shutdown path transitioning its own slot — chassis-cap
     /// mailboxes never route here.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn drop_mailbox(&self, id: MailboxId) -> Result<String, DropError> {
         let mut inner = self.inner.write().unwrap();
         let Some(slot) = inner.mailboxes.get_mut(&id) else {
@@ -536,8 +546,12 @@ impl Registry {
     /// channel is natural; a synchronous body that doesn't move
     /// payload reads as "I should be Inline."
     ///
-    /// Panics on a name collision — these are substrate-internal
-    /// names, collisions are bugs.
+    /// # Panics
+    /// Panics on a name collision (or if the inner `RwLock` is
+    /// poisoned) — fail-fast per ADR-0063: substrate-internal
+    /// registrations should never collide; use
+    /// [`Self::try_register_inbox`] when a collision is a recoverable
+    /// outcome rather than a bug.
     pub fn register_inbox(
         &self,
         name: impl Into<String>,
@@ -560,6 +574,11 @@ impl Registry {
     /// capability claim against the same mailbox during the
     /// transition diff) can surface the collision as a typed error
     /// rather than aborting the chassis.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn try_register_inbox(
         &self,
         name: impl Into<String>,
@@ -595,8 +614,12 @@ impl Registry {
     /// `to_vec()` clone; that clone is the visible "I should be
     /// Inbox" smell.
     ///
-    /// Panics on a name collision — these are substrate-internal
-    /// names, collisions are bugs.
+    /// # Panics
+    /// Panics on a name collision (or if the inner `RwLock` is
+    /// poisoned) — fail-fast per ADR-0063: substrate-internal
+    /// registrations should never collide; use
+    /// [`Self::try_register_inline`] when a collision is a recoverable
+    /// outcome rather than a bug.
     pub fn register_inline(
         &self,
         name: impl Into<String>,
@@ -614,6 +637,11 @@ impl Registry {
 
     /// Non-panicking variant of [`Self::register_inline`], symmetric
     /// with [`Self::try_register_inbox`].
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn try_register_inline(
         &self,
         name: impl Into<String>,
@@ -655,6 +683,11 @@ impl Registry {
     /// its id if so. The id itself is deterministic (ADR-0029) —
     /// callers that just want the id without a liveness check can use
     /// `MailboxId::from_name` directly.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn lookup(&self, name: &str) -> Option<MailboxId> {
         let id = MailboxId::from_name(name);
         let inner = self.inner.read().unwrap();
@@ -670,6 +703,11 @@ impl Registry {
     /// caller can drop the internal lock before invoking the handler
     /// (whether `Inbox` or `Inline`) — avoids holding the registry
     /// lock across arbitrary user code.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn entry(&self, id: MailboxId) -> Option<MailboxEntry> {
         self.inner
             .read()
@@ -682,6 +720,11 @@ impl Registry {
     /// Reverse of `lookup`: name for a given mailbox id, or `None` if
     /// the id is unknown. Used by the closure dispatch path to stamp
     /// `origin` on observation mail (ADR-0011).
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn mailbox_name(&self, id: MailboxId) -> Option<String> {
         self.inner
             .read()
@@ -701,6 +744,12 @@ impl Registry {
     /// `register_kind_with_descriptor` so the descriptor stored here
     /// matches the type definition and the derived id agrees with
     /// `<K as Kind>::ID` on the guest side.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard. The internal `expect("Bytes default cannot produce a
+    /// conflict")` is unreachable by construction.
     pub fn register_kind(&self, name: impl Into<String>) -> KindId {
         let name = name.into();
         let descriptor = KindDescriptor {
@@ -727,6 +776,11 @@ impl Registry {
     ///   than silent data corruption.
     ///
     /// Used by substrate boot (`descriptors::all()`) and `load_component`.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn register_kind_with_descriptor(
         &self,
         descriptor: KindDescriptor,
@@ -778,6 +832,11 @@ impl Registry {
     /// exact descriptor the caller is thinking of. Primarily used by
     /// the hub-inbound dispatch path, which needs to convert an
     /// incoming `kind_name` back to the registered id.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn kind_id(&self, name: &str) -> Option<KindId> {
         self.inner.read().unwrap().name_index.get(name).copied()
     }
@@ -786,6 +845,11 @@ impl Registry {
     /// isn't registered. Used by the dispatch path to hand mailbox
     /// closure handlers a kind name without them keeping their own
     /// map.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn kind_name(&self, kind: KindId) -> Option<String> {
         self.inner
             .read()
@@ -798,6 +862,11 @@ impl Registry {
     /// The descriptor stored for a given kind id, or `None` if the id
     /// isn't registered. Returned as an owned clone so callers don't
     /// hold the read lock while inspecting the encoding.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn kind_descriptor(&self, kind: KindId) -> Option<KindDescriptor> {
         self.inner
             .read()
@@ -813,6 +882,11 @@ impl Registry {
     /// unrelated kinds; name order preserves a human-readable grouping).
     /// Used by the control plane to ship an authoritative view to the
     /// hub after a runtime load or replace (ADR-0010 §4).
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn list_kind_descriptors(&self) -> Vec<KindDescriptor> {
         let mut out: Vec<KindDescriptor> = self
             .inner
@@ -839,6 +913,11 @@ impl Registry {
     /// trace was captured. Categorisation is a pure function of the
     /// mailbox name (`categorise_name`); the registry stores no
     /// per-mailbox category state.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn list_mailbox_descriptors(&self) -> Vec<MailboxDescriptor> {
         let mut out: Vec<MailboxDescriptor> = self
             .inner
@@ -861,10 +940,22 @@ impl Registry {
         out
     }
 
+    /// Number of registered mailbox entries (live + `Dropped`).
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn len(&self) -> usize {
         self.inner.read().unwrap().mailboxes.len()
     }
 
+    /// `true` when no mailbox has ever been registered.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
     pub fn is_empty(&self) -> bool {
         self.inner.read().unwrap().mailboxes.is_empty()
     }

--- a/crates/aether-substrate/src/render/capture.rs
+++ b/crates/aether-substrate/src/render/capture.rs
@@ -29,6 +29,12 @@ pub struct CaptureMeta {
 ///
 /// Returns the meta dims + format `finish_capture` will need after
 /// the GPU work completes.
+///
+/// # Panics
+/// Panics if the readback slot is missing immediately after being
+/// set — fail-fast per ADR-0063: the slot is populated inline above
+/// the lookup, so a `None` indicates a substrate-level invariant
+/// violation.
 pub fn prepare_capture_copy(
     device: &wgpu::Device,
     targets: &mut Targets,

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -245,6 +245,11 @@ impl Drop for TraceDrainerHandle {
 /// Idempotent in the sense that calling [`install_trace_queue`]
 /// twice with the same `queue` Arc is a no-op; the chassis builder
 /// installs the queue exactly once and pairs it with one drainer.
+///
+/// # Panics
+/// Panics if the OS refuses to spawn the drainer thread — fail-fast
+/// per ADR-0063: thread spawn is a substrate-boot prerequisite and a
+/// failure means the process is in an unrecoverable state.
 pub fn start_drainer(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>) -> TraceDrainerHandle {
     let (shutdown_tx, shutdown_rx) = channel::<()>();
     let handle = thread::Builder::new()

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -109,7 +109,12 @@ pub struct PoolHandle {
 impl PoolHandle {
     /// Hand out a clone of the ready-queue sender. PR C wires this
     /// into [`crate::scheduler::WakeHandle`]s when registering
-    /// dispatcher slots. Panics if the pool has been shut down.
+    /// dispatcher slots.
+    ///
+    /// # Panics
+    /// Panics if the pool has already been shut down (the sender slot
+    /// is `None`) — fail-fast per ADR-0063: registering a wake handle
+    /// after pool shutdown is a chassis-lifecycle bug.
     #[must_use]
     pub fn ready_tx(&self) -> Sender<Arc<dyn Drainable>> {
         self.ready_tx
@@ -171,6 +176,12 @@ impl Pool {
     /// Spawn the worker threads and return a [`PoolHandle`] holding
     /// the ready-queue sender. Each worker thread is named
     /// `aether-worker-<n>` (Open Question 10 resolution).
+    ///
+    /// # Panics
+    /// Panics if `config.workers < 1`, or if the OS refuses to spawn
+    /// any worker thread — fail-fast per ADR-0063: worker count is a
+    /// chassis-boot invariant and thread spawn is a substrate
+    /// prerequisite.
     pub fn start(config: PoolConfig, aborter: Arc<dyn FatalAborter>) -> PoolHandle {
         assert!(config.workers >= 1, "pool needs at least one worker");
         let (ready_tx, ready_rx) = unbounded::<Arc<dyn Drainable>>();


### PR DESCRIPTION
Phase 2.5 of iamacoffeepot/aether#854: sweep `clippy::missing_panics_doc` across the workspace.

- Added 91 real `# Panics` doc blocks; zero per-site `#[allow]` escapes. Most sites are fail-fast invariant assertions (poisoned `RwLock` / `Mutex`, capacity-overflow asserts, single-claim slot guards) and reference ADR-0063 as the rationale; a handful (`canonical_serialize_*`, `varint_usize_len`, `Aabb::mirror`) describe real precondition panics.
- Verification: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (zero `missing_panics_doc` warnings), `cargo fmt -- --check`, `cargo nextest run --workspace` (1001/1001), `cargo test --doc` — all green locally.

Closes iamacoffeepot/aether#875

🤖 Generated with [Claude Code](https://claude.com/claude-code)