### PR TITLE
fix(substrate): isolate closed_inbox_returns_closed wallclock budget (issue 896)

### DIFF
--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -616,7 +616,14 @@ pub mod tests {
         slot.state.try_wake();
         slot.close_inbox();
 
-        let result = run_one_cycle(&slot);
+        // Generous wallclock so only inbox-closed-and-empty can decide
+        // the cycle outcome — the standard 200μs wallclock can trip
+        // between the two iterations of `CounterSlot`'s drain loop
+        // (drain envelope 1 → try_recv sees closed && empty → Closed)
+        // under CI CPU contention, flipping the result to `Requeue`
+        // (iamacoffeepot/aether#896; sibling of iamacoffeepot/aether#869).
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let result = slot.run_cycle(budget);
         // Closed + non-empty: drain remaining first, then return
         // Closed on next try_recv. CounterSlot's loop checks closed +
         // empty first, so the first iteration drains envelope 1, the


### PR DESCRIPTION
Closes iamacoffeepot/aether#896

- Replace `run_one_cycle(&slot)` (which uses `BatchBudget::standard()` — 64 mails + 200μs wallclock) with `BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60))` so only the inbox-closed-and-empty condition can decide the cycle outcome. Same workaround pattern that fixed the three sibling tests in iamacoffeepot/aether#869.
- `run_one_cycle` helper kept — `post_empty_recheck_requeues_on_concurrent_send` still uses it (that test intentionally exercises both `Idle` and `Requeue` outcomes).
- Stress test result: `cargo nextest run -p aether-substrate scheduler::slot::tests::closed_inbox_returns_closed --stress-count 1000` → 1000/1000 passed (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)