### PR TITLE
chore(substrate): integrate Qodana Rust scanner in CI (issue 906)

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,0 +1,34 @@
+name: Qodana
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  qodana:
+    name: Qodana scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+    # Report-only while the EAP linter beds in — Qodana action defaults
+    # to exit-non-zero on findings, which would fail PR CI on every
+    # false positive. Flip to required by removing this line once the
+    # noise floor is understood.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Install ALSA dev headers (cpal Linux backend)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Qodana scan
+        uses: JetBrains/qodana-action@v2026.1
+        with:
+          args: --linter,qodana-rust
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,24 @@
+version: "1.0"
+
+# Rust linter — currently EAP (Early Access).
+linter: jetbrains/qodana-rust:2026.1-eap
+
+# Recommended profile = full inspection set. Start narrow (starter) if
+# the recommended profile is too noisy on the EAP linter; flip back via
+# follow-up once we've calibrated.
+profile:
+  name: qodana.recommended
+
+# Paths Qodana shouldn't analyse.
+exclude:
+  - name: All
+    paths:
+      - target
+      - .claude
+      - .cargo
+      - archive
+      - spikes
+
+# Native deps the linter needs to build before inspecting (mirrors the
+# clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
+bootstrap: sudo apt-get update && sudo apt-get install -y libasound2-dev


### PR DESCRIPTION
Closes iamacoffeepot/aether#906

- Adds `.github/workflows/qodana.yml` (workflow_dispatch + pull_request + push:main) with `continue-on-error: true` — Qodana lands report-only while the EAP Rust linter beds in.
- Adds `qodana.yaml` at repo root (`jetbrains/qodana-rust:2026.1-eap`, `qodana.recommended` profile, ALSA bootstrap mirroring the clippy job, excludes for `target`/`.claude`/`.cargo`/`archive`/`spikes`).
- Qodana is intentionally NOT added to the `CI pass` aggregator in `ci.yml`; follow-ups (flip off `continue-on-error`, promote to required check, possibly tune profile) are deferred per the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)