### PR TITLE
chore(substrate): close out 854 - sweep residual warns + restore -D warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
       - name: Install ALSA dev headers (cpal Linux backend)
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
-      # TODO(iamacoffeepot/aether#854): restore `-D warnings` after the warn-prune passes land.
-      - run: cargo clippy --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   # Workspace-wide tests run on linux only. Non-chassis crates
   # (aether-kinds, aether-data, aether-actor, aether-actor-derive,

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Qodana scan
         uses: JetBrains/qodana-action@v2026.1
         with:
-          args: --linter,qodana-rust
+          # Space-separated; comma form is deprecated as of action v2026.1.
+          args: --linter qodana-rust
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ spikes/*/target/
 # the directory itself.
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 .claude/skills/*
 !.claude/skills/adr/
 !.claude/skills/audit/

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -46,7 +46,7 @@ use quote::quote;
 use syn::{
     Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
     GenericArgument, ImplItem, Item, ItemImpl, ItemMod, Lit, Meta, PathArguments, Signature, Type,
-    parse_macro_input, spanned::Spanned,
+    parse_macro_input,
 };
 
 #[proc_macro_derive(Kind, attributes(kind))]

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -45,6 +45,10 @@ impl MailBridge {
     /// a lookup-miss status. The substrate warn-drops unknown
     /// recipients on its side, which is the diagnostic path; the guest
     /// can't surface the status anywhere meaningful.
+    #[allow(
+        clippy::must_use_candidate,
+        reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
+    )]
     pub fn send_mail(&self, recipient: u64, kind: u64, bytes: &[u8], count: u32) -> u32 {
         // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
         // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
@@ -71,6 +75,10 @@ impl MailBridge {
     /// Not `#[must_use]`: the trait surfaces (`OutboundReply::reply`,
     /// `MailCtx::reply`) are fire-and-forget by contract — see the
     /// matching rationale on `send_mail`.
+    #[allow(
+        clippy::must_use_candidate,
+        reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
+    )]
     pub fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
         // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
         // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -878,6 +878,11 @@ mod native {
 
     #[cfg(test)]
     mod tests {
+        // `sender.push(...).unwrap()` reads as test setup — the channel
+        // is local and never full / closed during the test. `.expect`
+        // per call would be pure noise.
+        #![allow(clippy::unwrap_used)]
+
         use super::*;
         use crate::test_chassis::{TestChassis, fresh_substrate};
         use aether_actor::Actor;

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -114,8 +114,7 @@ mod native {
         #[must_use]
         pub fn from_env() -> Self {
             let disabled = std::env::var("AETHER_AUDIO_DISABLE")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
             let requested_sample_rate = std::env::var("AETHER_AUDIO_SAMPLE_RATE")
                 .ok()
                 .and_then(|s| s.parse::<u32>().ok());

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -668,12 +668,11 @@ mod native {
             let nonce: u64 = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 // Nanosecond clock fits comfortably in u64 for the next ~584 years.
-                .map(|d| {
+                .map_or(0, |d| {
                     #[allow(clippy::cast_possible_truncation)]
                     let nanos = d.as_nanos() as u64;
                     nanos
-                })
-                .unwrap_or(0);
+                });
             let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
             std::fs::create_dir_all(&path).expect("test setup: scratch dir creates");
             path

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -126,15 +126,12 @@ impl HttpConfig {
 }
 
 fn disable_flag_env() -> bool {
-    std::env::var("AETHER_HTTP_DISABLE")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    std::env::var("AETHER_HTTP_DISABLE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 fn https_flag_env() -> bool {
     std::env::var("AETHER_HTTP_REQUIRE_HTTPS")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 fn parse_allowlist_env() -> HashSet<String> {

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -211,12 +211,11 @@ mod native {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             // Millisecond clock fits comfortably in u64 for the next ~584 million years.
-            .map(|d| {
+            .map_or(0, |d| {
                 #[allow(clippy::cast_possible_truncation)]
                 let ms = d.as_millis() as u64;
                 ms
             })
-            .unwrap_or(0)
     }
 
     #[cfg(test)]

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -239,12 +239,16 @@ mod native {
         fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
             if let Some(obs) = &self.config.observed_kinds {
                 obs.lock()
-                    .unwrap()
+                    .expect("mutex poisoned; fail-fast per ADR-0063")
                     .push(<DrawTriangle as Kind>::NAME.into());
             }
             let bytes: &[u8] = bytemuck::cast_slice(mails);
             let cap_bytes = self.config.vertex_buffer_bytes;
-            let mut verts = self.handles.frame_vertices.lock().unwrap();
+            let mut verts = self
+                .handles
+                .frame_vertices
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             let available = cap_bytes.saturating_sub(verts.len());
             let write_len = bytes.len().min(available);
             let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
@@ -277,9 +281,15 @@ mod native {
         #[handler]
         fn on_camera(&self, _ctx: &mut NativeCtx<'_>, mail: Camera) {
             if let Some(obs) = &self.config.observed_kinds {
-                obs.lock().unwrap().push(<Camera as Kind>::NAME.into());
+                obs.lock()
+                    .expect("mutex poisoned; fail-fast per ADR-0063")
+                    .push(<Camera as Kind>::NAME.into());
             }
-            *self.handles.camera_state.lock().unwrap() = mail.view_proj;
+            *self
+                .handles
+                .camera_state
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063") = mail.view_proj;
         }
 
         /// `CaptureFrame` handler. The cap dispatcher thread doesn't
@@ -305,7 +315,7 @@ mod native {
         fn on_capture_frame(&self, ctx: &mut NativeCtx<'_>, mail: CaptureFrame) {
             if let Some(obs) = &self.config.observed_kinds {
                 obs.lock()
-                    .unwrap()
+                    .expect("mutex poisoned; fail-fast per ADR-0063")
                     .push(<CaptureFrame as Kind>::NAME.into());
             }
 
@@ -514,8 +524,14 @@ mod native {
         ) -> Result<(), RenderError> {
             let gpu = self.expect_gpu();
             {
-                let mut live = self.frame_vertices.lock().unwrap();
-                let mut last = self.last_submitted.lock().unwrap();
+                let mut live = self
+                    .frame_vertices
+                    .lock()
+                    .expect("mutex poisoned; fail-fast per ADR-0063");
+                let mut last = self
+                    .last_submitted
+                    .lock()
+                    .expect("mutex poisoned; fail-fast per ADR-0063");
                 if !live.is_empty() {
                     // Producer emitted: swap into cache.
                     std::mem::swap(&mut *live, &mut *last);
@@ -534,9 +550,18 @@ mod native {
                 // else: replay-cache + empty live — leave cache
                 // alone, render its current contents.
             }
-            let view_proj = *self.camera_state.lock().unwrap();
-            let last = self.last_submitted.lock().unwrap();
-            let targets = gpu.targets.lock().unwrap();
+            let view_proj = *self
+                .camera_state
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            let last = self
+                .last_submitted
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            let targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             record_main_pass(
                 &gpu.queue,
                 encoder,
@@ -559,7 +584,10 @@ mod native {
         /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
             let gpu = self.expect_gpu();
-            let mut targets = gpu.targets.lock().unwrap();
+            let mut targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             prepare_capture_copy(&gpu.device, &mut targets, encoder)
         }
 
@@ -572,7 +600,10 @@ mod native {
         /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
             let gpu = self.expect_gpu();
-            let targets = gpu.targets.lock().unwrap();
+            let targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             finish_capture(&gpu.device, &targets, meta)
         }
 
@@ -584,7 +615,10 @@ mod native {
         /// mutex is poisoned — fail-fast per ADR-0063.
         pub fn resize(&self, width: u32, height: u32) {
             let gpu = self.expect_gpu();
-            let mut targets = gpu.targets.lock().unwrap();
+            let mut targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             targets.resize(&gpu.device, width, height);
         }
 
@@ -622,7 +656,11 @@ mod native {
         /// mutex is poisoned — fail-fast per ADR-0063.
         #[must_use]
         pub fn color_size(&self) -> (u32, u32) {
-            let targets = self.expect_gpu().targets.lock().unwrap();
+            let targets = self
+                .expect_gpu()
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             (targets.width(), targets.height())
         }
 
@@ -640,7 +678,10 @@ mod native {
             F: FnOnce(&wgpu::Texture) -> R,
         {
             let gpu = self.expect_gpu();
-            let targets = gpu.targets.lock().unwrap();
+            let targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
             f(targets.color_texture())
         }
     }

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -534,7 +534,7 @@ mod native {
                 std::env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
                 std::env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");
             }
-            observer_with(Duration::from_millis(60_000), 1000)
+            observer_with(Duration::from_mins(1), 1000)
         }
 
         fn observer_with(retention: Duration, max_roots: usize) -> TraceObserverCapability {
@@ -706,7 +706,7 @@ mod native {
 
         #[test]
         fn max_roots_evicts_oldest() {
-            let mut obs = observer_with(Duration::from_secs(3600), 3);
+            let mut obs = observer_with(Duration::from_hours(1), 3);
             for cid in 1..=5 {
                 let m = mail(1, cid);
                 apply_sent_event(
@@ -759,7 +759,7 @@ mod native {
                 roots: HashMap::new(),
                 mails: HashMap::new(),
                 t_sent_index: BTreeSet::new(),
-                retention: Duration::from_secs(60),
+                retention: Duration::from_mins(1),
                 max_roots: 1000,
                 mailer: Arc::clone(&mailer),
                 settled_kind,
@@ -979,7 +979,7 @@ mod native {
             // Exceeding `max_roots` evicts the oldest by `last_event_at`,
             // and `drop_orphaned_mails` should prune the secondary
             // index for the evicted mails too.
-            let mut obs = observer_with(Duration::from_secs(3600), 3);
+            let mut obs = observer_with(Duration::from_hours(1), 3);
             for cid in 1..=5u64 {
                 let m = mail(1, cid);
                 apply_sent_event(

--- a/crates/aether-mesh/examples/dsl_to_obj.rs
+++ b/crates/aether-mesh/examples/dsl_to_obj.rs
@@ -5,6 +5,9 @@
 
 // CLI diagnostic before tracing subscriber is installed (issue 891).
 #![allow(clippy::print_stderr)]
+// CLI emits OBJ text to stdout for piping/redirect — the documented use case
+// (see the usage line above).
+#![allow(clippy::print_stdout)]
 
 use std::process::ExitCode;
 

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -55,8 +55,7 @@ impl Default for PoolConfig {
             // (`num_cpus::get().saturating_sub(reserved)`); for now
             // `reserved == 1` covers the chassis frame loop.
             workers: thread::available_parallelism()
-                .map(|n| n.get().saturating_sub(1).max(1))
-                .unwrap_or(2),
+                .map_or(2, |n| n.get().saturating_sub(1).max(1)),
             budget_template: BudgetTemplate::Standard,
         }
     }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -527,7 +527,7 @@ pub mod tests {
         // envelopes regardless of CPU contention. This test validates the
         // state-machine invariant ("drain-to-empty leaves Idle"), not the
         // per-cycle budget — `drain_budget_yields_for_requeue` covers that.
-        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_mins(1));
         let outcome = slot.run_cycle(budget);
 
         assert_eq!(outcome, CycleResult::Idle);
@@ -550,7 +550,7 @@ pub mod tests {
         // dispatch some `N < BATCH_MAX_MAILS` and flake the assert
         // (iamacoffeepot/aether#869). Same workaround `drain_empty_returns_idle`
         // uses for the same reason.
-        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_mins(1));
         let result = slot.run_cycle(budget);
         assert_eq!(result, CycleResult::Requeue);
         assert_eq!(slot.dispatched(), BATCH_MAX_MAILS);
@@ -559,7 +559,7 @@ pub mod tests {
         // Second cycle drains the rest. Same wallclock isolation — the
         // remaining 50 envelopes shouldn't trip the count budget but
         // could trip the 200μs wallclock under contention.
-        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_mins(1));
         let result = slot.run_cycle(budget);
         assert_eq!(result, CycleResult::Idle);
         assert_eq!(slot.dispatched(), BATCH_MAX_MAILS + 50);
@@ -626,7 +626,7 @@ pub mod tests {
         // (drain envelope 1 → try_recv sees closed && empty → Closed)
         // under CI CPU contention, flipping the result to `Requeue`
         // (iamacoffeepot/aether#896; sibling of iamacoffeepot/aether#869).
-        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_secs(60));
+        let budget = BatchBudget::custom(BATCH_MAX_MAILS, Duration::from_mins(1));
         let result = slot.run_cycle(budget);
         // Closed + non-empty: drain remaining first, then return
         // Closed on next try_recv. CounterSlot's loop checks closed +

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -21,4 +21,5 @@ exclude:
 
 # Native deps the linter needs to build before inspecting (mirrors the
 # clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
-bootstrap: sudo apt-get update && sudo apt-get install -y libasound2-dev
+# Runs inside the Qodana container as root — no `sudo` available.
+bootstrap: apt-get update && apt-get install -y libasound2-dev


### PR DESCRIPTION
Closes iamacoffeepot/aether#854.

The closeout PR for the Phase 2 clippy adoption — fixes the residual 48 warnings the per-cluster sweeps left behind, then restores `-D warnings` in the CI clippy step so the workspace stays at zero going forward.

## Residual fixes

- **`clippy::unwrap_used` (38 hits, all `aether-capabilities`)** — production `.lock().unwrap()` patterns in `render.rs` (15 sites) became `.lock().expect("mutex poisoned; fail-fast per ADR-0063")` per the umbrella message convention. Audio test scaffolding in `audio.rs` (8 sites) took a single module-level `#![allow(clippy::unwrap_used)]` with rationale — the `sender.push(...).unwrap()` test setup is local-channel-never-full and a per-call `.expect` would be pure noise.
- **`clippy::must_use_candidate` (6 hits, `aether-actor`)** — `MailBridge::send_mail` / `reply_mail` got `#[allow(clippy::must_use_candidate, reason = "fire-and-forget by contract")]`. The `#[must_use]` annotations were removed in iamacoffeepot/aether#892 with that exact rationale; the lint re-flagging the same functions as candidates is the inverse direction of the same idiom decision.
- **`unused_imports` (3 hits, `aether-actor-derive`)** — dropped the unused `spanned::Spanned` import.
- **`clippy::print_stdout` (1 hit, `aether-mesh/examples/dsl_to_obj.rs`)** — file-level `#![allow]` with rationale; the example is a CLI documented to write OBJ text to stdout for piping.

## CI re-enable

- `.github/workflows/ci.yml` line 55 restores `-- -D warnings` on the `cargo clippy --workspace --all-targets` invocation. The TODO comment pointing back at iamacoffeepot/aether#854 is gone.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- `cargo nextest run --workspace` — 1001/1001 passing.
- `cargo check --workspace --all-targets` — clean.
