### PR TITLE
chore(ci): upload qodana sarif as workflow artifact

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -58,6 +58,13 @@ jobs:
           # We own restore/save (steps above + below); qodana-action's
           # built-in cache save runs root-owned and trips tar exit 2.
           use-caches: false
+          # Upload SARIF + qodana.sarif.json as a workflow artifact
+          # ('qodana-report') so triagers can grab findings without
+          # depending on the JB web dashboard. Needed for the Phase 2+
+          # sweeps in iamacoffeepot/aether#913 — re-triaging against
+          # the new 424-finding baseline (post rust-src components fix
+          # on commit 08e452c) requires local SARIF access.
+          upload-result: true
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
 


### PR DESCRIPTION
## What

Enable `upload-result: true` on the qodana-action invocation. Each run will now publish the SARIF report (and supporting files) as the `qodana-report` workflow artifact.

## Why

Unblocks the Phase 2-6 sweeps in iamacoffeepot/aether#913. The phase finding-counts (10 unused deps, 33 notices, 20 member order, 295 path prefix, etc.) were derived from the original 412-finding / 2-Critical baseline. After the toolchain components fix (iamacoffeepot/aether#916, commit 08e452c), main settled at 424 / 0 Critical / 14 High / 410 Moderate. Re-triaging the 14 High + 410 Moderate against the new baseline needs local SARIF access — the JB web dashboard's filters aren't precise enough for per-crate phase planning.

## Verification

This PR's own CI run should produce a `qodana-report` artifact downloadable from the run summary.

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
