### PR TITLE
chore(substrate): sweep style cluster (issue 881)

### DIFF
--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -163,9 +163,8 @@ pub fn set_native_log_shipper(hook: NativeLogShipper) {
 /// declared no drain), or (on native) no [`with_actor_dispatch`] is
 /// active.
 pub fn drain_buffer() {
-    let entries = match LogBuffer::try_with_mut(|b| core::mem::take(&mut b.0)) {
-        Some(es) => es,
-        None => return,
+    let Some(entries) = LogBuffer::try_with_mut(|b| core::mem::take(&mut b.0)) else {
+        return;
     };
     if entries.is_empty() {
         return;
@@ -187,9 +186,8 @@ pub fn drain_buffer() {
         let Some(shipper) = shipper::load() else {
             return;
         };
-        let bytes = match postcard::to_allocvec(&batch) {
-            Ok(b) => b,
-            Err(_) => return,
+        let Ok(bytes) = postcard::to_allocvec(&batch) else {
+            return;
         };
         shipper(mailbox, <LogBatch as Kind>::ID, &bytes);
     }

--- a/crates/aether-actor/src/mail/mailbox.rs
+++ b/crates/aether-actor/src/mail/mailbox.rs
@@ -83,6 +83,10 @@ impl<K: Kind> KindId<K> {
 /// Built via `resolve_mailbox::<K>(name)` during init, or constructed
 /// inline by hand-rolled callers that compute the mailbox id
 /// themselves.
+// The `mailbox` field name is intentional: this struct is a typed
+// wrapper around the raw mailbox id, and `Mailbox::mailbox()` returns
+// it — matching the existing kind/`kind()` pair on the same struct.
+#[allow(clippy::struct_field_names)]
 pub struct Mailbox<K: Kind> {
     mailbox: u64,
     kind: u64,

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -669,29 +669,29 @@ mod native {
     /// docs for the `!Send` rationale), and a shutdown channel that
     /// signals the worker to exit on drop.
     ///
-    /// `audio_sender` is `None` when the cpal pipeline isn't running
+    /// `sender` is `None` when the cpal pipeline isn't running
     /// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In
     /// that mode `NoteOn` / `NoteOff` no-op and `SetMasterGain` replies
     /// `Err`.
     ///
-    /// Issue 629 / Phase B: `audio_thread` and `audio_shutdown` are
+    /// Issue 629 / Phase B: `thread` and `shutdown` are
     /// plain fields. Pre-Phase-A they sat behind a `Mutex<AudioTeardown>`
     /// so `Drop::drop(&mut self)` could `.take()` them while handlers
     /// ran with `&self` (Arc-shared). Post-Phase-A the dispatcher owns
     /// the cap as `Box<A>` and `Drop` runs with exclusive `&mut self`,
     /// so the wrapping mutex retires.
     pub struct AudioCapability {
-        audio_sender: Option<AudioEventSender>,
-        audio_thread: Option<JoinHandle<()>>,
-        audio_shutdown: Option<mpsc::Sender<()>>,
+        sender: Option<AudioEventSender>,
+        thread: Option<JoinHandle<()>>,
+        shutdown: Option<mpsc::Sender<()>>,
     }
 
     impl AudioCapability {
         fn nop() -> Self {
             Self {
-                audio_sender: None,
-                audio_thread: None,
-                audio_shutdown: None,
+                sender: None,
+                thread: None,
+                shutdown: None,
             }
         }
     }
@@ -701,8 +701,8 @@ mod native {
             // Drop the shutdown sender first; the worker's `recv()`
             // returns, it drops the cpal::Stream on its own thread, and
             // exits. Then we join.
-            self.audio_shutdown.take();
-            if let Some(t) = self.audio_thread.take() {
+            self.shutdown.take();
+            if let Some(t) = self.thread.take() {
                 let _ = t.join();
             }
         }
@@ -729,10 +729,10 @@ mod native {
                 return Ok(Self::nop());
             }
             match spawn_audio_worker(config.requested_sample_rate) {
-                Ok((audio_sender, audio_thread, audio_shutdown)) => Ok(Self {
-                    audio_sender: Some(audio_sender),
-                    audio_thread: Some(audio_thread),
-                    audio_shutdown: Some(audio_shutdown),
+                Ok((sender, thread, shutdown)) => Ok(Self {
+                    sender: Some(sender),
+                    thread: Some(thread),
+                    shutdown: Some(shutdown),
                 }),
                 Err(e) => {
                     tracing::warn!(
@@ -753,7 +753,7 @@ mod native {
         /// the same triple is a no-op.
         #[handler]
         fn on_note_on(&self, ctx: &mut NativeCtx<'_>, mail: NoteOn) {
-            let Some(s) = self.audio_sender.as_ref() else {
+            let Some(s) = self.sender.as_ref() else {
                 return;
             };
             let ev = AudioEvent::NoteOn {
@@ -776,7 +776,7 @@ mod native {
         /// Fire-and-forget.
         #[handler]
         fn on_note_off(&self, ctx: &mut NativeCtx<'_>, mail: NoteOff) {
-            let Some(s) = self.audio_sender.as_ref() else {
+            let Some(s) = self.sender.as_ref() else {
                 return;
             };
             let ev = AudioEvent::NoteOff {
@@ -800,7 +800,7 @@ mod native {
         #[handler]
         fn on_set_master_gain(&self, ctx: &mut NativeCtx<'_>, mail: SetMasterGain) {
             let applied = mail.gain.clamp(0.0, 1.0);
-            match self.audio_sender.as_ref() {
+            match self.sender.as_ref() {
                 Some(s) => {
                     let _ = s.push(AudioEvent::SetMasterGain { gain: applied });
                     ctx.reply(&SetMasterGainResult::Ok {

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -539,7 +539,8 @@ mod tests {
         // all across dispatcher threads — give it a generous deadline.
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            if let Some(value) = *recorded.lock().unwrap() {
+            let snapshot = *recorded.lock().unwrap();
+            if let Some(value) = snapshot {
                 assert_eq!(value, 42, "echoed value routed back through the proxy");
                 return;
             }

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -300,6 +300,8 @@ mod native {
 
     impl HttpAdapter for UreqHttpAdapter {
         fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
+            use ureq::RequestExt;
+
             let parsed =
                 url::Url::parse(&req.url).map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
 
@@ -351,7 +353,6 @@ mod native {
                 .body(req.body)
                 .map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
 
-            use ureq::RequestExt;
             let mut response = http_req
                 .with_agent(&self.agent)
                 .configure()

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -751,7 +751,7 @@ mod tests {
     #[test]
     fn ping_pong_roundtrip() {
         let (registry, mailer) = fresh_substrate();
-        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
                 peer_kind: test_peer_kind(),
@@ -759,7 +759,7 @@ mod tests {
             .build_passive()
             .expect("rpc server boots");
 
-        let port = _chassis
+        let port = chassis
             .handle::<RpcServerHandle>()
             .expect("RpcServerHandle published")
             .local_port;
@@ -804,7 +804,7 @@ mod tests {
         use aether_data::{Kind, mailbox_id_from_name};
 
         let (registry, mailer) = fresh_substrate();
-        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             // TraceObserver folds substrate-wide trace events into per-
             // root counters and fires `Settled { root }` mail at the
             // chassis-mailbox once a root drains. Without it,
@@ -819,7 +819,7 @@ mod tests {
             .build_passive()
             .expect("caps boot");
 
-        let port = _chassis
+        let port = chassis
             .handle::<RpcServerHandle>()
             .expect("RpcServerHandle published")
             .local_port;
@@ -902,7 +902,7 @@ mod tests {
         use aether_data::{Kind, mailbox_id_from_name};
 
         let (registry, mailer) = fresh_substrate();
-        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<TestEchoActor>(())
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
@@ -911,7 +911,7 @@ mod tests {
             .build_passive()
             .expect("caps boot");
 
-        let port = _chassis
+        let port = chassis
             .handle::<RpcServerHandle>()
             .expect("RpcServerHandle published")
             .local_port;
@@ -968,7 +968,7 @@ mod tests {
     #[test]
     fn wire_version_mismatch_kicks_connection() {
         let (registry, mailer) = fresh_substrate();
-        let _chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
                 peer_kind: test_peer_kind(),
@@ -976,7 +976,7 @@ mod tests {
             .build_passive()
             .expect("rpc server boots");
 
-        let port = _chassis
+        let port = chassis
             .handle::<RpcServerHandle>()
             .expect("RpcServerHandle published")
             .local_port;

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -215,10 +215,7 @@ fn decode_cast_field(
 fn render_type_id_value(id: u64, type_id: u64, _path: &str) -> Result<Value, DecodeError> {
     let _expected = aether_data::tag_for_type_id(type_id)
         .ok_or(DecodeError::UnsupportedSchema("unknown TypeId in schema"))?;
-    match aether_data::tagged_id::encode(id) {
-        Some(s) => Ok(Value::String(s)),
-        None => Ok(Value::from(id)),
-    }
+    Ok(aether_data::tagged_id::encode(id).map_or_else(|| Value::from(id), Value::String))
 }
 
 fn read_primitive_cast(

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -1027,6 +1027,21 @@ mod tests {
 
     #[test]
     fn cast_nested_struct_drawtriangle_layout() {
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
+        struct Vertex {
+            x: f32,
+            y: f32,
+            r: f32,
+            g: f32,
+            b: f32,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
+        struct DrawTriangle {
+            verts: [Vertex; 3],
+        }
+
         // DrawTriangle's shape: { verts: [Vertex; 3] } where Vertex is
         // 5 f32s. Cast wire format = 60 bytes, no internal padding.
         let vertex = SchemaType::Struct {
@@ -1052,20 +1067,6 @@ mod tests {
         let bytes = encode_schema(&params, &triangle).unwrap();
         assert_eq!(bytes.len(), 60);
 
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
-        struct Vertex {
-            x: f32,
-            y: f32,
-            r: f32,
-            g: f32,
-            b: f32,
-        }
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Debug, PartialEq)]
-        struct DrawTriangle {
-            verts: [Vertex; 3],
-        }
         let back: DrawTriangle = bytemuck::cast_slice(&bytes)[0];
         let v_struct = Vertex {
             x: 0.0,

--- a/crates/aether-data/src/canonical/labels.rs
+++ b/crates/aether-data/src/canonical/labels.rs
@@ -35,9 +35,10 @@ pub const fn canonical_len_labels(labels: &KindLabels) -> usize {
 const fn label_node_len(node: &LabelNode) -> usize {
     match node {
         LabelNode::Anonymous => 1,
-        LabelNode::Option(cell) => 1 + label_cell_len(cell),
-        LabelNode::Vec(cell) => 1 + label_cell_len(cell),
-        LabelNode::Array(cell) => 1 + label_cell_len(cell),
+        LabelNode::Option(cell)
+        | LabelNode::Vec(cell)
+        | LabelNode::Array(cell)
+        | LabelNode::Ref(cell) => 1 + label_cell_len(cell),
         LabelNode::Struct {
             type_label,
             field_names,
@@ -74,7 +75,6 @@ const fn label_node_len(node: &LabelNode) -> usize {
             }
             total
         }
-        LabelNode::Ref(cell) => 1 + label_cell_len(cell),
         LabelNode::Map { key, value } => 1 + label_cell_len(key) + label_cell_len(value),
     }
 }

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -49,13 +49,11 @@ const PRIM_F64: u8 = 9;
 #[must_use]
 pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
     match schema {
-        SchemaType::Unit => 1,
-        SchemaType::Bool => 1,
+        SchemaType::Unit | SchemaType::Bool | SchemaType::String | SchemaType::Bytes => 1,
         SchemaType::Scalar(_) => 1 + 1,
-        SchemaType::String => 1,
-        SchemaType::Bytes => 1,
-        SchemaType::Option(cell) => 1 + canonical_len_cell(cell),
-        SchemaType::Vec(cell) => 1 + canonical_len_cell(cell),
+        SchemaType::Option(cell) | SchemaType::Vec(cell) | SchemaType::Ref(cell) => {
+            1 + canonical_len_cell(cell)
+        }
         SchemaType::Array { element, len } => {
             1 + canonical_len_cell(element) + varint_u32_len(*len)
         }
@@ -79,7 +77,6 @@ pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
             }
             total
         }
-        SchemaType::Ref(cell) => 1 + canonical_len_cell(cell),
         SchemaType::Map { key, value } => 1 + canonical_len_cell(key) + canonical_len_cell(value),
         SchemaType::TypeId(id) => 1 + varint_u64_len(*id),
     }
@@ -305,7 +302,7 @@ pub fn kind_id_from_shape(shape: &crate::schema::KindShape) -> u64 {
 /// the canonical-bytes path can hash `KIND_DOMAIN ++ bytes` without
 /// a transient `Vec<u8>` — same offset basis and prime, identical
 /// output.
-pub(crate) const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
+pub const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     let mut i = 0;
     while i < prefix.len() {

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -573,8 +573,7 @@ impl From<bytemuck::PodCastError> for DecodeError {
                 expected: 0,
                 actual: 0,
             },
-            TargetAlignmentGreaterAndInputNotAligned => Self::Alignment,
-            AlignmentMismatch => Self::Alignment,
+            TargetAlignmentGreaterAndInputNotAligned | AlignmentMismatch => Self::Alignment,
         }
     }
 }

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -517,9 +517,10 @@ impl PartialEq for LabelNode {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Anonymous, Self::Anonymous) => true,
-            (Self::Option(a), Self::Option(b)) => a == b,
-            (Self::Vec(a), Self::Vec(b)) => a == b,
-            (Self::Array(a), Self::Array(b)) => a == b,
+            (Self::Option(a), Self::Option(b))
+            | (Self::Vec(a), Self::Vec(b))
+            | (Self::Array(a), Self::Array(b))
+            | (Self::Ref(a), Self::Ref(b)) => a == b,
             (
                 Self::Struct {
                     type_label: la,
@@ -542,7 +543,6 @@ impl PartialEq for LabelNode {
                     variants: vb,
                 },
             ) => la == lb && va == vb,
-            (Self::Ref(a), Self::Ref(b)) => a == b,
             (Self::Map { key: ka, value: va }, Self::Map { key: kb, value: vb }) => {
                 ka == kb && va == vb
             }

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -197,6 +197,8 @@ impl Vec3 {
     /// while rejecting visibly-different axes.
     #[inline]
     #[must_use]
+    // `mag_a_sq` / `mag_b_sq` are intuitive math names for the two operands.
+    #[allow(clippy::similar_names)]
     pub fn parallel_sign(self, other: Self) -> Option<f32> {
         let mag_a_sq = self.length_squared();
         let mag_b_sq = other.length_squared();

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -566,9 +566,9 @@ fn level_to_str(level: u8) -> &'static str {
     match level {
         0 => "trace",
         1 => "debug",
-        2 => "info",
         3 => "warn",
         4 => "error",
+        // 2 is "info"; out-of-band bytes also render as "info".
         _ => "info",
     }
 }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -329,9 +329,8 @@ pub fn parse_obj(text: &str) -> Result<Vec<DrawTriangle>, ObjParseError> {
             continue;
         }
         let mut parts = trimmed.split_whitespace();
-        let head = match parts.next() {
-            Some(h) => h,
-            None => continue,
+        let Some(head) = parts.next() else {
+            continue;
         };
         match head {
             "v" => {

--- a/crates/aether-mesh/examples/dsl_to_obj.rs
+++ b/crates/aether-mesh/examples/dsl_to_obj.rs
@@ -7,9 +7,7 @@ use std::process::ExitCode;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
-    let path = if let Some(p) = args.get(1) {
-        p
-    } else {
+    let Some(path) = args.get(1) else {
         eprintln!("usage: {} <path-to-.dsl>", args[0]);
         return ExitCode::from(2);
     };

--- a/crates/aether-mesh/src/cleanup/invariants.rs
+++ b/crates/aether-mesh/src/cleanup/invariants.rs
@@ -24,7 +24,7 @@ use crate::point::Point3;
 
 /// One twin-edge violation surfaced by [`find_twin_edges`].
 #[derive(Debug, Clone)]
-pub(crate) struct TwinEdgeViolation {
+pub struct TwinEdgeViolation {
     pub plane: Plane3,
     pub color: u32,
     pub edge: (VertexId, VertexId),
@@ -35,7 +35,7 @@ pub(crate) struct TwinEdgeViolation {
 /// fixed-point coordinates — both mean the welded mesh's vertex identity
 /// guarantee broke.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PostWeldViolation {
+pub enum PostWeldViolation {
     /// Polygon[`poly_idx`] references `vertex_id ≥ pool_size`.
     OrphanedId {
         poly_idx: usize,
@@ -55,7 +55,7 @@ pub(crate) enum PostWeldViolation {
 /// strictly interior to some polygon's edge, meaning the repair pass
 /// didn't reach a fixed point.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct UnrepairedTJunction {
+pub struct UnrepairedTJunction {
     pub edge: (VertexId, VertexId),
     pub interior_vertex: VertexId,
 }
@@ -64,7 +64,7 @@ pub(crate) struct UnrepairedTJunction {
 /// dropped below 3 vertices (should have been retained-out by the pass)
 /// or carries adjacent duplicate `VertexId`s (the dedup didn't fire).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PostSliverViolation {
+pub enum PostSliverViolation {
     /// Polygon has fewer than 3 vertices.
     TooFewVertices { poly_idx: usize, len: usize },
     /// `polygon.vertices[i] == polygon.vertices[(i+1) % n]`.
@@ -81,7 +81,7 @@ pub(crate) enum PostSliverViolation {
 /// that already lives elsewhere in the loop, but any non-adjacent repeat
 /// breaks the simple-polygon contract that downstream passes assume.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct NonSimpleLoopViolation {
+pub struct NonSimpleLoopViolation {
     pub poly_idx: usize,
     pub vertex_id: VertexId,
     /// First two positions in `poly.vertices` where `vertex_id` appears.
@@ -102,7 +102,7 @@ fn bucket_key(plane: &Plane3, color: u32) -> BucketKey {
 /// emit a non-simple loop is identifiable.
 ///
 /// O(P · V) — one `HashSet` per polygon, single linear scan.
-pub(crate) fn find_non_simple_loops(mesh: &IndexedMesh) -> Vec<NonSimpleLoopViolation> {
+pub fn find_non_simple_loops(mesh: &IndexedMesh) -> Vec<NonSimpleLoopViolation> {
     use std::collections::HashMap;
     let mut violations: Vec<NonSimpleLoopViolation> = Vec::new();
     for (poly_idx, poly) in mesh.polygons.iter().enumerate() {
@@ -135,7 +135,7 @@ pub(crate) fn find_non_simple_loops(mesh: &IndexedMesh) -> Vec<NonSimpleLoopViol
 /// Returns one violation per surviving twin pair. Buckets are scanned
 /// in undefined order; within a bucket, `edge` is the lexicographically
 /// smaller direction so each twin pair surfaces exactly once.
-pub(crate) fn find_twin_edges(mesh: &IndexedMesh) -> Vec<TwinEdgeViolation> {
+pub fn find_twin_edges(mesh: &IndexedMesh) -> Vec<TwinEdgeViolation> {
     use std::collections::HashMap;
     let mut directed: HashMap<BucketKey, HashMap<(VertexId, VertexId), usize>> = HashMap::new();
     for poly in &mesh.polygons {
@@ -194,7 +194,7 @@ pub(crate) fn find_twin_edges(mesh: &IndexedMesh) -> Vec<TwinEdgeViolation> {
 ///
 /// O(P + V) — orphan check is per-polygon-vertex, duplicate check is
 /// one linear sweep into a `HashMap<Point3, VertexId>`.
-pub(crate) fn find_post_weld_violations(mesh: &IndexedMesh) -> Vec<PostWeldViolation> {
+pub fn find_post_weld_violations(mesh: &IndexedMesh) -> Vec<PostWeldViolation> {
     use std::collections::HashMap;
     let mut violations: Vec<PostWeldViolation> = Vec::new();
     let pool_size = mesh.vertices.len();
@@ -247,7 +247,7 @@ pub(crate) fn find_post_weld_violations(mesh: &IndexedMesh) -> Vec<PostWeldViola
 /// check is warn-only diagnostic; if it dominates cleanup time the
 /// soak-then-promote cadence in the module doc applies (cull the warn
 /// or move it behind a `cfg(debug_assertions)`).
-pub(crate) fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJunction> {
+pub fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJunction> {
     use std::collections::HashSet;
     let mut edges: HashSet<(VertexId, VertexId)> = HashSet::new();
     for poly in &mesh.polygons {
@@ -289,7 +289,7 @@ pub(crate) fn find_unrepaired_tjunctions(mesh: &IndexedMesh) -> Vec<UnrepairedTJ
 /// before retain), so violations here mean a regression in either step.
 ///
 /// O(P · `V_avg`).
-pub(crate) fn find_post_sliver_violations(mesh: &IndexedMesh) -> Vec<PostSliverViolation> {
+pub fn find_post_sliver_violations(mesh: &IndexedMesh) -> Vec<PostSliverViolation> {
     let mut violations: Vec<PostSliverViolation> = Vec::new();
     for (poly_idx, poly) in mesh.polygons.iter().enumerate() {
         let n = poly.vertices.len();

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -488,6 +488,8 @@ fn extract_loops(
 /// from the incoming direction `prev → cur`. With a single unvisited
 /// candidate, returns it; with several, picks the smallest absolute
 /// turn angle, `VertexId` tiebreak.
+// `in_dx` / `in_dy` are intuitive 2D component names paired by axis.
+#[allow(clippy::similar_names)]
 fn pick_continuation(
     vertices: &[Point3],
     axes: (usize, usize),
@@ -546,6 +548,9 @@ fn pick_continuation(
 /// `VertexId` tiebreak in `pick_continuation` resolves the choice — that
 /// only triggers for input coords near the i32 fixed-point limits,
 /// and erring deterministic at the edge is fine.
+// `in_dx`/`in_dy`, `a_dx`/`a_dy`, `b_dx`/`b_dy` are the canonical 2D
+// component-pair names for the three vectors compared here.
+#[allow(clippy::similar_names)]
 fn cmp_turn(
     in_dx: i64,
     in_dy: i64,
@@ -979,6 +984,9 @@ mod tests {
     /// Cross-plane shared edges must keep matching `VertexId`s. Different
     /// planes land in different buckets, but the manifold validator
     /// walks edges across all polygons regardless of plane.
+    // `xy_poly` / `xz_poly` are the natural names; renaming dilutes the
+    // test's intent.
+    #[allow(clippy::similar_names)]
     #[test]
     fn cross_plane_shared_edge_keeps_matching_vertex_ids() {
         let xy = Plane3 {

--- a/crates/aether-mesh/src/cleanup/mesh.rs
+++ b/crates/aether-mesh/src/cleanup/mesh.rs
@@ -15,18 +15,18 @@ use crate::loop_polygon::Polygon;
 use crate::plane::Plane3;
 use crate::point::Point3;
 
-pub(crate) type VertexId = usize;
+pub type VertexId = usize;
 
-pub(crate) struct IndexedMesh {
-    pub(crate) vertices: Vec<Point3>,
-    pub(crate) polygons: Vec<IndexedPolygon>,
+pub struct IndexedMesh {
+    pub vertices: Vec<Point3>,
+    pub polygons: Vec<IndexedPolygon>,
 }
 
 #[derive(Clone)]
-pub(crate) struct IndexedPolygon {
-    pub(crate) vertices: Vec<VertexId>,
-    pub(crate) plane: Plane3,
-    pub(crate) color: u32,
+pub struct IndexedPolygon {
+    pub vertices: Vec<VertexId>,
+    pub plane: Plane3,
+    pub color: u32,
 }
 
 impl IndexedMesh {

--- a/crates/aether-mesh/src/cleanup/provenance.rs
+++ b/crates/aether-mesh/src/cleanup/provenance.rs
@@ -77,9 +77,8 @@ pub fn analyze_unmatched_boundaries(input: Vec<Polygon>) -> Vec<BoundaryEdgeProv
 
     let mut report: Vec<BoundaryEdgeProvenance> = Vec::with_capacity(unmatched.len());
     for (a, b) in unmatched {
-        let polygon_idx = match find_polygon_with_edge(&cleaned.polygons, a, b) {
-            Some(idx) => idx,
-            None => continue,
+        let Some(polygon_idx) = find_polygon_with_edge(&cleaned.polygons, a, b) else {
+            continue;
         };
         let polygon = &cleaned.polygons[polygon_idx];
         let pa = cleaned.vertices[a];

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -525,7 +525,7 @@ fn mesh_sweep(
                 u = u.rotate_axis_angle(axis_n, angle);
             }
         }
-        let scale = scales.map(|s| s[k]).unwrap_or(1.0);
+        let scale = scales.map_or(1.0, |s| s[k]);
         let p_world = offset + *p;
         let mut ring = Vec::with_capacity(n);
         for pt in profile {

--- a/crates/aether-mesh/src/simplify.rs
+++ b/crates/aether-mesh/src/simplify.rs
@@ -76,6 +76,9 @@ pub fn simplify(node: &Node) -> Node {
                 child: inner_child,
             } = &child
             {
+                // match arms read clearer than `.map_or(default, |sign| ...)`
+                // when the closure body and default both bind locals.
+                #[allow(clippy::option_if_let_else)]
                 match parallel_sign(*axis, *inner_axis) {
                     Some(sign) => (*angle + sign * *inner_angle, (**inner_child).clone()),
                     None => (*angle, child),
@@ -148,10 +151,10 @@ pub fn simplify(node: &Node) -> Node {
 /// the rotate-fold rewrite to decide whether two adjacent rotations
 /// can collapse.
 fn parallel_sign(a: Vec3, b: Vec3) -> Option<f32> {
+    const TOL: f32 = 1e-4;
     let na = a.normalize_or(Vec3::Y);
     let nb = b.normalize_or(Vec3::Y);
     let dot = na.dot(nb);
-    const TOL: f32 = 1e-4;
     if dot > 1.0 - TOL {
         Some(1.0)
     } else if dot < -1.0 + TOL {

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -103,7 +103,7 @@ pub fn tessellate_polygon_integer(
 
     // Build a flat vertex pool — CDT's `triangulate_loops` takes
     // (pool, loops as VertexId sequences, plane).
-    let total = outer.len() + holes.iter().map(|h| h.len()).sum::<usize>();
+    let total = outer.len() + holes.iter().map(Vec::len).sum::<usize>();
     let mut vertices: Vec<Point3> = Vec::with_capacity(total);
     let mut all_loops: Vec<Vec<usize>> = Vec::with_capacity(1 + holes.len());
 

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -164,6 +164,10 @@ impl Mesh {
     /// their back-pointers redirected). The two original slots are
     /// reused for the new triangles to keep `TriId`s compact in the
     /// common flip-heavy case.
+    // `pv1`/`pv2`, `s_ab_v1`/`s_ab_v2`, `s_v1v2_a`/`s_v1v2_b`, and the
+    // four `n_after_*_in_t*` names are the standard CDT flip naming
+    // convention; renaming would hurt readability for this geometric kernel.
+    #[allow(clippy::similar_names)]
     pub(super) fn flip_edge(&mut self, tid: TriId, edge_idx: usize) -> Option<(TriId, TriId)> {
         let t1 = self.triangles[tid].clone()?;
         let n_tid = t1.neighbors[edge_idx]?;
@@ -288,13 +292,11 @@ impl Mesh {
                     }
                     // Find the vertex of the neighbor that's not on the
                     // shared edge — that's the candidate to flip toward.
-                    let n_tri = match self.triangles[n_tid].as_ref() {
-                        Some(t) => t.clone(),
-                        None => continue,
+                    let Some(n_tri) = self.triangles[n_tid].clone() else {
+                        continue;
                     };
-                    let opp = match n_tri.verts.iter().find(|&&v| v != a && v != b) {
-                        Some(&v) => v,
-                        None => continue,
+                    let Some(&opp) = n_tri.verts.iter().find(|&&v| v != a && v != b) else {
+                        continue;
                     };
                     // In-circle: triangle (tri.verts[i], a, b) is CCW
                     // (inherited from the parent triangle's CCW winding,
@@ -336,9 +338,8 @@ impl Mesh {
             if self.has_edge(u, v) {
                 return Ok(());
             }
-            let (tid, edge_idx) = match self.find_crossing_edge(u, v) {
-                Some(x) => x,
-                None => return Err(()), // no crossing but edge missing — topology bug
+            let Some((tid, edge_idx)) = self.find_crossing_edge(u, v) else {
+                return Err(()); // no crossing but edge missing — topology bug
             };
             // Try to flip. If non-convex, scan for any other crossing
             // edge that IS flippable.

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -192,6 +192,9 @@ fn projected_loops_lookup(
 /// crosses an edge iff the edge straddles the test y AND the
 /// intersection x is to the right of the test x. We avoid division by
 /// cross-multiplying by `denom = pi.y - pj.y` and tracking its sign.
+// `pix3` / `piy3` and `pjx3` / `pjy3` are the canonical 2D component-pair
+// names for the two edge endpoints.
+#[allow(clippy::similar_names)]
 fn point_in_polygon_3x(cx3: i128, cy3: i128, poly: &[Point2]) -> bool {
     let mut inside = false;
     let n = poly.len();
@@ -589,12 +592,13 @@ mod tests {
 
     #[test]
     fn total_area_is_preserved_across_inputs() {
+        type Case = (&'static str, Vec<Point3>, Vec<Vec<VertexId>>, i128);
+
         // Property test: sum of triangle areas == outer area − sum(hole
         // areas) for every input the triangulator handles. If a future
         // change silently drops triangles or routes them wrong, this
         // catches it across any of the test cases at once.
         let unit = 1_i128 << 16;
-        type Case = (&'static str, Vec<Point3>, Vec<Vec<VertexId>>, i128);
         let cases: Vec<Case> = vec![
             (
                 "triangle",

--- a/crates/aether-mesh/src/test_helpers.rs
+++ b/crates/aether-mesh/src/test_helpers.rs
@@ -7,7 +7,7 @@
 use crate::fixed::f32_to_fixed;
 use crate::point::Point3;
 
-pub(crate) fn pt(x: f32, y: f32, z: f32) -> Point3 {
+pub fn pt(x: f32, y: f32, z: f32) -> Point3 {
     Point3 {
         x: f32_to_fixed(x).unwrap(),
         y: f32_to_fixed(y).unwrap(),

--- a/crates/aether-mesh/tests/mesh_v2.rs
+++ b/crates/aether-mesh/tests/mesh_v2.rs
@@ -165,6 +165,9 @@ fn round_trip_torus_and_sweep() {
 /// other sweep round-trip test in the suite.
 #[test]
 fn round_trip_open_sweep() {
+    use aether_math::Vec3;
+    use aether_mesh::ast::Node;
+
     let text = "(sweep ((0 0) (1 0) (1 1) (0 1))
                        ((0 0 0) (0 1 0))
                        :open true
@@ -175,8 +178,6 @@ fn round_trip_open_sweep() {
     assert_eq!(ast1, ast2);
     // Pin the AST shape so a regression in the parser silently
     // dropping `:open` would surface as a structural mismatch.
-    use aether_math::Vec3;
-    use aether_mesh::ast::Node;
     assert_eq!(
         ast1,
         Node::Sweep {

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -30,9 +30,8 @@ use aether_substrate_bundle::test_bench::{
 /// see what dimensions they actually got.
 fn parse_size_env() -> (u32, u32) {
     use aether_substrate_bundle::test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH};
-    let raw = match std::env::var("AETHER_TEST_BENCH_SIZE") {
-        Ok(s) => s,
-        Err(_) => return (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+    let Ok(raw) = std::env::var("AETHER_TEST_BENCH_SIZE") else {
+        return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
     };
     if let Some((w, h)) = raw.split_once('x') {
         match (w.parse::<u32>(), h.parse::<u32>()) {
@@ -225,13 +224,13 @@ fn run_frame(
                     break;
                 }
             }
-            let result = match pre_failed {
-                Some(error) => CaptureFrameResult::Err { error },
-                None => match gpu.render_and_capture() {
+            let result = pre_failed.map_or_else(
+                || match gpu.render_and_capture() {
                     Ok(png) => CaptureFrameResult::Ok { png },
                     Err(error) => CaptureFrameResult::Err { error },
                 },
-            };
+                |error| CaptureFrameResult::Err { error },
+            );
             for mail in req.after_mails {
                 queue.push(mail);
             }

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -105,6 +105,9 @@ impl DesktopEnv {
         let namespace_roots = NamespaceRoots::from_env();
         let audio = AudioConf::from_env();
 
+        // nested matches read clearer than `map_or_else` here because both
+        // arms have multi-line bodies (warn-log path on parse failure).
+        #[allow(clippy::option_if_let_else)]
         let (boot_mode, boot_size) = match std::env::var("AETHER_WINDOW_MODE") {
             Ok(s) => match parse_window_mode_env(&s) {
                 Ok(parsed) => parsed,

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -527,13 +527,13 @@ impl ApplicationHandler<UserEvent> for App {
                                     break;
                                 }
                             }
-                            let result = match pre_failed {
-                                Some(error) => CaptureFrameResult::Err { error },
-                                None => match gpu.render_and_capture() {
+                            let result = pre_failed.map_or_else(
+                                || match gpu.render_and_capture() {
                                     Ok(png) => CaptureFrameResult::Ok { png },
                                     Err(error) => CaptureFrameResult::Err { error },
                                 },
-                            };
+                                |error| CaptureFrameResult::Err { error },
+                            );
                             for mail in req.after_mails {
                                 self.queue.push(mail);
                             }

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -36,6 +36,9 @@ pub const DEFAULT_TICK_HZ: u32 = 60;
 /// constructing `HeadlessEnv` with a chosen `tick_period` directly.
 #[must_use]
 pub fn parse_tick_hz_env() -> u32 {
+    // Match arms read cleaner than `map_or` here because the Ok arm
+    // is a chained iterator/closure that warn-logs on parse failure.
+    #[allow(clippy::option_if_let_else)]
     match std::env::var("AETHER_TICK_HZ") {
         Ok(s) => s
             .trim()

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -180,7 +180,7 @@ pub struct TestBench {
     /// the bench's lifetime so the passives' dispatcher threads
     /// stay alive; drops in reverse declaration order before
     /// `_boot`, so render+log shut down before the scheduler joins.
-    _passive: PassiveChassis<TestBenchChassis>,
+    passive: PassiveChassis<TestBenchChassis>,
 }
 
 /// Fixed UUID used as the `SessionToken` for in-process replies.
@@ -331,7 +331,7 @@ impl TestBench {
             stashed_replies: HashMap::new(),
             observed_kinds,
             _boot: boot,
-            _passive: passive,
+            passive,
         })
     }
 
@@ -430,7 +430,7 @@ impl TestBench {
         payload: Vec<u8>,
     ) -> Result<(), TestBenchError> {
         let cid = self.fresh_correlation_id();
-        let registry = self._passive.settlement_registry();
+        let registry = self.passive.settlement_registry();
         let root = push_chassis_root_mail(&self.queue, cid, mailbox, kind, payload, 1);
         let rx = registry.subscribe_settlement(root);
         match rx.recv_timeout(SETTLEMENT_TIMEOUT) {
@@ -458,14 +458,14 @@ impl TestBench {
             + aether_substrate::NativeActor
             + aether_substrate::NativeDispatch,
     {
-        self._passive.spawn_actor::<A>(subname, config)
+        self.passive.spawn_actor::<A>(subname, config)
     }
 
     /// Borrow the bench's [`aether_substrate::ActorRegistry`]. Used
     /// alongside `spawn_actor` so tests can inspect the live entry's
     /// `MailboxId` directly.
     pub fn actor_registry(&self) -> &Arc<aether_substrate::ActorRegistry> {
-        self._passive.actor_registry()
+        self.passive.actor_registry()
     }
 
     /// Send `mail` to `recipient_name` with this bench's session as
@@ -756,7 +756,7 @@ impl TestBench {
             // surfacing it as `SettlementTimeout` lets the failing
             // test name the actual cause instead of timing out
             // generically on the reply pump.
-            let registry = self._passive.settlement_registry();
+            let registry = self.passive.settlement_registry();
             let tick_root = push_chassis_root_mail(
                 &self.queue,
                 self.fresh_correlation_id(),
@@ -891,6 +891,8 @@ mod tests {
         use aether_substrate::mail::registry::MailDispatch;
         use std::sync::Mutex;
 
+        type CapturedRow = (MailId, MailId, Option<MailId>);
+
         let mut tb = match TestBench::start_with_size(64, 48) {
             Ok(tb) => tb,
             Err(e) => {
@@ -913,7 +915,6 @@ mod tests {
         // `SettlementTimeout`, which is the right shape — the
         // handler that owns the bracket gets to advertise its
         // contract via the variant choice.
-        type CapturedRow = (MailId, MailId, Option<MailId>);
         let captured: Arc<Mutex<Vec<CapturedRow>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
         let subscriber_mbox = tb.registry.register_inline(

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -233,6 +233,9 @@ impl TestBenchChassis {
         // this was a post-build `boot.add_actor::<FsCapability>` call
         // with the same silent-skip semantics; the new shape moves
         // the validation up so all caps go through one boot path.
+        // Nested match keeps the warn-log path readable; converting to
+        // `map_or` buries the side-effect under closures.
+        #[allow(clippy::option_if_let_else)]
         let io_roots = match namespace_roots {
             Some(roots) => match roots.ensure_dirs() {
                 Ok(()) => Some(roots),

--- a/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
@@ -129,6 +129,9 @@ pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
         eprintln!("skipping: no wgpu adapter available");
         return None;
     }
+    // The else arm runs side effects (assert + eprintln); `map_or_else`
+    // would bury that under closures with no clarity win.
+    #[allow(clippy::option_if_let_else)]
     if let Some(path) = locate_component_wasm(crate_name) {
         Some(path)
     } else {

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -287,7 +287,7 @@ impl<'a> NativeCtx<'a> {
     }
 }
 
-impl<'a> NativeCtx<'a> {
+impl NativeCtx<'_> {
     /// ADR-0080 §5: derive the `parent_mail` to stamp on outbound
     /// mail from this ctx's in-flight context. `MailId::NONE` collapses
     /// to `None` (chassis-root or close/init ctx).
@@ -312,7 +312,7 @@ impl<'a> NativeCtx<'a> {
     }
 }
 
-impl<'a> NativeCtx<'a> {
+impl NativeCtx<'_> {
     /// Lineage-aware multicast: encode `payload` once, then push one copy
     /// to every `recipient`. The inbound `(mail_id, root)` from this ctx
     /// propagate as `parent_mail` + `inherited_root`, so each fanned-out
@@ -417,7 +417,7 @@ impl<'a> NativeCtx<'a> {
     }
 }
 
-impl<'a> Sender for NativeCtx<'a> {
+impl Sender for NativeCtx<'_> {
     fn send<R, K>(&mut self, payload: &K)
     where
         R: Actor + HandlesKind<K>,
@@ -467,7 +467,7 @@ impl<'a> Sender for NativeCtx<'a> {
     }
 }
 
-impl<'a> MailCtx for NativeCtx<'a> {
+impl MailCtx for NativeCtx<'_> {
     /// Stage 2: route the reply through the substrate's `Mailer::send_reply`
     /// (Component recipient → push as Mail with the originator's
     /// correlation echoed and reply-to None; Session / `EngineMailbox`
@@ -595,7 +595,7 @@ impl<'a> NativeInitCtx<'a> {
 // FFI-side wiring (issue 607 phase 4 / ADR-0079) will program against
 // the trait the same way native callers do.
 
-impl<'a> MailSender for NativeCtx<'a> {
+impl MailSender for NativeCtx<'_> {
     fn send<R, K>(&mut self, payload: &K)
     where
         R: Actor + HandlesKind<K>,
@@ -649,7 +649,7 @@ impl<'a> MailSender for NativeCtx<'a> {
     }
 }
 
-impl<'a> OutboundReply for NativeCtx<'a> {
+impl OutboundReply for NativeCtx<'_> {
     type ReplyHandle = ReplyTo;
 
     /// Always `Some` on native — the substrate's per-handler dispatcher
@@ -679,7 +679,7 @@ impl<'a> OutboundReply for NativeCtx<'a> {
     }
 }
 
-impl<'a> SyncWaiter for NativeCtx<'a> {
+impl SyncWaiter for NativeCtx<'_> {
     fn wait_reply<K, E>(
         &self,
         timeout_ms: u32,
@@ -699,7 +699,7 @@ impl<'a> SyncWaiter for NativeCtx<'a> {
     }
 }
 
-impl<'a> LifecycleControl for NativeCtx<'a> {
+impl LifecycleControl for NativeCtx<'_> {
     type MonitorHandle = MonitorHandle;
     type MonitorError = MonitorError;
 

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -54,7 +54,7 @@ use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
 /// per-actor counter (no live consumer post-PR-4: `wait_instanced_quiesce`
 /// retired in favour of ADR-0080 settlement gating, but the counter
 /// stays plumbed for the trampoline's `tx.send` accounting).
-pub(crate) fn dispatch_loop_run<A>(
+pub fn dispatch_loop_run<A>(
     binding: &Arc<NativeBinding>,
     actor: &mut Box<A>,
     slots: &ActorSlots,
@@ -70,9 +70,8 @@ pub(crate) fn dispatch_loop_run<A>(
         if binding.should_shutdown() {
             break;
         }
-        let env = match binding.recv_blocking() {
-            Some(e) => e,
-            None => break,
+        let Some(env) = binding.recv_blocking() else {
+            break;
         };
         let inbound_mail_id = env.mail_id;
         // ADR-0080 §2 producer hook: `Received` at handler entry.

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -80,7 +80,7 @@ use crate::scheduler::{BatchBudget, CycleResult, Drainable, SlotState};
 /// registry finalize run when the cap shuts down) and weakly by the
 /// pool's [`crate::scheduler::WakeHandle`] (so a wake after the cap
 /// is gone silently no-ops).
-pub(crate) struct DispatcherSlot<A>
+pub struct DispatcherSlot<A>
 where
     A: NativeActor + NativeDispatch,
 {
@@ -177,7 +177,7 @@ where
         let tx = self
             .close_done_tx
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
         if let Some(tx) = tx {
             // Receiver may have hung up if the wait already timed out.
@@ -290,7 +290,7 @@ where
         let mut actor_guard = self
             .actor
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let Some(actor) = actor_guard.as_mut() else {
             // Slot already finalized. Nothing to do.
             drop(actor_guard);
@@ -365,6 +365,9 @@ where
         //     is already requeued — we return `Idle`.
         debug_assert!(inbox_empty);
         self.state.mark_idle();
+        // match arms read clearer than `map_or_else(|| ..., |env| ...)` here
+        // because the Some arm runs multi-line side effects.
+        #[allow(clippy::option_if_let_else)]
         match self.binding.try_recv() {
             Some(env) => {
                 self.dispatch_one(actor, env);
@@ -403,7 +406,7 @@ where
         let guard = self
             .actor
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         guard.is_none()
     }
 
@@ -422,7 +425,7 @@ where
         let prior = self
             .close_done_tx
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .replace(tx);
         // Defensive: if a prior sender was installed (shouldn't happen
         // — `shutdown_instanced` runs once per chassis), drop it. The

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -36,8 +36,8 @@ pub struct NativeActorMailbox<'a, R> {
     _r: PhantomData<fn() -> R>,
 }
 
-impl<'a, R> Copy for NativeActorMailbox<'a, R> {}
-impl<'a, R> Clone for NativeActorMailbox<'a, R> {
+impl<R> Copy for NativeActorMailbox<'_, R> {}
+impl<R> Clone for NativeActorMailbox<'_, R> {
     fn clone(&self) -> Self {
         *self
     }
@@ -75,7 +75,7 @@ impl<'a, R> NativeActorMailbox<'a, R> {
     }
 }
 
-impl<'a, R: Actor> NativeActorMailbox<'a, R> {
+impl<R: Actor> NativeActorMailbox<'_, R> {
     /// Send a single payload of kind `K` to actor `R`. Compile-checked
     /// against `R: HandlesKind<K>`. Wire shape (cast or postcard)
     /// follows `Kind::encode_into_bytes`.

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -462,8 +462,7 @@ impl ActorRegistry {
             .read()
             .unwrap()
             .get(&target)
-            .map(|v| v.len())
-            .unwrap_or(0)
+            .map_or(0, Vec::len)
     }
 
     /// Number of targets `watcher` is monitoring right now. Test-facing
@@ -474,8 +473,7 @@ impl ActorRegistry {
             .read()
             .unwrap()
             .get(&watcher)
-            .map(|v| v.len())
-            .unwrap_or(0)
+            .map_or(0, Vec::len)
     }
 }
 
@@ -499,8 +497,8 @@ mod tests {
     /// liveness check passes. Uses a throwaway sender so the test
     /// doesn't drag in `NativeActor`.
     fn insert_live_stub(r: &ActorRegistry, id: MailboxId) {
-        let (tx, _rx) = std::sync::mpsc::channel::<crate::actor::native::envelope::Envelope>();
         struct Stub;
+        let (tx, _rx) = std::sync::mpsc::channel::<crate::actor::native::envelope::Envelope>();
         r.insert_live(
             id,
             Arc::new(tx),

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -65,9 +65,11 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
          len: u32,
          count: u32|
          -> u32 {
-            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
-                Some(m) => m,
-                None => return 1, // guest exports no memory
+            let Some(memory) = caller
+                .get_export("memory")
+                .and_then(wasmtime::Extern::into_memory)
+            else {
+                return 1; // guest exports no memory
             };
 
             // Copy the bytes out of guest memory so the mail outlives
@@ -118,9 +120,11 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
                 ));
                 return SAVE_STATE_TOO_LARGE;
             }
-            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
-                Some(m) => m,
-                None => return SAVE_STATE_NO_MEMORY,
+            let Some(memory) = caller
+                .get_export("memory")
+                .and_then(wasmtime::Extern::into_memory)
+            else {
+                return SAVE_STATE_NO_MEMORY;
             };
             let data = memory.data(&caller);
             let start = ptr as usize;
@@ -155,9 +159,11 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
          len: u32,
          count: u32|
          -> u32 {
-            let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
-                Some(m) => m,
-                None => return REPLY_OOB,
+            let Some(memory) = caller
+                .get_export("memory")
+                .and_then(wasmtime::Extern::into_memory)
+            else {
+                return REPLY_OOB;
             };
             let data = memory.data(&caller);
             let start = ptr as usize;
@@ -278,7 +284,10 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
             // a `-2` from the transport means the payload exceeded
             // `out_cap` and the transport already parked the envelope
             // on its overflow for a retry.
-            let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
+            let Some(memory) = caller
+                .get_export("memory")
+                .and_then(wasmtime::Extern::into_memory)
+            else {
                 return WAIT_BUFFER_TOO_SMALL;
             };
             let start = out_ptr as usize;
@@ -332,7 +341,10 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
         "aether",
         "init_failed_p32",
         |mut caller: Caller<'_, ComponentCtx>, ptr: u32, len: u32| {
-            let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) else {
+            let Some(memory) = caller
+                .get_export("memory")
+                .and_then(wasmtime::Extern::into_memory)
+            else {
                 return;
             };
             let data = memory.data(&caller);

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -216,7 +216,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                 caps.handlers.push(HandlerCapability {
                     id,
                     name: name.into_owned(),
-                    doc: doc.map(|d| d.into_owned()),
+                    doc: doc.map(std::borrow::Cow::into_owned),
                 });
             }
             InputsRecord::Fallback { doc } => {
@@ -226,7 +226,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                     ));
                 }
                 caps.fallback = Some(FallbackCapability {
-                    doc: doc.map(|d| d.into_owned()),
+                    doc: doc.map(std::borrow::Cow::into_owned),
                 });
             }
             InputsRecord::Component { doc } => {

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -100,7 +100,7 @@ impl SubstrateBoot {
     }
 }
 
-impl<'a> SubstrateBootBuilder<'a> {
+impl SubstrateBootBuilder<'_> {
     /// Execute the boot: registers `aether_kinds::descriptors::all()`,
     /// wires the diagnostic sink, and prepares the runtime handles
     /// (engine, registry, mailer, linker, outbound, input subscribers)

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1211,13 +1211,10 @@ fn boot_passives(
     // (`available_parallelism() - 1`, min 1); `Some(n)` swaps the
     // worker count while preserving every other default field
     // (`budget_template`, etc.).
-    let pool_config = match workers {
-        Some(n) => PoolConfig {
-            workers: n,
-            ..PoolConfig::default()
-        },
-        None => PoolConfig::default(),
-    };
+    let pool_config = workers.map_or_else(PoolConfig::default, |n| PoolConfig {
+        workers: n,
+        ..PoolConfig::default()
+    });
     let pool = Pool::start(pool_config, Arc::clone(aborter));
 
     // ADR-0080 §3 trace pipeline. `init_substrate_start` pins the
@@ -1299,7 +1296,10 @@ fn boot_passives(
     // Helper: undo every advanced passive in `booted` in reverse,
     // then propagate `err`. Spawn-pass failures additionally pass
     // already-spawned shutdowns; this helper handles those too.
-    #[allow(clippy::too_many_arguments)]
+    //
+    // Placed mid-block intentionally — sits next to the call sites in
+    // the boot sequence rather than hoisted to the top of `boot_into`.
+    #[allow(clippy::too_many_arguments, clippy::items_after_statements)]
     fn rollback(
         registry: &Arc<Registry>,
         mailer: &Arc<Mailer>,

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -150,6 +150,8 @@ impl HandleStore {
     /// back to the default with a warn log so a typo doesn't silently
     /// shrink the cache to zero.
     pub fn from_env() -> Self {
+        // Nested match keeps the warn-log path readable.
+        #[allow(clippy::option_if_let_else)]
         let max_bytes = match std::env::var(ENV_MAX_BYTES) {
             Ok(raw) => match raw.parse::<usize>() {
                 Ok(n) => n,
@@ -357,10 +359,7 @@ impl HandleStore {
     /// the guard.
     pub fn take_parked(&self, id: HandleId) -> Vec<Mail> {
         let mut inner = self.inner.write().unwrap();
-        match inner.parked.remove(&id) {
-            Some(q) => q.into(),
-            None => Vec::new(),
-        }
+        inner.parked.remove(&id).map_or_else(Vec::new, Into::into)
     }
 
     /// Sum of `bytes.len()` across every entry in the store.
@@ -395,8 +394,7 @@ impl HandleStore {
             .unwrap()
             .parked
             .get(&id)
-            .map(|q| q.len())
-            .unwrap_or(0)
+            .map_or(0, VecDeque::len)
     }
 
     /// Configured byte cap; eviction kicks in once `total_bytes`
@@ -476,7 +474,10 @@ pub fn schema_contains_ref(schema: &SchemaType) -> bool {
         | SchemaType::Bool
         | SchemaType::Scalar(_)
         | SchemaType::String
-        | SchemaType::Bytes => false,
+        | SchemaType::Bytes
+        // ADR-0065: typed-id leaves carry no nested fields and so
+        // can never embed a `Ref`.
+        | SchemaType::TypeId(_) => false,
         SchemaType::Option(inner) | SchemaType::Vec(inner) => schema_contains_ref(inner),
         SchemaType::Array { element, .. } => schema_contains_ref(element),
         SchemaType::Struct { fields, .. } => fields.iter().any(|f| schema_contains_ref(&f.ty)),
@@ -490,9 +491,6 @@ pub fn schema_contains_ref(schema: &SchemaType) -> bool {
         // those defensively rather than the type system, so be
         // conservative and walk both sides.
         SchemaType::Map { key, value } => schema_contains_ref(key) || schema_contains_ref(value),
-        // ADR-0065: typed-id leaves carry no nested fields and so
-        // can never embed a `Ref`.
-        SchemaType::TypeId(_) => false,
     }
 }
 

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -231,12 +231,10 @@ impl Mailer {
     {
         match sender.target {
             ReplyTarget::None => false,
-            ReplyTarget::Session(_) | ReplyTarget::EngineMailbox { .. } => {
-                match self.outbound.as_ref() {
-                    Some(outbound) => outbound.send_reply(sender, result),
-                    None => false,
-                }
-            }
+            ReplyTarget::Session(_) | ReplyTarget::EngineMailbox { .. } => self
+                .outbound
+                .as_ref()
+                .is_some_and(|outbound| outbound.send_reply(sender, result)),
             ReplyTarget::Component(mailbox) => {
                 let payload = match postcard::to_allocvec(result) {
                     Ok(p) => p,
@@ -810,9 +808,9 @@ mod tests {
         let mut leftover = Vec::new();
         while let Some(event) = queue.pop() {
             let belongs = match &event {
-                TraceEvent::Sent { mail_id, .. } => mail_id.sender == sender,
-                TraceEvent::Received { mail_id, .. } => mail_id.sender == sender,
-                TraceEvent::Finished { mail_id, .. } => mail_id.sender == sender,
+                TraceEvent::Sent { mail_id, .. }
+                | TraceEvent::Received { mail_id, .. }
+                | TraceEvent::Finished { mail_id, .. } => mail_id.sender == sender,
             };
             if belongs {
                 out.push(event);
@@ -1120,14 +1118,7 @@ mod tests {
                 MailboxEntry::Dropped => "Dropped",
             }
         }
-        // Touch the helper so the compiler considers it live.
-        let _ = dispatch_path_for_entry(&MailboxEntry::Dropped);
 
-        let queue = ensure_trace_queue();
-        // Each case: (case-name, expectation, push-fn that returns
-        // the stamped mail_id to filter on). Cases construct their
-        // own Mailer fixtures so chassis-router / outbound / handle-
-        // store-Parked setups can vary independently.
         enum Expect {
             /// Sync handler ran inline → Received + Finished.
             Bracket,
@@ -1147,6 +1138,15 @@ mod tests {
             // Returns the `MailId` to filter the trace queue on.
             run: Box<dyn FnOnce() -> MailId>,
         }
+
+        // Touch the helper so the compiler considers it live.
+        let _ = dispatch_path_for_entry(&MailboxEntry::Dropped);
+
+        let queue = ensure_trace_queue();
+        // Each case: (case-name, expectation, push-fn that returns
+        // the stamped mail_id to filter on). Cases construct their
+        // own Mailer fixtures so chassis-router / outbound / handle-
+        // store-Parked setups can vary independently.
 
         let cases: Vec<Case> = vec![
             // 1. Inline arm — bracket.

--- a/crates/aether-substrate/src/mail/outbound.rs
+++ b/crates/aether-substrate/src/mail/outbound.rs
@@ -313,10 +313,7 @@ impl HubOutbound {
 
     /// Whether a backend is wired and reports itself connected.
     pub fn is_connected(&self) -> bool {
-        self.backend
-            .get()
-            .map(|b| b.is_connected())
-            .unwrap_or(false)
+        self.backend.get().is_some_and(|b| b.is_connected())
     }
 
     /// Reply or push mail addressed at a Claude session.

--- a/crates/aether-substrate/src/render/capture.rs
+++ b/crates/aether-substrate/src/render/capture.rs
@@ -47,10 +47,10 @@ pub fn prepare_capture_copy(
     let padded_row_bytes = align_up(unpadded_row_bytes, COPY_ROW_ALIGN);
     let buffer_size = u64::from(padded_row_bytes) * u64::from(height);
 
-    let needs_realloc = match &targets.readback {
-        Some(rb) => rb.width != width || rb.height != height,
-        None => true,
-    };
+    let needs_realloc = targets
+        .readback
+        .as_ref()
+        .is_none_or(|rb| rb.width != width || rb.height != height);
     if needs_realloc {
         let buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("capture readback"),

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -32,6 +32,10 @@ pub enum RenderError {
 /// group. Built once at chassis boot via [`build_main_pipeline`];
 /// each frame's vertex blob and view-projection matrix are uploaded
 /// via [`record_main_pass`].
+// The `pipeline` field carries the `wgpu::RenderPipeline`; the wrapping
+// struct holds adjacent buffers + bind groups. Renaming to `render` or
+// `inner` loses the "this is the GPU pipeline handle" signal.
+#[allow(clippy::struct_field_names)]
 pub struct Pipeline {
     pub(super) pipeline: wgpu::RenderPipeline,
     pub(super) vertex_buffer: wgpu::Buffer,

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -113,7 +113,7 @@ pub fn with_actor_dispatch<R>(dispatch: &dyn MailDispatch, f: impl FnOnce() -> R
 /// it. No-op when no dispatch is stamped (out-of-actor `drain_buffer`
 /// calls — shouldn't happen in normal flow).
 fn ship_via_stamped_dispatch(mailbox: MailboxId, kind: KindId, payload: &[u8]) {
-    let Some(dispatch) = ACTOR_DISPATCH.with(|slot| slot.get()) else {
+    let Some(dispatch) = ACTOR_DISPATCH.with(std::cell::Cell::get) else {
         return;
     };
     dispatch.send(mailbox, kind, payload);

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -60,10 +60,10 @@ fn make_hook(
 fn emit_event(info: &PanicHookInfo<'_>) {
     let thread = std::thread::current();
     let thread_name = thread.name().unwrap_or("<unnamed>");
-    let location = info
-        .location()
-        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
-        .unwrap_or_else(|| "<unknown>".to_string());
+    let location = info.location().map_or_else(
+        || "<unknown>".to_string(),
+        |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
+    );
     let payload = payload_string(info.payload());
     let backtrace = capture_backtrace();
 
@@ -96,6 +96,9 @@ fn emit_event(info: &PanicHookInfo<'_>) {
 /// `panic!("{}", thing)`) — and falls back to a `TypeId` mention for
 /// anything else. Mirrors the default hook's behaviour without
 /// duplicating its full dance.
+// Chained if-let on disjoint downcasts reads cleaner than a deep
+// `map_or_else` ladder over two Options.
+#[allow(clippy::option_if_let_else)]
 fn payload_string(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -314,8 +314,7 @@ fn ship_batch(
     if !mailer
         .registry()
         .entry(recipient)
-        .map(|e| matches!(e, crate::mail::registry::MailboxEntry::Inbox(_)))
-        .unwrap_or(false)
+        .is_some_and(|e| matches!(e, crate::mail::registry::MailboxEntry::Inbox(_)))
     {
         // Observer not registered (or dropped); silently discard the
         // batch. Test isolation: a chassis without

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -270,6 +270,9 @@ fn worker_loop(
 }
 
 fn format_panic_payload(payload: &Box<dyn Any + Send>, actor_label: &str) -> String {
+    // Chained if-let on disjoint downcasts reads cleaner than a deep
+    // `map_or_else` ladder over two Options.
+    #[allow(clippy::option_if_let_else)]
     let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()
     } else if let Some(s) = payload.downcast_ref::<String>() {

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -343,7 +343,7 @@ impl WakeHandle {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub mod tests {
     use super::*;
     use std::any::Any;
     use std::sync::Mutex;

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -246,7 +246,6 @@ impl Sokoban {
             for (x, ch) in row.chars().enumerate() {
                 let cell = match ch {
                     '#' => CELL_WALL,
-                    '.' => CELL_FLOOR,
                     '$' => CELL_BOX,
                     'T' => CELL_TARGET,
                     '*' => CELL_BOX_ON_TARGET,
@@ -258,6 +257,7 @@ impl Sokoban {
                         player = (x as u32, y as u32);
                         CELL_TARGET
                     }
+                    // '.' and any unknown char fall through to floor.
                     _ => CELL_FLOOR,
                 };
                 cells[y * GRID_MAX + x] = cell;
@@ -283,6 +283,8 @@ impl Sokoban {
     /// Returns `true` when the player moved; `false` when the step
     /// was rejected (wall, out of bounds, unpushable box, post-solve,
     /// diagonal or invalid delta).
+    // `delta_gx` / `delta_gy` are the natural grid-axis component names.
+    #[allow(clippy::similar_names)]
     fn apply_step(&mut self, dx: i32, dy: i32) -> bool {
         if self.state.solved == 1 {
             return false;
@@ -304,7 +306,6 @@ impl Sokoban {
 
         let target = cell_at(&self.state, tx as u32, ty as u32);
         match target {
-            CELL_WALL => return false,
             CELL_FLOOR | CELL_TARGET => {}
             CELL_BOX | CELL_BOX_ON_TARGET => {
                 let bx = tx + delta_gx;
@@ -328,6 +329,7 @@ impl Sokoban {
                 };
                 set_cell(&mut self.state, tx as u32, ty as u32, vacated);
             }
+            // CELL_WALL or any unrecognised tile blocks the step.
             _ => return false,
         }
 


### PR DESCRIPTION
Drains the medium-count style-cluster lints left over from iamacoffeepot/aether#876's long-tail Phase 2.6 cleanup. Per-site fixes where the suggestion is clearly better; per-call-site allow with a one-line rationale where the closure body or chained warn-log path would suffer.

- Fixed every warning in the 12 lints listed in iamacoffeepot/aether#881 (manual_let_else, redundant_closure_for_method_calls, option_if_let_else, match_same_arms, redundant_pub_crate, elidable_lifetime_names, similar_names, items_after_statements, map_unwrap_or, used_underscore_binding, struct_field_names, significant_drop_in_scrutinee). Verified by parsing clippy output — zero remaining in those lints, all 1001 nextest cases green, sokoban + mesh-viewer wasm builds clean.
- Renamed audio cap fields (audio_sender to sender, etc.) and _passive to passive on TestBench, the only structural renames; everything else is mechanical (let-else, fn-elision, Vec::len, PoisonError::into_inner, etc.).

Closes iamacoffeepot/aether#881