### PR TITLE
fix(substrate): qodana scans don't analyse — CARGO_HOME perm-denied + drop dead host install

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Install ALSA dev headers (cpal Linux backend)
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - name: Qodana scan
         uses: JetBrains/qodana-action@v2026.1
         with:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -19,6 +19,14 @@ exclude:
       - archive
       - spikes
 
+# Override CARGO_HOME so Qodana's non-root scan user can write the
+# cargo registry index + global-cache. The container's default
+# /usr/local/cargo is owned by a different user, causing
+# `cargo metadata` (which Qodana runs to load the workspace) to fail
+# with permission-denied — leaving the entire workspace unanalysed.
+env:
+  - CARGO_HOME=/tmp/qodana-cargo
+
 # No bootstrap: the qodana-rust:2026.1-eap container runs bootstrap as
 # a non-root user with no sudo binary and no write access to
 # /var/lib/apt, so we cannot apt-get install system packages. Without


### PR DESCRIPTION
## What

Two related fixes on the Qodana setup:

### 1. Qodana wasn't actually analysing anything

Latest main scan log shows `cargo metadata` failing because the qodana-rust container's `/usr/local/cargo` (default `CARGO_HOME`) is owned by a different user than the one Qodana's analysis process runs as:

```
warning: failed to write cache, path: /usr/local/cargo/registry/index/.../anyhow,
  error: Permission denied (os error 13)
unable to open database file: /usr/local/cargo/.global-cache
  Error code 14: unable to open database file
[IDE]: Some Cargo projects failed to load: Workspace: failed
       (Failed to run Cargo: Execution failed (exit code 101))
```

Result: zero Rust inspections actually ran. The JOB conclusion is `success` because `continue-on-error: true`, but the dashboard is empty.

Fix: override `CARGO_HOME=/tmp/qodana-cargo` via the `env:` block in `qodana.yaml`. The scan user can write there. Cargo re-downloads crates each run (no persistence across runs without further work), but at least `cargo metadata` succeeds and inspections run.

### 2. Drop the useless host-install step from the workflow

`.github/workflows/qodana.yml` had `Install ALSA dev headers (cpal Linux backend)` running `sudo apt-get install libasound2-dev` **on the GitHub Actions runner**. Qodana's analysis happens inside the qodana-rust container, which has its own filesystem — the host install never reached the container. Dead code.

If `libasound2-dev` turns out to be needed for the cpal-bearing crates to actually link inside the container, the fix is a custom linter Dockerfile (`FROM jetbrains/qodana-rust:2026.1-eap; RUN apt-get install -y libasound2-dev`), not a host install.

## Why both need to land on main

Same pattern as the prior three Qodana fixes — `pr-mode: true` reads the merge-base's `qodana.yaml`, so config fixes have to land on main before PR-level baseline scans pick them up.
