### PR TITLE
fix(substrate): qodana CARGO_HOME via --env CLI arg (env: not a yaml key)

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Qodana scan
         uses: JetBrains/qodana-action@v2026.1
         with:
-          # Space-separated; comma form is deprecated as of action v2026.1.
-          args: --linter qodana-rust
+          # Space-separated args. The --env passes CARGO_HOME into the
+          # container so cargo metadata doesn't perm-deny on the
+          # baked /usr/local/cargo (owned by a different user than
+          # Qodana's non-root scan process).
+          args: --linter qodana-rust --env CARGO_HOME=/tmp/qodana-cargo
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -19,13 +19,10 @@ exclude:
       - archive
       - spikes
 
-# Override CARGO_HOME so Qodana's non-root scan user can write the
-# cargo registry index + global-cache. The container's default
-# /usr/local/cargo is owned by a different user, causing
-# `cargo metadata` (which Qodana runs to load the workspace) to fail
-# with permission-denied — leaving the entire workspace unanalysed.
-env:
-  - CARGO_HOME=/tmp/qodana-cargo
+# CARGO_HOME override (so cargo metadata doesn't perm-deny on
+# /usr/local/cargo) is passed via `--env CARGO_HOME=…` in the
+# workflow's args, NOT via this file — `env:` is not a recognized
+# qodana.yaml key ("Unexpected keys in qodana.yaml: [env]").
 
 # No bootstrap: the qodana-rust:2026.1-eap container runs bootstrap as
 # a non-root user with no sudo binary and no write access to


### PR DESCRIPTION
Qodana surfaces `Unexpected keys in qodana.yaml: [env]` — the `env:` key isn't a recognized `qodana.yaml` schema key, so my prior CARGO_HOME override was silently ignored. The Qodana CLI accepts env vars via `--env KEY=VAL` at scan time, which the action's `args:` forwards into the container.

This PR:
- drops the bad `env:` block from `qodana.yaml`
- adds `--env CARGO_HOME=/tmp/qodana-cargo` to the workflow's `args:`

Same baseline-config pattern as the prior four Qodana fixes — needs to land on main so PR-mode baseline scans pick it up.

Once this lands, the next main Qodana run should actually run `cargo metadata` successfully and analyze the workspace for the first time.
