### PR TITLE
chore(deps): bump png, thiserror, signal-hook in aether-substrate-bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,12 +239,12 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "ctrlc",
- "png 0.17.16",
+ "png 0.18.1",
  "pollster",
  "postcard",
  "serde",
  "signal-hook",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "wgpu",
  "winit",
@@ -3671,9 +3671,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -44,7 +44,7 @@ aether-kinds = { path = "../aether-kinds" }
 # Same crate as `wasmtime::Result` re-exports (issue #571).
 anyhow = "1"
 bytemuck = { version = "1.19", features = ["derive"] }
-png = "0.17"
+png = "0.18"
 pollster = "0.4.0"
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 # `rmcp` / `axum` / `base64` / `schemars` retired with the embedded MCP
@@ -54,7 +54,7 @@ serde = { version = "1", features = ["derive"] }
 # `test_bench::visual::ImageError` derives `thiserror::Error` (moved
 # from `aether-scenario` per issue 821). New runtime dep here because
 # `aether-substrate-bundle` had no prior thiserror consumer.
-thiserror = "1"
+thiserror = "2"
 tracing = "0.1"
 wgpu = "29.0.1"
 winit = "0.30.13"
@@ -68,7 +68,7 @@ winit = "0.30.13"
 # Ctrl-C only (matches the pre-tokio-retirement behavior, which also
 # distinguished SIGINT/SIGTERM only on Unix).
 [target.'cfg(unix)'.dependencies]
-signal-hook = "0.3"
+signal-hook = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3"

--- a/crates/aether-substrate-bundle/src/test_bench/visual.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/visual.rs
@@ -4,6 +4,8 @@
 //! `&Image` so a single capture can drive many asserts without
 //! re-decoding.
 
+use std::io::Cursor;
+
 use thiserror::Error;
 
 /// Decoded frame: RGBA8 pixels in row-major top-down order, width
@@ -28,7 +30,10 @@ pub enum ImageError {
 /// always emits 8-bit RGBA, so non-RGBA decodes are flagged as
 /// `UnsupportedColor` rather than silently coerced.
 pub fn decode_png(bytes: &[u8]) -> Result<Image, ImageError> {
-    let decoder = png::Decoder::new(bytes);
+    // png 0.18 requires `BufRead + Seek` on the reader. Wrap the byte
+    // slice in a `Cursor` to satisfy both bounds (the slice itself is
+    // already `Read` but neither `BufRead` nor `Seek`).
+    let decoder = png::Decoder::new(Cursor::new(bytes));
     let mut reader = decoder
         .read_info()
         .map_err(|e| ImageError::Decode(e.to_string()))?;
@@ -39,7 +44,12 @@ pub fn decode_png(bytes: &[u8]) -> Result<Image, ImageError> {
     if color != png::ColorType::Rgba {
         return Err(ImageError::UnsupportedColor(color));
     }
-    let mut buf = vec![0u8; reader.output_buffer_size()];
+    // png 0.18 returns `Option<usize>` here (None on size overflow);
+    // surface it as a decode error rather than panicking.
+    let buf_size = reader
+        .output_buffer_size()
+        .ok_or_else(|| ImageError::Decode("output buffer size overflowed".to_string()))?;
+    let mut buf = vec![0u8; buf_size];
     reader
         .next_frame(&mut buf)
         .map_err(|e| ImageError::Decode(e.to_string()))?;


### PR DESCRIPTION
Part of the Qodana Phase 2b dependency sweep tracked in iamacoffeepot/aether#913.

Bumps three direct dependencies in `crates/aether-substrate-bundle/Cargo.toml`:

- `png` `0.17` -> `0.18`
- `thiserror` `1` -> `2` (unifies with `aether-mesh`, which already uses thiserror 2)
- `signal-hook` `0.3` -> `0.4`

## API changes absorbed

`png` 0.18 tightened `Decoder::new` to require `BufRead + Seek` on its reader (previously just `Read`) and made `Reader::output_buffer_size` return `Option<usize>` so callers handle the multiply-overflow case explicitly. `test_bench::visual::decode_png` is updated:

- The `&[u8]` input is wrapped in `std::io::Cursor` to satisfy the new bounds.
- `output_buffer_size()` is surfaced as `ImageError::Decode("output buffer size overflowed")` rather than panicking.

`thiserror` 2 and `signal-hook` 0.4 were source-compatible at this crate's use sites (the `signal-hook` iterator API used by the hub chassis is unchanged in 0.4).

## Verification

- `cargo check --workspace --all-targets` -- clean
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo nextest run --workspace` -- 1001 / 1001 passing
