### PR TITLE
fix(ci): install rust-src + rust-analyzer for qodana analysis

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -24,13 +24,18 @@ exclude:
 # - libasound2-dev: cpal Linux backend (mirrors the clippy job in ci.yml).
 # - rustup install/default 1.95.0: the qodana-rust:2026.1-eap image
 #   ships rustc 1.94.0. Our workspace builds with 1.95.0 (stable since
-#   2026-04-14); the gap surfaces as "Failure"-severity false positives
-#   in the inspection results — Qodana's own self-diagnosis flags the 2
-#   findings as "analysis could be incorrect." Bumping the toolchain
-#   inside the container to match what we actually build against
-#   should eliminate them.
+#   2026-04-14); the gap surfaced as "Failure"-severity false positives
+#   in earlier runs.
+# - rustup component add rust-src rust-analyzer: an earlier bump used
+#   `--profile minimal` and regressed: +106 Critical "Derived trait not
+#   implemented" + 2 Critical "Unresolved path" Sanity-Check findings.
+#   Root cause: Qodana's Rust analyzer needs the stdlib source
+#   (rust-src) to resolve std types in derive expansion, and the
+#   bundled rust-analyzer to walk the project model. `--profile
+#   default` plus the explicit rust-src + rust-analyzer components
+#   restores both.
 #
 # Both run as root (workflow passes -u root to qodana scan); see the
 # rationale on `args:` in .github/workflows/qodana.yml. Bootstrap
-# adds ~30-60s per run.
-bootstrap: apt-get update && apt-get install -y libasound2-dev && rustup install 1.95.0 --profile minimal --no-self-update && rustup default 1.95.0
+# adds ~60-90s per run.
+bootstrap: apt-get update && apt-get install -y libasound2-dev && rustup install 1.95.0 --profile default --no-self-update && rustup default 1.95.0 && rustup component add rust-src rust-analyzer


### PR DESCRIPTION
## What

Switch Qodana's bootstrap rustc 1.95 install from `--profile minimal` to `--profile default` and explicitly add `rust-src` + `rust-analyzer` components.

## Why

The rustc 1.95 bootstrap (PR iamacoffeepot/aether#915, commit `6fc427f` on main) regressed Qodana on main:

| | Total | Critical |
|---|---|---|
| Before (1.94 stock) | 412 | 2 |
| After 1.95 minimal | 518 | 108 |

The new Critical findings:
- **106 × "Derived trait not implemented"** — all false positives
- **2 × "Unresolved path"** in `frame_loop.rs` (flagged by Qodana's own Sanity Check)

Root cause: `--profile minimal` skipped `rust-src` (stdlib source for analysis) and `rust-analyzer` (the language server Qodana wraps). With them missing, the bumped 1.95 toolchain actually had *less* analysis metadata than the container's stock 1.94, so derive macro expansion couldn't resolve `std::*` types and everything went red.

## Expected outcome

- Critical drops back to ≤ 2 (ideally 0 if the 2 originals were truly toolchain-gap FPs)
- Total drops from 518 back toward 412 ± noise
- Bootstrap time +~30s for `--profile default` + components

If the 2 original Critical findings (Format macro error + Type checker) persist, that confirms they're real Qodana false positives independent of toolchain version, and they go into the baseline-suppression bucket per iamacoffeepot/aether#913.

## Verification

PR CI run produces the comparison; main run after merge produces the official next baseline.

## References

- iamacoffeepot/aether#915 — the rustc bump that introduced the regression
- iamacoffeepot/aether#913 — Qodana triage umbrella (depends on baseline being stable)
