### PR TITLE
chore(lints): enable rustdoc redundant_explicit_links + add Docs CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,30 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  docs:
+    name: Docs
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install ALSA dev headers (cpal Linux backend)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: Swatinem/rust-cache@v2
+      # `[workspace.lints.rustdoc]` in the root Cargo.toml tracks
+      # specific rustdoc lints at `warn`. RUSTDOCFLAGS escalates the
+      # tracked subset to hard failures here without poisoning local
+      # `cargo doc` runs (which still emit pre-existing broken /
+      # private intra-doc-link warnings we haven't swept yet — those
+      # land under a separate cleanup).
+      - name: cargo doc with tracked rustdoc lints denied
+        env:
+          RUSTDOCFLAGS: "-D rustdoc::redundant_explicit_links"
+        run: cargo doc --workspace --no-deps
+
   # Workspace-wide tests run on linux only. Non-chassis crates
   # (aether-kinds, aether-data, aether-actor, aether-actor-derive,
   # demo components) are pure Rust with no per-OS behavior — a matrix
@@ -172,7 +196,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, clippy, test, desktop ]
+    needs: [ changes, fmt, clippy, docs, test, desktop ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -180,12 +204,14 @@ jobs:
           echo "changes: ${{ needs.changes.result }}"
           echo "fmt:     ${{ needs.fmt.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
+          echo "docs:    ${{ needs.docs.result }}"
           echo "test:    ${{ needs.test.result }}"
           echo "desktop: ${{ needs.desktop.result }}"
           fail=0
           [[ "${{ needs.changes.result }}" == "success" ]] || fail=1
           [[ "${{ needs.fmt.result }}"     == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
+          [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.test.result }}"    == "success" || "${{ needs.test.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.desktop.result }}" == "success" || "${{ needs.desktop.result }}" == "skipped" ]] || fail=1
           exit $fail

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,15 @@ edition = "2024"
 # prelude has `size_of` in scope).
 unused_qualifications = "warn"
 
+[workspace.lints.rustdoc]
+# Phase 5 of iamacoffeepot/aether#913 doc-comment fix — flag
+# `[`Foo`](crate::path::to::Foo)` when the bracket label already
+# resolves to the same target via intra-doc-link lookup. Enforced by
+# CI's `Docs` job (`cargo doc --workspace --no-deps` under
+# `RUSTDOCFLAGS='-D warnings'`); `warn` here keeps local `cargo doc`
+# usable for developers without forcing -D on every dev run.
+redundant_explicit_links = "warn"
+
 [workspace.lints.clippy]
 # Baseline — both groups as warn, then opt out of the idiom-fight bucket below.
 pedantic = { level = "warn", priority = -1 }

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -1,8 +1,8 @@
 //! Actor SDK primitive: the marker trait surface (here in `mod.rs`)
 //! plus per-mail / per-init / per-drop ctx machinery
-//! ([`ctx`](crate::actor::ctx)), the `Sender` / `MailCtx` traits
-//! ([`sender`](crate::actor::sender)), and the `Slot` single-instance
-//! backing store ([`slot`](crate::actor::slot)). Marker traits are
+//! ([`ctx`]), the `Sender` / `MailCtx` traits
+//! ([`sender`]), and the `Slot` single-instance
+//! backing store ([`slot`]). Marker traits are
 //! pure compile-time markers — no transport machinery, no lifecycle
 //! methods, just identity (`Actor`), singleton-ness (`Singleton`),
 //! and per-handler-kind gating (`HandlesKind`).

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -7,10 +7,10 @@
 //! `PriorState` bundle, and `ReplyTo` opaque handle live here in
 //! `mod.rs` (pure decoders, no transport coupling). The
 //! [`Mailbox<K>`](crate::mail::mailbox) addressing token lives in
-//! the [`mailbox`](crate::mail::mailbox) submodule; the
+//! the [`mailbox`] submodule; the
 //! [`WaitError`](crate::mail::sync::WaitError) trait + the rc-decode
 //! helper for `wait_reply` returns live in
-//! [`sync`](crate::mail::sync).
+//! [`sync`].
 //!
 //! Issue 665 retired the `MailTransport` trait that previously sat at
 //! `transport.rs` here. Per-stage capability traits in

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -88,7 +88,7 @@ pub trait DriverRunning: 'static {
 }
 
 /// Phantom [`DriverCapability`] for passive chassis (test-bench, future
-/// embedder-driven chassis kinds). The [`Chassis`](crate::chassis::Chassis)
+/// embedder-driven chassis kinds). The [`Chassis`]
 /// trait requires `type Driver: DriverCapability`; passive chassis
 /// declare this as their driver to satisfy the bound, but the value is
 /// never instantiated (the `Builder<C, NoDriver>` path produces a

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -3,7 +3,7 @@
 //! [`FrameBoundClaim`] / [`DropOnShutdownClaim`] result shapes, and
 //! the [`ChassisCtx`] threaded through every cap's boot. Sibling
 //! modules: error types live in `chassis::error`; the cross-flavour
-//! [`Envelope`](crate::actor::native::envelope::Envelope) shape lives
+//! [`Envelope`] shape lives
 //! in `actor::native::envelope`.
 
 use std::collections::HashSet;


### PR DESCRIPTION
## What

Two coupled changes that lock down rustdoc's `redundant_explicit_links` lint:

1. **`[workspace.lints.rustdoc] redundant_explicit_links = "warn"`** in the workspace `Cargo.toml`.
2. **New `Docs` CI job** in `ci.yml` running `cargo doc --workspace --no-deps` under `RUSTDOCFLAGS='-D rustdoc::redundant_explicit_links'` — escalates the tracked lint to a hard fail in CI without poisoning local `cargo doc`.

Plus sweep the 7 current findings — all of the same shape, where the bracket label already resolves to the same target via intra-doc-link lookup:

| File | Fix |
|---|---|
| `aether-actor/src/actor/mod.rs` (3) | `[`ctx`]`, `[`sender`]`, `[`slot`]` — module links |
| `aether-actor/src/mail/mod.rs` (2) | `[`mailbox`]`, `[`sync`]` — submodule links |
| `aether-substrate/src/chassis/builder.rs` (1) | `[`Chassis`]` — trait link |
| `aether-substrate/src/chassis/ctx.rs` (1) | `[`Envelope`]` — type link |

## Why

Mirrors the iamacoffeepot/aether#930 pattern (enable a workspace lint + sweep existing hits in the same PR so the lint runs clean on main immediately). Addresses the doc-comment subset of the iamacoffeepot/aether#913 Phase 5 residuals that rustc's `unused_qualifications` doesn't catch (different lint family — rustdoc owns intra-doc link resolution).

## Scope note

The `RUSTDOCFLAGS` deny is **scoped to just `redundant_explicit_links`**, not blanket `-D warnings`. The broader form would surface a backlog of pre-existing `broken_intra_doc_links` / `private_intra_doc_links` in `aether-mesh` and `aether-substrate-bundle` (legacy doc references to modules / methods that moved during the various refactors). Those are real cleanups but unrelated to the Qodana triage — a focused follow-up PR.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001/1001 passed
- `cargo doc --workspace --no-deps` under the scoped deny — succeeds, 0 `redundant_explicit_links` remaining

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
- iamacoffeepot/aether#930 — sibling lint enable PR (`unused_qualifications`); same pattern
