### PR TITLE
chore(capabilities): sweep clippy::unwrap_used in aether-capabilities (issue 888)

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -433,7 +433,10 @@ mod proxy_reply_sink {
 
         #[handler]
         fn on_reply(&mut self, _ctx: &mut NativeCtx<'_>, reply: TestEchoReply) {
-            *self.recorded.lock().unwrap() = Some(reply.value);
+            *self
+                .recorded
+                .lock()
+                .expect("test setup: recorded mutex poisoned") = Some(reply.value);
         }
     }
 }
@@ -519,13 +522,15 @@ mod tests {
         let fwd = aether_kinds::ForwardEnvelope {
             mailbox: echo_mailbox,
             kind: <TestEchoRequest as Kind>::ID,
-            payload: postcard::to_allocvec(&TestEchoRequest { value: 42 }).unwrap(),
+            payload: postcard::to_allocvec(&TestEchoRequest { value: 42 })
+                .expect("test setup: TestEchoRequest serializes via postcard"),
         };
         mailer.push(
             Mail::new(
                 proxy_mailbox,
                 <aether_kinds::ForwardEnvelope as Kind>::ID,
-                postcard::to_allocvec(&fwd).unwrap(),
+                postcard::to_allocvec(&fwd)
+                    .expect("test setup: ForwardEnvelope serializes via postcard"),
                 1,
             )
             .with_reply_to(ReplyTo::with_correlation(
@@ -539,7 +544,9 @@ mod tests {
         // all across dispatcher threads — give it a generous deadline.
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            let snapshot = *recorded.lock().unwrap();
+            let snapshot = *recorded
+                .lock()
+                .expect("test setup: recorded mutex poisoned");
             if let Some(value) = snapshot {
                 assert_eq!(value, 42, "echoed value routed back through the proxy");
                 return;

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -385,17 +385,29 @@ mod sink {
 
         #[handler]
         fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
-            *self.cells.list.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex poisoned") = Some(reply);
         }
 
         #[handler]
         fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
-            *self.cells.spawn.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .spawn
+                .lock()
+                .expect("test setup: spawn cell mutex poisoned") = Some(reply);
         }
 
         #[handler]
         fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
-            *self.cells.terminate.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .terminate
+                .lock()
+                .expect("test setup: terminate cell mutex poisoned") = Some(reply);
         }
     }
 }
@@ -467,7 +479,11 @@ mod tests {
     fn list_on_empty_cap_is_empty() {
         let (_chassis, mailer, cells) = boot();
         let result = drive(&mailer, &ListEngines {}, || {
-            cells.list.lock().unwrap().take()
+            cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex poisoned")
+                .take()
         });
         assert!(result.engines.is_empty(), "fresh cap supervises no engines");
     }
@@ -483,7 +499,13 @@ mod tests {
                 binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
                 args: vec![],
             },
-            || cells.spawn.lock().unwrap().take(),
+            || {
+                cells
+                    .spawn
+                    .lock()
+                    .expect("test setup: spawn cell mutex poisoned")
+                    .take()
+            },
         );
         match result {
             SpawnEngineResult::Err { error } => {
@@ -508,7 +530,13 @@ mod tests {
             &TerminateEngine {
                 engine_id: "not-a-uuid".to_owned(),
             },
-            || cells.terminate.lock().unwrap().take(),
+            || {
+                cells
+                    .terminate
+                    .lock()
+                    .expect("test setup: terminate cell mutex poisoned")
+                    .take()
+            },
         );
         assert!(
             matches!(malformed, TerminateEngineResult::Err { .. }),
@@ -520,7 +548,13 @@ mod tests {
             &TerminateEngine {
                 engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
             },
-            || cells.terminate.lock().unwrap().take(),
+            || {
+                cells
+                    .terminate
+                    .lock()
+                    .expect("test setup: terminate cell mutex poisoned")
+                    .take()
+            },
         );
         assert!(
             matches!(unknown, TerminateEngineResult::Err { .. }),

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -675,7 +675,7 @@ mod native {
                 })
                 .unwrap_or(0);
             let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
-            std::fs::create_dir_all(&path).unwrap();
+            std::fs::create_dir_all(&path).expect("test setup: scratch dir creates");
             path
         }
 
@@ -689,16 +689,17 @@ mod native {
                 assets: root.join("assets"),
                 config: root.join("config"),
             };
-            std::fs::create_dir_all(&r.save).unwrap();
-            std::fs::create_dir_all(&r.assets).unwrap();
-            std::fs::create_dir_all(&r.config).unwrap();
+            std::fs::create_dir_all(&r.save).expect("test setup: save root creates");
+            std::fs::create_dir_all(&r.assets).expect("test setup: assets root creates");
+            std::fs::create_dir_all(&r.config).expect("test setup: config root creates");
             r
         }
 
         #[test]
         fn resolve_rejects_parent_traversal() {
             let root = scratch_root("resolve-parent");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.read("../etc/passwd"), Err(FsError::Forbidden)));
             assert!(matches!(
                 a.read("sub/../../escape"),
@@ -710,7 +711,8 @@ mod native {
         #[test]
         fn resolve_rejects_absolute() {
             let root = scratch_root("resolve-abs");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.read("/etc/passwd"), Err(FsError::Forbidden)));
             cleanup(&root);
         }
@@ -718,7 +720,8 @@ mod native {
         #[test]
         fn resolve_permits_dot_segments() {
             let root = scratch_root("resolve-dot");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.read("./nonexistent"), Err(FsError::NotFound)));
             cleanup(&root);
         }
@@ -726,7 +729,8 @@ mod native {
         #[test]
         fn read_missing_file_returns_not_found() {
             let root = scratch_root("read-missing");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.read("slot.bin"), Err(FsError::NotFound)));
             cleanup(&root);
         }
@@ -734,28 +738,42 @@ mod native {
         #[test]
         fn write_then_read_roundtrip() {
             let root = scratch_root("write-read");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("slot.bin", &[1, 2, 3, 4]).unwrap();
-            assert_eq!(a.read("slot.bin").unwrap(), vec![1, 2, 3, 4]);
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("slot.bin", &[1, 2, 3, 4])
+                .expect("test setup: adapter accepts write");
+            assert_eq!(
+                a.read("slot.bin")
+                    .expect("test setup: adapter returns written bytes"),
+                vec![1, 2, 3, 4]
+            );
             cleanup(&root);
         }
 
         #[test]
         fn write_creates_parent_directories() {
             let root = scratch_root("write-parents");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("deep/sub/dir/slot.bin", b"hi").unwrap();
-            assert_eq!(a.read("deep/sub/dir/slot.bin").unwrap(), b"hi");
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("deep/sub/dir/slot.bin", b"hi")
+                .expect("test setup: adapter writes through deep path");
+            assert_eq!(
+                a.read("deep/sub/dir/slot.bin")
+                    .expect("test setup: adapter reads through deep path"),
+                b"hi"
+            );
             cleanup(&root);
         }
 
         #[test]
         fn write_is_atomic_no_tmp_left_behind() {
             let root = scratch_root("write-atomic");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("slot.bin", &[0u8; 16]).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("slot.bin", &[0u8; 16])
+                .expect("test setup: adapter accepts atomic write");
             let siblings: Vec<String> = std::fs::read_dir(a.root())
-                .unwrap()
+                .expect("test setup: adapter root is readable")
                 .filter_map(std::result::Result::ok)
                 .filter_map(|e| e.file_name().to_str().map(std::string::ToString::to_string))
                 .collect();
@@ -769,7 +787,8 @@ mod native {
         #[test]
         fn write_on_read_only_returns_forbidden() {
             let root = scratch_root("write-readonly");
-            let a = LocalFileAdapter::new(root.clone(), false).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), false)
+                .expect("test setup: read-only LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.write("x.bin", &[]), Err(FsError::Forbidden)));
             cleanup(&root);
         }
@@ -777,7 +796,8 @@ mod native {
         #[test]
         fn delete_missing_returns_not_found() {
             let root = scratch_root("delete-missing");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.delete("ghost.bin"), Err(FsError::NotFound)));
             cleanup(&root);
         }
@@ -785,9 +805,12 @@ mod native {
         #[test]
         fn delete_removes_file() {
             let root = scratch_root("delete-works");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("slot.bin", b"x").unwrap();
-            a.delete("slot.bin").unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("slot.bin", b"x")
+                .expect("test setup: adapter accepts write");
+            a.delete("slot.bin")
+                .expect("test setup: adapter deletes existing file");
             assert!(matches!(a.read("slot.bin"), Err(FsError::NotFound)));
             cleanup(&root);
         }
@@ -795,7 +818,8 @@ mod native {
         #[test]
         fn delete_on_read_only_returns_forbidden() {
             let root = scratch_root("delete-readonly");
-            let a = LocalFileAdapter::new(root.clone(), false).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), false)
+                .expect("test setup: read-only LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.delete("x.bin"), Err(FsError::Forbidden)));
             cleanup(&root);
         }
@@ -803,30 +827,47 @@ mod native {
         #[test]
         fn list_empty_root_returns_empty_vec() {
             let root = scratch_root("list-empty");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            assert_eq!(a.list("").unwrap(), Vec::<String>::new());
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            assert_eq!(
+                a.list("").expect("test setup: adapter lists empty root"),
+                Vec::<String>::new()
+            );
             cleanup(&root);
         }
 
         #[test]
         fn list_returns_sorted_names_at_root() {
             let root = scratch_root("list-root");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("c.bin", b"").unwrap();
-            a.write("a.bin", b"").unwrap();
-            a.write("b.bin", b"").unwrap();
-            assert_eq!(a.list("").unwrap(), vec!["a.bin", "b.bin", "c.bin"]);
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("c.bin", b"")
+                .expect("test setup: adapter accepts c.bin write");
+            a.write("a.bin", b"")
+                .expect("test setup: adapter accepts a.bin write");
+            a.write("b.bin", b"")
+                .expect("test setup: adapter accepts b.bin write");
+            assert_eq!(
+                a.list("").expect("test setup: adapter lists root"),
+                vec!["a.bin", "b.bin", "c.bin"]
+            );
             cleanup(&root);
         }
 
         #[test]
         fn list_under_subdirectory() {
             let root = scratch_root("list-sub");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
-            a.write("saves/slot1.bin", b"").unwrap();
-            a.write("saves/slot2.bin", b"").unwrap();
-            a.write("cfg/keys.toml", b"").unwrap();
-            let saves = a.list("saves").unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
+            a.write("saves/slot1.bin", b"")
+                .expect("test setup: adapter accepts saves/slot1.bin write");
+            a.write("saves/slot2.bin", b"")
+                .expect("test setup: adapter accepts saves/slot2.bin write");
+            a.write("cfg/keys.toml", b"")
+                .expect("test setup: adapter accepts cfg/keys.toml write");
+            let saves = a
+                .list("saves")
+                .expect("test setup: adapter lists saves subdir");
             assert_eq!(saves, vec!["slot1.bin", "slot2.bin"]);
             cleanup(&root);
         }
@@ -834,7 +875,8 @@ mod native {
         #[test]
         fn list_missing_directory_returns_not_found() {
             let root = scratch_root("list-missing");
-            let a = LocalFileAdapter::new(root.clone(), true).unwrap();
+            let a = LocalFileAdapter::new(root.clone(), true)
+                .expect("test setup: LocalFileAdapter constructs on scratch root");
             assert!(matches!(a.list("nope"), Err(FsError::NotFound)));
             cleanup(&root);
         }
@@ -849,8 +891,10 @@ mod native {
         #[test]
         fn registry_registers_and_retrieves_adapter() {
             let root = scratch_root("reg-basic");
-            let adapter: Arc<dyn FileAdapter> =
-                Arc::new(LocalFileAdapter::new(root.clone(), true).unwrap());
+            let adapter: Arc<dyn FileAdapter> = Arc::new(
+                LocalFileAdapter::new(root.clone(), true)
+                    .expect("test setup: LocalFileAdapter constructs on scratch root"),
+            );
             let mut reg = AdapterRegistry::new();
             reg.register("save", adapter);
             assert!(reg.has("save"));
@@ -862,8 +906,10 @@ mod native {
         use aether_substrate::mail::outbound::EgressEvent;
 
         fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
-            let adapter: Arc<dyn FileAdapter> =
-                Arc::new(LocalFileAdapter::new(root.to_path_buf(), writable).unwrap());
+            let adapter: Arc<dyn FileAdapter> = Arc::new(
+                LocalFileAdapter::new(root.to_path_buf(), writable)
+                    .expect("test setup: LocalFileAdapter constructs on supplied root"),
+            );
             let mut r = AdapterRegistry::new();
             r.register("save", adapter);
             Arc::new(r)
@@ -890,7 +936,9 @@ mod native {
         fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
             rx: &std::sync::mpsc::Receiver<EgressEvent>,
         ) -> K {
-            let event = rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap();
+            let event = rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("test: egress event arrives within 1s deadline");
             let EgressEvent::ToSession {
                 kind_name, payload, ..
             } = event
@@ -898,7 +946,7 @@ mod native {
                 panic!("expected ToSession egress, got {event:?}");
             };
             assert_eq!(kind_name, K::NAME);
-            postcard::from_bytes(&payload).unwrap()
+            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
         }
 
         /// Boot the cap against a fresh tempdir; assert the mailbox
@@ -927,14 +975,15 @@ mod native {
         fn cap_init_fails_when_adapter_init_fails() {
             let root = scratch_root("init-fails");
             let save_path = root.join("save_is_actually_a_file");
-            std::fs::write(&save_path, b"not a dir").unwrap();
+            std::fs::write(&save_path, b"not a dir")
+                .expect("test setup: write save_path as a regular file");
             let roots = NamespaceRoots {
                 save: save_path,
                 assets: root.join("assets"),
                 config: root.join("config"),
             };
-            std::fs::create_dir_all(&roots.assets).unwrap();
-            std::fs::create_dir_all(&roots.config).unwrap();
+            std::fs::create_dir_all(&roots.assets).expect("test setup: assets root creates");
+            std::fs::create_dir_all(&roots.config).expect("test setup: config root creates");
 
             let (registry, mailer) = fresh_substrate();
             let result = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
@@ -972,9 +1021,9 @@ mod native {
             let root = scratch_root("cap-read");
             let reg = build_save_only_registry(&root, true);
             reg.get("save")
-                .unwrap()
+                .expect("test setup: save adapter is registered")
                 .write("slot.bin", &[9, 9, 9])
-                .unwrap();
+                .expect("test setup: adapter accepts write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
             fix.cap.on_read(
@@ -1072,7 +1121,11 @@ mod native {
                 WriteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
             }
             assert_eq!(
-                reg_clone.get("save").unwrap().read("slot.bin").unwrap(),
+                reg_clone
+                    .get("save")
+                    .expect("test setup: save adapter is registered")
+                    .read("slot.bin")
+                    .expect("test setup: adapter reads written bytes"),
                 vec![1, 2, 3]
             );
             cleanup(&root);
@@ -1107,7 +1160,10 @@ mod native {
             let root = scratch_root("cap-del");
             let reg = build_save_only_registry(&root, true);
             let reg_clone = Arc::clone(&reg);
-            reg.get("save").unwrap().write("x.bin", b"x").unwrap();
+            reg.get("save")
+                .expect("test setup: save adapter is registered")
+                .write("x.bin", b"x")
+                .expect("test setup: adapter accepts write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
             fix.cap.on_delete(
@@ -1125,7 +1181,10 @@ mod native {
                 DeleteResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
             }
             assert!(matches!(
-                reg_clone.get("save").unwrap().read("x.bin"),
+                reg_clone
+                    .get("save")
+                    .expect("test setup: save adapter is registered")
+                    .read("x.bin"),
                 Err(FsError::NotFound)
             ));
             cleanup(&root);
@@ -1135,8 +1194,14 @@ mod native {
         fn cap_list_returns_sorted_entries() {
             let root = scratch_root("cap-list");
             let reg = build_save_only_registry(&root, true);
-            reg.get("save").unwrap().write("b.bin", b"").unwrap();
-            reg.get("save").unwrap().write("a.bin", b"").unwrap();
+            reg.get("save")
+                .expect("test setup: save adapter is registered")
+                .write("b.bin", b"")
+                .expect("test setup: adapter accepts b.bin write");
+            reg.get("save")
+                .expect("test setup: save adapter is registered")
+                .write("a.bin", b"")
+                .expect("test setup: adapter accepts a.bin write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
             fix.cap.on_list(

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -212,7 +212,8 @@ mod native {
                 kind_id: KindId(0xCAFE),
                 bytes: vec![1, 2, 3, 4, 5],
             };
-            let bytes = postcard::to_allocvec(&req).unwrap();
+            let bytes = postcard::to_allocvec(&req)
+                .expect("test setup: HandlePublish serializes via postcard");
             handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
                 kind: <HandlePublish as Kind>::ID,
                 kind_name: "aether.handle.publish".to_owned(),
@@ -240,7 +241,8 @@ mod native {
                 EgressEvent::ToSession { payload, .. } => payload,
                 other => panic!("expected ToSession egress, got {other:?}"),
             };
-            let result: HandlePublishResult = postcard::from_bytes(&payload).unwrap();
+            let result: HandlePublishResult = postcard::from_bytes(&payload)
+                .expect("test setup: HandlePublishResult decodes via postcard");
             let HandlePublishResult::Ok {
                 kind_id,
                 id: handle_id,
@@ -250,7 +252,9 @@ mod native {
             };
             assert_eq!(kind_id, KindId(0xCAFE));
             assert_ne!(handle_id, HandleId(0));
-            let (stored_kind, stored_bytes) = store.get(handle_id).unwrap();
+            let (stored_kind, stored_bytes) = store
+                .get(handle_id)
+                .expect("test setup: stored handle should be retrievable");
             assert_eq!(stored_kind, KindId(0xCAFE));
             assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
 

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -558,7 +558,10 @@ mod native {
 
         impl HttpAdapter for StubAdapter {
             fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
-                *self.last_request.lock().unwrap() = Some(FetchRequest {
+                *self
+                    .last_request
+                    .lock()
+                    .expect("test stub: last_request mutex poisoned") = Some(FetchRequest {
                     url: req.url.clone(),
                     method: req.method,
                     headers: req.headers.clone(),
@@ -567,7 +570,7 @@ mod native {
                 });
                 self.response
                     .lock()
-                    .unwrap()
+                    .expect("test stub: response mutex poisoned")
                     .take()
                     .expect("stub response already consumed")
             }
@@ -594,7 +597,9 @@ mod native {
         fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
             rx: &std::sync::mpsc::Receiver<EgressEvent>,
         ) -> K {
-            let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            let event = rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("test: egress event arrives within 1s deadline");
             let EgressEvent::ToSession {
                 kind_name, payload, ..
             } = event
@@ -602,7 +607,7 @@ mod native {
                 panic!("expected ToSession egress, got {event:?}");
             };
             assert_eq!(kind_name, K::NAME);
-            postcard::from_bytes(&payload).unwrap()
+            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
         }
 
         /// Boot the cap against a default disabled `HttpConfig` and confirm
@@ -869,7 +874,7 @@ mod native {
             let observed = stub_clone
                 .last_request
                 .lock()
-                .unwrap()
+                .expect("test stub: last_request mutex poisoned")
                 .take()
                 .expect("adapter was not called");
             assert!(observed.timeout > Duration::ZERO);

--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -359,7 +359,8 @@ mod tests {
             PeerKind::Client { .. } => panic!("expected Substrate peer kind from server"),
         }
 
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 }).unwrap();
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 })
+            .expect("test setup: TestEchoRequest serializes via postcard");
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         let cid = conn
             .client

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -720,7 +720,7 @@ mod tests {
             TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+            .expect("test: set_read_timeout on TcpStream");
 
         write_frame(
             &mut stream,
@@ -772,7 +772,7 @@ mod tests {
             TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+            .expect("test: set_read_timeout on TcpStream");
 
         // Send a Hello first so the handshake completes, then drain the
         // HelloAck reply before the Ping/Pong roundtrip.
@@ -786,8 +786,9 @@ mod tests {
                 },
             }),
         )
-        .unwrap();
-        let _: WireFrame = read_frame(&mut stream).unwrap();
+        .expect("test: write_frame Hello to rpc server");
+        let _: WireFrame =
+            read_frame(&mut stream).expect("test: read_frame after Hello returns HelloAck");
 
         write_frame(&mut stream, &WireFrame::Ping(0x00c0_ffee)).expect("write Ping");
         let reply: WireFrame = read_frame(&mut stream).expect("read Pong");
@@ -832,7 +833,7 @@ mod tests {
             TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
+            .expect("test: set_read_timeout on TcpStream");
 
         // Handshake.
         write_frame(
@@ -845,12 +846,14 @@ mod tests {
                 },
             }),
         )
-        .unwrap();
-        let _: WireFrame = read_frame(&mut stream).unwrap();
+        .expect("test: write_frame Hello to rpc server");
+        let _: WireFrame =
+            read_frame(&mut stream).expect("test: read_frame after Hello returns HelloAck");
 
         // Fire a Call against the echo actor. cid = 0xabc; the cap
         // correlates and ends with ReplyEnd matching the same cid.
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 }).unwrap();
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 })
+            .expect("test setup: TestEchoRequest serializes via postcard");
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -865,7 +868,7 @@ mod tests {
                 },
             },
         )
-        .unwrap();
+        .expect("test: write_frame Call to rpc server");
 
         // First frame back should be the ReplyEvent carrying the
         // TestEchoReply with the echoed value.
@@ -924,7 +927,7 @@ mod tests {
             TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+            .expect("test: set_read_timeout on TcpStream");
 
         // Handshake.
         write_frame(
@@ -937,13 +940,15 @@ mod tests {
                 },
             }),
         )
-        .unwrap();
-        let _: WireFrame = read_frame(&mut stream).unwrap();
+        .expect("test: write_frame Hello to rpc server");
+        let _: WireFrame =
+            read_frame(&mut stream).expect("test: read_frame after Hello returns HelloAck");
 
         // Fire-and-forget Call (cid = None). The echo actor will
         // still reply, but with cid None there's no in-flight entry
         // so the reply has no matching correlation and gets dropped.
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 7 }).unwrap();
+        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 7 })
+            .expect("test setup: TestEchoRequest serializes via postcard");
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -958,12 +963,13 @@ mod tests {
                 },
             },
         )
-        .unwrap();
+        .expect("test: write_frame fire-and-forget Call to rpc server");
 
         // Immediately Ping. If the fire-and-forget Call had leaked
         // reply correlation, a ReplyEvent / ReplyEnd would arrive
         // before the Pong. Asserting we see Pong first proves no leak.
-        write_frame(&mut stream, &WireFrame::Ping(0x00c0_ffee)).unwrap();
+        write_frame(&mut stream, &WireFrame::Ping(0x00c0_ffee))
+            .expect("test: write_frame Ping to rpc server");
         let reply: WireFrame = read_frame(&mut stream).expect("read Pong");
         assert_eq!(reply, WireFrame::Pong(0x00c0_ffee));
     }
@@ -989,7 +995,7 @@ mod tests {
             TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to rpc server");
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+            .expect("test: set_read_timeout on TcpStream");
 
         write_frame(
             &mut stream,
@@ -1001,7 +1007,7 @@ mod tests {
                 },
             }),
         )
-        .unwrap();
+        .expect("test: write_frame future-version Hello to rpc server");
 
         let reply: WireFrame = read_frame(&mut stream).expect("read Bye");
         match reply {

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -599,9 +599,18 @@ mod native {
                 Nanos(100),
             );
             assert_eq!(obs.roots.len(), 1);
-            assert_eq!(obs.roots.get(&m).unwrap().in_flight, 1);
+            assert_eq!(
+                obs.roots
+                    .get(&m)
+                    .expect("root entry exists for mail")
+                    .in_flight,
+                1
+            );
             assert_eq!(obs.mails.len(), 1);
-            assert_eq!(obs.mails.get(&m).unwrap().t_sent, Nanos(100));
+            assert_eq!(
+                obs.mails.get(&m).expect("mail node exists for mail").t_sent,
+                Nanos(100)
+            );
         }
 
         #[test]
@@ -630,8 +639,20 @@ mod native {
                 Nanos(200),
             );
             assert_eq!(obs.roots.len(), 1);
-            assert_eq!(obs.roots.get(&root).unwrap().in_flight, 2);
-            assert_eq!(obs.mails.get(&child).unwrap().parent, Some(root));
+            assert_eq!(
+                obs.roots
+                    .get(&root)
+                    .expect("root entry exists for root mail")
+                    .in_flight,
+                2
+            );
+            assert_eq!(
+                obs.mails
+                    .get(&child)
+                    .expect("child mail node exists")
+                    .parent,
+                Some(root)
+            );
         }
 
         #[test]
@@ -657,8 +678,14 @@ mod native {
                 mail_id: m,
                 t: Nanos(300),
             });
-            assert_eq!(obs.roots.get(&m).unwrap().in_flight, 0);
-            let node = obs.mails.get(&m).unwrap();
+            assert_eq!(
+                obs.roots
+                    .get(&m)
+                    .expect("root entry exists for mail")
+                    .in_flight,
+                0
+            );
+            let node = obs.mails.get(&m).expect("mail node exists for mail");
             assert_eq!(node.t_received, Some(Nanos(200)));
             assert_eq!(node.t_finished, Some(Nanos(300)));
             assert_eq!(node.thread_name.as_deref(), Some("aether-root-test"));
@@ -721,7 +748,10 @@ mod native {
                 if mail.kind == settled_kind
                     && let Ok(notice) = postcard::from_bytes::<Settled>(&mail.payload)
                 {
-                    captured_for_router.lock().unwrap().push(notice);
+                    captured_for_router
+                        .lock()
+                        .expect("test stub: captured mutex poisoned")
+                        .push(notice);
                 }
             }));
 
@@ -747,13 +777,18 @@ mod native {
                 Nanos(100),
             );
             // No Settled yet — in_flight is 1.
-            assert!(captured.lock().unwrap().is_empty());
+            assert!(
+                captured
+                    .lock()
+                    .expect("test stub: captured mutex poisoned")
+                    .is_empty()
+            );
             obs.apply_event(TraceEvent::Finished {
                 mail_id: root,
                 t: Nanos(200),
             });
             // Settled fired; chassis-router decoded the mail.
-            let captured = captured.lock().unwrap();
+            let captured = captured.lock().expect("test stub: captured mutex poisoned");
             assert_eq!(captured.len(), 1);
             assert_eq!(captured[0].root, root);
         }


### PR DESCRIPTION
Closes iamacoffeepot/aether#888

- Replace bare `.unwrap()` with `.expect("...")` across 95 sites in `aether-capabilities` (engine/proxy, engine/server, fs, handle, http, rpc/client, rpc/server, trace) so panics fail-fast with a meaningful message per ADR-0063 instead of a useless line number.
- All sites are inside `cfg(test)` modules; tests use `expect("test setup: ...")` / `expect("test stub: ... mutex poisoned")` framing per the issue's strategy.
- `cargo clippy -p aether-capabilities --all-targets` now reports zero `unwrap_used` warnings for the crate; `cargo check --workspace --all-targets`, `cargo fmt -- --check`, and `cargo nextest run --workspace` (1001 tests) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)