### PR TITLE
chore(qodana): phase 3 low-volume notices sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "cpal",
  "crossbeam-queue",
  "dirs",
- "png 0.18.1",
+ "png",
  "postcard",
  "serde",
  "tracing",
@@ -214,7 +214,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "crossbeam-queue",
- "png 0.18.1",
+ "png",
  "postcard",
  "serde",
  "tracing",
@@ -239,7 +239,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "ctrlc",
- "png 0.18.1",
+ "png",
  "pollster",
  "postcard",
  "serde",
@@ -2809,19 +2809,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "png"

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -334,8 +334,8 @@ impl FfiDropCtx<'_> {
     /// unrecoverable state.
     pub fn save_state(&mut self, version: u32, bytes: &[u8]) {
         let status = PERSIST_BRIDGE.save_state(version, bytes);
-        assert!(
-            status == 0,
+        assert_eq!(
+            status, 0,
             "aether-actor: save_state failed (status {status})"
         );
     }
@@ -387,8 +387,8 @@ impl MailSender for FfiDropCtx<'_> {
 impl Persistence for FfiDropCtx<'_> {
     fn save_state(&mut self, version: u32, bytes: &[u8]) {
         let status = PERSIST_BRIDGE.save_state(version, bytes);
-        assert!(
-            status == 0,
+        assert_eq!(
+            status, 0,
             "aether-actor: save_state failed (status {status})"
         );
     }

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -236,7 +236,7 @@ mod native_impl {
 
     impl Drop for StampGuard {
         fn drop(&mut self) {
-            CURRENT_SLOTS.with(|slot| slot.set(self.prev));
+            CURRENT_SLOTS.set(self.prev);
         }
     }
 

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -248,14 +248,14 @@ struct PipelineGuard;
 
 impl PipelineGuard {
     fn enter() -> Self {
-        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(true));
+        pipeline_tls::IN_LOG_PIPELINE.set(true);
         Self
     }
 }
 
 impl Drop for PipelineGuard {
     fn drop(&mut self) {
-        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(false));
+        pipeline_tls::IN_LOG_PIPELINE.set(false);
     }
 }
 

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -248,14 +248,14 @@ struct PipelineGuard;
 
 impl PipelineGuard {
     fn enter() -> Self {
-        pipeline_tls::IN_LOG_PIPELINE.set(true);
+        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(true));
         Self
     }
 }
 
 impl Drop for PipelineGuard {
     fn drop(&mut self) {
-        pipeline_tls::IN_LOG_PIPELINE.set(false);
+        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(false));
     }
 }
 

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -83,12 +83,12 @@ pub trait ComponentHostNativeExt {
     /// Resolve a typed peer-component mailbox for the loaded component
     /// named `name`. The full mailbox address is
     /// `format!("{}:{}", WasmTrampoline::NAMESPACE, name)`.
-    fn loaded<'a, R: Actor>(&'a self, name: &str) -> NativeActorMailbox<'a, R>;
+    fn loaded<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl ComponentHostNativeExt for NativeActorMailbox<'_, ComponentHostCapability> {
-    fn loaded<'b, R: Actor>(&'b self, name: &str) -> NativeActorMailbox<'b, R> {
+    fn loaded<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
         self.resolve_peer::<R>(&format!("{}:{}", WasmTrampoline::NAMESPACE, name))
     }
 }

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -279,7 +279,7 @@ mod proxy_native {
             let on_frame = move || {
                 wake_mailer.push(Mail::new(self_mailbox, wake_kind, Vec::new(), 1));
             };
-            match RpcClient::connect(
+            return match RpcClient::connect(
                 addr,
                 PeerKind::Client {
                     client_name: "aether.engine.proxy".to_owned(),
@@ -287,15 +287,15 @@ mod proxy_native {
                 },
                 on_frame,
             ) {
-                Ok(conn) => return Ok(conn),
+                Ok(conn) => Ok(conn),
                 Err(e) => {
                     if retry && is_transient_connect_error(&e) && Instant::now() < deadline {
                         std::thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
                         continue;
                     }
-                    return Err(e);
+                    Err(e)
                 }
-            }
+            };
         }
     }
 

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -229,11 +229,11 @@ pub trait TcpNativeExt {
     /// returned handle inherits the parent mailbox's `'a` binding ref
     /// so `.send::<K>(&mail)` dispatches through the same
     /// `NativeBinding` without re-threading the ctx.
-    fn listener<'a, R: Actor>(&'a self, name: &str) -> NativeActorMailbox<'a, R>;
+    fn listener<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R>;
 
     /// Resolve a typed session-instance mailbox. See
     /// [`TcpFfiExt::session`] for the addressing rationale.
-    fn session<'a, R: Actor>(&'a self, name: &str) -> NativeActorMailbox<'a, R>;
+    fn session<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -266,10 +266,10 @@ impl TcpNativeExt for NativeActorMailbox<'_, TcpCapability> {
         self.session::<TcpSessionActor>(session_name)
             .send(&SessionClose::default());
     }
-    fn listener<'b, R: Actor>(&'b self, name: &str) -> NativeActorMailbox<'b, R> {
+    fn listener<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
         self.resolve_peer::<R>(&format!("{}:{}", TcpListenerActor::NAMESPACE, name))
     }
-    fn session<'b, R: Actor>(&'b self, name: &str) -> NativeActorMailbox<'b, R> {
+    fn session<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
         self.resolve_peer::<R>(&format!("{}:{}", TcpSessionActor::NAMESPACE, name))
     }
 }

--- a/crates/aether-math/src/quat.rs
+++ b/crates/aether-math/src/quat.rs
@@ -182,9 +182,9 @@ mod tests {
     fn conjugate_is_inverse_for_unit_quats() {
         let q = Quat::from_axis_angle(Vec3::new(1.0, 2.0, 3.0).normalize(), 0.7);
         let r = q * q.conjugate();
-        assert!((r.x).abs() < EPS);
-        assert!((r.y).abs() < EPS);
-        assert!((r.z).abs() < EPS);
+        assert!(r.x.abs() < EPS);
+        assert!(r.y.abs() < EPS);
+        assert!(r.z.abs() < EPS);
         assert!((r.w - 1.0).abs() < EPS);
     }
 

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -346,8 +346,8 @@ mod tests {
             *counts.entry(v).or_insert(0) += 1;
         }
         for (&v, &c) in &counts {
-            assert!(
-                c == 1,
+            assert_eq!(
+                c, 1,
                 "vertex {v} appears {c} times in repaired polygon {target:?} — spike emitted"
             );
         }

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -407,7 +407,7 @@ pub fn validate_normal_coherence(polygons: &[Polygon]) -> Vec<GeometryViolation>
         if !seen.insert(pair) {
             continue;
         }
-        let cos = (n0).dot(n1);
+        let cos = n0.dot(n1);
         if cos < tol::FOLD_COS {
             out.push(GeometryViolation::FoldedNormals {
                 v0: from_key(*a),
@@ -468,8 +468,8 @@ pub fn validate_no_t_junctions(polygons: &[Polygon]) -> Vec<GeometryViolation> {
     for (a_key, b_key) in &edges {
         let a = from_key(*a_key);
         let b = from_key(*b_key);
-        let ab = (b) - (a);
-        let ab_len_sq = (ab).dot(ab);
+        let ab = b - a;
+        let ab_len_sq = ab.dot(ab);
         if ab_len_sq <= 0.0 {
             continue;
         }
@@ -477,8 +477,8 @@ pub fn validate_no_t_junctions(polygons: &[Polygon]) -> Vec<GeometryViolation> {
             if *v_key == *a_key || *v_key == *b_key {
                 continue;
             }
-            let av = (*v) - (a);
-            let t = (av).dot(ab) / ab_len_sq;
+            let av = *v - a;
+            let t = av.dot(ab) / ab_len_sq;
             // Open interior — exclude endpoints by a small parametric margin
             // proportional to the snap tolerance vs. edge length.
             let margin = (tol::T_JUNCTION / ab_len_sq.sqrt()).min(0.5);

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -630,9 +630,6 @@ mod tests {
         let s = plane.side(extreme_query);
         // The opposite corner from the plane's centroid must be on
         // the positive side (the normal points outward).
-        assert_ne!(
-            s, 0,
-            "extreme query should not coincidentally lie on plane"
-        );
+        assert_ne!(s, 0, "extreme query should not coincidentally lie on plane");
     }
 }

--- a/crates/aether-mesh/src/plane.rs
+++ b/crates/aether-mesh/src/plane.rs
@@ -630,8 +630,8 @@ mod tests {
         let s = plane.side(extreme_query);
         // The opposite corner from the plane's centroid must be on
         // the positive side (the normal points outward).
-        assert!(
-            s != 0,
+        assert_ne!(
+            s, 0,
             "extreme query should not coincidentally lie on plane"
         );
     }

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -609,7 +609,11 @@ mod tests {
             p(0.199_996_95, 0.453_582_76, 0.346_405_03),
             p(0.199_996_95, 1.0, 0.346_405_03),
         ];
-        let normal = Vec3::new(-0.707_106_77, 0.0, -0.707_106_77);
+        let normal = Vec3::new(
+            -core::f32::consts::FRAC_1_SQRT_2,
+            0.0,
+            -core::f32::consts::FRAC_1_SQRT_2,
+        );
         assert!(
             is_convex(&verts, &normal),
             "snap-rounded near-collinear vertex should not flip convex classification"
@@ -625,8 +629,8 @@ mod tests {
             d: 0,
         };
         let n = unit_normal(&xy);
-        assert!((n.x).abs() < 1e-6);
-        assert!((n.y).abs() < 1e-6);
+        assert!(n.x.abs() < 1e-6);
+        assert!(n.y.abs() < 1e-6);
         assert!((n.z - 1.0).abs() < 1e-6, "expected +z, got {n:?}");
     }
 

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -168,7 +168,7 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
             engine_id,
             rpc_port,
         } => {
-            assert!(rpc_port != 0, "cap should report the assigned RPC port");
+            assert_ne!(rpc_port, 0, "cap should report the assigned RPC port");
             engine_id
         }
         SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -74,7 +74,7 @@ struct DispatchGuard {
 
 impl Drop for DispatchGuard {
     fn drop(&mut self) {
-        ACTOR_DISPATCH.with(|slot| slot.set(self.prev));
+        ACTOR_DISPATCH.set(self.prev);
     }
 }
 

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -413,8 +413,9 @@ pub mod tests {
 
         fn drain_one(&self, env: u32) {
             let n = self.dispatched.fetch_add(1, Ordering::AcqRel) + 1;
-            assert!(
-                Some(n) != self.panic_at,
+            assert_ne!(
+                Some(n),
+                self.panic_at,
                 "CounterSlot panic at envelope #{n} (test-induced)"
             );
             std::hint::black_box(env);


### PR DESCRIPTION
## What

Phase 3 of the iamacoffeepot/aether#913 Qodana triage — sweep 35 of 37 `note`-severity inspections across the workspace. The remaining 2 are tracked false positives, called out below for the eventual baseline absorption.

## Fixes by rule

| Rule | Count | Strategy |
|---|---|---|
| `RsAssertEqual` | 6 | `assert!(a == b)` → `assert_eq!(a, b)`, mirror for `!=` |
| `RsNeedlessLifetimes` | 6 | Elide `'a`/`'b` parameters the compiler infers via standard rules |
| `RsThreadLocalStableMethodCanBeUsed` | 4 | `LOCAL.with(\|c\| c.set(x))` → `LOCAL.set(x)` (`LocalKey<Cell<T>>` shortcut, stable since 1.73) |
| `RsUnnecessaryParentheses` | 16 | Drop wrapping parens on method receivers and binary-op operands |
| `RsApproxConstant` | 1 | `0.707_106_77` → `core::f32::consts::FRAC_1_SQRT_2` |
| `RsLift` | 1 | Lift `return` out of a `match` whose arms both branch through it |

## Known false positives (skipped, queued for baseline absorption)

- **TomlUnresolvedReference at root `Cargo.toml:23`** — Qodana can't parse the workspace glob `exclude = ["spikes/*"]` and flags the `*` as an unresolved file. The glob is valid TOML / cargo manifest syntax.
- **RsConstantConditionIf at `chassis/builder.rs:444`** — Qodana evaluates the generic trait const `A::FRAME_BARRIER` against the trait's default (`false`) and concludes "always false"; concrete impls override it to `true`. Documented FP pattern (we hit the same shape during clippy adoption with PR iamacoffeepot/aether#788).

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1001/1001 passed

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
- Phase 4 (impl member order, 20 hits) and Phase 5 (path prefix sweep, 295 hits) remain.
