### PR TITLE
chore(substrate): sweep clippy::doc_markdown (issue 854 phase 2.3)

### DIFF
--- a/crates/aether-mesh/src/cleanup/invariants.rs
+++ b/crates/aether-mesh/src/cleanup/invariants.rs
@@ -101,7 +101,7 @@ fn bucket_key(plane: &Plane3, color: u32) -> BucketKey {
 /// or choke on. Checked at every cleanup stage so the first pass to
 /// emit a non-simple loop is identifiable.
 ///
-/// O(P · V) — one HashSet per polygon, single linear scan.
+/// O(P · V) — one `HashSet` per polygon, single linear scan.
 pub(crate) fn find_non_simple_loops(mesh: &IndexedMesh) -> Vec<NonSimpleLoopViolation> {
     use std::collections::HashMap;
     let mut violations: Vec<NonSimpleLoopViolation> = Vec::new();
@@ -288,7 +288,7 @@ pub(crate) fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJ
 /// conditions tautologically (retain on `len >= 3`, dedup-consecutive
 /// before retain), so violations here mean a regression in either step.
 ///
-/// O(P · V_avg).
+/// O(P · `V_avg`).
 pub(crate) fn find_post_sliver_violations(mesh: &IndexedMesh) -> Vec<PostSliverViolation> {
     let mut violations: Vec<PostSliverViolation> = Vec::new();
     for (poly_idx, poly) in mesh.polygons.iter().enumerate() {
@@ -580,7 +580,7 @@ mod tests {
         );
     }
 
-    /// Two distinct VertexIds resolving to identical fixed-point
+    /// Two distinct `VertexId`s resolving to identical fixed-point
     /// coords — exactly what the welding pass should have folded
     /// together. Surfacing this means the tolerance lookup missed.
     #[test]

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -62,9 +62,9 @@
 //! BSP fragments inherit their parent triangle's plane field-for-field
 //! so all fragments of one source share a key.
 //!
-//! Determinism: HashMap iteration order doesn't leak — bucket keys are
+//! Determinism: `HashMap` iteration order doesn't leak — bucket keys are
 //! sorted before processing, and loop extraction walks edges in
-//! deterministic order (sorted starts, sorted outgoing lists, VertexId
+//! deterministic order (sorted starts, sorted outgoing lists, `VertexId`
 //! tiebreak in the angular pick).
 
 use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
@@ -422,7 +422,7 @@ pub(super) fn normalize_loop(loop_verts: &[VertexId]) -> Vec<Vec<VertexId>> {
 ///
 /// At each vertex with multiple unvisited outgoing edges, the angular
 /// continuation rule picks the candidate whose direction is closest to
-/// the incoming direction (smallest absolute turn angle). VertexId
+/// the incoming direction (smallest absolute turn angle). `VertexId`
 /// breaks turn-angle ties for determinism. The first edge of a loop
 /// has no incoming direction; it's chosen by the sort order of
 /// `boundary`. See module-level docs for why this is the right rule
@@ -483,7 +483,7 @@ fn extract_loops(
 /// Pick the next outgoing edge from `cur` that continues most directly
 /// from the incoming direction `prev → cur`. With a single unvisited
 /// candidate, returns it; with several, picks the smallest absolute
-/// turn angle, VertexId tiebreak.
+/// turn angle, `VertexId` tiebreak.
 fn pick_continuation(
     vertices: &[Point3],
     axes: (usize, usize),
@@ -539,7 +539,7 @@ fn pick_continuation(
 ///   the inequality flips.
 ///
 /// On i128 multiplication overflow falls back to `Equal` so the
-/// VertexId tiebreak in `pick_continuation` resolves the choice — that
+/// `VertexId` tiebreak in `pick_continuation` resolves the choice — that
 /// only triggers for input coords near the i32 fixed-point limits,
 /// and erring deterministic at the edge is fine.
 fn cmp_turn(
@@ -972,7 +972,7 @@ mod tests {
         }
     }
 
-    /// Cross-plane shared edges must keep matching VertexIds. Different
+    /// Cross-plane shared edges must keep matching `VertexId`s. Different
     /// planes land in different buckets, but the manifold validator
     /// walks edges across all polygons regardless of plane.
     #[test]
@@ -1320,7 +1320,7 @@ mod tests {
 
     /// A reverse that exists only inside this bucket does NOT count as
     /// externally backed — bucket-internal twins were already cancelled
-    /// before extract_loops ran. This is the "subtract bucket from
+    /// before `extract_loops` ran. This is the "subtract bucket from
     /// global" check working as intended.
     #[test]
     fn collapse_ignores_intra_bucket_reverses() {
@@ -1363,7 +1363,7 @@ mod tests {
         assert!(boundary.is_empty());
     }
 
-    /// Pathological topology where extract_loops returns None and the
+    /// Pathological topology where `extract_loops` returns None and the
     /// fallback emits the bucket's originals unchanged. Pinned because
     /// the fallback path otherwise has zero coverage.
     #[test]

--- a/crates/aether-mesh/src/cleanup/weld.rs
+++ b/crates/aether-mesh/src/cleanup/weld.rs
@@ -110,7 +110,7 @@ impl IndexedMesh {
 
 /// Look up `v` against pool entries within tolerance (Chebyshev), via
 /// the 27 neighboring spatial buckets. Returns the existing entry's
-/// VertexId if any is within tolerance; otherwise inserts as new.
+/// `VertexId` if any is within tolerance; otherwise inserts as new.
 fn lookup_or_insert(
     pool: &mut Vec<Point3>,
     buckets: &mut HashMap<BucketKey, Vec<VertexId>>,

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -508,7 +508,7 @@ pub struct Summary {
     pub vertex_count_avg: f32,
     pub hole_count_total: usize,
     /// Polygons grouped by canonical plane direction signature.
-    /// (sign(n_x), sign(n_y), sign(n_z)) → count. For axis-aligned
+    /// (`sign(n_x)`, `sign(n_y)`, `sign(n_z)`) → count. For axis-aligned
     /// meshes like cubes, expect 6 distinct entries.
     pub by_plane_direction: HashMap<(i8, i8, i8), usize>,
 }

--- a/crates/aether-mesh/src/loop_polygon.rs
+++ b/crates/aether-mesh/src/loop_polygon.rs
@@ -538,7 +538,7 @@ mod tests {
     /// diagonal plane with normal `(n,n,n)`, so vertices with `|side|`
     /// up to `3n` (perpendicular distance up to `√3 ≈ 1.73`) absorbed
     /// as COPLANAR — including this triangle's `±2n` sides (perp ~1.15).
-    /// The polygon routed to coplanar_front instead of being split,
+    /// The polygon routed to `coplanar_front` instead of being split,
     /// dropping the back fragment and producing the boundary edges
     /// observed in the box-minus-sphere/cylinder regressions.
     ///

--- a/crates/aether-mesh/src/obj.rs
+++ b/crates/aether-mesh/src/obj.rs
@@ -1,7 +1,7 @@
 //! Wavefront OBJ writer for the spike's mesher output.
 //!
 //! OBJ is the simplest text format every 3D viewer can open (Preview.app on
-//! macOS, Blender, MeshLab, …). For spike measurability this beats stdout
+//! macOS, Blender, `MeshLab`, …). For spike measurability this beats stdout
 //! triangle dumps — you can actually look at the mesh.
 //!
 //! Per-face color is not standard OBJ; we emit one OBJ group per palette

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -12,7 +12,7 @@
 //! then [`crate::cleanup::run_to_loops`] to recover the boundary
 //! loops the cleanup pipeline produces; a future PR will skip the
 //! triangle round-trip by taking the polygon-domain path through
-//! ``union`/`intersection`/`difference` (retired ADR-0062)` directly.
+//! `union` / `intersection` / `difference` (retired ADR-0062) directly.
 //!
 //! Hole representation: `Polygon::holes` is the explicit
 //! polygon-with-holes form chosen for v1. The cleanup pipeline emits
@@ -61,7 +61,7 @@ pub struct Polygon {
 /// Goes directly through [`crate::mesh::mesh_polygons_internal`] —
 /// the polygon-domain mesh evaluator that operates polygon-in /
 /// polygon-out throughout (no triangle round-trip). This is the fix
-/// for the protruding_sphere SingularEdges: the previous path went
+/// for the `protruding_sphere` `SingularEdges`: the previous path went
 /// `mesh → Vec<Triangle> → from_triangle (re-derives plane via cross
 /// product) → polygons`, and `from_triangle` flips `n_z` sign on
 /// CDT-output sliver triangles. Skipping the triangle hop avoids the

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -8,7 +8,7 @@
 //! 2. Inserting input vertices one at a time. For each insertion:
 //!    - Walk to the triangle containing the new point (orient2d steps).
 //!    - Expand the **cavity** = set of triangles whose circumcircle
-//!      contains the new point (BFS via neighbor pointers + in_circle).
+//!      contains the new point (BFS via neighbor pointers + `in_circle`).
 //!    - Delete cavity triangles, then re-triangulate the cavity by
 //!      connecting the new vertex to each cavity-boundary edge.
 //!    - Stitch neighbor pointers across the new fan.
@@ -504,7 +504,7 @@ impl Mesh {
         unreachable!("first_alive called on empty mesh");
     }
 
-    /// Expand the cavity around vertex `vid` outward via in_circle.
+    /// Expand the cavity around vertex `vid` outward via `in_circle`.
     /// The starting triangle is always in the cavity (its circumcircle
     /// contains `vid` by construction — `vid` is in its interior).
     fn expand_cavity(&self, start: TriId, vid: VertId) -> Vec<TriId> {

--- a/crates/aether-mesh/src/tessellate/cdt/predicates.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/predicates.rs
@@ -9,7 +9,7 @@
 //!
 //! - **orient2d**: a single 2×2 determinant of i64 differences;
 //!   bounded by 2 · 2^25 · 2^25 = 2^51. Trivial.
-//! - **in_circle**: 3×3 determinant whose third column carries
+//! - **`in_circle`**: 3×3 determinant whose third column carries
 //!   squared-sum entries (≤ 2^51). Expanding along row 0 keeps the
 //!   small (linear-difference, ≤ 2^25) multiplier on the outside of
 //!   the largest 2×2 sub-determinant. Each of the three terms is

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -5,7 +5,7 @@
 //! holds the per-actor state — mailer + self mailbox + inbox +
 //! correlation counter + wait-overflow queue — directly as fields,
 //! reached via `&self` on every inherent method. No thread-locals,
-//! no install/uninstall ceremony, no RefCell runtime borrow checks.
+//! no install/uninstall ceremony, no `RefCell` runtime borrow checks.
 //! The actor binding is type-system-tracked through the
 //! `&NativeBinding` references the SDK threads into
 //! [`super::ctx::NativeCtx`], [`super::mailbox::NativeActorMailbox`],
@@ -149,7 +149,7 @@ impl NativeBinding {
     /// Capabilities authored under a [`crate::ChassisCtx`] should
     /// prefer [`Self::from_ctx`], which inherits the chassis's
     /// shared set + aborter automatically; the explicit constructor
-    /// is for harnesses that don't go through a chassis (TestBench
+    /// is for harnesses that don't go through a chassis (`TestBench`
     /// internals) or for tests that want to substitute a custom
     /// aborter.
     pub fn new(
@@ -188,7 +188,7 @@ impl NativeBinding {
     /// same PR keep using [`Self::new_for_test`] (or call
     /// [`Self::new`] explicitly with their chosen guard state); the
     /// guard is a no-op for non-frame-bound callers and the
-    /// PanicAborter default is harmless for production caps that
+    /// `PanicAborter` default is harmless for production caps that
     /// never call `wait_reply`.
     pub fn from_ctx(ctx: &ChassisCtx<'_>, self_mailbox: MailboxId, frame_bound: bool) -> Self {
         Self::new(
@@ -335,7 +335,7 @@ impl NativeBinding {
 /// "no inbox installed" by name in the error.
 const ERR_NO_INBOX_I32: i32 = 100;
 
-/// Inherent send / wait_reply / prev_correlation entry points the
+/// Inherent send / `wait_reply` / `prev_correlation` entry points the
 /// per-handler [`super::ctx::NativeCtx`] / [`super::ctx::NativeInitCtx`]
 /// route through. Issue 665 retired the prior `MailTransport` trait
 /// impl; the FFI-shaped wrapper served no purpose for native (Mailer
@@ -718,7 +718,7 @@ mod tests {
 
     /// ADR-0074 §Decision 5: a frame-bound caller blocking on a
     /// free-running recipient must abort. Verified via the
-    /// PanicAborter — the panic message names both mailboxes plus
+    /// `PanicAborter` — the panic message names both mailboxes plus
     /// the ADR.
     #[test]
     #[should_panic(expected = "forbidden by ADR-0074")]

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -388,7 +388,7 @@ impl<'a> NativeCtx<'a> {
     ///
     /// Use this when the cap is acting on an external event (wire-
     /// borne RPC call, file watcher, timer) rather than forwarding a
-    /// mail that was already in flight. The RpcServer cap's `Call`
+    /// mail that was already in flight. The `RpcServer` cap's `Call`
     /// handler is the motivating case: the inbound that wakes the cap
     /// is an internal wake mail causally unrelated to the wire-borne
     /// `Call` — inheriting its chain would attribute the dispatch to
@@ -455,7 +455,7 @@ impl<'a> Sender for NativeCtx<'a> {
 impl<'a> MailCtx for NativeCtx<'a> {
     /// Stage 2: route the reply through the substrate's `Mailer::send_reply`
     /// (Component recipient → push as Mail with the originator's
-    /// correlation echoed and reply-to None; Session / EngineMailbox
+    /// correlation echoed and reply-to None; Session / `EngineMailbox`
     /// → outbound bridge; None → silent drop). This is the same path
     /// pre-stage-2 caps walked manually via `self.mailer.send_reply(sender, &result)`
     /// — caps now reach for `ctx.reply(&result)` and the per-mail

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -84,7 +84,7 @@ pub(crate) struct DispatcherSlot<A>
 where
     A: NativeActor + NativeDispatch,
 {
-    /// The slot's atomic state machine. Shared with the WakeHandle.
+    /// The slot's atomic state machine. Shared with the `WakeHandle`.
     pub(crate) state: Arc<SlotState>,
     /// The actor itself. The state machine guarantees only one worker
     /// is in `Running` at a time, so the `Mutex` is uncontested in
@@ -228,7 +228,7 @@ where
         }
     }
 
-    /// Phase 3 of the dispatch_loop_run lifecycle. Wraps `actor.unwire`
+    /// Phase 3 of the `dispatch_loop_run` lifecycle. Wraps `actor.unwire`
     /// in the same `with_stamped` + `with_actor_dispatch` envelope so a
     /// final tracing event from the close hook still routes to
     /// `LogCapability`.

--- a/crates/aether-substrate/src/actor/native/envelope.rs
+++ b/crates/aether-substrate/src/actor/native/envelope.rs
@@ -15,7 +15,7 @@ use crate::mail::{KindId, MailId, ReplyTo};
 /// inbound mail's identity and causal-chain pointers. The native
 /// dispatcher reads them to populate the per-handler `NativeCtx`'s
 /// `in_flight()` accessors so child sends inherit the correct root.
-/// PR 2 of issue #707 plumbs the data; PR 2's TraceObserver hooks
+/// PR 2 of issue #707 plumbs the data; PR 2's `TraceObserver` hooks
 /// emit `TraceEvent::Received { mail_id, .. }` against the same value
 /// the producer's `Sent` event carried.
 #[derive(Debug)]
@@ -33,7 +33,7 @@ pub struct Envelope {
 
 /// Issue iamacoffeepot/aether#848 PR 3: move every field out of
 /// the inbound [`OwnedDispatch`] into a fresh [`Envelope`]. No
-/// allocations — payload + kind_name + origin all transfer
+/// allocations — payload + `kind_name` + origin all transfer
 /// ownership. Replaces the legacy `build_envelope(&MailDispatch)`
 /// path inside production cap registration closures, which paid
 /// `Vec<u8>` + `String` clones per dispatch.

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -46,7 +46,7 @@
 //!   sibling state recreates the shared-state coupling the actor
 //!   model is designed to eliminate. The chassis-level
 //!   `chassis.actor::<X>() -> Arc<X>` retired with issue 629 / Phase A;
-//!   external runtimes (drivers, TestBench, MCP) reach for
+//!   external runtimes (drivers, `TestBench`, MCP) reach for
 //!   cap-exported handles instead.
 //!
 //! ## Catch-all caps (issue 576)

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -174,7 +174,7 @@ impl Spawner {
     /// `timeout`-bounded loop. Under nextest contention the worker that
     /// observed the wake could be scheduled out long enough that the
     /// 2 s deadline elapsed before the close cycle ran, surfacing as
-    /// the chassis_teardown_runs_unwire flake. The waker now installs a
+    /// the `chassis_teardown_runs_unwire` flake. The waker now installs a
     /// one-shot `crossbeam_channel::bounded(1)` per entry; the slot's
     /// close cycle fires it after `unwire` + registry close land, so
     /// teardown wakes the instant the cycle settles instead of polling.
@@ -653,7 +653,7 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
 
     /// Append `mail` to the bootstrap sequence. Order-preserving —
     /// the spawned actor sees envelopes in the order they were added.
-    /// Sender on each envelope is the spawner's reply target; reply_to
+    /// Sender on each envelope is the spawner's reply target; `reply_to`
     /// defaults to the spawner's mailbox.
     ///
     /// `A: HandlesKind<K>` ensures only kinds the actor's handler set

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -1,7 +1,7 @@
 //! ADR-0080 §12 thread-spawn primitives.
 //!
 //! Caps that own threads driven by external events (TCP per-connection
-//! workers, future drivers like WebSocketCapability or pollers,
+//! workers, future drivers like `WebSocketCapability` or pollers,
 //! occasional CPU-offload workers) need a structured way to send mail
 //! from those threads while staying coherent with the trace pipeline.
 //! The pattern matches the per-handler [`super::ctx::NativeCtx`]:
@@ -435,7 +435,7 @@ mod tests {
     }
 
     /// `RootCtx`-spawned thread's `send_to_named` mints a fresh root
-    /// chain — root == its own mail_id, parent_mail = None.
+    /// chain — root == its own `mail_id`, `parent_mail` = None.
     #[test]
     fn root_ctx_send_mints_fresh_root_with_no_parent() {
         let (registry, mailer) = fresh_substrate();
@@ -566,7 +566,7 @@ mod tests {
 
     /// Setup smoke: a `Mail` pushed bare via `Mailer` doesn't trigger
     /// the spawn primitives but verifies the test fixture's
-    /// register_capture closure works.
+    /// `register_capture` closure works.
     #[test]
     fn fixture_smoke_capture_observes_bare_push() {
         let (registry, mailer) = fresh_substrate();

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -73,7 +73,7 @@ pub struct ActorRegistry {
     /// Retired full names. `spawn_child` rejects reuse; lookups
     /// distinguish "never existed" from "previously existed and
     /// closed." Single static membership — no per-tombstone allocation
-    /// beyond the HashSet entry itself.
+    /// beyond the `HashSet` entry itself.
     tombstones: RwLock<HashSet<MailboxId>>,
 
     /// One owner per `NAMESPACE`. Populated at chassis-build for
@@ -233,7 +233,7 @@ impl ActorRegistry {
     /// [`super::PassiveChassis::resolve_actors`] iterates over;
     /// callers that don't originate from the spawn path (today: none;
     /// tests use empty strings) pass `""` and accept they won't show
-    /// up in the resolve_actors iterator.
+    /// up in the `resolve_actors` iterator.
     pub(crate) fn insert_live(
         &self,
         id: MailboxId,

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -121,8 +121,8 @@ pub struct ComponentCtx {
 impl ComponentCtx {
     /// Build a fresh ctx with empty state-migration slots and an
     /// empty sender table. Using this over the struct literal keeps
-    /// the private fields (reply_table, saved_state,
-    /// save_state_error) internal to the wiring — callers should
+    /// the private fields (`reply_table`, `saved_state`,
+    /// `save_state_error`) internal to the wiring — callers should
     /// never set them directly.
     pub fn new(
         sender: MailboxId,
@@ -955,7 +955,7 @@ mod tests {
     }
 
     /// Issue 584 Phase 2b: a component without a `wire` / `unwire`
-    /// export is a no-op (matches the on_replace pattern).
+    /// export is a no-op (matches the `on_replace` pattern).
     #[test]
     fn unwire_on_component_without_export_is_noop() {
         let mut component = instantiate(WAT_NO_HOOKS);

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -41,7 +41,7 @@ use crate::mail::{Mail, ReplyTo};
 /// pre-mail the render cap pushed before parking this request
 /// (iamacoffeepot/aether#860). The driver waits on each receiver
 /// before rendering so the cross-thread causal chain triggered by
-/// the pre-mails (component handlers → emitted DrawTriangle →
+/// the pre-mails (component handlers → emitted `DrawTriangle` →
 /// render cap accumulator) has fully landed before readback. Empty
 /// when there were no pre-mails or when the chassis didn't install
 /// a settlement registry (in which case the driver renders

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -6,7 +6,7 @@
 //! A chassis composes passive capabilities (dispatcher-thread sinks
 //! per ADR-0070) plus exactly one [`DriverCapability`] that owns the
 //! chassis main thread. The type-state [`Builder`] enforces "exactly
-//! one driver" structurally; embedders that drive manually (TestBench,
+//! one driver" structurally; embedders that drive manually (`TestBench`,
 //! future embedded harnesses) build a [`PassiveChassis`] via the
 //! no-driver path.
 //!
@@ -382,7 +382,7 @@ enum BootState<A: NativeActor + NativeDispatch> {
 /// the sum dispatch trait the `#[actor] impl NativeActor for A`
 /// macro emits.
 ///
-/// Stage 2d: FRAME_BARRIER caps go through this path too. The
+/// Stage 2d: `FRAME_BARRIER` caps go through this path too. The
 /// frame-bound claim (`claim_frame_bound_mailbox_with_override`)
 /// registers the per-mailbox `pending` counter into the chassis's
 /// `frame_bound_pending` Vec; the dispatcher thread decrements after
@@ -924,7 +924,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
 
     /// No-driver build path. Boots every passive in declaration order
     /// and returns a [`PassiveChassis`] whose embedder is responsible
-    /// for driving the loop manually (TestBench).
+    /// for driving the loop manually (`TestBench`).
     pub fn build_passive(self) -> Result<PassiveChassis<C>, BootError> {
         let booted = boot_passives(
             &self.registry,
@@ -1078,8 +1078,8 @@ struct BootedPassives {
     /// Issue 607 Phase 2 / Phase 3 (ADR-0079): per-chassis actor
     /// lifecycle registry, plus the spawn machinery that writes into
     /// it. Both built once at boot; `Spawner` carries `Arc` clones of
-    /// the chassis-level handles (registry, actor_registry, mailer,
-    /// frame_bound_set, aborter) so future per-handler `spawn_child`
+    /// the chassis-level handles (registry, `actor_registry`, mailer,
+    /// `frame_bound_set`, aborter) so future per-handler `spawn_child`
     /// reaches them without separate plumbing.
     actor_registry: Arc<crate::ActorRegistry>,
     spawner: Arc<crate::Spawner>,
@@ -1489,7 +1489,7 @@ impl<C: Chassis> BuiltChassis<C> {
     /// `TcpListenerActor`) hold their own cap-local map of children
     /// and update it on `MonitorNotice` — they don't enumerate via
     /// the chassis registry from a handler. Reach for this from a
-    /// driver / TestBench / scenario inspection step, not from
+    /// driver / `TestBench` / scenario inspection step, not from
     /// production cap state. ADR-0079 supervisor-as-cap pattern.
     pub fn resolve_actors<A: aether_actor::Instanced + NativeActor>(
         &self,
@@ -1541,7 +1541,7 @@ impl<C: Chassis> BuiltChassis<C> {
     }
 }
 
-/// A chassis built without a driver. The embedder (TestBench, future
+/// A chassis built without a driver. The embedder (`TestBench`, future
 /// embedded harnesses) drives any loop manually. Passives are booted
 /// and accessible via [`Self::capability`]; they shut down when the
 /// `PassiveChassis` is dropped.
@@ -1572,7 +1572,7 @@ impl<C: Chassis> PassiveChassis<C> {
 
     /// Issue 629 / Phase A: retrieve a clone of a cap-published handle
     /// bundle of type `H`. Mirrors [`DriverCtx::handle`] for embedders
-    /// that drive a `PassiveChassis` directly (TestBench, integration
+    /// that drive a `PassiveChassis` directly (`TestBench`, integration
     /// harnesses). `None` if no booted cap published a handle of that
     /// type.
     pub fn handle<H: std::any::Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
@@ -1589,7 +1589,7 @@ impl<C: Chassis> PassiveChassis<C> {
     }
 
     /// Snapshot of every frame-bound mailbox's pending counter
-    /// collected during passive boot. Embedders (TestBench, bin
+    /// collected during passive boot. Embedders (`TestBench`, bin
     /// drivers) clone this once and feed it to
     /// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`] each frame —
     /// same role as [`crate::chassis::builder::DriverCtx::frame_bound_pending`]
@@ -1600,7 +1600,7 @@ impl<C: Chassis> PassiveChassis<C> {
 
     /// Issue 607 Phase 5 (ADR-0079): mirror of
     /// [`BuiltChassis::resolve_actor`] for embedders that drive
-    /// passive chassis directly (TestBench, integration tests).
+    /// passive chassis directly (`TestBench`, integration tests).
     /// Issue 629 / Phase A: returns the address (`MailboxId`); the
     /// actor itself never escapes its dispatcher thread.
     ///
@@ -1972,7 +1972,7 @@ mod tests {
         drop(chassis);
     }
 
-    /// Issue 552 stage 2d: with_actor accepts FRAME_BARRIER caps.
+    /// Issue 552 stage 2d: `with_actor` accepts `FRAME_BARRIER` caps.
     /// The chassis claims through `claim_frame_bound_mailbox`, the
     /// pending counter feeds the chassis's `frame_bound_pending` Vec,
     /// and the dispatcher decrements after each handler dispatch so
@@ -2335,7 +2335,7 @@ mod tests {
 
     /// Issue 607 Phase 4a verify: `ctx.shutdown()` from inside an
     /// instanced actor's handler triggers the drain → unwire → exit
-    /// path, flips the actor_registry slot to `Dead`, and inserts the
+    /// path, flips the `actor_registry` slot to `Dead`, and inserts the
     /// id into `tombstones`. A reused subname after retirement returns
     /// `SpawnError::SubnameRetired`.
     #[test]
@@ -2551,7 +2551,7 @@ mod tests {
     }
 
     /// Issue 714: stress version of the chassis-teardown contract.
-    /// Spawn N=64 instanced actors and assert all N close_observed
+    /// Spawn N=64 instanced actors and assert all N `close_observed`
     /// counters tick to exactly 1 after `drop(chassis)`. Pre-714 the
     /// polling-based `shutdown_instanced` could lose individual wakes
     /// under contention; the channel-signal rewrite is deterministic
@@ -3346,7 +3346,7 @@ mod tests {
     /// grandchild. Phase 3b shipped `Arc<Spawner>` threading through
     /// every spawned actor's transport precisely so this works; this
     /// test is the first end-to-end coverage of the instanced→instanced
-    /// path. Phase 6b (TcpListenerActor → TcpSessionActor) structurally
+    /// path. Phase 6b (`TcpListenerActor` → `TcpSessionActor`) structurally
     /// depends on this — listeners spawning sessions IS the recursive
     /// case.
     ///

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -140,7 +140,7 @@ impl MailboxSender {
 /// must claim through this method instead of
 /// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] — otherwise the
 /// chassis has no counter to wait on and the barrier degrades to
-/// "components only", reintroducing the race the FRAME_BARRIER
+/// "components only", reintroducing the race the `FRAME_BARRIER`
 /// classification exists to close.
 #[derive(Debug)]
 pub struct FrameBoundClaim {
@@ -490,7 +490,7 @@ impl<'a> ChassisCtx<'a> {
     /// `frame_bound_set`, and the id from `claimed_actor_mailboxes`.
     /// Idempotent: calling on an id that wasn't claimed is a no-op.
     ///
-    /// Used in the singleton-boot unwind path (chassis_builder /
+    /// Used in the singleton-boot unwind path (`chassis_builder` /
     /// capability) when `init` fails after the cap mailbox was
     /// claimed. Without this, the failed cap leaves a sink registered
     /// against its namespace and a stuck counter in

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -32,7 +32,7 @@
 //!   subscribers have drained are no-ops (the `HashSet` hit short-
 //!   circuits).
 //!
-//! The `settled` HashSet grows unboundedly within a chassis lifetime
+//! The `settled` `HashSet` grows unboundedly within a chassis lifetime
 //! today. PR 5 (or a later cleanup) wires retention against the
 //! observer's eviction policy. For v1 — a chassis runs for a session,
 //! not forever — the cap-by-count plus per-process tear-down keeps

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -8,7 +8,7 @@
 //!
 //! Wire format (postcard, ADR-0045 §1):
 //! - Inline arm: discriminant 0 + K postcard bytes.
-//! - Handle arm: discriminant 1 + varint(id) + varint(kind_id).
+//! - Handle arm: discriminant 1 + `varint(id)` + `varint(kind_id)`.
 //!
 //! Resolution is structural: the walker reads the schema and skips
 //! through the payload bytes, splicing inline-discriminant + cached
@@ -295,7 +295,7 @@ impl HandleStore {
     /// re-routes through `route_mail` (re-walks the payload, possibly
     /// parks again on a different missing id, dispatches if fully
     /// resolved). Returns the drained mails in FIFO order; the
-    /// HashMap entry itself is removed so a subsequent `parked_count`
+    /// `HashMap` entry itself is removed so a subsequent `parked_count`
     /// returns 0.
     pub fn take_parked(&self, id: HandleId) -> Vec<Mail> {
         let mut inner = self.inner.write().unwrap();
@@ -1147,7 +1147,7 @@ mod tests {
         assert!(matches!(err, WalkError::Truncated));
     }
 
-    /// Locks down the Cow::Borrowed fast path: a kind with no Refs in
+    /// Locks down the `Cow::Borrowed` fast path: a kind with no Refs in
     /// its schema must never allocate. Pin the outcome shape so a
     /// regression that always builds an Owned vec is loud.
     #[test]

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -65,7 +65,7 @@ pub struct Mailer {
     /// in that case.
     chassis_router: OnceLock<Box<dyn Fn(Mail) + Send + Sync>>,
     /// ADR-0080 §6 settlement registry handle, exposed so capabilities
-    /// hosting external entry points (RpcServer, future event-source
+    /// hosting external entry points (`RpcServer`, future event-source
     /// caps) can subscribe to settlement of mail they dispatch from
     /// their handlers. Threaded through the Mailer rather than down
     /// every `NativeBinding` because settlement is a chassis-wide
@@ -892,7 +892,7 @@ mod tests {
 
     /// Issue 838 diff 2: synchronous dispatch via the `Inline`
     /// arm runs the handler inline AND emits a `Received`/`Finished`
-    /// bracket so the chain's in_flight balances and settlement
+    /// bracket so the chain's `in_flight` balances and settlement
     /// subscribers wake. Mirrors what the actor-dispatch loop does
     /// for `Inbox` recipients, but on the pushing thread.
     #[test]
@@ -940,8 +940,8 @@ mod tests {
     /// side. The actor's dispatch loop at
     /// `actor/native/dispatch.rs:85` owns the bracket; doubling it
     /// here fires settlement prematurely and breaks
-    /// `aether-substrate-bundle::rpc_engine_routing` (ReplyEnd
-    /// before ReplyEvent). This test pins the contract so a
+    /// `aether-substrate-bundle::rpc_engine_routing` (`ReplyEnd`
+    /// before `ReplyEvent`). This test pins the contract so a
     /// future "let's add the bracket for symmetry" refactor fails
     /// loudly.
     #[test]
@@ -1106,7 +1106,7 @@ mod tests {
     /// - Original iamacoffeepot/aether#838 leak: `Inline` case would have shown no
     ///   Finished, expected Bracket.
     /// - iamacoffeepot/aether#839-attempt-1 double-count: `Inbox` case would have shown
-    ///   Finished from the Mailer side, expected NeitherFromMailer.
+    ///   Finished from the Mailer side, expected `NeitherFromMailer`.
     #[test]
     fn every_mailer_push_path_produces_correct_lifecycle_events() {
         // Static link to `MailboxEntry`: a new variant added there

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -67,7 +67,7 @@ pub struct Mail {
     /// ADR-0080 §1: this mail's identity. The producer mints it from
     /// `MailId::new(producer_mailbox, producer_per_actor_correlation)`
     /// before pushing through `Mailer`. PR 2 stamps it inert (no
-    /// trace-event consumer reads it yet); PR 2's TraceObserver hooks
+    /// trace-event consumer reads it yet); PR 2's `TraceObserver` hooks
     /// emit `TraceEvent::Sent { mail_id, .. }` against this value.
     /// `MailId::NONE` for legacy paths that haven't migrated.
     pub mail_id: MailId,

--- a/crates/aether-substrate/src/mail/outbound.rs
+++ b/crates/aether-substrate/src/mail/outbound.rs
@@ -268,8 +268,8 @@ impl EgressBackend for RecordingBackend {
 }
 
 /// Substrate-side outbound facade. Threads through every place that
-/// emits hub-bound mail (mailer bubble-up, host_fns guest sends,
-/// log_capture, control kind announcements, lifecycle dying-broadcast,
+/// emits hub-bound mail (mailer bubble-up, `host_fns` guest sends,
+/// `log_capture`, control kind announcements, lifecycle dying-broadcast,
 /// boot-installed broadcast sink). Holds an `OnceLock<Arc<dyn EgressBackend>>`:
 /// pre-attach the lock is empty and every method drops silently;
 /// post-attach the wired backend handles the egress (the standard

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -136,7 +136,7 @@ pub struct MailDispatch<'a> {
 /// borrow shape is wrong for actor-enqueue handlers — the borrow
 /// can't outlive the synchronous push call, so any handler that
 /// wants to enqueue must first clone. `OwnedDispatch` owns its
-/// payload + kind_name so it can be moved cross-thread directly.
+/// payload + `kind_name` so it can be moved cross-thread directly.
 #[derive(Clone, Debug)]
 pub struct OwnedDispatch {
     /// Kind id (`K::ID`, ADR-0030 schema hash) the producer stamped.
@@ -281,7 +281,7 @@ pub enum MailboxEntry {
     /// public [`Registry::register_inbox`] /
     /// [`Registry::try_register_inbox`] for callers that own a
     /// separate dispatcher loop. Handler receives [`OwnedDispatch`]
-    /// so payload + kind_name move into the downstream envelope —
+    /// so payload + `kind_name` move into the downstream envelope —
     /// see [`InboxHandler`] for the full contract.
     Inbox(Arc<dyn InboxHandler>),
     /// The handler body does its work inline on the pushing thread;
@@ -350,8 +350,8 @@ struct Inner {
     /// `KindDescriptor`, substrate boot from `descriptors::all()`.
     kinds: HashMap<KindId, KindSlot>,
     /// O(1) name → id reverse lookup. Kept as a parallel map rather
-    /// than scanning `kinds` because the dispatch path (reply_mail kind
-    /// validation, hub_client inbound-mail name→id) runs on every mail.
+    /// than scanning `kinds` because the dispatch path (`reply_mail` kind
+    /// validation, `hub_client` inbound-mail name→id) runs on every mail.
     /// Every insert into `kinds` mirrors into `name_index`; every slot
     /// has exactly one entry here.
     name_index: HashMap<String, KindId>,

--- a/crates/aether-substrate/src/runtime/lifecycle.rs
+++ b/crates/aether-substrate/src/runtime/lifecycle.rs
@@ -18,7 +18,7 @@
 //! anyway.
 //!
 //! [`FatalAborter`] is the indirection that lets call sites that
-//! don't naturally hold a [`HubOutbound`] (the cross-class wait_reply
+//! don't naturally hold a [`HubOutbound`] (the cross-class `wait_reply`
 //! guard in [`crate::actor::native::binding`], future ADR-0074 §Decision-7
 //! checks) request an abort without plumbing outbound through every
 //! layer. Production chassis construct an [`OutboundFatalAborter`];
@@ -100,7 +100,7 @@ impl FatalAborter for OutboundFatalAborter {
 /// Test [`FatalAborter`] that panics instead of `process::exit`-ing.
 /// Lets a `#[should_panic]` test assert the cross-class guard fires
 /// without taking down the whole test runner. Also the default for
-/// chassis built without an explicit aborter (tests, the TestBench
+/// chassis built without an explicit aborter (tests, the `TestBench`
 /// in-process driver) so an abort surfaces as a panic the harness
 /// catches.
 pub struct PanicAborter;

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -3,7 +3,7 @@
 //! `install_log_target` / `ship_host_event` from `aether-actor::log`:
 //! `tracing::*` events emitted outside any actor stamp (substrate
 //! boot, scheduler thread, panic hook) hit stderr via the registered
-//! fmt::Layer for operator visibility but do not enter the mail
+//! `fmt::Layer` for operator visibility but do not enter the mail
 //! system. Until those code paths run as actors, their events stay
 //! out of `engine_logs`. The chassis-pushed `ConfigureLogDrain` mail
 //! and per-actor [`aether_actor::log::LogDrainSlot`] handle every
@@ -122,7 +122,7 @@ fn ship_via_stamped_dispatch(mailbox: MailboxId, kind: KindId, payload: &[u8]) {
 /// Tracing layer that routes in-actor events into the per-actor
 /// [`LogBuffer`] for the chassis-installed drain to ship as
 /// [`aether_kinds::LogBatch`] mail. Out-of-actor events drop here —
-/// stderr fmt::Layer, registered alongside in [`init_subscriber`],
+/// stderr `fmt::Layer`, registered alongside in [`init_subscriber`],
 /// keeps them visible to operators. Issue #601 retired the
 /// host-branch shortcut that previously routed out-of-actor events
 /// through a process-global egress; the actor model's invariant is

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(payload_string(payload.as_ref()), "owned reason");
     }
 
-    /// Anything else falls through to a TypeId mention so the message
+    /// Anything else falls through to a `TypeId` mention so the message
     /// at least identifies the payload shape.
     #[test]
     fn payload_string_handles_unknown_type() {
@@ -177,7 +177,7 @@ mod tests {
     }
 
     /// `init_panic_hook` is idempotent — calling it many times must
-    /// not double-install or panic. The OnceLock guard is the
+    /// not double-install or panic. The `OnceLock` guard is the
     /// load-bearing piece; this test makes regressions loud.
     #[test]
     fn init_is_idempotent() {

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -25,8 +25,8 @@
 //! `Arc<SegQueue<TraceEvent>>` through every binding constructor is
 //! invasive churn for a feature that runs at most once per process.
 //! The global is initialised exactly once at chassis boot and never
-//! reset — multi-chassis test fixtures (TestBench) share the queue
-//! across their substrates, which is fine because each TraceEvent
+//! reset — multi-chassis test fixtures (`TestBench`) share the queue
+//! across their substrates, which is fine because each `TraceEvent`
 //! carries the producer's [`MailboxId`] so the observer can attribute
 //! events even if the queue is shared.
 
@@ -51,7 +51,7 @@ static SUBSTRATE_START: OnceLock<Instant> = OnceLock::new();
 /// Process-global trace queue. Set by [`install_trace_queue`] at
 /// chassis boot; producer-side hooks push when present, no-op when
 /// absent. Wrapped in `OnceLock<Arc<SegQueue>>` so the drainer thread
-/// can hold a clone for `pop` without contending on the OnceLock
+/// can hold a clone for `pop` without contending on the `OnceLock`
 /// itself on every read.
 static TRACE_QUEUE: OnceLock<Arc<SegQueue<TraceEvent>>> = OnceLock::new();
 
@@ -179,7 +179,7 @@ pub fn record_finished(mail_id: MailId) {
 /// own `AtomicU64` counter, symmetric with each per-actor `NativeBinding`'s
 /// counter). Pre-PR 4 the test bench / hub minters were the only
 /// chassis-side counters; this helper shapes them as ADR-0080 §1
-/// chassis-root MailIds.
+/// chassis-root `MailId`s.
 pub fn push_chassis_root_mail(
     mailer: &Mailer,
     correlation_id: u64,


### PR DESCRIPTION
Phase 2.3 of iamacoffeepot/aether#854 lint adoption: sweep `clippy::doc_markdown`.

- Backticked code references across 31 files / 85 doc comments (acronyms + identifiers like `TestBench`, `HashSet`, `RefCell`, `VertexId`, `FRAME_BARRIER`, etc.) so the lint surface is clean.
- One fixed unbalanced-backtick block in `aether-mesh/src/polygon.rs` doc (`` ``union`/`intersection`/`difference` (retired ADR-0062)` `` → `` `union` / `intersection` / `difference` (retired ADR-0062) ``).
- No `#![allow(clippy::doc_markdown)]` escapes added — every hit fixed in prose.

Verification: `cargo check --workspace --all-targets`, `cargo fmt -- --check`, `cargo clippy --workspace --all-targets` (zero `doc_markdown`), `cargo nextest run --workspace` (1001/1001), `cargo test --doc` all green locally.

Closes iamacoffeepot/aether#873

🤖 Generated with [Claude Code](https://claude.com/claude-code)