### PR TITLE
chore(substrate): qodana phase 5 — drop unnecessary path qualifications

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -914,8 +914,8 @@ mod tests {
             sender: ReplyTo::with_correlation(ReplyTarget::None, correlation),
             payload,
             count: 1,
-            mail_id: crate::mail::MailId::NONE,
-            root: crate::mail::MailId::NONE,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
             parent_mail: None,
         }
     }

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -167,7 +167,7 @@ impl<'a> NativeCtx<'a> {
     /// reads this to populate `LogEntry::origin` from the envelope
     /// rather than the payload.
     #[must_use]
-    pub fn origin(&self) -> Option<aether_data::MailboxId> {
+    pub fn origin(&self) -> Option<MailboxId> {
         match self.sender.target {
             crate::mail::ReplyTarget::Component(id) => Some(id),
             _ => None,
@@ -241,7 +241,7 @@ impl<'a> NativeCtx<'a> {
     /// [`NativeBinding::new_for_test`] (no spawner / actor registry
     /// wired) — fail-fast per ADR-0063: production transports always
     /// carry both, so handler code never reaches the panic.
-    pub fn monitor(&self, target: aether_data::MailboxId) -> Result<MonitorHandle, MonitorError> {
+    pub fn monitor(&self, target: MailboxId) -> Result<MonitorHandle, MonitorError> {
         let spawner = self
             .binding
             .spawner()
@@ -537,7 +537,7 @@ impl<'a> NativeInitCtx<'a> {
     /// registration completes; replies route correctly once the spawn
     /// lifecycle finishes inserting the entry.
     #[must_use]
-    pub fn self_id(&self) -> crate::mail::MailboxId {
+    pub fn self_id(&self) -> MailboxId {
         self.binding.self_mailbox()
     }
 
@@ -663,7 +663,7 @@ impl OutboundReply for NativeCtx<'_> {
         Some(self.sender)
     }
 
-    fn origin(&self) -> Option<aether_data::MailboxId> {
+    fn origin(&self) -> Option<MailboxId> {
         match self.sender.target {
             crate::mail::ReplyTarget::Component(id) => Some(id),
             _ => None,
@@ -687,7 +687,7 @@ impl SyncWaiter for NativeCtx<'_> {
         expected_correlation: u64,
     ) -> Result<K, E>
     where
-        K: aether_data::Kind + serde::de::DeserializeOwned,
+        K: Kind + serde::de::DeserializeOwned,
         E: WaitError,
     {
         aether_actor::actor::ctx::sync_waiter::wait_reply_via::<K, E>(
@@ -707,7 +707,7 @@ impl LifecycleControl for NativeCtx<'_> {
         self.binding.signal_shutdown();
     }
 
-    fn monitor(&self, target: aether_data::MailboxId) -> Result<MonitorHandle, MonitorError> {
+    fn monitor(&self, target: MailboxId) -> Result<MonitorHandle, MonitorError> {
         let spawner = self.binding.spawner().expect(
             "NativeCtx::monitor requires a chassis-built transport (no spawner installed — likely a `new_for_test` transport)",
         );
@@ -794,7 +794,7 @@ mod tests {
         const SCHEDULING: aether_actor::Scheduling = aether_actor::Scheduling::Dedicated;
     }
 
-    impl aether_actor::Singleton for StubActor {}
+    impl Singleton for StubActor {}
 
     impl NativeActor for StubActor {
         type Config = ();

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -563,7 +563,7 @@ mod tests {
             inherited_mail_id,
             inherited_root,
             move |mut inherit| {
-                std::thread::sleep(Duration::from_millis(50));
+                thread::sleep(Duration::from_millis(50));
                 pause_done_clone.store(true, Ordering::SeqCst);
                 <InheritCtx<StubActor> as Sender>::send_to_named(
                     &mut inherit,
@@ -593,7 +593,7 @@ mod tests {
         let recipient = registry
             .lookup("test.spawn_thread.recipient")
             .expect("recipient registered");
-        let kind = <aether_kinds::Tick as aether_data::Kind>::ID;
+        let kind = <aether_kinds::Tick as Kind>::ID;
         let payload = aether_data::encode_empty::<aether_kinds::Tick>();
         mailer.push(Mail::new(recipient, KindId(kind.0), payload, 1));
 

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -562,14 +562,9 @@ mod tests {
     /// doesn't drag in `NativeActor`.
     fn insert_live_stub(r: &ActorRegistry, id: MailboxId) {
         struct Stub;
-        let (tx, _rx) = std::sync::mpsc::channel::<crate::actor::native::envelope::Envelope>();
-        r.insert_live(
-            id,
-            Arc::new(tx),
-            std::any::TypeId::of::<Stub>(),
-            String::new(),
-        )
-        .expect("fresh slot");
+        let (tx, _rx) = std::sync::mpsc::channel::<Envelope>();
+        r.insert_live(id, Arc::new(tx), TypeId::of::<Stub>(), String::new())
+            .expect("fresh slot");
     }
 
     #[test]

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -1235,11 +1235,7 @@ mod tests {
     fn send_propagates_in_flight_lineage_on_closure_branch() {
         use std::sync::Mutex;
 
-        type Captured = (
-            crate::mail::MailId,
-            crate::mail::MailId,
-            Option<crate::mail::MailId>,
-        );
+        type Captured = (MailId, MailId, Option<MailId>);
         let captured: Arc<Mutex<Vec<Captured>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
 
@@ -1272,8 +1268,8 @@ mod tests {
 
         // Inbound lineage: the chassis-driven tick chain we're "in"
         // when the wasm guest's on_tick handler fires its outbound.
-        let inbound_root = crate::mail::MailId::new(MailboxId::CHASSIS_MAILBOX_ID, 7);
-        let inbound_mail = crate::mail::MailId::new(
+        let inbound_root = MailId::new(MailboxId::CHASSIS_MAILBOX_ID, 7);
+        let inbound_mail = MailId::new(
             MailboxId(aether_data::with_tag(
                 aether_data::tagged_id::Tag::Mailbox,
                 0x99,
@@ -1307,11 +1303,7 @@ mod tests {
     fn send_without_in_flight_mints_fresh_root_chain() {
         use std::sync::Mutex;
 
-        type Captured = (
-            crate::mail::MailId,
-            crate::mail::MailId,
-            Option<crate::mail::MailId>,
-        );
+        type Captured = (MailId, MailId, Option<MailId>);
         let captured: Arc<Mutex<Vec<Captured>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_for_handler = Arc::clone(&captured);
 

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -221,7 +221,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                 caps.handlers.push(HandlerCapability {
                     id,
                     name: name.into_owned(),
-                    doc: doc.map(std::borrow::Cow::into_owned),
+                    doc: doc.map(Cow::into_owned),
                 });
             }
             InputsRecord::Fallback { doc } => {
@@ -231,7 +231,7 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                     ));
                 }
                 caps.fallback = Some(FallbackCapability {
-                    doc: doc.map(std::borrow::Cow::into_owned),
+                    doc: doc.map(Cow::into_owned),
                 });
             }
             InputsRecord::Component { doc } => {

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1497,7 +1497,7 @@ impl<C: Chassis> BuiltChassis<C> {
         subname: &str,
     ) -> Option<MailboxId> {
         let full_name = format!("{}:{}", A::NAMESPACE, subname);
-        let id = MailboxId(aether_data::mailbox_id_from_name(&full_name).0);
+        let id = MailboxId(mailbox_id_from_name(&full_name).0);
         let type_id = self.booted.actor_registry.type_id_at(id)?;
         if type_id != std::any::TypeId::of::<A>() {
             return None;
@@ -1644,7 +1644,7 @@ impl<C: Chassis> PassiveChassis<C> {
         subname: &str,
     ) -> Option<MailboxId> {
         let full_name = format!("{}:{}", A::NAMESPACE, subname);
-        let id = MailboxId(aether_data::mailbox_id_from_name(&full_name).0);
+        let id = MailboxId(mailbox_id_from_name(&full_name).0);
         let type_id = self.booted.actor_registry.type_id_at(id)?;
         if type_id != std::any::TypeId::of::<A>() {
             return None;
@@ -1711,22 +1711,19 @@ mod tests {
     /// (per-cap dispatch coverage lives in `aether-capabilities`); the
     /// real caps would force a circular dep, so this stub stands in.
     struct StubLog;
-    impl aether_actor::Actor for StubLog {
+    impl Actor for StubLog {
         const NAMESPACE: &'static str = "test.chassis_builder.stub_log";
     }
     impl aether_actor::Singleton for StubLog {}
 
-    impl crate::actor::native::NativeActor for StubLog {
+    impl NativeActor for StubLog {
         type Config = ();
-        fn init(
-            (): Self::Config,
-            _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
+        fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             Ok(Self)
         }
     }
 
-    impl crate::actor::native::NativeDispatch for StubLog {
+    impl NativeDispatch for StubLog {
         fn __aether_dispatch_envelope(
             &mut self,
             _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -1839,23 +1836,20 @@ mod tests {
     #[test]
     fn failed_singleton_init_releases_namespace_and_sink() {
         struct FailingCap;
-        impl aether_actor::Actor for FailingCap {
+        impl Actor for FailingCap {
             const NAMESPACE: &'static str = "test.phase7.failing_cap";
         }
         impl aether_actor::Singleton for FailingCap {}
 
-        impl crate::actor::native::NativeActor for FailingCap {
+        impl NativeActor for FailingCap {
             type Config = ();
-            fn init(
-                (): (),
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Err(BootError::Other(Box::new(std::io::Error::other(
                     "intentional init failure for Phase 7 cleanup test",
                 ))))
             }
         }
-        impl crate::actor::native::NativeDispatch for FailingCap {
+        impl NativeDispatch for FailingCap {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -1911,7 +1905,7 @@ mod tests {
             const NAME: &'static str = "test.with_actor.ping";
             const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0001);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -1926,18 +1920,15 @@ mod tests {
         struct ProbeCap {
             received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for ProbeCap {
+        impl Actor for ProbeCap {
             const NAMESPACE: &'static str = "test.with_actor.probe";
         }
         impl aether_actor::Singleton for ProbeCap {}
-        impl aether_actor::HandlesKind<Ping> for ProbeCap {}
+        impl HandlesKind<Ping> for ProbeCap {}
 
-        impl crate::actor::native::NativeActor for ProbeCap {
+        impl NativeActor for ProbeCap {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { received: config })
             }
         }
@@ -1945,7 +1936,7 @@ mod tests {
         // Hand-rolled NativeDispatch — what the macro arm emits in
         // task #731. The if-arm decodes Ping bytes, calls the
         // handler, returns Some(()) on success.
-        impl crate::actor::native::NativeDispatch for ProbeCap {
+        impl NativeDispatch for ProbeCap {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -1977,7 +1968,7 @@ mod tests {
         // sink handler. The dispatcher thread pulls from its inbox
         // and routes through __aether_dispatch_envelope → on_ping.
         let mailbox_id = registry
-            .lookup(<ProbeCap as aether_actor::Actor>::NAMESPACE)
+            .lookup(<ProbeCap as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
         let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
         else {
@@ -2017,23 +2008,20 @@ mod tests {
     #[test]
     fn with_actor_supports_frame_barrier_caps() {
         struct FrameBoundProbe;
-        impl aether_actor::Actor for FrameBoundProbe {
+        impl Actor for FrameBoundProbe {
             const NAMESPACE: &'static str = "test.with_actor.frame_bound";
             const FRAME_BARRIER: bool = true;
         }
         impl aether_actor::Singleton for FrameBoundProbe {}
 
-        impl crate::actor::native::NativeActor for FrameBoundProbe {
+        impl NativeActor for FrameBoundProbe {
             type Config = ();
-            fn init(
-                (): (),
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self)
             }
         }
 
-        impl crate::actor::native::NativeDispatch for FrameBoundProbe {
+        impl NativeDispatch for FrameBoundProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2080,7 +2068,7 @@ mod tests {
             const NAME: &'static str = "test.local.tick";
             const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0002);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2097,11 +2085,11 @@ mod tests {
         struct LocalProbe {
             observed: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for LocalProbe {
+        impl Actor for LocalProbe {
             const NAMESPACE: &'static str = "test.local.probe";
         }
         impl aether_actor::Singleton for LocalProbe {}
-        impl aether_actor::HandlesKind<Tick> for LocalProbe {}
+        impl HandlesKind<Tick> for LocalProbe {}
 
         // Newtype-per-slot is the Local convention: each
         // logical storage gets its own type, so two probes that
@@ -2112,12 +2100,9 @@ mod tests {
         #[aether_actor::local]
         struct Counter(u32);
 
-        impl crate::actor::native::NativeActor for LocalProbe {
+        impl NativeActor for LocalProbe {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 // Init runs inside the chassis builder's stamp guard
                 // — write a sentinel so the handler test below proves
                 // the same slots are reused across init→dispatch.
@@ -2126,7 +2111,7 @@ mod tests {
             }
         }
 
-        impl crate::actor::native::NativeDispatch for LocalProbe {
+        impl NativeDispatch for LocalProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2152,7 +2137,7 @@ mod tests {
             .expect("LocalProbe boots");
 
         let mailbox_id = registry
-            .lookup(<LocalProbe as aether_actor::Actor>::NAMESPACE)
+            .lookup(<LocalProbe as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
         let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
         else {
@@ -2210,7 +2195,7 @@ mod tests {
             const NAME: &'static str = "test.spawn_child.hatch";
             const ID: DataKindId = DataKindId(0xC0C1_C2C3_C4C5_C6C7);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2229,7 +2214,7 @@ mod tests {
             const NAME: &'static str = "test.spawn_child.ping";
             const ID: DataKindId = DataKindId(0xD0D1_D2D3_D4D5_D6D7);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2242,21 +2227,18 @@ mod tests {
         struct ChildCap {
             received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for ChildCap {
+        impl Actor for ChildCap {
             const NAMESPACE: &'static str = "test.spawn_child.child";
         }
         impl Instanced for ChildCap {}
         impl HandlesKind<Ping> for ChildCap {}
-        impl crate::actor::native::NativeActor for ChildCap {
+        impl NativeActor for ChildCap {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { received: config })
             }
         }
-        impl crate::actor::native::NativeDispatch for ChildCap {
+        impl NativeDispatch for ChildCap {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2276,16 +2258,16 @@ mod tests {
             spawn_count: Arc<AtomicU32>,
             child_received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for ParentCap {
+        impl Actor for ParentCap {
             const NAMESPACE: &'static str = "test.spawn_child.parent";
         }
         impl aether_actor::Singleton for ParentCap {}
         impl HandlesKind<Hatch> for ParentCap {}
-        impl crate::actor::native::NativeActor for ParentCap {
+        impl NativeActor for ParentCap {
             type Config = (Arc<AtomicU32>, Arc<AtomicU32>);
             fn init(
                 (spawn_count, child_received): Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
+                _ctx: &mut NativeInitCtx<'_>,
             ) -> Result<Self, BootError> {
                 Ok(Self {
                     spawn_count,
@@ -2293,7 +2275,7 @@ mod tests {
                 })
             }
         }
-        impl crate::actor::native::NativeDispatch for ParentCap {
+        impl NativeDispatch for ParentCap {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2327,7 +2309,7 @@ mod tests {
         // calls `ctx.spawn_child::<ChildCap>` which in turn pushes a
         // Ping at the new child via the after_init bootstrap.
         let parent_id = registry
-            .lookup(<ParentCap as aether_actor::Actor>::NAMESPACE)
+            .lookup(<ParentCap as Actor>::NAMESPACE)
             .expect("ParentCap claimed");
         let MailboxEntry::Inbox(handler) = registry.entry(parent_id).expect("sink") else {
             panic!("expected mailbox entry");
@@ -2358,8 +2340,7 @@ mod tests {
         );
 
         // Child is Live in the chassis's actor registry.
-        let child_id =
-            crate::mail::MailboxId(aether_data::mailbox_id_from_name("test.spawn_child.child:0").0);
+        let child_id = MailboxId(mailbox_id_from_name("test.spawn_child.child:0").0);
         assert!(
             chassis.actor_registry().is_live(child_id),
             "spawned child should be Live in the actor registry under the deterministic full-name id"
@@ -2390,7 +2371,7 @@ mod tests {
             const NAME: &'static str = "test.shutdown.quit";
             const ID: DataKindId = DataKindId(0xE0E1_E2E3_E4E5_E6E7);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2403,17 +2384,14 @@ mod tests {
         struct Closer {
             close_observed: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Closer {
+        impl Actor for Closer {
             const NAMESPACE: &'static str = "test.shutdown.closer";
         }
         impl Instanced for Closer {}
         impl HandlesKind<Quit> for Closer {}
-        impl crate::actor::native::NativeActor for Closer {
+        impl NativeActor for Closer {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     close_observed: config,
                 })
@@ -2422,7 +2400,7 @@ mod tests {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for Closer {
+        impl NativeDispatch for Closer {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2526,16 +2504,13 @@ mod tests {
         struct Quiet {
             close_observed: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Quiet {
+        impl Actor for Quiet {
             const NAMESPACE: &'static str = "test.teardown.quiet";
         }
         impl Instanced for Quiet {}
-        impl crate::actor::native::NativeActor for Quiet {
+        impl NativeActor for Quiet {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     close_observed: config,
                 })
@@ -2544,7 +2519,7 @@ mod tests {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for Quiet {
+        impl NativeDispatch for Quiet {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2600,16 +2575,13 @@ mod tests {
         struct Quiet {
             close_observed: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Quiet {
+        impl Actor for Quiet {
             const NAMESPACE: &'static str = "test.teardown.quiet_many";
         }
         impl Instanced for Quiet {}
-        impl crate::actor::native::NativeActor for Quiet {
+        impl NativeActor for Quiet {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     close_observed: config,
                 })
@@ -2618,7 +2590,7 @@ mod tests {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for Quiet {
+        impl NativeDispatch for Quiet {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2687,7 +2659,7 @@ mod tests {
             const NAME: &'static str = "test.monitor.quit";
             const ID: DataKindId = DataKindId(0xC0DE_C0DE_4B4B_4B4B);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2708,7 +2680,7 @@ mod tests {
             const NAME: &'static str = "test.monitor.watch_order";
             const ID: DataKindId = DataKindId(0x4B4B_C0DE_C0DE_C0DE);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2720,21 +2692,18 @@ mod tests {
 
         // Target — handles Quit by self-shutting.
         struct Target;
-        impl aether_actor::Actor for Target {
+        impl Actor for Target {
             const NAMESPACE: &'static str = "test.monitor.target";
         }
         impl Instanced for Target {}
         impl HandlesKind<Quit> for Target {}
-        impl crate::actor::native::NativeActor for Target {
+        impl NativeActor for Target {
             type Config = ();
-            fn init(
-                (): Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self)
             }
         }
-        impl crate::actor::native::NativeDispatch for Target {
+        impl NativeDispatch for Target {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2758,18 +2727,15 @@ mod tests {
             last_target: Arc<AtomicU64>,
             handle: Mutex<Option<crate::actor::monitor::MonitorHandle>>,
         }
-        impl aether_actor::Actor for Watcher {
+        impl Actor for Watcher {
             const NAMESPACE: &'static str = "test.monitor.watcher";
         }
         impl Instanced for Watcher {}
         impl HandlesKind<WatchOrder> for Watcher {}
         impl HandlesKind<aether_kinds::MonitorNotice> for Watcher {}
-        impl crate::actor::native::NativeActor for Watcher {
+        impl NativeActor for Watcher {
             type Config = (Arc<AtomicU32>, Arc<AtomicU64>);
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     notice_count: config.0,
                     last_target: config.1,
@@ -2777,7 +2743,7 @@ mod tests {
                 })
             }
         }
-        impl crate::actor::native::NativeDispatch for Watcher {
+        impl NativeDispatch for Watcher {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -2786,18 +2752,15 @@ mod tests {
             ) -> Option<()> {
                 if kind.0 == WatchOrder::ID.0 {
                     let order = WatchOrder::decode_from_bytes(payload)?;
-                    let target = aether_data::MailboxId(order.target_id);
+                    let target = MailboxId(order.target_id);
                     let h = ctx
                         .monitor(target)
                         .expect("target must be Live at order time");
                     *self.handle.lock().unwrap() = Some(h);
                     return Some(());
                 }
-                if kind.0 == <aether_kinds::MonitorNotice as aether_data::Kind>::ID.0 {
-                    let notice =
-                        <aether_kinds::MonitorNotice as aether_data::Kind>::decode_from_bytes(
-                            payload,
-                        )?;
+                if kind.0 == <aether_kinds::MonitorNotice as Kind>::ID.0 {
+                    let notice = <aether_kinds::MonitorNotice as Kind>::decode_from_bytes(payload)?;
                     self.last_target
                         .store(notice.target.0, AtomicOrdering::SeqCst);
                     self.notice_count.fetch_add(1, AtomicOrdering::SeqCst);
@@ -2944,7 +2907,7 @@ mod tests {
             const NAME: &'static str = "test.monitor.quit2";
             const ID: DataKindId = DataKindId(0xCAFE_BABE_DEAD_BEEF);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2962,7 +2925,7 @@ mod tests {
             const NAME: &'static str = "test.monitor.watch_order2";
             const ID: DataKindId = DataKindId(0xBEEF_DEAD_BABE_CAFE);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -2973,20 +2936,17 @@ mod tests {
         }
 
         struct Target;
-        impl aether_actor::Actor for Target {
+        impl Actor for Target {
             const NAMESPACE: &'static str = "test.monitor.target2";
         }
         impl Instanced for Target {}
-        impl crate::actor::native::NativeActor for Target {
+        impl NativeActor for Target {
             type Config = ();
-            fn init(
-                (): Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self)
             }
         }
-        impl crate::actor::native::NativeDispatch for Target {
+        impl NativeDispatch for Target {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3001,18 +2961,15 @@ mod tests {
             handle: Mutex<Option<crate::actor::monitor::MonitorHandle>>,
             close_observed: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Watcher {
+        impl Actor for Watcher {
             const NAMESPACE: &'static str = "test.monitor.watcher2";
         }
         impl Instanced for Watcher {}
         impl HandlesKind<WatchOrder> for Watcher {}
         impl HandlesKind<Quit> for Watcher {}
-        impl crate::actor::native::NativeActor for Watcher {
+        impl NativeActor for Watcher {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     handle: Mutex::new(None),
                     close_observed: config,
@@ -3022,7 +2979,7 @@ mod tests {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for Watcher {
+        impl NativeDispatch for Watcher {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3031,7 +2988,7 @@ mod tests {
             ) -> Option<()> {
                 if kind.0 == WatchOrder::ID.0 {
                     let order = WatchOrder::decode_from_bytes(payload)?;
-                    let target = aether_data::MailboxId(order.target_id);
+                    let target = MailboxId(order.target_id);
                     let h = ctx.monitor(target).expect("target Live");
                     *self.handle.lock().unwrap() = Some(h);
                     return Some(());
@@ -3154,7 +3111,7 @@ mod tests {
             const NAME: &'static str = "test.resolve.quit";
             const ID: DataKindId = DataKindId(0xF00D_F00D_F00D_F00D);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -3173,21 +3130,18 @@ mod tests {
         struct Member {
             tag: u32,
         }
-        impl aether_actor::Actor for Member {
+        impl Actor for Member {
             const NAMESPACE: &'static str = "test.resolve.member";
         }
         impl Instanced for Member {}
         impl HandlesKind<Quit> for Member {}
-        impl crate::actor::native::NativeActor for Member {
+        impl NativeActor for Member {
             type Config = u32;
-            fn init(
-                tag: u32,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(tag: u32, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { tag })
             }
         }
-        impl crate::actor::native::NativeDispatch for Member {
+        impl NativeDispatch for Member {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3303,20 +3257,17 @@ mod tests {
         use aether_actor::Instanced;
 
         struct Foo;
-        impl aether_actor::Actor for Foo {
+        impl Actor for Foo {
             const NAMESPACE: &'static str = "test.resolve_mismatch.foo";
         }
         impl Instanced for Foo {}
-        impl crate::actor::native::NativeActor for Foo {
+        impl NativeActor for Foo {
             type Config = ();
-            fn init(
-                (): (),
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self)
             }
         }
-        impl crate::actor::native::NativeDispatch for Foo {
+        impl NativeDispatch for Foo {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3328,20 +3279,17 @@ mod tests {
         }
 
         struct Bar;
-        impl aether_actor::Actor for Bar {
+        impl Actor for Bar {
             const NAMESPACE: &'static str = "test.resolve_mismatch.bar";
         }
         impl Instanced for Bar {}
-        impl crate::actor::native::NativeActor for Bar {
+        impl NativeActor for Bar {
             type Config = ();
-            fn init(
-                (): (),
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self)
             }
         }
-        impl crate::actor::native::NativeDispatch for Bar {
+        impl NativeDispatch for Bar {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3411,7 +3359,7 @@ mod tests {
             const NAME: &'static str = "test.recursive.hatch";
             const ID: DataKindId = DataKindId(0xA00A_A00A_A00A_A00A);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -3431,7 +3379,7 @@ mod tests {
             const NAME: &'static str = "test.recursive.ping";
             const ID: DataKindId = DataKindId(0xB00B_B00B_B00B_B00B);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -3451,7 +3399,7 @@ mod tests {
             const NAME: &'static str = "test.recursive.quit";
             const ID: DataKindId = DataKindId(0xC00C_C00C_C00C_C00C);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -3464,21 +3412,18 @@ mod tests {
         struct Grandchild {
             received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Grandchild {
+        impl Actor for Grandchild {
             const NAMESPACE: &'static str = "test.recursive.grandchild";
         }
         impl Instanced for Grandchild {}
         impl HandlesKind<Ping> for Grandchild {}
-        impl crate::actor::native::NativeActor for Grandchild {
+        impl NativeActor for Grandchild {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { received: config })
             }
         }
-        impl crate::actor::native::NativeDispatch for Grandchild {
+        impl NativeDispatch for Grandchild {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3497,24 +3442,21 @@ mod tests {
         struct Parent {
             grandchild_received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Parent {
+        impl Actor for Parent {
             const NAMESPACE: &'static str = "test.recursive.parent";
         }
         impl Instanced for Parent {}
         impl HandlesKind<Hatch> for Parent {}
         impl HandlesKind<Quit> for Parent {}
-        impl crate::actor::native::NativeActor for Parent {
+        impl NativeActor for Parent {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self {
                     grandchild_received: config,
                 })
             }
         }
-        impl crate::actor::native::NativeDispatch for Parent {
+        impl NativeDispatch for Parent {
             fn __aether_dispatch_envelope(
                 &mut self,
                 ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3588,9 +3530,7 @@ mod tests {
         // Grandchild is Live in the registry under the deterministic
         // full-name id (NAMESPACE = "test.recursive.grandchild",
         // subname = "only").
-        let grandchild_id = crate::mail::MailboxId(
-            aether_data::mailbox_id_from_name("test.recursive.grandchild:only").0,
-        );
+        let grandchild_id = MailboxId(mailbox_id_from_name("test.recursive.grandchild:only").0);
         assert!(
             chassis.actor_registry().is_live(grandchild_id),
             "grandchild should be Live in the registry under the deterministic full-name id",
@@ -3652,23 +3592,20 @@ mod tests {
         struct WireProbe {
             wire_count: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for WireProbe {
+        impl Actor for WireProbe {
             const NAMESPACE: &'static str = "test.wire.singleton";
         }
         impl aether_actor::Singleton for WireProbe {}
-        impl crate::actor::native::NativeActor for WireProbe {
+        impl NativeActor for WireProbe {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_count: config })
             }
             fn wire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
                 self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for WireProbe {
+        impl NativeDispatch for WireProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3730,7 +3667,7 @@ mod tests {
             const NAME: &'static str = "test.barrier.wire_ping";
             const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -3743,16 +3680,13 @@ mod tests {
         struct Pinger {
             wire_ran: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Pinger {
+        impl Actor for Pinger {
             const NAMESPACE: &'static str = "test.barrier.pinger";
         }
         impl aether_actor::Singleton for Pinger {}
-        impl crate::actor::native::NativeActor for Pinger {
+        impl NativeActor for Pinger {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_ran: config })
             }
             fn wire(&mut self, ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
@@ -3763,7 +3697,7 @@ mod tests {
                 self.wire_ran.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for Pinger {
+        impl NativeDispatch for Pinger {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3777,21 +3711,18 @@ mod tests {
         struct Ponger {
             received: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for Ponger {
+        impl Actor for Ponger {
             const NAMESPACE: &'static str = "test.barrier.ponger";
         }
         impl aether_actor::Singleton for Ponger {}
-        impl aether_actor::HandlesKind<WireBarrierPing> for Ponger {}
-        impl crate::actor::native::NativeActor for Ponger {
+        impl HandlesKind<WireBarrierPing> for Ponger {}
+        impl NativeActor for Ponger {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { received: config })
             }
         }
-        impl crate::actor::native::NativeDispatch for Ponger {
+        impl NativeDispatch for Ponger {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
@@ -3858,23 +3789,20 @@ mod tests {
         struct WireSpawnProbe {
             wire_count: Arc<AtomicU32>,
         }
-        impl aether_actor::Actor for WireSpawnProbe {
+        impl Actor for WireSpawnProbe {
             const NAMESPACE: &'static str = "test.spawn_wire.probe";
         }
         impl Instanced for WireSpawnProbe {}
-        impl crate::actor::native::NativeActor for WireSpawnProbe {
+        impl NativeActor for WireSpawnProbe {
             type Config = Arc<AtomicU32>;
-            fn init(
-                config: Self::Config,
-                _ctx: &mut crate::actor::native::ctx::NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
+            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_count: config })
             }
             fn wire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
                 self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
-        impl crate::actor::native::NativeDispatch for WireSpawnProbe {
+        impl NativeDispatch for WireSpawnProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -307,7 +307,7 @@ mod tests {
 
     fn root(sender: u64, cid: u64) -> MailId {
         MailId {
-            sender: aether_data::MailboxId(sender),
+            sender: MailboxId(sender),
             correlation_id: cid,
         }
     }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -524,7 +524,7 @@ mod tests {
     /// mailbox id / kind / payload / count the caller pushed.
     #[test]
     fn unknown_mailbox_with_connected_outbound_bubbles_up() {
-        let (outbound, outbound_rx) = crate::mail::outbound::HubOutbound::attached_loopback();
+        let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(64 * 1024));
 
@@ -599,13 +599,13 @@ mod tests {
 
     fn note_schema() -> SchemaType {
         SchemaType::Struct {
-            fields: std::borrow::Cow::Owned(vec![
+            fields: Cow::Owned(vec![
                 NamedField {
-                    name: std::borrow::Cow::Borrowed("body"),
+                    name: Cow::Borrowed("body"),
                     ty: SchemaType::String,
                 },
                 NamedField {
-                    name: std::borrow::Cow::Borrowed("seq"),
+                    name: Cow::Borrowed("seq"),
                     ty: SchemaType::Scalar(Primitive::U32),
                 },
             ]),
@@ -615,13 +615,13 @@ mod tests {
 
     fn held_note_schema() -> SchemaType {
         SchemaType::Struct {
-            fields: std::borrow::Cow::Owned(vec![
+            fields: Cow::Owned(vec![
                 NamedField {
-                    name: std::borrow::Cow::Borrowed("held"),
+                    name: Cow::Borrowed("held"),
                     ty: SchemaType::Ref(SchemaCell::owned(note_schema())),
                 },
                 NamedField {
-                    name: std::borrow::Cow::Borrowed("seq"),
+                    name: Cow::Borrowed("seq"),
                     ty: SchemaType::Scalar(Primitive::U32),
                 },
             ]),
@@ -881,7 +881,7 @@ mod tests {
         let sender = MailboxId(0x8380_0003_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
-        let (outbound, outbound_rx) = crate::mail::outbound::HubOutbound::attached_loopback();
+        let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Mailer::new(Arc::clone(&registry), store).with_outbound(Arc::clone(&outbound));
@@ -1243,7 +1243,7 @@ mod tests {
                 run: Box::new(|| {
                     let sender = MailboxId(0x8380_DD05_0000_0000);
                     let mail_id = MailId::new(sender, 1);
-                    let (outbound, _rx) = crate::mail::outbound::HubOutbound::attached_loopback();
+                    let (outbound, _rx) = HubOutbound::attached_loopback();
                     let registry = Arc::new(Registry::new());
                     let store = Arc::new(HandleStore::new(64 * 1024));
                     let mailer = Mailer::new(registry, store).with_outbound(outbound);
@@ -1328,13 +1328,8 @@ mod tests {
                     let (_registry, mailer, _store) = make_mailer();
                     mailer.install_chassis_router(Box::new(|_| {}));
                     mailer.push(
-                        Mail::new(
-                            aether_data::MailboxId::CHASSIS_MAILBOX_ID,
-                            KindId(0xFEED),
-                            vec![],
-                            1,
-                        )
-                        .with_lineage(mail_id, mail_id, None),
+                        Mail::new(MailboxId::CHASSIS_MAILBOX_ID, KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
                     );
                     mail_id
                 }),
@@ -1348,13 +1343,8 @@ mod tests {
                     let mail_id = MailId::new(sender, 1);
                     let (_registry, mailer, _store) = make_mailer();
                     mailer.push(
-                        Mail::new(
-                            aether_data::MailboxId::CHASSIS_MAILBOX_ID,
-                            KindId(0xFEED),
-                            vec![],
-                            1,
-                        )
-                        .with_lineage(mail_id, mail_id, None),
+                        Mail::new(MailboxId::CHASSIS_MAILBOX_ID, KindId(0xFEED), vec![], 1)
+                            .with_lineage(mail_id, mail_id, None),
                     );
                     mail_id
                 }),

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -113,7 +113,7 @@ pub fn with_actor_dispatch<R>(dispatch: &dyn MailDispatch, f: impl FnOnce() -> R
 /// it. No-op when no dispatch is stamped (out-of-actor `drain_buffer`
 /// calls — shouldn't happen in normal flow).
 fn ship_via_stamped_dispatch(mailbox: MailboxId, kind: KindId, payload: &[u8]) {
-    let Some(dispatch) = ACTOR_DISPATCH.with(std::cell::Cell::get) else {
+    let Some(dispatch) = ACTOR_DISPATCH.with(Cell::get) else {
         return;
     };
     dispatch.send(mailbox, kind, payload);

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -302,7 +302,7 @@ fn ship_batch(
     queue: &Arc<SegQueue<TraceEvent>>,
     mailer: &Arc<Mailer>,
     recipient: MailboxId,
-    kind: aether_data::KindId,
+    kind: KindId,
 ) {
     let mut batch = Vec::with_capacity(BATCH_MAX);
     for _ in 0..BATCH_MAX {

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -318,7 +318,7 @@ mod tests {
             if f() {
                 return true;
             }
-            std::thread::sleep(Duration::from_millis(2));
+            thread::sleep(Duration::from_millis(2));
         }
         f()
     }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -275,7 +275,7 @@ pub trait Drainable: Send + Sync + 'static {
     /// Default no-op: mock fixtures don't have a real close cycle so
     /// they never need to signal. Idempotent — the slot only fires the
     /// first installed sender once; a re-install after close is a no-op.
-    fn set_close_done_tx(&self, _tx: crossbeam_channel::Sender<()>) {}
+    fn set_close_done_tx(&self, _tx: Sender<()>) {}
 
     /// Upcast helper for downcasting in tests. Production code doesn't
     /// reach for this.


### PR DESCRIPTION
Phase 5 of iamacoffeepot/aether#913 Qodana triage. `aether-substrate` held 186 of the 295 total `unused_qualifications` findings — the biggest single-crate slice.

Auto-applied via `cargo fix` with the `unused_qualifications` lint, then `cargo fmt` collapsed multi-line function signatures whose only reason for wrapping was the now-shortened paths. The compile-time delta is purely cosmetic: every removed path segment was already in scope via an existing `use`.

## Stats

- 161 individual lint sites fixed across 13 files
- `git diff --shortstat`: 13 files changed, 158 insertions(+), 253 deletions(-) — the deletion-heavy delta is the fmt cleanup, not extra removals.
- Re-running the lint after the first pass surfaced one cascade warning (`aether_data::mailbox_id_from_name` at `chassis/builder.rs:2362`) that became visible once an adjacent qualifier was removed; included in the count above.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001 passed, 0 skipped
- `cargo check -p aether-substrate --features render` — clean
- `cargo check -p aether-substrate --features render,audio` — clean

Scope is strictly `crates/aether-substrate/`; sibling agents are simultaneously fixing other crates so there are no cross-crate touches.

## Residuals

None known under the `unused_qualifications` lint with any combination of features I tested (default, `render`, `render,audio`). The lint was added to `src/lib.rs` for the workflow and reverted before commit, so this PR only carries the substantive edits.
