### PR TITLE
chore(ci): qodana hardening — rustc 1.95, bootstrap flatten, split cache cycle

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -24,6 +24,21 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      # Cache cycle is split out of qodana-action so we can interleave
+      # an ownership chown between the root-written scan and the tar
+      # save — qodana-action's internal cache save runs inside its own
+      # step, before any post-scan step we could add, so we can't fix
+      # the ownership in time without taking over the save side.
+      - name: Restore Qodana cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/qodana/caches
+          key: qodana-2026.1-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            qodana-2026.1-${{ github.ref }}-
+            qodana-2026.1-
+
       - name: Qodana scan
         uses: JetBrains/qodana-action@v2026.1
         with:
@@ -40,21 +55,30 @@ jobs:
           # § "Run as a non-root user". The CARGO_HOME override on
           # the prior approach (#911) is now unnecessary.
           args: --linter qodana-rust -u root
+          # We own restore/save (steps above + below); qodana-action's
+          # built-in cache save runs root-owned and trips tar exit 2.
+          use-caches: false
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+
       - name: Reclaim qodana cache ownership for tar
-        # Qodana ran as root in the container; cache files inherit
-        # uid 0 on the bind-mount. qodana-action's post-step then
-        # tries to tar the cache as the runner user (uid 1001) and
-        # fails with exit code 2 ('No cache found' on the next run,
-        # because save never completed). Chown the tree back to the
-        # runner user so the post-step can read everything.
+        # Qodana ran as root in the container; new cache files inherit
+        # uid 0 on the bind-mount. The save step below runs as the
+        # runner user (uid 1001) and would tar-exit-2 on those files.
+        # Chown the tree back so save can read everything.
         #
         # `if: always()` so the chown still runs when qodana itself
         # exits non-zero on findings. `|| true` because the cache dir
         # may not exist at all if the scan crashed before populating.
         if: always()
         run: |
-          if [ -d /home/runner/work/_temp/qodana/caches ]; then
-            sudo chown -R "$(id -u):$(id -g)" /home/runner/work/_temp/qodana/caches || true
+          if [ -d "${RUNNER_TEMP}/qodana/caches" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "${RUNNER_TEMP}/qodana/caches" || true
           fi
+
+      - name: Save Qodana cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/qodana/caches
+          key: qodana-2026.1-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -42,3 +42,19 @@ jobs:
           args: --linter qodana-rust -u root
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+      - name: Reclaim qodana cache ownership for tar
+        # Qodana ran as root in the container; cache files inherit
+        # uid 0 on the bind-mount. qodana-action's post-step then
+        # tries to tar the cache as the runner user (uid 1001) and
+        # fails with exit code 2 ('No cache found' on the next run,
+        # because save never completed). Chown the tree back to the
+        # runner user so the post-step can read everything.
+        #
+        # `if: always()` so the chown still runs when qodana itself
+        # exits non-zero on findings. `|| true` because the cache dir
+        # may not exist at all if the scan crashed before populating.
+        if: always()
+        run: |
+          if [ -d /home/runner/work/_temp/qodana/caches ]; then
+            sudo chown -R "$(id -u):$(id -g)" /home/runner/work/_temp/qodana/caches || true
+          fi

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -33,7 +33,4 @@ exclude:
 # Both run as root (workflow passes -u root to qodana scan); see the
 # rationale on `args:` in .github/workflows/qodana.yml. Bootstrap
 # adds ~30-60s per run.
-bootstrap: |
-  apt-get update && apt-get install -y libasound2-dev
-  rustup install 1.95.0 --profile minimal --no-self-update
-  rustup default 1.95.0
+bootstrap: apt-get update && apt-get install -y libasound2-dev && rustup install 1.95.0 --profile minimal --no-self-update && rustup default 1.95.0

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -19,11 +19,21 @@ exclude:
       - archive
       - spikes
 
-# Native deps the linter needs to build before inspecting (mirrors the
-# clippy job in ci.yml — cpal Linux backend pulls ALSA headers).
-# Runs as root now that the workflow passes `-u root` to qodana scan,
-# so apt-get works without sudo. Prior attempts at this line failed
-# because the container was non-root by default (sudo missing, then
-# /var/lib/apt write-denied) — see the `-u root` rationale in
-# .github/workflows/qodana.yml.
-bootstrap: apt-get update && apt-get install -y libasound2-dev
+# Native deps + toolchain bump.
+#
+# - libasound2-dev: cpal Linux backend (mirrors the clippy job in ci.yml).
+# - rustup install/default 1.95.0: the qodana-rust:2026.1-eap image
+#   ships rustc 1.94.0. Our workspace builds with 1.95.0 (stable since
+#   2026-04-14); the gap surfaces as "Failure"-severity false positives
+#   in the inspection results — Qodana's own self-diagnosis flags the 2
+#   findings as "analysis could be incorrect." Bumping the toolchain
+#   inside the container to match what we actually build against
+#   should eliminate them.
+#
+# Both run as root (workflow passes -u root to qodana scan); see the
+# rationale on `args:` in .github/workflows/qodana.yml. Bootstrap
+# adds ~30-60s per run.
+bootstrap: |
+  apt-get update && apt-get install -y libasound2-dev
+  rustup install 1.95.0 --profile minimal --no-self-update
+  rustup default 1.95.0


### PR DESCRIPTION
Incremental hardening pass on the Qodana CI setup. Each fix lands as its own commit so the rationale stays attached; PR-mode landing target is one squash-merge.

## In flight (committed)

- **Bump rustc 1.94 → 1.95 in container** via bootstrap. Image ships rustc 1.94.0; our workspace builds with 1.95.0. Gap surfaces as 2 `Failure`-severity false positives Qodana itself flags as "analysis could be incorrect."
- **Flatten multi-line `bootstrap: |` to single &&-chained command** — the literal block scalar appears to only execute the first line; flattening guarantees the full chain runs with fail-fast semantics.
- **Reclaim cache ownership for tar** post-scan. `-u root` writes cache as uid 0; runner user's `tar` then can't read it → `Failed to save: tar exit 2` on every run → cache never persists → `No cache found` on every restore. `if: always()` chown step reclaims to runner user before qodana-action's post-step archives.

## Queued (incrementally, one per commit)

- Enable `upload-result: true` → makes SARIF downloadable as `qodana-report` artifact (task iamacoffeepot/aether#170).
- Fix `actions/checkout` ref fragility (`ref:` resolves to empty string on push events).
- Drop unused `workflow_dispatch:` trigger or document it.
- Trim verbose comment blocks on `args:` once the dust settles.

## Verification path

Each commit's Qodana run on this branch verifies the prior change. Final landing only when all queued items land and the dashboard reflects:
- Bootstrap runs all 4 commands (apt-get + libasound + rustup install + rustup default).
- Cache restores on second push (`Cache restored from key:` instead of `No cache found`).
- SARIF artifact present in run summary.
- 2 Failure FPs gone (if rustc bump silences them).

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella (this PR is the prerequisite "make Qodana work properly" pass; phase work lands after)
