### PR TITLE
chore(substrate): sweep design-touching pedantic cluster (issue 882)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -67,6 +67,11 @@ pub fn derive_schema(input: TokenStream) -> TokenStream {
     }
 }
 
+// Single expansion entry point: emits `Kind` impl, optional
+// `CastEligible`, manifest consts, and retention statics — the surface
+// is wide enough that extracting helpers would force per-helper
+// generic-context arguments without saving readability.
+#[allow(clippy::too_many_lines)]
 fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
     let KindAttr { name: kind_name } = parse_kind_attr(&input.attrs)?;
@@ -879,6 +884,12 @@ fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
     Ok(opts)
 }
 
+// Single-pass `#[bridge]` expander: walks the inner mod, splits wasm
+// stub vs native impl emission, and wires the cardinality marker.
+// The pieces share captured spans / item refs so factoring out helpers
+// would force ad-hoc shared-state structs that read worse than a
+// linear walk.
+#[allow(clippy::too_many_lines)]
 fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenStream2> {
     let BridgeOpts {
         cardinality,
@@ -1458,6 +1469,7 @@ fn attr_is_fallback(attr: &Attribute) -> bool {
 /// init wrapper, `aether.kinds.inputs` manifest consts, kind retention
 /// statics, plus the `HandlesKind<K>` and `Actor` impls common to both
 /// shapes.
+#[allow(clippy::too_many_lines)] // emits the full wasm-actor surface in one go
 fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
@@ -1584,7 +1596,7 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     let helper_methods_tokens = helpers.iter();
 
     let inputs_manifest_consts =
-        build_inputs_manifest_consts(&handlers, fallback.as_ref(), &component_doc);
+        build_inputs_manifest_consts(&handlers, fallback.as_ref(), component_doc.as_ref());
     let kind_retention_statics = build_kinds_section_retention_statics(self_ty, &handlers);
 
     // Issue 525 Phase 4: trait consts (NAMESPACE, FRAME_BARRIER) live
@@ -1673,6 +1685,11 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
 ///
 /// `#[fallback]` is rejected — native actors are typed receivers;
 /// unknown kinds are programming errors, not fallback paths.
+// Emits the full `NativeActor` surface in one walk: dispatch table,
+// `init` wrapper, `HandlesKind<K>` impls per handler, plus the
+// dispatch ABI plumbing. Splitting into helpers would force shared
+// per-handler context structs without saving readability.
+#[allow(clippy::too_many_lines)]
 fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
@@ -2256,14 +2273,14 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 fn build_inputs_manifest_consts(
     handlers: &[HandlerFn],
     fallback: Option<&FallbackFn>,
-    component_doc: &Option<String>,
+    component_doc: Option<&String>,
 ) -> TokenStream2 {
     let mut len_terms: Vec<TokenStream2> = Vec::new();
     let mut copy_blocks: Vec<TokenStream2> = Vec::new();
 
     for h in handlers {
         let k = &h.kind_ty;
-        let doc_expr = option_str_token(&h.agent_doc);
+        let doc_expr = option_str_token(h.agent_doc.as_ref());
         // `inputs_handler_len` / `write_inputs_handler` take a raw `u64`
         // for the wire bytes; `Kind::ID` is `KindId` post-issue 466 so
         // we drop into `.0` here.
@@ -2301,7 +2318,7 @@ fn build_inputs_manifest_consts(
     }
 
     if let Some(f) = fallback {
-        let doc_expr = option_str_token(&f.agent_doc);
+        let doc_expr = option_str_token(f.agent_doc.as_ref());
         len_terms.push(quote! {
             (1 + ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr))
         });
@@ -2323,7 +2340,7 @@ fn build_inputs_manifest_consts(
         });
     }
 
-    if let Some(doc) = component_doc.as_ref() {
+    if let Some(doc) = component_doc {
         let doc_lit = doc.as_str();
         len_terms.push(quote! {
             (1 + ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit))
@@ -2399,6 +2416,7 @@ fn build_inputs_manifest_consts(
 /// component that declares them, or is the hub with its own server
 /// component). If that assumption ever breaks, extend this emitter to
 /// walk `Sink<K>` resolutions too.
+#[allow(clippy::too_many_lines)] // per-handler retention static block; one walk keeps each emitted static contiguous
 fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn]) -> TokenStream2 {
     let self_ty_hint = type_hint(self_ty);
 
@@ -2550,7 +2568,7 @@ fn type_hint(ty: &Type) -> syn::Ident {
 /// Produce the token stream for `Option<&'static str>` from an
 /// `Option<String>` captured at macro expansion. Used for every
 /// rustdoc-sourced doc field.
-fn option_str_token(doc: &Option<String>) -> TokenStream2 {
+fn option_str_token(doc: Option<&String>) -> TokenStream2 {
     if let Some(s) = doc {
         let lit = s.as_str();
         quote! { ::core::option::Option::Some(#lit) }

--- a/crates/aether-actor/examples/caller.rs
+++ b/crates/aether-actor/examples/caller.rs
@@ -16,6 +16,11 @@
 //! hatch — the echoer's actor type lives in a sibling cdylib this
 //! crate can't import without colliding FFI exports.
 
+// Handlers take `&mut self` per the ADR-0033 / ADR-0038 dispatch
+// contract; a stub handler that ignores both `self` and the mail
+// payload still has to match the trampoline ABI.
+#![allow(clippy::unused_self)]
+
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
 use aether_capabilities::InputCapability;
 use aether_data::{Kind, MailboxId, Schema};

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -16,6 +16,11 @@
 //! MCP via the same section so the harness sees typed capabilities
 //! plus author-written intent for each inbox.
 
+// `#[handler]` methods take `&mut self` to match the dispatch ABI
+// (ADR-0033 / ADR-0038); a stateless handler that ignores `self` is
+// fine but must keep the signature.
+#![allow(clippy::unused_self)]
+
 use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
 use aether_capabilities::{InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -14,6 +14,10 @@
 //! walker retired earlier in #403); components subscribe explicitly
 //! via `ctx.subscribe_input::<K>()` in `init`.
 
+// Stateless logger: each `#[handler]` keeps `&mut self` for the
+// ADR-0033 / ADR-0038 dispatch ABI but doesn't need any field access.
+#![allow(clippy::unused_self)]
+
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::InputCapability;
 use aether_data::{Kind, MailboxId};

--- a/crates/aether-actor/examples/postcard_echoer.rs
+++ b/crates/aether-actor/examples/postcard_echoer.rs
@@ -18,6 +18,11 @@
 //! to wasm; load via `mcp__aether-hub__load_component` and send
 //! `demo.postcard_request` to verify the dispatch.
 
+// `#[handler]` keeps `&mut self` per the ADR-0033 / ADR-0038 dispatch
+// ABI; the echo body decodes the payload and replies without touching
+// component state.
+#![allow(clippy::unused_self)]
+
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_data::{Kind, Schema};
 use serde::{Deserialize, Serialize};

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -176,6 +176,10 @@ impl FfiCtx<'_> {
     /// # Panics
     /// Always panics — that's the point. The trap propagates to the
     /// substrate's ADR-0063 fail-fast escalation path.
+    // Mirrors `aether_substrate::actor::native::NativeCtx::fatal_abort`
+    // — `reason` is owned because callers `format!(...)` inline and the
+    // diverging body means no further use.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn fatal_abort(&self, reason: alloc::string::String) -> ! {
         panic!("aether-actor: fatal_abort: {reason}")
     }

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -408,6 +408,9 @@ impl<'a> PriorState<'a> {
 }
 
 #[cfg(test)]
+// Mail-decode tests hold per-test guards / borrows across the assert
+// block; the snapshot is the test's atomic read.
+#[allow(clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
     use crate::mail::mailbox::KindId;

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -16,6 +16,10 @@
 //! Component record" check.
 
 #![allow(dead_code)]
+// Manifest-probe fixture's `#[handler]` / `#[fallback]` bodies are
+// stubs that exercise the const-emission path — they have to keep
+// `&mut self` to match the dispatch ABI but don't read state.
+#![allow(clippy::unused_self)]
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_data::Kind;

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -1,6 +1,10 @@
 // Camera math: bounded tick counts cast to f32 for orbit angle
 // accumulation are domain-correct.
 #![allow(clippy::cast_precision_loss)]
+// `#[handler]` methods take the decoded mail by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded payload and hands it off, so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
 
 //! Multi-camera runtime. Hosts N named cameras (each in one of two
 //! modes — orbit or orthographic top-down), advances every camera each

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -23,6 +23,11 @@
 //! ADR-0078 — the cap is single-threaded, every handler runs on the
 //! cap's dispatcher thread.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 use aether_actor::{Actor, FfiActorMailbox};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::UnsubscribeAll;

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -29,6 +29,11 @@
 //! emits the wasm-side marker stub so `aether-capabilities` still
 //! compiles for `wasm32`.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -116,6 +116,10 @@ impl LocalFileAdapter {
     /// path is canonicalized so later comparisons (including the
     /// symlink-safety check the v2 asset loader wants) work against
     /// the real filesystem location.
+    // `root` is owned for builder ergonomics — callers pass the result
+    // of `dirs::data_dir()` / a `PathBuf::from(env)` straight in and
+    // we shadow-rebind to the canonicalised form.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(root: PathBuf, writable: bool) -> std::io::Result<Self> {
         std::fs::create_dir_all(&root)?;
         let root = root.canonicalize()?;
@@ -202,6 +206,12 @@ impl FileAdapter for LocalFileAdapter {
     }
 }
 
+// `err` taken by value so callers can use it directly as a
+// `.map_err(fs_error_from_std)` callback (the closure-converted form
+// is the natural shape at every call site here); `kind()` and
+// `to_string()` both borrow, so technically `&Error` would work, but
+// it'd force ad-hoc closures at every call site.
+#[allow(clippy::needless_pass_by_value)]
 fn fs_error_from_std(err: std::io::Error) -> FsError {
     match err.kind() {
         ErrorKind::NotFound => FsError::NotFound,

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -8,6 +8,11 @@
 //! at boot; the chassis builder's `with_actor::<HandleCapability>(())`
 //! is the boot site.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -17,6 +17,11 @@
 //! domain so the chassis-internal component-host cap (`aether.component`,
 //! formerly `aether.control`) only carries component-lifecycle concerns.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 use aether_actor::FfiActorMailbox;
 use aether_data::{KindId, MailboxId};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -19,6 +19,11 @@
 //! [`LogReadResult`]. ADR-0023 §4 contract restored under the
 //! forward model (RPC pull instead of frame push).
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 use aether_kinds::{LogBatch, LogRead};
 
 #[aether_actor::bridge(singleton)]

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -19,6 +19,17 @@
 //! in place of [`RenderCapability`] (issue 603 Phase 2 § Resolved
 //! Decision 5).
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+// Frame-vertex / last-submitted Mutex guards are held through the
+// per-frame swap and append sequence on purpose — the swap and
+// subsequent length math read the buffer's current state and write
+// back; releasing the guard mid-sequence opens a TOCTOU window
+// where a sibling tick's producer mutates the buffer in between.
+#![allow(clippy::significant_drop_tightening)]
+
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
@@ -874,12 +885,16 @@ mod native_headless {
         /// `DrawTriangle` lands here as a no-op so headless boots of
         /// desktop-designed components (which emit `DrawTriangle` every
         /// tick) don't trip the unknown-mailbox warn path.
+        // `&self` keeps the dispatch ABI (ADR-0033 / ADR-0038); the body
+        // is a no-op by design — see the doc comment above.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, _mails: &[DrawTriangle]) {}
 
         /// `Camera` lands here as a no-op for the same reason as
         /// `on_draw_triangle` — desktop-designed components publish
         /// `aether.camera` every tick.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_camera(&self, _ctx: &mut NativeCtx<'_>, _mail: Camera) {}
 

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -17,6 +17,11 @@
 //! connection; the settlement notice closes the call with a
 //! `ReplyEnd`.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds need to be importable at file root for the
 // `#[bridge]`-emitted `HandlesKind<K>` markers.
 use aether_kinds::{RpcInboundReady, trace::Settled};

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -71,6 +71,10 @@ mod test_echo_actor {
             Ok(Self)
         }
 
+        // Stateless echo handler — keeps `&mut self` to match the
+        // dispatch ABI (ADR-0033 / ADR-0038) even though the body
+        // doesn't touch component state.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) {
             ctx.reply(&TestEchoReply { value: mail.value });

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -169,6 +169,9 @@ mod listener_native {
         /// `TcpCapability` mails this; we shut down so the dispatcher
         /// drains, runs `unwire`, and the close fan-out fires
         /// `MonitorNotice` to the cap.
+        // Stateless close request: `&mut self` rides the dispatch ABI;
+        // shutdown is requested through `ctx`, not through any field.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: Close) {
             ctx.shutdown();

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -25,6 +25,11 @@
 //! A future user-space TCP observer (monitor-based or session-
 //! targeted mail) is the replacement path.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds need to be importable at file root for
 // the `#[bridge]`-emitted `HandlesKind` markers.
 use aether_kinds::{SessionClose, SessionDataReady, SessionWrite};
@@ -246,6 +251,9 @@ mod session_native {
         /// Cooperative external close. Peer mails this, we call
         /// `ctx.shutdown()`, the dispatcher drains remaining inbox
         /// mail, runs `unwire` (which joins the read thread).
+        // Stateless close-request handler: `&mut self` is required by
+        // the dispatch ABI (ADR-0033 / ADR-0038); shutdown is via ctx.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionClose) {
             ctx.shutdown();

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -509,6 +509,10 @@ mod native {
     }
 
     #[cfg(test)]
+    // Tests hold the capture `Mutex` guard across the assertion block
+    // so the snapshot reads atomically against the concurrent
+    // observer-side push.
+    #[allow(clippy::significant_drop_tightening)]
     mod tests {
         use super::*;
         use aether_substrate::handle_store::HandleStore;

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -59,6 +59,11 @@
 //!   ADR-0022 + ADR-0038 invariants hold because the inbox channel is
 //!   the trampoline's `NativeBinding` and outlives the swap.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds must be importable at file root so the
 // `#[bridge]`-emitted `impl HandlesKind<K> for WasmTrampoline {}`
 // markers (always-on, outside the cfg gate) resolve.

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -266,6 +266,11 @@ fn alignment_of_schema(ty: &SchemaType) -> Result<usize, DecodeError> {
     }
 }
 
+// Schema-driven postcard decoder: one match arm per `SchemaType`
+// variant. Each arm is short but the arm count adds up — extracting
+// per-type helpers obscures the schema → wire mapping that's the
+// purpose of this fn.
+#[allow(clippy::too_many_lines)]
 fn decode_postcard(
     cur: &mut Cursor<'_>,
     schema: &SchemaType,
@@ -643,6 +648,10 @@ mod tests {
     /// Encode → decode → assert equal. The single most load-bearing
     /// invariant: every kind shape the encoder accepts, the decoder
     /// inverts.
+    // `value` is owned because the test passes a freshly-built `Value`
+    // (e.g. `Value::String("…".to_owned())`) inline at the call site;
+    // taking `&Value` would force ad-hoc bindings at every site.
+    #[allow(clippy::needless_pass_by_value)]
     fn roundtrip(value: Value, schema: &SchemaType) {
         let bytes = encode_schema(&value, schema)
             .unwrap_or_else(|e| panic!("encode failed for {value:?}: {e}"));

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -152,6 +152,10 @@ pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, Enc
 /// Recursively encode `value` into postcard wire format under `schema`.
 /// `path` is a dotted breadcrumb (`$.field.subfield[2]`) used to make
 /// error messages locate the offending field in deeply-nested params.
+// One match arm per `SchemaType`; each arm is short but they sum up.
+// Splitting the arms into helpers would force per-arm context structs
+// without saving readability.
+#[allow(clippy::too_many_lines)]
 fn encode_postcard(
     value: &Value,
     schema: &SchemaType,

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -175,6 +175,13 @@ pub(super) const fn write_str(s: &str, out: &mut [u8], cursor: usize) -> usize {
 
 /// `Option<Cow<'static, str>>` length/write — used by the labels
 /// serializer where nominal labels ride as owned/borrowed `Cow`s.
+///
+/// Takes `&Option<Cow<...>>` rather than `Option<&Cow<...>>` to keep
+/// the const-fn call sites simple — `Option::as_ref` is only `const`
+/// since Rust 1.83 and the workspace tracks stable, so a per-site
+/// allow here avoids forcing toolchain bumps on every label-emitting
+/// crate.
+#[allow(clippy::ref_option)]
 pub(super) const fn option_str_len(s: &Option<Cow<'static, str>>) -> usize {
     match s {
         None => 1,
@@ -182,6 +189,7 @@ pub(super) const fn option_str_len(s: &Option<Cow<'static, str>>) -> usize {
     }
 }
 
+#[allow(clippy::ref_option)]
 pub(super) const fn write_option_str(
     s: &Option<Cow<'static, str>>,
     out: &mut [u8],

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -532,6 +532,9 @@ fn json<T: serde::Serialize>(value: &T) -> Result<String, McpError> {
     serde_json::to_string(value).map_err(|e| McpError::internal_error(e.to_string(), None))
 }
 
+// `e` is owned because callers do `.map_err(internal)` — the closure-
+// converted form needs an `FnOnce(anyhow::Error) -> McpError`.
+#[allow(clippy::needless_pass_by_value)]
 fn internal(e: anyhow::Error) -> McpError {
     McpError::internal_error(e.to_string(), None)
 }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -115,6 +115,10 @@ impl FfiActor for MeshViewer {
     /// `namespace` is the short prefix with no `://` — `"save"`,
     /// `"assets"`, `"config"`. `path` is relative to the namespace
     /// root and must end in `.dsl` or `.obj`.
+    // `&mut self` and `msg: LoadMesh` match the dispatch ABI
+    // (ADR-0033 / ADR-0038); the load body delegates straight to
+    // `FsCapability` via `ctx`.
+    #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
     #[handler]
     fn on_load(&mut self, ctx: &mut FfiCtx<'_>, msg: LoadMesh) {
         tracing::info!(

--- a/crates/aether-mesh/src/ast.rs
+++ b/crates/aether-mesh/src/ast.rs
@@ -82,28 +82,28 @@ pub enum Node {
     },
 
     // Structural
-    Composition(Vec<Node>),
+    Composition(Vec<Self>),
     Translate {
         offset: Vec3,
-        child: std::boxed::Box<Node>,
+        child: std::boxed::Box<Self>,
     },
     Rotate {
         axis: Vec3,
         angle: f32,
-        child: std::boxed::Box<Node>,
+        child: std::boxed::Box<Self>,
     },
     Scale {
         factor: Vec3,
-        child: std::boxed::Box<Node>,
+        child: std::boxed::Box<Self>,
     },
     Mirror {
         axis: Axis,
-        child: std::boxed::Box<Node>,
+        child: std::boxed::Box<Self>,
     },
     Array {
         count: u32,
         spacing: Vec3,
-        child: std::boxed::Box<Node>,
+        child: std::boxed::Box<Self>,
     },
 }
 
@@ -118,18 +118,18 @@ impl Axis {
     #[must_use]
     pub fn as_symbol(self) -> &'static str {
         match self {
-            Axis::X => "x",
-            Axis::Y => "y",
-            Axis::Z => "z",
+            Self::X => "x",
+            Self::Y => "y",
+            Self::Z => "z",
         }
     }
 
     #[must_use]
     pub fn from_symbol(sym: &str) -> Option<Self> {
         match sym {
-            "x" => Some(Axis::X),
-            "y" => Some(Axis::Y),
-            "z" => Some(Axis::Z),
+            "x" => Some(Self::X),
+            "y" => Some(Self::Y),
+            "z" => Some(Self::Z),
             _ => None,
         }
     }
@@ -140,9 +140,9 @@ impl Axis {
     #[must_use]
     pub fn index(self) -> usize {
         match self {
-            Axis::X => 0,
-            Axis::Y => 1,
-            Axis::Z => 2,
+            Self::X => 0,
+            Self::Y => 1,
+            Self::Z => 2,
         }
     }
 }

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -92,7 +92,7 @@ fn bucket_key(p: &IndexedPolygon) -> BucketKey {
 
 impl IndexedMesh {
     pub(super) fn merge_coplanar(self) -> Self {
-        let IndexedMesh { vertices, polygons } = self;
+        let Self { vertices, polygons } = self;
 
         let buckets = group_by_bucket(&polygons);
         let mut sorted_keys: Vec<&BucketKey> = buckets.keys().collect();
@@ -111,7 +111,7 @@ impl IndexedMesh {
             process_bucket(&vertices, &polygons, bucket, &global_directed, &mut merged);
         }
 
-        IndexedMesh {
+        Self {
             vertices,
             polygons: merged,
         }

--- a/crates/aether-mesh/src/cleanup/mesh.rs
+++ b/crates/aether-mesh/src/cleanup/mesh.rs
@@ -35,7 +35,7 @@ impl IndexedMesh {
     /// `cleanup::run_to_loops` and by pipeline tests inspecting the
     /// post-merge / post-tjunction state.
     pub(crate) fn into_polygons(self) -> Vec<Polygon> {
-        let IndexedMesh { vertices, polygons } = self;
+        let Self { vertices, polygons } = self;
         let mut out = Vec::with_capacity(polygons.len());
         for poly in polygons {
             let verts = poly.vertices.iter().map(|&i| vertices[i]).collect();

--- a/crates/aether-mesh/src/cleanup/slivers.rs
+++ b/crates/aether-mesh/src/cleanup/slivers.rs
@@ -59,7 +59,7 @@ const MAX_SLIVER_ITERATIONS: usize = 64;
 
 impl IndexedMesh {
     pub(super) fn remove_slivers(self) -> Self {
-        let IndexedMesh {
+        let Self {
             vertices,
             mut polygons,
         } = self;
@@ -105,7 +105,7 @@ impl IndexedMesh {
             });
         }
 
-        IndexedMesh { vertices, polygons }
+        Self { vertices, polygons }
     }
 }
 

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -38,7 +38,7 @@ const MAX_TJUNCTION_ITERATIONS: usize = 256;
 
 impl IndexedMesh {
     pub(super) fn repair_tjunctions(self) -> Self {
-        let IndexedMesh {
+        let Self {
             vertices,
             mut polygons,
         } = self;
@@ -122,7 +122,7 @@ impl IndexedMesh {
             polygons = next_polygons;
         }
 
-        IndexedMesh { vertices, polygons }
+        Self { vertices, polygons }
     }
 }
 

--- a/crates/aether-mesh/src/cleanup/weld.rs
+++ b/crates/aether-mesh/src/cleanup/weld.rs
@@ -101,7 +101,7 @@ impl IndexedMesh {
             });
         }
 
-        IndexedMesh {
+        Self {
             vertices: vertex_pool,
             polygons: indexed,
         }

--- a/crates/aether-mesh/src/loop_polygon.rs
+++ b/crates/aether-mesh/src/loop_polygon.rs
@@ -44,7 +44,7 @@ impl Polygon {
         if plane.is_degenerate() {
             return None;
         }
-        Some(Polygon {
+        Some(Self {
             vertices: vec![v0, v1, v2],
             plane,
             color,
@@ -67,10 +67,10 @@ impl Polygon {
     pub fn split(
         &self,
         partitioner: &Plane3,
-        coplanar_front: &mut Vec<Polygon>,
-        coplanar_back: &mut Vec<Polygon>,
-        front: &mut Vec<Polygon>,
-        back: &mut Vec<Polygon>,
+        coplanar_front: &mut Vec<Self>,
+        coplanar_back: &mut Vec<Self>,
+        front: &mut Vec<Self>,
+        back: &mut Vec<Self>,
     ) {
         // Plane-identity short-circuit: when this polygon's stored plane
         // matches the partitioner structurally (same canonical key), the
@@ -155,14 +155,14 @@ impl Polygon {
                     }
                 }
                 if f.len() >= 3 {
-                    front.push(Polygon {
+                    front.push(Self {
                         vertices: f,
                         plane: self.plane,
                         color: self.color,
                     });
                 }
                 if b.len() >= 3 {
-                    back.push(Polygon {
+                    back.push(Self {
                         vertices: b,
                         plane: self.plane,
                         color: self.color,

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -94,6 +94,10 @@ fn polygons_to_triangles(polys: &[LoopPolygon]) -> Vec<Triangle> {
 
 /// Recursive AST evaluator in polygon domain. Primitives emit n-gon
 /// polygons directly; structural ops walk children.
+// One match arm per `Node` variant — each arm delegates to a per-
+// primitive `mesh_*` helper but the dispatch table itself is long;
+// extracting it would obscure the AST → primitive mapping.
+#[allow(clippy::too_many_lines)]
 fn mesh_into_polygons(
     out: &mut Vec<LoopPolygon>,
     node: &Node,

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -67,7 +67,7 @@ impl Plane3 {
         let d = (n_x as i128) * (a.x as i128)
             + (n_y as i128) * (a.y as i128)
             + (n_z as i128) * (a.z as i128);
-        Plane3 { n_x, n_y, n_z, d }
+        Self { n_x, n_y, n_z, d }
     }
 
     /// Zero-normal plane comes from collinear input (degenerate triangle).
@@ -127,7 +127,7 @@ impl Plane3 {
 
     #[must_use]
     pub fn invert(self) -> Self {
-        Plane3 {
+        Self {
             n_x: -self.n_x,
             n_y: -self.n_y,
             n_z: -self.n_z,
@@ -173,7 +173,7 @@ impl Plane3 {
     /// coplanar-front from coplanar-back when classifying a polygon
     /// against a partitioner whose plane it shares.
     #[must_use]
-    pub fn normal_dot_sign(&self, other: &Plane3) -> i32 {
+    pub fn normal_dot_sign(&self, other: &Self) -> i32 {
         let dot = (self.n_x as i128) * (other.n_x as i128)
             + (self.n_y as i128) * (other.n_y as i128)
             + (self.n_z as i128) * (other.n_z as i128);

--- a/crates/aether-mesh/src/point.rs
+++ b/crates/aether-mesh/src/point.rs
@@ -13,7 +13,7 @@ pub struct Point3 {
 
 impl Point3 {
     pub fn from_f32(p: Vec3) -> Result<Self, FixedError> {
-        Ok(Point3 {
+        Ok(Self {
             x: f32_to_fixed(p.x)?,
             y: f32_to_fixed(p.y)?,
             z: f32_to_fixed(p.z)?,

--- a/crates/aether-mesh/src/serialize.rs
+++ b/crates/aether-mesh/src/serialize.rs
@@ -25,6 +25,10 @@ pub fn serialize(node: &Node) -> String {
     String::from_utf8(buf).expect("lexpr emits utf-8")
 }
 
+// One match arm per `Node` variant emits its s-expression form
+// inline; extracting per-variant helpers would just move the same
+// per-field plumbing one level out.
+#[allow(clippy::too_many_lines)]
 pub fn node_to_value(node: &Node) -> Value {
     match node {
         Node::Box { x, y, z, color } => list([

--- a/crates/aether-mesh/src/simplify.rs
+++ b/crates/aether-mesh/src/simplify.rs
@@ -28,6 +28,7 @@ use aether_math::Vec3;
 /// has one element via `simplified.len() == 1` before the `unwrap`,
 /// so an unwrap failure would indicate a mid-iter mutation that
 /// cannot occur in safe code.
+#[allow(clippy::too_many_lines)] // one arm per Node variant; splitting obscures the simplify rules table
 pub fn simplify(node: &Node) -> Node {
     match node {
         Node::Box { .. }

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -237,6 +237,11 @@ fn triangulate_indexed(mesh: IndexedMesh) -> Vec<Polygon> {
 }
 
 #[cfg(test)]
+// Geometry regression tests carry inline vertex fixtures (large
+// `Point3` array literals) so the case under test is readable in
+// context; per-fn allow is the cleaner shape than splitting fixtures
+// across helpers each test would have to thread through.
+#[allow(clippy::too_many_lines)]
 mod tests {
     use super::cleanup::mesh::IndexedPolygon;
     use super::*;

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -90,7 +90,7 @@ impl Mesh {
     /// Build the Delaunay triangulation of the given points. Returns
     /// an empty mesh if `points` is empty.
     pub(super) fn build(points: Vec<Point2>) -> Self {
-        let mut mesh = Mesh {
+        let mut mesh = Self {
             vertices: Vec::new(),
             triangles: Vec::new(),
             super_count: 0,

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -102,7 +102,10 @@ fn main() -> anyhow::Result<()> {
 /// driver — runs until every `EventSender` clone drops (clean
 /// shutdown via the `chassis_control` handler clones being released)
 /// or a fatal abort tears the process down.
-#[allow(clippy::too_many_arguments)]
+// All arguments take ownership for the lifetime of the main-thread
+// event loop; the borrow form would just be `&` versions threaded
+// through the same closure.
+#[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
 fn drive_events_loop(
     events_rx: events::EventReceiver,
     capture_queue: CaptureQueue,

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -356,6 +356,11 @@ impl App {
         }
     }
 
+    // `env` is owned because the dispatch borrows `env.sender`,
+    // `env.payload`, and `env.kind` separately as it walks the
+    // window-control kind set; taking `&Envelope` works but loses the
+    // owning-handoff symmetry with the rest of the dispatch surface.
+    #[allow(clippy::needless_pass_by_value)]
     fn dispatch_window_envelope(&mut self, env: Envelope) {
         if env.kind == self.kind_set_window_mode {
             let payload: SetWindowMode = match postcard::from_bytes(&env.payload) {
@@ -465,6 +470,10 @@ impl ApplicationHandler<UserEvent> for App {
         self.publish_window_size(initial_size.width, initial_size.height);
     }
 
+    // winit's `window_event` dispatches one arm per `WindowEvent`
+    // variant; we route every variant through this single fn so the
+    // event-to-engine bridging lives in one place.
+    #[allow(clippy::too_many_lines)]
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -102,6 +102,16 @@ impl Gpu {
     /// Panics if surface creation, adapter selection, or device
     /// acquisition fail — fail-fast per ADR-0063: the desktop chassis
     /// can't proceed without a usable GPU pipeline.
+    // One-shot GPU pipeline setup: instance, surface, adapter, device,
+    // shader, pipeline, depth, uniform — all tied together in a single
+    // boot path. Splitting into helpers would force passing 6+
+    // intermediate `wgpu` handles around without saving readability.
+    //
+    // `window` is owned because the boot path is a one-shot handoff:
+    // the driver builds the `Arc<Window>` once and the GPU pipeline
+    // takes a clone via `Arc::clone(&window)` for the surface; the
+    // owning form mirrors the `RenderHandles` argument.
+    #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
     pub fn new(window: Arc<Window>, render_handles: RenderHandles) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -43,6 +43,7 @@ impl Chassis for HubChassis {
 /// `rpc_addr` is the `aether.rpc.server` bind — the target the
 /// out-of-process `aether-mcp` coordinator dials. `AETHER_RPC_PORT`
 /// overrides the port.
+#[derive(Clone, Copy)]
 pub struct HubEnv {
     pub rpc_addr: SocketAddr,
 }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -708,6 +708,10 @@ impl TestBench {
     /// the `pump_until_reply` caller surfaces the timeout rather than
     /// waiting on a reply that will never arrive — the substrate is
     /// in a stuck state and the test should fail loudly.
+    // `event` is owned because the match destructures it; clippy
+    // doesn't track the partial-move via the `Advance { reply_to, .. }`
+    // pattern.
+    #[allow(clippy::needless_pass_by_value)]
     fn dispatch_event(&mut self, event: ChassisEvent) -> Result<(), TestBenchError> {
         match event {
             ChassisEvent::Advance { reply_to, ticks } => {
@@ -840,6 +844,12 @@ fn correlation_of(event: &EgressEvent) -> Option<u64> {
 }
 
 #[cfg(test)]
+// Integration tests stage actors, sender threads, and per-step
+// assertions inline so the boot/dispatch sequence reads top-to-bottom;
+// extracting helpers would scatter the staging context across files.
+// Tests also hold capture `Mutex` guards across the assertion block
+// so the snapshot reads atomically against the concurrent push path.
+#[allow(clippy::too_many_lines, clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -13,6 +13,11 @@
 //! agents fail fast. Mirrors the pattern from
 //! `RenderCapability` / `HeadlessRenderCapability`.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).

--- a/crates/aether-substrate-bundle/tests/engine_logs.rs
+++ b/crates/aether-substrate-bundle/tests/engine_logs.rs
@@ -40,6 +40,10 @@ fn require_wgpu_only() -> bool {
 /// Read `LogRead` against the bench and unwrap the `Ok` arm. Tests
 /// panic-and-print on `Err` rather than threading match across every
 /// site — the cap's healthy path only returns `Ok`.
+// `request` is owned for the same ergonomic reason `send_mail<K>()`
+// takes `K` by value — tests build the request inline at the call
+// site and immediately hand it off.
+#[allow(clippy::needless_pass_by_value)]
 fn read(
     bench: &mut TestBench,
     request: LogRead,

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -8,6 +8,11 @@
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap
 )]
+// `ReplyTable` Mutex guards are intentionally held across the
+// register/lookup/dispatch sequence — early-drop opens a TOCTOU
+// window where a sibling thread mutates the pending-reply map between
+// the lookup and the dispatch decision.
+#![allow(clippy::significant_drop_tightening)]
 
 //! ADR-0074 §Decision (revisited by issue 665): native per-actor
 //! binding state.

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -191,6 +191,10 @@ where
     /// Wraps the dispatch call in `local::with_stamped` +
     /// `log_install::with_actor_dispatch` so tracing events carry the
     /// actor's mailbox id and the per-handler `LogBatch` ships at exit.
+    // `env` is taken by value because dispatch may move fields out
+    // (reply_to, payload) into the actor; the helper here doesn't
+    // happen to, but the surface mirrors the owning dispatch loop.
+    #[allow(clippy::needless_pass_by_value)]
     fn dispatch_one(&self, actor: &mut Box<A>, env: crate::actor::native::Envelope) {
         let inbound_mail_id = env.mail_id;
         // Issue 734: capture the OS thread name at the dispatcher's

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -266,6 +266,11 @@ impl Spawner {
     /// 6. Insert `Live` entry into the actor registry.
     /// 7. Pre-load `after_init_mail` into the inbox.
     /// 8. Spawn dispatcher thread, move actor in.
+    // Spawn pipeline runs as one linear function so the eight-step
+    // sequence above maps 1:1 to the code. Splitting steps into
+    // helpers would scatter the rollback bookkeeping each step relies
+    // on across multiple sites.
+    #[allow(clippy::too_many_lines)]
     fn spawn_actor<A>(
         self: Arc<Self>,
         subname: Subname<'_>,
@@ -659,6 +664,11 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
     /// `A: HandlesKind<K>` ensures only kinds the actor's handler set
     /// covers can be pre-loaded; the strict-receiver miss path stays
     /// off the bootstrap surface.
+    // `mail` is taken by value so the builder API mirrors the rest of
+    // the spawn surface (`config: A::Config` is also by value); the
+    // value flows straight into `encode_into_bytes` whose owned form
+    // matches `Kind`'s wire-encoding convention.
+    #[allow(clippy::needless_pass_by_value)]
     #[must_use]
     pub fn after_init<K>(mut self, mail: K) -> Self
     where

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -326,6 +326,10 @@ where
 }
 
 #[cfg(test)]
+// Test helpers use `Mutex<Vec<...>>` as a capture buffer; the guard
+// is held through `.push(...)` which is the captured payload — that's
+// the intended sequence, not a tightening opportunity.
+#[allow(clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
     use std::sync::Mutex;

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -16,6 +16,12 @@
 //! sit side-by-side so the lifecycle work doesn't perturb the routing
 //! path.
 
+// Registry RwLock guards are intentionally held across the full
+// read-then-update or match-then-mutate sequence — releasing the
+// guard mid-sequence would open a TOCTOU window where another writer
+// could mutate the map between the `get` and the dependent action.
+#![allow(clippy::significant_drop_tightening)]
+
 use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::Sender;

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -130,7 +130,7 @@ impl ComponentCtx {
         queue: Arc<Mailer>,
         outbound: Arc<HubOutbound>,
     ) -> Self {
-        ComponentCtx {
+        Self {
             sender,
             registry,
             queue,
@@ -672,6 +672,9 @@ impl Component {
 }
 
 #[cfg(test)]
+// Tests hold the capture `Mutex` guard across the assertion block so
+// the snapshot reads atomically against the concurrent push path.
+#[allow(clippy::significant_drop_tightening)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -54,6 +54,11 @@ pub const MAX_WAIT_TIMEOUT_MS: u32 = 30_000;
 /// Register the substrate host functions on `linker`. Components that
 /// want these capabilities must be instantiated via a linker that this
 /// function has been called on.
+//
+// One linker.func_wrap block per host fn — extracting them into per-fn
+// helpers would force per-fn Caller<'_, ComponentCtx> glue without
+// saving readability; the v0 host-fn list is small and stable.
+#[allow(clippy::too_many_lines)]
 pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
     linker.func_wrap(
         "aether",

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -49,7 +49,7 @@ pub enum RunError {
 impl fmt::Display for RunError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RunError::Other(e) => write!(f, "driver run failed: {e}"),
+            Self::Other(e) => write!(f, "driver run failed: {e}"),
         }
     }
 }
@@ -57,7 +57,7 @@ impl fmt::Display for RunError {
 impl StdError for RunError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            RunError::Other(e) => Some(&**e),
+            Self::Other(e) => Some(&**e),
         }
     }
 }
@@ -1013,7 +1013,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
     /// installed — fail-fast per ADR-0063: the typestate guarantees
     /// `with_driver` has run, so a missing driver is a builder API bug.
     pub fn build(self) -> Result<BuiltChassis<C>, BootError> {
-        let Builder {
+        let Self {
             registry,
             mailer,
             passives,
@@ -1185,6 +1185,12 @@ impl Drop for BootedPassives {
     }
 }
 
+// Linear boot pipeline: claim mailbox -> wire FFI exports -> spawn
+// each passive in declared order, plus rollback bookkeeping. The
+// pieces share enough state that splitting into helpers obscures the
+// boot ordering — leaving it as one function keeps the chassis boot
+// sequence readable in one place.
+#[allow(clippy::too_many_lines)]
 fn boot_passives(
     registry: &Arc<Registry>,
     mailer: &Arc<Mailer>,
@@ -1548,7 +1554,7 @@ impl<C: Chassis> BuiltChassis<C> {
     /// as [`RunError`]; passives still tear down before the error
     /// returns to the caller.
     pub fn run(self) -> Result<(), RunError> {
-        let BuiltChassis { booted, driver, .. } = self;
+        let Self { booted, driver, .. } = self;
         let result = driver.run();
         // Passives drop here, triggering reverse-order shutdown via
         // BootedPassives::Drop. Holding `booted` until after `result`
@@ -1685,6 +1691,11 @@ impl<C: Chassis> PassiveChassis<C> {
 }
 
 #[cfg(test)]
+// Chassis-level integration tests stage many caps, sender threads,
+// and assertions in a single test function so the boot-and-route
+// sequence reads top-to-bottom; extracting helpers would either lose
+// the staging context or add fixtures that aren't reused elsewhere.
+#[allow(clippy::too_many_lines)]
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate/src/chassis/error.rs
+++ b/crates/aether-substrate/src/chassis/error.rs
@@ -35,13 +35,13 @@ pub enum BootError {
 impl fmt::Display for BootError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BootError::MailboxAlreadyClaimed { name } => {
+            Self::MailboxAlreadyClaimed { name } => {
                 write!(f, "mailbox {name:?} already claimed")
             }
-            BootError::FallbackRouterAlreadyClaimed => {
+            Self::FallbackRouterAlreadyClaimed => {
                 f.write_str("fallback router slot already claimed")
             }
-            BootError::Other(e) => write!(f, "capability boot failed: {e}"),
+            Self::Other(e) => write!(f, "capability boot failed: {e}"),
         }
     }
 }
@@ -49,7 +49,7 @@ impl fmt::Display for BootError {
 impl StdError for BootError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            BootError::Other(e) => Some(&**e),
+            Self::Other(e) => Some(&**e),
             _ => None,
         }
     }
@@ -57,7 +57,7 @@ impl StdError for BootError {
 
 impl From<NameConflict> for BootError {
     fn from(e: NameConflict) -> Self {
-        BootError::MailboxAlreadyClaimed { name: e.name }
+        Self::MailboxAlreadyClaimed { name: e.name }
     }
 }
 
@@ -69,7 +69,7 @@ impl From<NameConflict> for BootError {
 /// per-call `.map_err` glue.
 impl From<wasmtime::Error> for BootError {
     fn from(e: wasmtime::Error) -> Self {
-        BootError::Other(Box::new(std::io::Error::other(format!("{e}"))))
+        Self::Other(Box::new(std::io::Error::other(format!("{e}"))))
     }
 }
 

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -93,10 +93,10 @@ impl SettlementSubscriber {
     /// which resolves the recipient inline on the firing thread.
     fn fire(self, root: MailId) {
         match self {
-            SettlementSubscriber::Channel(tx) => {
+            Self::Channel(tx) => {
                 let _ = tx.try_send(());
             }
-            SettlementSubscriber::Mail {
+            Self::Mail {
                 target,
                 kind,
                 mailer,
@@ -277,6 +277,10 @@ fn push_settlement_notice(
 }
 
 #[cfg(test)]
+// Settlement tests hold per-test `Mutex` guards across the assertion
+// sequence so the captured state stays consistent against the
+// concurrent firing thread.
+#[allow(clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
     use crate::handle_store::HandleStore;

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -3,6 +3,12 @@
 // format below; `u32 → u64` widenings move handle ids into the
 // 64-bit id slot. Both are part of the load-bearing wire layout.
 #![allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+// `HandleStore` Mutex guards are intentionally held across read-then-
+// update sequences (lookup + refcount mutation, eviction scan + drop)
+// — releasing the guard mid-sequence opens a TOCTOU window where
+// another caller could mutate the store between the read and the
+// dependent action.
+#![allow(clippy::significant_drop_tightening)]
 
 //! ADR-0045 typed-handle store and ref-walking dispatch hook.
 //!
@@ -604,6 +610,10 @@ impl<'a> State<'a> {
 /// wire. Returns `Ok(Some((handle, kind)))` to signal "park on this
 /// handle", `Ok(None)` for fully-walked, `Err(...)` for malformed
 /// wire.
+// One match arm per `SchemaType` variant; extracting per-type helpers
+// would force per-arm `&mut State<'_>` plumbing without saving
+// readability.
+#[allow(clippy::too_many_lines)]
 fn walk(
     schema: &SchemaType,
     state: &mut State<'_>,

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -1,3 +1,9 @@
+// Mailer locks are held across the lookup + dispatch pair on
+// purpose — dropping the guard between resolving the recipient and
+// pushing the envelope would open a TOCTOU window where the mailbox
+// could be unregistered or replaced mid-call.
+#![allow(clippy::significant_drop_tightening)]
+
 // Inline router (ADR-0038 Phase 3 + issue 603).
 //
 // Phase 2 retired the VecDeque + router thread; Phase 3 retired the
@@ -273,6 +279,11 @@ impl Mailer {
 /// splice inline-form bytes into a fresh payload; mail that hits a
 /// missing handle parks in the store and returns immediately
 /// without dispatch.
+// Routing pipeline runs as one function: chassis-mail switch,
+// ref-resolver walk + dispatch, registry lookup, outbound forward.
+// Splitting the steps would scatter the per-mail Vec<u8> buffer reuse
+// and lose the linear "where does this envelope go?" read.
+#[allow(clippy::too_many_lines)]
 fn route_mail(
     mut mail: Mail,
     registry: &Registry,
@@ -490,6 +501,10 @@ fn route_mail(
 }
 
 #[cfg(test)]
+// Mailer integration tests stage senders / receivers / multi-step
+// dispatch fixtures inline so the round-trip read top-to-bottom;
+// extracting helpers would split the path-under-test across files.
+#[allow(clippy::too_many_lines)]
 mod tests {
     use std::sync::RwLock;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -10,6 +10,12 @@
 // client. Reads take a shared lock and are cheap; writes are rare
 // (boot + load/replace/drop).
 
+// Registry RwLock guards are intentionally held across read-then-update
+// sequences — releasing the guard mid-sequence would open a TOCTOU
+// window where a concurrent writer could mutate the map between the
+// `get` and the dependent action. Writes are rare, contention is low.
+#![allow(clippy::significant_drop_tightening)]
+
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
@@ -411,8 +417,8 @@ pub enum DropError {
 impl fmt::Display for DropError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DropError::UnknownId(id) => write!(f, "unknown mailbox id {id:?}"),
-            DropError::AlreadyDropped(id) => write!(f, "mailbox {id:?} already dropped"),
+            Self::UnknownId(id) => write!(f, "unknown mailbox id {id:?}"),
+            Self::AlreadyDropped(id) => write!(f, "mailbox {id:?} already dropped"),
         }
     }
 }

--- a/crates/aether-substrate/src/runtime/lifecycle.rs
+++ b/crates/aether-substrate/src/runtime/lifecycle.rs
@@ -43,6 +43,12 @@ pub const FATAL_EXIT_CODE: i32 = 2;
 /// trait threads one through. Pre-#775 it carried the final
 /// `SubstrateDying` broadcast; today the only sink that observed it
 /// retired, and the parameter is unused at this call site.
+// `reason` is owned because every call site constructs it via
+// `format!(...)` directly — taking `&str` would force callers to
+// either bind a `let s = format!(...); &s` first or stamp `&format!`
+// at every site. The aborter consumes the value into a logged
+// `%reason` tracing field; the diverging return means no further use.
+#[allow(clippy::needless_pass_by_value)]
 pub fn fatal_abort(_outbound: &HubOutbound, reason: String) -> ! {
     tracing::error!(
         target: "aether_substrate::lifecycle",

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -58,7 +58,7 @@ pub trait MailDispatch: Send + Sync {
 /// `MailDispatch`).
 impl MailDispatch for NativeBinding {
     fn send(&self, mailbox: MailboxId, kind: KindId, payload: &[u8]) {
-        let _ = NativeBinding::send_mail(self, mailbox.0, kind.0, payload, 1);
+        let _ = Self::send_mail(self, mailbox.0, kind.0, payload, 1);
     }
 }
 

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -121,6 +121,9 @@ fn capture_backtrace_with(forced: bool) -> Option<Backtrace> {
 }
 
 #[cfg(test)]
+// Tests hold the capture `Mutex` guard across the assertion block so
+// the event snapshot reads atomically against the panic hook's push.
+#[allow(clippy::significant_drop_tightening)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -266,6 +266,9 @@ pub fn start_drainer(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>) -> T
     }
 }
 
+// All arguments are taken by value so the spawned drainer thread
+// owns them for its lifetime.
+#[allow(clippy::needless_pass_by_value)]
 fn drainer_loop(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>, shutdown_rx: Receiver<()>) {
     let recipient = aether_data::mailbox_id_from_name(TRACE_OBSERVER_MAILBOX_NAME);
     let kind = <BatchedTraceEvents as aether_data::Kind>::ID;

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -182,6 +182,10 @@ impl Pool {
     /// any worker thread — fail-fast per ADR-0063: worker count is a
     /// chassis-boot invariant and thread spawn is a substrate
     /// prerequisite.
+    // `config` and `aborter` are taken by value for the builder-style
+    // boot path (callers compose the config once and hand it off to
+    // the pool); fields are read but not moved out.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn start(config: PoolConfig, aborter: Arc<dyn FatalAborter>) -> PoolHandle {
         assert!(config.workers >= 1, "pool needs at least one worker");
         let (ready_tx, ready_rx) = unbounded::<Arc<dyn Drainable>>();
@@ -212,6 +216,9 @@ impl Pool {
     }
 }
 
+// All arguments are taken by value so the spawned thread owns them
+// for its lifetime — the function is the worker thread's body.
+#[allow(clippy::needless_pass_by_value)]
 fn worker_loop(
     ready_rx: Receiver<Arc<dyn Drainable>>,
     ready_tx: Sender<Arc<dyn Drainable>>,

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -14,6 +14,11 @@
 //! working `Actor + HandlesKind + NativeActor + NativeDispatch`
 //! stack on a real cap shape.
 
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -351,6 +351,10 @@ impl Sokoban {
 
     /// Emit one `DrawTriangle` for the player body, centered at the
     /// supplied world coords.
+    // Stateless render helper — kept on `&self` for symmetry with
+    // sibling helpers (`world_to_clip`, future `render_*` methods)
+    // that do read state.
+    #[allow(clippy::unused_self)]
     fn render_player(&self, ctx: &mut FfiCtx<'_>, px: f32, py: f32) {
         let body = DrawTriangle {
             verts: [


### PR DESCRIPTION
Sweeps the six design-touching pedantic / nursery lints deferred from the iamacoffeepot/aether#876 long-tail chunk. Mix of mechanical fixes (`use_self`, `ref_option`) and per-site `#[allow]` with rationale where the suggestion fights an ADR contract (dispatcher `&mut self`, wire-encode owned args, TOCTOU-sensitive guard scopes).

- **`use_self` (51)** + **`ref_option` (4)** — mechanical rewrites, no behaviour change. `aether-data` const-fn helpers keep `&Option<Cow<...>>` under per-site allow (const-fn rebind ergonomics on stable Rust).
- **`unused_self` (17)** + **`needless_pass_by_value` (46)** — per-method / per-file allow citing the ADR-0033 / ADR-0038 dispatch ABI for `#[handler]` methods; `#[bridge]`-wrapped capability modules get a single file-level `#![allow(clippy::needless_pass_by_value)]`. Per-fn allow for `.map_err`-shaped helpers and owning thread-spawn pipelines. `HubEnv` got a `Copy` derive (only field is `SocketAddr`).
- **`too_many_lines` (27)** + **`significant_drop_tightening` (28)** — per-fn allow on linear boot pipelines (mostly schema-driven match arms over `SchemaType` / `Node` variants), per-mod allow on test modules. Mail / handle-store / actor registries get a file-level `#![allow(clippy::significant_drop_tightening)]` for guards intentionally held across read-then-update sequences.

Zero behaviour change. All checks green: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (zero warnings in the six listed lints), `cargo fmt -- --check`, `cargo nextest run --workspace` (1001 passed), `cargo test --doc`, and `cargo check -p aether-camera -p aether-mesh-viewer --target wasm32-unknown-unknown`.

Closes iamacoffeepot/aether#882
