### PR TITLE
chore(qodana): phase 4 impl member order sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "cpal",
  "crossbeam-queue",
  "dirs",
- "png 0.18.1",
+ "png",
  "postcard",
  "serde",
  "tracing",
@@ -214,7 +214,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "crossbeam-queue",
- "png 0.18.1",
+ "png",
  "postcard",
  "serde",
  "tracing",
@@ -239,7 +239,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "ctrlc",
- "png 0.18.1",
+ "png",
  "pollster",
  "postcard",
  "serde",
@@ -2809,19 +2809,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "png"

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -335,22 +335,6 @@ impl MessageBuilder {
 }
 
 impl Visit for MessageBuilder {
-    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
-        if field.name() == "message" {
-            let _ = write!(&mut self.message, "{value:?}");
-        } else {
-            self.append_field(field.name(), "=", format_args!("{value:?}"));
-        }
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.message.push_str(value);
-        } else {
-            self.append_field(field.name(), "=", format_args!("{value}"));
-        }
-    }
-
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.append_field(field.name(), "=", format_args!("{value}"));
     }
@@ -361,6 +345,22 @@ impl Visit for MessageBuilder {
 
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.append_field(field.name(), "=", format_args!("{value}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            self.append_field(field.name(), "=", format_args!("{value}"));
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(&mut self.message, "{value:?}");
+        } else {
+            self.append_field(field.name(), "=", format_args!("{value:?}"));
+        }
     }
 }
 

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -71,16 +71,16 @@ fn deserialize_id<'de, D: Deserializer<'de>>(d: D, expected: Tag) -> Result<u64,
             )
         }
 
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<u64, E> {
-            tagged_id::decode_with_tag(v, self.expected).map_err(de::Error::custom)
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<u64, E> {
+            v.try_into().map_err(|_| de::Error::custom("negative id"))
         }
 
         fn visit_u64<E: de::Error>(self, v: u64) -> Result<u64, E> {
             Ok(v)
         }
 
-        fn visit_i64<E: de::Error>(self, v: i64) -> Result<u64, E> {
-            v.try_into().map_err(|_| de::Error::custom("negative id"))
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<u64, E> {
+            tagged_id::decode_with_tag(v, self.expected).map_err(de::Error::custom)
         }
     }
 

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -423,24 +423,6 @@ impl App {
 }
 
 impl ApplicationHandler<UserEvent> for App {
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
-        match event {
-            UserEvent::Capture => {
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
-            }
-        }
-    }
-
-    /// winit fires this between events. Issue 603 Phase 3 makes the
-    /// driver itself the cap for `aether.window`, so the per-frame
-    /// drain happens here instead of riding through `EventLoopProxy`
-    /// from a separate dispatcher thread.
-    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
-        self.drain_window_inbox();
-    }
-
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -468,6 +450,16 @@ impl ApplicationHandler<UserEvent> for App {
         self.window = Some(window);
         self.started = Some(Instant::now());
         self.publish_window_size(initial_size.width, initial_size.height);
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+        match event {
+            UserEvent::Capture => {
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
+            }
+        }
     }
 
     // winit's `window_event` dispatches one arm per `WindowEvent`
@@ -619,6 +611,14 @@ impl ApplicationHandler<UserEvent> for App {
             }
             _ => {}
         }
+    }
+
+    /// winit fires this between events. Issue 603 Phase 3 makes the
+    /// driver itself the cap for `aether.window`, so the per-frame
+    /// drain happens here instead of riding through `EventLoopProxy`
+    /// from a separate dispatcher thread.
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        self.drain_window_inbox();
     }
 }
 

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1016,14 +1016,14 @@ mod tests {
         impl DataKind for Bump {
             const NAME: &'static str = "test.spawn.bump";
             const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1910,14 +1910,14 @@ mod tests {
         impl Kind for Ping {
             const NAME: &'static str = "test.with_actor.ping";
             const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0001);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2079,14 +2079,14 @@ mod tests {
         impl Kind for Tick {
             const NAME: &'static str = "test.local.tick";
             const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0002);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2209,14 +2209,14 @@ mod tests {
         impl Kind for Hatch {
             const NAME: &'static str = "test.spawn_child.hatch";
             const ID: DataKindId = DataKindId(0xC0C1_C2C3_C4C5_C6C7);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2228,14 +2228,14 @@ mod tests {
         impl Kind for Ping {
             const NAME: &'static str = "test.spawn_child.ping";
             const ID: DataKindId = DataKindId(0xD0D1_D2D3_D4D5_D6D7);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2389,14 +2389,14 @@ mod tests {
         impl Kind for Quit {
             const NAME: &'static str = "test.shutdown.quit";
             const ID: DataKindId = DataKindId(0xE0E1_E2E3_E4E5_E6E7);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2686,14 +2686,14 @@ mod tests {
         impl Kind for Quit {
             const NAME: &'static str = "test.monitor.quit";
             const ID: DataKindId = DataKindId(0xC0DE_C0DE_4B4B_4B4B);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2707,14 +2707,14 @@ mod tests {
         impl Kind for WatchOrder {
             const NAME: &'static str = "test.monitor.watch_order";
             const ID: DataKindId = DataKindId(0x4B4B_C0DE_C0DE_C0DE);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -2943,14 +2943,14 @@ mod tests {
         impl Kind for Quit {
             const NAME: &'static str = "test.monitor.quit2";
             const ID: DataKindId = DataKindId(0xCAFE_BABE_DEAD_BEEF);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
         #[repr(C)]
@@ -2961,14 +2961,14 @@ mod tests {
         impl Kind for WatchOrder {
             const NAME: &'static str = "test.monitor.watch_order2";
             const ID: DataKindId = DataKindId(0xBEEF_DEAD_BABE_CAFE);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -3153,14 +3153,14 @@ mod tests {
         impl Kind for Quit {
             const NAME: &'static str = "test.resolve.quit";
             const ID: DataKindId = DataKindId(0xF00D_F00D_F00D_F00D);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -3410,14 +3410,14 @@ mod tests {
         impl Kind for Hatch {
             const NAME: &'static str = "test.recursive.hatch";
             const ID: DataKindId = DataKindId(0xA00A_A00A_A00A_A00A);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -3430,14 +3430,14 @@ mod tests {
         impl Kind for Ping {
             const NAME: &'static str = "test.recursive.ping";
             const ID: DataKindId = DataKindId(0xB00B_B00B_B00B_B00B);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -3450,14 +3450,14 @@ mod tests {
         impl Kind for Quit {
             const NAME: &'static str = "test.recursive.quit";
             const ID: DataKindId = DataKindId(0xC00C_C00C_C00C_C00C);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 
@@ -3729,14 +3729,14 @@ mod tests {
         impl Kind for WireBarrierPing {
             const NAME: &'static str = "test.barrier.wire_ping";
             const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != core::mem::size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
+            }
+            fn encode_into_bytes(&self) -> Vec<u8> {
+                bytemuck::bytes_of(self).to_vec()
             }
         }
 

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -320,11 +320,11 @@ mod tests {
     struct StringVisit<'a>(&'a mut String);
 
     impl Visit for StringVisit<'_> {
-        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-            let _ = write!(self.0, "{}={:?};", field.name(), value);
-        }
         fn record_str(&mut self, field: &Field, value: &str) {
             let _ = write!(self.0, "{}={};", field.name(), value);
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let _ = write!(self.0, "{}={:?};", field.name(), value);
         }
     }
 }


### PR DESCRIPTION
## What

Phase 4 of the iamacoffeepot/aether#913 Qodana triage — reorder methods inside `impl Trait for X` blocks to match each trait's declaration order. Address 19 of 20 `RsSortImplTraitMembers` findings; the 20th is a suspected Qodana FP, documented below.

Pure cosmetic — no behavior change.

## Fixes by file

| File | Hits | Reorder |
|---|---|---|
| `aether-substrate/src/chassis/builder.rs` | 14 | 14 test-only `impl Kind for X` blocks: swap `encode_into_bytes` and `decode_from_bytes` (trait order is decode → encode). Single `replace_all` since the method bodies are byte-identical across all blocks. |
| `aether-actor/src/log.rs` | 1 | `impl Visit for MessageBuilder` — `record_i64 → record_u64 → record_bool → record_str → record_debug` (the required `record_debug` goes last in tracing-core's trait declaration). |
| `aether-substrate/src/runtime/panic_hook.rs` | 1 | `impl Visit for StringVisit<'_>` — `record_str` before `record_debug`, same trait. |
| `aether-substrate-bundle/src/desktop/driver.rs` | 1 | `impl ApplicationHandler<UserEvent> for App` — `resumed → user_event → window_event → about_to_wait` per winit's trait order. |
| `aether-data/src/ids.rs` | 1 | `impl Visitor<'_> for IdVisitor` — `visit_i64 → visit_u64 → visit_str` per serde's `Visitor` order. |
| `aether-substrate-bundle/src/test_bench/bench.rs` | 1 | `impl DataKind for Bump` — same decode-before-encode swap. |

## Suspected false positive (skipped)

- `crates/aether-mcp/src/tools.rs:439` — the finding line is inside `impl Mcp { async fn deliver_one(...) }`, a single-method **inherent** impl with no trait. `RsSortImplTraitMembers` should only fire on trait impls. The adjacent `#[tool_handler] impl ServerHandler for Mcp` at line 444 only defines `get_info`, so there's nothing to reorder there either. Likely Qodana is confused by the `#[tool_handler]` macro expansion adding hidden trait members it then can't find in source. Queued for baseline absorption.

## Verification (lessons from PR iamacoffeepot/aether#924 applied)

- `cargo check --workspace --all-targets` — clean
- `cargo build --target wasm32-unknown-unknown -p <crate>` for the 5 component crates (`aether-actor`, `aether-camera`, `aether-mesh-viewer`, `aether-test-fixture-probe`, `aether-demo-sokoban`) — all green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001/1001 passed

`Cargo.lock` carries a small auto-cleanup byproduct of cargo resolving the workspace from a clean state (the duplicated `png 0.17.16` + `png 0.18.1` entries collapse to a single `png 0.18.1`; same for a few other transitive crates). Not a substantive change.

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
- iamacoffeepot/aether#924 — Phase 3 (whose CI failures motivated the wasm32 + fmt pre-flight additions used here)
