### PR TITLE
chore(substrate): sweep clippy::unwrap_used in aether-substrate (issue 886)

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -328,7 +328,11 @@ impl NativeBinding {
         // The mutex guard stays held across `recv()`. Dispatcher
         // threads are single-tasked while parked here; nothing else
         // on this thread contends.
-        inbox.lock().unwrap().recv().ok()
+        inbox
+            .lock()
+            .expect("inbox mutex poisoned; fail-fast per ADR-0063")
+            .recv()
+            .ok()
     }
 
     /// Non-blocking variant of [`Self::recv_blocking`]. Returns
@@ -342,7 +346,11 @@ impl NativeBinding {
     /// guard, which is itself a substrate-level invariant violation.
     pub fn try_recv(&self) -> Option<Envelope> {
         let inbox = self.inbox.get()?;
-        inbox.lock().unwrap().try_recv().ok()
+        inbox
+            .lock()
+            .expect("inbox mutex poisoned; fail-fast per ADR-0063")
+            .try_recv()
+            .ok()
     }
 
     /// Reply path for native actors. Routes through the substrate's
@@ -473,7 +481,10 @@ impl NativeBinding {
         // `wait_reply` prune. The opportunistic cap below stops a
         // runaway sender that never paired a wait from leaking.
         {
-            let mut pending = self.pending_recipients.lock().unwrap();
+            let mut pending = self
+                .pending_recipients
+                .lock()
+                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063");
             if pending.len() >= MAX_PENDING_RECIPIENTS
                 && let Some(&drop_key) = pending.keys().next()
             {
@@ -532,10 +543,14 @@ impl NativeBinding {
             && let Some(recipient) = self
                 .pending_recipients
                 .lock()
-                .unwrap()
+                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063")
                 .get(&expected_correlation)
                 .copied()
-            && !self.frame_bound_set.read().unwrap().contains(&recipient)
+            && !self
+                .frame_bound_set
+                .read()
+                .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
+                .contains(&recipient)
         {
             self.aborter.abort(format!(
                 "frame-bound actor {} attempted wait_reply on free-running recipient {} \
@@ -554,7 +569,10 @@ impl NativeBinding {
             // have parked envelopes that match this kind /
             // correlation.
             let from_overflow = {
-                let mut overflow = self.overflow.lock().unwrap();
+                let mut overflow = self
+                    .overflow
+                    .lock()
+                    .expect("overflow mutex poisoned; fail-fast per ADR-0063");
                 let pos = overflow
                     .iter()
                     .position(|env| matches_filter(env, expected_kind, expected_correlation));
@@ -566,7 +584,10 @@ impl NativeBinding {
                     // Buffer too small: park back at the front so a
                     // retry with a larger buffer picks it up before
                     // anything newer.
-                    self.overflow.lock().unwrap().push_front(env);
+                    self.overflow
+                        .lock()
+                        .expect("overflow mutex poisoned; fail-fast per ADR-0063")
+                        .push_front(env);
                 }
                 break rc;
             }
@@ -577,7 +598,10 @@ impl NativeBinding {
             // single-tasked while parked here, so no other code on
             // this thread contends with the lock.
             let remaining = deadline.saturating_duration_since(Instant::now());
-            let recv_outcome = inbox_mutex.lock().unwrap().recv_timeout(remaining);
+            let recv_outcome = inbox_mutex
+                .lock()
+                .expect("inbox mutex poisoned; fail-fast per ADR-0063")
+                .recv_timeout(remaining);
 
             match recv_outcome {
                 Ok(env) => {
@@ -586,11 +610,17 @@ impl NativeBinding {
                         if rc == -2 {
                             // Same retry-friendly disposition as
                             // overflow-matched: park at the front.
-                            self.overflow.lock().unwrap().push_front(env);
+                            self.overflow
+                                .lock()
+                                .expect("overflow mutex poisoned; fail-fast per ADR-0063")
+                                .push_front(env);
                         }
                         break rc;
                     }
-                    self.overflow.lock().unwrap().push_back(env);
+                    self.overflow
+                        .lock()
+                        .expect("overflow mutex poisoned; fail-fast per ADR-0063")
+                        .push_back(env);
                     // Loop continues — try again with whatever time
                     // is left on the deadline.
                 }
@@ -606,7 +636,7 @@ impl NativeBinding {
         if expected_correlation != ReplyTo::NO_CORRELATION {
             self.pending_recipients
                 .lock()
-                .unwrap()
+                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063")
                 .remove(&expected_correlation);
         }
         rc
@@ -644,6 +674,10 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
     use crate::mail::registry::Registry;

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -185,7 +185,10 @@ impl Spawner {
     /// the today behavior pre-685).
     pub(crate) fn shutdown_instanced(&self, timeout: std::time::Duration) {
         let entries: Vec<InstancedSlotEntry> = {
-            let mut guard = self.instanced_slots.lock().unwrap();
+            let mut guard = self
+                .instanced_slots
+                .lock()
+                .expect("instanced_slots mutex poisoned; fail-fast per ADR-0063");
             guard.drain().map(|(_id, entry)| entry).collect()
         };
         if entries.is_empty() {
@@ -584,13 +587,16 @@ impl Spawner {
                 // one wake per slot after signaling shutdown.
                 drop(slot);
                 let teardown_wake = wake.clone();
-                self.instanced_slots.lock().unwrap().insert(
-                    id,
-                    InstancedSlotEntry {
-                        slot: slot_dyn,
-                        wake: teardown_wake,
-                    },
-                );
+                self.instanced_slots
+                    .lock()
+                    .expect("instanced_slots mutex poisoned; fail-fast per ADR-0063")
+                    .insert(
+                        id,
+                        InstancedSlotEntry {
+                            slot: slot_dyn,
+                            wake: teardown_wake,
+                        },
+                    );
                 // Pre-loaded `after_init` mail (lines above) was sent
                 // straight to the inbox via `tx.send`, which bypasses
                 // the closure's wake hook. Fire one wake now so the

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -330,6 +330,10 @@ where
 // is held through `.push(...)` which is the captured payload — that's
 // the intended sequence, not a tightening opportunity.
 #[allow(clippy::significant_drop_tightening)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and capture panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
     use std::sync::Mutex;

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -152,7 +152,10 @@ impl ActorRegistry {
     /// ADR-0063: a poisoned lock means a prior writer panicked under
     /// the guard, a substrate-level invariant violation.
     pub fn is_live(&self, id: MailboxId) -> bool {
-        let actors = self.actors.read().unwrap();
+        let actors = self
+            .actors
+            .read()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         matches!(actors.get(&id), Some(ActorEntry::Live { .. }))
     }
 
@@ -166,7 +169,10 @@ impl ActorRegistry {
     /// ADR-0063: a poisoned lock means a prior writer panicked under
     /// the guard, a substrate-level invariant violation.
     pub fn live_sender(&self, id: MailboxId) -> Option<Sender<Envelope>> {
-        let actors = self.actors.read().unwrap();
+        let actors = self
+            .actors
+            .read()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         match actors.get(&id) {
             Some(ActorEntry::Live { sender, .. }) => Some((**sender).clone()),
             _ => None,
@@ -182,7 +188,10 @@ impl ActorRegistry {
     /// ADR-0063: a poisoned lock means a prior writer panicked under
     /// the guard, a substrate-level invariant violation.
     pub fn type_id_at(&self, id: MailboxId) -> Option<TypeId> {
-        let actors = self.actors.read().unwrap();
+        let actors = self
+            .actors
+            .read()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         match actors.get(&id) {
             Some(ActorEntry::Live { type_id, .. }) => Some(*type_id),
             _ => None,
@@ -197,7 +206,10 @@ impl ActorRegistry {
     /// ADR-0063: a poisoned lock means a prior writer panicked under
     /// the guard, a substrate-level invariant violation.
     pub fn is_tombstoned(&self, id: MailboxId) -> bool {
-        self.tombstones.read().unwrap().contains(&id)
+        self.tombstones
+            .read()
+            .expect("tombstones lock poisoned; fail-fast per ADR-0063")
+            .contains(&id)
     }
 
     /// `TypeId` that owns the given namespace, if any. Populated at
@@ -208,7 +220,11 @@ impl ActorRegistry {
     /// ADR-0063: a poisoned lock means a prior writer panicked under
     /// the guard, a substrate-level invariant violation.
     pub fn namespace_owner(&self, namespace: &'static str) -> Option<TypeId> {
-        self.name_owners.read().unwrap().get(namespace).copied()
+        self.name_owners
+            .read()
+            .expect("name_owners lock poisoned; fail-fast per ADR-0063")
+            .get(namespace)
+            .copied()
     }
 
     /// Claim ownership of `namespace` for `type_id`. Returns `Ok(())` on
@@ -222,7 +238,10 @@ impl ActorRegistry {
         namespace: &'static str,
         type_id: TypeId,
     ) -> Result<(), TypeId> {
-        let mut owners = self.name_owners.write().unwrap();
+        let mut owners = self
+            .name_owners
+            .write()
+            .expect("name_owners lock poisoned; fail-fast per ADR-0063");
         match owners.get(namespace) {
             Some(&existing) if existing == type_id => Ok(()),
             Some(&existing) => Err(existing),
@@ -246,7 +265,10 @@ impl ActorRegistry {
     /// Crate-private — only the boot-failure paths in
     /// [`crate::chassis::ctx`] / [`crate::chassis::builder`] call this.
     pub(crate) fn release_namespace(&self, namespace: &'static str, type_id: TypeId) -> bool {
-        let mut owners = self.name_owners.write().unwrap();
+        let mut owners = self
+            .name_owners
+            .write()
+            .expect("name_owners lock poisoned; fail-fast per ADR-0063");
         match owners.get(namespace) {
             Some(&existing) if existing == type_id => {
                 owners.remove(namespace);
@@ -273,7 +295,10 @@ impl ActorRegistry {
         type_id: TypeId,
         subname: String,
     ) -> Result<(), ()> {
-        let mut actors = self.actors.write().unwrap();
+        let mut actors = self
+            .actors
+            .write()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         if let Some(ActorEntry::Live { .. }) = actors.get(&id) {
             Err(())
         } else {
@@ -317,7 +342,10 @@ impl ActorRegistry {
     where
         T: std::any::Any + 'static,
     {
-        let actors = self.actors.read().unwrap();
+        let actors = self
+            .actors
+            .read()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         let target = TypeId::of::<T>();
         actors
             .iter()
@@ -338,10 +366,16 @@ impl ActorRegistry {
     /// an already-`Dead` slot leaves it `Dead` and doesn't double-
     /// insert into `tombstones`.
     pub(crate) fn mark_dead(&self, id: MailboxId) {
-        let mut actors = self.actors.write().unwrap();
+        let mut actors = self
+            .actors
+            .write()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         actors.insert(id, ActorEntry::Dead);
         drop(actors);
-        let mut tombstones = self.tombstones.write().unwrap();
+        let mut tombstones = self
+            .tombstones
+            .write()
+            .expect("tombstones lock poisoned; fail-fast per ADR-0063");
         tombstones.insert(id);
     }
 
@@ -377,7 +411,10 @@ impl ActorRegistry {
         // boot path to insert `Live`); callers who reach for monitor
         // before that lift see `TargetNotFound`, which matches the
         // wire contract for "this id has no live actor."
-        let actors = self.actors.read().unwrap();
+        let actors = self
+            .actors
+            .read()
+            .expect("actors lock poisoned; fail-fast per ADR-0063");
         if !matches!(actors.get(&target), Some(ActorEntry::Live { .. })) {
             return Err(MonitorError::TargetNotFound);
         }
@@ -390,13 +427,13 @@ impl ActorRegistry {
         // direction missing just means one cleanup step is a no-op.
         self.monitors_of
             .write()
-            .unwrap()
+            .expect("monitors_of lock poisoned; fail-fast per ADR-0063")
             .entry(target)
             .or_default()
             .push(entry);
         self.monitoring
             .write()
-            .unwrap()
+            .expect("monitoring lock poisoned; fail-fast per ADR-0063")
             .entry(watcher)
             .or_default()
             .push(target);
@@ -409,10 +446,20 @@ impl ActorRegistry {
     /// forward index) is a no-op. Called by [`crate::actor::monitor::MonitorHandle::Drop`]
     /// when the handle goes out of scope.
     pub(crate) fn deregister_monitor(&self, watcher: MailboxId, target: MailboxId) {
-        if let Some(entries) = self.monitors_of.write().unwrap().get_mut(&target) {
+        if let Some(entries) = self
+            .monitors_of
+            .write()
+            .expect("monitors_of lock poisoned; fail-fast per ADR-0063")
+            .get_mut(&target)
+        {
             entries.retain(|e| e.watcher != watcher);
         }
-        if let Some(targets) = self.monitoring.write().unwrap().get_mut(&watcher) {
+        if let Some(targets) = self
+            .monitoring
+            .write()
+            .expect("monitoring lock poisoned; fail-fast per ADR-0063")
+            .get_mut(&watcher)
+        {
             targets.retain(|t| *t != target);
         }
     }
@@ -438,7 +485,7 @@ impl ActorRegistry {
         let watchers: Vec<MailboxId> = self
             .monitors_of
             .write()
-            .unwrap()
+            .expect("monitors_of lock poisoned; fail-fast per ADR-0063")
             .remove(&id)
             .unwrap_or_default()
             .into_iter()
@@ -447,9 +494,16 @@ impl ActorRegistry {
         // Reverse index: walk each target the closing actor was
         // monitoring and remove it from that target's forward list.
         // Mirrors `deregister_monitor` per-target, but in bulk.
-        let monitoring_targets = self.monitoring.write().unwrap().remove(&id);
+        let monitoring_targets = self
+            .monitoring
+            .write()
+            .expect("monitoring lock poisoned; fail-fast per ADR-0063")
+            .remove(&id);
         if let Some(targets) = monitoring_targets {
-            let mut forward = self.monitors_of.write().unwrap();
+            let mut forward = self
+                .monitors_of
+                .write()
+                .expect("monitors_of lock poisoned; fail-fast per ADR-0063");
             for target in targets {
                 if let Some(entries) = forward.get_mut(&target) {
                     entries.retain(|e| e.watcher != id);
@@ -466,7 +520,7 @@ impl ActorRegistry {
     pub(crate) fn monitor_count(&self, target: MailboxId) -> usize {
         self.monitors_of
             .read()
-            .unwrap()
+            .expect("monitors_of lock poisoned; fail-fast per ADR-0063")
             .get(&target)
             .map_or(0, Vec::len)
     }
@@ -477,13 +531,17 @@ impl ActorRegistry {
     pub(crate) fn monitoring_count(&self, watcher: MailboxId) -> usize {
         self.monitoring
             .read()
-            .unwrap()
+            .expect("monitoring lock poisoned; fail-fast per ADR-0063")
             .get(&watcher)
             .map_or(0, Vec::len)
     }
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -675,6 +675,10 @@ impl Component {
 // Tests hold the capture `Mutex` guard across the assertion block so
 // the snapshot reads atomically against the concurrent push path.
 #[allow(clippy::significant_drop_tightening)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -488,6 +488,10 @@ fn merge_variant(shape: &aether_data::VariantShape, label: Option<&VariantLabel>
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
     use aether_data::{LabelCell, LabelNode, Primitive, SchemaShape, VariantShape};

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -75,7 +75,10 @@ impl CaptureQueue {
     /// a poisoned mutex means a prior holder panicked under the guard.
     #[must_use]
     pub fn request(&self, pending: PendingCapture) -> bool {
-        let mut slot = self.slot.lock().unwrap();
+        let mut slot = self
+            .slot
+            .lock()
+            .expect("capture slot mutex poisoned; fail-fast per ADR-0063");
         if slot.is_some() {
             return false;
         }
@@ -92,7 +95,10 @@ impl CaptureQueue {
     /// a poisoned mutex means a prior holder panicked under the guard.
     #[must_use]
     pub fn take(&self) -> Option<PendingCapture> {
-        self.slot.lock().unwrap().take()
+        self.slot
+            .lock()
+            .expect("capture slot mutex poisoned; fail-fast per ADR-0063")
+            .take()
     }
 }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1699,6 +1699,10 @@ impl<C: Chassis> PassiveChassis<C> {
 // sequence reads top-to-bottom; extracting helpers would either lose
 // the staging context or add fixtures that aren't reused elsewhere.
 #[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -478,7 +478,10 @@ impl<'a> ChassisCtx<'a> {
         // recipient of this `wait_reply` frame-bound?" with a single
         // read-lock — without each transport having to scan the
         // pending-counter Vec on every check.
-        self.frame_bound_set.write().unwrap().insert(id);
+        self.frame_bound_set
+            .write()
+            .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
+            .insert(id);
         self.claimed_actor_mailboxes.push(id);
         Ok(FrameBoundClaim {
             id,
@@ -509,7 +512,10 @@ impl<'a> ChassisCtx<'a> {
     pub fn unclaim_mailbox(&mut self, id: MailboxId) {
         self.registry.remove_closure(id);
         self.frame_bound_pending.retain(|(i, _)| *i != id);
-        self.frame_bound_set.write().unwrap().remove(&id);
+        self.frame_bound_set
+            .write()
+            .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
+            .remove(&id);
         self.claimed_actor_mailboxes.retain(|i| *i != id);
     }
 

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -133,7 +133,10 @@ impl SettlementRegistry {
     /// a poisoned mutex means a prior holder panicked under the guard.
     pub fn subscribe_settlement(&self, root: MailId) -> Receiver<()> {
         let (tx, rx) = bounded::<()>(1);
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("settlement registry mutex poisoned; fail-fast per ADR-0063");
         if inner.settled.contains(&root) {
             // Pre-fire — root already settled. `try_send` rather
             // than `send` so a closed receiver (caller dropped it
@@ -168,7 +171,10 @@ impl SettlementRegistry {
         kind: KindId,
         mailer: Arc<crate::mail::mailer::Mailer>,
     ) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("settlement registry mutex poisoned; fail-fast per ADR-0063");
         if inner.settled.contains(&root) {
             // Drop the mutex before pushing — `push` may run hot
             // (resolves the recipient inline on this thread).
@@ -203,7 +209,10 @@ impl SettlementRegistry {
         // tight and removes a re-entrancy hazard if a future
         // subscriber type re-enters the registry.
         let subs = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = self
+                .inner
+                .lock()
+                .expect("settlement registry mutex poisoned; fail-fast per ADR-0063");
             inner.settled.insert(root);
             inner.pending.remove(&root)
         };
@@ -221,7 +230,7 @@ impl SettlementRegistry {
     fn pending_count(&self) -> usize {
         self.inner
             .lock()
-            .unwrap()
+            .expect("settlement registry mutex poisoned; fail-fast per ADR-0063")
             .pending
             .values()
             .flat_map(|v| v.iter())
@@ -233,7 +242,11 @@ impl SettlementRegistry {
     /// settled.
     #[cfg(test)]
     fn settled_count(&self) -> usize {
-        self.inner.lock().unwrap().settled.len()
+        self.inner
+            .lock()
+            .expect("settlement registry mutex poisoned; fail-fast per ADR-0063")
+            .settled
+            .len()
     }
 
     /// Test introspection: count of pending mail subscribers across all
@@ -242,7 +255,7 @@ impl SettlementRegistry {
     fn pending_mail_count(&self) -> usize {
         self.inner
             .lock()
-            .unwrap()
+            .expect("settlement registry mutex poisoned; fail-fast per ADR-0063")
             .pending
             .values()
             .flat_map(|v| v.iter())
@@ -281,6 +294,10 @@ fn push_settlement_notice(
 // sequence so the captured state stays consistent against the
 // concurrent firing thread.
 #[allow(clippy::significant_drop_tightening)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
     use crate::handle_store::HandleStore;

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -193,7 +193,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn next_ephemeral(&self) -> HandleId {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         let counter = inner.next_ephemeral;
         inner.next_ephemeral = inner.next_ephemeral.wrapping_add(1);
         if inner.next_ephemeral == 0 {
@@ -213,7 +216,10 @@ impl HandleStore {
     /// pass underflows the byte accounting — fail-fast per ADR-0063:
     /// both indicate a substrate-level invariant violation.
     pub fn put(&self, id: HandleId, kind: KindId, bytes: Vec<u8>) -> Result<(), PutError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         let (prior_size, refcount, pinned) = match inner.entries.get(&id) {
             Some(e) if e.kind != kind => {
                 return Err(PutError::KindMismatch {
@@ -259,7 +265,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn pin(&self, id: HandleId) -> bool {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         if let Some(entry) = inner.entries.get_mut(&id) {
             entry.pinned = true;
             true
@@ -276,7 +285,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn unpin(&self, id: HandleId) -> bool {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         if let Some(entry) = inner.entries.get_mut(&id) {
             entry.pinned = false;
             true
@@ -294,7 +306,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn inc_ref(&self, id: HandleId) -> bool {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         if let Some(entry) = inner.entries.get_mut(&id) {
             entry.refcount = entry.refcount.saturating_add(1);
             true
@@ -312,7 +327,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn dec_ref(&self, id: HandleId) -> bool {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         if let Some(entry) = inner.entries.get_mut(&id) {
             entry.refcount = entry.refcount.saturating_sub(1);
             true
@@ -331,7 +349,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn get(&self, id: HandleId) -> Option<(KindId, Vec<u8>)> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         let access = bump_clock(&mut inner);
         let entry = inner.entries.get_mut(&id)?;
         entry.last_access = access;
@@ -347,7 +368,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn park(&self, handle_id: HandleId, mail: Mail) {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         inner.parked.entry(handle_id).or_default().push_back(mail);
     }
 
@@ -364,7 +388,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn take_parked(&self, id: HandleId) -> Vec<Mail> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
         inner.parked.remove(&id).map_or_else(Vec::new, Into::into)
     }
 
@@ -375,7 +402,10 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn total_bytes(&self) -> usize {
-        self.inner.read().unwrap().total_bytes
+        self.inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .total_bytes
     }
 
     /// Count of stored entries (parked-mail queues not included).
@@ -385,7 +415,11 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn entry_count(&self) -> usize {
-        self.inner.read().unwrap().entries.len()
+        self.inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .entries
+            .len()
     }
 
     /// Number of mails currently parked under `id`.
@@ -397,7 +431,7 @@ impl HandleStore {
     pub fn parked_count(&self, id: HandleId) -> usize {
         self.inner
             .read()
-            .unwrap()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
             .parked
             .get(&id)
             .map_or(0, VecDeque::len)
@@ -416,7 +450,11 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn contains(&self, id: HandleId) -> bool {
-        self.inner.read().unwrap().entries.contains_key(&id)
+        self.inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .entries
+            .contains_key(&id)
     }
 }
 
@@ -785,6 +823,10 @@ fn skip_primitive_postcard(state: &mut State<'_>, p: Primitive) -> Result<(), Wa
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -503,6 +503,10 @@ fn route_mail(
 // dispatch fixtures inline so the round-trip read top-to-bottom;
 // extracting helpers would split the path-under-test across files.
 #[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use std::sync::RwLock;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -447,7 +447,10 @@ impl Registry {
     /// fail-fast per ADR-0063: a poisoned lock means a prior holder
     /// panicked under the guard.
     pub fn set_on_mailbox_change(&self, hook: MailboxChangeHook) {
-        *self.on_mailbox_change.write().unwrap() = Some(hook);
+        *self
+            .on_mailbox_change
+            .write()
+            .expect("on_mailbox_change lock poisoned; fail-fast per ADR-0063") = Some(hook);
     }
 
     /// Snapshot the inventory and invoke the hook (if installed).
@@ -457,7 +460,11 @@ impl Registry {
     /// released — so a concurrent registration sees a consistent
     /// (post-this-insert) view rather than a torn one.
     fn notify_mailbox_change(&self) {
-        let hook = self.on_mailbox_change.read().unwrap().clone();
+        let hook = self
+            .on_mailbox_change
+            .read()
+            .expect("on_mailbox_change lock poisoned; fail-fast per ADR-0063")
+            .clone();
         if let Some(hook) = hook {
             hook(self.list_mailbox_descriptors());
         }
@@ -481,7 +488,10 @@ impl Registry {
             // literally registering "aether.chassis".
             return Err(NameConflict { name });
         }
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
         match inner.mailboxes.get_mut(&id) {
             Some(slot) if matches!(slot.entry, MailboxEntry::Dropped) && slot.name == name => {
                 slot.entry = entry;
@@ -513,7 +523,10 @@ impl Registry {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn drop_mailbox(&self, id: MailboxId) -> Result<String, DropError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
         let Some(slot) = inner.mailboxes.get_mut(&id) else {
             return Err(DropError::UnknownId(id));
         };
@@ -675,7 +688,10 @@ impl Registry {
     /// a drop, chassis-bound mailboxes are torn down on cap
     /// teardown and the id can be freshly recreated.
     pub(crate) fn remove_closure(&self, id: MailboxId) -> bool {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
         match inner.mailboxes.get(&id) {
             Some(slot)
                 if matches!(slot.entry, MailboxEntry::Inbox(_) | MailboxEntry::Inline(_)) =>
@@ -698,7 +714,10 @@ impl Registry {
     /// the guard.
     pub fn lookup(&self, name: &str) -> Option<MailboxId> {
         let id = MailboxId::from_name(name);
-        let inner = self.inner.read().unwrap();
+        let inner = self
+            .inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
         match inner.mailboxes.get(&id) {
             Some(slot) if slot.name == name && !matches!(slot.entry, MailboxEntry::Dropped) => {
                 Some(id)
@@ -719,7 +738,7 @@ impl Registry {
     pub fn entry(&self, id: MailboxId) -> Option<MailboxEntry> {
         self.inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .mailboxes
             .get(&id)
             .map(|m| m.entry.clone())
@@ -736,7 +755,7 @@ impl Registry {
     pub fn mailbox_name(&self, id: MailboxId) -> Option<String> {
         self.inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .mailboxes
             .get(&id)
             .map(|m| m.name.clone())
@@ -801,7 +820,10 @@ impl Registry {
         reject_conflict: bool,
     ) -> Result<KindId, KindConflict> {
         let id = KindId(kind_id_from_parts(&descriptor.name, &descriptor.schema));
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
         if let Some(slot) = inner.kinds.get(&id) {
             if reject_conflict
                 && canonical_kind_bytes(&slot.descriptor.name, &slot.descriptor.schema)
@@ -845,7 +867,12 @@ impl Registry {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn kind_id(&self, name: &str) -> Option<KindId> {
-        self.inner.read().unwrap().name_index.get(name).copied()
+        self.inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
+            .name_index
+            .get(name)
+            .copied()
     }
 
     /// Reverse of `kind_id`: name for a given id, or `None` if the id
@@ -860,7 +887,7 @@ impl Registry {
     pub fn kind_name(&self, kind: KindId) -> Option<String> {
         self.inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .kinds
             .get(&kind)
             .map(|s| s.name.clone())
@@ -877,7 +904,7 @@ impl Registry {
     pub fn kind_descriptor(&self, kind: KindId) -> Option<KindDescriptor> {
         self.inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .kinds
             .get(&kind)
             .map(|s| s.descriptor.clone())
@@ -898,7 +925,7 @@ impl Registry {
         let mut out: Vec<KindDescriptor> = self
             .inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .kinds
             .values()
             .map(|s| s.descriptor.clone())
@@ -929,7 +956,7 @@ impl Registry {
         let mut out: Vec<MailboxDescriptor> = self
             .inner
             .read()
-            .unwrap()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
             .mailboxes
             .iter()
             .map(|(id, m)| MailboxDescriptor {
@@ -954,7 +981,11 @@ impl Registry {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn len(&self) -> usize {
-        self.inner.read().unwrap().mailboxes.len()
+        self.inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
+            .mailboxes
+            .len()
     }
 
     /// `true` when no mailbox has ever been registered.
@@ -964,7 +995,11 @@ impl Registry {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn is_empty(&self) -> bool {
-        self.inner.read().unwrap().mailboxes.is_empty()
+        self.inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063")
+            .mailboxes
+            .is_empty()
     }
 }
 
@@ -1004,6 +1039,10 @@ fn categorise_mailbox_name(name: &str) -> Option<MailboxCategory> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
+)]
 mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -127,6 +127,10 @@ fn capture_backtrace_with(forced: bool) -> Option<Backtrace> {
 // Tests hold the capture `Mutex` guard across the assertion block so
 // the event snapshot reads atomically against the panic hook's push.
 #[allow(clippy::significant_drop_tightening)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: backtrace capture and Mutex lock panic on failure is the assertion"
+)]
 mod tests {
     use std::fmt::Write as _;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -291,6 +291,10 @@ fn format_panic_payload(payload: &Box<dyn Any + Send>, actor_label: &str) -> Str
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: queue recv panic on failure is the assertion"
+)]
 mod tests {
     use super::*;
     use crate::runtime::lifecycle::PanicAborter;

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -343,6 +343,10 @@ impl WakeHandle {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture inbox `Mutex` lock and decode panic on failure is the assertion"
+)]
 pub mod tests {
     use super::*;
     use std::any::Any;


### PR DESCRIPTION
Closes #886

<!-- pr-body-ok: b — issue numbers in body intended as closing keyword and reference only -->

Sweeps the clippy::unwrap_used warn-level backlog in aether-substrate (~246 hits on this branch's pre-sweep run). Acceptance criterion met: zero unwrap_used warnings under cargo clippy -p aether-substrate --all-targets.

- Production-path RwLock/Mutex .unwrap() rewrites → .expect("<lock> poisoned; fail-fast per ADR-0063") across handle_store, mail/registry, actor/registry, actor/native/{binding,spawn}, chassis/{ctx,settlement}, and capture.
- Test modules with all-test-setup unwraps carry a module-level #[allow(clippy::unwrap_used, reason = "...")] (terse rationale per umbrella guidance — converting 150+ uniform fixture-call test sites to .expect("test setup: ...") would have been pure noise).
- cargo check --workspace --all-targets, cargo fmt -- --check, and cargo nextest run --workspace (1001 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)