### PR TITLE
fix(substrate): silence qodana FP failures via explicit type binding (913 phase 1)

### DIFF
--- a/crates/aether-mesh/src/serialize.rs
+++ b/crates/aether-mesh/src/serialize.rs
@@ -197,7 +197,12 @@ fn kw(s: &str) -> Value {
 }
 
 fn num(f: f32) -> Value {
-    Value::Number(Number::from_f64(f64::from(f)).expect("non-finite float in AST"))
+    // Explicit `let widened: f64 = …` keeps Qodana's Rust EAP linter from
+    // mis-inferring `f64::from(f)` as `f32` (false-positive E0308 on the
+    // call to `Number::from_f64`, which clearly takes `f64`). No-op for
+    // cargo / clippy.
+    let widened: f64 = f64::from(f);
+    Value::Number(Number::from_f64(widened).expect("non-finite float in AST"))
 }
 
 fn uint(n: u32) -> Value {

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -72,6 +72,13 @@ pub fn drain_frame_bound_or_abort(pending: &[(MailboxId, Arc<AtomicU64>)], outbo
             None => return,
             Some((mbox, count)) => {
                 if Instant::now() >= deadline {
+                    // Explicit annotation to keep Qodana's Rust EAP linter from
+                    // losing the `u64` type through the Option destructure
+                    // (false-positive "u64 does not implement Display"). The
+                    // tuple's second element is annotated `u64` at the
+                    // `still_pending` declaration above; this is a no-op rebind
+                    // for cargo / clippy.
+                    let count: u64 = count;
                     let reason = format!(
                         "frame-bound dispatcher wedged: mailbox={mbox} pending={count} waited={DRAIN_BUDGET:?}"
                     );


### PR DESCRIPTION
Phase 1 of iamacoffeepot/aether#913 — silence the 2 Qodana false-positive `Failure` findings via explicit type re-binding rather than `// noinspection` suppression comments. Same end result (Qodana stops complaining); strictly more honest code (the annotations are no-ops for `cargo`/`clippy` and serve only to spell out what's already true).

## Changes

### `crates/aether-substrate/src/chassis/frame_loop.rs`
Qodana false-positive: `u64 does not implement Display (required by {count})` on line 76. `count` is `u64` per the `Option<(MailboxId, u64)>` annotation on `still_pending` — Qodana's EAP type checker loses the type through the destructure.

Fix: shadow `let count: u64 = count;` immediately before the `format!` call.

### `crates/aether-mesh/src/serialize.rs`
Qodana false-positive: `expected f64, but found f32` on line 200's `Number::from_f64(f64::from(f))`. `f64::from(f)` widens `f32 → f64` correctly; Qodana mis-infers the inner expression's type.

Fix: split into `let widened: f64 = f64::from(f);` then `Number::from_f64(widened)`.

## Trade-off

Either approach (this one vs `// noinspection`) silences Qodana. Going with type-binding because:

- The binding makes the type explicit at the use site, which is a real (small) readability win even ignoring Qodana.
- `// noinspection` requires the exact inspection ID, which only surfaces via the Cloud dashboard's per-finding detail panel.
- If a future Qodana version fixes the inference bug, the type binding stays harmless; a `// noinspection` would become misleading dead config.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt -- --check` clean
- Next Qodana run on this PR will confirm whether the upcast actually silences the two findings. If not, fall back to `// noinspection` with the IDs read from the dashboard.

Doesn't close iamacoffeepot/aether#913 — first of 7 phases.
