### PR TITLE
chore(docs): sweep rustdoc broken + private intra-doc-link backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,17 @@ jobs:
       - name: Install ALSA dev headers (cpal Linux backend)
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
-      # `[workspace.lints.rustdoc]` in the root Cargo.toml tracks
-      # specific rustdoc lints at `warn`. RUSTDOCFLAGS escalates the
-      # tracked subset to hard failures here without poisoning local
-      # `cargo doc` runs (which still emit pre-existing broken /
-      # private intra-doc-link warnings we haven't swept yet — those
-      # land under a separate cleanup).
+      # `[workspace.lints.rustdoc]` in the root Cargo.toml tracks the
+      # rustdoc lints at `warn`. RUSTDOCFLAGS escalates the tracked
+      # set to hard failures here without poisoning local `cargo doc`
+      # runs. Phase 5c (iamacoffeepot/aether#913) swept the broken /
+      # private intra-doc-link backlog so all three can deny now.
       - name: cargo doc with tracked rustdoc lints denied
         env:
-          RUSTDOCFLAGS: "-D rustdoc::redundant_explicit_links"
+          RUSTDOCFLAGS: >-
+            -D rustdoc::redundant_explicit_links
+            -D rustdoc::broken_intra_doc_links
+            -D rustdoc::private_intra_doc_links
         run: cargo doc --workspace --no-deps
 
   # Workspace-wide tests run on linux only. Non-chassis crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,19 @@ edition = "2024"
 unused_qualifications = "warn"
 
 [workspace.lints.rustdoc]
-# Phase 5 of iamacoffeepot/aether#913 doc-comment fix — flag
-# `[`Foo`](crate::path::to::Foo)` when the bracket label already
-# resolves to the same target via intra-doc-link lookup. Enforced by
-# CI's `Docs` job (`cargo doc --workspace --no-deps` under
-# `RUSTDOCFLAGS='-D warnings'`); `warn` here keeps local `cargo doc`
-# usable for developers without forcing -D on every dev run.
+# Phase 5 / 5c of iamacoffeepot/aether#913 doc-comment cleanup.
+# `redundant_explicit_links` flags `[`Foo`](crate::path::to::Foo)`
+# when the bracket label already resolves to the same target via
+# intra-doc-link lookup. `broken_intra_doc_links` catches dangling
+# `[Foo]` after a rename. `private_intra_doc_links` catches public
+# docs pointing at private items. CI's `Docs` job (`cargo doc
+# --workspace --no-deps` under `RUSTDOCFLAGS='-D rustdoc::...'`)
+# escalates these to hard failures; `warn` here keeps local
+# `cargo doc` usable for developers without forcing -D on every
+# dev run.
 redundant_explicit_links = "warn"
+broken_intra_doc_links = "warn"
+private_intra_doc_links = "warn"
 
 [workspace.lints.clippy]
 # Baseline — both groups as warn, then opt out of the idiom-fight bucket below.

--- a/crates/aether-actor/src/actor/ctx/outbound_reply.rs
+++ b/crates/aether-actor/src/actor/ctx/outbound_reply.rs
@@ -69,6 +69,6 @@ pub trait OutboundReply: MailSender {
     ///
     /// Same wire-shape contract as [`Self::reply`]. Native impls route
     /// through `NativeBinding::send_reply_for_handler`; FFI impls route
-    /// through [`crate::ffi::bridge::MAIL_BRIDGE::reply_mail`].
+    /// through [`crate::ffi::bridge::MailBridge::reply_mail`].
     fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: Self::ReplyHandle, payload: &K);
 }

--- a/crates/aether-actor/src/actor/ctx/resolver.rs
+++ b/crates/aether-actor/src/actor/ctx/resolver.rs
@@ -13,14 +13,14 @@
 //! makes that boundary structural rather than convention.
 //!
 //! Subscribing to input streams is just a regular mail send to
-//! `aether.input` (the [`InputCapability`] cap), not a special trait
-//! method — the receiver-side handler decoded the [`SubscribeInput`]
-//! payload and inserted into its subscriber table. Components write
+//! `aether.input` (the `InputCapability` cap, in `aether-capabilities`),
+//! not a special trait method — the receiver-side handler decoded the
+//! [`SubscribeInput`] payload and inserted into its subscriber table.
+//! Components write
 //! `ctx.send::<InputCapability, _>(&SubscribeInput { kind, mailbox })`
 //! from `wire` directly.
 //!
 //! [`MailSender`]: crate::actor::ctx::MailSender
-//! [`InputCapability`]: aether_capabilities::InputCapability
 //! [`SubscribeInput`]: aether_kinds::SubscribeInput
 
 use aether_data::Kind;
@@ -31,7 +31,7 @@ use crate::mail::mailbox::{KindId, Mailbox};
 /// Components subscribe to input streams from `wire` (where the ctx
 /// impls both `Resolver` and [`crate::actor::ctx::MailSender`]) by
 /// sending [`SubscribeInput`](aether_kinds::SubscribeInput) directly
-/// to the [`InputCapability`](aether_capabilities::InputCapability).
+/// to the `InputCapability` (in `aether-capabilities`).
 pub trait Resolver {
     /// The component's own mailbox id — the value the substrate uses
     /// to address `receive` calls to this instance.

--- a/crates/aether-actor/src/actor/ctx/sync_waiter.rs
+++ b/crates/aether-actor/src/actor/ctx/sync_waiter.rs
@@ -7,7 +7,7 @@
 //! mints a correlation; sync wait is one of the strategies for
 //! consuming the reply).
 //!
-//! FFI ctxs route to [`crate::ffi::bridge::SyncWait::wait_reply`].
+//! FFI ctxs route to [`crate::ffi::bridge::SyncWaitBridge::wait_reply`].
 //! Native ctxs route to `NativeBinding::wait_reply` (which carries
 //! the ADR-0074 §Decision 5 cross-class guard inline). Either side
 //! ships the same return-code contract: `>= 0` = bytes written,

--- a/crates/aether-actor/src/actor/sender.rs
+++ b/crates/aether-actor/src/actor/sender.rs
@@ -15,7 +15,7 @@
 //!
 //! [`Sender`] is the addressing minimum every per-handler ctx and
 //! every init-time ctx exposes — single-payload `send`, batched
-//! `send_many` (cast-only, see [`crate::mail::mailbox::Mailbox::send_many`]
+//! `send_many` (cast-only, see [`crate::actor::ctx::MailSender::send_many`]
 //! for the wire-shape rationale), plus `send_to_named` as the
 //! string-keyed escape hatch for cases where the caller genuinely
 //! has no Rust type at compile site.

--- a/crates/aether-actor/src/ffi/bridge/persist.rs
+++ b/crates/aether-actor/src/ffi/bridge/persist.rs
@@ -6,18 +6,18 @@
 //!
 //! ZST whose only inherent method is `save_state`, the ADR-0016
 //! deposit hook called inside `on_replace` to hand a typed bundle to
-//! the replacement instance. `PersistBridgeence` is conceptually distinct
+//! the replacement instance. `Persistence` is conceptually distinct
 //! from mail (it's a one-shot byte deposit, not a routed envelope),
 //! so it lives in its own bridge rather than on [`super::mail::MailBridge`].
 //!
 //! Native actors do not have a `replace_component`-style hot reload
 //! path — only wasm components do. The native ctx structs deliberately
-//! do not impl [`crate::actor::ctx::PersistBridgeence`].
+//! do not impl [`crate::actor::ctx::Persistence`].
 
 use crate::ffi::raw;
 
 /// ZST FFI bridge for `save_state`. Borrow [`PERSIST_BRIDGE`] from any ctx
-/// that impls [`crate::actor::ctx::PersistBridgeence`] to forward the
+/// that impls [`crate::actor::ctx::Persistence`] to forward the
 /// typed-bundle bytes through the host fn.
 pub struct PersistBridge;
 

--- a/crates/aether-actor/src/ffi/bridge/sync_wait.rs
+++ b/crates/aether-actor/src/ffi/bridge/sync_wait.rs
@@ -10,7 +10,7 @@
 //! mints a correlation regardless of whether the caller sync-waits,
 //! so correlation lives on the mail bridge, not here.
 //!
-//! Per-stage [`crate::actor::ctx::SyncWaitBridgeer`] impls route through
+//! Per-stage [`crate::actor::ctx::SyncWaiter`] impls route through
 //! [`SYNC_WAIT_BRIDGE`] for FFI guests; native ctxs route through
 //! `NativeBinding::wait_reply` (ADR-0074 §Decision 5 cross-class
 //! guard lives in the native binding's inherent body).
@@ -18,7 +18,7 @@
 use crate::ffi::raw;
 
 /// ZST FFI bridge for `wait_reply`. Borrow [`SYNC_WAIT_BRIDGE`] from a
-/// [`crate::actor::ctx::SyncWaitBridgeer`] impl.
+/// [`crate::actor::ctx::SyncWaiter`] impl.
 pub struct SyncWaitBridge;
 
 /// Process-wide [`SyncWaitBridge`] instance.

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -104,8 +104,8 @@ impl Resolver for FfiInitCtx<'_> {
 /// capability handle for FFI guests. Exposes send, reply, and
 /// resolution primitives. Issue 703 added [`Resolver`] + a
 /// `mailbox_id` field so `wire`-stage explicit subscribes
-/// (`ctx.subscribe_input::<K>()`, gated by the [`crate::actor::ctx::Subscriber`]
-/// blanket) can self-address.
+/// (sending [`SubscribeInput`](aether_kinds::SubscribeInput) to the
+/// `InputCapability`) can self-address.
 pub struct FfiCtx<'a> {
     mailbox: u64,
     sender: Option<u32>,

--- a/crates/aether-actor/src/ffi/mailbox.rs
+++ b/crates/aether-actor/src/ffi/mailbox.rs
@@ -87,7 +87,7 @@ impl<R: Actor> FfiActorMailbox<R> {
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —
-    /// see [`crate::mail::mailbox::Mailbox::send_many`] for the
+    /// see [`crate::actor::ctx::MailSender::send_many`] for the
     /// wire-shape rationale.
     pub fn send_many<K>(&self, payloads: &[K])
     where

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -13,8 +13,8 @@
 //! `MailTransport` trait that originally tied the FFI and native
 //! halves together — the cross-target abstraction is now the
 //! per-stage capability traits in [`actor::ctx`]; the per-target
-//! dispatch surfaces are [`ffi::bridge`] (FFI: [`ffi::MAIL`],
-//! [`ffi::PERSIST`], [`ffi::SYNC_WAIT`]) and the inherent methods on
+//! dispatch surfaces are [`ffi::bridge`] (FFI: [`ffi::MAIL_BRIDGE`],
+//! [`ffi::PERSIST_BRIDGE`], [`ffi::SYNC_WAIT_BRIDGE`]) and the inherent methods on
 //! `aether_substrate::actor::native::binding::NativeBinding`.
 //!
 //! Public surface:

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -249,7 +249,7 @@ mod native_impl {
     /// this around each handler dispatch (and around `init`); the
     /// pointer is restored to its prior value (almost always
     /// null) before this returns. Panics propagate out — the TLS
-    /// slot is restored via the [`StampGuard`] drop, not via
+    /// slot is restored via an internal RAII guard's drop, not via
     /// explicit unwind handling.
     pub fn with_stamped<R>(slots: &ActorSlots, f: impl FnOnce() -> R) -> R {
         let _guard = CURRENT_SLOTS.with(|slot| {

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -160,8 +160,9 @@ pub fn set_native_log_shipper(hook: NativeLogShipper) {
 /// one [`LogBatch`] mail to the configured target. No-op when the
 /// buffer is empty, the [`LogDrainSlot`] is still at its default
 /// (chassis hasn't dispatched `ConfigureLogDrain` yet, or chassis
-/// declared no drain), or (on native) no [`with_actor_dispatch`] is
-/// active.
+/// declared no drain), or (on native) no
+/// `aether_substrate::runtime::log_install::with_actor_dispatch`
+/// envelope is active.
 pub fn drain_buffer() {
     let Some(entries) = LogBuffer::try_with_mut(|b| core::mem::take(&mut b.0)) else {
         return;
@@ -238,7 +239,7 @@ mod pipeline_tls {
 /// `true` iff we're currently inside the drain / host-ship path.
 /// Read by [`crate::log::is_in_pipeline`] consumers (chiefly the
 /// actor-aware layer in `aether-substrate::log_install`); set + cleared
-/// by [`PipelineGuard`].
+/// by the internal `PipelineGuard` RAII helper.
 #[must_use]
 pub fn is_in_pipeline() -> bool {
     pipeline_tls::IN_LOG_PIPELINE.with(core::cell::Cell::get)

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -27,7 +27,7 @@
 //! construction. The worker builds the `cpal::Stream`, parks on a
 //! shutdown channel, and drops the stream when the channel
 //! disconnects. The cap itself holds an
-//! [`Arc<ArrayQueue<AudioEvent>>`] (Send) that the cpal callback
+//! `Arc<ArrayQueue<AudioEvent>>` (Send) that the cpal callback
 //! reads from; `on_note_on` / `on_note_off` push to that queue
 //! directly with no thread hop. This is the one cap with a worker
 //! thread — every other cap is single-threaded by design; cpal's
@@ -663,10 +663,10 @@ mod native {
     }
 
     /// `aether.audio` mailbox cap. Holds the producer side of the synth
-    /// event queue ([`AudioEventSender`]), the audio worker thread that
-    /// owns the [`cpal::Stream`] (see module-level "per-cap audio worker"
-    /// docs for the `!Send` rationale), and a shutdown channel that
-    /// signals the worker to exit on drop.
+    /// event queue (the crate-internal `AudioEventSender`), the audio
+    /// worker thread that owns the [`cpal::Stream`] (see module-level
+    /// "per-cap audio worker" docs for the `!Send` rationale), and a
+    /// shutdown channel that signals the worker to exit on drop.
     ///
     /// `sender` is `None` when the cpal pipeline isn't running
     /// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -7,16 +7,17 @@
 //! forwards each to the addressed trampoline preserving the
 //! original `reply_to`, so the trampoline replies directly to the
 //! agent. The cap holds no per-component bookkeeping; the
-//! trampoline manages its own lifecycle as an instanced
-//! [`NativeActor`].
+//! trampoline manages its own lifecycle as an instanced [`NativeActor`].
 //!
 //! Pre-Phase-4 the cap also owned the wasm dispatcher infrastructure
-//! ([`ComponentEntry`], `dispatcher_loop`, `kill_actor`,
+//! (the retired `ComponentEntry`, `dispatcher_loop`, `kill_actor`,
 //! `splice_inbox`, etc.) and installed itself as the `Mailer`'s
-//! [`ComponentRouter`] for component-bound routing. All of that
+//! `ComponentRouter` for component-bound routing. All of that
 //! retired with the trampoline migration: dispatch lives on the
 //! framework's `NativeActor` loop, replace is `Component`-swap
 //! inside the trampoline, drop flows through `ctx.shutdown()`.
+//!
+//! [`NativeActor`]: aether_substrate::actor::native::NativeActor
 //!
 //! The cap is a `#[bridge] mod native { ... }` per the ADR-0076 /
 //! issue 565 pattern. Plain fields (no `Arc<Inner>` wrapper) per
@@ -123,7 +124,7 @@ mod native {
     /// Configuration for [`ComponentHostCapability`]. `engine` and
     /// `linker` are the wasmtime instances every load instantiates
     /// against (handed through to the trampoline's
-    /// [`Component::instantiate`] call); `hub_outbound` is the egress
+    /// `Component::instantiate` call); `hub_outbound` is the egress
     /// handle the cap uses for `aether.kinds.changed` announcements
     /// after each load. ADR-0021 fan-out is mail-driven post-issue-640
     /// — the cap mails subscribe / unsubscribe to `aether.input`

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -1,6 +1,6 @@
 //! `aether.engine.proxy:<id>` — per-engine proxy actor (issue 763 P3).
 //!
-//! An instanced [`NativeActor`] that wraps one *outbound* RPC client
+//! An instanced `NativeActor` that wraps one *outbound* RPC client
 //! connection to a substrate. The forward-model architecture (issue
 //! 763) makes every substrate an RPC server; the hub is the client.
 //! Each substrate the hub talks to gets one proxy, addressed
@@ -9,11 +9,11 @@
 //! ## What it does
 //!
 //! - **`init`** dials the substrate's `RpcServerCapability` via
-//!   [`RpcClient::connect`] and spawns the reader sidecar. The
+//!   `RpcClient::connect` and spawns the reader sidecar. The
 //!   handshake's `HelloAck` identity is kept on `conn.server`.
 //! - **`on_forward`** ([`ForwardEnvelope`]) wraps the `mailbox`,
 //!   `kind`, and `payload` into an RPC `Call` and writes it down the
-//!   connection. The inbound mail's [`ReplyTo`] is parked under the
+//!   connection. The inbound mail's `ReplyTo` is parked under the
 //!   wire `cid` so the eventual reply can route back to the sender.
 //! - **`on_inbound_ready`** ([`RpcInboundReady`]) is the reader
 //!   sidecar's wake: it drains `conn.inbound`, lifting `ReplyEvent`
@@ -30,7 +30,7 @@
 //! engines cap. The cached `HelloAck` manifest the describe handler
 //! will read is already in hand on `conn.server`.
 //!
-//! Native-only: the module owns a `TcpStream` (via [`RpcConnection`])
+//! Native-only: the module owns a `TcpStream` (via `RpcConnection`)
 //! and an OS thread. The `#[bridge]` macro emits the wasm-side marker
 //! stub so `aether-capabilities` still compiles for `wasm32`.
 

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -1,7 +1,7 @@
 //! `aether.engine` — engines capability (issue 763 P4).
 //!
-//! A `#[bridge(singleton)]` [`NativeActor`] that supervises a fleet of
-//! [`EngineProxy`] actors — the engine-management surface of the
+//! A `#[bridge(singleton)]` `NativeActor` that supervises a fleet of
+//! `EngineProxy` actors — the engine-management surface of the
 //! forward-model architecture (issue 763). Three handlers:
 //!
 //! - **`on_spawn`** ([`SpawnEngine`]) picks a free localhost port,
@@ -9,11 +9,11 @@
 //!   then boots an `aether.engine.proxy:<id>` child actor that dials
 //!   it. The proxy owns the forked child from there — startup-dial
 //!   retry, kill-on-failed-boot, kill-on-drop. Reply:
-//!   [`SpawnEngineResult`].
+//!   `SpawnEngineResult`.
 //! - **`on_list`** ([`ListEngines`]) reports every supervised engine.
 //! - **`on_terminate`** ([`TerminateEngine`]) forwards the kind to the
 //!   engine's proxy (which SIGKILLs its substrate and self-shuts-down)
-//!   and drops the table entry. Reply: [`TerminateEngineResult`].
+//!   and drops the table entry. Reply: `TerminateEngineResult`.
 //!
 //! ## Scope (issue 763 P4 vs P5)
 //!

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -253,7 +253,7 @@ pub fn build_registry(
 impl NamespaceRoots {
     /// Pre-validate the configured roots: create each directory if
     /// missing, then canonicalize. Mirrors what `LocalFileAdapter::new`
-    /// does inside [`FsCapability::init`], but exposed so embedders
+    /// does inside `FsCapability::init`, but exposed so embedders
     /// can validate before building the chassis. Used by chassis
     /// builders that want to surface root-validity as a "skip the
     /// `aether.fs` cap and continue" decision rather than letting

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -75,7 +75,7 @@ impl HttpAdapter for DisabledHttpAdapter {
 /// mains read env vars (`AETHER_HTTP_DISABLE`, `AETHER_HTTP_ALLOWLIST`,
 /// `AETHER_HTTP_REQUIRE_HTTPS`, `AETHER_HTTP_MAX_BODY_BYTES`,
 /// `AETHER_HTTP_TIMEOUT_MS`) into a `HttpConfig` and pass it to
-/// [`HttpCapability::new`]. Tests build a `HttpConfig` directly,
+/// `HttpCapability::new`. Tests build a `HttpConfig` directly,
 /// never touching process env (issue 464).
 #[derive(Clone, Debug)]
 pub struct HttpConfig {

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -7,7 +7,7 @@
 //! plain field on `&mut self` (single-threaded — every handler runs on
 //! the cap's dispatcher thread). Drivers don't read the table; they push
 //! input events as mail to `aether.input` and the cap fans out one mail
-//! per subscriber via [`Mailer::push`]. `ComponentHostCapability` mails
+//! per subscriber via `Mailer::push`. `ComponentHostCapability` mails
 //! `SubscribeInput` (one per stream-shaped handler the loaded wasm
 //! declares) on load and `UnsubscribeAll` on drop, so cap-state mutation
 //! is also mail-driven.

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -16,7 +16,7 @@
 //!
 //! Issue 776 retired the hub-bound egress path and put a bounded
 //! ring inside this cap; the cap now serves [`LogRead`] requests via
-//! [`LogReadResult`]. ADR-0023 §4 contract restored under the
+//! `LogReadResult`. ADR-0023 §4 contract restored under the
 //! forward model (RPC pull instead of frame push).
 
 // `#[handler]` methods take their decoded payload by value per the

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -304,7 +304,7 @@ mod cap_native {
     /// Singleton control-plane cap. Owns the listener fleet directly
     /// — the cap is the supervisor, not a thin shim over the chassis
     /// registry. Each spawn registers a monitor on the new listener
-    /// and inserts a [`ListenerEntry`] into the cap-local map; the
+    /// and inserts a `ListenerEntry` into the cap-local map; the
     /// `on_monitor_notice` handler removes the entry on listener
     /// close.
     ///

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -1,4 +1,4 @@
-//! `WasmTrampoline` — a [`NativeActor`] that delegates to a wasm
+//! `WasmTrampoline` — a `NativeActor` that delegates to a wasm
 //! `Component`. Each loaded wasm component is one trampoline instance
 //! addressed at `aether.component.trampoline:NAME` (issue 634 Phase 4
 //! PR 1).
@@ -10,7 +10,7 @@
 //! constant split across two crates (substrate for the actor; cap-side
 //! mirror for wasm-component senders). The trampoline now sits next to
 //! [`crate::component::ComponentHostCapability`] — its only consumer —
-//! and the namespace is whatever [`WasmTrampoline::NAMESPACE`] says it
+//! and the namespace is whatever `WasmTrampoline::NAMESPACE` says it
 //! is. Single declaration, cap-owned, reachable on every target via
 //! the `Actor` trait const.
 //!
@@ -25,11 +25,11 @@
 //!
 //! ## Shape
 //!
-//! Plain instanced [`NativeActor`]. Anything it doesn't handle natively
+//! Plain instanced `NativeActor`. Anything it doesn't handle natively
 //! (today: `DropComponent`, `ReplaceComponent`) falls through
 //! `#[fallback]` to the wasm guest via `Component::deliver`. The
 //! framework dispatcher reads from the trampoline's `NativeBinding`;
-//! un-handled kinds reach [`forward_to_wasm`]; the guest's
+//! un-handled kinds reach `forward_to_wasm`; the guest's
 //! `wait_reply_p32` / `send_mail_p32` / `reply_mail_p32` host fns
 //! route through the same binding.
 //!
@@ -44,17 +44,17 @@
 //!
 //! ## Lifecycle
 //!
-//! - **Load**: [`crate::component::ComponentHostCapability::on_load_component`]
+//! - **Load**: `crate::component::ComponentHostCapability::on_load_component`
 //!   spawns a trampoline via the runtime spawn machinery (subname = the
 //!   agent-supplied component name); the spawn path runs
-//!   [`WasmTrampoline::init`] which instantiates the wasm `Component`
+//!   `WasmTrampoline::init` which instantiates the wasm `Component`
 //!   against the trampoline's binding.
 //! - **Drop**: `DropComponent` mail addressed to the trampoline's
-//!   mailbox lands on [`Self::on_drop_component`], which calls
+//!   mailbox lands on `Self::on_drop_component`, which calls
 //!   `ctx.shutdown()`. The framework drains the inbox, runs `unwire`,
 //!   and the dispatcher exits.
 //! - **Replace**: `ReplaceComponent` mail lands on
-//!   [`Self::on_replace_component`], which instantiates a new
+//!   `Self::on_replace_component`, which instantiates a new
 //!   `Component` against the same binding and swaps `self.component`.
 //!   ADR-0022 + ADR-0038 invariants hold because the inbox channel is
 //!   the trampoline's `NativeBinding` and outlives the swap.

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -649,14 +649,14 @@ mod engine {
 
     /// `aether.engine.list` — ask the engines cap (`aether.engine`) to
     /// enumerate every engine it currently supervises. Fieldless
-    /// request; the reply is an [`EngineList`]. Issue 763 P4.
+    /// request; the reply is a [`ListEnginesResult`]. Issue 763 P4.
     #[derive(
         aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
     )]
     #[kind(name = "aether.engine.list")]
     pub struct ListEngines {}
 
-    /// One supervised engine, as reported in an [`EngineList`].
+    /// One supervised engine, as reported in a [`ListEnginesResult`].
     ///
     /// `engine_id` is the plain UUID string the engines cap minted at
     /// spawn time — `EngineId` itself doesn't implement `Schema`, so
@@ -685,7 +685,7 @@ mod engine {
     /// `RpcServerCapability`, injects it as `AETHER_RPC_PORT`, forks
     /// `binary_path` with `args` forwarded verbatim, then boots an
     /// `aether.engine.proxy:<id>` actor that dials it. Reply:
-    /// [`SpawnResult`].
+    /// [`SpawnEngineResult`].
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.spawn")]
     pub struct SpawnEngine {
@@ -713,7 +713,8 @@ mod engine {
     /// The cap forwards this kind to the engine's
     /// `aether.engine.proxy:<id>` actor, which SIGKILLs the child
     /// substrate it forked and self-shuts-down. `engine_id` is the
-    /// plain UUID string from [`SpawnResult`] / [`EngineList`].
+    /// plain UUID string from [`SpawnEngineResult`] /
+    /// [`ListEnginesResult`].
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.terminate")]
     pub struct TerminateEngine {

--- a/crates/aether-mesh/src/cleanup.rs
+++ b/crates/aether-mesh/src/cleanup.rs
@@ -1,8 +1,10 @@
 //! Post-CSG mesh cleanup pipeline (ADR-0055, refactored under ADR-0057).
 //!
-//! Runs on the polygon stream produced by `ops::{union, intersection,
-//! difference}`. The pipeline operates in the same fixed-point integer
-//! domain as the BSP CSG core; passes are pure and exact.
+//! Runs on the polygon stream that boolean composition used to produce
+//! (`union` / `intersection` / `difference` retired with ADR-0062 and
+//! archived on the `archive/csg-bsp` branch). The pipeline operates in
+//! the same fixed-point integer domain as the BSP CSG core; passes are
+//! pure and exact.
 //!
 //! Four passes (composed in order):
 //!
@@ -33,8 +35,8 @@
 //! not cleanup. The polygon-domain public API ([`run_to_loops`] +
 //! [`crate::polygon::mesh_polygons`]) skips tessellation entirely
 //! because n-gon polygons are the canonical mesh form per ADR-0057;
-//! the legacy triangle-domain ops in [`super::ops`] compose cleanup
-//! and tessellation explicitly via [`super::tessellate::run`].
+//! the retired triangle-domain ops composed cleanup and tessellation
+//! explicitly via [`super::tessellate::run`].
 
 mod invariants;
 mod merge;

--- a/crates/aether-mesh/src/cleanup/provenance.rs
+++ b/crates/aether-mesh/src/cleanup/provenance.rs
@@ -17,9 +17,10 @@
 //! "fixed" the imbalance by collapsing one endpoint into another.
 //!
 //! The diagnostic re-runs cleanup with snapshots at each stage —
-//! production callers go through [`super::run_to_indexed`] which
-//! doesn't pay the snapshot cost. Designed to debug issue 370
-//! (inter-bucket rim mismatch on curved × sphere CSG); not stable API.
+//! production callers go through the crate-internal `run_to_indexed`
+//! entry point, which doesn't pay the snapshot cost. Designed to debug
+//! issue 370 (inter-bucket rim mismatch on curved × sphere CSG); not
+//! stable API.
 
 use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
 use crate::loop_polygon::Polygon;

--- a/crates/aether-mesh/src/debug.rs
+++ b/crates/aether-mesh/src/debug.rs
@@ -40,7 +40,7 @@ use std::fmt::Write as _;
 /// units above that floor so f32 reconstruction noise and plane
 /// re-derivation drift don't trip the validators on legitimate output.
 pub mod tol {
-    /// Vertex-to-stored-plane distance allowed in [`validate_planarity`].
+    /// Vertex-to-stored-plane distance allowed in [`super::validate_planarity`].
     /// ~46 fixed-point units — enough for f32 round-trip drift on cleanup
     /// output plus the per-canonicalize snap-rounding drift introduced
     /// by ADR-0061's BigInt-rationals-with-deferred-snap pipeline, tight
@@ -54,7 +54,7 @@ pub mod tol {
     pub const PLANARITY: f32 = 7e-4;
 
     /// Edge length below which an edge is "sliver" in
-    /// [`validate_polygon_quality`]. ~65 fixed-point units — smaller
+    /// [`super::validate_polygon_quality`]. ~65 fixed-point units — smaller
     /// than any usable face edge but well above snap noise.
     pub const SLIVER_EDGE: f32 = 1e-3;
 

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -19,9 +19,9 @@
 //! consumers (notably `aether-mesh-viewer`) hand polygons to
 //! the GPU upload step rather than triangles.
 //!
-//! [`mesh_polygons`] is the polygon-domain analogue of [`crate::mesh`]:
+//! [`mesh_polygons`] is the polygon-domain analogue of [`crate::mesh()`]:
 //! parses the same AST, runs the same CSG, but returns n-gon polygons
-//! instead of triangles. Internally it goes through [`crate::mesh`]
+//! instead of triangles. Internally it goes through [`crate::mesh()`]
 //! then [`crate::cleanup::run_to_loops`] to recover the boundary
 //! loops the cleanup pipeline produces; a future PR will skip the
 //! triangle round-trip by taking the polygon-domain path through
@@ -79,7 +79,7 @@ pub struct Polygon {
 /// product) → polygons`, and `from_triangle` flips `n_z` sign on
 /// CDT-output sliver triangles. Skipping the triangle hop avoids the
 /// re-derivation entirely — n-gon loops travel from CSG cleanup
-/// straight into [`group_loops`].
+/// straight into the crate-internal `group_loops` step.
 pub fn mesh_polygons(node: &crate::ast::Node) -> Result<Vec<Polygon>, MeshError> {
     let loops = crate::mesh::mesh_polygons_internal(node)?;
     Ok(group_loops(loops))

--- a/crates/aether-mesh/src/tessellate.rs
+++ b/crates/aether-mesh/src/tessellate.rs
@@ -60,7 +60,8 @@ fn plane_color_key(p: &Plane3, color: u32) -> PlaneColorKey {
 
 /// Run cleanup + CDT triangulation. Returns one `Polygon` per
 /// triangle (3 vertices each) in `Vec<Polygon>` form so the caller can
-/// fan-flatten to `Vec<Triangle>` via [`super::polygons_to_triangles`].
+/// fan-flatten to `Vec<Triangle>` via the crate-internal
+/// `polygons_to_triangles` helper.
 #[must_use]
 pub fn run(polygons: Vec<Polygon>) -> Vec<Polygon> {
     let cleaned = cleanup::run_to_indexed(polygons);

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -4,7 +4,7 @@
 //! drives per-frame work, the small bag of winit/wgpu mapping helpers
 //! the chassis needs to read its own state, and the
 //! `AETHER_WINDOW_MODE` parser. Wraps everything in a
-//! [`DesktopDriverCapability`] so [`crate::chassis::DesktopChassis`]
+//! `DesktopDriverCapability` so `crate::chassis::DesktopChassis`
 //! composes one driver alongside its passive capabilities
 //! (`LogCapability`, `FsCapability`, `HttpCapability`, `AudioCapability`,
 //! `RenderCapability` — composed via `chassis_builder::Builder::with_actor`
@@ -626,7 +626,7 @@ impl ApplicationHandler<UserEvent> for App {
 /// ADR-0071 driver capability for the desktop chassis. Owns the
 /// pieces the winit event-loop body needs at construction time, then
 /// `boot()`-builds the App + `DriverRunning` that drives the loop.
-/// `boot()` looks up [`RenderCapability`] via [`DriverCtx::expect`]
+/// `boot()` looks up `RenderCapability` via `DriverCtx::expect`
 /// (booted earlier in the `.with()` chain) and pulls the accumulator
 /// handles out of it.
 ///

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -34,7 +34,7 @@ use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 
 /// Marker type for the headless chassis. Carries no fields — the
 /// chassis instance is the [`BuiltChassis<HeadlessChassis>`] returned
-/// by [`Self::build`]. Same shape as [`crate::DesktopChassis`] post
+/// by `Self::build`. Same shape as `crate::DesktopChassis` post
 /// ADR-0071 phase 3.
 pub struct HeadlessChassis;
 

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -7,7 +7,7 @@
 //! tick generator (default 60 Hz, `AETHER_TICK_HZ` override) that
 //! pumps `Tick` mail to subscribed mailboxes, drains the mail queue,
 //! and emits frame-stats observation every
-//! [`frame_loop::LOG_EVERY_FRAMES`] frames.
+//! `frame_loop::LOG_EVERY_FRAMES` frames.
 //!
 //! No `Send` bound on the driver capability or its running — the
 //! headless tick loop runs on the chassis main thread end-to-end (no

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -63,7 +63,7 @@ pub const DEFAULT_HEIGHT: u32 = 600;
 /// `Advance` and `Capture` pass through `Err` variants from the
 /// substrate's reply. `SettlementTimeout` surfaces when a
 /// `send_mail` / `send_bytes` chain didn't drain within
-/// [`SETTLEMENT_TIMEOUT`] — issue 834: the bench waits on each
+/// `SETTLEMENT_TIMEOUT` — issue 834: the bench waits on each
 /// pushed chain's `Settled { root }` so the next observation
 /// (`capture()`, the next typed send, an assertion) is causally
 /// after the producer's full descendant tree dispatched.
@@ -384,7 +384,7 @@ impl TestBench {
     /// Issue 834: this is synchronous-on-settle. The mail is minted
     /// as a chassis-root via [`push_chassis_root_mail`] so the trace
     /// pipeline tracks the chain; the bench then subscribes to
-    /// `Settled { root }` and waits up to [`SETTLEMENT_TIMEOUT`] for
+    /// `Settled { root }` and waits up to `SETTLEMENT_TIMEOUT` for
     /// the chain (the recipient's handler + every descendant mail
     /// it spawned) to drain. By the time this returns, any
     /// subsequent observation (`capture()`, the next send, an

--- a/crates/aether-substrate/src/actor/monitor.rs
+++ b/crates/aether-substrate/src/actor/monitor.rs
@@ -23,7 +23,7 @@ use crate::actor::registry::ActorRegistry;
 /// close (the target's close drains `monitors_of[target]` after firing
 /// `MonitorNotice`; the watcher's close walks `monitoring[watcher]` to
 /// remove `watcher` from each target's forward list). `Drop` calls
-/// [`ActorRegistry::deregister_monitor`] which is idempotent —
+/// the registry's internal `deregister_monitor`, which is idempotent —
 /// dropping a handle whose entry the close path already removed is a
 /// no-op.
 ///

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -193,7 +193,8 @@ impl NativeBinding {
 
     /// Convenience constructor that pulls the cross-class guard
     /// state (frame-bound set + aborter) from a [`ChassisCtx`]. The
-    /// natural call site is inside a [`crate::Capability::boot`]:
+    /// natural call site is inside a
+    /// [`crate::DriverCapability::boot`] body:
     ///
     /// ```ignore
     /// let claim = ctx.claim_mailbox_drop_on_shutdown(NAME)?;
@@ -404,9 +405,10 @@ impl NativeBinding {
     /// ADR-0080 §1 / §5: variant of [`Self::send_mail`] that accepts
     /// the in-flight handler's lineage so the outgoing [`Mail`] picks
     /// up the correct `parent_mail` and inherited `root`. The
-    /// per-handler [`super::ctx::NativeCtx`]'s [`Sender`] impl reads
-    /// from its `in_flight_mail_id()` / `in_flight_root()` accessors
-    /// and threads them in.
+    /// per-handler [`super::ctx::NativeCtx`]'s
+    /// [`aether_actor::actor::sender::Sender`] impl reads from its
+    /// `in_flight_mail_id()` / `in_flight_root()` accessors and threads
+    /// them in.
     ///
     /// `parent_mail = None` and `inherited_root = None` mean
     /// chassis-root: the outgoing mail's `MailId` becomes its own

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -38,12 +38,12 @@ use super::{NativeActor, NativeDispatch};
 
 /// Per-mail context for a [`NativeActor`] handler. Borrows the
 /// actor's [`NativeBinding`] for outbound mail and carries the
-/// inbound's reply target so [`MailCtx::reply::<K>(&payload)`] can
-/// route back to the originator without rethreading the handle.
+/// inbound's reply target so the `MailCtx::reply::<K>(&payload)` API
+/// can route back to the originator without rethreading the handle.
 ///
 /// Stage 1 ships the wiring; the actual reply routing through
-/// [`NativeBinding::reply_mail`] / `Mailer::send_reply` is the
-/// stage-2 migration's responsibility (today's caps reply via
+/// [`NativeBinding::send_reply_for_handler`] / `Mailer::send_reply` is
+/// the stage-2 migration's responsibility (today's caps reply via
 /// `mailer.send_reply(...)` directly; stage 2 routes those onto
 /// `ctx.reply(...)`).
 pub struct NativeCtx<'a> {
@@ -211,9 +211,10 @@ impl<'a> NativeCtx<'a> {
     /// Diverging — does not return. Used by handlers that observe a
     /// non-recoverable invariant violation (today: the wasm trampoline
     /// on a guest trap). Native impl forwards to
-    /// [`NativeBinding::fatal_abort`]. See also the [`crate::ffi::FfiCtx`]
-    /// counterpart, which `panic!`s — the substrate's wasm runtime
-    /// catches the trap and ADR-0063 escalates symmetrically.
+    /// [`NativeBinding::fatal_abort`]. See also the
+    /// [`aether_actor::ffi::FfiCtx`] counterpart, which `panic!`s — the
+    /// substrate's wasm runtime catches the trap and ADR-0063 escalates
+    /// symmetrically.
     pub fn fatal_abort(&self, reason: String) -> ! {
         self.binding.fatal_abort(reason);
     }

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Shape
 //!
-//! ```ignore
+//! ```text
 //! #[capability]
 //! #[derive(Singleton)]
 //! pub struct ExampleCap { /* plain fields — single-threaded ownership */ }

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -35,7 +35,7 @@ use crate::mail::registry::{NameConflict, Registry};
 use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
 
-/// How to derive the subname for a [`Spawner::spawn_actor`] call. The
+/// How to derive the subname for a [`SpawnBuilder::finish`] call. The
 /// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
 /// hashes that string deterministically (ADR-0029) to produce the
 /// returned [`MailboxId`].
@@ -53,7 +53,7 @@ pub enum Subname<'a> {
     Named(&'a str),
 }
 
-/// Failure modes for [`Spawner::spawn_actor`] / [`SpawnBuilder::finish`].
+/// Failure modes for the [`SpawnBuilder::finish`] spawn pipeline.
 /// Returned in the order the lifecycle checks them: validate → owner
 /// check → tombstone check → name uniqueness → init.
 #[derive(Debug)]

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -6,9 +6,9 @@
 //! Phase 2 of issue 607 lands the storage shape; Phase 3 wires
 //! `NativeCtx::spawn_child` as the first writer (`Live` slot
 //! insertion); Phase 4a flips `Live` → `Dead` and inserts tombstones
-//! at close; Phase 4b adds [`Self::monitors_of`] / [`Self::monitoring`]
-//! plus the [`Self::register_monitor`] / [`Self::deregister_monitor`]
-//! / [`Self::close_actor`] surface.
+//! at close; Phase 4b adds the crate-internal `monitors_of` /
+//! `monitoring` indices plus the `register_monitor` /
+//! `deregister_monitor` / `close_actor` surface.
 //!
 //! Distinct from [`crate::mail::registry::Registry`] — that one owns
 //! mailbox-name → handler routing and kind descriptors. This one owns
@@ -34,8 +34,8 @@ use crate::mail::MailboxId;
 /// (for direct mail routing into the dispatcher), the actor's
 /// `TypeId` (gates type-keyed `resolve_actors` enumeration), and its
 /// subname (Phase 5 — surfaced through
-/// [`super::PassiveChassis::resolve_actors`] so callers can iterate
-/// `(subname, MailboxId)` pairs). `Dead` is a sentinel for entries
+/// [`crate::chassis::builder::PassiveChassis::resolve_actors`] so callers
+/// can iterate `(subname, MailboxId)` pairs). `Dead` is a sentinel for entries
 /// whose dispatcher has joined and whose actor has dropped — mail
 /// addressed to the slot warn-drops, and `spawn_child` rejects the
 /// name for reuse. ADR-0079 §Drop / lifecycle.
@@ -103,21 +103,21 @@ pub struct ActorRegistry {
     monitoring: RwLock<HashMap<MailboxId, Vec<MailboxId>>>,
 }
 
-/// One entry in [`ActorRegistry::monitors_of`]. Today only carries the
-/// watcher's id; the struct shape leaves room for a future per-monitor
-/// option (monitor reason, reply-target override) without rewriting the
-/// vec storage.
+/// One entry in the registry's internal `monitors_of` index. Today
+/// only carries the watcher's id; the struct shape leaves room for a
+/// future per-monitor option (monitor reason, reply-target override)
+/// without rewriting the vec storage.
 #[derive(Debug, Clone, Copy)]
 pub struct MonitorEntry {
     pub watcher: MailboxId,
 }
 
-/// Failure modes for [`ActorRegistry::register_monitor`] /
-/// [`crate::actor::native::ctx::NativeCtx::monitor`]. ADR-0079 v1: monitors
-/// must address an actor that is currently `Live`. Tombstoned targets
-/// (retired-and-closed full names) can't be monitored — the mail
-/// wouldn't fire anyway, since the close fan-out already ran when the
-/// slot flipped `Live` → `Dead`.
+/// Failure modes for the registry's internal `register_monitor` entry
+/// point (reached from [`crate::actor::native::ctx::NativeCtx::monitor`]).
+/// ADR-0079 v1: monitors must address an actor that is currently `Live`.
+/// Tombstoned targets (retired-and-closed full names) can't be monitored
+/// — the mail wouldn't fire anyway, since the close fan-out already
+/// ran when the slot flipped `Live` → `Dead`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MonitorError {
     /// No `Live` entry at the target id. Either the actor never existed

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -85,15 +85,16 @@ pub struct ComponentCtx {
     /// `dispatch_load_component` reports it like any other
     /// instantiation error. None on the success path.
     pub init_failure: Option<String>,
-    /// Trampoline binding whose `wait_reply` the
-    /// [`crate::actor::wasm::host_fns::wait_reply_p32`] host fn delegates to.
-    /// `Some` for ctx instances built by [`WasmTrampoline::init`]
-    /// (issue 634 Phase 4 PR 3 — `binding.wait_reply` is now the
-    /// single source of inbox / overflow / correlation-filter
-    /// truth); `None` for the test paths that build `ComponentCtx`
-    /// without a real trampoline (the host fn returns
-    /// [`crate::actor::wasm::host_fns::WAIT_CANCELLED`] in that case, matching
-    /// the pre-Phase-4 "no inbox installed" disposition).
+    /// Trampoline binding whose `wait_reply` the `wait_reply_p32` host
+    /// fn (in [`crate::actor::wasm::host_fns`]) delegates to.
+    /// `Some` for ctx instances built by `WasmTrampoline::init`
+    /// (in `aether-capabilities`; issue 634 Phase 4 PR 3 —
+    /// `binding.wait_reply` is now the single source of inbox /
+    /// overflow / correlation-filter truth); `None` for the test paths
+    /// that build `ComponentCtx` without a real trampoline (the host
+    /// fn returns [`crate::actor::wasm::host_fns::WAIT_CANCELLED`] in
+    /// that case, matching the pre-Phase-4 "no inbox installed"
+    /// disposition).
     pub binding: Option<Arc<NativeBinding>>,
     /// ADR-0042 correlation counter. Per-component (one
     /// `ComponentCtx` per component instance). Holds the *next* id
@@ -147,9 +148,9 @@ impl ComponentCtx {
     }
 
     /// Wire the trampoline's `NativeBinding` into the ctx so the
-    /// [`crate::actor::wasm::host_fns::wait_reply_p32`] host fn can route through
-    /// it. Called by `WasmTrampoline::init` (in `aether-capabilities`)
-    /// right after constructing the ctx and before
+    /// `wait_reply_p32` host fn (in [`crate::actor::wasm::host_fns`])
+    /// can route through it. Called by `WasmTrampoline::init` (in
+    /// `aether-capabilities`) right after constructing the ctx and before
     /// `Component::instantiate` — the host-fn closure captures the ctx
     /// via the wasmtime `Store` data pointer at instantiation time,
     /// not at host-fn call time, so installing later than that is

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1,7 +1,7 @@
 //! ADR-0071 Phase 2A: driver-capability traits + chassis builder
 //! type-state.
 //!
-//! Sibling to ADR-0070's [`Capability`] family (post-issue-525-Phase-2:
+//! Sibling to ADR-0070's [`NativeActor`] family (post-issue-525-Phase-2:
 //! one struct per cap, `Drop` replaces `RunningCapability::shutdown`).
 //! A chassis composes passive capabilities (dispatcher-thread sinks
 //! per ADR-0070) plus exactly one [`DriverCapability`] that owns the
@@ -874,9 +874,10 @@ impl<C: Chassis> Builder<C, NoDriver> {
 
     /// Issue 552 stage 1: boot a [`NativeActor`] with its associated
     /// `Config`. The chassis claims the cap's mailbox under
-    /// `A::NAMESPACE`, runs `A::init(config, ctx)`, stores `Arc<A>`
-    /// in the chassis-side [`Actors`] map, and spawns a dispatcher
-    /// thread that drives the cap via [`NativeDispatch`].
+    /// `A::NAMESPACE`, runs `A::init(config, ctx)`, hands ownership of
+    /// the cap to a freshly-spawned dispatcher thread that drives it
+    /// via [`NativeDispatch`], and tracks the live entry through
+    /// [`crate::ActorRegistry`].
     ///
     /// Boot order is declaration order; `.with_actor` calls before
     /// and after `.driver(_)` boot together before the driver runs.
@@ -1008,8 +1009,9 @@ impl<C: Chassis> Builder<C, HasDriver> {
 
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
-    /// shuts down the passives that already booted (via
-    /// [`BootedPassives::Drop`]) before propagating the error.
+    /// shuts down the passives that already booted (via the
+    /// crate-internal `BootedPassives` Drop) before propagating the
+    /// error.
     ///
     /// # Panics
     /// Panics if the `HasDriver` typestate is reached without a driver
@@ -1569,8 +1571,8 @@ impl<C: Chassis> BuiltChassis<C> {
 
 /// A chassis built without a driver. The embedder (`TestBench`, future
 /// embedded harnesses) drives any loop manually. Passives are booted
-/// and accessible via [`Self::capability`]; they shut down when the
-/// `PassiveChassis` is dropped.
+/// and addressable via [`Self::resolve_actor`] / [`Self::resolve_actors`];
+/// they shut down when the `PassiveChassis` is dropped.
 pub struct PassiveChassis<C: Chassis> {
     booted: BootedPassives,
     _chassis: PhantomData<fn() -> C>,

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -59,7 +59,7 @@ pub struct DropOnShutdownClaim {
     /// Issue 635 PR C: optional wake hook for `Pooled` actors. The
     /// mailbox closure invokes this after a successful inbox push so
     /// the chassis worker pool re-queues the actor's
-    /// [`crate::scheduler::DispatcherSlot`]. `Dedicated` actors
+    /// [`Drainable`](crate::scheduler::Drainable) slot. `Dedicated` actors
     /// (today: every cap) leave this empty — the closure's `get()`
     /// is a single atomic load, ~free.
     ///
@@ -72,7 +72,7 @@ pub struct DropOnShutdownClaim {
 /// Cell holding the optional wake hook a `Pooled` mailbox fires after
 /// each accepted send. The mailbox closure captures `Arc<MailboxWakeSlot>`
 /// at registration time; the spawn path populates it once the
-/// [`crate::scheduler::DispatcherSlot`] exists.
+/// [`Drainable`](crate::scheduler::Drainable) slot exists.
 #[derive(Default)]
 pub struct MailboxWakeSlot {
     inner: std::sync::OnceLock<MailboxWakeFn>,

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -105,8 +105,8 @@ impl Mailer {
 
     /// ADR-0080 §5 chassis-mail router installation. Called once by
     /// the chassis builder at boot to wire the closure that handles
-    /// mail addressed to [`MailboxId::CHASSIS_MAILBOX_ID`]. Subsequent
-    /// calls are no-ops — the router slot is single-claim.
+    /// mail addressed to [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`].
+    /// Subsequent calls are no-ops — the router slot is single-claim.
     pub fn install_chassis_router(&self, router: Box<dyn Fn(Mail) + Send + Sync>) {
         let _ = self.chassis_router.set(router);
     }
@@ -123,9 +123,11 @@ impl Mailer {
         let _ = self.settlement_registry.set(registry);
     }
 
-    /// Borrow the wired [`SettlementRegistry`], or `None` if no
-    /// registry was installed (test fixtures, chassis that don't bring
-    /// up the trace pipeline). Capabilities subscribe via
+    /// Borrow the wired
+    /// [`SettlementRegistry`](crate::chassis::settlement::SettlementRegistry),
+    /// or `None` if no registry was installed (test fixtures, chassis
+    /// that don't bring up the trace pipeline). Capabilities subscribe
+    /// via
     /// [`crate::chassis::settlement::SettlementRegistry::subscribe_settlement_mail`].
     pub fn settlement_registry(
         &self,

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -12,9 +12,9 @@
 //! Two entry points:
 //!   - [`init_subscriber`] — called from `SubstrateBoot::build`.
 //!     Installs `EnvFilter` + `tsfmt::Layer` + [`ActorAwareLayer`]
-//!     as `tracing`'s global default, and registers
-//!     [`ship_via_stamped_dispatch`] as `aether-actor::log`'s native
-//!     log shipper. Idempotent.
+//!     as `tracing`'s global default, and registers a crate-internal
+//!     `ship_via_stamped_dispatch` callback as `aether-actor::log`'s
+//!     native log shipper. Idempotent.
 //!   - [`with_actor_dispatch`] — called from each chassis dispatcher
 //!     trampoline. Stamps an actor's transport into TLS for the
 //!     duration of a handler so the actor's `tracing::*` events drain
@@ -39,9 +39,10 @@ use tracing_subscriber::{Layer, fmt as tsfmt};
 /// — the wasm side ships through `FFI_TRANSPORT` directly. The
 /// chassis stamps an actor's transport per-handler via
 /// [`with_actor_dispatch`]; the substrate-registered
-/// `aether-actor` shipper hook ([`ship_via_stamped_dispatch`])
-/// reads the stamp to route the actor's `LogBatch` through the same
-/// transport every other outbound `send` uses.
+/// `aether-actor` shipper hook (the crate-internal
+/// `ship_via_stamped_dispatch`) reads the stamp to route the actor's
+/// `LogBatch` through the same transport every other outbound `send`
+/// uses.
 pub trait MailDispatch: Send + Sync {
     /// Push `payload` (already postcard-encoded `LogBatch` bytes) to
     /// `mailbox`. The implementer's `send_mail` attaches the actor's
@@ -158,9 +159,10 @@ const FILTER_ENV: &str = "AETHER_LOG_FILTER";
 
 /// Install the tracing subscriber stack: `EnvFilter` (reads
 /// `AETHER_LOG_FILTER`, default `info`) + `tsfmt::Layer` to stderr +
-/// [`ActorAwareLayer`]. Also registers [`ship_via_stamped_dispatch`]
-/// as `aether-actor::log`'s native shipper so `drain_buffer` calls
-/// from native actors route through the chassis-stamped transport.
+/// [`ActorAwareLayer`]. Also registers the crate-internal
+/// `ship_via_stamped_dispatch` callback as `aether-actor::log`'s
+/// native shipper so `drain_buffer` calls from native actors route
+/// through the chassis-stamped transport.
 /// Called from `SubstrateBoot::build`; idempotent (later calls no-op
 /// via `try_init`; the shipper hook overwrite is a no-op since it's
 /// the same pointer).

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -55,10 +55,10 @@ static SUBSTRATE_START: OnceLock<Instant> = OnceLock::new();
 /// itself on every read.
 static TRACE_QUEUE: OnceLock<Arc<SegQueue<TraceEvent>>> = OnceLock::new();
 
-/// Initialise the [`SUBSTRATE_START`] reference. Called once during
-/// chassis boot before any actor is wired so every subsequent
-/// timestamp has a stable origin. Safe to call multiple times — the
-/// `OnceLock` ignores subsequent calls.
+/// Initialise the crate-internal `SUBSTRATE_START` reference. Called
+/// once during chassis boot before any actor is wired so every
+/// subsequent timestamp has a stable origin. Safe to call multiple
+/// times — the `OnceLock` ignores subsequent calls.
 pub fn init_substrate_start() {
     let _ = SUBSTRATE_START.set(Instant::now());
 }
@@ -78,10 +78,10 @@ pub fn trace_queue() -> Option<&'static Arc<SegQueue<TraceEvent>>> {
     TRACE_QUEUE.get()
 }
 
-/// Compute the current [`Nanos`] timestamp relative to
-/// [`SUBSTRATE_START`]. `0` if `SUBSTRATE_START` was not initialised
-/// (the producer hooks early-out before this in that case, but the
-/// guard makes the function safe to call standalone).
+/// Compute the current [`Nanos`] timestamp relative to the
+/// crate-internal `SUBSTRATE_START` reference. `0` if `SUBSTRATE_START`
+/// was not initialised (the producer hooks early-out before this in
+/// that case, but the guard makes the function safe to call standalone).
 pub fn now_nanos() -> Nanos {
     let start = match SUBSTRATE_START.get() {
         Some(s) => *s,
@@ -241,10 +241,10 @@ impl Drop for TraceDrainerHandle {
 }
 
 /// Spawn the chassis-owned drainer thread. The thread loop-drains up
-/// to [`BATCH_MAX`] events from the trace queue every
-/// [`BATCH_INTERVAL`] and ships a [`BatchedTraceEvents`] mail to the
-/// [`TRACE_OBSERVER_MAILBOX_NAME`] sink. Returns a handle whose
-/// `Drop` joins the thread.
+/// to `BATCH_MAX` events (crate-internal const) from the trace queue
+/// every `BATCH_INTERVAL` (also crate-internal) and ships a
+/// [`BatchedTraceEvents`] mail to the [`TRACE_OBSERVER_MAILBOX_NAME`]
+/// sink. Returns a handle whose `Drop` joins the thread.
 ///
 /// Idempotent in the sense that calling [`install_trace_queue`]
 /// twice with the same `queue` Arc is a no-op; the chassis builder

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -14,8 +14,9 @@
 //! - [`Pool`] owns the pool worker threads + the ready-queue sender.
 //!   Constructed once at chassis boot.
 //! - [`Drainable`] is the trait [`crate::actor`]-side dispatcher slots
-//!   implement (PR C wires the concrete `DispatcherSlot<A>` over
-//!   [`crate::actor::native::dispatch::dispatch_loop_run`]'s body).
+//!   implement (PR C wires the concrete `DispatcherSlot<A>` over the
+//!   crate-internal `dispatch_loop_run` body in
+//!   `crate::actor::native::dispatch`).
 //! - [`SlotState`] is the per-slot atomic that orchestrates Idle ↔
 //!   Ready ↔ Running transitions between sender-side wakeups and
 //!   worker-side drain claims.

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -36,7 +36,7 @@ use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
 
-/// Configuration for [`Pool::new`]. Defaults via [`PoolConfig::default`]
+/// Configuration for [`Pool::start`]. Defaults via [`PoolConfig::default`]
 /// give `num_cpus`-derived sizing; chassis mains override per
 /// `AETHER_WORKERS` once the pool is wired (PR C).
 #[derive(Debug, Clone)]
@@ -85,10 +85,10 @@ impl BudgetTemplate {
 }
 
 /// Handle to a running [`Pool`]. The chassis owns this; calling
-/// [`PoolHandle::shutdown`] drops the shutdown sender, which
-/// disconnects each worker's `select!` arm and tells them to exit
-/// after the current cycle. Joining the worker threads is part of
-/// `shutdown`.
+/// [`PoolHandle::shutdown_with_results`] drops the shutdown sender,
+/// which disconnects each worker's `select!` arm and tells them to
+/// exit after the current cycle. Joining the worker threads is part
+/// of shutdown.
 ///
 /// Why a separate shutdown channel? Workers hold their own clones of
 /// `ready_tx` (for re-queueing yielded slots). That keeps the ready

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -217,16 +217,15 @@ pub enum CycleResult {
 
 /// Trait the chassis-side dispatcher slot implements. PR C will
 /// implement this for `DispatcherSlot<A>` (one per `Pooled` actor).
-/// PR B exercises it via the in-module test fixture
-/// [`tests::CounterSlot`].
+/// PR B exercises it via an in-module `CounterSlot` test fixture.
 ///
 /// Implementors own:
 /// - The per-slot [`SlotState`] (so this trait can poll it).
 /// - The actor's inbox (so [`run_cycle`](Self::run_cycle) can drain).
 /// - Whatever the actor's handler invocation needs (a `Box<A>` plus
-///   the per-envelope wrapping that [`crate::actor::native::dispatch::dispatch_loop_run`]
-///   does — `local::with_stamped`, `log_install::with_actor_dispatch`,
-///   etc).
+///   the per-envelope wrapping that the crate-internal
+///   `dispatch_loop_run` does in `crate::actor::native::dispatch` —
+///   `local::with_stamped`, `log_install::with_actor_dispatch`, etc).
 pub trait Drainable: Send + Sync + 'static {
     /// One drain cycle. Sequence:
     /// 1. CAS `Ready → Running` (caller holds the invariant: this
@@ -267,10 +266,11 @@ pub trait Drainable: Send + Sync + 'static {
     /// Issue 714: install a one-shot completion sender the slot fires
     /// when its [`CycleResult::Closed`] cycle finishes — i.e. after
     /// `unwire` + registry close ran and the actor box was taken out.
-    /// [`crate::actor::native::spawn::Spawner::shutdown_instanced`]
-    /// uses this to settle on each spawned slot via `recv_timeout`
-    /// instead of polling [`Self::is_closed`] in a 2 ms loop, which
-    /// flaked under nextest contention.
+    /// The crate-internal `Spawner::shutdown_instanced` (in
+    /// `crate::actor::native::spawn`) uses this to settle on each
+    /// spawned slot via `recv_timeout` instead of polling
+    /// [`Self::is_closed`] in a 2 ms loop, which flaked under nextest
+    /// contention.
     ///
     /// Default no-op: mock fixtures don't have a real close cycle so
     /// they never need to signal. Idempotent — the slot only fires the


### PR DESCRIPTION
## What

Phase 5c of the iamacoffeepot/aether#913 Qodana triage — clear the ~120-warning rustdoc backlog so the workspace can keep `broken_intra_doc_links` and `private_intra_doc_links` denied in CI, preventing future stale doc references from accumulating.

## Fixes

| Source | Count | Notes |
|---|---|---|
| Dispatched agent | ~90 | Typos, path corrections, dead-reference unlinks across `aether-actor`, `aether-mesh`, `aether-substrate`, `aether-kinds`, `aether-capabilities`, parts of `aether-substrate-bundle`. Notable: `SyncWaitBridgeer` / `PersistBridgeence` — autocomplete-mangled trait names — corrected to `SyncWaiter` / `Persistence`. |
| Orchestrator (script + manual) | 29 + 3 + 1 | Mass `[`Foo`] → `` `Foo` `` unlink for cross-crate symbols, 3 hand-touched remainders in substrate-bundle desktop/headless docs, and an invalid rust codeblock language tag (`ignore` → `text`) in `aether-substrate/src/actor/native/mod.rs`. |

The unlink strategy preserves doc readability where the symbol exists in the workspace but isn't directly addressable from the referencing crate. Where the symbol genuinely no longer exists, the link target was removed alongside the brackets.

## Lint config

`Cargo.toml` `[workspace.lints.rustdoc]` gains:

```toml
broken_intra_doc_links = "warn"
private_intra_doc_links = "warn"
```

joining the existing `redundant_explicit_links` from iamacoffeepot/aether#932. CI's `Docs` job `RUSTDOCFLAGS` escalates all three to hard fails:

```
-D rustdoc::redundant_explicit_links
-D rustdoc::broken_intra_doc_links
-D rustdoc::private_intra_doc_links
```

## Verification

- `cargo doc --workspace --no-deps` under the broadened `RUSTDOCFLAGS` — 0 remaining warnings
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --target wasm32-unknown-unknown -p <crate>` for the 5 component crates — all green
- `cargo fmt -- --check` — clean
- `cargo nextest run --workspace` — 1001/1001 passed

## References

- iamacoffeepot/aether#913 — Qodana triage umbrella
- iamacoffeepot/aether#932 — sibling lint enable PR for `redundant_explicit_links`; same pattern extended here
