### PR TITLE
chore(substrate): sweep clippy::cast_* wire-encode cluster (854 phase 2.1)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -446,6 +446,9 @@ fn expand_schema_enum(data: &DataEnum) -> syn::Result<TokenStream2> {
 
     let variant_entries = data.variants.iter().enumerate().map(|(idx, v)| {
         let name = v.ident.to_string();
+        // Enum variants past `u32::MAX` aren't a realistic schema; the
+        // canonical-bytes wire format stores discriminants as u32.
+        #[allow(clippy::cast_possible_truncation)]
         let discriminant = idx as u32;
         match &v.fields {
             Fields::Unit => quote! {

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -1,3 +1,8 @@
+// Wire-encode: `usize → u32` narrowings forward `(ptr, len)` pairs
+// to the wasm32 host-fn ABI. wasm32 already has 32-bit addresses;
+// `_p32`-suffixed FFI per ADR-0024 documents the convention.
+#![allow(clippy::cast_possible_truncation)]
+
 //! [`MailBridge`] — outbound-mail FFI bridge.
 //!
 //! ZST whose inherent methods forward to the matching `extern "C"`

--- a/crates/aether-actor/src/ffi/bridge/persist.rs
+++ b/crates/aether-actor/src/ffi/bridge/persist.rs
@@ -1,3 +1,7 @@
+// Wire-encode: `usize → u32` narrowings forward `(ptr, len)` pairs
+// to the wasm32 host-fn ABI (`_p32` convention, ADR-0024).
+#![allow(clippy::cast_possible_truncation)]
+
 //! [`PersistBridge`] — migration-bundle FFI bridge.
 //!
 //! ZST whose only inherent method is `save_state`, the ADR-0016

--- a/crates/aether-actor/src/ffi/bridge/sync_wait.rs
+++ b/crates/aether-actor/src/ffi/bridge/sync_wait.rs
@@ -1,3 +1,7 @@
+// Wire-encode: `usize → u32` narrowings forward `(ptr, len)` pairs
+// to the wasm32 host-fn ABI (`_p32` convention, ADR-0024).
+#![allow(clippy::cast_possible_truncation)]
+
 //! [`SyncWaitBridge`] — blocking-reply FFI bridge.
 //!
 //! ZST whose only inherent method is `wait_reply`, the ADR-0042 sync

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -1,3 +1,7 @@
+// Wire-encode: `usize → u32` narrowings forward `(ptr, len)` pairs
+// to the wasm32 host-fn ABI (`_p32` convention, ADR-0024).
+#![allow(clippy::cast_possible_truncation)]
+
 //! Concrete FFI ctx structs — [`FfiInitCtx`] / [`FfiCtx`] / [`FfiDropCtx`].
 //!
 //! Replaces the pre-issue-663 parametric `Ctx<'a, T>` / `InitCtx<'a, T>` /

--- a/crates/aether-actor/src/ffi/mailbox.rs
+++ b/crates/aether-actor/src/ffi/mailbox.rs
@@ -1,3 +1,7 @@
+// Wire-encode: `usize → u32` narrowings forward batch lengths to the
+// wasm32 host-fn ABI (`_p32` convention, ADR-0024).
+#![allow(clippy::cast_possible_truncation)]
+
 //! [`FfiActorMailbox`] — actor-typed sender handle for FFI guests.
 //!
 //! Issue 665 split the prior parametric `ActorMailbox<'a, R, T>` into

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -1,3 +1,8 @@
+// Wire-encode: `usize → u32` narrowings forward sizes to the wasm32
+// host-fn ABI (`_p32` convention, ADR-0024) and stage test payloads
+// in the in-process decode-roundtrip fixtures.
+#![allow(clippy::cast_possible_truncation)]
+
 //! Mail layer of the actor SDK: the inbound `Mail` envelope,
 //! `PriorState` bundle, and `ReplyTo` opaque handle live here in
 //! `mod.rs` (pure decoders, no transport coupling). The

--- a/crates/aether-actor/src/mail/sync.rs
+++ b/crates/aether-actor/src/mail/sync.rs
@@ -48,6 +48,8 @@ where
         -2 => Err(E::buffer_too_small()),
         -3 => Err(E::cancelled()),
         n if n >= 0 => {
+            // Match arm gates `n >= 0`, so the sign-loss cast is sound.
+            #[allow(clippy::cast_sign_loss)]
             let len = n as usize;
             postcard::from_bytes(&buf[..len]).map_err(|e| E::decode(alloc::format!("{e}")))
         }

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -915,6 +915,8 @@ mod native {
                     instrument_id: 0,
                 })
                 .unwrap();
+            // Compile-time constant; trivially exact for usize.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let release_samples = (0.5 * 48_000.0) as usize;
             let mut tail = vec![0.0f32; release_samples];
             synth.fill(&mut tail, 1);

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -657,7 +657,12 @@ mod native {
             let pid = std::process::id();
             let nonce: u64 = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
+                // Nanosecond clock fits comfortably in u64 for the next ~584 years.
+                .map(|d| {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let nanos = d.as_nanos() as u64;
+                    nanos
+                })
                 .unwrap_or(0);
             let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
             std::fs::create_dir_all(&path).unwrap();

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -205,7 +205,12 @@ mod native {
     fn now_unix_ms() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
+            // Millisecond clock fits comfortably in u64 for the next ~584 million years.
+            .map(|d| {
+                #[allow(clippy::cast_possible_truncation)]
+                let ms = d.as_millis() as u64;
+                ms
+            })
             .unwrap_or(0)
     }
 

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -305,6 +305,10 @@ mod native {
             // (O(log N + matches) per pass).
             let count = range.clone().count();
             if count > max {
+                // `max` is u32 on the wire; `count` is bounded by the
+                // BTreeSet which can't exceed `u32::MAX` in any realistic
+                // tracing window.
+                #[allow(clippy::cast_possible_truncation)]
                 return DescribeWindowResult::Err {
                     too_many: Some(count as u32),
                 };

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -1,3 +1,10 @@
+// Wire-decode: bytes laid out per `SchemaType` → serde_json. The
+// narrowing casts (`u64 → u32`, varint slot to signed via
+// `cast_possible_wrap`) are the load-bearing inverse of the encode
+// path; `From::from` / `try_into` would obscure the byte-layout
+// contract this function implements.
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
 // `decode_schema`: wire bytes + `SchemaType` descriptor → serde_json
 // value the agent can read directly. Mirror of `encoder::encode_schema`
 // — same two paths, picked the same way:

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -1,3 +1,10 @@
+// Wire-encode: serde_json input → bytes laid out per `SchemaType`.
+// The narrowing casts (`u64 → u32 / u16 / u8`, signed varint slot
+// reuse) and sign-loss casts (`i*` to the `u*` zigzag-encoded slot)
+// are the load-bearing byte layout — `From::from` / `try_into` would
+// obscure the wire-format contract these functions implement.
+#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
 // `encode_schema`: serde_json params + `SchemaType` descriptor → wire
 // bytes the substrate's decode path is happy with. Pure function; no
 // hub state, no async.

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -73,6 +73,10 @@ impl From<postcard::Error> for FrameError {
 pub fn encode_frame<T: Serialize>(msg: &T) -> Vec<u8> {
     let body = postcard::to_allocvec(msg).expect("postcard encode to Vec is infallible");
     let mut out = Vec::with_capacity(4 + body.len());
+    // 4-byte LE length prefix is the wire format; bodies above 4 GiB
+    // would overflow but no protocol that rides this framing emits
+    // anything close (worst case is a few MiB of MailFrame).
+    #[allow(clippy::cast_possible_truncation)]
     out.extend_from_slice(&(body.len() as u32).to_le_bytes());
     out.extend_from_slice(&body);
     out

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -1,3 +1,9 @@
+// Wire-encode: postcard varint slot writes narrow `u64 → u8` after
+// the LEB128 logic guarantees the high bytes are zero (or the
+// continuation bit is set). The byte layout is the load-bearing
+// contract; `try_into` would obscure the wire-format shape.
+#![allow(clippy::cast_possible_truncation)]
+
 //! Const-fn postcard primitives shared across the canonical
 //! submodules (schema / labels / inputs). Varint encoders, string
 //! length + write helpers, `Option<str>` helpers, and the `Cow`

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -364,6 +364,11 @@ mod schema_impls {
     impl<T: Schema + 'static, const N: usize> Schema for [T; N] {
         const SCHEMA: SchemaType = SchemaType::Array {
             element: SchemaCell::Static(&T::SCHEMA),
+            // Schema array lengths are bounded by `u32` on the wire
+            // (canonical bytes format). Const-context `try_into` is
+            // unavailable; arrays exceeding `u32::MAX` aren't a
+            // realistic schema shape and would fail elsewhere first.
+            #[allow(clippy::cast_possible_truncation)]
             len: N as u32,
         };
         const LABEL: Option<&'static str> = None;

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -1,7 +1,8 @@
 // Coplanar merge: single-letter `a` / `b` for directed-edge twins is
 // the canonical edge-cancellation vocabulary. `cast_lossless` fires on
-// the routine `i32 → i64` widening of integer-grid edge components
-// fed into the exact-arithmetic merge predicates.
+// routine `i32 → i64 → i128` widenings of snapped fixed-point edge
+// components fed into the exact-arithmetic merge predicates — all
+// widenings are structurally lossless.
 #![allow(clippy::many_single_char_names, clippy::cast_lossless)]
 
 //! Pass 2: coplanar polygon merging — emits boundary loops as n-gons.

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -2,7 +2,8 @@
 // accumulators that don't benefit from FMA, and single-letter names
 // for edge / vertex / face math are canonical. `cast_possible_truncation`
 // fires on the bounded `usize` vertex/face counts cast to `u32` for
-// debug counter formatting.
+// debug counter formatting; the polygon pipeline caps element counts
+// well below `u32::MAX`.
 #![allow(
     clippy::cast_precision_loss,
     clippy::suboptimal_flops,

--- a/crates/aether-mesh/src/fixed.rs
+++ b/crates/aether-mesh/src/fixed.rs
@@ -1,8 +1,9 @@
 // Fixed-point conversion: bounded `i32` snapped grid values cast to
-// f32 are domain-correct at the CSG ↔ float boundary; the
-// truncating casts (`f32 → i32`, `i64 → i32`) in this file are gated
-// by explicit range checks against `MAX_INPUT_MAGNITUDE` / `SCALE`
-// per the module doc.
+// f32 are domain-correct at the CSG ↔ float boundary; the truncating
+// casts in this file (`f32 → i32`, `i64 → i32`) are gated by explicit
+// range checks against `MAX_INPUT_MAGNITUDE` / `SCALE` per the module
+// doc, and the snapped fixed-point value is by construction ≤ 2^24
+// so the narrowing back to `i32` cannot lose data.
 #![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 
 //! 16:16 binary fixed-point conversion at the CSG boundary.

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -2,7 +2,7 @@
 // scalar accumulators that don't benefit from FMA, and `a`/`b`/`c`/`d`
 // for triangle vertices and matrix elements are the canonical vocabulary.
 // `cast_lossless` fires on the routine `i32 → i64` widening into the
-// exact-arithmetic integer-grid coord pipeline.
+// exact-arithmetic integer-grid coord pipeline — structurally lossless.
 #![allow(
     clippy::cast_precision_loss,
     clippy::suboptimal_flops,

--- a/crates/aether-mesh/src/parse.rs
+++ b/crates/aether-mesh/src/parse.rs
@@ -190,6 +190,10 @@ fn check_no_extra_keywords(
     Ok(())
 }
 
+// DSL numbers parse as f64; mesh AST is f32. Narrowing in this fn is
+// the intended precision boundary (DSL author writes the literal;
+// we keep the lower-precision in-engine representation).
+#[allow(clippy::cast_possible_truncation)]
 fn as_f32(value: &Value) -> Result<f32, ParseError> {
     value
         .as_f64()
@@ -469,7 +473,7 @@ mod tests {
     /// surface a parse error rather than producing a different mesh.
     #[test]
     fn as_u32_rejects_values_above_u32_max() {
-        let dsl = format!("(box 1 1 1 :color {})", u32::MAX as u64 + 1);
+        let dsl = format!("(box 1 1 1 :color {})", u64::from(u32::MAX) + 1);
         let err = parse(&dsl).expect_err("values above u32::MAX must error");
         match err {
             ParseError::ExpectedInteger(msg) => {

--- a/crates/aether-mesh/src/point.rs
+++ b/crates/aether-mesh/src/point.rs
@@ -129,6 +129,8 @@ mod tests {
         // Smallest representable step on each axis must produce a
         // distinct Point3. Documents that the grid resolution is
         // 1/SCALE = 1/65536 and points closer than that fold together.
+        // SCALE = 2^16; trivially exact in f32 (mantissa fits 24 bits).
+        #[allow(clippy::cast_possible_truncation)]
         let one_ulp = 1.0 / SCALE as f32;
         let origin = Point3::from_f32(Vec3::new(0.0, 0.0, 0.0)).unwrap();
         let nudges = [

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -1,6 +1,15 @@
 // Polygon math: bounded vertex counts cast to f32 for centroid /
 // averaging, scalar accumulators that don't benefit from FMA.
-#![allow(clippy::cast_precision_loss, clippy::suboptimal_flops)]
+// Integer-grid arithmetic: `i32 → i64 → i128` widenings on snapped
+// fixed-point coords feed the exact 2D projection and area predicates;
+// bounded `usize` vertex counts cast to `u32` for indexing into wire
+// buffers stay well below `u32::MAX`.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::suboptimal_flops,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation
+)]
 
 //! Public n-gon polygon API (ADR-0057).
 //!

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -1,6 +1,14 @@
 // Tessellation math: bounded vertex counts cast to f32 for fan
 // triangulation indices are domain-correct.
-#![allow(clippy::cast_precision_loss)]
+// Integer-grid arithmetic: `i32 → i64` widenings move snapped
+// fixed-point coordinates into the exact-arithmetic CDT predicates;
+// bounded `usize` vertex/triangle counts cast to `u32` for the wire
+// index buffers stay well below `u32::MAX`.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation
+)]
 
 //! Polygon → triangle conversion for the wire `Vec<Triangle>` path.
 //!

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -1,3 +1,9 @@
+// Integer-grid arithmetic: `i32 → i64` widenings on snapped fixed-point
+// coordinates feed the exact incircle / orient2d predicates; bounded
+// `usize` triangle counts cast to `u32` for the wire vertex index
+// space stay well below `u32::MAX`.
+#![allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+
 //! Bowyer-Watson incremental Delaunay triangulation (ADR-0056 PR 2).
 //!
 //! Builds an unconstrained Delaunay triangulation of a set of 2D

--- a/crates/aether-mesh/src/tessellate/cdt/predicates.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/predicates.rs
@@ -1,3 +1,8 @@
+// Every cast in this file widens `i64 → i128` for the exact
+// determinant arithmetic per the magnitude budget in the module doc.
+// Widening is structurally lossless.
+#![allow(clippy::cast_lossless)]
+
 //! Exact integer geometric predicates for CDT (ADR-0056).
 //!
 //! Both predicates take 2D points as `(i64, i64)` and return an `i32`

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -1,3 +1,8 @@
+// Integer-grid arithmetic: `i32 → i64` widenings move snapped
+// fixed-point coords through the 2D projection into the exact CDT
+// predicates. Widening is structurally lossless.
+#![allow(clippy::cast_lossless)]
+
 //! Public CDT entry point: project loops to 2D, build Delaunay, enforce
 //! boundary edges as constraints, mark inside vs outside, return the
 //! triangles inside the polygon.

--- a/crates/aether-mesh/tests/mesh_box.rs
+++ b/crates/aether-mesh/tests/mesh_box.rs
@@ -1,3 +1,8 @@
+// Test geometry uses small integer-valued f32 coords (±1, ±2); casting
+// vertex `f32 → i32` for the corner snap is exact in the value range
+// this test exercises.
+#![allow(clippy::cast_possible_truncation)]
+
 //! Verify the box mesher produces 12 triangles at the expected corners.
 
 use aether_mesh::{mesh, parse};

--- a/crates/aether-mesh/tests/mesh_v1_remaining.rs
+++ b/crates/aether-mesh/tests/mesh_v1_remaining.rs
@@ -1,3 +1,8 @@
+// Test geometry uses small integer-valued f32 coords; casting vertex
+// `f32 → i32` for corner snapping is exact in the value range these
+// tests exercise.
+#![allow(clippy::cast_possible_truncation)]
+
 //! Tests for the v1 vocabulary completion: cylinder, cone, wedge,
 //! sphere, extrude, mirror, array. Promoted alongside ADR-0051's
 //! formalization of the v1 vocabulary.

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -598,6 +598,10 @@ impl ApplicationHandler<UserEvent> for App {
                 );
             }
             WindowEvent::CursorMoved { position, .. } => {
+                // winit reports cursor position as f64; the input wire
+                // kind carries f32. Realistic window sizes (< 2^20 px)
+                // stay well inside f32 mantissa.
+                #[allow(clippy::cast_possible_truncation)]
                 let payload = encode(&MouseMove {
                     x: position.x as f32,
                     y: position.y as f32,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -181,6 +181,9 @@ impl HeadlessChassis {
             ),
         );
 
+        // Tick rates are bounded well below `u32::MAX` Hz (typically
+        // 60-240 Hz); the `u128 → u32` narrowing is safe in practice.
+        #[allow(clippy::cast_possible_truncation)]
         let tick_hz = (Duration::from_secs(1).as_nanos() / tick_period.as_nanos().max(1)) as u32;
         tracing::info!(
             target: "aether_substrate::boot",

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -1,3 +1,14 @@
+// Wire-encode: the FFI-mirror `wait_reply` ABI returns `i32` with
+// `-1`/`-2`/`-3` reserved for timeout/buffer/cancelled and non-negative
+// values returning the byte length; the `len → i32` cast (and matching
+// `i32 → u64 → Duration` widening on `timeout_ms`) preserve the wire
+// shape `aether-actor`'s sync wrapper expects.
+#![allow(
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+
 //! ADR-0074 §Decision (revisited by issue 665): native per-actor
 //! binding state.
 //!

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -437,11 +437,15 @@ impl<'a> Sender for NativeCtx<'a> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
+        // Batch count rides as `u32` on the wire (matches the FFI ABI);
+        // realistic mail batches stay well below `u32::MAX`.
+        #[allow(clippy::cast_possible_truncation)]
+        let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
-            payloads.len() as u32,
+            count,
             self.outbound_parent(),
             self.outbound_root(),
         );
@@ -611,11 +615,15 @@ impl<'a> MailSender for NativeCtx<'a> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
+        // Batch count rides as `u32` on the wire (matches the FFI ABI);
+        // realistic mail batches stay well below `u32::MAX`.
+        #[allow(clippy::cast_possible_truncation)]
+        let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
-            payloads.len() as u32,
+            count,
             self.outbound_parent(),
             self.outbound_root(),
         );

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -95,8 +95,11 @@ impl<'a, R: Actor> NativeActorMailbox<'a, R> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        self.binding
-            .send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32);
+        // Batch count rides as `u32` on the wire (matches the FFI ABI);
+        // realistic mail batches stay well below `u32::MAX`.
+        #[allow(clippy::cast_possible_truncation)]
+        let count = payloads.len() as u32;
+        self.binding.send_mail(self.mailbox, K::ID.0, bytes, count);
     }
 
     /// ADR-0080: like [`Self::send`] but returns the minted `MailId`

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -130,11 +130,15 @@ impl<A: Actor> Sender for InheritCtx<A> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
+        // Batch count rides as `u32` on the wire (matches the FFI ABI);
+        // realistic mail batches stay well below `u32::MAX`.
+        #[allow(clippy::cast_possible_truncation)]
+        let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
-            payloads.len() as u32,
+            count,
             self.outbound_parent(),
             self.outbound_root(),
         );
@@ -226,11 +230,15 @@ impl<A: Actor> Sender for RootCtx<A> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
+        // Batch count rides as `u32` on the wire (matches the FFI ABI);
+        // realistic mail batches stay well below `u32::MAX`.
+        #[allow(clippy::cast_possible_truncation)]
+        let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
-            payloads.len() as u32,
+            count,
             None,
             None,
         );

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -547,6 +547,9 @@ impl Component {
         };
         self.memory
             .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
+        // Wasm32 ABI carries `u32` byte lengths; mail payloads are
+        // bounded by guest memory size (well below `u32::MAX`).
+        #[allow(clippy::cast_possible_truncation)]
         let byte_len = mail.payload.len() as u32;
         // ADR-0080 §5 (issue iamacoffeepot/aether#722): publish the
         // inbound's lineage on `ComponentCtx` so any guest-triggered
@@ -624,10 +627,11 @@ impl Component {
         };
         self.memory
             .write(&mut self.store, STATE_OFFSET as usize, &bundle.bytes)?;
-        f.call(
-            &mut self.store,
-            (bundle.version, STATE_OFFSET, bundle.bytes.len() as u32),
-        )?;
+        // Wasm32 ABI carries `u32` byte lengths; bundle bytes are
+        // bounded by guest memory size (well below `u32::MAX`).
+        #[allow(clippy::cast_possible_truncation)]
+        let byte_len = bundle.bytes.len() as u32;
+        f.call(&mut self.store, (bundle.version, STATE_OFFSET, byte_len))?;
         Ok(())
     }
 

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -1,3 +1,9 @@
+// Wire-encode: `usize → u32` narrowings encode handle-cache byte
+// lengths into the postcard varint slots described in the wire
+// format below; `u32 → u64` widenings move handle ids into the
+// 64-bit id slot. Both are part of the load-bearing wire layout.
+#![allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+
 //! ADR-0045 typed-handle store and ref-walking dispatch hook.
 //!
 //! The substrate keeps a refcounted, byte-addressed cache of handle

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -198,6 +198,9 @@ pub fn record_main_pass(
         queue.write_buffer(&pipeline.vertex_buffer, 0, vertices);
     }
     queue.write_buffer(&pipeline.camera_buffer, 0, bytemuck::cast_slice(view_proj));
+    // `wgpu::RenderPass::draw` takes a `u32` vertex count; vertex
+    // buffer is bounded by `MAX_VERTEX_BYTES` (well below `u32::MAX`).
+    #[allow(clippy::cast_possible_truncation)]
     let vertex_count = (vertex_bytes as u64 / VERTEX_STRIDE) as u32;
 
     let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -88,6 +88,10 @@ pub fn now_nanos() -> Nanos {
         None => return Nanos(0),
     };
     let elapsed = Instant::now().saturating_duration_since(start);
+    // u128 → u64: trace timestamps overflow after ~584 years; the
+    // substrate's `SUBSTRATE_START` is set at boot, so realistic
+    // runtimes are well within u64 range.
+    #[allow(clippy::cast_possible_truncation)]
     Nanos(elapsed.as_nanos() as u64)
 }
 

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -470,7 +470,10 @@ mod tests {
 
         for (i, slot) in slots.iter().enumerate() {
             for n in 0..1000 {
-                slot.push((i * 1000 + n) as u32);
+                // Test fixture uses tiny indices that fit in u32.
+                #[allow(clippy::cast_possible_truncation)]
+                let value = (i * 1000 + n) as u32;
+                slot.push(value);
             }
             wakes[i].wake();
         }

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -1,7 +1,16 @@
 // Sokoban grid math: bounded `usize` grid coordinates cast to f32 for
 // world-space placement, and single-letter `a` / `b` / `c` for triangle
 // vertices are the canonical vocabulary.
-#![allow(clippy::cast_precision_loss, clippy::many_single_char_names)]
+// `usize ↔ u32 ↔ i32` casts are bounded by `GRID_MAX` (≪ `i32::MAX`);
+// `i32 → u32 / usize` sign-loss casts are gated by in-bounds checks;
+// `i32 → i32` step deltas don't wrap inside the 8x8 grid budget.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::many_single_char_names,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
 
 //! Sokoban demo: a grid-based puzzle world. The world owns walls,
 //! boxes, targets, the player's grid position, *and* the player's


### PR DESCRIPTION
Closes iamacoffeepot/aether#871

- Annotates the wire-encode cast cluster (`cast_lossless`, `cast_possible_truncation`, `cast_possible_wrap`, `cast_sign_loss`) across 47 files; module-level allows for files whose whole purpose is bounded integer arithmetic / wire byte layout (codec encode+decode+frame, canonical primitives, integer-grid mesh + CDT predicates, FFI bridges, handle_store, sokoban grid), per-site allows elsewhere with one-line rationale.
- Two genuine catches fixed by rewriting: `f as f64` → `f64::from(f)` in mesh serialize, `u32::MAX as u64` → `u64::from(u32::MAX)` in mesh parse test.
- 534 cast-cluster hits → 0; lints stay at workspace warn-level per the issue 854 disposition.
