### PR TITLE
chore(mesh): qodana phase 5 — drop unnecessary path qualifications in mesh + bundle

### DIFF
--- a/crates/aether-mesh/src/ast.rs
+++ b/crates/aether-mesh/src/ast.rs
@@ -85,25 +85,25 @@ pub enum Node {
     Composition(Vec<Self>),
     Translate {
         offset: Vec3,
-        child: std::boxed::Box<Self>,
+        child: Box<Self>,
     },
     Rotate {
         axis: Vec3,
         angle: f32,
-        child: std::boxed::Box<Self>,
+        child: Box<Self>,
     },
     Scale {
         factor: Vec3,
-        child: std::boxed::Box<Self>,
+        child: Box<Self>,
     },
     Mirror {
         axis: Axis,
-        child: std::boxed::Box<Self>,
+        child: Box<Self>,
     },
     Array {
         count: u32,
         spacing: Vec3,
-        child: std::boxed::Box<Self>,
+        child: Box<Self>,
     },
 }
 

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -341,7 +341,7 @@ mod tests {
         let mesh = IndexedMesh { vertices, polygons };
         let repaired = mesh.repair_tjunctions();
         let target = &repaired.polygons[1].vertices;
-        let mut counts = std::collections::HashMap::new();
+        let mut counts = HashMap::new();
         for &v in target {
             *counts.entry(v).or_insert(0) += 1;
         }
@@ -554,7 +554,7 @@ mod tests {
 
         // Every emitted polygon must be simple (no repeated vertex).
         for p in &repaired.polygons {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             for &v in &p.vertices {
                 assert!(
                     seen.insert(v),

--- a/crates/aether-mesh/src/cleanup/weld.rs
+++ b/crates/aether-mesh/src/cleanup/weld.rs
@@ -281,7 +281,7 @@ mod tests {
 
         // Find each shared coordinate's VertexId in each polygon and
         // assert they match.
-        let id_for = |poly_idx: usize, coord: Point3| -> super::VertexId {
+        let id_for = |poly_idx: usize, coord: Point3| -> VertexId {
             let poly = &mesh.polygons[poly_idx];
             for &id in &poly.vertices {
                 if mesh.vertices[id] == coord {

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -163,7 +163,7 @@ pub fn validate_manifold(polygons: &[Polygon]) -> Vec<ManifoldViolation> {
     }
 
     let mut violations = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     for &(a, b) in directed.keys() {
         let canonical = if a < b { (a, b) } else { (b, a) };
         if !seen.insert(canonical) {

--- a/crates/aether-mesh/src/parse.rs
+++ b/crates/aether-mesh/src/parse.rs
@@ -408,7 +408,7 @@ fn parse_translate(
     check_no_extra_keywords("translate", keywords, &[])?;
     Ok(Node::Translate {
         offset: as_vec3("translate", positional[0])?,
-        child: std::boxed::Box::new(parse_node(positional[1])?),
+        child: Box::new(parse_node(positional[1])?),
     })
 }
 
@@ -418,7 +418,7 @@ fn parse_rotate(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<
     Ok(Node::Rotate {
         axis: as_vec3("rotate", positional[0])?,
         angle: as_f32(positional[1])?,
-        child: std::boxed::Box::new(parse_node(positional[2])?),
+        child: Box::new(parse_node(positional[2])?),
     })
 }
 
@@ -427,7 +427,7 @@ fn parse_scale(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     check_no_extra_keywords("scale", keywords, &[])?;
     Ok(Node::Scale {
         factor: as_vec3("scale", positional[0])?,
-        child: std::boxed::Box::new(parse_node(positional[1])?),
+        child: Box::new(parse_node(positional[1])?),
     })
 }
 
@@ -441,7 +441,7 @@ fn parse_mirror(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<
         Axis::from_symbol(axis_sym).ok_or_else(|| ParseError::InvalidAxis(axis_sym.to_string()))?;
     Ok(Node::Mirror {
         axis,
-        child: std::boxed::Box::new(parse_node(positional[1])?),
+        child: Box::new(parse_node(positional[1])?),
     })
 }
 
@@ -451,7 +451,7 @@ fn parse_array(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     Ok(Node::Array {
         count: as_u32(positional[0])?,
         spacing: as_vec3("array", positional[1])?,
-        child: std::boxed::Box::new(parse_node(positional[2])?),
+        child: Box::new(parse_node(positional[2])?),
     })
 }
 

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -302,7 +302,7 @@ impl Mesh {
                     // (inherited from the parent triangle's CCW winding,
                     // since cyclic permutation preserves orientation).
                     let v_self = tri.verts[i];
-                    if super::predicates::in_circle(
+                    if in_circle(
                         self.vertices[v_self],
                         self.vertices[a],
                         self.vertices[b],

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -51,7 +51,7 @@ pub struct DesktopChassis;
 
 impl Chassis for DesktopChassis {
     const PROFILE: &'static str = "desktop";
-    type Driver = super::driver::DesktopDriverCapability;
+    type Driver = DesktopDriverCapability;
     type Env = DesktopEnv;
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -40,7 +40,7 @@ pub struct HeadlessChassis;
 
 impl Chassis for HeadlessChassis {
     const PROFILE: &'static str = "headless";
-    type Driver = super::driver::HeadlessTimerCapability;
+    type Driver = HeadlessTimerCapability;
     type Env = HeadlessEnv;
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -114,7 +114,7 @@ impl fmt::Display for TestBenchError {
 /// Per-send settlement timeout. Mirrors the `run_frame` tick wait at
 /// `bench.rs::run_frame`; long enough to absorb wasm compile + cap
 /// dispatcher wake under nextest CPU contention.
-const SETTLEMENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const SETTLEMENT_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl std::error::Error for TestBenchError {}
 
@@ -315,7 +315,7 @@ impl TestBench {
         let outbound = Arc::clone(&boot.outbound);
         let registry = Arc::clone(&boot.registry);
         let input_mailbox = aether_data::mailbox_id_from_name(
-            <aether_capabilities::InputCapability as aether_actor::Actor>::NAMESPACE,
+            <aether_capabilities::InputCapability as Actor>::NAMESPACE,
         );
         let frame_bound_pending = passive.frame_bound_pending();
 
@@ -433,7 +433,7 @@ impl TestBench {
         &self,
         recipient_name: &str,
         kind_name: &'static str,
-        mailbox: aether_data::MailboxId,
+        mailbox: MailboxId,
         kind: KindId,
         payload: Vec<u8>,
     ) -> Result<(), TestBenchError> {
@@ -583,7 +583,7 @@ impl TestBench {
     /// chassis-peripheral kinds; each one now routes to its own cap
     /// (`aether.render.capture_frame`, `aether.test_bench.advance`,
     /// `aether.window.set_mode`, etc.).
-    fn push_to_mailbox<K>(&self, mailbox: aether_data::MailboxId, mail: &K, cid: u64)
+    fn push_to_mailbox<K>(&self, mailbox: MailboxId, mail: &K, cid: u64)
     where
         K: Kind + serde::Serialize,
     {
@@ -950,7 +950,7 @@ mod tests {
         tb.send_mail(
             "aether.input",
             &SubscribeInput {
-                kind: aether_kinds::Tick::ID,
+                kind: Tick::ID,
                 mailbox: subscriber_mbox,
             },
         )
@@ -1017,7 +1017,7 @@ mod tests {
             const NAME: &'static str = "test.spawn.bump";
             const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != core::mem::size_of::<Self>() {
+                if bytes.len() != size_of::<Self>() {
                     return None;
                 }
                 Some(bytemuck::pod_read_unaligned(bytes))
@@ -1045,7 +1045,7 @@ mod tests {
             fn __aether_dispatch_envelope(
                 &mut self,
                 _ctx: &mut NativeCtx<'_>,
-                kind: aether_substrate::KindId,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Bump::ID.0 {
@@ -1102,9 +1102,9 @@ mod tests {
 
         // Wait briefly for the two pre-loaded `Bump` mails to land in
         // the first instance's dispatcher.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
         while received.load(AtomicOrdering::SeqCst) < 2 && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+            std::thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             received.load(AtomicOrdering::SeqCst),

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -304,8 +304,8 @@ impl TestBenchChassis {
         // bundle on the chassis's `ExportedHandles` map during `init`.
         // Embedders retrieve via `PassiveChassis::handle::<H>()` — no
         // `Arc<RenderCapability>` ever escapes the dispatcher thread.
-        let render_handles: aether_capabilities::RenderHandles =
-            passive.handle::<aether_capabilities::RenderHandles>().ok_or_else(|| {
+        let render_handles: RenderHandles =
+            passive.handle::<RenderHandles>().ok_or_else(|| {
                 anyhow::anyhow!(
                     "TestBenchChassis::build: RenderHandles not published — RenderCapability must boot via with_actor before TestBench builds",
                 )


### PR DESCRIPTION
Phase 5 of the Qodana triage tracked by iamacoffeepot/aether#913. Sweeps `unused_qualifications` warnings across the `aether-mesh` and `aether-substrate-bundle` crates.

## Scope

- 15 sites in `aether-mesh` (`ast.rs`, `parse.rs`, `debug.rs`, `cleanup/tjunctions.rs`, `cleanup/weld.rs`, `tessellate/cdt/bowyer_watson.rs`)
- 14 sites in `aether-substrate-bundle` (`desktop/chassis.rs`, `headless/chassis.rs`, `test_bench/bench.rs`, `test_bench/chassis.rs`)

In each case the qualifier is redundant because the referenced item is already imported in scope (or, for `size_of`, available via the Rust 2024 prelude).

## Method

Approximating `cargo fix` with `unused_qualifications` enabled: a temporary `#![warn(unused_qualifications)]` was placed at each crate root, the warnings were enumerated via `cargo check`, the suggested edits applied verbatim from rustc's `help: remove the unnecessary path segments` hints, and the temporary attribute removed before commit.

## Diff size

10 files changed, 28 insertions(+), 28 deletions(-). Purely mechanical token removal — no behavioural change.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001 / 1001 passing
