### PR TITLE
chore(lints): enable rust unused_qualifications workspace lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,15 @@ exclude = ["spikes/*"]
 version = "0.2.0-alpha"
 edition = "2024"
 
+[workspace.lints.rust]
+# Phase 5 of iamacoffeepot/aether#913 swept ~244 RsUnnecessaryQualifications
+# findings across the workspace. Enabling rustc's matching lint here at
+# `warn` prevents reintroduction — CI's `cargo clippy -- -D warnings`
+# escalates it to a hard fail on any new qualified path that the
+# compiler can elide (e.g. `core::mem::size_of` when the edition-2024
+# prelude has `size_of` in scope).
+unused_qualifications = "warn"
+
 [workspace.lints.clippy]
 # Baseline — both groups as warn, then opt out of the idiom-fight bucket below.
 pedantic = { level = "warn", priority = -1 }

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -177,10 +177,7 @@ fn run_frame(
     input_mailbox: MailboxId,
     kind_tick: aether_data::KindId,
     capture_queue: &CaptureQueue,
-    frame_bound_pending: &[(
-        aether_substrate::MailboxId,
-        Arc<std::sync::atomic::AtomicU64>,
-    )],
+    frame_bound_pending: &[(MailboxId, Arc<std::sync::atomic::AtomicU64>)],
     gpu: &mut Gpu,
     chassis_correlation: &std::sync::atomic::AtomicU64,
 ) {


### PR DESCRIPTION
## What

Add a `[workspace.lints.rust]` section with `unused_qualifications = "warn"`. CI runs `cargo clippy -- -D warnings`, so this becomes effectively a deny — any future reintroduction of an elidable path prefix breaks the build.

Plus one residual fix in `aether-substrate-bundle/src/bin/test-bench.rs` — a trailing `aether_substrate::MailboxId` qualification the Phase 5 bundle sweep missed because the test-bench binary entry point was outside the agent's lib-pass focus. The multi-line type collapses back onto one line after the prefix drops.

## Why

Phase 5 of iamacoffeepot/aether#913 swept ~244 rustc-catchable `RsUnnecessaryQualifications` hits across the workspace. Without enabling the lint, future code can reintroduce them and we'd be running the sweep forever.

## Residual ~50 Qodana hits not addressed here

Qodana's `RsUnnecessaryQualifications` is stricter than rustc's `unused_qualifications`. The leftover hits fall into two legitimate-pattern buckets:

- **Doc-comment rustdoc links** — `[`Foo`](crate::path::Foo)` is the idiomatic rustdoc form. Removing the path breaks the link target.
- **Defensive leading `::` in macro-callable consts** — `const ID: ::aether_data::KindId = ::aether_data::KindId(...)`. The leading `::` guards against scope shadowing when the const is expanded inside a caller's module.

Both will be absorbed via the Qodana baseline at Phase Final.

## Verification

- `cargo check --workspace --all-targets` — clean, 0 `unused_qualifications` warnings
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --target wasm32-unknown-unknown -p <crate>` for the 5 component crates — all green
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001/1001 passed

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
- iamacoffeepot/aether#926, iamacoffeepot/aether#927, iamacoffeepot/aether#928, iamacoffeepot/aether#929 — Phase 5 sweep PRs
