### PR TITLE
chore(data): qodana phase 5 — drop unnecessary path qualifications in data-layer cluster

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -309,7 +309,7 @@ mod native {
             if let Some(drain) = aether_actor::log::current_drain() {
                 let cfg = aether_kinds::ConfigureLogDrain { mailbox: drain };
                 let cfg_payload = bytemuck::bytes_of(&cfg).to_vec();
-                let kind = <aether_kinds::ConfigureLogDrain as aether_data::Kind>::ID;
+                let kind = <aether_kinds::ConfigureLogDrain as Kind>::ID;
                 self.mailer
                     .push(Mail::new(mailbox_id, kind, cfg_payload, 1));
             }

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -773,8 +773,8 @@ mod native {
                 .expect("test setup: adapter accepts atomic write");
             let siblings: Vec<String> = std::fs::read_dir(a.root())
                 .expect("test setup: adapter root is readable")
-                .filter_map(std::result::Result::ok)
-                .filter_map(|e| e.file_name().to_str().map(std::string::ToString::to_string))
+                .filter_map(Result::ok)
+                .filter_map(|e| e.file_name().to_str().map(ToString::to_string))
                 .collect();
             assert!(
                 !siblings.iter().any(|s| s.contains(".tmp-")),

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -591,7 +591,7 @@ mod native {
             (mailer, rx)
         }
 
-        fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
+        fn decode_reply<K: Kind + serde::de::DeserializeOwned>(
             rx: &std::sync::mpsc::Receiver<EgressEvent>,
         ) -> K {
             let event = rx

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -225,7 +225,7 @@ mod server_native {
             // Stop the accept thread.
             self.accept_shutdown.store(true, Ordering::Release);
             let addr_str = format!("127.0.0.1:{}", self.listener_port);
-            if let Ok(addr) = addr_str.parse::<std::net::SocketAddr>() {
+            if let Ok(addr) = addr_str.parse::<SocketAddr>() {
                 let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
             }
             if let Some(t) = self.accept_thread.take() {

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -152,7 +152,7 @@ mod listener_native {
             // connect timeout so a misconfigured listener (port
             // unreachable) doesn't hang the close path.
             let addr_str = format!("127.0.0.1:{}", self.local_port);
-            if let Ok(addr) = addr_str.parse::<std::net::SocketAddr>() {
+            if let Ok(addr) = addr_str.parse::<SocketAddr>() {
                 let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
             }
             if let Some(thread) = self.accept_thread.take() {

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -1507,8 +1507,7 @@ mod tests {
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
         let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let s = aether_data::tagged_id::encode(mailbox.0)
-            .expect("test setup: encode tagged mailbox id");
+        let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         let bytes = encode_schema(&json!({ "mailbox": s }), &schema)
             .expect("test setup: encode typed-id postcard field");
         let mut expected = Vec::new();
@@ -1541,11 +1540,9 @@ mod tests {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
-        let knd_string = aether_data::tagged_id::encode(aether_data::with_tag(
-            aether_data::Tag::Kind,
-            0xdead_beef,
-        ))
-        .expect("test setup: encode wrongly-tagged kind id");
+        let knd_string =
+            tagged_id::encode(aether_data::with_tag(aether_data::Tag::Kind, 0xdead_beef))
+                .expect("test setup: encode wrongly-tagged kind id");
         let err = encode_schema(&json!({ "mailbox": knd_string }), &schema)
             .expect_err("wrong tag must surface OutOfRange");
         assert!(matches!(err, EncodeError::OutOfRange { .. }));
@@ -1565,8 +1562,7 @@ mod tests {
             },
         ]);
         let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let s = aether_data::tagged_id::encode(mailbox.0)
-            .expect("test setup: encode tagged mailbox id");
+        let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         let bytes = encode_schema(&json!({ "stream": 1, "mailbox": s }), &schema)
             .expect("test setup: encode typed-id cast field");
         assert_eq!(bytes.len(), 16);

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -179,7 +179,7 @@ impl<T: CastEligible, const N: usize> CastEligible for [T; N] {
 impl CastEligible for alloc::string::String {
     const ELIGIBLE: bool = false;
 }
-impl<T> CastEligible for alloc::vec::Vec<T> {
+impl<T> CastEligible for Vec<T> {
     const ELIGIBLE: bool = false;
 }
 impl<T> CastEligible for Option<T> {
@@ -487,7 +487,7 @@ pub mod __derive_runtime {
     /// cast kinds aren't poisoned by a trait they can't satisfy.
     #[must_use]
     pub fn decode_cast<T: bytemuck::AnyBitPattern>(bytes: &[u8]) -> Option<T> {
-        if bytes.len() != core::mem::size_of::<T>() {
+        if bytes.len() != size_of::<T>() {
             return None;
         }
         Some(bytemuck::pod_read_unaligned(bytes))
@@ -522,14 +522,14 @@ pub mod __derive_runtime {
     /// call without the user crate needing `bytemuck` in scope. The
     /// `NoUninit` bound lives on the helper so non-cast kinds aren't
     /// poisoned by a trait their `#[repr(C)]`-less layout can't satisfy.
-    pub fn encode_cast<T: bytemuck::NoUninit>(value: &T) -> alloc::vec::Vec<u8> {
+    pub fn encode_cast<T: bytemuck::NoUninit>(value: &T) -> Vec<u8> {
         ::bytemuck::bytes_of(value).to_vec()
     }
 
     /// Postcard-shape encode helper. Mirror of `decode_postcard`. The
     /// `Serialize` bound lives here, not on `Kind`, so cast kinds stay
     /// independent of `serde`.
-    pub fn encode_postcard<T: serde::Serialize>(value: &T) -> alloc::vec::Vec<u8> {
+    pub fn encode_postcard<T: serde::Serialize>(value: &T) -> Vec<u8> {
         ::postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
     }
 }
@@ -598,9 +598,9 @@ pub fn encode_slice<T: Kind + bytemuck::NoUninit>(items: &[T]) -> Vec<u8> {
 /// Decode a single POD value. The input must match `size_of::<T>()`
 /// exactly and meet `T`'s alignment requirement.
 pub fn decode<T: Kind + bytemuck::AnyBitPattern + Copy>(bytes: &[u8]) -> Result<T, DecodeError> {
-    if bytes.len() != core::mem::size_of::<T>() {
+    if bytes.len() != size_of::<T>() {
         return Err(DecodeError::SizeMismatch {
-            expected: core::mem::size_of::<T>(),
+            expected: size_of::<T>(),
             actual: bytes.len(),
         });
     }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -186,7 +186,7 @@ pub struct DrawTriangle {
 /// has one canonical source. `repr(C)` + `Pod` + `[Vertex; 3]` packs
 /// without padding, so `size_of::<DrawTriangle>()` is exactly the
 /// per-triangle wire footprint.
-pub const DRAW_TRIANGLE_BYTES: usize = core::mem::size_of::<DrawTriangle>();
+pub const DRAW_TRIANGLE_BYTES: usize = size_of::<DrawTriangle>();
 
 /// Camera state: column-major `view_proj` matrix (world → clip). The
 /// desktop chassis's `camera` sink writes the latest payload into the

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -138,7 +138,7 @@ pub struct BatchedTraceEvents {
 )]
 #[kind(name = "aether.trace.describe_tree")]
 pub struct DescribeTree {
-    pub root: aether_data::MailId,
+    pub root: MailId,
 }
 
 /// Issue 718: reply to [`DescribeTree`]. `Ok` carries the root's
@@ -152,12 +152,12 @@ pub struct DescribeTree {
 #[kind(name = "aether.trace.describe_tree_result")]
 pub enum DescribeTreeResult {
     Ok {
-        root: aether_data::MailId,
+        root: MailId,
         in_flight: u32,
         mails: Vec<MailNodeWire>,
     },
     Err {
-        not_found: aether_data::MailId,
+        not_found: MailId,
     },
 }
 
@@ -336,5 +336,5 @@ pub enum DescribeWindowResult {
 )]
 #[kind(name = "aether.trace.settled")]
 pub struct Settled {
-    pub root: aether_data::MailId,
+    pub root: MailId,
 }

--- a/crates/aether-math/src/mat.rs
+++ b/crates/aether-math/src/mat.rs
@@ -361,6 +361,6 @@ mod tests {
 
     #[test]
     fn repr_c_size() {
-        assert_eq!(core::mem::size_of::<Mat4>(), 64);
+        assert_eq!(size_of::<Mat4>(), 64);
     }
 }

--- a/crates/aether-math/src/quat.rs
+++ b/crates/aether-math/src/quat.rs
@@ -196,6 +196,6 @@ mod tests {
 
     #[test]
     fn repr_c_size() {
-        assert_eq!(core::mem::size_of::<Quat>(), 16);
+        assert_eq!(size_of::<Quat>(), 16);
     }
 }

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -465,9 +465,9 @@ mod tests {
 
     #[test]
     fn repr_c_layout() {
-        assert_eq!(core::mem::size_of::<Vec2>(), 8);
-        assert_eq!(core::mem::size_of::<Vec3>(), 12);
-        assert_eq!(core::mem::size_of::<Vec4>(), 16);
-        assert_eq!(core::mem::align_of::<Vec4>(), 4);
+        assert_eq!(size_of::<Vec2>(), 8);
+        assert_eq!(size_of::<Vec3>(), 12);
+        assert_eq!(size_of::<Vec4>(), 16);
+        assert_eq!(align_of::<Vec4>(), 4);
     }
 }


### PR DESCRIPTION
Auto-applied via `cargo clippy --fix` with `-W unused_qualifications` across the five data-layer-adjacent crates: `aether-data`, `aether-kinds`, `aether-math`, `aether-capabilities`, and `aether-codec`. Followed by `cargo fmt` to absorb the suggestion's whitespace in `aether-codec/src/encode.rs`.

Diff is mechanical: drop redundant module prefixes when the symbol is already in scope.

Per-crate scope (matches Qodana's predictions for Phase 5):

| Crate | Files touched | Lines |
|---|---|---|
| aether-data | 1 | 12 |
| aether-kinds | 2 | 10 |
| aether-math | 3 | 12 |
| aether-capabilities | 5 | 12 |
| aether-codec | 1 | 14 |

The four no_std-friendly crates (`aether-data`, `aether-kinds`, `aether-codec`, `aether-math`) got both native and wasm32 passes so the import set stays matched across target sets. `aether-capabilities` is native-only.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo build --target wasm32-unknown-unknown -p aether-data -p aether-kinds -p aether-codec -p aether-math` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001 / 1001 pass

Refs iamacoffeepot/aether#913.

---

Generated with [Claude Code](https://claude.com/claude-code)
