### PR TITLE
fix(substrate): drop qodana bootstrap — apt-get blocked in linter container

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -19,11 +19,12 @@ exclude:
       - archive
       - spikes
 
-# Native deps the linter needs to build before inspecting (mirrors the
-# clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
-# Runs inside the Qodana container as root — no `sudo` available. The
-# qodana-rust:2026.1-eap image ships without /var/lib/apt/lists/partial
-# (slimmed to keep the image small), so `apt-get update` fails with
-# 'List directory /var/lib/apt/lists/partial is missing' unless we
-# create it first.
-bootstrap: mkdir -p /var/lib/apt/lists/partial && apt-get update && apt-get install -y libasound2-dev
+# No bootstrap: the qodana-rust:2026.1-eap container runs bootstrap as
+# a non-root user with no sudo binary and no write access to
+# /var/lib/apt, so we cannot apt-get install system packages. Without
+# `libasound2-dev` the `cpal` Linux backend won't link, so any crate
+# that depends on cpal (aether-substrate-bundle desktop chassis,
+# aether-capabilities audio) surfaces as a build error in the scan
+# rather than producing inspection findings. Other crates analyze
+# fine. Revisit via a custom linter Dockerfile if cpal-bearing
+# inspections matter.


### PR DESCRIPTION
## What

The `jetbrains/qodana-rust:2026.1-eap` container runs `bootstrap` as a non-root user with neither `sudo` available nor write access to `/var/lib/apt`:

```
mkdir: cannot create directory '/var/lib/apt': Permission denied
```

Three iterations of trying to massage the bootstrap line have failed (sudo missing → partial dir missing → permission denied). The container actively prevents apt-get installs from `bootstrap`. Dropping the line.

## Trade-off

Without `libasound2-dev`, the `cpal` Linux backend won't link. Crates that depend on `cpal` (`aether-substrate-bundle` desktop chassis, `aether-capabilities` audio) surface as **build errors** in the Qodana scan instead of producing inspection findings. Other crates (math, mesh, codec, kinds, data, actor, etc.) analyze fine.

For the dashboard, this means some inspections are missing from the cpal-dependent files. The signal is incomplete but non-zero — most of the workspace is unaffected.

## Follow-up (deferred)

If cpal-bearing inspections matter, the path is a **custom linter Dockerfile** that pre-installs `libasound2-dev` in a derived image (`FROM jetbrains/qodana-rust:2026.1-eap; RUN apt-get update && apt-get install -y libasound2-dev`), then point `linter:` at the custom image. Heavier setup; deferred until the missing-coverage gap actually bites.

## Why this needs to land on main

Same pattern as the prior two Qodana fixes — `pr-mode: true` reads the merge-base's qodana.yaml, so the fix has to land on main before PR-level baseline scans pick it up.
