### PR TITLE
chore(actor): address unused_must_use call sites (issue 892)

### DIFF
--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -38,7 +38,13 @@ impl MailBridge {
     /// Returns `0` on success; `1` on substrate-side recipient
     /// lookup miss. Other non-zero values are reserved for future
     /// host-side failure surfaces.
-    #[must_use]
+    ///
+    /// Not `#[must_use]`: the public ctx surfaces (`MailSender::send`,
+    /// `MailSender::send_to_named`, `OutboundReply::reply`, etc.) are
+    /// trait-defined as fire-and-forget and have no return channel for
+    /// a lookup-miss status. The substrate warn-drops unknown
+    /// recipients on its side, which is the diagnostic path; the guest
+    /// can't surface the status anywhere meaningful.
     pub fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
         // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
         // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
@@ -61,7 +67,10 @@ impl MailBridge {
     /// threaded onto the ctx at receive time; the substrate routes it
     /// to the right Claude session, sibling component, or remote
     /// engine mailbox.
-    #[must_use]
+    ///
+    /// Not `#[must_use]`: the trait surfaces (`OutboundReply::reply`,
+    /// `MailCtx::reply`) are fire-and-forget by contract — see the
+    /// matching rationale on `send_mail`.
     pub fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
         // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
         // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -222,9 +222,14 @@ mod server_native {
 
             // Forward to the proxy: it SIGKILLs its substrate and
             // self-shuts-down. Fire-and-forget — the proxy doesn't
-            // reply, and the table entry is already gone.
+            // reply, and the table entry is already gone, so the
+            // returned MailId has nothing to subscribe against.
             let payload = mail.encode_into_bytes();
-            ctx.send_envelope_traced(entry.proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
+            let _ = ctx.send_envelope_traced(
+                entry.proxy_mailbox,
+                <TerminateEngine as Kind>::ID,
+                &payload,
+            );
             ctx.reply(&TerminateEngineResult::Ok);
         }
 

--- a/crates/aether-math/src/aabb.rs
+++ b/crates/aether-math/src/aabb.rs
@@ -475,6 +475,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "axis_index")]
     fn mirror_panics_on_bad_axis() {
-        Aabb::from_half_extents(1.0, 1.0, 1.0).mirror(3);
+        // Panic is the assertion; the returned Aabb is unreachable.
+        let _ = Aabb::from_half_extents(1.0, 1.0, 1.0).mirror(3);
     }
 }

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -204,7 +204,11 @@ impl Spawner {
             entry.slot.set_close_done_tx(tx);
             waiters.push(rx);
             entry.slot.signal_shutdown();
-            entry.wake.wake();
+            // Shutdown wake: schedule the slot so the worker observes
+            // the shutdown signal. The CAS-win bool is meaningful only
+            // for callers wiring up first-time scheduling races; here
+            // we just need *some* worker to pick the slot up.
+            let _ = entry.wake.wake();
         }
         let deadline = std::time::Instant::now() + timeout;
         let mut stuck = 0usize;
@@ -590,9 +594,15 @@ impl Spawner {
                 // the closure and wake on their own.
                 let manual_wake = wake.clone();
                 wake_slot.set(Arc::new(move || {
-                    wake.wake();
+                    // Inbox-sender hook: the CAS-win bool would tell us
+                    // whether *this* sender owns the schedule push, but
+                    // the scheduler self-deduplicates so either outcome
+                    // is fine.
+                    let _ = wake.wake();
                 }));
-                manual_wake.wake();
+                // Manual catch-up wake for inbox mail that landed
+                // before the closure was installed (see comment above).
+                let _ = manual_wake.wake();
             }
         }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -673,9 +673,12 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 // Pooled branch carries (issue 635 Phase 3).
                 let manual_wake = wake.clone();
                 wake_slot.set(Arc::new(move || {
-                    wake.wake();
+                    // Inbox-sender hook — same fire-and-forget shape
+                    // as the spawn.rs analogue: scheduler deduplicates
+                    // the CAS, so the bool is irrelevant here.
+                    let _ = wake.wake();
                 }));
-                manual_wake.wake();
+                let _ = manual_wake.wake();
                 Ok(Box::new(PooledActorShutdown::<A> {
                     slot: Some(slot),
                     mailbox_sender: Some(mailbox_sender),

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -372,8 +372,10 @@ mod tests {
             a.push(n);
             b.push(n);
         }
-        wake_a.wake();
-        wake_b.wake();
+        // Test asserts via `wait_until` on `dispatched()` below; the
+        // CAS-win bool is uninteresting at this seeding step.
+        let _ = wake_a.wake();
+        let _ = wake_b.wake();
 
         assert!(wait_until(Duration::from_secs(3), || {
             a.dispatched() == 40 && b.dispatched() == 40
@@ -415,7 +417,9 @@ mod tests {
         slot.push(1);
         slot.push(2); // this one panics
         slot.push(3);
-        wake.wake();
+        // Seeding wake — test asserts on `dispatched()` / panic
+        // outcome, not on the CAS-win bool.
+        let _ = wake.wake();
 
         // Wait for at least the first envelope to dispatch.
         assert!(wait_until(Duration::from_secs(2), || slot.dispatched() >= 1));
@@ -486,7 +490,8 @@ mod tests {
                 let value = (i * 1000 + n) as u32;
                 slot.push(value);
             }
-            wakes[i].wake();
+            // Stress seeding — bool ignored; test asserts via total().
+            let _ = wakes[i].wake();
         }
 
         let total_expected: u32 = 4 * 1000;


### PR DESCRIPTION
Phase 2.9 of iamacoffeepot/aether#854 — sweep the `unused_must_use` rustc-built-in backlog across `aether-actor`, `aether-substrate`, `aether-capabilities`, and `aether-math` (~23 hits after dedup on the host target).

## Distribution

- `aether-actor` (12 hits) — `MailBridge::send_mail` / `reply_mail` calls in `ffi/ctx.rs` + `ffi/mailbox.rs`.
- `aether-substrate` (9 hits) — `WakeHandle::wake` calls in `actor/native/spawn.rs`, `chassis/builder.rs`, `scheduler/pool.rs`.
- `aether-capabilities` (1 hit) — `NativeCtx::send_envelope_traced` in `engine/server.rs`.
- `aether-math` (1 hit) — `Aabb::mirror` in a `#[should_panic]` test.

## Fix shape

Two patterns, per the issue body:

**Removed `#[must_use]` annotations** (declaration mismatch — the public ctx trait surfaces these feed are fire-and-forget by contract):

- `aether-actor::MailBridge::send_mail` — the public ctx surfaces (`MailSender::send`, `MailSender::send_to_named`, `OutboundReply::reply`, etc.) are trait-defined as fire-and-forget; no return channel exists for the `1 = lookup-miss` status. Substrate already warn-drops on its side.
- `aether-actor::MailBridge::reply_mail` — same rationale; the trait surfaces (`OutboundReply::reply`, `MailCtx::reply`) are fire-and-forget by contract.

Rationale recorded in each function's doc-comment so the next pass doesn't re-add the attribute.

**Bound `let _ = ...`** with one-line rationale at sites where the return is genuinely diagnostic elsewhere but the specific caller intentionally discards:

- `WakeHandle::wake` call sites in `Spawner::shutdown_instanced`, the post-init catch-up wake in `Spawner::spawn_actor`, the matching path in `chassis/builder.rs`, and four test-fixture seeding wakes in `scheduler/pool.rs` (tests assert via `wait_until` / `dispatched()`).
- `NativeCtx::send_envelope_traced` in `EngineServer::on_terminate` — the table entry is already gone, so the returned `MailId` has nothing to subscribe against.
- `Aabb::mirror` in a `#[should_panic]` test — panic is the assertion; the returned value is unreachable.

No blanket `#[allow(unused_must_use)]` — every warning got addressed individually.

## Acceptance

- `cargo build --workspace --all-targets`: zero `unused_must_use` warnings.
- `cargo clippy --workspace --all-targets`: zero `unused_must_use` warnings.
- `cargo check --workspace --all-targets`: green.
- `cargo fmt -- --check`: green.
- `cargo nextest run --workspace`: 1001 passed / 0 failed.
- `cargo test --doc`: green.

Closes iamacoffeepot/aether#892

🤖 Generated with [Claude Code](https://claude.com/claude-code)