### PR TITLE
chore(substrate): sweep perf/string-manipulation cluster (issue 883)

### DIFF
--- a/crates/aether-mesh/src/cleanup/invariants.rs
+++ b/crates/aether-mesh/src/cleanup/invariants.rs
@@ -264,7 +264,7 @@ pub(crate) fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJ
 
     let mut violations: Vec<UnrepairedTJunction> = Vec::new();
     let mut sorted_edges: Vec<(VertexId, VertexId)> = edges.into_iter().collect();
-    sorted_edges.sort();
+    sorted_edges.sort_unstable();
     for &(a, b) in &sorted_edges {
         let pa = mesh.vertices[a];
         let pb = mesh.vertices[b];

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -204,7 +204,7 @@ fn boundary_edges_after_twin_cancellation(
     let mut edges = Vec::new();
     let mut seen = std::collections::HashSet::new();
     let mut keys: Vec<(VertexId, VertexId)> = directed.keys().copied().collect();
-    keys.sort();
+    keys.sort_unstable();
 
     for (a, b) in keys {
         let canonical = if a < b { (a, b) } else { (b, a) };
@@ -443,11 +443,11 @@ fn extract_loops(
         outgoing.entry(a).or_default().push(b);
     }
     for v in outgoing.values_mut() {
-        v.sort();
+        v.sort_unstable();
     }
 
     let mut starts: Vec<(VertexId, VertexId)> = boundary.to_vec();
-    starts.sort();
+    starts.sort_unstable();
 
     let mut visited: std::collections::HashSet<(VertexId, VertexId)> =
         std::collections::HashSet::new();
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn square_with_square_hole_emits_outer_and_hole_loops() {
-        let vertices = annular_indexed_mesh().vertices.clone();
+        let vertices = annular_indexed_mesh().vertices;
         let merged = annular_indexed_mesh().merge_coplanar();
         assert_eq!(
             merged.polygons.len(),

--- a/crates/aether-mesh/src/cleanup/provenance.rs
+++ b/crates/aether-mesh/src/cleanup/provenance.rs
@@ -125,7 +125,7 @@ fn unmatched_edges(directed: &HashMap<(VertexId, VertexId), u32>) -> Vec<(Vertex
     let mut out: Vec<(VertexId, VertexId)> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     let mut keys: Vec<(VertexId, VertexId)> = directed.keys().copied().collect();
-    keys.sort();
+    keys.sort_unstable();
     for (a, b) in keys {
         let canonical = if a < b { (a, b) } else { (b, a) };
         if !seen.insert(canonical) {

--- a/crates/aether-mesh/src/cleanup/slivers.rs
+++ b/crates/aether-mesh/src/cleanup/slivers.rs
@@ -217,10 +217,7 @@ mod tests {
         // through unchanged.
         let vertices = vec![p(0, 0, 0), p(10000, 0, 0), p(0, 10000, 0)];
         let polygons = vec![poly(vec![0, 1, 2])];
-        let mesh = IndexedMesh {
-            vertices: vertices.clone(),
-            polygons: polygons.clone(),
-        };
+        let mesh = IndexedMesh { vertices, polygons };
         let cleaned = mesh.remove_slivers();
         assert_eq!(cleaned.polygons.len(), 1);
         assert_eq!(cleaned.polygons[0].vertices, vec![0, 1, 2]);

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -58,7 +58,7 @@ impl IndexedMesh {
             }
 
             let mut sorted_edges: Vec<(VertexId, VertexId)> = edges.into_iter().collect();
-            sorted_edges.sort();
+            sorted_edges.sort_unstable();
 
             let mut subdivisions: HashMap<(VertexId, VertexId), VertexId> = HashMap::new();
             for &(a, b) in &sorted_edges {
@@ -300,10 +300,7 @@ mod tests {
         let plane = xy_plane();
         let vertices = vec![pt(0.0, 0.0, 0.0), pt(1.0, 0.0, 0.0), pt(0.0, 1.0, 0.0)];
         let polygons = vec![poly(vec![0, 1, 2], plane, 0)];
-        let mesh = IndexedMesh {
-            vertices: vertices.clone(),
-            polygons: polygons.clone(),
-        };
+        let mesh = IndexedMesh { vertices, polygons };
         let repaired = mesh.repair_tjunctions();
         assert_eq!(repaired.polygons.len(), 1);
         assert_eq!(repaired.polygons[0].vertices, vec![0, 1, 2]);

--- a/crates/aether-mesh/src/cleanup/weld.rs
+++ b/crates/aether-mesh/src/cleanup/weld.rs
@@ -232,7 +232,7 @@ mod tests {
         let tri_b =
             Polygon::from_triangle(pt(0.0, 0.0, 0.0), pt(0.0, 1.0, 0.0), pt(0.0, 0.0, 1.0), 9)
                 .unwrap();
-        let original = vec![tri_a.clone(), tri_b.clone()];
+        let original = vec![tri_a, tri_b];
         let round_tripped = IndexedMesh::weld(original.clone()).into_polygons();
 
         assert_eq!(round_tripped.len(), original.len());

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -31,6 +31,7 @@
 use crate::polygon::Polygon;
 use aether_math::Vec3;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 /// Default tolerances for geometric validators. All in world units.
 ///
@@ -587,13 +588,20 @@ pub fn dump(polygons: &[Polygon]) -> String {
         let cx: f32 = outer.iter().map(|v| v.x).sum::<f32>() / outer.len() as f32;
         let cy: f32 = outer.iter().map(|v| v.y).sum::<f32>() / outer.len() as f32;
         let cz: f32 = outer.iter().map(|v| v.z).sum::<f32>() / outer.len() as f32;
-        out.push_str(&format!(
-            "[{:>3}] color={} normal=({:+.3},{:+.3},{:+.3}) verts={:>2} holes={} centroid=({:+.3},{:+.3},{:+.3})\n",
-            i, p.color,
-            p.plane_normal.x, p.plane_normal.y, p.plane_normal.z,
-            p.vertices.len(), p.holes.len(),
-            cx, cy, cz,
-        ));
+        let _ = writeln!(
+            out,
+            "[{:>3}] color={} normal=({:+.3},{:+.3},{:+.3}) verts={:>2} holes={} centroid=({:+.3},{:+.3},{:+.3})",
+            i,
+            p.color,
+            p.plane_normal.x,
+            p.plane_normal.y,
+            p.plane_normal.z,
+            p.vertices.len(),
+            p.holes.len(),
+            cx,
+            cy,
+            cz,
+        );
     }
     out
 }
@@ -612,29 +620,32 @@ pub fn report(polygons: &[Polygon]) -> String {
     let violations = validate_manifold(polygons);
     let summ = summary(polygons);
     let mut out = String::new();
-    out.push_str(&format!(
-        "polygon mesh report: {} polygons, {} triangles after fan-tessellate, {} holes total\n",
+    let _ = writeln!(
+        out,
+        "polygon mesh report: {} polygons, {} triangles after fan-tessellate, {} holes total",
         summ.polygon_count, summ.triangle_count_after_fan, summ.hole_count_total
-    ));
-    out.push_str(&format!(
-        "  vertices/poly: min={} max={} avg={:.1}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  vertices/poly: min={} max={} avg={:.1}",
         summ.vertex_count_min, summ.vertex_count_max, summ.vertex_count_avg
-    ));
+    );
     let mut keys: Vec<&(i8, i8, i8)> = summ.by_plane_direction.keys().collect();
     keys.sort();
     out.push_str("  by plane direction (sign x,y,z → count):\n");
     for k in keys {
-        out.push_str(&format!(
-            "    ({:+},{:+},{:+}) → {}\n",
+        let _ = writeln!(
+            out,
+            "    ({:+},{:+},{:+}) → {}",
             k.0, k.1, k.2, summ.by_plane_direction[k]
-        ));
+        );
     }
     if violations.is_empty() {
         out.push_str("  manifold: OK (closed, consistent winding)\n");
     } else {
-        out.push_str(&format!("  manifold: {} VIOLATIONS:\n", violations.len()));
+        let _ = writeln!(out, "  manifold: {} VIOLATIONS:", violations.len());
         for v in &violations {
-            out.push_str(&format!("    {v:?}\n"));
+            let _ = writeln!(out, "    {v:?}");
         }
     }
     let planarity = validate_planarity(polygons);
@@ -645,14 +656,14 @@ pub fn report(polygons: &[Polygon]) -> String {
     if total_geom == 0 {
         out.push_str("  geometry: OK (planar, well-shaped, coherent, no T-junctions)\n");
     } else {
-        out.push_str(&format!("  geometry: {total_geom} VIOLATIONS:\n"));
+        let _ = writeln!(out, "  geometry: {total_geom} VIOLATIONS:");
         for v in planarity
             .iter()
             .chain(&quality)
             .chain(&normals)
             .chain(&tjunctions)
         {
-            out.push_str(&format!("    {v:?}\n"));
+            let _ = writeln!(out, "    {v:?}");
         }
     }
     out.push_str("\nfull dump:\n");

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -99,7 +99,7 @@ fn group_loops(loops: Vec<loop_polygon::Polygon>) -> Vec<Polygon> {
 
     // Sort keys so output order is deterministic across runs / platforms.
     let mut sorted_keys: Vec<GroupKey> = groups.keys().copied().collect();
-    sorted_keys.sort();
+    sorted_keys.sort_unstable();
 
     let mut out: Vec<Polygon> = Vec::with_capacity(sorted_keys.len());
     for key in sorted_keys {
@@ -757,9 +757,9 @@ mod tests {
 
         let plane = xy_plane_pos_z();
         let loops = vec![
-            loop_poly(outer_a.clone(), plane, 7),
-            loop_poly(outer_b.clone(), plane, 7),
-            loop_poly(hole_a.clone(), plane, 7),
+            loop_poly(outer_a, plane, 7),
+            loop_poly(outer_b, plane, 7),
+            loop_poly(hole_a, plane, 7),
         ];
         let polys = group_loops(loops);
         assert_eq!(polys.len(), 2, "two outers => two output polygons");
@@ -813,8 +813,8 @@ mod tests {
         let loops = vec![
             loop_poly(outer_a, plane, 3),
             loop_poly(outer_b, plane, 3),
-            loop_poly(hole_a.clone(), plane, 3),
-            loop_poly(hole_b.clone(), plane, 3),
+            loop_poly(hole_a, plane, 3),
+            loop_poly(hole_b, plane, 3),
         ];
         let polys = group_loops(loops);
         assert_eq!(polys.len(), 2);

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -555,7 +555,7 @@ impl Mesh {
         // Sort for determinism — the BFS pop order depends on stack
         // mechanics and adjacency, but the final cavity set is
         // determined by geometry. Sorting normalizes downstream walks.
-        cavity.sort();
+        cavity.sort_unstable();
         cavity
     }
 

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -457,7 +457,7 @@ impl Spawner {
                 id,
                 Arc::clone(&strong_sender),
                 TypeId::of::<A>(),
-                subname_str.clone(),
+                subname_str,
             )
             .is_err()
         {

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -518,7 +518,7 @@ mod tests {
         // Correlation ids are monotonic per actor — three sends, three
         // distinct values.
         let mut ids: Vec<u64> = captured.iter().map(|d| d.mail_id.correlation_id).collect();
-        ids.sort();
+        ids.sort_unstable();
         ids.dedup();
         assert_eq!(ids.len(), 3, "three distinct correlation ids");
     }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -557,8 +557,7 @@ impl Registry {
         name: impl Into<String>,
         handler: Arc<dyn InboxHandler>,
     ) -> MailboxId {
-        let name = name.into();
-        match self.insert(name.clone(), MailboxEntry::Inbox(handler)) {
+        match self.insert(name.into(), MailboxEntry::Inbox(handler)) {
             Ok(id) => {
                 self.notify_mailbox_change();
                 id
@@ -627,8 +626,7 @@ impl Registry {
         name: impl Into<String>,
         handler: Arc<dyn InlineHandler>,
     ) -> MailboxId {
-        let name = name.into();
-        match self.insert(name.clone(), MailboxEntry::Inline(handler)) {
+        match self.insert(name.into(), MailboxEntry::Inline(handler)) {
             Ok(id) => {
                 self.notify_mailbox_change();
                 id
@@ -755,9 +753,8 @@ impl Registry {
     /// the guard. The internal `expect("Bytes default cannot produce a
     /// conflict")` is unreachable by construction.
     pub fn register_kind(&self, name: impl Into<String>) -> KindId {
-        let name = name.into();
         let descriptor = KindDescriptor {
-            name: name.clone(),
+            name: name.into(),
             schema: SchemaType::Bytes,
         };
         // A fresh `Bytes` descriptor can only conflict with a prior
@@ -1361,7 +1358,7 @@ mod tests {
         // Sorted by name.
         let names: Vec<&str> = snap.iter().map(|d| d.name.as_str()).collect();
         let mut sorted = names.clone();
-        sorted.sort();
+        sorted.sort_unstable();
         assert_eq!(names, sorted, "snapshot must be sorted by name");
 
         // Each name maps to the expected category.

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -122,6 +122,7 @@ fn capture_backtrace_with(forced: bool) -> Option<Backtrace> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -310,10 +311,10 @@ mod tests {
 
     impl Visit for StringVisit<'_> {
         fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-            self.0.push_str(&format!("{}={:?};", field.name(), value));
+            let _ = write!(self.0, "{}={:?};", field.name(), value);
         }
         fn record_str(&mut self, field: &Field, value: &str) {
-            self.0.push_str(&format!("{}={};", field.name(), value));
+            let _ = write!(self.0, "{}={};", field.name(), value);
         }
     }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#883

- Replaced sort() with sort_unstable() on Vec<u32/u64/usize/tuple/&str> (clippy::stable_sort_primitive, 10 sites across aether-mesh + aether-substrate).
- Dropped redundant clone() at last-use of owned values across mesh cleanup tests + substrate registry (clippy::redundant_clone, 13 sites).
- Replaced s.push_str(format!(...)) with write! / writeln! to skip the intermediate allocation (clippy::format_push_string, 10 sites in debug.rs + panic_hook tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
