### PR TITLE
chore(substrate): sweep clippy::unwrap_used in small-crates batch (issue 890)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -2703,7 +2703,8 @@ mod tests {
 
     #[test]
     fn allows_btreemap_field() {
-        let parsed: syn::Type = parse_str("BTreeMap<String, String>").unwrap();
+        let parsed: syn::Type =
+            parse_str("BTreeMap<String, String>").expect("test setup: BTreeMap type parses");
         assert!(reject_hashmap(&parsed).is_ok());
     }
 
@@ -2716,7 +2717,8 @@ mod tests {
             "Option<String>",
             "BTreeSet<u64>",
         ] {
-            let parsed: syn::Type = parse_str(ty).unwrap();
+            let parsed: syn::Type =
+                parse_str(ty).expect("test setup: candidate type parses as syn::Type");
             assert!(
                 reject_hashmap(&parsed).is_ok(),
                 "rejected {ty} unexpectedly"

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -468,7 +468,9 @@ mod tests {
         // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId::__new(7);
-        let out = mail.decode(kind).unwrap();
+        let out = mail
+            .decode(kind)
+            .expect("test setup: matching kind id decodes");
         assert_eq!(out, value);
     }
 
@@ -503,7 +505,9 @@ mod tests {
         // SAFETY: see module-level test fixture justification above.
         let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
         let kind: KindId<FakePod> = KindId::__new(7);
-        let out = mail.decode_slice(kind).unwrap();
+        let out = mail
+            .decode_slice(kind)
+            .expect("test setup: matching kind id decodes slice");
         assert_eq!(out, &values);
     }
 
@@ -562,7 +566,9 @@ mod tests {
         // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
-        let out = mail.decode_typed::<FakePod>().unwrap();
+        let out = mail
+            .decode_typed::<FakePod>()
+            .expect("test setup: matching kind id decodes typed");
         assert_eq!(out, value);
     }
 
@@ -597,7 +603,9 @@ mod tests {
         // SAFETY: see module-level test fixture justification above.
         let mail =
             unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
-        let out = mail.decode_slice_typed::<FakePod>().unwrap();
+        let out = mail
+            .decode_slice_typed::<FakePod>()
+            .expect("test setup: matching kind id decodes typed slice");
         assert_eq!(out, &values);
     }
 
@@ -607,7 +615,8 @@ mod tests {
             tag: alloc::string::String::from("greet"),
             ids: alloc::vec![1, 2, 3, 4],
         };
-        let bytes = postcard::to_allocvec(&value).unwrap();
+        let bytes =
+            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
         // SAFETY: `bytes` (a `Vec<u8>` from postcard) outlives `mail`;
         // its `(addr, len)` pair is valid for the rest of the body.
         let mail = unsafe {
@@ -661,7 +670,8 @@ mod tests {
             tag: alloc::string::String::from("x"),
             ids: alloc::vec![],
         };
-        let bytes = postcard::to_allocvec(&value).unwrap();
+        let bytes =
+            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -682,7 +692,8 @@ mod tests {
             tag: alloc::string::String::from("x"),
             ids: alloc::vec![],
         };
-        let bytes = postcard::to_allocvec(&value).unwrap();
+        let bytes =
+            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -703,7 +714,8 @@ mod tests {
             tag: alloc::string::String::from("longer"),
             ids: alloc::vec![1, 2, 3],
         };
-        let bytes = postcard::to_allocvec(&value).unwrap();
+        let bytes =
+            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
         // Pretend the substrate only wrote the first 2 bytes —
         // `decode_from_bytes` (postcard arm) gets the truncated slice
         // and surfaces the parse error as `None`.
@@ -786,7 +798,8 @@ mod tests {
 
     fn frame_bundle<K: Kind + Schema + Serialize>(value: &K) -> Vec<u8> {
         let mut out = Vec::from(K::ID.0.to_le_bytes());
-        let payload = postcard::to_allocvec(value).unwrap();
+        let payload =
+            postcard::to_allocvec(value).expect("test setup: postcard encodes test value");
         out.extend_from_slice(&payload);
         out
     }
@@ -808,7 +821,9 @@ mod tests {
         };
         let buf = frame_bundle(&value);
         let prior = prior_from(&buf, 0);
-        let decoded = prior.as_kind::<StateStruct>().unwrap();
+        let decoded = prior
+            .as_kind::<StateStruct>()
+            .expect("test setup: round-trip frame decodes back to StateStruct");
         assert_eq!(decoded, value);
     }
 

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -425,7 +425,7 @@ mod tests {
         assert_eq!(
             decoded,
             InputsRecord::Fallback {
-                doc: Some(DOC.unwrap().into()),
+                doc: Some(DOC.expect("test setup: DOC is Some by construction").into()),
             }
         );
     }
@@ -448,7 +448,8 @@ mod tests {
         for &v in &[0u64, 1, 0x7f, 0x80, 0xff, 0xffff_ffff, u64::MAX] {
             let mut out = [0u8; 10];
             let used = write_varint_u64(v, &mut out, 0);
-            let postcard_bytes = postcard::to_allocvec(&v).unwrap();
+            let postcard_bytes =
+                postcard::to_allocvec(&v).expect("test setup: postcard encodes u64");
             assert_eq!(&out[..used], &postcard_bytes[..], "mismatch for {v:#x}");
             assert_eq!(used, varint_u64_len(v), "len mismatch for {v:#x}");
         }

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -695,7 +695,7 @@ mod tests {
         let v = TestPod { a: 42, b: 1.5 };
         let bytes = encode(&v);
         assert_eq!(bytes.len(), 8);
-        let back: TestPod = decode(&bytes).unwrap();
+        let back: TestPod = decode(&bytes).expect("test setup: cast round-trip decodes");
         assert_eq!(back, v);
     }
 
@@ -704,14 +704,16 @@ mod tests {
         let verts = [Vertex { x: 0.0, y: 0.5 }, Vertex { x: 1.0, y: -0.5 }];
         let bytes = encode_slice(&verts);
         assert_eq!(bytes.len(), 16);
-        let decoded: &[Vertex] = decode_slice(&bytes).unwrap();
+        let decoded: &[Vertex] =
+            decode_slice(&bytes).expect("test setup: aligned slice decodes zero-copy");
         assert_eq!(decoded, &verts);
     }
 
     #[test]
     fn pod_decode_size_mismatch_rejected() {
         let bytes = [0u8; 7]; // TestPod is 8 bytes
-        let err = decode::<TestPod>(&bytes).unwrap_err();
+        let err =
+            decode::<TestPod>(&bytes).expect_err("test setup: short buffer must fail size check");
         assert!(matches!(
             err,
             DecodeError::SizeMismatch {
@@ -728,13 +730,15 @@ mod tests {
             label: alloc::string::String::from("hello"),
         };
         let bytes = encode_struct(&v);
-        let back: TestStruct = decode_struct(&bytes).unwrap();
+        let back: TestStruct =
+            decode_struct(&bytes).expect("test setup: postcard round-trip decodes TestStruct");
         assert_eq!(back, v);
     }
 
     #[test]
     fn struct_decode_malformed_rejected() {
-        let err = decode_struct::<TestStruct>(&[0x00]).unwrap_err();
+        let err = decode_struct::<TestStruct>(&[0x00])
+            .expect_err("test setup: single-byte buffer must fail postcard decode");
         assert!(matches!(err, DecodeError::Postcard(_)));
     }
 
@@ -809,8 +813,9 @@ mod tests {
             label: alloc::string::String::from("hello"),
         };
         let r = Ref::Inline(v);
-        let bytes = postcard::to_allocvec(&r).unwrap();
-        let back: Ref<TestStruct> = postcard::from_bytes(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&r).expect("test setup: postcard encodes Inline Ref");
+        let back: Ref<TestStruct> =
+            postcard::from_bytes(&bytes).expect("test setup: postcard decodes Inline Ref");
         assert_eq!(back, r);
     }
 
@@ -820,8 +825,9 @@ mod tests {
             id: 0xdead_beef_cafe_babe,
             kind_id: 0x1234_5678_9abc_def0,
         };
-        let bytes = postcard::to_allocvec(&r).unwrap();
-        let back: Ref<TestStruct> = postcard::from_bytes(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&r).expect("test setup: postcard encodes Handle Ref");
+        let back: Ref<TestStruct> =
+            postcard::from_bytes(&bytes).expect("test setup: postcard decodes Handle Ref");
         assert_eq!(back, r);
     }
 
@@ -832,8 +838,10 @@ mod tests {
             label: alloc::string::String::from("x"),
         });
         let handle: Ref<TestStruct> = Ref::Handle { id: 1, kind_id: 1 };
-        let inline_bytes = postcard::to_allocvec(&inline).unwrap();
-        let handle_bytes = postcard::to_allocvec(&handle).unwrap();
+        let inline_bytes =
+            postcard::to_allocvec(&inline).expect("test setup: postcard encodes Inline Ref");
+        let handle_bytes =
+            postcard::to_allocvec(&handle).expect("test setup: postcard encodes Handle Ref");
         assert_eq!(inline_bytes[0], 0, "Inline discriminant must be 0");
         assert_eq!(handle_bytes[0], 1, "Handle discriminant must be 1");
     }

--- a/crates/aether-data/src/tagged_id.rs
+++ b/crates/aether-data/src/tagged_id.rs
@@ -208,8 +208,11 @@ mod tests {
                 let id = with_tag(tag, hash);
                 assert_eq!(tag_of(id), Some(tag));
                 assert_eq!(body_of(id), hash & HASH_MASK);
-                let s = encode(id).unwrap();
-                assert_eq!(decode(&s).unwrap(), id);
+                let s = encode(id).expect("test setup: tagged id encodes (tag is non-zero)");
+                assert_eq!(
+                    decode(&s).expect("test setup: round-trip decode of encoded id"),
+                    id
+                );
             }
         }
     }
@@ -217,7 +220,7 @@ mod tests {
     #[test]
     fn encoding_shape() {
         let id = with_tag(Tag::Mailbox, 0);
-        let s = encode(id).unwrap();
+        let s = encode(id).expect("test setup: Mailbox id encodes (tag is non-zero)");
         assert_eq!(s.len(), 18);
         assert!(s.starts_with("mbx-"));
         assert_eq!(s, "mbx-aaaa-aaaa-aaaa");
@@ -226,7 +229,7 @@ mod tests {
     #[test]
     fn alphabet_excludes_digit_lookalikes() {
         let id = with_tag(Tag::Kind, HASH_MASK);
-        let s = encode(id).unwrap();
+        let s = encode(id).expect("test setup: Kind id encodes (tag is non-zero)");
         assert_eq!(s, "knd-7777-7777-7777");
         assert!(!s.contains('0'));
         assert!(!s.contains('1'));
@@ -261,16 +264,23 @@ mod tests {
     #[test]
     fn decode_is_case_insensitive() {
         let id = with_tag(Tag::Handle, 0x1234_5678_9abc_def0 & HASH_MASK);
-        let lower = encode(id).unwrap();
+        let lower = encode(id).expect("test setup: Handle id encodes (tag is non-zero)");
         let upper = lower.to_uppercase();
-        assert_eq!(decode(&lower).unwrap(), id);
-        assert_eq!(decode(&upper).unwrap(), id);
+        assert_eq!(
+            decode(&lower).expect("test setup: lowercase form decodes back to id"),
+            id
+        );
+        assert_eq!(
+            decode(&upper).expect("test setup: uppercase form decodes back to id"),
+            id
+        );
     }
 
     #[test]
     fn decode_with_tag_catches_mismatch() {
-        let mailbox = encode(with_tag(Tag::Mailbox, 0x42)).unwrap();
-        let err = decode_with_tag(&mailbox, Tag::Kind).unwrap_err();
+        let mailbox = encode(with_tag(Tag::Mailbox, 0x42)).expect("test setup: Mailbox id encodes");
+        let err = decode_with_tag(&mailbox, Tag::Kind)
+            .expect_err("test setup: Mailbox bytes must reject Kind tag");
         assert_eq!(
             err,
             DecodeError::TagMismatch {

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -136,7 +136,10 @@ mod tests {
         // `Pod` derive that would silently flip the wire format.
         let descs = all();
         for name in [Read::NAME, Write::NAME, Delete::NAME, List::NAME] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: io request kind is registered in descriptor inventory");
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
@@ -155,7 +158,10 @@ mod tests {
             DeleteResult::NAME,
             ListResult::NAME,
         ] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: io result kind is registered in descriptor inventory");
             assert!(
                 matches!(d.schema, SchemaType::Enum { .. }),
                 "{name} should be Enum, got {:?}",
@@ -176,14 +182,20 @@ mod tests {
             ReplaceComponent::NAME,
             DropComponent::NAME,
         ] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: control request kind is registered in descriptor inventory");
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
             assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
         }
         for name in [LoadResult::NAME, DropResult::NAME, ReplaceResult::NAME] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: control result kind is registered in descriptor inventory");
             assert!(
                 matches!(d.schema, SchemaType::Enum { .. }),
                 "{name} should be Enum, got {:?}",
@@ -205,7 +217,10 @@ mod tests {
             NoteOff::NAME,
             SetMasterGain::NAME,
         ] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: cast kind is registered in descriptor inventory");
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("expected Struct for {name}, got {:?}", d.schema);
             };
@@ -217,7 +232,10 @@ mod tests {
     fn signal_kinds_emit_unit() {
         let descs = all();
         for name in [Tick::NAME, MouseButton::NAME] {
-            let d = descs.iter().find(|d| d.name == name).unwrap();
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: signal kind is registered in descriptor inventory");
             assert_eq!(d.schema, SchemaType::Unit, "{name} should be Unit");
         }
     }
@@ -225,7 +243,10 @@ mod tests {
     #[test]
     fn key_field_layout() {
         let descs = all();
-        let key = descs.iter().find(|d| d.name == Key::NAME).unwrap();
+        let key = descs
+            .iter()
+            .find(|d| d.name == Key::NAME)
+            .expect("test setup: Key kind is registered in descriptor inventory");
         let SchemaType::Struct { fields, .. } = &key.schema else {
             panic!("expected Struct")
         };
@@ -237,7 +258,10 @@ mod tests {
     #[test]
     fn mouse_move_field_layout() {
         let descs = all();
-        let mm = descs.iter().find(|d| d.name == MouseMove::NAME).unwrap();
+        let mm = descs
+            .iter()
+            .find(|d| d.name == MouseMove::NAME)
+            .expect("test setup: MouseMove kind is registered in descriptor inventory");
         let SchemaType::Struct { fields, .. } = &mm.schema else {
             panic!("expected Struct")
         };
@@ -251,7 +275,10 @@ mod tests {
     #[test]
     fn draw_triangle_recurses_into_vertex() {
         let descs = all();
-        let dt = descs.iter().find(|d| d.name == DrawTriangle::NAME).unwrap();
+        let dt = descs
+            .iter()
+            .find(|d| d.name == DrawTriangle::NAME)
+            .expect("test setup: DrawTriangle kind is registered in descriptor inventory");
         let SchemaType::Struct { fields, repr_c } = &dt.schema else {
             panic!("expected Struct")
         };

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1788,7 +1788,7 @@ mod tests {
         let k = Key { code: 42 };
         let bytes = encode(&k);
         assert_eq!(bytes.len(), 4);
-        let back: Key = decode(&bytes).unwrap();
+        let back: Key = decode(&bytes).expect("test setup: Key cast round-trip decodes");
         assert_eq!(back, k);
     }
 
@@ -1797,7 +1797,8 @@ mod tests {
         let m = MouseMove { x: 1.5, y: -3.25 };
         let bytes = encode(&m);
         assert_eq!(bytes.len(), 8);
-        let back: MouseMove = decode(&bytes).unwrap();
+        let back: MouseMove =
+            decode(&bytes).expect("test setup: MouseMove cast round-trip decodes");
         assert_eq!(back, m);
     }
 
@@ -1817,7 +1818,8 @@ mod tests {
         ];
         let bytes = encode_slice(&tris);
         assert_eq!(bytes.len(), 2 * 72);
-        let back: &[DrawTriangle] = decode_slice(&bytes).unwrap();
+        let back: &[DrawTriangle] =
+            decode_slice(&bytes).expect("test setup: DrawTriangle slice decodes zero-copy");
         assert_eq!(back, &tris);
     }
 
@@ -1954,8 +1956,9 @@ mod tests {
                 namespace: "save".to_string(),
                 path: "slot1.bin".to_string(),
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: Read = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&r).expect("test setup: postcard encodes Read");
+            let back: Read =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes Read");
             assert_eq!(back.namespace, r.namespace);
             assert_eq!(back.path, r.path);
         }
@@ -1967,8 +1970,10 @@ mod tests {
                 path: "slot.bin".to_string(),
                 bytes: vec![1, 2, 3, 4],
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: ReadResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes ReadResult::Ok");
+            let back: ReadResult =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes ReadResult::Ok");
             match back {
                 ReadResult::Ok {
                     namespace,
@@ -1990,8 +1995,10 @@ mod tests {
                 path: "ghost.bin".to_string(),
                 error: FsError::NotFound,
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: ReadResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes ReadResult::Err");
+            let back: ReadResult =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes ReadResult::Err");
             match back {
                 ReadResult::Err {
                     namespace,
@@ -2009,8 +2016,9 @@ mod tests {
         #[test]
         fn io_error_adapter_carries_payload() {
             let e = FsError::AdapterError("disk full".to_string());
-            let bytes = postcard::to_allocvec(&e).unwrap();
-            let back: FsError = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&e).expect("test setup: postcard encodes FsError");
+            let back: FsError =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes FsError");
             match back {
                 FsError::AdapterError(msg) => assert_eq!(msg, "disk full"),
                 other => panic!("expected AdapterError, got {other:?}"),
@@ -2024,8 +2032,9 @@ mod tests {
                 path: "state.bin".to_string(),
                 bytes: vec![0xde, 0xad, 0xbe, 0xef],
             };
-            let bytes = postcard::to_allocvec(&w).unwrap();
-            let back: Write = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&w).expect("test setup: postcard encodes Write");
+            let back: Write =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes Write");
             assert_eq!(back.bytes, vec![0xde, 0xad, 0xbe, 0xef]);
         }
 
@@ -2036,8 +2045,10 @@ mod tests {
                 prefix: "slots/".to_string(),
                 entries: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: ListResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes ListResult::Ok");
+            let back: ListResult =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes ListResult::Ok");
             match back {
                 ListResult::Ok {
                     namespace,
@@ -2061,8 +2072,10 @@ mod tests {
                 namespace: "save".to_string(),
                 path: "state.bin".to_string(),
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: WriteResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes WriteResult::Ok");
+            let back: WriteResult =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes WriteResult::Ok");
             match back {
                 WriteResult::Ok { namespace, path } => {
                     assert_eq!(namespace, "save");
@@ -2079,8 +2092,10 @@ mod tests {
                 path: "ghost.bin".to_string(),
                 error: FsError::NotFound,
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: DeleteResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes DeleteResult::Err");
+            let back: DeleteResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes DeleteResult::Err");
             match back {
                 DeleteResult::Err {
                     namespace,
@@ -2131,8 +2146,9 @@ mod tests {
                 body: vec![b'{', b'}'],
                 timeout_ms: Some(5000),
             };
-            let bytes = postcard::to_allocvec(&f).unwrap();
-            let back: Fetch = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&f).expect("test setup: postcard encodes Fetch");
+            let back: Fetch =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes Fetch");
             assert_eq!(back.url, f.url);
             assert_eq!(back.method, HttpMethod::Post);
             assert_eq!(back.headers, f.headers);
@@ -2149,8 +2165,10 @@ mod tests {
                 body: vec![],
                 timeout_ms: None,
             };
-            let bytes = postcard::to_allocvec(&f).unwrap();
-            let back: Fetch = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&f).expect("test setup: postcard encodes Fetch (no timeout)");
+            let back: Fetch = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes Fetch (no timeout)");
             assert_eq!(back.timeout_ms, None);
             assert_eq!(back.method, HttpMethod::Get);
         }
@@ -2163,8 +2181,10 @@ mod tests {
                 headers: sample_headers(),
                 body: vec![0xde, 0xad, 0xbe, 0xef],
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: FetchResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes FetchResult::Ok");
+            let back: FetchResult =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes FetchResult::Ok");
             match back {
                 FetchResult::Ok {
                     url,
@@ -2187,8 +2207,10 @@ mod tests {
                 url: "https://api.example.com/gone".to_string(),
                 error: HttpError::Timeout,
             };
-            let bytes = postcard::to_allocvec(&r).unwrap();
-            let back: FetchResult = postcard::from_bytes(&bytes).unwrap();
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes FetchResult::Err");
+            let back: FetchResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes FetchResult::Err");
             match back {
                 FetchResult::Err { url, error } => {
                     assert_eq!(url, "https://api.example.com/gone");
@@ -2201,8 +2223,10 @@ mod tests {
         #[test]
         fn http_error_invalid_url_carries_payload() {
             let e = HttpError::InvalidUrl("not a url".to_string());
-            let bytes = postcard::to_allocvec(&e).unwrap();
-            let back: HttpError = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&e)
+                .expect("test setup: postcard encodes HttpError::InvalidUrl");
+            let back: HttpError = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes HttpError::InvalidUrl");
             match back {
                 HttpError::InvalidUrl(s) => assert_eq!(s, "not a url"),
                 other => panic!("expected InvalidUrl, got {other:?}"),
@@ -2212,8 +2236,10 @@ mod tests {
         #[test]
         fn http_error_adapter_carries_detail() {
             let e = HttpError::AdapterError("dns lookup failed".to_string());
-            let bytes = postcard::to_allocvec(&e).unwrap();
-            let back: HttpError = postcard::from_bytes(&bytes).unwrap();
+            let bytes = postcard::to_allocvec(&e)
+                .expect("test setup: postcard encodes HttpError::AdapterError");
+            let back: HttpError = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes HttpError::AdapterError");
             match back {
                 HttpError::AdapterError(s) => assert_eq!(s, "dns lookup failed"),
                 other => panic!("expected AdapterError, got {other:?}"),
@@ -2228,8 +2254,10 @@ mod tests {
                 HttpError::AllowlistDenied,
                 HttpError::Disabled,
             ] {
-                let bytes = postcard::to_allocvec(&e).unwrap();
-                let back: HttpError = postcard::from_bytes(&bytes).unwrap();
+                let bytes = postcard::to_allocvec(&e)
+                    .expect("test setup: postcard encodes HttpError unit variant");
+                let back: HttpError = postcard::from_bytes(&bytes)
+                    .expect("test setup: postcard decodes HttpError unit variant");
                 assert_eq!(back, e);
             }
         }
@@ -2245,8 +2273,10 @@ mod tests {
                 HttpMethod::Head,
                 HttpMethod::Options,
             ] {
-                let bytes = postcard::to_allocvec(&m).unwrap();
-                let back: HttpMethod = postcard::from_bytes(&bytes).unwrap();
+                let bytes = postcard::to_allocvec(&m)
+                    .expect("test setup: postcard encodes HttpMethod variant");
+                let back: HttpMethod = postcard::from_bytes(&bytes)
+                    .expect("test setup: postcard decodes HttpMethod variant");
                 assert_eq!(back, m);
             }
         }

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -80,14 +80,21 @@ impl RpcSession {
                             // Drop every pending sender so each waiting
                             // `call()` future sees `None` and errors
                             // out rather than hanging forever.
-                            router_pending.lock().unwrap().clear();
+                            router_pending
+                                .lock()
+                                .expect("router pending mutex is never poisoned")
+                                .clear();
                             break;
                         }
                         // Hello / HelloAck / Call / Ping / Pong: a
                         // client-side router never expects these.
                         _ => continue,
                     };
-                    if let Some(tx) = router_pending.lock().unwrap().get(&cid) {
+                    if let Some(tx) = router_pending
+                        .lock()
+                        .expect("router pending mutex is never poisoned")
+                        .get(&cid)
+                    {
                         // A failed send just means a stray frame for an
                         // already-finished call — drop it.
                         let _ = tx.send(frame);
@@ -118,11 +125,14 @@ impl RpcSession {
     pub async fn call(&self, envelope: MailEnvelope) -> anyhow::Result<Vec<MailEnvelope>> {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let cid = {
-            let mut pending = self.pending.lock().unwrap();
+            let mut pending = self
+                .pending
+                .lock()
+                .expect("rpc pending mutex is never poisoned");
             let cid = self
                 .client
                 .lock()
-                .unwrap()
+                .expect("rpc client mutex is never poisoned")
                 .call(envelope)
                 .map_err(|e| anyhow::anyhow!("rpc call write failed: {e}"))?;
             pending.insert(cid, tx);
@@ -146,7 +156,10 @@ impl RpcSession {
                 }
             }
         };
-        self.pending.lock().unwrap().remove(&cid);
+        self.pending
+            .lock()
+            .expect("rpc pending mutex is never poisoned")
+            .remove(&cid);
         outcome.map(|()| events)
     }
 

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -211,7 +211,7 @@ impl Mcp {
             }) => {
                 self.components
                     .lock()
-                    .unwrap()
+                    .expect("component cache mutex is never poisoned")
                     .insert((engine, mailbox_id), capabilities.clone());
                 json(&serde_json::json!({
                     "mailbox_id": mailbox_id,
@@ -256,7 +256,7 @@ impl Mcp {
             Some(ReplaceResult::Ok { capabilities }) => {
                 self.components
                     .lock()
-                    .unwrap()
+                    .expect("component cache mutex is never poisoned")
                     .insert((engine, mailbox_id), capabilities.clone());
                 json(&capabilities)
             }
@@ -323,7 +323,7 @@ impl Mcp {
         let caps = self
             .components
             .lock()
-            .unwrap()
+            .expect("component cache mutex is never poisoned")
             .get(&(engine, mailbox_id))
             .cloned();
         match caps {
@@ -824,10 +824,11 @@ mod tests {
         );
 
         // Seed the cache, then it round-trips.
-        let engine = EngineId(Uuid::parse_str(engine_id).unwrap());
+        let engine =
+            EngineId(Uuid::parse_str(engine_id).expect("test setup: engine_id is a valid uuid"));
         mcp.components
             .lock()
-            .unwrap()
+            .expect("test setup: component cache mutex is never poisoned")
             .insert((engine, mailbox), ComponentCapabilities::default());
         let hit = mcp
             .describe_component(Parameters(DescribeComponentArgs {
@@ -845,12 +846,24 @@ mod tests {
     /// land on `2`).
     #[test]
     fn parse_level_round_trips_documented_strings() {
-        assert_eq!(parse_level("trace").unwrap(), 0);
-        assert_eq!(parse_level("debug").unwrap(), 1);
-        assert_eq!(parse_level("info").unwrap(), 2);
-        assert_eq!(parse_level("warn").unwrap(), 3);
-        assert_eq!(parse_level("error").unwrap(), 4);
-        assert_eq!(parse_level("INFO").unwrap(), 2);
+        assert_eq!(
+            parse_level("trace").expect("test setup: \"trace\" parses"),
+            0
+        );
+        assert_eq!(
+            parse_level("debug").expect("test setup: \"debug\" parses"),
+            1
+        );
+        assert_eq!(parse_level("info").expect("test setup: \"info\" parses"), 2);
+        assert_eq!(parse_level("warn").expect("test setup: \"warn\" parses"), 3);
+        assert_eq!(
+            parse_level("error").expect("test setup: \"error\" parses"),
+            4
+        );
+        assert_eq!(
+            parse_level("INFO").expect("test setup: case-insensitive \"INFO\" parses"),
+            2
+        );
         assert!(parse_level("verbose").is_err());
     }
 
@@ -860,7 +873,8 @@ mod tests {
     #[test]
     fn level_to_str_matches_parse_level_and_falls_back_to_info() {
         for level in 0..=4u8 {
-            let parsed = parse_level(level_to_str(level)).unwrap();
+            let parsed = parse_level(level_to_str(level))
+                .expect("test setup: level_to_str output round-trips through parse_level");
             assert_eq!(parsed, level);
         }
         assert_eq!(level_to_str(99), "info");

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -418,7 +418,7 @@ mod tests {
             v 0 1 0\n\
             f 1 2 3\n\
             f 1 3 4\n";
-        let tris = parse_obj(obj).unwrap();
+        let tris = parse_obj(obj).expect("test setup: well-formed OBJ parses");
         assert_eq!(tris.len(), 2);
     }
 
@@ -430,7 +430,7 @@ mod tests {
             v 1 1 0\n\
             v 0 1 0\n\
             f 1 2 3 4\n";
-        let tris = parse_obj(obj).unwrap();
+        let tris = parse_obj(obj).expect("test setup: quad OBJ parses");
         assert_eq!(tris.len(), 2, "quad should triangulate to 2 triangles");
     }
 
@@ -447,7 +447,8 @@ mod tests {
             s off\n\
             g group_name\n\
             f 1 2 3\n";
-        let tris = parse_obj(obj).unwrap();
+        let tris =
+            parse_obj(obj).expect("test setup: OBJ with unknown directives still parses faces");
         assert_eq!(tris.len(), 1);
     }
 
@@ -458,7 +459,7 @@ mod tests {
             v 1 0 0\n\
             v 1 1 0\n\
             f 1/1/1 2/2/1 3/3/1\n";
-        let tris = parse_obj(obj).unwrap();
+        let tris = parse_obj(obj).expect("test setup: OBJ with v/vt/vn refs parses");
         assert_eq!(tris.len(), 1);
     }
 

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -793,28 +793,32 @@ mod tests {
 
     #[test]
     fn parse_windowed_defaults() {
-        let (m, s) = parse_window_mode_env("windowed").unwrap();
+        let (m, s) =
+            parse_window_mode_env("windowed").expect("test setup: \"windowed\" is a valid spec");
         assert!(matches!(m, WindowMode::Windowed));
         assert_eq!(s, None);
     }
 
     #[test]
     fn parse_windowed_with_size() {
-        let (m, s) = parse_window_mode_env("windowed:1280x720").unwrap();
+        let (m, s) = parse_window_mode_env("windowed:1280x720")
+            .expect("test setup: \"windowed:WxH\" is a valid spec");
         assert!(matches!(m, WindowMode::Windowed));
         assert_eq!(s, Some((1280, 720)));
     }
 
     #[test]
     fn parse_fullscreen_borderless() {
-        let (m, s) = parse_window_mode_env("fullscreen-borderless").unwrap();
+        let (m, s) = parse_window_mode_env("fullscreen-borderless")
+            .expect("test setup: \"fullscreen-borderless\" is a valid spec");
         assert!(matches!(m, WindowMode::FullscreenBorderless));
         assert_eq!(s, None);
     }
 
     #[test]
     fn parse_exclusive_converts_hz_to_mhz() {
-        let (m, s) = parse_window_mode_env("exclusive:1920x1080@60").unwrap();
+        let (m, s) = parse_window_mode_env("exclusive:1920x1080@60")
+            .expect("test setup: \"exclusive:WxH@HZ\" is a valid spec");
         let WindowMode::FullscreenExclusive {
             width,
             height,
@@ -836,7 +840,8 @@ mod tests {
 
     #[test]
     fn parse_ignores_whitespace() {
-        let (m, _) = parse_window_mode_env("  windowed  ").unwrap();
+        let (m, _) = parse_window_mode_env("  windowed  ")
+            .expect("test setup: surrounding whitespace is trimmed");
         assert!(matches!(m, WindowMode::Windowed));
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -355,7 +355,7 @@ impl TestBench {
     pub fn count_observed(&self, kind_name: &str) -> usize {
         self.observed_kinds
             .lock()
-            .unwrap()
+            .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
             .iter()
             .filter(|n| n.as_str() == kind_name)
             .count()
@@ -370,7 +370,10 @@ impl TestBench {
     /// per ADR-0063: a poisoned mutex means a prior holder panicked
     /// under the guard.
     pub fn observed_kinds(&self) -> Vec<String> {
-        self.observed_kinds.lock().unwrap().clone()
+        self.observed_kinds
+            .lock()
+            .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
+            .clone()
     }
 
     /// Push a typed mail and block until the dispatched chain
@@ -935,11 +938,10 @@ mod tests {
         let subscriber_mbox = tb.registry.register_inline(
             "issue_723_test_subscriber",
             Arc::new(move |dispatch: MailDispatch<'_>| {
-                captured_for_handler.lock().unwrap().push((
-                    dispatch.mail_id,
-                    dispatch.root,
-                    dispatch.parent_mail,
-                ));
+                captured_for_handler
+                    .lock()
+                    .expect("test setup: captured mutex is never poisoned")
+                    .push((dispatch.mail_id, dispatch.root, dispatch.parent_mail));
             }),
         );
 
@@ -960,7 +962,9 @@ mod tests {
         // and threads them through `ctx.fanout` to every subscriber.
         let _ = tb.advance(1).expect("advance");
 
-        let captured = captured.lock().unwrap();
+        let captured = captured
+            .lock()
+            .expect("test setup: captured mutex is never poisoned");
         assert!(
             !captured.is_empty(),
             "subscriber received no mail — fanout never reached it",
@@ -984,7 +988,7 @@ mod tests {
         // parent — it's a child node in the trace tree.
         assert_ne!(
             mail_id,
-            parent.unwrap(),
+            parent.expect("test setup: parent was asserted non-None above"),
             "fanned-out mail_id should differ from parent (each fanout copy gets a fresh id)"
         );
     }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -278,7 +278,7 @@ impl TestBenchChassis {
                         }
                         observed_for_handler
                             .lock()
-                            .unwrap()
+                            .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
                             .push(dispatch.kind_name.to_owned());
                     },
                 ),

--- a/crates/aether-substrate-bundle/src/test_bench/visual.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/visual.rs
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn not_all_black_fails_on_pure_black() {
         let img = solid(4, 4, [0, 0, 0, 255]);
-        let err = not_all_black(&img).unwrap_err();
+        let err = not_all_black(&img).expect_err("test setup: solid black must fail");
         assert!(err.contains("4x4"));
     }
 
@@ -148,7 +148,8 @@ mod tests {
     #[test]
     fn differs_from_background_fails_on_uniform_color() {
         let img = solid(8, 8, [69, 79, 105, 255]);
-        let err = differs_from_background(&img, 5).unwrap_err();
+        let err =
+            differs_from_background(&img, 5).expect_err("test setup: uniform background must fail");
         assert!(err.contains("69,79,105"));
         assert!(err.contains("8x8"));
     }
@@ -178,7 +179,8 @@ mod tests {
             height: 0,
             rgba: Vec::new(),
         };
-        let err = differs_from_background(&img, 5).unwrap_err();
+        let err = differs_from_background(&img, 5)
+            .expect_err("test setup: empty image must fail with \"too small\"");
         assert!(err.contains("too small"));
     }
 }

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -69,17 +69,29 @@ mod sink {
 
         #[handler]
         fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
-            *self.cells.list.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex is never poisoned") = Some(reply);
         }
 
         #[handler]
         fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
-            *self.cells.spawn.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .spawn
+                .lock()
+                .expect("test setup: spawn cell mutex is never poisoned") = Some(reply);
         }
 
         #[handler]
         fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
-            *self.cells.terminate.lock().unwrap() = Some(reply);
+            *self
+                .cells
+                .terminate
+                .lock()
+                .expect("test setup: terminate cell mutex is never poisoned") = Some(reply);
         }
     }
 }
@@ -143,7 +155,13 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
             args: vec![],
         },
         Duration::from_secs(30),
-        || cells.spawn.lock().unwrap().take(),
+        || {
+            cells
+                .spawn
+                .lock()
+                .expect("test setup: spawn cell mutex is never poisoned")
+                .take()
+        },
     );
     let engine_id = match spawn {
         SpawnEngineResult::Ok {
@@ -158,7 +176,11 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
 
     // List: the freshly-spawned engine shows up in the cap's table.
     let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-        cells.list.lock().unwrap().take()
+        cells
+            .list
+            .lock()
+            .expect("test setup: list cell mutex is never poisoned")
+            .take()
     });
     assert!(
         list.engines.iter().any(|e| e.engine_id == engine_id),
@@ -173,7 +195,13 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
             engine_id: engine_id.clone(),
         },
         Duration::from_secs(5),
-        || cells.terminate.lock().unwrap().take(),
+        || {
+            cells
+                .terminate
+                .lock()
+                .expect("test setup: terminate cell mutex is never poisoned")
+                .take()
+        },
     );
     assert!(
         matches!(terminate, TerminateEngineResult::Ok),
@@ -182,7 +210,11 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
 
     // After terminate, the engine is gone from the table.
     let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-        cells.list.lock().unwrap().take()
+        cells
+            .list
+            .lock()
+            .expect("test setup: list cell mutex is never poisoned")
+            .take()
     });
     assert!(
         !list_after.engines.iter().any(|e| e.engine_id == engine_id),

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -140,7 +140,7 @@ fn hub_routes_engine_addressed_calls_to_a_real_substrate() {
     // substrate and waiting for it to bind its RPC port.
     stream
         .set_read_timeout(Some(Duration::from_secs(30)))
-        .unwrap();
+        .expect("test setup: setting socket read timeout on a connected stream succeeds");
 
     // Handshake.
     write_frame(


### PR DESCRIPTION
Sweep the `clippy::unwrap_used` warn-level backlog in the seven small crates from iamacoffeepot/aether#890, replacing bare `.unwrap()` / `.unwrap_err()` with `.expect("...")` messages that name the invariant being relied on (ADR-0063 fail-fast: the bare panic line number is useless on its own).

- src/tests: round-trip and lookup expects describe what's being asserted (`"test setup: postcard encodes ListResult::Ok"`, `"test setup: cast kind is registered in descriptor inventory"`, `"test setup: matching kind id decodes typed slice"`).
- runtime mutexes (`aether-mcp` pending/components, `TestBench` observed_kinds, engines_cap reply cells): expect carries the never-poisoned rationale tied to ADR-0063.

Per-crate hits addressed:
- aether-kinds 44 (descriptors 9 + lib 35) | aether-substrate-bundle 25 (driver 5 + bench 5 + chassis 1 + visual 3 + engines_cap 7 + rpc_engine_routing 1 + 3 dedup) | aether-mcp 25 (rpc 5 + tools 12 + 8 dedup) | aether-data 22 (canonical 2 + lib 11 + tagged_id 9)
- aether-actor 10 (mail/mod.rs) | aether-mesh-viewer 4 | aether-actor-derive 2

Verified: `cargo check --workspace --all-targets`, `cargo fmt -- --check`, `cargo nextest run --workspace` (1001 passed), `cargo test --doc` (in-scope crates) — clippy filtered by file path shows zero remaining `unwrap_used` warnings in the seven scope crates.

Closes iamacoffeepot/aether#890

🤖 Generated with [Claude Code](https://claude.com/claude-code)