### PR TITLE
chore(substrate-bundle): sweep print_stderr warn cluster (issue 891)

### DIFF
--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -20,6 +20,10 @@
 //! "every mail arrived" assertion that previously rode on draining the
 //! recording channel.
 
+// Integration-test diagnostic: emit measured ratio via stderr so
+// `cargo test --nocapture` surfaces it (issue 891).
+#![allow(clippy::print_stderr)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};

--- a/crates/aether-mesh/examples/dsl_to_obj.rs
+++ b/crates/aether-mesh/examples/dsl_to_obj.rs
@@ -3,6 +3,9 @@
 //! Usage:
 //!   `cargo run --example dsl_to_obj -- examples/box.dsl > out.obj && open out.obj`
 
+// CLI diagnostic before tracing subscriber is installed (issue 891).
+#![allow(clippy::print_stderr)]
+
 use std::process::ExitCode;
 
 fn main() -> ExitCode {

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -1,6 +1,9 @@
 //! Hub chassis binary entry point. The hub chassis lives in
 //! `aether-hub`; this binary just reads env and runs.
 
+// CLI diagnostic before tracing subscriber is installed (issue 891).
+#![allow(clippy::print_stderr)]
+
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
 
 fn main() -> anyhow::Result<()> {

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -113,7 +113,7 @@ impl DriverRunning for HubServerDriverRunning {
     fn run(self: Box<Self>) -> Result<(), RunError> {
         let Self { boot } = *self;
         let sig = shutdown_signal();
-        eprintln!("aether-substrate-hub: {sig} received, shutting down");
+        tracing::info!("aether-substrate-hub: {sig} received, shutting down");
         // `boot` drops here — actor registries shut down, dispatcher
         // threads see their inbox senders drop and exit.
         drop(boot);
@@ -138,7 +138,7 @@ fn shutdown_signal() -> &'static str {
     let mut signals = match Signals::new([SIGINT, SIGTERM]) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "aether-substrate-hub: signal handler install failed: {e}; \
                  parking thread — SIGKILL is the only exit"
             );
@@ -165,7 +165,7 @@ fn shutdown_signal() -> &'static str {
     if let Err(e) = ctrlc::set_handler(move || {
         let _ = tx.send(());
     }) {
-        eprintln!(
+        tracing::error!(
             "aether-substrate-hub: ctrl-c handler install failed: {e}; \
              parking thread — SIGKILL is the only exit"
         );

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -17,6 +17,11 @@
 //! in-flight requests would be unambiguous — though `TestBench`'s
 //! synchronous shape means at most one is ever outstanding.
 
+// Test-only skip diagnostics emit `eprintln!` so `cargo test` runners
+// surface a visible "skipping: ..." line alongside `test ... ok`;
+// not routed through `tracing` (issue 891).
+#![cfg_attr(test, allow(clippy::print_stderr))]
+
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;

--- a/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
@@ -119,6 +119,11 @@ pub fn locate_component_wasm(crate_name: &str) -> Option<PathBuf> {
 /// not pre-built — fail-fast per ADR-0063: CI relies on the strict
 /// mode to catch missing pre-build entries.
 #[must_use]
+// Test-only skip diagnostic — emitted from `cargo test` runners so a
+// skipped test is visible alongside `test ... ok` lines. Not routed
+// through `tracing` because the test harness already captures stderr
+// and surfaces it on failure (issue 891).
+#[allow(clippy::print_stderr)]
 pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
     let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     if !has_wgpu_adapter() {

--- a/crates/aether-substrate-bundle/tests/engine_logs.rs
+++ b/crates/aether-substrate-bundle/tests/engine_logs.rs
@@ -19,6 +19,10 @@
 //! runners without `mesa-vulkan-drivers`); CI's
 //! `AETHER_REQUIRE_RUNTIME=1` flips that into a hard panic.
 
+// Integration-test skip diagnostic: emit via stderr so `cargo test`
+// surfaces "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+
 use aether_kinds::{LogBatch, LogEvent, LogRead, LogReadResult};
 use aether_substrate_bundle::test_bench::{TestBench, test_helpers::has_wgpu_adapter};
 

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -23,6 +23,10 @@
 //! `TestBench::builder().namespace_roots(...)` rather than env-var
 //! mutation.
 
+// Integration-test skip diagnostic: emit via stderr so `cargo test`
+// surfaces "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+
 use std::path::Path;
 
 use aether_data::{Kind, mailbox_id_from_name};

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -1,3 +1,8 @@
+// Test-only skip diagnostics emit `eprintln!` so `cargo test` runners
+// surface a visible "skipping: ..." line alongside `test ... ok`;
+// not routed through `tracing` (issue 891).
+#![cfg_attr(test, allow(clippy::print_stderr))]
+
 // ADR-0028 / ADR-0032: read a component's embedded kind manifest
 // from two wasm custom sections — `aether.kinds` (canonical bytes,
 // the `Kind::ID` hash input) and `aether.kinds.labels` (Rust-nominal


### PR DESCRIPTION
<!-- pr-body-ok: b — Closes #891 needs literal '#' for auto-close; umbrella reference '#854' is a sibling issue link -->

Phase 2.8 of iamacoffeepot/aether#854's clippy-warn adoption sweep. Quiets the `clippy::print_stderr` cluster (~17 hits across the targeted crates).

- **3 sites in library code** rewrote `eprintln!` to `tracing::info!` / `tracing::error!` in `hub/chassis.rs` (tracing subscriber is up by the time `DriverRunning::run` fires — `SubstrateBoot::build` installs it).
- **14 sites took scoped `#[allow]`**: CLI bin (`bin/hub.rs`) and mesh example (`examples/dsl_to_obj.rs`) get file-head `#![allow]` with the rationale comment from the umbrella; `#[cfg(test)]` modules (`test_bench/bench.rs`, `actor/wasm/kind_manifest.rs`) get `#![cfg_attr(test, allow(...))]`; integration tests (`engine_logs`, `test_bench_scenario`, `log_pool_stress`) get file-head `#![allow]`; `test_helpers::require_runtime` gets a per-fn `#[allow]`.
- `cargo clippy --workspace --all-targets` shows zero `print_stderr` warnings; `cargo check`, `cargo fmt -- --check`, and `cargo nextest run --workspace` (1001 passed) all green.

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)