### PR TITLE
fix(substrate): qodana bootstrap fails on missing /var/lib/apt/lists/partial

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -21,5 +21,9 @@ exclude:
 
 # Native deps the linter needs to build before inspecting (mirrors the
 # clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
-# Runs inside the Qodana container as root — no `sudo` available.
-bootstrap: apt-get update && apt-get install -y libasound2-dev
+# Runs inside the Qodana container as root — no `sudo` available. The
+# qodana-rust:2026.1-eap image ships without /var/lib/apt/lists/partial
+# (slimmed to keep the image small), so `apt-get update` fails with
+# 'List directory /var/lib/apt/lists/partial is missing' unless we
+# create it first.
+bootstrap: mkdir -p /var/lib/apt/lists/partial && apt-get update && apt-get install -y libasound2-dev


### PR DESCRIPTION
## What

The `jetbrains/qodana-rust:2026.1-eap` image ships without `/var/lib/apt/lists/partial` (a staging dir `apt-get update` writes downloaded package lists into — slimmed to keep the image small). Our bootstrap line then fails before installing `libasound2-dev`:

```
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (2: No such file or directory)
```

Fix: `mkdir -p` the directory before `apt-get update`.

## Why this needs to land on main (not a PR's branch)

Qodana in `pr-mode: true` reads the **baseline** (merge-base) commit's `qodana.yaml`, not the PR head's. A bootstrap fix on a feature branch is ignored until main has it too — same pattern that hit on the prior sudo fix.

## Verification

YAML-only change, no other gates needed. CI's clippy/test/format jobs will run as usual; Qodana's own run on the merged commit will exercise the fix.
