### PR TITLE
fix(substrate): qodana scan -u root — keep container at design-default user

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -27,10 +27,18 @@ jobs:
       - name: Qodana scan
         uses: JetBrains/qodana-action@v2026.1
         with:
-          # Space-separated args. The --env passes CARGO_HOME into the
-          # container so cargo metadata doesn't perm-deny on the
-          # baked /usr/local/cargo (owned by a different user than
-          # Qodana's non-root scan process).
-          args: --linter qodana-rust --env CARGO_HOME=/tmp/qodana-cargo
+          # -u root forwards through `qodana scan` to the underlying
+          # `docker run`, keeping the container's design-default user.
+          # The qodana-action's wrapper otherwise passes `-u $(id -u)`
+          # to preserve the runner user's ownership of the workspace
+          # dir — but that flips the container to non-root, and the
+          # baked /usr/local/cargo (registry + global-cache) is
+          # root-owned, so cargo metadata perm-denies and Qodana
+          # leaves the entire workspace unanalysed. Running as root
+          # inside the container is the documented default — see
+          # https://www.jetbrains.com/help/qodana/docker-image-configuration.html
+          # § "Run as a non-root user". The CARGO_HOME override on
+          # the prior approach (#911) is now unnecessary.
+          args: --linter qodana-rust -u root
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -19,17 +19,11 @@ exclude:
       - archive
       - spikes
 
-# CARGO_HOME override (so cargo metadata doesn't perm-deny on
-# /usr/local/cargo) is passed via `--env CARGO_HOME=…` in the
-# workflow's args, NOT via this file — `env:` is not a recognized
-# qodana.yaml key ("Unexpected keys in qodana.yaml: [env]").
-
-# No bootstrap: the qodana-rust:2026.1-eap container runs bootstrap as
-# a non-root user with no sudo binary and no write access to
-# /var/lib/apt, so we cannot apt-get install system packages. Without
-# `libasound2-dev` the `cpal` Linux backend won't link, so any crate
-# that depends on cpal (aether-substrate-bundle desktop chassis,
-# aether-capabilities audio) surfaces as a build error in the scan
-# rather than producing inspection findings. Other crates analyze
-# fine. Revisit via a custom linter Dockerfile if cpal-bearing
-# inspections matter.
+# Native deps the linter needs to build before inspecting (mirrors the
+# clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
+# Runs as root now that the workflow passes `-u root` to qodana scan,
+# so apt-get works without sudo. Prior attempts at this line failed
+# because the container was non-root by default (sudo missing, then
+# /var/lib/apt write-denied) — see the `-u root` rationale in
+# .github/workflows/qodana.yml.
+bootstrap: apt-get update && apt-get install -y libasound2-dev


### PR DESCRIPTION
## What

Pass `-u root` to the `qodana scan` CLI via the action's `args:` so the analysis container runs as its design-default root user instead of being forced to non-root by the GitHub Action wrapper.

## Why

The qodana-rust image bakes `/usr/local/cargo` (cargo registry + global-cache) as root-owned per the JetBrains [Docker image config docs](https://www.jetbrains.com/help/qodana/docker-image-configuration.html). The `actions/checkout@v4` step sets the workspace dir's owner to the GitHub runner user, and the qodana-action's wrapper passes `-u $(id -u):$(id -g)` to the container so the analysis process matches that ownership. That flips the container to non-root, at which point cargo metadata can no longer write to `/usr/local/cargo/registry` and Qodana fails to load the Rust workspace.

Symptom that motivated 5 prior fix iterations (sudo missing, partial dir stripped, mkdir denied, cargo registry denied, env: not a yaml key) was always this same root cause. `-u root` addresses the user identity directly instead of routing around the consequences.

## Changes

- `.github/workflows/qodana.yml` — `args:` now `--linter qodana-rust -u root`. The `--env CARGO_HOME=/tmp/qodana-cargo` from iamacoffeepot/aether#911 is removed since the override is no longer needed.

## Why this needs to land on main

Same baseline-config pattern as the prior Qodana fixes — `pr-mode: true` reads the merge-base's workflow + config, so fixes have to land on main before PR-level baseline scans pick them up.

## How to verify

Once merged, the next main Qodana run should log no permission-denied errors against `/usr/local/cargo`, `cargo metadata` succeeds, the workspace loads, and the dashboard receives the fullest signal yet (dependency-aware inspections included).
