### PR TITLE
chore(qodana): phase final — baseline absorb + strictness flip (closes iamacoffeepot/aether#913)

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -14,11 +14,10 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
-    # Report-only while the EAP linter beds in — Qodana action defaults
-    # to exit-non-zero on findings, which would fail PR CI on every
-    # false positive. Flip to required by removing this line once the
-    # noise floor is understood.
-    continue-on-error: true
+    # Strictness flip (iamacoffeepot/aether#913 Phase Final): the
+    # `continue-on-error: true` is gone now that the noise floor is
+    # baselined. The Qodana action exits non-zero only on findings
+    # NEW relative to the qodana.sarif.json baseline at repo root.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/qodana.sarif.json
+++ b/qodana.sarif.json
@@ -1,0 +1,19312 @@
+{
+  "$schema": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "QDRST",
+          "fullName": "Qodana for Rust",
+          "version": "261.24231",
+          "rules": [],
+          "taxa": [
+            {
+              "id": "Rust",
+              "name": "Rust"
+            },
+            {
+              "id": "HTTP Client",
+              "name": "HTTP Client"
+            },
+            {
+              "id": "Rust/Lints",
+              "name": "Lints",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "Rust",
+                    "index": 0,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "Rust/Lints/Naming conventions",
+              "name": "Naming conventions",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "Rust/Lints",
+                    "index": 2,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "Shell script",
+              "name": "Shell script"
+            },
+            {
+              "id": "XML",
+              "name": "XML"
+            },
+            {
+              "id": "YAML",
+              "name": "YAML"
+            },
+            {
+              "id": "Proofreading",
+              "name": "Proofreading"
+            },
+            {
+              "id": "JSON and JSON5",
+              "name": "JSON and JSON5"
+            },
+            {
+              "id": "RegExp",
+              "name": "RegExp"
+            },
+            {
+              "id": "CSS",
+              "name": "CSS"
+            },
+            {
+              "id": "Rust/Cargo.toml",
+              "name": "Cargo.toml",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "Rust",
+                    "index": 0,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "HTML",
+              "name": "HTML"
+            },
+            {
+              "id": "CSS/Probable bugs",
+              "name": "Probable bugs",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CSS",
+                    "index": 10,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "General",
+              "name": "General"
+            },
+            {
+              "id": "HTML/Accessibility",
+              "name": "Accessibility",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "HTML",
+                    "index": 12,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "CSS/Invalid elements",
+              "name": "Invalid elements",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CSS",
+                    "index": 10,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "Structural search",
+              "name": "Structural search"
+            },
+            {
+              "id": "JSONPath",
+              "name": "JSONPath"
+            },
+            {
+              "id": "CSS/Code style issues",
+              "name": "Code style issues",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CSS",
+                    "index": 10,
+                    "toolComponent": {
+                      "name": "QDRST"
+                    }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "Security",
+              "name": "Security"
+            },
+            {
+              "id": "RELAX NG",
+              "name": "RELAX NG"
+            },
+            {
+              "id": "Internationalization",
+              "name": "Internationalization"
+            },
+            {
+              "id": "TOML",
+              "name": "TOML"
+            },
+            {
+              "id": "Version control",
+              "name": "Version control"
+            },
+            {
+              "id": "Qodana",
+              "name": "Qodana"
+            }
+          ],
+          "language": "en-US",
+          "contents": [
+            "localizedData",
+            "nonLocalizedData"
+          ],
+          "isComprehensive": false
+        },
+        "extensions": [
+          {
+            "name": "com.jetbrains.rust",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "RsFormatMacroErrors",
+                "shortDescription": {
+                  "text": "Format macro error"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in the use of macros that support formatting. Inspection ID: RsFormatMacroErrors",
+                  "markdown": "Reports errors in the use of macros that support formatting.\n\nInspection ID: RsFormatMacroErrors"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFormatMacroErrors",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsVariableCaptureFromOuterFunction",
+                "shortDescription": {
+                  "text": "Dynamic environment capture in `fn`"
+                },
+                "fullDescription": {
+                  "text": "Reports captures of a dynamic environment in a `fn` item. Inspection ID: RsVariableCaptureFromOuterFunction",
+                  "markdown": "Reports captures of a dynamic environment in a \\`fn\\` item.\n\nInspection ID: RsVariableCaptureFromOuterFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsVariableCaptureFromOuterFunction",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsOnlyAutoTraitsInTraitObject",
+                "shortDescription": {
+                  "text": "Additional non-auto trait in trait object"
+                },
+                "fullDescription": {
+                  "text": "Reports trait objects with additional non-auto traits. In trait objects, only auto traits can be added as additional traits. Inspection ID: RsOnlyAutoTraitsInTraitObject",
+                  "markdown": "Reports trait objects with additional non-auto traits. In trait objects, only auto traits can be added as additional traits.\n\nInspection ID: RsOnlyAutoTraitsInTraitObject"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsOnlyAutoTraitsInTraitObject",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFormatMacroWithoutFormatArguments",
+                "shortDescription": {
+                  "text": "Immutable reassigned"
+                },
+                "fullDescription": {
+                  "text": "Reports 'format!' calls with missing format arguments. Inspection ID: RsFormatMacroWithoutFormatArguments",
+                  "markdown": "Reports `format!` calls with missing format arguments.\n\nInspection ID: RsFormatMacroWithoutFormatArguments"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsFormatMacroWithoutFormatArguments",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSelfValueIsNotAvailable",
+                "shortDescription": {
+                  "text": "`self` unavailable in context"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `self` in contexts where it is not available. Inspection ID: RsSelfValueIsNotAvailable",
+                  "markdown": "Reports the use of \\`self\\` in contexts where it is not available.\n\nInspection ID: RsSelfValueIsNotAvailable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsSelfValueIsNotAvailable",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnnecessaryParentheses",
+                "shortDescription": {
+                  "text": "Unnecessary parentheses"
+                },
+                "fullDescription": {
+                  "text": "Detects unnecessary parentheses. Corresponds to the unused-parens Rust lint. Inspection ID: RsUnnecessaryParentheses",
+                  "markdown": "Detects unnecessary parentheses. Corresponds to the [unused-parens](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-parens) Rust lint.\n\nInspection ID: RsUnnecessaryParentheses"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnnecessaryParentheses",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDerivableTraitMembers",
+                "shortDescription": {
+                  "text": "Derived trait not implemented"
+                },
+                "fullDescription": {
+                  "text": "Reports members that do not implement the traits being derived. Inspection ID: RsDerivableTraitMembers",
+                  "markdown": "Reports members that do not implement the traits being derived.\n\nInspection ID: RsDerivableTraitMembers"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDerivableTraitMembers",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTupleLikeUnion",
+                "shortDescription": {
+                  "text": "Tuple-like union"
+                },
+                "fullDescription": {
+                  "text": "Reports union declarations with tuple syntax. Inspection ID: RsTupleLikeUnion",
+                  "markdown": "Reports union declarations with tuple syntax.\n\nInspection ID: RsTupleLikeUnion"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTupleLikeUnion",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypeAliasNaming",
+                "shortDescription": {
+                  "text": "Type alias naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if type alias names follow the Rust naming convention. Inspection ID: RsTypeAliasNaming",
+                  "markdown": "Checks if type alias names follow the Rust naming convention.\n\nInspection ID: RsTypeAliasNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsTypeAliasNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidLiteralSuffix",
+                "shortDescription": {
+                  "text": "Invalid literal suffix"
+                },
+                "fullDescription": {
+                  "text": "Reports literals with invalid suffixes. Inspection ID: RsInvalidLiteralSuffix",
+                  "markdown": "Reports literals with invalid suffixes.\n\nInspection ID: RsInvalidLiteralSuffix"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidLiteralSuffix",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLiteralOutOfRange",
+                "shortDescription": {
+                  "text": "Literal out of range"
+                },
+                "fullDescription": {
+                  "text": "Check if a numerical value is out of the range of the receiver. For example: 'let x: u8 = 256;'. Inspection ID: RsLiteralOutOfRange",
+                  "markdown": "Check if a numerical value is out of the range of the receiver. For example: `let x: u8 = 256;`.\n\nInspection ID: RsLiteralOutOfRange"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsLiteralOutOfRange",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTraitImplOrphanRules",
+                "shortDescription": {
+                  "text": "Foreign trait implementation"
+                },
+                "fullDescription": {
+                  "text": "Reports implementations of foreign traits (traits defined outside the current crate) for arbitrary types. Inspection ID: RsTraitImplOrphanRules",
+                  "markdown": "Reports implementations of foreign traits (traits defined outside the current crate) for arbitrary types.\n\nInspection ID: RsTraitImplOrphanRules"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTraitImplOrphanRules",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSuspiciousAssignment",
+                "shortDescription": {
+                  "text": "Suspicious assignment"
+                },
+                "fullDescription": {
+                  "text": "Detects use of the non-existent '=*', '=!' and '=-' operators that are probably typos. Corresponds to suspicious_assignment_formatting lint from Rust Clippy. Inspection ID: RsSuspiciousAssignment",
+                  "markdown": "Detects use of the non-existent `=*`, `=!` and `=-` operators that are probably typos.  \nCorresponds to [suspicious_assignment_formatting](https://rust-lang.github.io/rust-clippy/stable/#suspicious_assignment_formatting) lint from Rust Clippy.\n\nInspection ID: RsSuspiciousAssignment"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsSuspiciousAssignment",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMissingElse",
+                "shortDescription": {
+                  "text": "Missing `else`"
+                },
+                "fullDescription": {
+                  "text": "Detects suspiciously looking 'if'-statements with potentially missing 'else's. Partially corresponds to suspicious_else_formatting lint from Rust Clippy. Inspection ID: RsMissingElse",
+                  "markdown": "Detects suspiciously looking `if`-statements with potentially missing `else`s.  \nPartially corresponds to [suspicious_else_formatting](https://rust-lang.github.io/rust-clippy/stable/#suspicious_else_formatting) lint from Rust Clippy.\n\nInspection ID: RsMissingElse"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsMissingElse",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInclusiveRangeWithNoEnd",
+                "shortDescription": {
+                  "text": "Inclusive range without an end bound"
+                },
+                "fullDescription": {
+                  "text": "Reports inclusive ranges without a specified end bound (`..=b` or `a..=b`). Inspection ID: RsInclusiveRangeWithNoEnd",
+                  "markdown": "Reports inclusive ranges without a specified end bound (\\`..=b\\` or \\`a..=b\\`).\n\nInspection ID: RsInclusiveRangeWithNoEnd"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInclusiveRangeWithNoEnd",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDbgUsage",
+                "shortDescription": {
+                  "text": "`#[dbg]` usage"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of 'dbg!' macro. Inspection ID: RsDbgUsage",
+                  "markdown": "Reports usages of `dbg!` macro.\n\nInspection ID: RsDbgUsage"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsDbgUsage",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExternalLinter",
+                "shortDescription": {
+                  "text": "External linter"
+                },
+                "fullDescription": {
+                  "text": "This inspection runs external linter to check for rustc or clippy errors. Inspection ID: RsExternalLinter",
+                  "markdown": "This inspection runs external linter to check for rustc or clippy errors.\n\nInspection ID: RsExternalLinter"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExternalLinter",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsPlaceExpression",
+                "shortDescription": {
+                  "text": "Invalid place expression"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid place expressions. For example: '1 + 1 = 2'. Inspection ID: RsPlaceExpression",
+                  "markdown": "Reports invalid place expressions. For example: `1 + 1 = 2`.\n\nInspection ID: RsPlaceExpression"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsPlaceExpression",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAttrWithoutParentheses",
+                "shortDescription": {
+                  "text": "Attribute without parentheses"
+                },
+                "fullDescription": {
+                  "text": "Detects incomplete attributes that require parentheses. Inspection ID: RsAttrWithoutParentheses",
+                  "markdown": "Detects incomplete attributes that require parentheses.\n\nInspection ID: RsAttrWithoutParentheses"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAttrWithoutParentheses",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TomlUnclosedLiteral",
+                "shortDescription": {
+                  "text": "Unclosed string literal"
+                },
+                "fullDescription": {
+                  "text": "Reports string literals that are missing a closing quote. Inspection ID: TomlUnclosedLiteral",
+                  "markdown": "Reports string literals that are missing a closing quote.\n\nInspection ID: TomlUnclosedLiteral"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "TomlUnclosedLiteral",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsEdition2018Keywords",
+                "shortDescription": {
+                  "text": "Rust 2018 edition violation"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of keywords reserved in Rust 2018 edition, as well as features unavailable in Rust 2018 edition. Inspection ID: RsEdition2018Keywords",
+                  "markdown": "Reports the use of keywords reserved in Rust 2018 edition, as well as features unavailable in Rust 2018 edition.\n\nInspection ID: RsEdition2018Keywords"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsEdition2018Keywords",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsRedundantSemicolons",
+                "shortDescription": {
+                  "text": "Redundant semicolons"
+                },
+                "fullDescription": {
+                  "text": "Detects unnecessary trailing semicolons. Corresponds to the redundant_semicolons lint. Inspection ID: RsRedundantSemicolons",
+                  "markdown": "Detects unnecessary trailing semicolons. Corresponds to the [redundant_semicolons](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#redundant-semicolons) lint.\n\nInspection ID: RsRedundantSemicolons"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsRedundantSemicolons",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFieldWithoutType",
+                "shortDescription": {
+                  "text": "Missing struct field type"
+                },
+                "fullDescription": {
+                  "text": "Reports struct fields declared without a type. Inspection ID: RsFieldWithoutType",
+                  "markdown": "Reports struct fields declared without a type.\n\nInspection ID: RsFieldWithoutType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFieldWithoutType",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsProcMacroAttrInNonProcMacroCrate",
+                "shortDescription": {
+                  "text": "Proc macro defined outside `proc-macro` crate"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of '#[proc_macro]', '#[proc_macro_attribute]', and '#[proc_macro_derive]' attributes in non-procedural macro crates. These attributes only work for procedural macro crates (i.e. crates with the 'proc-macro' key set to 'true' in Cargo.toml). Inspection ID: RsProcMacroAttrInNonProcMacroCrate",
+                  "markdown": "Reports the use of `#[proc_macro]`, `#[proc_macro_attribute]`, and `#[proc_macro_derive]` attributes in non-procedural macro crates. These attributes only work for procedural macro crates (i.e. crates with the `proc-macro` key set to `true` in Cargo.toml).\n\nInspection ID: RsProcMacroAttrInNonProcMacroCrate"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsProcMacroAttrInNonProcMacroCrate",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNonExhaustiveMatch",
+                "shortDescription": {
+                  "text": "Non-exhaustive match"
+                },
+                "fullDescription": {
+                  "text": "Checks that 'match' expression is exhaustive, i.e. all possible patterns are covered. Inspection ID: RsNonExhaustiveMatch",
+                  "markdown": "Checks that `match` expression is exhaustive, i.e. all possible patterns are covered.\n\nInspection ID: RsNonExhaustiveMatch"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNonExhaustiveMatch",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsManualImplOfFnTrait",
+                "shortDescription": {
+                  "text": "Manual implementation of `Fn`, `FnMut`, or `FnOnce`"
+                },
+                "fullDescription": {
+                  "text": "Reports manual implementations of `Fn`, `FnMut`, and `FnOnce` traits. Such implementations are unstable and require a '#![feature(fn_traits, unboxed_closures)]' attribute. Inspection ID: RsManualImplOfFnTrait",
+                  "markdown": "Reports manual implementations of \\`Fn\\`, \\`FnMut\\`, and \\`FnOnce\\` traits. Such implementations are unstable and require a `#![feature(fn_traits, unboxed_closures)]` attribute.\n\nInspection ID: RsManualImplOfFnTrait"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsManualImplOfFnTrait",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDuplicateHashKey",
+                "shortDescription": {
+                  "text": "Duplicate hash key"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicate keys when creating hash maps. Inspection ID: RsDuplicateHashKey",
+                  "markdown": "Reports duplicate keys when creating hash maps.\n\nInspection ID: RsDuplicateHashKey"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsDuplicateHashKey",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidLetExpression",
+                "shortDescription": {
+                  "text": "Unsupported `let` expression"
+                },
+                "fullDescription": {
+                  "text": "Reports `let` expressions in places where they are unsupported. Inspection ID: RsInvalidLetExpression",
+                  "markdown": "Reports \\`let\\` expressions in places where they are unsupported.\n\nInspection ID: RsInvalidLetExpression"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidLetExpression",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionParametersAreSized",
+                "shortDescription": {
+                  "text": "Parameter type with unknown size"
+                },
+                "fullDescription": {
+                  "text": "Reports function parameters whose types are unknown at compile time. Inspection ID: RsFunctionParametersAreSized",
+                  "markdown": "Reports function parameters whose types are unknown at compile time.\n\nInspection ID: RsFunctionParametersAreSized"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionParametersAreSized",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDoubleMustUse",
+                "shortDescription": {
+                  "text": "Redundant `#[must_use]`"
+                },
+                "fullDescription": {
+                  "text": "Checks for a '#[must_use]' attribute without further information on functions and methods that return a type already marked as '#[must_use]'. Corresponds to double_must_use lint from Rust Clippy. Inspection ID: RsDoubleMustUse",
+                  "markdown": "Checks for a `#[must_use]` attribute without further information on functions and methods that return a type already marked as `#[must_use]`. Corresponds to [double_must_use](https://rust-lang.github.io/rust-clippy/stable#double_must_use) lint from Rust Clippy.\n\nInspection ID: RsDoubleMustUse"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsDoubleMustUse",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsImplDropForNonAdt",
+                "shortDescription": {
+                  "text": "Invalid `Drop` implementation"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid `Drop` implementations. The `Drop` trait can only be implemented for structs and enums. E0120 Inspection ID: RsImplDropForNonAdt",
+                  "markdown": "Reports invalid \\`Drop\\` implementations. The \\`Drop\\` trait can only be implemented for structs and enums. [E0120](https://doc.rust-lang.org/error_codes/E0120.html)\n\nInspection ID: RsImplDropForNonAdt"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsImplDropForNonAdt",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnresolvedPath",
+                "shortDescription": {
+                  "text": "Unresolved path"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved path references. Inspection ID: RsUnresolvedPath",
+                  "markdown": "Reports unresolved path references.\n\nInspection ID: RsUnresolvedPath"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnresolvedPath",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalUnresolvedPath",
+                "shortDescription": {
+                  "text": "Unresolved path (experimental)"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved path references. This inspection can report false positives. Inspection ID: RsExperimentalUnresolvedPath",
+                  "markdown": "Reports unresolved path references. This inspection can report false positives.\n\nInspection ID: RsExperimentalUnresolvedPath"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalUnresolvedPath",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CargoUnusedDependency",
+                "shortDescription": {
+                  "text": "Unused dependency"
+                },
+                "fullDescription": {
+                  "text": "Reports crates that are not used in the project's source code. Inspection ID: CargoUnusedDependency",
+                  "markdown": "Reports crates that are not used in the project's source code.\n\nInspection ID: CargoUnusedDependency"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CargoUnusedDependency",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDeprecation",
+                "shortDescription": {
+                  "text": "Deprecated element"
+                },
+                "fullDescription": {
+                  "text": "Detects the item marked with '#[deprecated(...)]' attribute, which is discouraged from using, typically because it is dangerous, or because a better alternative exists. Inspection ID: RsDeprecation",
+                  "markdown": "Detects the item marked with `#[deprecated(...)]` attribute, which is discouraged from using, typically because it is dangerous, or because a better alternative exists.\n\nInspection ID: RsDeprecation"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDeprecation",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCompileErrorMacro",
+                "shortDescription": {
+                  "text": "`compile_error!` macro"
+                },
+                "fullDescription": {
+                  "text": "Highlights `compile_error!()` macro invocation. Inspection ID: RsCompileErrorMacro",
+                  "markdown": "Highlights \\`compile_error!()\\` macro invocation.\n\nInspection ID: RsCompileErrorMacro"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCompileErrorMacro",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidBreakContinue",
+                "shortDescription": {
+                  "text": "Invalid 'break' or 'continue'"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of 'break' and 'continue' in loops. Inspection ID: RsInvalidBreakContinue",
+                  "markdown": "Reports invalid usages of `break` and `continue` in loops.\n\nInspection ID: RsInvalidBreakContinue"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidBreakContinue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsConstNaming",
+                "shortDescription": {
+                  "text": "Constant naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if constant names follow the Rust naming convention. Inspection ID: RsConstNaming",
+                  "markdown": "Checks if constant names follow the Rust naming convention.\n\nInspection ID: RsConstNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsConstNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnusedMut",
+                "shortDescription": {
+                  "text": "Unused `mut` modifier"
+                },
+                "fullDescription": {
+                  "text": "Detects unnecessary 'mut' qualifiers. Inspection ID: RsUnusedMut",
+                  "markdown": "Detects unnecessary `mut` qualifiers.\n\nInspection ID: RsUnusedMut"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnusedMut",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLoopOnlyKeywordOutsideOfLoop",
+                "shortDescription": {
+                  "text": "`continue`/`break` used outside `loop`/`while`"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `break`/`continue` keywords outside `loop`/`while` blocks. Inspection ID: RsLoopOnlyKeywordOutsideOfLoop",
+                  "markdown": "Reports the use of \\`break\\`/\\`continue\\` keywords outside \\`loop\\`/\\`while\\` blocks.\n\nInspection ID: RsLoopOnlyKeywordOutsideOfLoop"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsLoopOnlyKeywordOutsideOfLoop",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnclosedTextLiteral",
+                "shortDescription": {
+                  "text": "Unclosed text literal"
+                },
+                "fullDescription": {
+                  "text": "Reports unclosed text literals. Inspection ID: RsUnclosedTextLiteral",
+                  "markdown": "Reports unclosed text literals.\n\nInspection ID: RsUnclosedTextLiteral"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnclosedTextLiteral",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnderscoreInExpression",
+                "shortDescription": {
+                  "text": "`_` on the right-hand side of assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid use of underscores (`_`) in expressions: they are only allowed on the left-hand side of an assignment. Inspection ID: RsUnderscoreInExpression",
+                  "markdown": "Reports invalid use of underscores (\\`_\\`) in expressions: they are only allowed on the left-hand side of an assignment.\n\nInspection ID: RsUnderscoreInExpression"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnderscoreInExpression",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionNaming",
+                "shortDescription": {
+                  "text": "Function naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if function names follow the Rust naming convention. Inspection ID: RsFunctionNaming",
+                  "markdown": "Checks if function names follow the Rust naming convention.\n\nInspection ID: RsFunctionNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionSyntax",
+                "shortDescription": {
+                  "text": "Incorrect function syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect function syntax. Inspection ID: RsFunctionSyntax",
+                  "markdown": "Reports incorrect function syntax.\n\nInspection ID: RsFunctionSyntax"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionSyntax",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NewCrateVersionAvailable",
+                "shortDescription": {
+                  "text": "Newer crate version available"
+                },
+                "fullDescription": {
+                  "text": "Reports outdated crate versions in Cargo.toml. Inspection ID: NewCrateVersionAvailable",
+                  "markdown": "Reports outdated crate versions in Cargo.toml.\n\nInspection ID: NewCrateVersionAvailable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "NewCrateVersionAvailable",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSimplifyBooleanExpression",
+                "shortDescription": {
+                  "text": "Boolean expression can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Detects boolean expressions that can be safely simplified like 'a || true'. Does not simplify expressions if some side effects can be eliminated, such as 'return || true' for example. Inspection ID: RsSimplifyBooleanExpression",
+                  "markdown": "Detects boolean expressions that can be safely simplified like `a || true`.  \nDoes not simplify expressions if some side effects can be eliminated, such as `return || true` for example.\n\nInspection ID: RsSimplifyBooleanExpression"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsSimplifyBooleanExpression",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsStructInheritance",
+                "shortDescription": {
+                  "text": "Struct inheritance (unsupported)"
+                },
+                "fullDescription": {
+                  "text": "Reports struct inheritance, which is not supported in Rust. Inspection ID: RsStructInheritance",
+                  "markdown": "Reports struct inheritance, which is not supported in Rust.\n\nInspection ID: RsStructInheritance"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsStructInheritance",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReturnMustHaveValue",
+                "shortDescription": {
+                  "text": "`return` must have a value"
+                },
+                "fullDescription": {
+                  "text": "Reports `return;` statements contained in functions whose return type is not `()`. E0069 Inspection ID: RsReturnMustHaveValue",
+                  "markdown": "Reports \\`return;\\` statements contained in functions whose return type is not \\`()\\`. [E0069](https://doc.rust-lang.org/error_codes/E0069.html)\n\nInspection ID: RsReturnMustHaveValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsReturnMustHaveValue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAtLeastOneTraitForObjectType",
+                "shortDescription": {
+                  "text": "Object type with no traits"
+                },
+                "fullDescription": {
+                  "text": "Reports trait objects declared without a single trait. Inspection ID: RsAtLeastOneTraitForObjectType",
+                  "markdown": "Reports trait objects declared without a single trait.\n\nInspection ID: RsAtLeastOneTraitForObjectType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAtLeastOneTraitForObjectType",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCopyAndDropImpl",
+                "shortDescription": {
+                  "text": "Both `Copy` and `Drop` implemented"
+                },
+                "fullDescription": {
+                  "text": "Reports cases where the `Copy` trait is implemented along with `Drop`, which is considered unsafe and currently not allowed in the Rust language. E0184 Inspection ID: RsCopyAndDropImpl",
+                  "markdown": "Reports cases where the \\`Copy\\` trait is implemented along with \\`Drop\\`, which is considered unsafe and currently not allowed in the Rust language. [E0184](https://doc.rust-lang.org/error_codes/E0184.html)\n\nInspection ID: RsCopyAndDropImpl"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCopyAndDropImpl",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsThreadRngGen",
+                "shortDescription": {
+                  "text": "`thread_rng().gen()` can be replaced with `random()`"
+                },
+                "fullDescription": {
+                  "text": "Detects usage of 'thread_rng().gen()' that can be replaced with 'random()' from 'rand' crate. Inspection ID: RsThreadRngGen",
+                  "markdown": "Detects usage of `thread_rng().gen()` that can be replaced with `random()` from `rand` crate.\n\nInspection ID: RsThreadRngGen"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsThreadRngGen",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDuplicateEnumDiscriminant",
+                "shortDescription": {
+                  "text": "Repeated discriminant value"
+                },
+                "fullDescription": {
+                  "text": "Reports discriminant values that are present more than once in a single enum. Inspection ID: RsDuplicateEnumDiscriminant",
+                  "markdown": "Reports discriminant values that are present more than once in a single enum.\n\nInspection ID: RsDuplicateEnumDiscriminant"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDuplicateEnumDiscriminant",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLiveness",
+                "shortDescription": {
+                  "text": "Liveness analysis"
+                },
+                "fullDescription": {
+                  "text": "Reports unused local variables and parameters. Inspection ID: RsLiveness",
+                  "markdown": "Reports unused local variables and parameters.\n\nInspection ID: RsLiveness"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsLiveness",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDeriveOnUnsupportedItem",
+                "shortDescription": {
+                  "text": "`#[derive]` not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports `derive` attributes applied to items other than structs, enums, or unions. Inspection ID: RsDeriveOnUnsupportedItem",
+                  "markdown": "Reports \\`derive\\` attributes applied to items other than structs, enums, or unions.\n\nInspection ID: RsDeriveOnUnsupportedItem"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDeriveOnUnsupportedItem",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsImplToString",
+                "shortDescription": {
+                  "text": "`ToString` should not be implemented directly"
+                },
+                "fullDescription": {
+                  "text": "Detects implementations of 'ToString' trait which, as its documentation states, shouldn't be implemented directly and 'Display' trait should be implemented instead. Inspection ID: RsImplToString",
+                  "markdown": "Detects implementations of `ToString` trait which, as its documentation states, shouldn't be implemented directly and `Display` trait should be implemented instead.\n\nInspection ID: RsImplToString"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsImplToString",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDotDotDotMustBeLastInArgumentList",
+                "shortDescription": {
+                  "text": "Misplaced `...` argument"
+                },
+                "fullDescription": {
+                  "text": "Reports variadic functions where `...` is not positioned as the last argument. Inspection ID: RsDotDotDotMustBeLastInArgumentList",
+                  "markdown": "Reports variadic functions where \\`...\\` is not positioned as the last argument.\n\nInspection ID: RsDotDotDotMustBeLastInArgumentList"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDotDotDotMustBeLastInArgumentList",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDefaultTypeParametersSyntax",
+                "shortDescription": {
+                  "text": "Incorrect default type parameter syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in the use of default type parameters. Inspection ID: RsDefaultTypeParametersSyntax",
+                  "markdown": "Reports errors in the use of default type parameters.\n\nInspection ID: RsDefaultTypeParametersSyntax"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDefaultTypeParametersSyntax",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TomlJsonSchemaBased",
+                "shortDescription": {
+                  "text": "Schema violation"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in Cargo.toml related to structure, constraints, and data types. Inspection ID: TomlJsonSchemaBased",
+                  "markdown": "Reports errors in Cargo.toml related to structure, constraints, and data types.\n\nInspection ID: TomlJsonSchemaBased"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "TomlJsonSchemaBased",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDuplicatedTraitMethodBinding",
+                "shortDescription": {
+                  "text": "Duplicate trait method parameter name"
+                },
+                "fullDescription": {
+                  "text": "Checks duplicated parameter names of abstract trait methods. Inspection ID: RsDuplicatedTraitMethodBinding",
+                  "markdown": "Checks duplicated parameter names of abstract trait methods.\n\nInspection ID: RsDuplicatedTraitMethodBinding"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsDuplicatedTraitMethodBinding",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsImplForNonAdtError",
+                "shortDescription": {
+                  "text": "Inherent `impl` block not allowed for item"
+                },
+                "fullDescription": {
+                  "text": "Reports inherent `impl` blocks defined for items other than structs, enums, unions, or trait objects. Inspection ID: RsImplForNonAdtError",
+                  "markdown": "Reports inherent \\`impl\\` blocks defined for items other than structs, enums, unions, or trait objects.\n\nInspection ID: RsImplForNonAdtError"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsImplForNonAdtError",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsImplTraitNotAllowed",
+                "shortDescription": {
+                  "text": "`impl Trait` not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect use of `impl Trait`. Abstract return types are only allowed as function and inherent impl return types. Inspection ID: RsImplTraitNotAllowed",
+                  "markdown": "Reports incorrect use of \\`impl Trait\\`. Abstract return types are only allowed as function and inherent impl return types.\n\nInspection ID: RsImplTraitNotAllowed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsImplTraitNotAllowed",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionCannotBeVariadic",
+                "shortDescription": {
+                  "text": "Function cannot be variadic"
+                },
+                "fullDescription": {
+                  "text": "Reports functions that cannot be declared variadic. Inspection ID: RsFunctionCannotBeVariadic",
+                  "markdown": "Reports functions that cannot be declared variadic.\n\nInspection ID: RsFunctionCannotBeVariadic"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionCannotBeVariadic",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnreachablePatterns",
+                "shortDescription": {
+                  "text": "Unreachable patterns"
+                },
+                "fullDescription": {
+                  "text": "Checks that 'match' expression doesn't have unreachable patterns. Inspection ID: RsUnreachablePatterns",
+                  "markdown": "Checks that `match` expression doesn't have unreachable patterns.\n\nInspection ID: RsUnreachablePatterns"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsUnreachablePatterns",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsArgumentNaming",
+                "shortDescription": {
+                  "text": "Argument naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if function and method argument names follow the Rust naming convention. Inspection ID: RsArgumentNaming",
+                  "markdown": "Checks if function and method argument names follow the Rust naming convention.\n\nInspection ID: RsArgumentNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsArgumentNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAssertEqual",
+                "shortDescription": {
+                  "text": "Equality assertion can be simplified"
+                },
+                "fullDescription": {
+                  "text": "RsAssertEqualInspection Detect 'assert!(a == b)' (and 'assert!(a != b)') macro call that can be simplified into 'assert_eq!(a, b)' (or 'assert_ne!(a, b)'). Inspection ID: RsAssertEqual",
+                  "markdown": "Detect `assert!(a == b)` (and `assert!(a != b)`) macro call that can be simplified into `assert_eq!(a, b)` (or `assert_ne!(a, b)`).\n\nInspection ID: RsAssertEqual"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsAssertEqual",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsConstantConditionIf",
+                "shortDescription": {
+                  "text": "`if` condition is constant"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if' expressions that have 'true' or 'false' constant literal condition and can be simplified. Inspection ID: RsConstantConditionIf",
+                  "markdown": "Reports `if` expressions that have `true` or `false` constant literal condition and can be simplified.\n\nInspection ID: RsConstantConditionIf"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsConstantConditionIf",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnreachableCode",
+                "shortDescription": {
+                  "text": "Unreachable code"
+                },
+                "fullDescription": {
+                  "text": "Reports unreachable code. Inspection ID: RsUnreachableCode",
+                  "markdown": "Reports unreachable code.\n\nInspection ID: RsUnreachableCode"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsUnreachableCode",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypeAliasSyntax",
+                "shortDescription": {
+                  "text": "Incorrect type alias syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect type alias syntax. Inspection ID: RsTypeAliasSyntax",
+                  "markdown": "Reports incorrect type alias syntax.\n\nInspection ID: RsTypeAliasSyntax"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTypeAliasSyntax",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNonStructuralMatchTypeAsConstGenericParameter",
+                "shortDescription": {
+                  "text": "Non-structural-match type used for const generic parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of non-structural-match types for const generic parameters. Only structural-match types (types that derive 'PartialEq' and 'Eq' and implement 'ConstParamTy') can be used for const generic parameters. Inspection ID: RsNonStructuralMatchTypeAsConstGenericParameter",
+                  "markdown": "Reports the use of non-structural-match types for const generic parameters. Only structural-match types (types that derive `PartialEq` and `Eq` and implement `ConstParamTy`) can be used for const generic parameters.\n\nInspection ID: RsNonStructuralMatchTypeAsConstGenericParameter"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNonStructuralMatchTypeAsConstGenericParameter",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCStringPointer",
+                "shortDescription": {
+                  "text": "Unsafe CString pointer"
+                },
+                "fullDescription": {
+                  "text": "Detects unsafe usage of 'CString'. The code like 'CString::new(\"hello\").unwrap().as_ptr()' may lead to memory unsafety because the string is deallocated at the end of the expression. Inspection ID: RsCStringPointer",
+                  "markdown": "Detects unsafe usage of `CString`. The code like `CString::new(\"hello\").unwrap().as_ptr()` may lead to memory unsafety because the string is deallocated at the end of the expression.\n\nInspection ID: RsCStringPointer"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsCStringPointer",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsStructNaming",
+                "shortDescription": {
+                  "text": "Struct naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if struct names follow the Rust naming convention. Inspection ID: RsStructNaming",
+                  "markdown": "Checks if struct names follow the Rust naming convention.\n\nInspection ID: RsStructNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsStructNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsModuleNotFound",
+                "shortDescription": {
+                  "text": "No file found for module"
+                },
+                "fullDescription": {
+                  "text": "Reports module declarations with no corresponding file found. Inspection ID: RsModuleNotFound",
+                  "markdown": "Reports module declarations with no corresponding file found.\n\nInspection ID: RsModuleNotFound"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsModuleNotFound",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnstableItemUsage",
+                "shortDescription": {
+                  "text": "Unstable item"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of unstable items. Inspection ID: RsUnstableItemUsage",
+                  "markdown": "Reports the use of unstable items.\n\nInspection ID: RsUnstableItemUsage"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnstableItemUsage",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReassignImmutable",
+                "shortDescription": {
+                  "text": "Immutable variable reassigned"
+                },
+                "fullDescription": {
+                  "text": "Detects immutable bindings reassignments. Corresponds to E0384 Rust error. Inspection ID: RsReassignImmutable",
+                  "markdown": "Detects immutable bindings reassignments. Corresponds to [E0384](https://doc.rust-lang.org/error-index.html#E0384) Rust error.\n\nInspection ID: RsReassignImmutable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsReassignImmutable",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsModuleInsideBlockWithoutPath",
+                "shortDescription": {
+                  "text": "Non-inline module declaration missing path attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports non-inline modules declared inside a block and missing the path attribute. Inspection ID: RsModuleInsideBlockWithoutPath",
+                  "markdown": "Reports non-inline modules declared inside a block and missing the path attribute.\n\nInspection ID: RsModuleInsideBlockWithoutPath"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsModuleInsideBlockWithoutPath",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnknownCrateTypes",
+                "shortDescription": {
+                  "text": "Unknown crate types"
+                },
+                "fullDescription": {
+                  "text": "Detects an unknown crate type found in a 'crate_type' attribute. Inspection ID: RsUnknownCrateTypes",
+                  "markdown": "Detects an unknown crate type found in a `crate_type` attribute.\n\nInspection ID: RsUnknownCrateTypes"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnknownCrateTypes",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TomlDuplicatedKey",
+                "shortDescription": {
+                  "text": "Duplicate key"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicated keys within the same section of a 'Cargo.toml' file. Example: '[foo]\n  bar = 1 # Property redefinition is not allowed\n  bar = 2 # Property redefinition is not allowed' Inspection ID: TomlDuplicatedKey",
+                  "markdown": "Reports duplicated keys within the same section of a `Cargo.toml` file.\n\n**Example:**\n\n\n      [foo]\n      bar = 1 # Property redefinition is not allowed\n      bar = 2 # Property redefinition is not allowed\n\nInspection ID: TomlDuplicatedKey"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "TomlDuplicatedKey",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUndeclaredLifetime",
+                "shortDescription": {
+                  "text": "Undeclared lifetime name"
+                },
+                "fullDescription": {
+                  "text": "Reports undeclared lifetimes. Inspection ID: RsUndeclaredLifetime",
+                  "markdown": "Reports undeclared lifetimes.\n\nInspection ID: RsUndeclaredLifetime"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUndeclaredLifetime",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSelfImport",
+                "shortDescription": {
+                  "text": "Invalid `self` import"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid `self` imports. Inspection ID: RsSelfImport",
+                  "markdown": "Reports invalid \\`self\\` imports.\n\nInspection ID: RsSelfImport"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsSelfImport",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWrongGenericArgumentsNumber",
+                "shortDescription": {
+                  "text": "Wrong number of generic arguments"
+                },
+                "fullDescription": {
+                  "text": "Checks if the right number of generic arguments was used for a type, trait, function call or method call. Corresponds to the E0107 Rust error. Inspection ID: RsWrongGenericArgumentsNumber",
+                  "markdown": "Checks if the right number of generic arguments was used for a type, trait, function call or method call.   \nCorresponds to the [E0107](https://doc.rust-lang.org/error-index.html#E0107) Rust error.\n\nInspection ID: RsWrongGenericArgumentsNumber"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsWrongGenericArgumentsNumber",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCircularMods",
+                "shortDescription": {
+                  "text": "Circular modules"
+                },
+                "fullDescription": {
+                  "text": "Reports circular module declarations with the '#path' attribute. Such declarations produce an infinite module graph and cannot be compiled. A common example of this error is a file module that declares a child 'mod' referencing the current file: '// File: recursive_mod.rs #[path = \"recursive_mod.rs\"] mod child_mod;' Inspection ID: RsCircularMods",
+                  "markdown": "Reports circular module declarations with the `#path` attribute. Such declarations produce an infinite module graph and cannot be compiled. A common example of this error is a file module that declares a child `mod` referencing the current file:  \n`\n// File: recursive_mod.rs`  \n`\n#[path = \"recursive_mod.rs\"]`  \n`\nmod child_mod;`  \n`\n`\n\nInspection ID: RsCircularMods"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCircularMods",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSelfInStaticMethod",
+                "shortDescription": {
+                  "text": "`self` in static method"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of the `self` keyword in static methods. Inspection ID: RsSelfInStaticMethod",
+                  "markdown": "Reports the use of the \\`self\\` keyword in static methods.\n\nInspection ID: RsSelfInStaticMethod"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsSelfInStaticMethod",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CargoUnnecessaryPackageKey",
+                "shortDescription": {
+                  "text": "Unnecessary `package` field"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary 'package' keys in 'Cargo.toml' dependency declarations. The 'package' key is usually used for renaming dependencies, so it is unnecessary if its value matches the name of the dependency. Inspection ID: CargoUnnecessaryPackageKey",
+                  "markdown": "Reports unnecessary `package` keys in `Cargo.toml` dependency declarations. The `package` key is usually used for renaming dependencies, so it is unnecessary if its value matches the name of the dependency.\n\nInspection ID: CargoUnnecessaryPackageKey"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "CargoUnnecessaryPackageKey",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDefaultsConstGenericNotAllowed",
+                "shortDescription": {
+                  "text": "Defaults for const parameters not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid use of defaults for const parameters. They are only allowed in struct, enum, type, and trait definitions. Inspection ID: RsDefaultsConstGenericNotAllowed",
+                  "markdown": "Reports invalid use of defaults for const parameters. They are only allowed in struct, enum, type, and trait definitions.\n\nInspection ID: RsDefaultsConstGenericNotAllowed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDefaultsConstGenericNotAllowed",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsEnumVariantNaming",
+                "shortDescription": {
+                  "text": "Enum variant naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if enum variant names follow the Rust naming convention. Inspection ID: RsEnumVariantNaming",
+                  "markdown": "Checks if enum variant names follow the Rust naming convention.\n\nInspection ID: RsEnumVariantNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsEnumVariantNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidConstGenericArgument",
+                "shortDescription": {
+                  "text": "Const generic argument expression without braces"
+                },
+                "fullDescription": {
+                  "text": "Reports const generic argument expressions with missing braces. Inspection ID: RsInvalidConstGenericArgument",
+                  "markdown": "Reports const generic argument expressions with missing braces.\n\nInspection ID: RsInvalidConstGenericArgument"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidConstGenericArgument",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnsafeImpl",
+                "shortDescription": {
+                  "text": "Trait safety mismatch"
+                },
+                "fullDescription": {
+                  "text": "Reports mismatches between the safety of a trait's definition and its implementation. Inspection ID: RsUnsafeImpl",
+                  "markdown": "Reports mismatches between the safety of a trait's definition and its implementation.\n\nInspection ID: RsUnsafeImpl"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnsafeImpl",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNoIncDecOperator",
+                "shortDescription": {
+                  "text": "Use of increment/decrement operator (unsupported)"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `++` and `--` operators, which are not supported in Rust. Inspection ID: RsNoIncDecOperator",
+                  "markdown": "Reports the use of \\`++\\` and \\`--\\` operators, which are not supported in Rust.\n\nInspection ID: RsNoIncDecOperator"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNoIncDecOperator",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnreachableLabel",
+                "shortDescription": {
+                  "text": "Unreachable label"
+                },
+                "fullDescription": {
+                  "text": "Reports unreachable labels. Inspection ID: RsUnreachableLabel",
+                  "markdown": "Reports unreachable labels.\n\nInspection ID: RsUnreachableLabel"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnreachableLabel",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnnecessaryCast",
+                "shortDescription": {
+                  "text": "Unnecessary cast"
+                },
+                "fullDescription": {
+                  "text": "Detects unnecessary 'as' casts. Inspection ID: RsUnnecessaryCast",
+                  "markdown": "Detects unnecessary `as` casts.\n\nInspection ID: RsUnnecessaryCast"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnnecessaryCast",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMacroNaming",
+                "shortDescription": {
+                  "text": "Macro naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if macro names follow the Rust naming convention. Inspection ID: RsMacroNaming",
+                  "markdown": "Checks if macro names follow the Rust naming convention.\n\nInspection ID: RsMacroNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsMacroNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDuplicateDefinitionError",
+                "shortDescription": {
+                  "text": "Duplicate definition"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicate items (such as field declarations, type parameters, etc.). Inspection ID: RsDuplicateDefinitionError",
+                  "markdown": "Reports duplicate items (such as field declarations, type parameters, etc.).\n\nInspection ID: RsDuplicateDefinitionError"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDuplicateDefinitionError",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsEdition2024Keywords",
+                "shortDescription": {
+                  "text": "Rust 2024 edition violation"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of keywords reserved in Rust 2024 edition, as well as features unavailable in Rust 2024 edition. Inspection ID: RsEdition2024Keywords",
+                  "markdown": "Reports the use of keywords reserved in Rust 2024 edition, as well as features unavailable in Rust 2024 edition.\n\nInspection ID: RsEdition2024Keywords"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsEdition2024Keywords",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDefaultValue",
+                "shortDescription": {
+                  "text": "Default parameter values (unsupported)"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of default parameter values, which are not supported in Rust. Inspection ID: RsDefaultValue",
+                  "markdown": "Reports the use of default parameter values, which are not supported in Rust.\n\nInspection ID: RsDefaultValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDefaultValue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInherentImplDifferentCrate",
+                "shortDescription": {
+                  "text": "Inherent `impl` defined outside type's containing crate"
+                },
+                "fullDescription": {
+                  "text": "Reports inherent type implementations defined outside the type's original crate. Inspection ID: RsInherentImplDifferentCrate",
+                  "markdown": "Reports inherent type implementations defined outside the type's original crate.\n\nInspection ID: RsInherentImplDifferentCrate"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInherentImplDifferentCrate",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionCannotHaveAnonymousParameters",
+                "shortDescription": {
+                  "text": "Anonymous function parameters not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of anonymous parameters in functions that do not allow it. Inspection ID: RsFunctionCannotHaveAnonymousParameters",
+                  "markdown": "Reports the use of anonymous parameters in functions that do not allow it.\n\nInspection ID: RsFunctionCannotHaveAnonymousParameters"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionCannotHaveAnonymousParameters",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsConstSyntax",
+                "shortDescription": {
+                  "text": "Incorrect const syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect const syntax. Inspection ID: RsConstSyntax",
+                  "markdown": "Reports incorrect const syntax.\n\nInspection ID: RsConstSyntax"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsConstSyntax",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCrateName",
+                "shortDescription": {
+                  "text": "Invalid crate name"
+                },
+                "fullDescription": {
+                  "text": "Check if the crate name is valid, namely the crate name must not be empty, and must only contain Unicode alphanumeric or '_' (U+005F) characters. Inspection ID: RsCrateName",
+                  "markdown": "Check if the crate name is valid, namely the crate name must not be empty, and must only contain [Unicode alphanumeric](https://doc.rust-lang.org/std/primitive.char.html#method.is_alphanumeric) or `_` (U+005F) characters.\n\nInspection ID: RsCrateName"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCrateName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalChecks",
+                "shortDescription": {
+                  "text": "Experimental inspections"
+                },
+                "fullDescription": {
+                  "text": "Some unstable experimental checks which are disabled by default. Inspection ID: RsExperimentalChecks",
+                  "markdown": "Some unstable experimental checks which are disabled by default.\n\nInspection ID: RsExperimentalChecks"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalChecks",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsBareTraitObjects",
+                "shortDescription": {
+                  "text": "Missing `dyn` in trait objects"
+                },
+                "fullDescription": {
+                  "text": "Checks if trait objects are explicitly specified with 'dyn' keyword. Inspection ID: RsBareTraitObjects",
+                  "markdown": "Checks if trait objects are explicitly specified with `dyn` keyword.\n\nInspection ID: RsBareTraitObjects"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsBareTraitObjects",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsRepeatedIdentifierInPattern",
+                "shortDescription": {
+                  "text": "Repeated identifier in pattern"
+                },
+                "fullDescription": {
+                  "text": "Reports identifiers bound more than once in the same pattern. Inspection ID: RsRepeatedIdentifierInPattern",
+                  "markdown": "Reports identifiers bound more than once in the same pattern.\n\nInspection ID: RsRepeatedIdentifierInPattern"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsRepeatedIdentifierInPattern",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReplaceMatchExpr",
+                "shortDescription": {
+                  "text": "Match expression can be replaced with a method call"
+                },
+                "fullDescription": {
+                  "text": "Reports match expressions that can be replaced with a method call. Inspection ID: RsReplaceMatchExpr",
+                  "markdown": "Reports match expressions that can be replaced with a method call.\n\nInspection ID: RsReplaceMatchExpr"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsReplaceMatchExpr",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLifetimeNaming",
+                "shortDescription": {
+                  "text": "Lifetime naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if lifetime names follow the Rust naming convention. Inspection ID: RsLifetimeNaming",
+                  "markdown": "Checks if lifetime names follow the Rust naming convention.\n\nInspection ID: RsLifetimeNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsLifetimeNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCannotImplForDynAutoTrait",
+                "shortDescription": {
+                  "text": "Inherent `impl` for dyn auto trait"
+                },
+                "fullDescription": {
+                  "text": "Reports inherent implementations for dynamic auto traits. E0785 Inspection ID: RsCannotImplForDynAutoTrait",
+                  "markdown": "Reports inherent implementations for dynamic auto traits. [E0785](https://doc.rust-lang.org/error_codes/E0785.html)\n\nInspection ID: RsCannotImplForDynAutoTrait"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCannotImplForDynAutoTrait",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsItemStructure",
+                "shortDescription": {
+                  "text": "Item declaration misplaced"
+                },
+                "fullDescription": {
+                  "text": "Reports structs, enums, macro definitions and traits placed inside other structs, enums, macro definitions or traits. Inspection ID: RsItemStructure",
+                  "markdown": "Reports structs, enums, macro definitions and traits placed inside other structs, enums, macro definitions or traits.\n\nInspection ID: RsItemStructure"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsItemStructure",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsQuestionMarkOperator",
+                "shortDescription": {
+                  "text": "Invalid `?` usage"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect usage of the '?' operator. Inspection ID: RsQuestionMarkOperator",
+                  "markdown": "Reports incorrect usage of the `?` operator.\n\nInspection ID: RsQuestionMarkOperator"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsQuestionMarkOperator",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUndeclaredTypeOrModule",
+                "shortDescription": {
+                  "text": "'crate' misplaced in path"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect use of the literal `crate` in a path. The `crate` literal is only allowed at the beginning of the path. Inspection ID: RsUndeclaredTypeOrModule",
+                  "markdown": "Reports incorrect use of the literal \\`crate\\` in a path. The \\`crate\\` literal is only allowed at the beginning of the path.\n\nInspection ID: RsUndeclaredTypeOrModule"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUndeclaredTypeOrModule",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnresolvedMethod",
+                "shortDescription": {
+                  "text": "Unresolved method"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved method references. Inspection ID: RsUnresolvedMethod",
+                  "markdown": "Reports unresolved method references.\n\nInspection ID: RsUnresolvedMethod"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnresolvedMethod",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsRecursionInAsyncFunction",
+                "shortDescription": {
+                  "text": "No boxing for async recursion"
+                },
+                "fullDescription": {
+                  "text": "Reports recursion used in async functions without boxing. E0733 Inspection ID: RsRecursionInAsyncFunction",
+                  "markdown": "Reports recursion used in async functions without boxing. [E0733](https://doc.rust-lang.org/error_codes/E0733.html)\n\nInspection ID: RsRecursionInAsyncFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsRecursionInAsyncFunction",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsApproxConstant",
+                "shortDescription": {
+                  "text": "Approximated constants"
+                },
+                "fullDescription": {
+                  "text": "Reports hard coded numeric constants such as 'std::f64::consts::PI'. Corresponds to approx_constant lint from Rust Clippy. Inspection ID: RsApproxConstant",
+                  "markdown": "Reports hard coded numeric constants such as `std::f64::consts::PI`. Corresponds to [approx_constant](https://rust-lang.github.io/rust-clippy/stable/#approx_constant) lint from Rust Clippy.\n\nInspection ID: RsApproxConstant"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsApproxConstant",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnwrap",
+                "shortDescription": {
+                  "text": "Unwrap can be replaced with `?`"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to `unwrap()` that can be replaced with `?`. Inspection ID: RsUnwrap",
+                  "markdown": "Reports calls to \\`unwrap()\\` that can be replaced with \\`?\\`.\n\nInspection ID: RsUnwrap"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnwrap",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsModuleNaming",
+                "shortDescription": {
+                  "text": "Module naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if module names follow the Rust naming convention. Inspection ID: RsModuleNaming",
+                  "markdown": "Checks if module names follow the Rust naming convention.\n\nInspection ID: RsModuleNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsModuleNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMainFunctionNotFound",
+                "shortDescription": {
+                  "text": "Main function not found"
+                },
+                "fullDescription": {
+                  "text": "Checks if the 'main' function exists in the binary crates. Inspection ID: RsMainFunctionNotFound",
+                  "markdown": "Checks if the `main` function exists in the binary crates.\n\nInspection ID: RsMainFunctionNotFound"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsMainFunctionNotFound",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalTraitObligations",
+                "shortDescription": {
+                  "text": "Type does not implement trait (experimental)"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of types that do not implement the necessary traits. This inspection covers more cases than `Type does not implement trait`, however it may produce false positives. Inspection ID: RsExperimentalTraitObligations",
+                  "markdown": "Reports the use of types that do not implement the necessary traits. This inspection covers more cases than \\`Type does not implement trait\\`, however it may produce false positives.\n\nInspection ID: RsExperimentalTraitObligations"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalTraitObligations",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFieldNaming",
+                "shortDescription": {
+                  "text": "Field naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if field names follow the Rust naming convention. Inspection ID: RsFieldNaming",
+                  "markdown": "Checks if field names follow the Rust naming convention.\n\nInspection ID: RsFieldNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsFieldNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsForbiddenSizedImpl",
+                "shortDescription": {
+                  "text": "`Sized`/`Unsized` trait implemented explicitly"
+                },
+                "fullDescription": {
+                  "text": "Reports explicit implementations of the `Sized` and `Unsized` traits. Inspection ID: RsForbiddenSizedImpl",
+                  "markdown": "Reports explicit implementations of the \\`Sized\\` and \\`Unsized\\` traits.\n\nInspection ID: RsForbiddenSizedImpl"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsForbiddenSizedImpl",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCratesInPath",
+                "shortDescription": {
+                  "text": "`crate` not allowed in path"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid use of `crate` in paths (Rust 2015). Inspection ID: RsCratesInPath",
+                  "markdown": "Reports invalid use of \\`crate\\` in paths (Rust 2015).\n\nInspection ID: RsCratesInPath"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCratesInPath",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNonConstantInConstant",
+                "shortDescription": {
+                  "text": "A non-constant value was used in a constant expression"
+                },
+                "fullDescription": {
+                  "text": "Reports a non-constant value or function call used in a constant expression. Inspection ID: RsNonConstantInConstant",
+                  "markdown": "Reports a non-constant value or function call used in a constant expression.\n\nInspection ID: RsNonConstantInConstant"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNonConstantInConstant",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnusedLabels",
+                "shortDescription": {
+                  "text": "Unused labels"
+                },
+                "fullDescription": {
+                  "text": "Detects labels that are never used. Unused labels may signal a mistake or unfinished code. Corresponds to the unused_labels rust warning. Inspection ID: RsUnusedLabels",
+                  "markdown": "Detects labels that are never used. Unused labels may signal a mistake or unfinished code. Corresponds to the [unused_labels](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-labels) rust warning.\n\nInspection ID: RsUnusedLabels"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsUnusedLabels",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsBorrowChecker",
+                "shortDescription": {
+                  "text": "Borrow checker errors"
+                },
+                "fullDescription": {
+                  "text": "Reports basic borrow checker errors. Inspection ID: RsBorrowChecker",
+                  "markdown": "Reports basic borrow checker errors.\n\nInspection ID: RsBorrowChecker"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsBorrowChecker",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsIncorrectVisibilityRestriction",
+                "shortDescription": {
+                  "text": "Incorrect visibility restriction"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect visibility restrictions. Inspection ID: RsIncorrectVisibilityRestriction",
+                  "markdown": "Reports incorrect visibility restrictions.\n\nInspection ID: RsIncorrectVisibilityRestriction"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsIncorrectVisibilityRestriction",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsPathStatements",
+                "shortDescription": {
+                  "text": "Ineffective path statements"
+                },
+                "fullDescription": {
+                  "text": "Detects path statements with no effect. It is usually a mistake to have a statement that has no effect. Corresponds to the path_statements Rust lint. Inspection ID: RsPathStatements",
+                  "markdown": "Detects path statements with no effect. It is usually a mistake to have a statement that has no effect. Corresponds to the [path_statements](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#path-statements) Rust lint.\n\nInspection ID: RsPathStatements"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsPathStatements",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDotDotDotSyntaxIsDeprecated",
+                "shortDescription": {
+                  "text": "Deprecated `...` syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `...` deprecated syntax. Inspection ID: RsDotDotDotSyntaxIsDeprecated",
+                  "markdown": "Reports the use of \\`...\\` deprecated syntax.\n\nInspection ID: RsDotDotDotSyntaxIsDeprecated"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDotDotDotSyntaxIsDeprecated",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMultipleRelaxedBounds",
+                "shortDescription": {
+                  "text": "Multiple relaxed default bounds for type parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports type parameters with multiple relaxed default bounds. Only a single relaxed default bound is supported. Inspection ID: RsMultipleRelaxedBounds",
+                  "markdown": "Reports type parameters with multiple relaxed default bounds. Only a single relaxed default bound is supported.\n\nInspection ID: RsMultipleRelaxedBounds"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsMultipleRelaxedBounds",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDetachedFile",
+                "shortDescription": {
+                  "text": "Detached file"
+                },
+                "fullDescription": {
+                  "text": "Detects files that are not attached to any Rust module. Inspection ID: RsDetachedFile",
+                  "markdown": "Detects files that are not attached to any Rust module.\n\nInspection ID: RsDetachedFile"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDetachedFile",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMethodNaming",
+                "shortDescription": {
+                  "text": "Method naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if method names follow the Rust naming convention. Inspection ID: RsMethodNaming",
+                  "markdown": "Checks if method names follow the Rust naming convention.\n\nInspection ID: RsMethodNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsMethodNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReservedIdentifier",
+                "shortDescription": {
+                  "text": "Reserved keyword used as an identifier"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of reserved keywords. Inspection ID: RsReservedIdentifier",
+                  "markdown": "Reports the use of reserved keywords.\n\nInspection ID: RsReservedIdentifier"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsReservedIdentifier",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSelfNotAtTheBeginning",
+                "shortDescription": {
+                  "text": "`self`/`super` misplaced in path"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `self` and `super` keywords not at the beginning of the path. Inspection ID: RsSelfNotAtTheBeginning",
+                  "markdown": "Reports the use of \\`self\\` and \\`super\\` keywords not at the beginning of the path.\n\nInspection ID: RsSelfNotAtTheBeginning"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsSelfNotAtTheBeginning",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsPatternsAreNotAllowed",
+                "shortDescription": {
+                  "text": "Complex pattern in function"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect use of patterns in functions. Inspection ID: RsPatternsAreNotAllowed",
+                  "markdown": "Reports incorrect use of patterns in functions.\n\nInspection ID: RsPatternsAreNotAllowed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsPatternsAreNotAllowed",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCompilerFeatureIsUnavailable",
+                "shortDescription": {
+                  "text": "Compiler feature is unavailable"
+                },
+                "fullDescription": {
+                  "text": "Reports code that uses unavailable compiler features. Inspection ID: RsCompilerFeatureIsUnavailable",
+                  "markdown": "Reports code that uses unavailable compiler features.\n\nInspection ID: RsCompilerFeatureIsUnavailable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCompilerFeatureIsUnavailable",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnusedImport",
+                "shortDescription": {
+                  "text": "Unused import"
+                },
+                "fullDescription": {
+                  "text": "Detects unused 'use' directives. Inspection ID: RsUnusedImport",
+                  "markdown": "Detects unused `use` directives.\n\nInspection ID: RsUnusedImport"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsUnusedImport",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidCharLiteralLength",
+                "shortDescription": {
+                  "text": "Char literal empty or too long"
+                },
+                "fullDescription": {
+                  "text": "Reports char literals which are empty or too long. Inspection ID: RsInvalidCharLiteralLength",
+                  "markdown": "Reports char literals which are empty or too long.\n\nInspection ID: RsInvalidCharLiteralLength"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidCharLiteralLength",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidMacroVariableType",
+                "shortDescription": {
+                  "text": "Invalid macro variable type"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid fragment specifier of a macro variable. Inspection ID: RsInvalidMacroVariableType",
+                  "markdown": "Reports invalid fragment specifier of a macro variable.\n\nInspection ID: RsInvalidMacroVariableType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidMacroVariableType",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNestedImplTraitNotAllowed",
+                "shortDescription": {
+                  "text": "Nested `impl Trait` not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of nested `impl Trait`. `impl Trait` types cannot appear nested in the generic arguments of other `impl Trait` types. Inspection ID: RsNestedImplTraitNotAllowed",
+                  "markdown": "Reports the use of nested \\`impl Trait\\`. \\`impl Trait\\` types cannot appear nested in the generic arguments of other \\`impl Trait\\` types.\n\nInspection ID: RsNestedImplTraitNotAllowed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNestedImplTraitNotAllowed",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFieldInitShorthand",
+                "shortDescription": {
+                  "text": "Non-shorthand field initialization"
+                },
+                "fullDescription": {
+                  "text": "Reports cases where field initialization shorthand (RFC 1682) can be used. Inspection ID: RsFieldInitShorthand",
+                  "markdown": "Reports cases where field initialization shorthand ([RFC 1682](https://github.com/rust-lang/rfcs/blob/master/text/1682-field-init-shorthand.md)) can be used.\n\nInspection ID: RsFieldInitShorthand"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsFieldInitShorthand",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDropCopyType",
+                "shortDescription": {
+                  "text": "`Copy` type dropped"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'std::mem::drop' with values that derive the 'Copy' trait. Corresponds to the dropping_copy_types lint. Inspection ID: RsDropCopyType",
+                  "markdown": "Reports calls to `std::mem::drop` with values that derive the `Copy` trait.  \nCorresponds to the [dropping_copy_types](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#dropping-copy-types) lint.\n\nInspection ID: RsDropCopyType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDropCopyType",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCallExpr",
+                "shortDescription": {
+                  "text": "Attempt to call not a function"
+                },
+                "fullDescription": {
+                  "text": "When calling somethings, checks that it is function or method. Inspection ID: RsCallExpr",
+                  "markdown": "When calling somethings, checks that it is function or method.\n\nInspection ID: RsCallExpr"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCallExpr",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDoubleNeg",
+                "shortDescription": {
+                  "text": "Double negation"
+                },
+                "fullDescription": {
+                  "text": "Detects expressions of the form --x which might be mistook for pre-decrements. Corresponds to double_neg lint from Rust Clippy. Inspection ID: RsDoubleNeg",
+                  "markdown": "Detects expressions of the form --x which might be mistook for pre-decrements.  \nCorresponds to [double_neg](https://rust-lang.github.io/rust-clippy/stable/#double_neg) lint from Rust Clippy.\n\nInspection ID: RsDoubleNeg"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDoubleNeg",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsEnumReprIntIsRequired",
+                "shortDescription": {
+                  "text": "`#[repr(inttype)]` missing for enum"
+                },
+                "fullDescription": {
+                  "text": "Reports enums that require a `#[repr(inttype)]` attribute. Inspection ID: RsEnumReprIntIsRequired",
+                  "markdown": "Reports enums that require a \\`#\\[repr(inttype)\\]\\` attribute.\n\nInspection ID: RsEnumReprIntIsRequired"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsEnumReprIntIsRequired",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnionExprFieldsCount",
+                "shortDescription": {
+                  "text": "Union expression fields count"
+                },
+                "fullDescription": {
+                  "text": "Checks that union expr has exactly one field. Inspection ID: RsUnionExprFieldsCount",
+                  "markdown": "Checks that union expr has exactly one field.\n\nInspection ID: RsUnionExprFieldsCount"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnionExprFieldsCount",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsArrayOutOfBounds",
+                "shortDescription": {
+                  "text": "Literal out of range"
+                },
+                "fullDescription": {
+                  "text": "Check if the index of an array is out of bounds. 'let mut array: [i32; 3] = [0; 3]; array[4];'. Inspection ID: RsArrayOutOfBounds",
+                  "markdown": "Check if the index of an array is out of bounds. `\nlet mut array: [i32; 3] = [0; 3];\narray[4];\n`.\n\nInspection ID: RsArrayOutOfBounds"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsArrayOutOfBounds",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsVariableNaming",
+                "shortDescription": {
+                  "text": "Variable naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if variable names follow the Rust naming convention. Inspection ID: RsVariableNaming",
+                  "markdown": "Checks if variable names follow the Rust naming convention.\n\nInspection ID: RsVariableNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsVariableNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNestedQualificationOfLifetimeBounds",
+                "shortDescription": {
+                  "text": "Nested lifetime quantification"
+                },
+                "fullDescription": {
+                  "text": "Reports 'where' clauses containing nested quantification over lifetimes, which is not supported. Inspection ID: RsNestedQualificationOfLifetimeBounds",
+                  "markdown": "Reports `where` clauses containing nested quantification over lifetimes, which is not supported.\n\nInspection ID: RsNestedQualificationOfLifetimeBounds"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNestedQualificationOfLifetimeBounds",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExplicitDropCall",
+                "shortDescription": {
+                  "text": "Explicit call to `drop`"
+                },
+                "fullDescription": {
+                  "text": "Reports explicit calls to `drop`. It is not allowed to manually call destructors in Rust. Inspection ID: RsExplicitDropCall",
+                  "markdown": "Reports explicit calls to \\`drop\\`. It is not allowed to manually call destructors in Rust.\n\nInspection ID: RsExplicitDropCall"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExplicitDropCall",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsEnumNaming",
+                "shortDescription": {
+                  "text": "Enum naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if enum names follow the Rust naming convention. Inspection ID: RsEnumNaming",
+                  "markdown": "Checks if enum names follow the Rust naming convention.\n\nInspection ID: RsEnumNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsEnumNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsImplCopyForWrongType",
+                "shortDescription": {
+                  "text": "Invalid `Copy` implementation"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid `Copy` implementations. The `Copy` trait can only be implemented for structs, enums, and unions. E0206 Inspection ID: RsImplCopyForWrongType",
+                  "markdown": "Reports invalid \\`Copy\\` implementations. The \\`Copy\\` trait can only be implemented for structs, enums, and unions. [E0206](https://doc.rust-lang.org/error_codes/E0206.html)\n\nInspection ID: RsImplCopyForWrongType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsImplCopyForWrongType",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnsafeInherentImpl",
+                "shortDescription": {
+                  "text": "Unsafe inherent implementation"
+                },
+                "fullDescription": {
+                  "text": "Reports inherent implementations marked as unsafe. Inspection ID: RsUnsafeInherentImpl",
+                  "markdown": "Reports inherent implementations marked as unsafe.\n\nInspection ID: RsUnsafeInherentImpl"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnsafeInherentImpl",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTraitExpected",
+                "shortDescription": {
+                  "text": "Trait expected"
+                },
+                "fullDescription": {
+                  "text": "Reports non-trait items referenced as traits. Inspection ID: RsTraitExpected",
+                  "markdown": "Reports non-trait items referenced as traits.\n\nInspection ID: RsTraitExpected"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTraitExpected",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsRedundantColonColon",
+                "shortDescription": {
+                  "text": "Redundant `::`"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant '::'. Inspection ID: RsRedundantColonColon",
+                  "markdown": "Reports redundant `::`.\n\nInspection ID: RsRedundantColonColon"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsRedundantColonColon",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsPublicItemsInProcMacroCrate",
+                "shortDescription": {
+                  "text": "Public item in proc-macro crate"
+                },
+                "fullDescription": {
+                  "text": "Reports public items located in the root of a procedural macro crate and not marked with a #[proc_macro], #[proc_macro_attribute], or #[proc_macro_derive] attribute. Inspection ID: RsPublicItemsInProcMacroCrate",
+                  "markdown": "Reports public items located in the root of a procedural macro crate and not marked with a #\\[proc_macro\\], #\\[proc_macro_attribute\\], or #\\[proc_macro_derive\\] attribute.\n\nInspection ID: RsPublicItemsInProcMacroCrate"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsPublicItemsInProcMacroCrate",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnnecessaryVisibilityQualifier",
+                "shortDescription": {
+                  "text": "Unnecessary visibility qualifier"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary visibility qualifiers. Inspection ID: RsUnnecessaryVisibilityQualifier",
+                  "markdown": "Reports unnecessary visibility qualifiers.\n\nInspection ID: RsUnnecessaryVisibilityQualifier"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnnecessaryVisibilityQualifier",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnnecessaryQualifications",
+                "shortDescription": {
+                  "text": "Unnecessary path prefix"
+                },
+                "fullDescription": {
+                  "text": "Detects unnecessarily qualified paths. Inspection ID: RsUnnecessaryQualifications",
+                  "markdown": "Detects unnecessarily qualified paths.\n\nInspection ID: RsUnnecessaryQualifications"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnnecessaryQualifications",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidFieldsInStructLiteral",
+                "shortDescription": {
+                  "text": "Invalid fields in struct"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrect field use in struct literals. Inspection ID: RsInvalidFieldsInStructLiteral",
+                  "markdown": "Reports incorrect field use in struct literals.\n\nInspection ID: RsInvalidFieldsInStructLiteral"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidFieldsInStructLiteral",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsConstantMissingType",
+                "shortDescription": {
+                  "text": "Missing type for constant"
+                },
+                "fullDescription": {
+                  "text": "Reports constant declarations with missing types. Inspection ID: RsConstantMissingType",
+                  "markdown": "Reports constant declarations with missing types.\n\nInspection ID: RsConstantMissingType"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsConstantMissingType",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWrongGenericArgumentsOrder",
+                "shortDescription": {
+                  "text": "Incorrect generic argument order"
+                },
+                "fullDescription": {
+                  "text": "Reports mismatches between the declared order of generic parameters and the provided order of generic arguments. Inspection ID: RsWrongGenericArgumentsOrder",
+                  "markdown": "Reports mismatches between the declared order of generic parameters and the provided order of generic arguments.\n\nInspection ID: RsWrongGenericArgumentsOrder"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsWrongGenericArgumentsOrder",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsRedundantElse",
+                "shortDescription": {
+                  "text": "Redundant `else`"
+                },
+                "fullDescription": {
+                  "text": "Detects 'else'-statements preceded by irrefutable patterns. Inspection ID: RsRedundantElse",
+                  "markdown": "Detects `else`-statements preceded by irrefutable patterns.\n\nInspection ID: RsRedundantElse"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsRedundantElse",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAbiLiteralMustBeString",
+                "shortDescription": {
+                  "text": "Non-string ABI literal"
+                },
+                "fullDescription": {
+                  "text": "Reports non-string ABI literals. Inspection ID: RsAbiLiteralMustBeString",
+                  "markdown": "Reports non-string ABI literals.\n\nInspection ID: RsAbiLiteralMustBeString"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAbiLiteralMustBeString",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidMacroDefinition",
+                "shortDescription": {
+                  "text": "Invalid macro definition"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in `macro_rules!` definitions. For instance: Reports invalid metavariable fragment specifiers Detects 'pat' fragment specifiers followed by `|` (in 2021 Edition and later) Reports missing `;` (or `,` for macro 2.0) between macro rules. Inspection ID: RsInvalidMacroDefinition",
+                  "markdown": "Reports errors in \\`macro_rules!\\` definitions. For instance:\n\n* Reports invalid metavariable fragment specifiers\n* Detects `pat` fragment specifiers followed by \\`\\|\\` (in 2021 Edition and later)\n* Reports missing \\`;\\` (or \\`,\\` for macro 2.0) between macro rules.\n\nInspection ID: RsInvalidMacroDefinition"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidMacroDefinition",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsStructRestWithoutBaseExpression",
+                "shortDescription": {
+                  "text": "Base expression required after `..`"
+                },
+                "fullDescription": {
+                  "text": "Highlights '..' expression inside struct literal without base expression after it. Inspection ID: RsStructRestWithoutBaseExpression",
+                  "markdown": "Highlights `..` expression inside struct literal without base expression after it.\n\nInspection ID: RsStructRestWithoutBaseExpression"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsStructRestWithoutBaseExpression",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDuplicateMacroPattern",
+                "shortDescription": {
+                  "text": "Duplicate macro pattern"
+                },
+                "fullDescription": {
+                  "text": "Checks duplicated patterns in macro definitions. Inspection ID: RsDuplicateMacroPattern",
+                  "markdown": "Checks duplicated patterns in macro definitions.\n\nInspection ID: RsDuplicateMacroPattern"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsDuplicateMacroPattern",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsIncorrectlyPlacedInlineAttr",
+                "shortDescription": {
+                  "text": "`#[inline]` not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports `inline` attributes applied to items other than functions or closures. Inspection ID: RsIncorrectlyPlacedInlineAttr",
+                  "markdown": "Reports \\`inline\\` attributes applied to items other than functions or closures.\n\nInspection ID: RsIncorrectlyPlacedInlineAttr"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsIncorrectlyPlacedInlineAttr",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidLifetimeName",
+                "shortDescription": {
+                  "text": "Invalid lifetime name"
+                },
+                "fullDescription": {
+                  "text": "Reports lifetimes with invalid names. Inspection ID: RsInvalidLifetimeName",
+                  "markdown": "Reports lifetimes with invalid names.\n\nInspection ID: RsInvalidLifetimeName"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidLifetimeName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsItemCannotBeUnsafe",
+                "shortDescription": {
+                  "text": "Unsafe module"
+                },
+                "fullDescription": {
+                  "text": "Reports modules declared as unsafe. Inspection ID: RsItemCannotBeUnsafe",
+                  "markdown": "Reports modules declared as unsafe.\n\nInspection ID: RsItemCannotBeUnsafe"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsItemCannotBeUnsafe",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsMainWithGenerics",
+                "shortDescription": {
+                  "text": "`main` function with generic parameters"
+                },
+                "fullDescription": {
+                  "text": "Reports `main` functions defined with generic parameters. Inspection ID: RsMainWithGenerics",
+                  "markdown": "Reports \\`main\\` functions defined with generic parameters.\n\nInspection ID: RsMainWithGenerics"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsMainWithGenerics",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnnecessaryReturn",
+                "shortDescription": {
+                  "text": "Unnecessary return"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary return statements at the end of a block. Inspection ID: RsUnnecessaryReturn",
+                  "markdown": "Reports unnecessary return statements at the end of a block.\n\nInspection ID: RsUnnecessaryReturn"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnnecessaryReturn",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTestFailedLine",
+                "shortDescription": {
+                  "text": "Failed line in test"
+                },
+                "fullDescription": {
+                  "text": "Reports failed function calls or assertions in tests. It helps detect the failed line in code faster and start debugging it immediately. Inspection ID: RsTestFailedLine",
+                  "markdown": "Reports failed function calls or assertions in tests. It helps detect the failed line in code faster and start debugging it immediately.\n\nInspection ID: RsTestFailedLine"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsTestFailedLine",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLift",
+                "shortDescription": {
+                  "text": "`return` can be lifted"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if' and 'match' statements that can be converted to expressions by lifting a 'return' out. Inspection ID: RsLift",
+                  "markdown": "Reports `if` and `match` statements that can be converted to expressions by lifting a `return` out.\n\nInspection ID: RsLift"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsLift",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsGenericDefaultParamCannotUseForward",
+                "shortDescription": {
+                  "text": "Forward-declared identifier for parameter with default value"
+                },
+                "fullDescription": {
+                  "text": "Reports generic parameters with default values that use forward-declared identifiers. E0128 Inspection ID: RsGenericDefaultParamCannotUseForward",
+                  "markdown": "Reports generic parameters with default values that use forward-declared identifiers. [E0128](https://doc.rust-lang.org/error_codes/E0128.html)\n\nInspection ID: RsGenericDefaultParamCannotUseForward"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsGenericDefaultParamCannotUseForward",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDynOrImplInTraitBounds",
+                "shortDescription": {
+                  "text": "Use of `dyn`/`impl Trait` in type parameter bounds"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `dyn` and `impl Trait` in type parameter bounds. Inspection ID: RsDynOrImplInTraitBounds",
+                  "markdown": "Reports the use of \\`dyn\\` and \\`impl Trait\\` in type parameter bounds.\n\nInspection ID: RsDynOrImplInTraitBounds"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDynOrImplInTraitBounds",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsControlFlowExprInWhileConditionWithoutLoop",
+                "shortDescription": {
+                  "text": "Unlabeled `continue`/`break` in `while` loop condition"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `break`/`continue` keywords without labels in `while` loop conditions. Inspection ID: RsControlFlowExprInWhileConditionWithoutLoop",
+                  "markdown": "Reports the use of \\`break\\`/\\`continue\\` keywords without labels in \\`while\\` loop conditions.\n\nInspection ID: RsControlFlowExprInWhileConditionWithoutLoop"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsControlFlowExprInWhileConditionWithoutLoop",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsVariadicParametersUsedOnNonCABI",
+                "shortDescription": {
+                  "text": "Variadic parameters for non-C ABI function"
+                },
+                "fullDescription": {
+                  "text": "Reports C-variadic functions that do not use a compatible calling convention. Inspection ID: RsVariadicParametersUsedOnNonCABI",
+                  "markdown": "Reports C-variadic functions that do not use a compatible calling convention.\n\nInspection ID: RsVariadicParametersUsedOnNonCABI"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsVariadicParametersUsedOnNonCABI",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsFunctionCannotHaveSelf",
+                "shortDescription": {
+                  "text": "`self` function parameter not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `self` as a function parameter in case it is not allowed. Inspection ID: RsFunctionCannotHaveSelf",
+                  "markdown": "Reports the use of \\`self\\` as a function parameter in case it is not allowed.\n\nInspection ID: RsFunctionCannotHaveSelf"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsFunctionCannotHaveSelf",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTooManyLifetimeBoundsOnTraitObject",
+                "shortDescription": {
+                  "text": "Multiple lifetime bounds for trait object"
+                },
+                "fullDescription": {
+                  "text": "Reports trait objects with multiple lifetime bounds. Inspection ID: RsTooManyLifetimeBoundsOnTraitObject",
+                  "markdown": "Reports trait objects with multiple lifetime bounds.\n\nInspection ID: RsTooManyLifetimeBoundsOnTraitObject"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTooManyLifetimeBoundsOnTraitObject",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWrongGenericParametersNumber",
+                "shortDescription": {
+                  "text": "Wrong number of type or const parameters"
+                },
+                "fullDescription": {
+                  "text": "Checks if an attempted implementation of a trait method or an associated type has the right number of type or const parameters. Corresponds to the E0049 Rust error. Inspection ID: RsWrongGenericParametersNumber",
+                  "markdown": "Checks if an attempted implementation of a trait method or an associated type has the right number of type or const parameters.   \nCorresponds to the [E0049](https://doc.rust-lang.org/error-index.html#E0049) Rust error.\n\nInspection ID: RsWrongGenericParametersNumber"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsWrongGenericParametersNumber",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidMacroCall",
+                "shortDescription": {
+                  "text": "Invalid macro call"
+                },
+                "fullDescription": {
+                  "text": "Reports errors when calling macros. Inspection ID: RsInvalidMacroCall",
+                  "markdown": "Reports errors when calling macros.\n\nInspection ID: RsInvalidMacroCall"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidMacroCall",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDefaultKeywordIsNotAllowed",
+                "shortDescription": {
+                  "text": "`default` qualifier not allowed"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid `default` keyword placement. Inspection ID: RsDefaultKeywordIsNotAllowed",
+                  "markdown": "Reports invalid \\`default\\` keyword placement.\n\nInspection ID: RsDefaultKeywordIsNotAllowed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsDefaultKeywordIsNotAllowed",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWrongLifetimeParametersNumber",
+                "shortDescription": {
+                  "text": "Wrong number of lifetime parameters"
+                },
+                "fullDescription": {
+                  "text": "Checks if the right number of lifetime parameters was used for a type or trait. Corresponds to E0106 / E0107 Rust errors. Inspection ID: RsWrongLifetimeParametersNumber",
+                  "markdown": "Checks if the right number of lifetime parameters was used for a type or trait. Corresponds to [E0106](https://doc.rust-lang.org/error-index.html#E0106) / [E0107](https://doc.rust-lang.org/error-index.html#E0107) Rust errors.\n\nInspection ID: RsWrongLifetimeParametersNumber"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsWrongLifetimeParametersNumber",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReplaceCastWithSuffix",
+                "shortDescription": {
+                  "text": "Cast can be replaced with literal suffix"
+                },
+                "fullDescription": {
+                  "text": "Detects 'as' casts that can be replaced with literal suffixes. Inspection ID: RsReplaceCastWithSuffix",
+                  "markdown": "Detects `as` casts that can be replaced with literal suffixes.\n\nInspection ID: RsReplaceCastWithSuffix"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsReplaceCastWithSuffix",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNonShorthandFieldPatterns",
+                "shortDescription": {
+                  "text": "Non-shorthand field pattern"
+                },
+                "fullDescription": {
+                  "text": "Detects using 'Struct { x: x }' instead of 'Struct { x }' in a pattern. Inspection ID: RsNonShorthandFieldPatterns",
+                  "markdown": "Detects using `Struct { x: x }` instead of `Struct { x }` in a pattern.\n\nInspection ID: RsNonShorthandFieldPatterns"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsNonShorthandFieldPatterns",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDanglingElse",
+                "shortDescription": {
+                  "text": "Dangling `else`"
+                },
+                "fullDescription": {
+                  "text": "Detects suspiciously looking 'else if'-statements split by new lines. Partially corresponds to suspicious_else_formatting lint from Rust Clippy. Inspection ID: RsDanglingElse",
+                  "markdown": "Detects suspiciously looking `else if`-statements split by new lines.  \nPartially corresponds to [suspicious_else_formatting](https://rust-lang.github.io/rust-clippy/stable/#suspicious_else_formatting) lint from Rust Clippy.\n\nInspection ID: RsDanglingElse"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDanglingElse",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypeCannotBeIndexedBy",
+                "shortDescription": {
+                  "text": "Index expression has a wrong type"
+                },
+                "fullDescription": {
+                  "text": "Checks type of index expression. Inspection ID: RsTypeCannotBeIndexedBy",
+                  "markdown": "Checks type of index expression.\n\nInspection ID: RsTypeCannotBeIndexedBy"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTypeCannotBeIndexedBy",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLifetimeParametersBeforeTypeParameters",
+                "shortDescription": {
+                  "text": "Incorrect order of lifetime/type/const parameters"
+                },
+                "fullDescription": {
+                  "text": "Reports incorrectly ordered lifetime, type, and const parameters. Inspection ID: RsLifetimeParametersBeforeTypeParameters",
+                  "markdown": "Reports incorrectly ordered lifetime, type, and const parameters.\n\nInspection ID: RsLifetimeParametersBeforeTypeParameters"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsLifetimeParametersBeforeTypeParameters",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidLabelName",
+                "shortDescription": {
+                  "text": "Invalid label name"
+                },
+                "fullDescription": {
+                  "text": "Reports labels with invalid names. Inspection ID: RsInvalidLabelName",
+                  "markdown": "Reports labels with invalid names.\n\nInspection ID: RsInvalidLabelName"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidLabelName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnsafeError",
+                "shortDescription": {
+                  "text": "Unsafe item in safe context"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of unsafe items in a safe context. Inspection ID: RsUnsafeError",
+                  "markdown": "Reports the use of unsafe items in a safe context.\n\nInspection ID: RsUnsafeError"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnsafeError",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsThreadLocalStableMethodCanBeUsed",
+                "shortDescription": {
+                  "text": "`with` call can be replaced with thread local stable method"
+                },
+                "fullDescription": {
+                  "text": "Detects usages of 'LocalKey::with()' method that can be replaced with stable thread local methods. Inspection ID: RsThreadLocalStableMethodCanBeUsed",
+                  "markdown": "Detects usages of `LocalKey::with()` method that can be replaced with stable thread local methods.\n\nInspection ID: RsThreadLocalStableMethodCanBeUsed"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsThreadLocalStableMethodCanBeUsed",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnusedMustUse",
+                "shortDescription": {
+                  "text": "Unused `#[must_use]`"
+                },
+                "fullDescription": {
+                  "text": "Detects unused result of a type flagged as '#[must_use]'. Inspection ID: RsUnusedMustUse",
+                  "markdown": "Detects unused result of a type flagged as `#[must_use]`.\n\nInspection ID: RsUnusedMustUse"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsUnusedMustUse",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsStaticConstNaming",
+                "shortDescription": {
+                  "text": "Static constant naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if static constant names follow the Rust naming convention. Inspection ID: RsStaticConstNaming",
+                  "markdown": "Checks if static constant names follow the Rust naming convention.\n\nInspection ID: RsStaticConstNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsStaticConstNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInternalUnknownType",
+                "shortDescription": {
+                  "text": "Unknown type (internal)"
+                },
+                "fullDescription": {
+                  "text": "This inspection is for internal use only. Inspection ID: RsInternalUnknownType",
+                  "markdown": "This inspection is for internal use only.\n\nInspection ID: RsInternalUnknownType"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsInternalUnknownType",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsDropRef",
+                "shortDescription": {
+                  "text": "Reference dropped"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'std::mem::drop' with a reference instead of an owned value. Corresponds to the drop_ref lint from Rust Clippy. Inspection ID: RsDropRef",
+                  "markdown": "Reports calls to `std::mem::drop` with a reference instead of an owned value.  \nCorresponds to the [drop_ref](https://rust-lang.github.io/rust-clippy/stable/#drop_ref) lint from Rust Clippy.\n\nInspection ID: RsDropRef"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsDropRef",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUndeclaredLabel",
+                "shortDescription": {
+                  "text": "Undeclared label"
+                },
+                "fullDescription": {
+                  "text": "Reports undeclared labels. Inspection ID: RsUndeclaredLabel",
+                  "markdown": "Reports undeclared labels.\n\nInspection ID: RsUndeclaredLabel"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUndeclaredLabel",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSimplifyPrint",
+                "shortDescription": {
+                  "text": "`println!` macro can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Detects usages of 'println!(\"\")' which can be simplified to 'println!()' since from Rust 1.14.0. Inspection ID: RsSimplifyPrint",
+                  "markdown": "Detects usages of `println!(\"\")` which can be simplified to `println!()` since from Rust 1.14.0.\n\nInspection ID: RsSimplifyPrint"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsSimplifyPrint",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypeCheck",
+                "shortDescription": {
+                  "text": "Type checker"
+                },
+                "fullDescription": {
+                  "text": "The Rust type checker. Inspection ID: RsTypeCheck",
+                  "markdown": "The Rust type checker.\n\nInspection ID: RsTypeCheck"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTypeCheck",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAssociatedTypeMismatch",
+                "shortDescription": {
+                  "text": "Type mismatched the trait's associated type"
+                },
+                "fullDescription": {
+                  "text": "A type mismatched an associated type of a trait. Inspection ID: RsAssociatedTypeMismatch",
+                  "markdown": "A type mismatched an associated type of a trait.\n\nInspection ID: RsAssociatedTypeMismatch"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAssociatedTypeMismatch",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSleepInsideAsyncFunction",
+                "shortDescription": {
+                  "text": "Blocking `sleep` function cannot be used in `async` context"
+                },
+                "fullDescription": {
+                  "text": "Detects usages of blocking 'thread::sleep()' function in async contexts. Inspection ID: RsSleepInsideAsyncFunction",
+                  "markdown": "Detects usages of blocking `thread::sleep()` function in async contexts.\n\nInspection ID: RsSleepInsideAsyncFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsSleepInsideAsyncFunction",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalUnresolvedMethod",
+                "shortDescription": {
+                  "text": "Unresolved method (experimental)"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved method references. This inspection can report false positives. Inspection ID: RsExperimentalUnresolvedMethod",
+                  "markdown": "Reports unresolved method references. This inspection can report false positives.\n\nInspection ID: RsExperimentalUnresolvedMethod"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalUnresolvedMethod",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MissingFeatures",
+                "shortDescription": {
+                  "text": "Missing features"
+                },
+                "fullDescription": {
+                  "text": "Detects Cargo packages with missing cargo features in some of their dependency packages Inspection ID: MissingFeatures",
+                  "markdown": "Detects Cargo packages with missing cargo features in some of their dependency packages\n\nInspection ID: MissingFeatures"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "MissingFeatures",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAssignToImmutable",
+                "shortDescription": {
+                  "text": "Immutable reassigned"
+                },
+                "fullDescription": {
+                  "text": "Detects assignments to immutable. Corresponds to E0594 Rust error. Inspection ID: RsAssignToImmutable",
+                  "markdown": "Detects assignments to immutable. Corresponds to [E0594](https://doc.rust-lang.org/error-index.html#E0594) Rust error.\n\nInspection ID: RsAssignToImmutable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAssignToImmutable",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAttrError",
+                "shortDescription": {
+                  "text": "Attribute error"
+                },
+                "fullDescription": {
+                  "text": "Reports issues with attributes including misuse, redundancy, formatting errors, invalid entries, outdated syntax, and more. Inspection ID: RsAttrError",
+                  "markdown": "Reports issues with attributes including misuse, redundancy, formatting errors, invalid entries, outdated syntax, and more.\n\nInspection ID: RsAttrError"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAttrError",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReferenceIsNotPublic",
+                "shortDescription": {
+                  "text": "Invalid access of private item"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid attempts to access private fields or methods. Inspection ID: RsReferenceIsNotPublic",
+                  "markdown": "Reports invalid attempts to access private fields or methods.\n\nInspection ID: RsReferenceIsNotPublic"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsReferenceIsNotPublic",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CrateVersionInvalid",
+                "shortDescription": {
+                  "text": "Invalid crate version"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid crate versions in Cargo.toml. Inspection ID: CrateVersionInvalid",
+                  "markdown": "Reports invalid crate versions in Cargo.toml.\n\nInspection ID: CrateVersionInvalid"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CrateVersionInvalid",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsGenericArgumentsBeforeConstraints",
+                "shortDescription": {
+                  "text": "Constraint(s) preceding generic arguments"
+                },
+                "fullDescription": {
+                  "text": "Reports constraint(s) placed before generic arguments. Inspection ID: RsGenericArgumentsBeforeConstraints",
+                  "markdown": "Reports constraint(s) placed before generic arguments.\n\nInspection ID: RsGenericArgumentsBeforeConstraints"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsGenericArgumentsBeforeConstraints",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsPatStructInvalidFields",
+                "shortDescription": {
+                  "text": "Invalid fields in struct or tuple struct pattern"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid fields in struct and tuple struct patterns. Inspection ID: RsPatStructInvalidFields",
+                  "markdown": "Reports invalid fields in struct and tuple struct patterns.\n\nInspection ID: RsPatStructInvalidFields"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsPatStructInvalidFields",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAssocTypeNaming",
+                "shortDescription": {
+                  "text": "Associated type naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if associated type names follow the Rust naming convention. Inspection ID: RsAssocTypeNaming",
+                  "markdown": "Checks if associated type names follow the Rust naming convention.\n\nInspection ID: RsAssocTypeNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsAssocTypeNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTryMacro",
+                "shortDescription": {
+                  "text": "`try!` macro usage"
+                },
+                "fullDescription": {
+                  "text": "Finds usages of the 'try!' macro which can be replaced with '?' operator starting from Rust 1.13.0. Inspection ID: RsTryMacro",
+                  "markdown": "Finds usages of the `try!` macro which can be replaced with `?` operator starting from Rust 1.13.0.\n\nInspection ID: RsTryMacro"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsTryMacro",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNonExistentFieldAccess",
+                "shortDescription": {
+                  "text": "Non-existent field access"
+                },
+                "fullDescription": {
+                  "text": "Reports attempts to access non-existent fields. E0609, E0610, E0615 Inspection ID: RsNonExistentFieldAccess",
+                  "markdown": "Reports attempts to access non-existent fields. [E0609](https://doc.rust-lang.org/error_codes/E0609.html), [E0610](https://doc.rust-lang.org/error_codes/E0610.html), [E0615](https://doc.rust-lang.org/error_codes/E0615.html)\n\nInspection ID: RsNonExistentFieldAccess"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsNonExistentFieldAccess",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSelfConvention",
+                "shortDescription": {
+                  "text": "Self convention"
+                },
+                "fullDescription": {
+                  "text": "Checks some naming conventions for methods. Corresponds to wrong_self_convention lint from Rust Clippy. Inspection ID: RsSelfConvention",
+                  "markdown": "Checks some naming conventions for methods. Corresponds to [wrong_self_convention](https://rust-lang.github.io/rust-clippy/stable/#wrong_self_convention) lint from Rust Clippy.\n\nInspection ID: RsSelfConvention"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsSelfConvention",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSuperTraitIsNotImplemented",
+                "shortDescription": {
+                  "text": "Supertrait is not implemented"
+                },
+                "fullDescription": {
+                  "text": "Reports missing supertrait implementations. E0277 Inspection ID: RsSuperTraitIsNotImplemented",
+                  "markdown": "Reports missing supertrait implementations. [E0277](https://doc.rust-lang.org/error_codes/E0277.html)\n\nInspection ID: RsSuperTraitIsNotImplemented"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsSuperTraitIsNotImplemented",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTraitObligations",
+                "shortDescription": {
+                  "text": "Type does not implement trait"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of types that do not implement the necessary traits. Inspection ID: RsTraitObligations",
+                  "markdown": "Reports the use of types that do not implement the necessary traits.\n\nInspection ID: RsTraitObligations"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTraitObligations",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsLifetimeBoundsInParentheses",
+                "shortDescription": {
+                  "text": "Lifetime bounds in parentheses"
+                },
+                "fullDescription": {
+                  "text": "Reports lifetime bounds in parentheses. Inspection ID: RsLifetimeBoundsInParentheses",
+                  "markdown": "Reports lifetime bounds in parentheses.\n\nInspection ID: RsLifetimeBoundsInParentheses"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsLifetimeBoundsInParentheses",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTraitNaming",
+                "shortDescription": {
+                  "text": "Trait naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if trait names follow the Rust naming convention. Inspection ID: RsTraitNaming",
+                  "markdown": "Checks if trait names follow the Rust naming convention.\n\nInspection ID: RsTraitNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsTraitNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsChainedComparisonOperatorRequiresParentheses",
+                "shortDescription": {
+                  "text": "Missing parentheses for chained comparison"
+                },
+                "fullDescription": {
+                  "text": "Reports chained comparison operators with missing parentheses. Inspection ID: RsChainedComparisonOperatorRequiresParentheses",
+                  "markdown": "Reports chained comparison operators with missing parentheses.\n\nInspection ID: RsChainedComparisonOperatorRequiresParentheses"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsChainedComparisonOperatorRequiresParentheses",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalTypeCheck",
+                "shortDescription": {
+                  "text": "Type checker (experimental)"
+                },
+                "fullDescription": {
+                  "text": "The Rust type checker (experimental). Inspection ID: RsExperimentalTypeCheck",
+                  "markdown": "The Rust type checker (experimental).\n\nInspection ID: RsExperimentalTypeCheck"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalTypeCheck",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsSortImplTraitMembers",
+                "shortDescription": {
+                  "text": "`impl` member order differs from trait"
+                },
+                "fullDescription": {
+                  "text": "Checks if members in the impl have a same order as in the trait. Inspection ID: RsSortImplTraitMembers",
+                  "markdown": "Checks if members in the impl have a same order as in the trait.\n\nInspection ID: RsSortImplTraitMembers"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsSortImplTraitMembers",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAsyncMainFunction",
+                "shortDescription": {
+                  "text": "Entry point is async"
+                },
+                "fullDescription": {
+                  "text": "Checks if the entry point of the program was marked as 'async'. Inspection ID: RsAsyncMainFunction",
+                  "markdown": "Checks if the entry point of the program was marked as `async`.\n\nInspection ID: RsAsyncMainFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAsyncMainFunction",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsAsyncNonMoveClosureWithParameters",
+                "shortDescription": {
+                  "text": "`async` non-`move` closure with parameters (unsupported)"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of `async` non-`move` closures with parameters for Rust 1.76 or earlier versions that do not support it. Inspection ID: RsAsyncNonMoveClosureWithParameters",
+                  "markdown": "Reports the use of \\`async\\` non-\\`move\\` closures with parameters for Rust 1.76 or earlier versions that do not support it.\n\nInspection ID: RsAsyncNonMoveClosureWithParameters"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsAsyncNonMoveClosureWithParameters",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInternalUnexpandedMacro",
+                "shortDescription": {
+                  "text": "Unexpanded macro (internal)"
+                },
+                "fullDescription": {
+                  "text": "This is an internal only inspection. Inspection ID: RsInternalUnexpandedMacro",
+                  "markdown": "This is an internal only inspection.\n\nInspection ID: RsInternalUnexpandedMacro"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsInternalUnexpandedMacro",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsReservedLifetimeName",
+                "shortDescription": {
+                  "text": "Reserved lifetime name"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of reserved lifetime names. Inspection ID: RsReservedLifetimeName",
+                  "markdown": "Reports the use of reserved lifetime names.\n\nInspection ID: RsReservedLifetimeName"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsReservedLifetimeName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExperimentalAmbiguousMethodCall",
+                "shortDescription": {
+                  "text": "Ambiguous method call (experimental)"
+                },
+                "fullDescription": {
+                  "text": "Reports method calls that cannot be resolved because they match several method prototypes. Inspection ID: RsExperimentalAmbiguousMethodCall",
+                  "markdown": "Reports method calls that cannot be resolved because they match several method prototypes.\n\nInspection ID: RsExperimentalAmbiguousMethodCall"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExperimentalAmbiguousMethodCall",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypeParameterNaming",
+                "shortDescription": {
+                  "text": "Type parameter naming convention"
+                },
+                "fullDescription": {
+                  "text": "Checks if type parameter names follow the Rust naming convention. Inspection ID: RsTypeParameterNaming",
+                  "markdown": "Checks if type parameter names follow the Rust naming convention.\n\nInspection ID: RsTypeParameterNaming"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsTypeParameterNaming",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints/Naming conventions",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInternalFileMetadata",
+                "shortDescription": {
+                  "text": "File metadata for a Rust file (internal)"
+                },
+                "fullDescription": {
+                  "text": "This inspection is for internal use only. Inspection ID: RsInternalFileMetadata",
+                  "markdown": "This inspection is for internal use only.\n\nInspection ID: RsInternalFileMetadata"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsInternalFileMetadata",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsCommaSeparatedTraitBounds",
+                "shortDescription": {
+                  "text": "Comma-separated trait bounds"
+                },
+                "fullDescription": {
+                  "text": "Reports trait bounds for a single type that are separated with a comma instead of a `+` sign. Inspection ID: RsCommaSeparatedTraitBounds",
+                  "markdown": "Reports trait bounds for a single type that are separated with a comma instead of a \\`+\\` sign.\n\nInspection ID: RsCommaSeparatedTraitBounds"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsCommaSeparatedTraitBounds",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsModuleNotInModRs",
+                "shortDescription": {
+                  "text": "Module declared outside mod.rs"
+                },
+                "fullDescription": {
+                  "text": "Reports module declarations in files other than mod.rs. Inspection ID: RsModuleNotInModRs",
+                  "markdown": "Reports module declarations in files other than mod.rs.\n\nInspection ID: RsModuleNotInModRs"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsModuleNotInModRs",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInvalidReexport",
+                "shortDescription": {
+                  "text": "Re-export of a private item"
+                },
+                "fullDescription": {
+                  "text": "Reports private items that were re-exported publicly. Inspection ID: RsInvalidReexport",
+                  "markdown": "Reports private items that were re-exported publicly.\n\nInspection ID: RsInvalidReexport"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsInvalidReexport",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWhileTrueLoop",
+                "shortDescription": {
+                  "text": "`while true` can be replaced with `loop`"
+                },
+                "fullDescription": {
+                  "text": "Detects 'while' loops which can be replaced with 'loop'. Inspection ID: RsWhileTrueLoop",
+                  "markdown": "Detects `while` loops which can be replaced with `loop`.\n\nInspection ID: RsWhileTrueLoop"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsWhileTrueLoop",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsExternCrateSelfWithoutAsName",
+                "shortDescription": {
+                  "text": "`extern crate self` missing `as <name>`"
+                },
+                "fullDescription": {
+                  "text": "Reports `extern crate self` that is not followed by `as <name>`. Inspection ID: RsExternCrateSelfWithoutAsName",
+                  "markdown": "Reports \\`extern crate self\\` that is not followed by \\`as \\<name\\>\\`.\n\nInspection ID: RsExternCrateSelfWithoutAsName"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsExternCrateSelfWithoutAsName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsIncorrectFunctionArgumentCount",
+                "shortDescription": {
+                  "text": "Wrong number of arguments"
+                },
+                "fullDescription": {
+                  "text": "Reports function calls with an incorrect number of arguments. Inspection ID: RsIncorrectFunctionArgumentCount",
+                  "markdown": "Reports function calls with an incorrect number of arguments.\n\nInspection ID: RsIncorrectFunctionArgumentCount"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsIncorrectFunctionArgumentCount",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsInternalPartlyUnknownType",
+                "shortDescription": {
+                  "text": "Partly unknown type (internal)"
+                },
+                "fullDescription": {
+                  "text": "This inspection is for internal use only. Inspection ID: RsInternalPartlyUnknownType",
+                  "markdown": "This inspection is for internal use only.\n\nInspection ID: RsInternalPartlyUnknownType"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RsInternalPartlyUnknownType",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsUnlabeledControlFlowExpr",
+                "shortDescription": {
+                  "text": "Unlabeled `continue`/`break` in labeled block"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of unlabeled `break`/`continue` statements inside labeled blocks. Inspection ID: RsUnlabeledControlFlowExpr",
+                  "markdown": "Reports the use of unlabeled \\`break\\`/\\`continue\\` statements inside labeled blocks.\n\nInspection ID: RsUnlabeledControlFlowExpr"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsUnlabeledControlFlowExpr",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsNeedlessLifetimes",
+                "shortDescription": {
+                  "text": "Unnecessary lifetime annotations"
+                },
+                "fullDescription": {
+                  "text": "Checks for lifetime annotations which can be removed by relying on lifetime elision. Corresponds to needless_lifetimes lint from Rust Clippy. Inspection ID: RsNeedlessLifetimes",
+                  "markdown": "Checks for lifetime annotations which can be removed by relying on lifetime elision. Corresponds to [needless_lifetimes](https://rust-lang.github.io/rust-clippy/stable/#needless_lifetimes) lint from Rust Clippy.\n\nInspection ID: RsNeedlessLifetimes"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RsNeedlessLifetimes",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Lints",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsWrongAssocTypeArguments",
+                "shortDescription": {
+                  "text": "Wrong associated type arguments"
+                },
+                "fullDescription": {
+                  "text": "Checks if correct associated type arguments were used for a type or a trait reference. Corresponds to the E0191 and E0220 Rust errors. Inspection ID: RsWrongAssocTypeArguments",
+                  "markdown": "Checks if correct associated type arguments were used for a type or a trait reference.   \nCorresponds to the [E0191](https://doc.rust-lang.org/error-index.html#E0191) and [E0220](https://doc.rust-lang.org/error-index.html#E0220) Rust errors.\n\nInspection ID: RsWrongAssocTypeArguments"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsWrongAssocTypeArguments",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTraitImplementation",
+                "shortDescription": {
+                  "text": "Trait implementation issue"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in trait implementation like \"Missing members\", \"Unknown member\", etc. Inspection ID: RsTraitImplementation",
+                  "markdown": "Reports errors in trait implementation like \"Missing members\", \"Unknown member\", etc.\n\nInspection ID: RsTraitImplementation"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTraitImplementation",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CrateNotFound",
+                "shortDescription": {
+                  "text": "Crate not found"
+                },
+                "fullDescription": {
+                  "text": "Reports any unknown crates listed in Cargo.toml. Inspection ID: CrateNotFound",
+                  "markdown": "Reports any unknown crates listed in Cargo.toml.\n\nInspection ID: CrateNotFound"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CrateNotFound",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RsTypePlaceholderIsForbidden",
+                "shortDescription": {
+                  "text": "Type placeholder used in item signature"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of type placeholders ('_') in an item's signature. Inspection ID: RsTypePlaceholderIsForbidden",
+                  "markdown": "Reports the use of type placeholders (`_`) in an item's signature.\n\nInspection ID: RsTypePlaceholderIsForbidden"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RsTypePlaceholderIsForbidden",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust",
+                      "index": 0,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CargoTomlCyclicFeature",
+                "shortDescription": {
+                  "text": "Cyclic feature dependency"
+                },
+                "fullDescription": {
+                  "text": "Detects features that depend on themselves. Inspection ID: CargoTomlCyclicFeature",
+                  "markdown": "Detects features that depend on themselves.\n\nInspection ID: CargoTomlCyclicFeature"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CargoTomlCyclicFeature",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rust/Cargo.toml",
+                      "index": 11,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.jetbrains.restClient",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "HttpRequestCustomHttpMethodInspection",
+                "shortDescription": {
+                  "text": "Unknown HTTP method"
+                },
+                "fullDescription": {
+                  "text": "Reports possible custom HTTP methods. The quick fix suggests adding the custom HTTP method to project settings. Inspection ID: HttpRequestCustomHttpMethodInspection",
+                  "markdown": "Reports possible custom HTTP methods. The quick fix suggests adding the custom HTTP method to project settings.\n\nInspection ID: HttpRequestCustomHttpMethodInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestCustomHttpMethodInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestPlaceholder",
+                "shortDescription": {
+                  "text": "'$placeholder' in HTTP Request"
+                },
+                "fullDescription": {
+                  "text": "Reports a '$placeholder' inside a request. A '$placeholder' to be replaced by the user is created automatically when a tool cannot recognize a part of a request. For example, a request mapping '/aaaa/*/bbb' will be generated as 'GET localhost/aaaa/{{$placeholder}}/bbb'. Inspection ID: HttpRequestPlaceholder",
+                  "markdown": "Reports a `$placeholder` inside a request.\n\nA `$placeholder` to be replaced by the user is created automatically when a tool cannot recognize a part of a request. For example, a request mapping `/aaaa/*/bbb` will be generated as `GET localhost/aaaa/{{$placeholder}}/bbb`.\n\nInspection ID: HttpRequestPlaceholder"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestPlaceholder",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpClientUnresolvedVariable",
+                "shortDescription": {
+                  "text": "Unresolved environment variable"
+                },
+                "fullDescription": {
+                  "text": "Reports variables undeclared in the current environment HTTP Client. Executing requests with undeclared variables probably fail. Consider adding a variable to the environment or selecting an environment with this variable. Inspection doesn't report variables in request bodies, because it can be a valid syntax of the body. Some variables may be not reported as unresolved, because they are declared in response or pre-request handler scripts via 'client.global.set' or 'request.variables.set' functions call. Inspection ID: HttpClientUnresolvedVariable",
+                  "markdown": "Reports variables undeclared in the current environment HTTP Client.\n\n\nExecuting requests with undeclared variables probably fail.\nConsider adding a variable to the environment or selecting an environment with this variable.\n\nInspection doesn't report variables in request bodies, because it can be a valid syntax of the body.\n\n\nSome variables may be not reported as unresolved, because they are declared in response or pre-request handler scripts via\n`client.global.set` or `request.variables.set` functions call.\n\nInspection ID: HttpClientUnresolvedVariable"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpClientUnresolvedVariable",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestRequestSeparatorJsonBodyInspection",
+                "shortDescription": {
+                  "text": "Missing request separator in JSON body"
+                },
+                "fullDescription": {
+                  "text": "Reports possible requests in injected JSON body where request separator '###' is missing. The quick fix suggests adding the separator '###' before the request. Inspection ID: HttpRequestRequestSeparatorJsonBodyInspection",
+                  "markdown": "Reports possible requests in injected JSON body where request separator `###` is missing. The quick fix suggests adding the separator `###` before the request.\n\nInspection ID: HttpRequestRequestSeparatorJsonBodyInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestRequestSeparatorJsonBodyInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpClientRunRequestNameInspection",
+                "shortDescription": {
+                  "text": "Possible request name"
+                },
+                "fullDescription": {
+                  "text": "Highlights request name in run block which has no specified import file. Suggests adding import for the file which contains this named request. Inspection ID: HttpClientRunRequestNameInspection",
+                  "markdown": "Highlights request name in run block which has no specified import file. Suggests adding import for the file which contains this named request.\n\nInspection ID: HttpClientRunRequestNameInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpClientRunRequestNameInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestRequestSeparatorYamlBodyInspection",
+                "shortDescription": {
+                  "text": "Missing request separator in YAML body"
+                },
+                "fullDescription": {
+                  "text": "Reports possible requests in injected YAML body where request separator '###' is missing. The quick fix suggests adding the separator '###' before the request. Inspection ID: HttpRequestRequestSeparatorYamlBodyInspection",
+                  "markdown": "Reports possible requests in injected YAML body where request separator `###` is missing. The quick fix suggests adding the separator `###` before the request.\n\nInspection ID: HttpRequestRequestSeparatorYamlBodyInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestRequestSeparatorYamlBodyInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestWhitespaceInsideRequestTargetPath",
+                "shortDescription": {
+                  "text": "Whitespace in URL in request"
+                },
+                "fullDescription": {
+                  "text": "Highlights spaces inside URL path segments. HTTP Client will ignore them. For better composing use Split Lines action. Inspection ID: HttpRequestWhitespaceInsideRequestTargetPath",
+                  "markdown": "Highlights spaces inside URL path segments. HTTP Client will ignore them. For better composing use Split Lines action.\n\nInspection ID: HttpRequestWhitespaceInsideRequestTargetPath"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestWhitespaceInsideRequestTargetPath",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpClientUnresolvedAuthId",
+                "shortDescription": {
+                  "text": "Unresolved Auth identifier"
+                },
+                "fullDescription": {
+                  "text": "Highlights references to non-existent Auth configurations. Suggests creating a new one in the current environment. Inspection ID: HttpClientUnresolvedAuthId",
+                  "markdown": "Highlights references to non-existent Auth configurations. Suggests creating a new one in the current environment.\n\nInspection ID: HttpClientUnresolvedAuthId"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "HttpClientUnresolvedAuthId",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestAmbiguityEncoding",
+                "shortDescription": {
+                  "text": "Ambiguity Encoding Inspection"
+                },
+                "fullDescription": {
+                  "text": "Detects '+' in an encoded query string. It is ambiguous whether it should be encoded as space or as a '+' character. Example: 'GET https://example.com/api?name=John+Doe%40example.com' After the quick-fix is applied 'GET https://example.com/api?name=John%20Doe%40example.com' Inspection ID: HttpRequestAmbiguityEncoding",
+                  "markdown": "Detects '+' in an encoded query string. It is ambiguous whether it should be encoded as space or as a '+' character.\n\n**Example:**\n\n\n      GET https://example.com/api?name=John+Doe%40example.com\n\nAfter the quick-fix is applied\n\n\n      GET https://example.com/api?name=John%20Doe%40example.com\n\nInspection ID: HttpRequestAmbiguityEncoding"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestAmbiguityEncoding",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestEnvironmentAuthConfigurationValidationInspection",
+                "shortDescription": {
+                  "text": "Auth configuration validation"
+                },
+                "fullDescription": {
+                  "text": "Reports Auth configuration the following problems in HTTP Client environment files: Missing properties in Auth configuration Auth/Security configuration placed in private environment file Inspection ID: HttpRequestEnvironmentAuthConfigurationValidationInspection",
+                  "markdown": "Reports Auth configuration the following problems in HTTP Client environment files:\n\n* Missing properties in Auth configuration\n* Auth/Security configuration placed in private environment file\n\nInspection ID: HttpRequestEnvironmentAuthConfigurationValidationInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestEnvironmentAuthConfigurationValidationInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpUrlsUsage",
+                "shortDescription": {
+                  "text": "Link with unencrypted protocol"
+                },
+                "fullDescription": {
+                  "text": "Reports the links that use unencrypted protocols (such as HTTP), which can expose your data to man-in-the-middle attacks. These attacks are dangerous in general and may be especially harmful for artifact repositories. Use protocols with encryption, such as HTTPS, instead. See HTTPS: Difference from HTTP (wikipedia.org). Inspection ID: HttpUrlsUsage",
+                  "markdown": "Reports the links that use unencrypted protocols (such as HTTP), which can expose your data to man-in-the-middle attacks. These attacks\nare dangerous in general and may be especially harmful for artifact repositories. Use protocols with encryption, such as HTTPS,\ninstead.\n\nSee [HTTPS: Difference from HTTP (wikipedia.org)](https://en.wikipedia.org/wiki/HTTPS#Difference_from_HTTP).\n\nInspection ID: HttpUrlsUsage"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpUrlsUsage",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Security"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Security",
+                      "index": 20,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestContentLengthIsIgnored",
+                "shortDescription": {
+                  "text": "Redundant 'Content-Length'"
+                },
+                "fullDescription": {
+                  "text": "Reports an explicitly set 'Content-Length' header. The header is redundant because HTTP Client uses the actual request body length. Inspection ID: HttpRequestContentLengthIsIgnored",
+                  "markdown": "Reports an explicitly set `Content-Length` header. The header is redundant because HTTP Client uses the actual request body length.\n\nInspection ID: HttpRequestContentLengthIsIgnored"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestContentLengthIsIgnored",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestRequestSeparatorXmlBodyInspection",
+                "shortDescription": {
+                  "text": "Missing request separator in HTML/XML body"
+                },
+                "fullDescription": {
+                  "text": "Reports possible requests in injected XML/HTML body where request separator '###' is missing. The quick fix suggests adding the separator '###' before the request. Inspection ID: HttpRequestRequestSeparatorXmlBodyInspection",
+                  "markdown": "Reports possible requests in injected XML/HTML body where request separator `###` is missing. The quick fix suggests adding the separator `###` before the request.\n\nInspection ID: HttpRequestRequestSeparatorXmlBodyInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestRequestSeparatorXmlBodyInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IncorrectHttpHeaderInspection",
+                "shortDescription": {
+                  "text": "Incorrect HTTP header"
+                },
+                "fullDescription": {
+                  "text": "Reports unknown HTTP headers that do not match any publicly known headers. The quick fix suggests adding the header to the list of custom headers when the Use custom HTTP headers option is enabled. HTTP headers from the list of custom headers will not trigger the inspection. Inspection ID: IncorrectHttpHeaderInspection",
+                  "markdown": "Reports unknown HTTP headers that do not match any [publicly\nknown headers](https://www.iana.org/assignments/message-headers/message-headers.xml). The quick fix suggests adding the header to the list of custom headers when the **Use custom HTTP headers** option\nis enabled. HTTP headers from the list of custom headers will not trigger the inspection.\n\nInspection ID: IncorrectHttpHeaderInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "IncorrectHttpHeaderInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpClientDuplicateImportInspection",
+                "shortDescription": {
+                  "text": "Duplicate import"
+                },
+                "fullDescription": {
+                  "text": "Highlights already defined import. Suggests removing duplicated import definition. Inspection ID: HttpClientDuplicateImportInspection",
+                  "markdown": "Highlights already defined import. Suggests removing duplicated import definition.\n\nInspection ID: HttpClientDuplicateImportInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpClientDuplicateImportInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpRequestJsonBodyInspection",
+                "shortDescription": {
+                  "text": "Variable should be double-quoted"
+                },
+                "fullDescription": {
+                  "text": "Reports variables which should be double-quoted in json body. The quick fix suggests wrap variable with double quotes '\"{{variable}}\"'. Inspection ID: HttpRequestJsonBodyInspection",
+                  "markdown": "Reports variables which should be double-quoted in json body. The quick fix suggests wrap variable with double quotes `\"{{variable}}\"`.\n\nInspection ID: HttpRequestJsonBodyInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HttpRequestJsonBodyInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HttpClientInappropriateProtocolUsageInspection",
+                "shortDescription": {
+                  "text": "Inappropriate HTTP Protocol usage"
+                },
+                "fullDescription": {
+                  "text": "Reports inappropriate usage of HTTP protocol keyword, e.g. 'HTTP/2', with non-HTTP method requests. Such a usage will be ignored. Inspection ID: HttpClientInappropriateProtocolUsageInspection",
+                  "markdown": "Reports inappropriate usage of HTTP protocol keyword, e.g. `HTTP/2`, with non-HTTP method requests. Such a usage will be ignored.\n\nInspection ID: HttpClientInappropriateProtocolUsageInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HttpClientInappropriateProtocolUsageInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTTP Client",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.jetbrains.sh",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "ShellCheck",
+                "shortDescription": {
+                  "text": "ShellCheck"
+                },
+                "fullDescription": {
+                  "text": "Reports shell script bugs detected by the integrated ShellCheck static analysis tool. Inspection ID: ShellCheck",
+                  "markdown": "Reports shell script bugs detected by the integrated [ShellCheck](https://github.com/koalaman/shellcheck) static analysis tool.\n\nInspection ID: ShellCheck"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "ShellCheck",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Shell script",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.intellij",
+            "version": "261.24231",
+            "rules": [
+              {
+                "id": "XmlHighlighting",
+                "shortDescription": {
+                  "text": "XML highlighting"
+                },
+                "fullDescription": {
+                  "text": "Reports XML validation problems in the results of a batch code inspection. Inspection ID: XmlHighlighting",
+                  "markdown": "Reports XML validation problems in the results of a batch code inspection.\n\nInspection ID: XmlHighlighting"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlHighlighting",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlDuplicatedId",
+                "shortDescription": {
+                  "text": "Duplicate 'id' attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a duplicate values of the 'id' attribute in XML and HTML. Inspection ID: XmlDuplicatedId",
+                  "markdown": "Reports a duplicate values of the `id` attribute in XML and HTML.\n\nInspection ID: XmlDuplicatedId"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlDuplicatedId",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpDuplicateCharacterInClass",
+                "shortDescription": {
+                  "text": "Duplicate character in character class"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicate characters inside a RegExp character class. Duplicate characters are unnecessary and can be removed without changing the semantics of the regex. Example: '[aabc]' After the quick-fix is applied: '[abc]' Inspection ID: RegExpDuplicateCharacterInClass",
+                  "markdown": "Reports duplicate characters inside a RegExp character class. Duplicate characters are unnecessary and can be removed without changing the semantics of the regex.\n\n**Example:**\n\n\n      [aabc]\n\nAfter the quick-fix is applied:\n\n\n      [abc]\n\nInspection ID: RegExpDuplicateCharacterInClass"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpDuplicateCharacterInClass",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlUnknownBooleanAttribute",
+                "shortDescription": {
+                  "text": "Incorrect boolean attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports an HTML non-boolean attribute without a value. Suggests configuring attributes that should not be reported. Inspection ID: HtmlUnknownBooleanAttribute",
+                  "markdown": "Reports an HTML non-boolean attribute without a value. Suggests configuring attributes that should not be reported.\n\nInspection ID: HtmlUnknownBooleanAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlUnknownBooleanAttribute",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlInvalidId",
+                "shortDescription": {
+                  "text": "Unresolved 'id' reference"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of the 'id' that is not defined anywhere in XML and HTML. Inspection ID: XmlInvalidId",
+                  "markdown": "Reports the use of the `id` that is not defined anywhere in XML and HTML.\n\nInspection ID: XmlInvalidId"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlInvalidId",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlUnboundNsPrefix",
+                "shortDescription": {
+                  "text": "Unbound namespace prefix"
+                },
+                "fullDescription": {
+                  "text": "Reports an unbound namespace prefix in XML. Inspection ID: XmlUnboundNsPrefix",
+                  "markdown": "Reports an unbound namespace prefix in XML.\n\nInspection ID: XmlUnboundNsPrefix"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "XmlUnboundNsPrefix",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RequiredAttributes",
+                "shortDescription": {
+                  "text": "Missing required attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing mandatory attribute in an XML/HTML tag. Suggests configuring attributes that should not be reported. Inspection ID: RequiredAttributes",
+                  "markdown": "Reports a missing mandatory attribute in an XML/HTML tag. Suggests configuring attributes that should not be reported.\n\nInspection ID: RequiredAttributes"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RequiredAttributes",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DuplicatedCode",
+                "shortDescription": {
+                  "text": "Duplicated code fragment"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicated blocks of code from the selected scope: the same file or the entire project. The inspection features quick-fixes that help you to set the size of detected duplicates, navigate to repetitive code fragments, and compare them in a tool window. The inspection options allow you to select the scope of the reported duplicated fragments and set the initial size for the duplicated language constructs.",
+                  "markdown": "Reports duplicated blocks of code from the selected scope: the same file or the entire project.\n\nThe inspection features quick-fixes that help you to set the size of detected duplicates, navigate to repetitive code fragments, and compare them in a tool window.\n\nThe inspection options allow you to select the scope of the reported duplicated fragments and set the initial size for the duplicated language constructs."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "DuplicatedCode",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "InconsistentLineSeparators",
+                "shortDescription": {
+                  "text": "Inconsistent line separators"
+                },
+                "fullDescription": {
+                  "text": "Reports files with line separators different from the ones that are specified in the project's settings. For example, the inspection will be triggered if you set the line separator to '\\n' in Settings | Editor | Code Style | Line separator, while the file you are editing uses '\\r\\n' as a line separator. The inspection also warns you about mixed line separators within a file. Inspection ID: InconsistentLineSeparators",
+                  "markdown": "Reports files with line separators different from the ones that are specified in the project's settings.\n\nFor example, the inspection will be triggered if you set the line separator to `\\n` in\n[Settings \\| Editor \\| Code Style \\| Line separator](settings://preferences.sourceCode?Line%20separator),\nwhile the file you are editing uses `\\r\\n` as a line separator.\n\nThe inspection also warns you about mixed line separators within a file.\n\nInspection ID: InconsistentLineSeparators"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "InconsistentLineSeparators",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReassignedToPlainText",
+                "shortDescription": {
+                  "text": "Reassigned to plain text"
+                },
+                "fullDescription": {
+                  "text": "Reports files that were explicitly re-assigned to Plain Text File Type. This association is unnecessary because the platform auto-detects text files by content automatically. You can dismiss this warning by removing the file type association in Settings | Editor | File Types | Text. Inspection ID: ReassignedToPlainText",
+                  "markdown": "Reports files that were explicitly re-assigned to Plain Text File Type. This association is unnecessary because the platform auto-detects text files by content automatically.\n\nYou can dismiss this warning by removing the file type association\nin **Settings \\| Editor \\| File Types \\| Text**.\n\nInspection ID: ReassignedToPlainText"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "ReassignedToPlainText",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantSuppression",
+                "shortDescription": {
+                  "text": "Redundant suppression"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of the following elements that can be safely removed because the inspection they affect is no longer applicable in this context: '@SuppressWarning' annotation, or '// noinspection' line comment, or '/** noinspection */' JavaDoc comment Example: 'public class C {\n // symbol is already private,\n // but annotation is still around\n  @SuppressWarnings({\"WeakerAccess\"})\n  private boolean CONST = true;\n  void f() {\n    CONST = false;\n  }\n}' Inspection ID: RedundantSuppression",
+                  "markdown": "Reports usages of the following elements that can be safely removed because the inspection they affect is no longer applicable in this context:\n\n* `@SuppressWarning` annotation, or\n* `// noinspection` line comment, or\n* `/** noinspection */` JavaDoc comment\n\nExample:\n\n\n    public class C {\n     // symbol is already private,\n     // but annotation is still around\n      @SuppressWarnings({\"WeakerAccess\"})\n      private boolean CONST = true;\n      void f() {\n        CONST = false;\n      }\n    }\n\nInspection ID: RedundantSuppression"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RedundantSuppression",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProblematicWhitespace",
+                "shortDescription": {
+                  "text": "Problematic whitespace"
+                },
+                "fullDescription": {
+                  "text": "Reports the following problems: Tabs used for indentation when the code style is configured to use only spaces. Spaces used for indentation when the code style is configured to use only tabs. Spaces used for indentation and tabs used for alignment when the code style is configured to use smart tabs. Inspection ID: ProblematicWhitespace",
+                  "markdown": "Reports the following problems:\n\n* Tabs used for indentation when the code style is configured to use only spaces.\n* Spaces used for indentation when the code style is configured to use only tabs.\n* Spaces used for indentation and tabs used for alignment when the code style is configured to use smart tabs.\n\n\nInspection ID: ProblematicWhitespace"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "ProblematicWhitespace",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlUnknownTarget",
+                "shortDescription": {
+                  "text": "Unresolved file in a link"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved file in a link. Inspection ID: HtmlUnknownTarget",
+                  "markdown": "Reports an unresolved file in a link.\n\nInspection ID: HtmlUnknownTarget"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlUnknownTarget",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SSBasedInspection",
+                "shortDescription": {
+                  "text": "Structural search inspection"
+                },
+                "fullDescription": {
+                  "text": "Allows configuring Structural Search/Structural Replace templates that you can apply to the file you are editing. All matches will be highlighted and marked with the template name that you have configured. If you configure the Structural Replace pattern as well, the corresponding replace option will be available as a quick-fix. Inspection ID: SSBasedInspection",
+                  "markdown": "Allows configuring **Structural Search/Structural Replace** templates that you can apply to the file you are editing.\n\nAll matches will be highlighted and marked with the template name that you have configured.\nIf you configure the **Structural Replace** pattern as well, the corresponding replace option will be available as a quick-fix.\n\nInspection ID: SSBasedInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "SSBasedInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Structural search",
+                      "index": 17,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LongLine",
+                "shortDescription": {
+                  "text": "Line is longer than allowed by code style"
+                },
+                "fullDescription": {
+                  "text": "Reports lines that are longer than the Hard wrap at parameter specified in Settings | Editor | Code Style | General. Inspection ID: LongLine",
+                  "markdown": "Reports lines that are longer than the **Hard wrap at** parameter specified in [Settings \\| Editor \\| Code Style \\| General](settings://preferences.sourceCode?Hard%20wrap%20at).\n\nInspection ID: LongLine"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "LongLine",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlUnusedNamespaceDeclaration",
+                "shortDescription": {
+                  "text": "Unused schema declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports an unused namespace declaration or location hint in XML. Inspection ID: XmlUnusedNamespaceDeclaration",
+                  "markdown": "Reports an unused namespace declaration or location hint in XML.\n\nInspection ID: XmlUnusedNamespaceDeclaration"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "XmlUnusedNamespaceDeclaration",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpRedundantClassElement",
+                "shortDescription": {
+                  "text": "Redundant '\\d', '[:digit:]', or '\\D' class elements"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant '\\d' or '[:digit:]' that are used in one class with '\\w' or '[:word:]' ('\\D' with '\\W') and can be removed. Example: '[\\w\\d]' After the quick-fix is applied: '[\\w]' New in 2022.2 Inspection ID: RegExpRedundantClassElement",
+                  "markdown": "Reports redundant `\\d` or `[:digit:]` that are used in one class with `\\w` or `[:word:]` (`\\D` with `\\W`) and can be removed.\n\n**Example:**\n\n\n      [\\w\\d]\n\nAfter the quick-fix is applied:\n\n\n      [\\w]\n\nNew in 2022.2\n\nInspection ID: RegExpRedundantClassElement"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RegExpRedundantClassElement",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpSimplifiable",
+                "shortDescription": {
+                  "text": "Regular expression can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports regular expressions that can be simplified. Example: '[a] xx* [ah-hz]' After the quick-fix is applied: 'a x+ [ahz]' New in 2022.1 Inspection ID: RegExpSimplifiable",
+                  "markdown": "Reports regular expressions that can be simplified.\n\n**Example:**\n\n\n      [a] xx* [ah-hz]\n\nAfter the quick-fix is applied:\n\n\n      a x+ [ahz]\n\nNew in 2022.1\n\nInspection ID: RegExpSimplifiable"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RegExpSimplifiable",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlWrongRootElement",
+                "shortDescription": {
+                  "text": "Wrong root element"
+                },
+                "fullDescription": {
+                  "text": "Reports a root tag name different from the name specified in the '<doctype>' tag. Inspection ID: XmlWrongRootElement",
+                  "markdown": "Reports a root tag name different from the name specified in the `<doctype>` tag.\n\nInspection ID: XmlWrongRootElement"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlWrongRootElement",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpEmptyAlternationBranch",
+                "shortDescription": {
+                  "text": "Empty branch in alternation"
+                },
+                "fullDescription": {
+                  "text": "Reports empty branches in a RegExp alternation. An empty branch will only match the empty string, and in most cases that is not what is desired. This inspection will not report a single empty branch at the start or the end of an alternation. Example: '(alpha||bravo)' After the quick-fix is applied: '(alpha|bravo)' New in 2017.2 Inspection ID: RegExpEmptyAlternationBranch",
+                  "markdown": "Reports empty branches in a RegExp alternation. An empty branch will only match the empty string, and in most cases that is not what is desired. This inspection will not report a single empty branch at the start or the end of an alternation.\n\n**Example:**\n\n\n      (alpha||bravo)\n\nAfter the quick-fix is applied:\n\n\n      (alpha|bravo)\n\nNew in 2017.2\n\nInspection ID: RegExpEmptyAlternationBranch"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpEmptyAlternationBranch",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckValidXmlInScriptTagBody",
+                "shortDescription": {
+                  "text": "Malformed content of 'script' tag"
+                },
+                "fullDescription": {
+                  "text": "Reports contents of 'script' tags that are invalid XML. Example: '<script type=\"text/javascript\">\n    console.log('<');\n  </script>' After the quick-fix is applied: '<script type=\"text/javascript\">\n    console.log('&lt;');\n  </script>' Inspection ID: CheckValidXmlInScriptTagBody",
+                  "markdown": "Reports contents of `script` tags that are invalid XML.  \n\n**Example:**\n\n\n      <script type=\"text/javascript\">\n        console.log('<');\n      </script>\n\nAfter the quick-fix is applied:\n\n\n      <script type=\"text/javascript\">\n        console.log('&lt;');\n      </script>\n\nInspection ID: CheckValidXmlInScriptTagBody"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CheckValidXmlInScriptTagBody",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "Annotator",
+                "shortDescription": {
+                  "text": "Annotator"
+                },
+                "fullDescription": {
+                  "text": "Reports issues essential to this file (e.g., syntax errors) in the result of a batch code inspection run. These issues are usually always highlighted in the editor and can't be configured, unlike inspections. These options control the scope of checks performed by this inspection: Option \"Report syntax errors\": report parser-related issues. Option \"Report issues from language-specific annotators\": report issues found by annotators configured for the relevant language. See Custom Language Support: Annotators for details. Option \"Report other highlighting problems\": report issues specific to the language of the current file (e.g., type mismatches or unreported exceptions). See Custom Language Support: Highlighting for details. Inspection ID: Annotator",
+                  "markdown": "Reports issues essential to this file (e.g., syntax errors) in the result of a batch code inspection run. These issues are usually always highlighted in the editor and can't be configured, unlike inspections. These options control the scope of checks performed by this inspection:\n\n* Option \"**Report syntax errors**\": report parser-related issues.\n* Option \"**Report issues from language-specific annotators** \": report issues found by annotators configured for the relevant language. See [Custom Language Support: Annotators](https://plugins.jetbrains.com/docs/intellij/annotator.html) for details.\n* Option \"**Report other highlighting problems** \": report issues specific to the language of the current file (e.g., type mismatches or unreported exceptions). See [Custom Language Support: Highlighting](https://plugins.jetbrains.com/docs/intellij/syntax-highlighting-and-error-highlighting.html#semantic-highlighting) for details.\n\nInspection ID: Annotator"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "Annotator",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "InjectedReferences",
+                "shortDescription": {
+                  "text": "Injected references"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved references injected by Language Injections. Example: '@Language(\"file-reference\")\n    String fileName = \"/home/user/nonexistent.file\"; // highlighted if file doesn't exist' Inspection ID: InjectedReferences",
+                  "markdown": "Reports unresolved references injected by [Language Injections](https://www.jetbrains.com/help/idea/using-language-injections.html).\n\nExample:\n\n\n        @Language(\"file-reference\")\n        String fileName = \"/home/user/nonexistent.file\"; // highlighted if file doesn't exist\n\nInspection ID: InjectedReferences"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "InjectedReferences",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpSuspiciousBackref",
+                "shortDescription": {
+                  "text": "Suspicious back reference"
+                },
+                "fullDescription": {
+                  "text": "Reports back references that will not be resolvable at runtime. This means that the back reference can never match anything. A back reference will not be resolvable when the group is defined after the back reference, or if the group is defined in a different branch of an alternation. Example of a group defined after its back reference: '\\1(abc)' Example of a group and a back reference in different branches: 'a(b)c|(xy)\\1z' New in 2022.1 Inspection ID: RegExpSuspiciousBackref",
+                  "markdown": "Reports back references that will not be resolvable at runtime. This means that the back reference can never match anything. A back reference will not be resolvable when the group is defined after the back reference, or if the group is defined in a different branch of an alternation.\n\n**Example of a group defined after its back reference:**\n\n\n      \\1(abc)\n\n**Example of a group and a back reference in different branches:**\n\n\n      a(b)c|(xy)\\1z\n\nNew in 2022.1\n\nInspection ID: RegExpSuspiciousBackref"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpSuspiciousBackref",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlPathReference",
+                "shortDescription": {
+                  "text": "Unresolved file reference"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved file reference in XML. Inspection ID: XmlPathReference",
+                  "markdown": "Reports an unresolved file reference in XML.\n\nInspection ID: XmlPathReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlPathReference",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpSingleCharAlternation",
+                "shortDescription": {
+                  "text": "Single character alternation"
+                },
+                "fullDescription": {
+                  "text": "Reports single char alternation in a RegExp. It is simpler to use a character class instead. This may also provide better matching performance. Example: 'a|b|c|d' After the quick-fix is applied: '[abcd]' New in 2017.1 Inspection ID: RegExpSingleCharAlternation",
+                  "markdown": "Reports single char alternation in a RegExp. It is simpler to use a character class instead. This may also provide better matching performance.\n\n**Example:**\n\n\n      a|b|c|d\n\nAfter the quick-fix is applied:\n\n\n      [abcd]\n\n\nNew in 2017.1\n\nInspection ID: RegExpSingleCharAlternation"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpSingleCharAlternation",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Performance"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpUnnecessaryNonCapturingGroup",
+                "shortDescription": {
+                  "text": "Unnecessary non-capturing group"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary non-capturing groups, which have no influence on the match result. Example: 'Everybody be cool, (?:this) is a robbery!' After the quick-fix is applied: 'Everybody be cool, this is a robbery!' New in 2021.1 Inspection ID: RegExpUnnecessaryNonCapturingGroup",
+                  "markdown": "Reports unnecessary non-capturing groups, which have no influence on the match result.\n\n**Example:**\n\n\n      Everybody be cool, (?:this) is a robbery!\n\nAfter the quick-fix is applied:\n\n\n      Everybody be cool, this is a robbery!\n\nNew in 2021.1\n\nInspection ID: RegExpUnnecessaryNonCapturingGroup"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpUnnecessaryNonCapturingGroup",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TodoComment",
+                "shortDescription": {
+                  "text": "TODO comment"
+                },
+                "fullDescription": {
+                  "text": "Reports TODO comments in your code. You can configure the format for TODO comments in Settings | Editor | TODO. Enable the Only warn on TODO comments without any details option to only warn on empty TODO comments, that don't provide any description on the task that should be done. Disable to report all TODO comments. Inspection ID: TodoComment",
+                  "markdown": "Reports **TODO** comments in your code.\n\nYou can configure the format for **TODO** comments in [Settings \\| Editor \\| TODO](settings://preferences.toDoOptions).\n\nEnable the **Only warn on TODO comments without any details** option to only warn on empty TODO comments, that\ndon't provide any description on the task that should be done. Disable to report all TODO comments.\n\nInspection ID: TodoComment"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "TodoComment",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlUnknownAttribute",
+                "shortDescription": {
+                  "text": "Unknown attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown HTML attribute. Suggests configuring attributes that should not be reported. Inspection ID: HtmlUnknownAttribute",
+                  "markdown": "Reports an unknown HTML attribute. Suggests configuring attributes that should not be reported.\n\nInspection ID: HtmlUnknownAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlUnknownAttribute",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckTagEmptyBody",
+                "shortDescription": {
+                  "text": "Empty element content"
+                },
+                "fullDescription": {
+                  "text": "Reports XML elements without contents. Example: '<user>\n    <name></name>\n  </user>' After the quick-fix is applied: '<user>\n    <name/>\n  </user>' Inspection ID: CheckTagEmptyBody",
+                  "markdown": "Reports XML elements without contents.\n\n**Example:**\n\n\n      <user>\n        <name></name>\n      </user>\n\nAfter the quick-fix is applied:\n\n\n      <user>\n        <name/>\n      </user>\n\nInspection ID: CheckTagEmptyBody"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CheckTagEmptyBody",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpRedundantEscape",
+                "shortDescription": {
+                  "text": "Redundant character escape"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant character escape sequences that can be replaced with unescaped characters preserving the meaning. Many escape sequences that are necessary outside of a character class are redundant inside square brackets '[]' of a character class. Although unescaped opening curly braces '{' outside of character classes are allowed in some dialects (JavaScript, Python, and so on), it can cause confusion and make the pattern less portable, because there are dialects that require escaping curly braces as characters. For this reason the inspection does not report escaped opening curly braces. Example: '\\-\\;[\\.]' After the quick-fix is applied: '-;[.]' The Ignore escaped closing brackets '}' and ']' option specifies whether to report '\\}' and '\\]' outside of a character class when they are allowed to be unescaped by the RegExp dialect. Similarly, the Ignore escaped forward-slashes '/' option specifies whether to report '\\/' when they are allowed to be unescaped by the RegExp dialect. New in 2017.3 Inspection ID: RegExpRedundantEscape",
+                  "markdown": "Reports redundant character escape sequences that can be replaced with unescaped characters preserving the meaning. Many escape sequences that are necessary outside of a character class are redundant inside square brackets `[]` of a character class.\n\n\nAlthough unescaped opening curly braces `{` outside of character classes are allowed in some dialects (JavaScript, Python, and so on),\nit can cause confusion and make the pattern less portable, because there are dialects that require escaping curly braces as characters.\nFor this reason the inspection does not report escaped opening curly braces.\n\n**Example:**\n\n\n      \\-\\;[\\.]\n\nAfter the quick-fix is applied:\n\n\n      -;[.]\n\n\nThe **Ignore escaped closing brackets '}' and '\\]'** option specifies whether to report `\\}` and `\\]` outside of a character class\nwhen they are allowed to be unescaped by the RegExp dialect.\n\n\nSimilarly, the **Ignore escaped forward-slashes '/'** option specifies whether to report `\\/` when\nthey are allowed to be unescaped by the RegExp dialect.\n\nNew in 2017.3\n\nInspection ID: RegExpRedundantEscape"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpRedundantEscape",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnresolvedReference",
+                "shortDescription": {
+                  "text": "Unresolved reference"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved reference to a named pattern ('define') in RELAX-NG files that use XML syntax. Suggests creating the referenced 'define' element. Inspection ID: UnresolvedReference",
+                  "markdown": "Reports an unresolved reference to a named pattern (`define`) in RELAX-NG files that use XML syntax. Suggests creating the referenced `define` element.\n\nInspection ID: UnresolvedReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "UnresolvedReference",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RELAX NG",
+                      "index": 21,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlMissingClosingTag",
+                "shortDescription": {
+                  "text": "Missing closing tag"
+                },
+                "fullDescription": {
+                  "text": "Reports an HTML element without a closing tag. Some coding styles require that HTML elements have closing tags even where this is optional. Example: '<html>\n    <body>\n      <p>Behold!\n    </body>\n  </html>' After the quick-fix is applied: '<html>\n    <body>\n      <p>Behold!</p>\n    </body>\n  </html>' Inspection ID: HtmlMissingClosingTag",
+                  "markdown": "Reports an HTML element without a closing tag. Some coding styles require that HTML elements have closing tags even where this is optional.\n\n**Example:**\n\n\n      <html>\n        <body>\n          <p>Behold!\n        </body>\n      </html>\n\nAfter the quick-fix is applied:\n\n\n      <html>\n        <body>\n          <p>Behold!</p>\n        </body>\n      </html>\n\nInspection ID: HtmlMissingClosingTag"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HtmlMissingClosingTag",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlDeprecatedElement",
+                "shortDescription": {
+                  "text": "Deprecated symbol"
+                },
+                "fullDescription": {
+                  "text": "Reports a deprecated XML element or attribute. Symbols can be marked by XML comment or documentation tag with text 'deprecated'. Inspection ID: XmlDeprecatedElement",
+                  "markdown": "Reports a deprecated XML element or attribute.\n\nSymbols can be marked by XML comment or documentation tag with text 'deprecated'.\n\nInspection ID: XmlDeprecatedElement"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "XmlDeprecatedElement",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpRedundantNestedCharacterClass",
+                "shortDescription": {
+                  "text": "Redundant nested character class"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary nested character classes. Example: '[a-c[x-z]]' After the quick-fix is applied: '[a-cx-z]' New in 2020.2 Inspection ID: RegExpRedundantNestedCharacterClass",
+                  "markdown": "Reports unnecessary nested character classes.\n\n**Example:**\n\n\n      [a-c[x-z]]\n\nAfter the quick-fix is applied:\n\n\n      [a-cx-z]\n\nNew in 2020.2\n\nInspection ID: RegExpRedundantNestedCharacterClass"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpRedundantNestedCharacterClass",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CustomRegExpInspection",
+                "shortDescription": {
+                  "text": "Custom RegExp inspection"
+                },
+                "fullDescription": {
+                  "text": "Custom Regex Inspection Inspection ID: CustomRegExpInspection",
+                  "markdown": "Custom Regex Inspection\n\nInspection ID: CustomRegExpInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CustomRegExpInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IncorrectFormatting",
+                "shortDescription": {
+                  "text": "Incorrect formatting"
+                },
+                "fullDescription": {
+                  "text": "Reports formatting issues that appear if your code doesn't follow your project's code style settings. This inspection is not compatible with languages that require third-party formatters for code formatting, for example, Go or C with CLangFormat enabled. Inspection ID: IncorrectFormatting",
+                  "markdown": "Reports formatting issues that appear if your code doesn't\nfollow your project's code style settings.\n\n\nThis inspection is not compatible with languages that require\nthird-party formatters for code formatting, for example, Go or\nC with CLangFormat enabled.\n\nInspection ID: IncorrectFormatting"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "IncorrectFormatting",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlWrongAttributeValue",
+                "shortDescription": {
+                  "text": "Wrong attribute value"
+                },
+                "fullDescription": {
+                  "text": "Reports an incorrect HTML attribute value. Inspection ID: HtmlWrongAttributeValue",
+                  "markdown": "Reports an incorrect HTML attribute value.\n\nInspection ID: HtmlWrongAttributeValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlWrongAttributeValue",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlDefaultAttributeValue",
+                "shortDescription": {
+                  "text": "Redundant attribute with default value"
+                },
+                "fullDescription": {
+                  "text": "Reports a redundant assignment of the default value to an XML attribute. Inspection ID: XmlDefaultAttributeValue",
+                  "markdown": "Reports a redundant assignment of the default value to an XML attribute.\n\nInspection ID: XmlDefaultAttributeValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "XmlDefaultAttributeValue",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpOctalEscape",
+                "shortDescription": {
+                  "text": "Octal escape"
+                },
+                "fullDescription": {
+                  "text": "Reports octal escapes, which are easily confused with back references. Use hexadecimal escapes to avoid confusion. Example: '\\07' After the quick-fix is applied: '\\x07' New in 2017.1 Inspection ID: RegExpOctalEscape",
+                  "markdown": "Reports octal escapes, which are easily confused with back references. Use hexadecimal escapes to avoid confusion.\n\n**Example:**\n\n\n      \\07\n\nAfter the quick-fix is applied:\n\n\n      \\x07\n\nNew in 2017.1\n\nInspection ID: RegExpOctalEscape"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RegExpOctalEscape",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlExtraClosingTag",
+                "shortDescription": {
+                  "text": "Redundant closing tag"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant closing tags on empty elements, for example, 'img' or 'br'. Example: '<html>\n    <body>\n      <br></br>\n    </body>\n  </html>' After the quick-fix is applied: '<html>\n    <body>\n      <br>\n    </body>\n  </html>' Inspection ID: HtmlExtraClosingTag",
+                  "markdown": "Reports redundant closing tags on empty elements, for example, `img` or `br`.\n\n**Example:**\n\n\n      <html>\n        <body>\n          <br></br>\n        </body>\n      </html>\n\nAfter the quick-fix is applied:\n\n\n      <html>\n        <body>\n          <br>\n        </body>\n      </html>\n\nInspection ID: HtmlExtraClosingTag"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlExtraClosingTag",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedDefine",
+                "shortDescription": {
+                  "text": "Unused define"
+                },
+                "fullDescription": {
+                  "text": "Reports an unused named pattern ('define') in a RELAX-NG file (XML or Compact Syntax). 'define' elements that are used through an include in another file are ignored. Inspection ID: UnusedDefine",
+                  "markdown": "Reports an unused named pattern (`define`) in a RELAX-NG file (XML or Compact Syntax). `define` elements that are used through an include in another file are ignored.\n\nInspection ID: UnusedDefine"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "UnusedDefine",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RELAX NG",
+                      "index": 21,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlUnknownAnchorTarget",
+                "shortDescription": {
+                  "text": "Unresolved fragment in a link"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved last part of an URL after the '#' sign. Inspection ID: HtmlUnknownAnchorTarget",
+                  "markdown": "Reports an unresolved last part of an URL after the `#` sign.\n\nInspection ID: HtmlUnknownAnchorTarget"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlUnknownAnchorTarget",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpUnexpectedAnchor",
+                "shortDescription": {
+                  "text": "Begin or end anchor in unexpected position"
+                },
+                "fullDescription": {
+                  "text": "Reports '^' or '\\A' anchors not at the beginning of the pattern and '$', '\\Z' or '\\z' anchors not at the end of the pattern. In the wrong position these RegExp anchors prevent the pattern from matching anything. In case of the '^' and '$' anchors, most likely the literal character was meant and the escape forgotten. Example: '(Price $10)' New in 2018.1 Inspection ID: RegExpUnexpectedAnchor",
+                  "markdown": "Reports `^` or `\\A` anchors not at the beginning of the pattern and `$`, `\\Z` or `\\z` anchors not at the end of the pattern. In the wrong position these RegExp anchors prevent the pattern from matching anything. In case of the `^` and `$` anchors, most likely the literal character was meant and the escape forgotten.\n\n**Example:**\n\n\n      (Price $10)\n\n\nNew in 2018.1\n\nInspection ID: RegExpUnexpectedAnchor"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpUnexpectedAnchor",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EmptyDirectory",
+                "shortDescription": {
+                  "text": "Empty directory"
+                },
+                "fullDescription": {
+                  "text": "Reports empty directories. Available only from Code | Inspect Code or Code | Analyze Code | Run Inspection by Name and isn't reported in the editor. Use the Only report empty directories located under a source folder option to have only directories under source roots reported. Inspection ID: EmptyDirectory",
+                  "markdown": "Reports empty directories.\n\nAvailable only from **Code \\| Inspect Code** or\n**Code \\| Analyze Code \\| Run Inspection by Name** and isn't reported in the editor.\n\nUse the **Only report empty directories located under a source folder** option to have only directories under source\nroots reported.\n\n\nInspection ID: EmptyDirectory"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EmptyDirectory",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "General",
+                      "index": 14,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpAnonymousGroup",
+                "shortDescription": {
+                  "text": "Anonymous capturing group or numeric back reference"
+                },
+                "fullDescription": {
+                  "text": "Reports anonymous capturing groups and numeric back references in a RegExp. These are only reported when the RegExp dialect supports named group and named group references. Named groups and named back references improve code readability and are recommended to use instead. When a capture is not needed, matching can be more performant and use less memory by using a non-capturing group, i.e. '(?:xxx)' instead of '(xxx)'. Example: '(\\d\\d\\d\\d)\\1' A better regex pattern could look like this: '(?<quad>\\d\\d\\d\\d)\\k<quad>' New in 2017.2 Inspection ID: RegExpAnonymousGroup",
+                  "markdown": "Reports anonymous capturing groups and numeric back references in a RegExp. These are only reported when the RegExp dialect supports named group and named group references. Named groups and named back references improve code readability and are recommended to use instead. When a capture is not needed, matching can be more performant and use less memory by using a non-capturing group, i.e. `(?:xxx)` instead of `(xxx)`.\n\n**Example:**\n\n\n      (\\d\\d\\d\\d)\\1\n\nA better regex pattern could look like this:\n\n\n      (?<quad>\\d\\d\\d\\d)\\k<quad>\n\nNew in 2017.2\n\nInspection ID: RegExpAnonymousGroup"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpAnonymousGroup",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckDtdRefs",
+                "shortDescription": {
+                  "text": "Unresolved DTD reference"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistency in a DTD-specific reference, for example, in a reference to an XML entity or to a DTD element declaration. Works in DTD an XML files. Inspection ID: CheckDtdRefs",
+                  "markdown": "Reports inconsistency in a DTD-specific reference, for example, in a reference to an XML entity or to a DTD element declaration. Works in DTD an XML files.\n\nInspection ID: CheckDtdRefs"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CheckDtdRefs",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckXmlFileWithXercesValidator",
+                "shortDescription": {
+                  "text": "Failed external validation"
+                },
+                "fullDescription": {
+                  "text": "Reports a discrepancy in an XML file with the specified DTD or schema detected by the Xerces validator. Inspection ID: CheckXmlFileWithXercesValidator",
+                  "markdown": "Reports a discrepancy in an XML file with the specified DTD or schema detected by the Xerces validator.\n\nInspection ID: CheckXmlFileWithXercesValidator"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CheckXmlFileWithXercesValidator",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NonAsciiCharacters",
+                "shortDescription": {
+                  "text": "Non-ASCII characters"
+                },
+                "fullDescription": {
+                  "text": "Reports code elements that use non-ASCII symbols in an unusual context. Example: Non-ASCII characters used in identifiers, strings, or comments. Identifiers written in different languages, such as 'myСollection' with the letter 'C' written in Cyrillic. Comments or strings containing Unicode symbols, such as long dashes and arrows. Inspection ID: NonAsciiCharacters",
+                  "markdown": "Reports code elements that use non-ASCII symbols in an unusual context.\n\nExample:\n\n* Non-ASCII characters used in identifiers, strings, or comments.\n* Identifiers written in different languages, such as `my`**С**`ollection` with the letter **C** written in Cyrillic.\n* Comments or strings containing Unicode symbols, such as long dashes and arrows.\n\nInspection ID: NonAsciiCharacters"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "NonAsciiCharacters",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Internationalization",
+                      "index": 22,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "XmlUnresolvedReference",
+                "shortDescription": {
+                  "text": "Unresolved references"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved references in XML. Inspection ID: XmlUnresolvedReference",
+                  "markdown": "Reports an unresolved references in XML.\n\nInspection ID: XmlUnresolvedReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "XmlUnresolvedReference",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "XML",
+                      "index": 5,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlUnknownTag",
+                "shortDescription": {
+                  "text": "Unknown tag"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown HTML tag. Suggests configuring tags that should not be reported. Inspection ID: HtmlUnknownTag",
+                  "markdown": "Reports an unknown HTML tag. Suggests configuring tags that should not be reported.\n\nInspection ID: HtmlUnknownTag"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlUnknownTag",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LossyEncoding",
+                "shortDescription": {
+                  "text": "Lossy encoding"
+                },
+                "fullDescription": {
+                  "text": "Reports characters that cannot be displayed because of the current document encoding. Examples: If you type international characters in a document with the US-ASCII charset, some characters will be lost on save. If you load a UTF-8-encoded file using the ISO-8859-1 one-byte charset, some characters will be displayed incorrectly. You can fix this by changing the file encoding either by specifying the encoding directly in the file, e.g. by editing 'encoding=' attribute in the XML prolog of XML file, or by changing the corresponding options in Settings | Editor | File Encodings. Inspection ID: LossyEncoding",
+                  "markdown": "Reports characters that cannot be displayed because of the current document encoding.\n\nExamples:\n\n* If you type international characters in a document with the **US-ASCII** charset, some characters will be lost on save.\n* If you load a **UTF-8** -encoded file using the **ISO-8859-1** one-byte charset, some characters will be displayed incorrectly.\n\nYou can fix this by changing the file encoding\neither by specifying the encoding directly in the file, e.g. by editing `encoding=` attribute in the XML prolog of XML file,\nor by changing the corresponding options in **Settings \\| Editor \\| File Encodings**.\n\nInspection ID: LossyEncoding"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "LossyEncoding",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Internationalization",
+                      "index": 22,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpEscapedMetaCharacter",
+                "shortDescription": {
+                  "text": "Escaped meta character"
+                },
+                "fullDescription": {
+                  "text": "Reports escaped meta characters. Some RegExp coding styles specify that meta characters should be placed inside a character class, to make the regular expression easier to understand. This inspection does not warn about the meta character '[', ']' and '^', because those would need additional escaping inside a character class. Example: '\\d+\\.\\d+' After the quick-fix is applied: '\\d+[.]\\d+' New in 2017.1 Inspection ID: RegExpEscapedMetaCharacter",
+                  "markdown": "Reports escaped meta characters. Some RegExp coding styles specify that meta characters should be placed inside a character class, to make the regular expression easier to understand. This inspection does not warn about the meta character `[`, `]` and `^`, because those would need additional escaping inside a character class.\n\n**Example:**\n\n\n      \\d+\\.\\d+\n\nAfter the quick-fix is applied:\n\n\n      \\d+[.]\\d+\n\nNew in 2017.1\n\nInspection ID: RegExpEscapedMetaCharacter"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "RegExpEscapedMetaCharacter",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpDuplicateAlternationBranch",
+                "shortDescription": {
+                  "text": "Duplicate branch in alternation"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression. Example: '(alpha|bravo|charlie|alpha)' After the quick-fix is applied: '(alpha|bravo|charlie)' New in 2017.1 Inspection ID: RegExpDuplicateAlternationBranch",
+                  "markdown": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression.\n\n**Example:**\n\n\n      (alpha|bravo|charlie|alpha)\n\nAfter the quick-fix is applied:\n\n\n      (alpha|bravo|charlie)\n\nNew in 2017.1\n\nInspection ID: RegExpDuplicateAlternationBranch"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpDuplicateAlternationBranch",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Performance"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpRepeatedSpace",
+                "shortDescription": {
+                  "text": "Consecutive spaces"
+                },
+                "fullDescription": {
+                  "text": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier. Example: '(     )' After the quick-fix is applied: '( {5})' New in 2017.1 Inspection ID: RegExpRepeatedSpace",
+                  "markdown": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier.\n\n**Example:**\n\n\n      (     )\n\nAfter the quick-fix is applied:\n\n\n      ( {5})\n\n\nNew in 2017.1\n\nInspection ID: RegExpRepeatedSpace"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpRepeatedSpace",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 9,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IgnoreFileDuplicateEntry",
+                "shortDescription": {
+                  "text": "Ignore file duplicates"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicate entries (patterns) in the ignore file (e.g. .gitignore, .hgignore). Duplicate entries in these files are redundant and can be removed. Example: '# Output directories\n    /out/\n    /target/\n    /out/' Inspection ID: IgnoreFileDuplicateEntry",
+                  "markdown": "Reports duplicate entries (patterns) in the ignore file (e.g. .gitignore, .hgignore). Duplicate entries in these files are redundant and can be removed.\n\nExample:\n\n\n        # Output directories\n        /out/\n        /target/\n        /out/\n\nInspection ID: IgnoreFileDuplicateEntry"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "IgnoreFileDuplicateEntry",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Version control",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckEmptyScriptTag",
+                "shortDescription": {
+                  "text": "Empty tag"
+                },
+                "fullDescription": {
+                  "text": "Reports empty tags that do not work in some browsers. Example: '<html>\n    <script/>\n  </html>' After the quick-fix is applied: '<html>\n    <script></script>\n  </html>' Inspection ID: CheckEmptyScriptTag",
+                  "markdown": "Reports empty tags that do not work in some browsers.\n\n**Example:**\n\n\n      <html>\n        <script/>\n      </html>\n\nAfter the quick-fix is applied:\n\n\n      <html>\n        <script></script>\n      </html>\n\nInspection ID: CheckEmptyScriptTag"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CheckEmptyScriptTag",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "org.jetbrains.plugins.yaml",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "YAMLRecursiveAlias",
+                "shortDescription": {
+                  "text": "Recursive alias"
+                },
+                "fullDescription": {
+                  "text": "Reports recursion in YAML aliases. Alias can't be recursive and be used inside the data referenced by a corresponding anchor. Example: 'some_key: &some_anchor\n    sub_key1: value1\n    sub_key2: *some_anchor' Inspection ID: YAMLRecursiveAlias",
+                  "markdown": "Reports recursion in YAML aliases.\n\nAlias can't be recursive and be used inside the data referenced by a corresponding anchor.\n\n**Example:**\n\n\n      some_key: &some_anchor\n        sub_key1: value1\n        sub_key2: *some_anchor\n\nInspection ID: YAMLRecursiveAlias"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "YAMLRecursiveAlias",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLSchemaValidation",
+                "shortDescription": {
+                  "text": "Validation by JSON Schema"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistencies between a YAML file and a JSON Schema if the schema is specified. Scheme example: '{\n    \"properties\": {\n      \"SomeNumberProperty\": {\n        \"type\": \"number\"\n      }\n    }\n  }' The following is an example with the corresponding warning: 'SomeNumberProperty: hello world' Inspection ID: YAMLSchemaValidation",
+                  "markdown": "Reports inconsistencies between a YAML file and a JSON Schema if the schema is specified.\n\n**Scheme example:**\n\n\n      {\n        \"properties\": {\n          \"SomeNumberProperty\": {\n            \"type\": \"number\"\n          }\n        }\n      }\n\n**The following is an example with the corresponding warning:**\n\n\n      SomeNumberProperty: hello world\n\nInspection ID: YAMLSchemaValidation"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "YAMLSchemaValidation",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLIncompatibleTypes",
+                "shortDescription": {
+                  "text": "Suspicious type mismatch"
+                },
+                "fullDescription": {
+                  "text": "Reports a mismatch between a scalar value type in YAML file and types of the values in the similar positions. Example: 'myElements:\n  - value1\n  - value2\n  - false # <- reported, because it is a boolean value, while other values are strings' Inspection ID: YAMLIncompatibleTypes",
+                  "markdown": "Reports a mismatch between a scalar value type in YAML file and types of the values in the similar positions.\n\n**Example:**\n\n\n    myElements:\n      - value1\n      - value2\n      - false # <- reported, because it is a boolean value, while other values are strings\n\nInspection ID: YAMLIncompatibleTypes"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "YAMLIncompatibleTypes",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLDuplicatedKeys",
+                "shortDescription": {
+                  "text": "Duplicated YAML keys"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicated keys in YAML files. Example: 'same_key: some value\n  same_key: another value' Inspection ID: YAMLDuplicatedKeys",
+                  "markdown": "Reports duplicated keys in YAML files.\n\n**Example:**\n\n\n      same_key: some value\n      same_key: another value\n\nInspection ID: YAMLDuplicatedKeys"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "YAMLDuplicatedKeys",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLUnusedAnchor",
+                "shortDescription": {
+                  "text": "Unused anchor"
+                },
+                "fullDescription": {
+                  "text": "Reports unused anchors. Example: 'some_key: &some_anchor\n    key1: value1' Inspection ID: YAMLUnusedAnchor",
+                  "markdown": "Reports unused anchors.\n\n**Example:**\n\n\n      some_key: &some_anchor\n        key1: value1\n\nInspection ID: YAMLUnusedAnchor"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "YAMLUnusedAnchor",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLUnresolvedAlias",
+                "shortDescription": {
+                  "text": "Unresolved alias"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved aliases in YAML files. Example: 'some_key: *unknown_alias' Inspection ID: YAMLUnresolvedAlias",
+                  "markdown": "Reports unresolved aliases in YAML files.\n\n**Example:**\n\n\n      some_key: *unknown_alias\n\nInspection ID: YAMLUnresolvedAlias"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "YAMLUnresolvedAlias",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "YAMLSchemaDeprecation",
+                "shortDescription": {
+                  "text": "Deprecated YAML key"
+                },
+                "fullDescription": {
+                  "text": "Reports deprecated keys in YAML files. Deprecation is checked only if there exists a JSON schema associated with the corresponding YAML file. Note that the deprecation mechanism is not defined in the JSON Schema specification yet, and this inspection uses a non-standard 'deprecationMessage' extension. Scheme deprecation example: '{\n    \"properties\": {\n      \"SomeDeprecatedProperty\": {\n        \"deprecationMessage\": \"Baz\",\n        \"description\": \"Foo bar\"\n      }\n    }\n  }' The following is an example with the corresponding warning: 'SomeDeprecatedProperty: some value' Inspection ID: YAMLSchemaDeprecation",
+                  "markdown": "Reports deprecated keys in YAML files.\n\nDeprecation is checked only if there exists a JSON schema associated with the corresponding YAML file.\n\nNote that the deprecation mechanism is not defined in the JSON Schema specification yet,\nand this inspection uses a non-standard `deprecationMessage` extension.\n\n**Scheme deprecation example:**\n\n\n      {\n        \"properties\": {\n          \"SomeDeprecatedProperty\": {\n            \"deprecationMessage\": \"Baz\",\n            \"description\": \"Foo bar\"\n          }\n        }\n      }\n\n**The following is an example with the corresponding warning:**\n\n\n      SomeDeprecatedProperty: some value\n\nInspection ID: YAMLSchemaDeprecation"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "YAMLSchemaDeprecation",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "YAML",
+                      "index": 6,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "tanvd.grazi",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "GrazieStyle",
+                "shortDescription": {
+                  "text": "Style"
+                },
+                "fullDescription": {
+                  "text": "Identifies and highlights issues with writing style in your text. To view and update your current writing style settings, go to Settings | Editor | Natural Languages | Grammar and Style. Inspection ID: GrazieStyle",
+                  "markdown": "Identifies and highlights issues with writing style in your text. To view and update your current writing style settings, go to [Settings \\| Editor \\| Natural Languages \\| Grammar and Style](settings://reference.settingsdialog.project.grazie).\n\nInspection ID: GrazieStyle"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "GrazieStyle",
+                    "ideaSeverity": "STYLE_SUGGESTION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Proofreading",
+                      "index": 7,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LanguageDetectionInspection",
+                "shortDescription": {
+                  "text": "Natural language detection"
+                },
+                "fullDescription": {
+                  "text": "Detects natural languages and suggests enabling corresponding grammar and spelling checks. Inspection ID: LanguageDetectionInspection",
+                  "markdown": "Detects natural languages and suggests enabling corresponding grammar and spelling checks.\n\nInspection ID: LanguageDetectionInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "LanguageDetectionInspection",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Proofreading",
+                      "index": 7,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SpellCheckingInspection",
+                "shortDescription": {
+                  "text": "Spelling"
+                },
+                "fullDescription": {
+                  "text": "Reports typos and misspellings in your code, comments, and literals and fixes them with one click. Inspection ID: SpellCheckingInspection",
+                  "markdown": "Reports typos and misspellings in your code, comments, and literals and fixes them with one click.\n\nInspection ID: SpellCheckingInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "SpellCheckingInspection",
+                    "ideaSeverity": "TYPO",
+                    "qodanaSeverity": "Low",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Proofreading",
+                      "index": 7,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "GrazieInspection",
+                "shortDescription": {
+                  "text": "Grammar"
+                },
+                "fullDescription": {
+                  "text": "Reports grammar mistakes in your text. You can configure the inspection in Settings | Editor | Natural Languages | Grammar and Style. Inspection ID: GrazieInspection",
+                  "markdown": "Reports grammar mistakes in your text. You can configure the inspection in [Settings \\| Editor \\| Natural Languages \\| Grammar and Style](settings://reference.settingsdialog.project.grazie).\n\nInspection ID: GrazieInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "GrazieInspection",
+                    "ideaSeverity": "GRAMMAR_ERROR",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Proofreading",
+                      "index": 7,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "GrazieInspectionRunner",
+                "shortDescription": {
+                  "text": "Grammar"
+                },
+                "fullDescription": {
+                  "text": "Write your description here. Start the description with a verb in 3rd person singular, like reports, detects, highlights. In the first sentence, briefly explain what exactly the inspection helps you detect. Make sure the sentence is not very long and complicated. The first sentence must be in a dedicated paragraph separated from the rest of the text. This will make the description easier to read. Make sure the description doesn’t just repeat the inspection title. See https://plugins.jetbrains.com/docs/intellij/inspections.html#descriptions for more information. Embed code snippets: '// automatically highlighted according to inspection registration 'language' attribute' Text after this comment will only be shown in the settings of the inspection. To open related settings directly from the description, add a link with `settings://$` optionally followed by `?$` to pre-select a UI element. Inspection ID: GrazieInspectionRunner",
+                  "markdown": "Write your description here. Start the description with a verb in 3rd person singular, like reports, detects, highlights. In the first sentence, briefly explain what exactly the inspection helps you detect. Make sure the sentence is not very long and complicated.\n\n\nThe first sentence must be in a dedicated paragraph separated from the rest of the text. This will make the description easier to read.\nMake sure the description doesn't just repeat the inspection title.\n\n\nSee https://plugins.jetbrains.com/docs/intellij/inspections.html#descriptions for more information.\n\n\nEmbed code snippets:\n\n\n    // automatically highlighted according to inspection registration 'language' attribute\n\nText after this comment will only be shown in the settings of the inspection.\n\nTo open related settings directly from the description, add a link with \\`settings://$\\` optionally followed by \\`?$\\` to pre-select a UI\nelement.\n\nInspection ID: GrazieInspectionRunner"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "GrazieInspectionRunner",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Proofreading",
+                      "index": 7,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.intellij.modules.json",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "JsonSchemaDeprecation",
+                "shortDescription": {
+                  "text": "Deprecated JSON property"
+                },
+                "fullDescription": {
+                  "text": "Reports a deprecated property in a JSON file. Note that deprecation mechanism is not defined in the JSON Schema specification yet, and this inspection uses a non-standard extension 'deprecationMessage'. Inspection ID: JsonSchemaDeprecation",
+                  "markdown": "Reports a deprecated property in a JSON file.  \nNote that deprecation mechanism is not defined in the JSON Schema specification yet, and this inspection uses a non-standard extension 'deprecationMessage'.\n\nInspection ID: JsonSchemaDeprecation"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "JsonSchemaDeprecation",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonSchemaRefReference",
+                "shortDescription": {
+                  "text": "Unresolved '$ref' and '$schema' references"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved '$ref' or '$schema' path in a JSON schema. Inspection ID: JsonSchemaRefReference",
+                  "markdown": "Reports an unresolved `$ref` or `$schema` path in a JSON schema.  \n\nInspection ID: JsonSchemaRefReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonSchemaRefReference",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "Json5StandardCompliance",
+                "shortDescription": {
+                  "text": "Compliance with JSON5 standard"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistency with the language specification in a JSON5 file. Inspection ID: Json5StandardCompliance",
+                  "markdown": "Reports inconsistency with [the language specification](http://json5.org) in a JSON5 file.\n\nInspection ID: Json5StandardCompliance"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "Json5StandardCompliance",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonDuplicatePropertyKeys",
+                "shortDescription": {
+                  "text": "Duplicate keys in object literals"
+                },
+                "fullDescription": {
+                  "text": "Reports a duplicate key in an object literal. Inspection ID: JsonDuplicatePropertyKeys",
+                  "markdown": "Reports a duplicate key in an object literal.\n\nInspection ID: JsonDuplicatePropertyKeys"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonDuplicatePropertyKeys",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonSchemaCompliance",
+                "shortDescription": {
+                  "text": "Compliance with JSON schema"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistence between a JSON file and the JSON schema that is assigned to it. Inspection ID: JsonSchemaCompliance",
+                  "markdown": "Reports inconsistence between a JSON file and the [JSON schema](https://json-schema.org) that is assigned to it.  \n\nInspection ID: JsonSchemaCompliance"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonSchemaCompliance",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonStandardCompliance",
+                "shortDescription": {
+                  "text": "Compliance with JSON standard"
+                },
+                "fullDescription": {
+                  "text": "Reports the following discrepancies of a JSON file with the language specification: A line or block comment (configurable). Multiple top-level values (expect for JSON Lines files, configurable for others). A trailing comma in an object or array (configurable). A single quoted string. A property key is a not a double quoted strings. A NaN or Infinity/-Infinity numeric value as a floating point literal (configurable). Inspection ID: JsonStandardCompliance",
+                  "markdown": "Reports the following discrepancies of a JSON file with [the language specification](https://tools.ietf.org/html/rfc7159):\n\n* A line or block comment (configurable).\n* Multiple top-level values (expect for JSON Lines files, configurable for others).\n* A trailing comma in an object or array (configurable).\n* A single quoted string.\n* A property key is a not a double quoted strings.\n* A NaN or Infinity/-Infinity numeric value as a floating point literal (configurable).\n\nInspection ID: JsonStandardCompliance"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "JsonStandardCompliance",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSON and JSON5",
+                      "index": 8,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.intellij.css",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "CssUnusedSymbol",
+                "shortDescription": {
+                  "text": "Unused selector"
+                },
+                "fullDescription": {
+                  "text": "Reports a CSS class or an element IDs that appears in selectors but is not used in HTML. Note that complete inspection results are available only when running it via Code | Inspect Code or Code | Analyze Code | Run Inspection by Name. Due to performance reasons, style sheet files are not inspected on the fly. Inspection ID: CssUnusedSymbol",
+                  "markdown": "Reports a CSS class or an element IDs that appears in selectors but is not used in HTML.\n\n\nNote that complete inspection results are available only when running it via **Code \\| Inspect Code** or\n**Code \\| Analyze Code \\| Run Inspection by Name**.\nDue to performance reasons, style sheet files are not inspected on the fly.\n\nInspection ID: CssUnusedSymbol"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssUnusedSymbol",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssDeprecatedValue",
+                "shortDescription": {
+                  "text": "Deprecated value"
+                },
+                "fullDescription": {
+                  "text": "Reports a deprecated CSS value. Suggests replacing the deprecated value with its valid equivalent. Inspection ID: CssDeprecatedValue",
+                  "markdown": "Reports a deprecated CSS value. Suggests replacing the deprecated value with its valid equivalent.\n\nInspection ID: CssDeprecatedValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssDeprecatedValue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssNonIntegerLengthInPixels",
+                "shortDescription": {
+                  "text": "Non-integer length in pixels"
+                },
+                "fullDescription": {
+                  "text": "Reports a non-integer length in pixels. Example: 'width: 3.14px' Inspection ID: CssNonIntegerLengthInPixels",
+                  "markdown": "Reports a non-integer length in pixels.\n\n**Example:**\n\n     width: 3.14px\n\nInspection ID: CssNonIntegerLengthInPixels"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "CssNonIntegerLengthInPixels",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Probable bugs",
+                      "index": 13,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidImport",
+                "shortDescription": {
+                  "text": "Misplaced @import"
+                },
+                "fullDescription": {
+                  "text": "Reports a misplaced '@import' statement. According to the specification, an '@import' rule must be defined at the top of the stylesheet, before any other at-rule (except '@charset' and '@layer') and style declarations, or it will be ignored. Inspection ID: CssInvalidImport",
+                  "markdown": "Reports a misplaced `@import` statement.\n\n\nAccording to the [specification](https://developer.mozilla.org/en-US/docs/Web/CSS/@import),\nan `@import` rule must be defined at the top of the stylesheet, before any other at-rule\n(except `@charset` and `@layer`) and style declarations, or it will be ignored.\n\nInspection ID: CssInvalidImport"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidImport",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidHtmlTagReference",
+                "shortDescription": {
+                  "text": "Invalid type selector"
+                },
+                "fullDescription": {
+                  "text": "Reports a CSS type selector that matches an unknown HTML element. Inspection ID: CssInvalidHtmlTagReference",
+                  "markdown": "Reports a CSS [type selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors) that matches an unknown HTML element.\n\nInspection ID: CssInvalidHtmlTagReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidHtmlTagReference",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidAtRule",
+                "shortDescription": {
+                  "text": "Unknown at-rule"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown CSS at-rule. Inspection ID: CssInvalidAtRule",
+                  "markdown": "Reports an unknown [CSS at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule).\n\nInspection ID: CssInvalidAtRule"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidAtRule",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidCustomPropertyAtRuleDeclaration",
+                "shortDescription": {
+                  "text": "Invalid @property declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing required syntax, inherits, or initial-value property in a declaration of a custom property. Inspection ID: CssInvalidCustomPropertyAtRuleDeclaration",
+                  "markdown": "Reports a missing required [syntax](https://developer.mozilla.org/en-US/docs/web/css/@property/syntax), [inherits](https://developer.mozilla.org/en-US/docs/web/css/@property/inherits), or [initial-value](https://developer.mozilla.org/en-US/docs/web/css/@property/initial-value) property in a declaration of a custom property.\n\nInspection ID: CssInvalidCustomPropertyAtRuleDeclaration"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidCustomPropertyAtRuleDeclaration",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidFunction",
+                "shortDescription": {
+                  "text": "Invalid function"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown CSS function or an incorrect function parameter. Inspection ID: CssInvalidFunction",
+                  "markdown": "Reports an unknown [CSS function](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions) or an incorrect function parameter.\n\nInspection ID: CssInvalidFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidFunction",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssUnresolvedCustomProperty",
+                "shortDescription": {
+                  "text": "Unresolved custom property"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved reference to a custom property among the arguments of the 'var()' function. Inspection ID: CssUnresolvedCustomProperty",
+                  "markdown": "Reports an unresolved reference to a [custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) among the arguments of the `var()` function.\n\nInspection ID: CssUnresolvedCustomProperty"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssUnresolvedCustomProperty",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssOverwrittenProperties",
+                "shortDescription": {
+                  "text": "Overwritten property"
+                },
+                "fullDescription": {
+                  "text": "Reports a duplicated CSS property within a ruleset. Respects shorthand properties. Example: '.foo {\n  margin-bottom: 1px;\n  margin-bottom: 1px; /* duplicates margin-bottom */\n  margin: 0; /* overrides margin-bottom */\n}' Inspection ID: CssOverwrittenProperties",
+                  "markdown": "Reports a duplicated CSS property within a ruleset. Respects shorthand properties.\n\n**Example:**\n\n\n    .foo {\n      margin-bottom: 1px;\n      margin-bottom: 1px; /* duplicates margin-bottom */\n      margin: 0; /* overrides margin-bottom */\n    }\n\nInspection ID: CssOverwrittenProperties"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssOverwrittenProperties",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssMissingSemicolon",
+                "shortDescription": {
+                  "text": "Missing semicolon"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing semicolon at the end of a declaration. Inspection ID: CssMissingSemicolon",
+                  "markdown": "Reports a missing semicolon at the end of a declaration.\n\nInspection ID: CssMissingSemicolon"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssMissingSemicolon",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Code style issues",
+                      "index": 19,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssRedundantUnit",
+                "shortDescription": {
+                  "text": "Redundant measure unit"
+                },
+                "fullDescription": {
+                  "text": "Reports a measure unit of a zero value where units are not required by the specification. Example: 'width: 0px' Inspection ID: CssRedundantUnit",
+                  "markdown": "Reports a measure unit of a zero value where units are not required by the specification.\n\n**Example:**\n\n    width: 0px\n\nInspection ID: CssRedundantUnit"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssRedundantUnit",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Code style issues",
+                      "index": 19,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssUnknownTarget",
+                "shortDescription": {
+                  "text": "Unresolved file reference"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved file reference, for example, an incorrect path in an '@import' statement. Inspection ID: CssUnknownTarget",
+                  "markdown": "Reports an unresolved file reference, for example, an incorrect path in an `@import` statement.\n\nInspection ID: CssUnknownTarget"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssUnknownTarget",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssNegativeValue",
+                "shortDescription": {
+                  "text": "Negative property value"
+                },
+                "fullDescription": {
+                  "text": "Reports a negative value of a CSS property that is not expected to be less than zero, for example, object width or height. Inspection ID: CssNegativeValue",
+                  "markdown": "Reports a negative value of a CSS property that is not expected to be less than zero, for example, object width or height.\n\nInspection ID: CssNegativeValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssNegativeValue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssNoGenericFontName",
+                "shortDescription": {
+                  "text": "Missing generic font family name"
+                },
+                "fullDescription": {
+                  "text": "Verifies that the 'font-family' property contains a generic font family name as a fallback alternative. Generic font family names are: 'serif', 'sans-serif', 'cursive', 'fantasy', and 'monospace'. Inspection ID: CssNoGenericFontName",
+                  "markdown": "Verifies that the [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) property contains a generic font family name as a fallback alternative.\n\n\nGeneric font family names are: `serif`, `sans-serif`, `cursive`, `fantasy`,\nand `monospace`.\n\nInspection ID: CssNoGenericFontName"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssNoGenericFontName",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Probable bugs",
+                      "index": 13,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssUnresolvedClassInComposesRule",
+                "shortDescription": {
+                  "text": "Unresolved class in 'composes' rule"
+                },
+                "fullDescription": {
+                  "text": "Reports a CSS class reference in the 'composes' rule that cannot be resolved to any valid target. Example: '.className {/* ... */}\n\n  .otherClassName {\n    composes: className;\n  }' Inspection ID: CssUnresolvedClassInComposesRule",
+                  "markdown": "Reports a CSS class reference in the ['composes'](https://github.com/css-modules/css-modules#composition) rule that cannot be resolved to any valid target.\n\n**Example:**\n\n\n      .className {/* ... */}\n\n      .otherClassName {\n        composes: className;\n      }\n\nInspection ID: CssUnresolvedClassInComposesRule"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssUnresolvedClassInComposesRule",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidCharsetRule",
+                "shortDescription": {
+                  "text": "Misplaced or incorrect @charset"
+                },
+                "fullDescription": {
+                  "text": "Reports a misplaced '@charset' at-rule or an incorrect charset value. Inspection ID: CssInvalidCharsetRule",
+                  "markdown": "Reports a misplaced `@charset` at-rule or an incorrect charset value.\n\nInspection ID: CssInvalidCharsetRule"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidCharsetRule",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssMissingComma",
+                "shortDescription": {
+                  "text": "Missing comma in selector list"
+                },
+                "fullDescription": {
+                  "text": "Reports a multi-line selector. Most likely this means that several single-line selectors are actually intended but a comma is missing at the end of one or several lines. Example: 'input /* comma has probably been forgotten */\n.button {\n  margin: 1px;\n}' Inspection ID: CssMissingComma",
+                  "markdown": "Reports a multi-line selector. Most likely this means that several single-line selectors are actually intended but a comma is missing at the end of one or several lines.\n\n**Example:**\n\n\n    input /* comma has probably been forgotten */\n    .button {\n      margin: 1px;\n    }\n\nInspection ID: CssMissingComma"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssMissingComma",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Probable bugs",
+                      "index": 13,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidPropertyValue",
+                "shortDescription": {
+                  "text": "Invalid property value"
+                },
+                "fullDescription": {
+                  "text": "Reports an incorrect CSS property value. Inspection ID: CssInvalidPropertyValue",
+                  "markdown": "Reports an incorrect CSS property value.\n\nInspection ID: CssInvalidPropertyValue"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidPropertyValue",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssReplaceWithShorthandSafely",
+                "shortDescription": {
+                  "text": "Properties may be safely replaced with a shorthand"
+                },
+                "fullDescription": {
+                  "text": "Reports a set of longhand properties. Suggests replacing a complete set of longhand CSS properties with an equivalent shorthand form. For example, 4 properties: 'padding-top', 'padding-right', 'padding-bottom', and 'padding-left' can be safely replaced with a single 'padding' property. Note that this inspection doesn't show up if the set of longhand properties is incomplete (e.g. only 3 'padding-xxx' properties in a ruleset) because switching to a shorthand may change the result. For such cases consider the 'Properties may probably be replaced with a shorthand' inspection. Inspection ID: CssReplaceWithShorthandSafely",
+                  "markdown": "Reports a set of longhand properties. Suggests replacing a complete set of longhand CSS properties with an equivalent shorthand form.\n\n\nFor example, 4 properties: `padding-top`, `padding-right`, `padding-bottom`, and\n`padding-left`\ncan be safely replaced with a single `padding` property.\n\n\nNote that this inspection doesn't show up if the set of longhand properties is incomplete\n(e.g. only 3 `padding-xxx` properties in a ruleset)\nbecause switching to a shorthand may change the result.\nFor such cases consider the 'Properties may probably be replaced with a shorthand'\ninspection.\n\nInspection ID: CssReplaceWithShorthandSafely"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "CssReplaceWithShorthandSafely",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssBrowserCompatibilityForProperties",
+                "shortDescription": {
+                  "text": "Property is incompatible with selected browsers"
+                },
+                "fullDescription": {
+                  "text": "Reports a CSS property that is not supported by the specified browsers. Based on the MDN Compatibility Data. Inspection ID: CssBrowserCompatibilityForProperties",
+                  "markdown": "Reports a CSS property that is not supported by the specified browsers. Based on the [MDN Compatibility Data](https://github.com/mdn/browser-compat-data).\n\nInspection ID: CssBrowserCompatibilityForProperties"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssBrowserCompatibilityForProperties",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidCustomPropertyAtRuleName",
+                "shortDescription": {
+                  "text": "Invalid @property name"
+                },
+                "fullDescription": {
+                  "text": "Reports an invalid custom property name. Custom property name should be prefixed with two dashes. Example: '@property invalid-property-name {\n  ...\n}\n\n@property --valid-property-name {\n  ...\n}' Inspection ID: CssInvalidCustomPropertyAtRuleName",
+                  "markdown": "Reports an invalid custom property name. Custom property name should be prefixed with two dashes.\n\n**Example:**\n\n\n    @property invalid-property-name {\n      ...\n    }\n\n    @property --valid-property-name {\n      ...\n    }\n\nInspection ID: CssInvalidCustomPropertyAtRuleName"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidCustomPropertyAtRuleName",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssUnknownProperty",
+                "shortDescription": {
+                  "text": "Unknown property"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown CSS property or a property used in a wrong context. Add the unknown property to the 'Custom CSS properties' list to skip validation. Inspection ID: CssUnknownProperty",
+                  "markdown": "Reports an unknown CSS property or a property used in a wrong context.\n\nAdd the unknown property to the 'Custom CSS properties' list to skip validation.\n\nInspection ID: CssUnknownProperty"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssUnknownProperty",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidPseudoSelector",
+                "shortDescription": {
+                  "text": "Invalid pseudo-selector"
+                },
+                "fullDescription": {
+                  "text": "Reports an incorrect CSS pseudo-class pseudo-element. Inspection ID: CssInvalidPseudoSelector",
+                  "markdown": "Reports an incorrect CSS [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).\n\nInspection ID: CssInvalidPseudoSelector"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidPseudoSelector",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssConvertColorToHexInspection",
+                "shortDescription": {
+                  "text": "Color could be replaced with #-hex"
+                },
+                "fullDescription": {
+                  "text": "Reports an 'rgb()', 'hsl()', or other color function. Suggests replacing a color function with an equivalent hexadecimal notation. Example: 'rgb(12, 15, 255)' After the quick-fix is applied: '#0c0fff'. Inspection ID: CssConvertColorToHexInspection",
+                  "markdown": "Reports an `rgb()`, `hsl()`, or other color function.\n\nSuggests replacing a color function with an equivalent hexadecimal notation.\n\n**Example:**\n\n    rgb(12, 15, 255)\n\nAfter the quick-fix is applied:\n\n    #0c0fff.\n\nInspection ID: CssConvertColorToHexInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssConvertColorToHexInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssReplaceWithShorthandUnsafely",
+                "shortDescription": {
+                  "text": "Properties may probably be replaced with a shorthand"
+                },
+                "fullDescription": {
+                  "text": "Reports a set of longhand CSS properties and suggests replacing an incomplete set of longhand CSS properties with a shorthand form, which is however not 100% equivalent in this case. For example, 2 properties: 'outline-color' and 'outline-style' may be replaced with a single 'outline'. Such replacement is not 100% equivalent because shorthands reset all omitted sub-values to their initial states. In this example, switching to the 'outline' shorthand means that 'outline-width' is also set to its initial value, which is 'medium'. This inspection doesn't handle full sets of longhand properties (when switching to shorthand is 100% safe). For such cases see the 'Properties may be safely replaced with a shorthand' inspection instead. Inspection ID: CssReplaceWithShorthandUnsafely",
+                  "markdown": "Reports a set of longhand CSS properties and suggests replacing an incomplete set of longhand CSS properties with a shorthand form, which is however not 100% equivalent in this case.\n\n\nFor example, 2 properties: `outline-color` and `outline-style` may be replaced with a single `outline`.\nSuch replacement is not 100% equivalent because shorthands reset all omitted sub-values to their initial states.\nIn this example, switching to the `outline` shorthand means that `outline-width` is also set to its initial value,\nwhich is `medium`.\n\n\nThis inspection doesn't handle full sets of longhand properties (when switching to shorthand is 100% safe).\nFor such cases see the 'Properties may be safely replaced with a shorthand' inspection instead.\n\nInspection ID: CssReplaceWithShorthandUnsafely"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "CssReplaceWithShorthandUnsafely",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidNestedSelector",
+                "shortDescription": {
+                  "text": "Invalid nested selector"
+                },
+                "fullDescription": {
+                  "text": "Reports a nested selector starting with an identifier or a functional notation. Inspection ID: CssInvalidNestedSelector",
+                  "markdown": "Reports a nested selector starting with an identifier or a functional notation.\n\nInspection ID: CssInvalidNestedSelector"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidNestedSelector",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssUnknownUnit",
+                "shortDescription": {
+                  "text": "Unknown unit"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown unit. Inspection ID: CssUnknownUnit",
+                  "markdown": "Reports an unknown unit.\n\nInspection ID: CssUnknownUnit"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssUnknownUnit",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssInvalidMediaFeature",
+                "shortDescription": {
+                  "text": "Invalid media feature"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown CSS media feature or an incorrect media feature value. Inspection ID: CssInvalidMediaFeature",
+                  "markdown": "Reports an unknown [CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) or an incorrect media feature value.\n\nInspection ID: CssInvalidMediaFeature"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "CssInvalidMediaFeature",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS/Invalid elements",
+                      "index": 16,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CssConvertColorToRgbInspection",
+                "shortDescription": {
+                  "text": "Color could be replaced with rgb()"
+                },
+                "fullDescription": {
+                  "text": "Reports an 'hsl()' or 'hwb()' color function or a hexadecimal color notation. Suggests replacing such color value with an equivalent 'rgb()' or 'rgba()' color function. Example: '#0c0fff' After the quick-fix is applied: 'rgb(12, 15, 255)'. Inspection ID: CssConvertColorToRgbInspection",
+                  "markdown": "Reports an `hsl()` or `hwb()` color function or a hexadecimal color notation.\n\nSuggests replacing such color value with an equivalent `rgb()` or `rgba()` color function.\n\n**Example:**\n\n    #0c0fff\n\nAfter the quick-fix is applied:\n\n    rgb(12, 15, 255).\n\nInspection ID: CssConvertColorToRgbInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CssConvertColorToRgbInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "CSS",
+                      "index": 10,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "HtmlTools",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "HtmlRequiredAltAttribute",
+                "shortDescription": {
+                  "text": "Missing required 'alt' attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing 'alt' attribute in a 'img' or 'applet' tag or in a 'area' element of an image map. Suggests adding a required attribute with a text alternative for the contents of the tag. Based on WCAG 2.0: H24, H35, H36, H37. Inspection ID: HtmlRequiredAltAttribute",
+                  "markdown": "Reports a missing `alt` attribute in a `img` or `applet` tag or in a `area` element of an image map. Suggests adding a required attribute with a text alternative for the contents of the tag. Based on WCAG 2.0: [H24](https://www.w3.org/TR/WCAG20-TECHS/H24.html), [H35](https://www.w3.org/TR/WCAG20-TECHS/H35.html), [H36](https://www.w3.org/TR/WCAG20-TECHS/H36.html), [H37](https://www.w3.org/TR/WCAG20-TECHS/H37.html).\n\nInspection ID: HtmlRequiredAltAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlRequiredAltAttribute",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlDeprecatedTag",
+                "shortDescription": {
+                  "text": "Obsolete tag"
+                },
+                "fullDescription": {
+                  "text": "Reports an obsolete HTML5 tag. Suggests replacing the obsolete tag with a CSS or another tag. Inspection ID: HtmlDeprecatedTag",
+                  "markdown": "Reports an obsolete HTML5 tag. Suggests replacing the obsolete tag with a CSS or another tag.\n\nInspection ID: HtmlDeprecatedTag"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlDeprecatedTag",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CheckImageSize",
+                "shortDescription": {
+                  "text": "Mismatched image size"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'width' and 'height' attribute value of a 'img' tag that is different from the actual width and height of the referenced image. Inspection ID: CheckImageSize",
+                  "markdown": "Reports a `width` and `height` attribute value of a `img` tag that is different from the actual width and height of the referenced image.\n\nInspection ID: CheckImageSize"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CheckImageSize",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlFormInputWithoutLabel",
+                "shortDescription": {
+                  "text": "Missing associated label"
+                },
+                "fullDescription": {
+                  "text": "Reports a form element ('input', 'textarea', or 'select') without an associated label. Suggests creating a new label. Based on WCAG 2.0: H44. Inspection ID: HtmlFormInputWithoutLabel",
+                  "markdown": "Reports a form element (`input`, `textarea`, or `select`) without an associated label. Suggests creating a new label. Based on WCAG 2.0: [H44](https://www.w3.org/TR/WCAG20-TECHS/H44.html).  \n\nInspection ID: HtmlFormInputWithoutLabel"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlFormInputWithoutLabel",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlRequiredSummaryAttribute",
+                "shortDescription": {
+                  "text": "Missing required 'summary' attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing 'summary' attribute in a 'table' tag. Suggests adding a'summary' attribute. Based on WCAG 2.0: H73. Inspection ID: HtmlRequiredSummaryAttribute",
+                  "markdown": "Reports a missing `summary` attribute in a `table` tag. Suggests adding a`summary` attribute. Based on WCAG 2.0: [H73](https://www.w3.org/TR/WCAG20-TECHS/H73.html).\n\nInspection ID: HtmlRequiredSummaryAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HtmlRequiredSummaryAttribute",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlRequiredLangAttribute",
+                "shortDescription": {
+                  "text": "Missing required 'lang' attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing 'lang' (or 'xml:lang') attribute in a 'html' tag. Suggests adding a required attribute to state the default language of the document. Based on WCAG 2.0: H57. Inspection ID: HtmlRequiredLangAttribute",
+                  "markdown": "Reports a missing `lang` (or `xml:lang`) attribute in a `html` tag. Suggests adding a required attribute to state the default language of the document. Based on WCAG 2.0: [H57](https://www.w3.org/TR/WCAG20-TECHS/H57.html).\n\nInspection ID: HtmlRequiredLangAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlRequiredLangAttribute",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlNonExistentInternetResource",
+                "shortDescription": {
+                  "text": "Unresolved web link"
+                },
+                "fullDescription": {
+                  "text": "Reports an unresolved web link. Works by making network requests in the background. Inspection ID: HtmlNonExistentInternetResource",
+                  "markdown": "Reports an unresolved web link. Works by making network requests in the background.\n\nInspection ID: HtmlNonExistentInternetResource"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlNonExistentInternetResource",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlRequiredTitleAttribute",
+                "shortDescription": {
+                  "text": "Missing required 'title' attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing title attribute 'frame', 'iframe', 'dl', and 'a' tags. Suggests adding a title attribute. Based on WCAG 2.0: H33, H40, and H64. Inspection ID: HtmlRequiredTitleAttribute",
+                  "markdown": "Reports a missing title attribute `frame`, `iframe`, `dl`, and `a` tags. Suggests adding a title attribute. Based on WCAG 2.0: [H33](https://www.w3.org/TR/WCAG20-TECHS/H33.html), [H40](https://www.w3.org/TR/WCAG20-TECHS/H40.html), and [H64](https://www.w3.org/TR/WCAG20-TECHS/H64.html).\n\nInspection ID: HtmlRequiredTitleAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HtmlRequiredTitleAttribute",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlRequiredTitleElement",
+                "shortDescription": {
+                  "text": "Missing required 'title' element"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing 'title' element inside a 'head' section. Suggests adding a 'title' element. The title should describe the document. Based on WCAG 2.0: H25. Inspection ID: HtmlRequiredTitleElement",
+                  "markdown": "Reports a missing `title` element inside a `head` section. Suggests adding a `title` element. The title should describe the document. Based on WCAG 2.0: [H25](https://www.w3.org/TR/WCAG20-TECHS/H25.html).\n\nInspection ID: HtmlRequiredTitleElement"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlRequiredTitleElement",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML/Accessibility",
+                      "index": 15,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlDeprecatedAttribute",
+                "shortDescription": {
+                  "text": "Obsolete attribute"
+                },
+                "fullDescription": {
+                  "text": "Reports an obsolete HTML5 attribute. Inspection ID: HtmlDeprecatedAttribute",
+                  "markdown": "Reports an obsolete HTML5 attribute.\n\nInspection ID: HtmlDeprecatedAttribute"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "HtmlDeprecatedAttribute",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HtmlPresentationalElement",
+                "shortDescription": {
+                  "text": "Presentational tag"
+                },
+                "fullDescription": {
+                  "text": "Reports a presentational HTML tag. Suggests replacing the presentational tag with a CSS or another tag. Inspection ID: HtmlPresentationalElement",
+                  "markdown": "Reports a presentational HTML tag. Suggests replacing the presentational tag with a CSS or another tag.\n\nInspection ID: HtmlPresentationalElement"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "HtmlPresentationalElement",
+                    "ideaSeverity": "INFORMATION",
+                    "qodanaSeverity": "Info",
+                    "codeQualityCategory": "Code Style"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "HTML",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "com.intellij.jsonpath",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "JsonPathEvaluateUnknownKey",
+                "shortDescription": {
+                  "text": "Unknown property key used for JSONPath evaluate expression"
+                },
+                "fullDescription": {
+                  "text": "Reports a key in a JSONPath expression that is missing in the source JSON document to evaluate. Inspection ID: JsonPathEvaluateUnknownKey",
+                  "markdown": "Reports a key in a JSONPath expression that is missing in the source JSON document to evaluate.\n\nInspection ID: JsonPathEvaluateUnknownKey"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonPathEvaluateUnknownKey",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSONPath",
+                      "index": 18,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonPathUnknownFunction",
+                "shortDescription": {
+                  "text": "Unknown JSONPath function"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown name in a JSONPath function call instead of known standard function names: 'concat', 'keys', 'length', 'min', 'max', 'avg', 'stddev', 'sum'. Inspection ID: JsonPathUnknownFunction",
+                  "markdown": "Reports an unknown name in a JSONPath function call instead of known standard function names: `concat`, `keys`, `length`, `min`, `max`, `avg`, `stddev`, `sum`.\n\nInspection ID: JsonPathUnknownFunction"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonPathUnknownFunction",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSONPath",
+                      "index": 18,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JsonPathUnknownOperator",
+                "shortDescription": {
+                  "text": "Unknown JSONPath operator"
+                },
+                "fullDescription": {
+                  "text": "Reports an unknown operator on a JSONPath expression instead of one of the standard ones: 'in', 'nin', 'subsetof', 'anyof', 'noneof', 'size', 'empty', 'contains'. Inspection ID: JsonPathUnknownOperator",
+                  "markdown": "Reports an unknown operator on a JSONPath expression instead of one of the standard ones: `in`, `nin`, `subsetof`, `anyof`, `noneof`, `size`, `empty`, `contains`.\n\nInspection ID: JsonPathUnknownOperator"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "JsonPathUnknownOperator",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Reliability"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JSONPath",
+                      "index": 18,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "org.toml.lang",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "TomlUnresolvedReference",
+                "shortDescription": {
+                  "text": "Unresolved reference"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved references in TOML files. Inspection ID: TomlUnresolvedReference",
+                  "markdown": "Reports unresolved references in TOML files.\n\nInspection ID: TomlUnresolvedReference"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "TomlUnresolvedReference",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Sanity"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "TOML",
+                      "index": 23,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "org.intellij.qodana",
+            "version": "261.24231.0",
+            "rules": [
+              {
+                "id": "CyclomaticComplexityInspection",
+                "shortDescription": {
+                  "text": "Code metrics"
+                },
+                "fullDescription": {
+                  "text": "Calculates cyclomatic complexity. Inspection ID: CyclomaticComplexityInspection",
+                  "markdown": "Calculates cyclomatic complexity.\n\nInspection ID: CyclomaticComplexityInspection"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CyclomaticComplexityInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High",
+                    "codeQualityCategory": "Unspecified"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Qodana",
+                      "index": 25,
+                      "toolComponent": {
+                        "name": "QDRST"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          }
+        ]
+      },
+      "invocations": [
+        {
+          "startTimeUtc": "2026-05-18T08:49:18.181235553Z",
+          "exitCode": 0,
+          "executionSuccessful": true
+        }
+      ],
+      "language": "en-US",
+      "versionControlProvenance": [
+        {
+          "repositoryUri": "https://github.com/iamacoffeepot/aether.git",
+          "revisionId": "abc9f380639f6a6f1b04b778d09029e4ccd7746c",
+          "branch": "main",
+          "properties": {
+            "repoUrl": "https://github.com/iamacoffeepot/aether.git",
+            "lastAuthorName": "iamacoffeepot",
+            "vcsType": "Git",
+            "lastAuthorEmail": "me@iamateapot.dev"
+          }
+        }
+      ],
+      "originalUriBaseIds": {
+        "SRCROOT": {
+          "description": {
+            "text": "The subdirectory within the project that was analyzed (--project-dir qodana CLI parameter)"
+          }
+        }
+      },
+      "results": [
+        {
+          "ruleId": "CargoUnusedDependency",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Unused crate: anyhow",
+            "markdown": "Unused crate: anyhow"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/Cargo.toml",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 39,
+                  "startColumn": 1,
+                  "charOffset": 1775,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "anyhow = \"1\""
+                  },
+                  "sourceLanguage": "TOML"
+                },
+                "contextRegion": {
+                  "startLine": 37,
+                  "startColumn": 1,
+                  "charOffset": 1644,
+                  "charLength": 214,
+                  "snippet": {
+                    "text": "# call sites to `anyhow::Result` is a zero-cost rename — it just\n# stops advertising a wasmtime dep that isn't there (issue #571).\nanyhow = \"1\"\nbytemuck = \"1.19\"\npostcard = { version = \"1.1\", features = [\"alloc\"] }"
+                  },
+                  "sourceLanguage": "TOML"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "630e23acec455d03",
+            "equalIndicator/v1": "004dbae7ab74f27af356a63178b1f8dd37605e610f5f788608e1df677f338a1d"
+          },
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "problemType": "REGULAR",
+            "tags": [
+              "TOML"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 146,
+                  "startColumn": 9,
+                  "charOffset": 5961,
+                  "charLength": 163,
+                  "snippet": {
+                    "text": "for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *entry.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 146,
+                  "startColumn": 1,
+                  "charOffset": 5953,
+                  "charLength": 171,
+                  "snippet": {
+                    "text": "        for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *entry.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 126,
+                  "startColumn": 9,
+                  "charOffset": 5896,
+                  "charLength": 166,
+                  "snippet": {
+                    "text": "for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *directed.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 126,
+                  "startColumn": 1,
+                  "charOffset": 5888,
+                  "charLength": 174,
+                  "snippet": {
+                    "text": "        for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *directed.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 163,
+                  "startColumn": 9,
+                  "charOffset": 7072,
+                  "charLength": 166,
+                  "snippet": {
+                    "text": "for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *directed.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 163,
+                  "startColumn": 1,
+                  "charOffset": 7064,
+                  "charLength": 174,
+                  "snippet": {
+                    "text": "        for i in 0..m {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % m];\n            *directed.entry((a, b)).or_insert(0) += 1;\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "12f5bbaa021d201b",
+            "equalIndicator/v1": "0732a4a35f7deb3cc4fb0e96def266980d4de8fb084954adb706839575c5cd5a"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 257,
+                  "startColumn": 9,
+                  "charOffset": 9737,
+                  "charLength": 238,
+                  "snippet": {
+                    "text": "for i in 0..n {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % n];\n            if a == b {\n                continue;\n            }\n            edges.insert(if a < b { (a, b) } else { (b, a) });\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 257,
+                  "startColumn": 1,
+                  "charOffset": 9729,
+                  "charLength": 246,
+                  "snippet": {
+                    "text": "        for i in 0..n {\n            let a = poly.vertices[i];\n            let b = poly.vertices[(i + 1) % n];\n            if a == b {\n                continue;\n            }\n            edges.insert(if a < b { (a, b) } else { (b, a) });\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/tjunctions.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 51,
+                  "startColumn": 17,
+                  "charOffset": 2195,
+                  "charLength": 294,
+                  "snippet": {
+                    "text": "for i in 0..n {\n                    let a = poly.vertices[i];\n                    let b = poly.vertices[(i + 1) % n];\n                    if a == b {\n                        continue;\n                    }\n                    edges.insert(if a < b { (a, b) } else { (b, a) });\n                }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 51,
+                  "startColumn": 1,
+                  "charOffset": 2179,
+                  "charLength": 310,
+                  "snippet": {
+                    "text": "                for i in 0..n {\n                    let a = poly.vertices[i];\n                    let b = poly.vertices[(i + 1) % n];\n                    if a == b {\n                        continue;\n                    }\n                    edges.insert(if a < b { (a, b) } else { (b, a) });\n                }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "35f433da46a5192e",
+            "equalIndicator/v1": "0cfa519c32d54540d5a16a9d08fae8482acf95197438451bfb5a19d79c9891b3"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate-bundle/src/desktop/chassis.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 268,
+                  "startColumn": 27,
+                  "charOffset": 10950,
+                  "charLength": 550,
+                  "snippet": {
+                    "text": "Builder::<Self>::new(registry, Arc::clone(&mailer))\n            .with_aborter(aborter)\n            .with_workers(workers)\n            .with_actor::<HandleCapability>(())\n            .with_actor::<LogCapability>(())\n            .with_actor::<TraceObserverCapability>(())\n            .with_actor::<InputCapability>(input_config)\n            .with_actor::<ComponentHostCapability>(component_host_config)\n            .with_actor::<FsCapability>(namespace_roots)\n            .with_actor::<HttpCapability>(http)\n            .with_actor::<TcpCapability>(())"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 268,
+                  "startColumn": 1,
+                  "charOffset": 10924,
+                  "charLength": 576,
+                  "snippet": {
+                    "text": "        let mut builder = Builder::<Self>::new(registry, Arc::clone(&mailer))\n            .with_aborter(aborter)\n            .with_workers(workers)\n            .with_actor::<HandleCapability>(())\n            .with_actor::<LogCapability>(())\n            .with_actor::<TraceObserverCapability>(())\n            .with_actor::<InputCapability>(input_config)\n            .with_actor::<ComponentHostCapability>(component_host_config)\n            .with_actor::<FsCapability>(namespace_roots)\n            .with_actor::<HttpCapability>(http)\n            .with_actor::<TcpCapability>(())"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate-bundle/src/headless/chassis.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 218,
+                  "startColumn": 27,
+                  "charOffset": 9212,
+                  "charLength": 550,
+                  "snippet": {
+                    "text": "Builder::<Self>::new(registry, Arc::clone(&mailer))\n            .with_aborter(aborter)\n            .with_workers(workers)\n            .with_actor::<HandleCapability>(())\n            .with_actor::<LogCapability>(())\n            .with_actor::<TraceObserverCapability>(())\n            .with_actor::<InputCapability>(input_config)\n            .with_actor::<ComponentHostCapability>(component_host_config)\n            .with_actor::<FsCapability>(namespace_roots)\n            .with_actor::<HttpCapability>(http)\n            .with_actor::<TcpCapability>(())"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 218,
+                  "startColumn": 1,
+                  "charOffset": 9186,
+                  "charLength": 576,
+                  "snippet": {
+                    "text": "        let mut builder = Builder::<Self>::new(registry, Arc::clone(&mailer))\n            .with_aborter(aborter)\n            .with_workers(workers)\n            .with_actor::<HandleCapability>(())\n            .with_actor::<LogCapability>(())\n            .with_actor::<TraceObserverCapability>(())\n            .with_actor::<InputCapability>(input_config)\n            .with_actor::<ComponentHostCapability>(component_host_config)\n            .with_actor::<FsCapability>(namespace_roots)\n            .with_actor::<HttpCapability>(http)\n            .with_actor::<TcpCapability>(())"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "3322e5cfff0e8c3b",
+            "equalIndicator/v1": "143f5baf143256eaa8ea34da351d387e1147d062d602b912a1615071be2782dd"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/loop_polygon.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 94,
+                  "startColumn": 13,
+                  "charOffset": 3840,
+                  "charLength": 185,
+                  "snippet": {
+                    "text": "if partitioner.normal_dot_sign(&self.plane) > 0 {\n                coplanar_front.push(self.clone());\n            } else {\n                coplanar_back.push(self.clone());\n            }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 94,
+                  "startColumn": 1,
+                  "charOffset": 3828,
+                  "charLength": 197,
+                  "snippet": {
+                    "text": "            if partitioner.normal_dot_sign(&self.plane) > 0 {\n                coplanar_front.push(self.clone());\n            } else {\n                coplanar_back.push(self.clone());\n            }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/loop_polygon.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 127,
+                  "startColumn": 17,
+                  "charOffset": 5091,
+                  "charLength": 201,
+                  "snippet": {
+                    "text": "if partitioner.normal_dot_sign(&self.plane) > 0 {\n                    coplanar_front.push(self.clone());\n                } else {\n                    coplanar_back.push(self.clone());\n                }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 127,
+                  "startColumn": 1,
+                  "charOffset": 5075,
+                  "charLength": 217,
+                  "snippet": {
+                    "text": "                if partitioner.normal_dot_sign(&self.plane) > 0 {\n                    coplanar_front.push(self.clone());\n                } else {\n                    coplanar_back.push(self.clone());\n                }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "4de5a72649cefdbc",
+            "equalIndicator/v1": "16ac3db93acc0add69607372d1277d0d4be764ec716cb9b954fb4fb3c1492593"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-data/src/canonical/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 117,
+                  "startColumn": 9,
+                  "charOffset": 5076,
+                  "charLength": 443,
+                  "snippet": {
+                    "text": "SchemaShape::Enum {\n            variants: vec![\n                VariantShape::Unit { discriminant: 0 },\n                VariantShape::Tuple {\n                    discriminant: 1,\n                    fields: vec![SchemaShape::Scalar(Primitive::U64)],\n                },\n                VariantShape::Struct {\n                    discriminant: 2,\n                    fields: vec![SchemaShape::String],\n                },\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 117,
+                  "startColumn": 1,
+                  "charOffset": 5068,
+                  "charLength": 451,
+                  "snippet": {
+                    "text": "        SchemaShape::Enum {\n            variants: vec![\n                VariantShape::Unit { discriminant: 0 },\n                VariantShape::Tuple {\n                    discriminant: 1,\n                    fields: vec![SchemaShape::Scalar(Primitive::U64)],\n                },\n                VariantShape::Struct {\n                    discriminant: 2,\n                    fields: vec![SchemaShape::String],\n                },\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/wasm/kind_manifest.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 786,
+                  "startColumn": 21,
+                  "charOffset": 32171,
+                  "charLength": 491,
+                  "snippet": {
+                    "text": "SchemaShape::Enum {\n                variants: vec![\n                    VariantShape::Unit { discriminant: 0 },\n                    VariantShape::Tuple {\n                        discriminant: 1,\n                        fields: vec![SchemaShape::Scalar(Primitive::U64)],\n                    },\n                    VariantShape::Struct {\n                        discriminant: 2,\n                        fields: vec![SchemaShape::String],\n                    },\n                ],\n            }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 786,
+                  "startColumn": 1,
+                  "charOffset": 32151,
+                  "charLength": 512,
+                  "snippet": {
+                    "text": "            schema: SchemaShape::Enum {\n                variants: vec![\n                    VariantShape::Unit { discriminant: 0 },\n                    VariantShape::Tuple {\n                        discriminant: 1,\n                        fields: vec![SchemaShape::Scalar(Primitive::U64)],\n                    },\n                    VariantShape::Struct {\n                        discriminant: 2,\n                        fields: vec![SchemaShape::String],\n                    },\n                ],\n            },"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0df3da320ed9bba2",
+            "equalIndicator/v1": "2b0db248bc40e7ab8d435b7322a1972717e85e347844fa83aaf0302093add15b"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/handle.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 200,
+                  "startColumn": 13,
+                  "charOffset": 7954,
+                  "charLength": 215,
+                  "snippet": {
+                    "text": "let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<HandleCapability>(())\n                .build_passive()\n                .expect(\"capability boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 200,
+                  "startColumn": 1,
+                  "charOffset": 7942,
+                  "charLength": 227,
+                  "snippet": {
+                    "text": "            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<HandleCapability>(())\n                .build_passive()\n                .expect(\"capability boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/handle.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 272,
+                  "startColumn": 13,
+                  "charOffset": 10936,
+                  "charLength": 215,
+                  "snippet": {
+                    "text": "let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<HandleCapability>(())\n                .build_passive()\n                .expect(\"capability boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 272,
+                  "startColumn": 1,
+                  "charOffset": 10924,
+                  "charLength": 227,
+                  "snippet": {
+                    "text": "            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<HandleCapability>(())\n                .build_passive()\n                .expect(\"capability boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d9695fd4d0ecddcd",
+            "equalIndicator/v1": "39c7b8f7df68b529b0582c1d8423afb0aede4d771f3bf66e45e205efc8eea75b"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/audio.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1029,
+                  "startColumn": 27,
+                  "charOffset": 37921,
+                  "charLength": 265,
+                  "snippet": {
+                    "text": "Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<AudioCapability>(AudioConfig {\n                    disabled: true,\n                    ..AudioConfig::default()\n                })\n                .build_passive()"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1029,
+                  "startColumn": 1,
+                  "charOffset": 37895,
+                  "charLength": 291,
+                  "snippet": {
+                    "text": "            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<AudioCapability>(AudioConfig {\n                    disabled: true,\n                    ..AudioConfig::default()\n                })\n                .build_passive()"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/audio.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1053,
+                  "startColumn": 23,
+                  "charOffset": 38828,
+                  "charLength": 265,
+                  "snippet": {
+                    "text": "Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<AudioCapability>(AudioConfig {\n                    disabled: true,\n                    ..AudioConfig::default()\n                })\n                .build_passive()"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1053,
+                  "startColumn": 1,
+                  "charOffset": 38806,
+                  "charLength": 287,
+                  "snippet": {
+                    "text": "            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n                .with_actor::<AudioCapability>(AudioConfig {\n                    disabled: true,\n                    ..AudioConfig::default()\n                })\n                .build_passive()"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d8efc1414ac21bd5",
+            "equalIndicator/v1": "407b2b90356453d14f3ad3e0825c1b76d10c1d179ed886712725a9e0a895af72"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/decode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 875,
+                  "startColumn": 23,
+                  "charOffset": 31158,
+                  "charLength": 691,
+                  "snippet": {
+                    "text": "vec![\n                EnumVariant::Unit {\n                    name: \"Pending\".into(),\n                    discriminant: 0,\n                },\n                EnumVariant::Tuple {\n                    name: \"Ok\".into(),\n                    discriminant: 1,\n                    fields: vec![SchemaType::Scalar(Primitive::U64)].into(),\n                },\n                EnumVariant::Struct {\n                    name: \"Err\".into(),\n                    discriminant: 2,\n                    fields: vec![NamedField {\n                        name: \"reason\".into(),\n                        ty: SchemaType::String,\n                    }]\n                    .into(),\n                },\n            ]"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 875,
+                  "startColumn": 1,
+                  "charOffset": 31136,
+                  "charLength": 713,
+                  "snippet": {
+                    "text": "            variants: vec![\n                EnumVariant::Unit {\n                    name: \"Pending\".into(),\n                    discriminant: 0,\n                },\n                EnumVariant::Tuple {\n                    name: \"Ok\".into(),\n                    discriminant: 1,\n                    fields: vec![SchemaType::Scalar(Primitive::U64)].into(),\n                },\n                EnumVariant::Struct {\n                    name: \"Err\".into(),\n                    discriminant: 2,\n                    fields: vec![NamedField {\n                        name: \"reason\".into(),\n                        ty: SchemaType::String,\n                    }]\n                    .into(),\n                },\n            ]"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/encode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1263,
+                  "startColumn": 21,
+                  "charOffset": 47560,
+                  "charLength": 615,
+                  "snippet": {
+                    "text": "vec![\n            EnumVariant::Unit {\n                name: \"Pending\".into(),\n                discriminant: 0,\n            },\n            EnumVariant::Tuple {\n                name: \"Ok\".into(),\n                discriminant: 1,\n                fields: vec![SchemaType::Scalar(Primitive::U64)].into(),\n            },\n            EnumVariant::Struct {\n                name: \"Err\".into(),\n                discriminant: 2,\n                fields: vec![NamedField {\n                    name: \"reason\".into(),\n                    ty: SchemaType::String,\n                }]\n                .into(),\n            },\n        ]"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1263,
+                  "startColumn": 1,
+                  "charOffset": 47540,
+                  "charLength": 636,
+                  "snippet": {
+                    "text": "        enum_schema(vec![\n            EnumVariant::Unit {\n                name: \"Pending\".into(),\n                discriminant: 0,\n            },\n            EnumVariant::Tuple {\n                name: \"Ok\".into(),\n                discriminant: 1,\n                fields: vec![SchemaType::Scalar(Primitive::U64)].into(),\n            },\n            EnumVariant::Struct {\n                name: \"Err\".into(),\n                discriminant: 2,\n                fields: vec![NamedField {\n                    name: \"reason\".into(),\n                    ty: SchemaType::String,\n                }]\n                .into(),\n            },\n        ])"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "7d155fa000a959bb",
+            "equalIndicator/v1": "42da8adc6f5aea565755e653390ebb953b3a6beb142e44f92d4c4c4a00fe8bf6"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-math/src/mat.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 244,
+                  "startColumn": 9,
+                  "charOffset": 7551,
+                  "charLength": 101,
+                  "snippet": {
+                    "text": "(a.x - b.x).abs() < EPS\n            && (a.y - b.y).abs() < EPS\n            && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 244,
+                  "startColumn": 1,
+                  "charOffset": 7543,
+                  "charLength": 109,
+                  "snippet": {
+                    "text": "        (a.x - b.x).abs() < EPS\n            && (a.y - b.y).abs() < EPS\n            && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-math/src/quat.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 137,
+                  "startColumn": 9,
+                  "charOffset": 3718,
+                  "charLength": 77,
+                  "snippet": {
+                    "text": "(a.x - b.x).abs() < EPS && (a.y - b.y).abs() < EPS && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 137,
+                  "startColumn": 1,
+                  "charOffset": 3710,
+                  "charLength": 85,
+                  "snippet": {
+                    "text": "        (a.x - b.x).abs() < EPS && (a.y - b.y).abs() < EPS && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/obj.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 61,
+                  "startColumn": 5,
+                  "charOffset": 2228,
+                  "charLength": 77,
+                  "snippet": {
+                    "text": "(a.x - b.x).abs() < EPS && (a.y - b.y).abs() < EPS && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 61,
+                  "startColumn": 1,
+                  "charOffset": 2224,
+                  "charLength": 81,
+                  "snippet": {
+                    "text": "    (a.x - b.x).abs() < EPS && (a.y - b.y).abs() < EPS && (a.z - b.z).abs() < EPS"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "796f7187556d7d60",
+            "equalIndicator/v1": "46c3e4fa69edfe54cc4659494b5032e259b2afdb3d267a2845433a24c18b4093"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 701,
+                  "startColumn": 9,
+                  "charOffset": 26841,
+                  "charLength": 412,
+                  "snippet": {
+                    "text": "let polys = vec![\n            Polygon::from_triangle(c, nw, ne, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, ne, se, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, se, sw, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, sw, nw, 0).expect(\"test setup: non-degenerate triangle\"),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 701,
+                  "startColumn": 1,
+                  "charOffset": 26833,
+                  "charLength": 420,
+                  "snippet": {
+                    "text": "        let polys = vec![\n            Polygon::from_triangle(c, nw, ne, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, ne, se, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, se, sw, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(c, sw, nw, 0).expect(\"test setup: non-degenerate triangle\"),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 725,
+                  "startColumn": 9,
+                  "charOffset": 28025,
+                  "charLength": 426,
+                  "snippet": {
+                    "text": "let polys = vec![\n            Polygon::from_triangle(bl, br, inner, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, inner, mid, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, mid, top, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, top, tl, 0).expect(\"test setup: non-degenerate triangle\"),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 725,
+                  "startColumn": 1,
+                  "charOffset": 28017,
+                  "charLength": 434,
+                  "snippet": {
+                    "text": "        let polys = vec![\n            Polygon::from_triangle(bl, br, inner, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, inner, mid, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, mid, top, 0).expect(\"test setup: non-degenerate triangle\"),\n            Polygon::from_triangle(bl, top, tl, 0).expect(\"test setup: non-degenerate triangle\"),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2c6ab53723adab97",
+            "equalIndicator/v1": "477270f4d2d8c71c2035899ed152d9ffa4beb6b40e63a3e7e0224353100aa183"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate-bundle/src/bin/test-bench.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 227,
+                  "startColumn": 13,
+                  "charOffset": 8404,
+                  "charLength": 363,
+                  "snippet": {
+                    "text": "let result = pre_failed.map_or_else(\n                || match gpu.render_and_capture() {\n                    Ok(png) => CaptureFrameResult::Ok { png },\n                    //noinspection DuplicatedCode\n                    Err(error) => CaptureFrameResult::Err { error },\n                },\n                |error| CaptureFrameResult::Err { error },\n            );"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 227,
+                  "startColumn": 1,
+                  "charOffset": 8392,
+                  "charLength": 375,
+                  "snippet": {
+                    "text": "            let result = pre_failed.map_or_else(\n                || match gpu.render_and_capture() {\n                    Ok(png) => CaptureFrameResult::Ok { png },\n                    //noinspection DuplicatedCode\n                    Err(error) => CaptureFrameResult::Err { error },\n                },\n                |error| CaptureFrameResult::Err { error },\n            );"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate-bundle/src/desktop/driver.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 531,
+                  "startColumn": 29,
+                  "charOffset": 22919,
+                  "charLength": 409,
+                  "snippet": {
+                    "text": "let result = pre_failed.map_or_else(\n                                || match gpu.render_and_capture() {\n                                    Ok(png) => CaptureFrameResult::Ok { png },\n                                    Err(error) => CaptureFrameResult::Err { error },\n                                },\n                                |error| CaptureFrameResult::Err { error },\n                            );"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 531,
+                  "startColumn": 1,
+                  "charOffset": 22891,
+                  "charLength": 437,
+                  "snippet": {
+                    "text": "                            let result = pre_failed.map_or_else(\n                                || match gpu.render_and_capture() {\n                                    Ok(png) => CaptureFrameResult::Ok { png },\n                                    Err(error) => CaptureFrameResult::Err { error },\n                                },\n                                |error| CaptureFrameResult::Err { error },\n                            );"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "82bd4273bcd71f2a",
+            "equalIndicator/v1": "47e53d20d2b87d05dc13df2e5ccf28ea32a025c96fb5f2142fc620fddad18b60"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/decode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 746,
+                  "startColumn": 9,
+                  "charOffset": 27094,
+                  "charLength": 356,
+                  "snippet": {
+                    "text": "let vertex = SchemaType::Struct {\n            repr_c: true,\n            fields: vec![\n                scalar(\"x\", Primitive::F32),\n                scalar(\"y\", Primitive::F32),\n                scalar(\"r\", Primitive::F32),\n                scalar(\"g\", Primitive::F32),\n                scalar(\"b\", Primitive::F32),\n            ]\n            .into(),\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 746,
+                  "startColumn": 1,
+                  "charOffset": 27086,
+                  "charLength": 364,
+                  "snippet": {
+                    "text": "        let vertex = SchemaType::Struct {\n            repr_c: true,\n            fields: vec![\n                scalar(\"x\", Primitive::F32),\n                scalar(\"y\", Primitive::F32),\n                scalar(\"r\", Primitive::F32),\n                scalar(\"g\", Primitive::F32),\n                scalar(\"b\", Primitive::F32),\n            ]\n            .into(),\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/encode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1070,
+                  "startColumn": 9,
+                  "charOffset": 41241,
+                  "charLength": 356,
+                  "snippet": {
+                    "text": "let vertex = SchemaType::Struct {\n            repr_c: true,\n            fields: vec![\n                scalar(\"x\", Primitive::F32),\n                scalar(\"y\", Primitive::F32),\n                scalar(\"r\", Primitive::F32),\n                scalar(\"g\", Primitive::F32),\n                scalar(\"b\", Primitive::F32),\n            ]\n            .into(),\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1070,
+                  "startColumn": 1,
+                  "charOffset": 41233,
+                  "charLength": 364,
+                  "snippet": {
+                    "text": "        let vertex = SchemaType::Struct {\n            repr_c: true,\n            fields: vec![\n                scalar(\"x\", Primitive::F32),\n                scalar(\"y\", Primitive::F32),\n                scalar(\"r\", Primitive::F32),\n                scalar(\"g\", Primitive::F32),\n                scalar(\"b\", Primitive::F32),\n            ]\n            .into(),\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "1d8e0c8d0031aaf0",
+            "equalIndicator/v1": "4f6f240cc33bc7c7830102edc672c583604526eb61b6dd603c69bb79e27abd38"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 348,
+                  "startColumn": 9,
+                  "charOffset": 12363,
+                  "charLength": 264,
+                  "snippet": {
+                    "text": "let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 348,
+                  "startColumn": 1,
+                  "charOffset": 12355,
+                  "charLength": 272,
+                  "snippet": {
+                    "text": "        let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 487,
+                  "startColumn": 9,
+                  "charOffset": 17320,
+                  "charLength": 264,
+                  "snippet": {
+                    "text": "let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 487,
+                  "startColumn": 1,
+                  "charOffset": 17312,
+                  "charLength": 272,
+                  "snippet": {
+                    "text": "        let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 555,
+                  "startColumn": 9,
+                  "charOffset": 19793,
+                  "charLength": 264,
+                  "snippet": {
+                    "text": "let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 555,
+                  "startColumn": 1,
+                  "charOffset": 19785,
+                  "charLength": 272,
+                  "snippet": {
+                    "text": "        let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/invariants.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 697,
+                  "startColumn": 9,
+                  "charOffset": 24749,
+                  "charLength": 264,
+                  "snippet": {
+                    "text": "let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 697,
+                  "startColumn": 1,
+                  "charOffset": 24741,
+                  "charLength": 272,
+                  "snippet": {
+                    "text": "        let mesh = IndexedMesh {\n            vertices: vec![pt(0, 0, 0), pt(1, 0, 0), pt(0, 1, 0)],\n            polygons: vec![IndexedPolygon {\n                vertices: vec![0, 1, 2],\n                plane: xy_plane(),\n                color: 0,\n            }],\n        };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e4e7d72b349c6a5f",
+            "equalIndicator/v1": "5d0a35211de42f2f1a3978ccbf0fe80d013613cf178ede7431aa605160e963a0"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/local.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 171,
+                  "startColumn": 13,
+                  "charOffset": 6999,
+                  "charLength": 494,
+                  "snippet": {
+                    "text": "let cell_ptr: *const RefCell<T> = {\n                let mut map = self.by_type.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);\n                core::ptr::from_ref::<RefCell<T>>(\n                    entry\n                        .downcast_ref::<RefCell<T>>()\n                        .expect(\"TypeId<T> ⇒ RefCell<T>\"),\n                )\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 171,
+                  "startColumn": 1,
+                  "charOffset": 6987,
+                  "charLength": 506,
+                  "snippet": {
+                    "text": "            let cell_ptr: *const RefCell<T> = {\n                let mut map = self.by_type.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);\n                core::ptr::from_ref::<RefCell<T>>(\n                    entry\n                        .downcast_ref::<RefCell<T>>()\n                        .expect(\"TypeId<T> ⇒ RefCell<T>\"),\n                )\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/local.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 199,
+                  "startColumn": 13,
+                  "charOffset": 8253,
+                  "charLength": 494,
+                  "snippet": {
+                    "text": "let cell_ptr: *const RefCell<T> = {\n                let mut map = self.by_type.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);\n                core::ptr::from_ref::<RefCell<T>>(\n                    entry\n                        .downcast_ref::<RefCell<T>>()\n                        .expect(\"TypeId<T> ⇒ RefCell<T>\"),\n                )\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 199,
+                  "startColumn": 1,
+                  "charOffset": 8241,
+                  "charLength": 506,
+                  "snippet": {
+                    "text": "            let cell_ptr: *const RefCell<T> = {\n                let mut map = self.by_type.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);\n                core::ptr::from_ref::<RefCell<T>>(\n                    entry\n                        .downcast_ref::<RefCell<T>>()\n                        .expect(\"TypeId<T> ⇒ RefCell<T>\"),\n                )\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "5d91c1b09a592b68",
+            "equalIndicator/v1": "70327efe8442b859cae02dba369777e748cad3483542889c5e2223642a7d2327"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/local.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 82,
+                  "startColumn": 13,
+                  "charOffset": 3569,
+                  "charLength": 422,
+                  "snippet": {
+                    "text": "let cell_ptr: *const RefCell<T> = {\n                let mut map = map_cell.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);\n                entry\n                    .downcast_ref::<RefCell<T>>()\n                    .expect(\"TypeId<T> ⇒ RefCell<T>\") as *const RefCell<T>\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 82,
+                  "startColumn": 1,
+                  "charOffset": 3557,
+                  "charLength": 434,
+                  "snippet": {
+                    "text": "            let cell_ptr: *const RefCell<T> = {\n                let mut map = map_cell.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);\n                entry\n                    .downcast_ref::<RefCell<T>>()\n                    .expect(\"TypeId<T> ⇒ RefCell<T>\") as *const RefCell<T>\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/local.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 107,
+                  "startColumn": 13,
+                  "charOffset": 4676,
+                  "charLength": 422,
+                  "snippet": {
+                    "text": "let cell_ptr: *const RefCell<T> = {\n                let mut map = map_cell.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);\n                entry\n                    .downcast_ref::<RefCell<T>>()\n                    .expect(\"TypeId<T> ⇒ RefCell<T>\") as *const RefCell<T>\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 107,
+                  "startColumn": 1,
+                  "charOffset": 4664,
+                  "charLength": 434,
+                  "snippet": {
+                    "text": "            let cell_ptr: *const RefCell<T> = {\n                let mut map = map_cell.borrow_mut();\n                let entry = map\n                    .entry(TypeId::of::<T>())\n                    .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any>);\n                entry\n                    .downcast_ref::<RefCell<T>>()\n                    .expect(\"TypeId<T> ⇒ RefCell<T>\") as *const RefCell<T>\n            };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "a9832926d9191a90",
+            "equalIndicator/v1": "7e7e935c24fd79c1a28f2e28b13a6a4931d37aa6e1afda95754837d4056aac85"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/envelope.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 21,
+                  "charOffset": 1075,
+                  "charLength": 239,
+                  "snippet": {
+                    "text": "{\n    pub kind: KindId,\n    pub kind_name: String,\n    pub origin: Option<String>,\n    pub sender: ReplyTo,\n    pub payload: Vec<u8>,\n    pub count: u32,\n    pub mail_id: MailId,\n    pub root: MailId,\n    pub parent_mail: Option<MailId>,\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 23,
+                  "startColumn": 1,
+                  "charOffset": 1055,
+                  "charLength": 259,
+                  "snippet": {
+                    "text": "pub struct Envelope {\n    pub kind: KindId,\n    pub kind_name: String,\n    pub origin: Option<String>,\n    pub sender: ReplyTo,\n    pub payload: Vec<u8>,\n    pub count: u32,\n    pub mail_id: MailId,\n    pub root: MailId,\n    pub parent_mail: Option<MailId>,\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/registry.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 149,
+                  "startColumn": 26,
+                  "charOffset": 6247,
+                  "charLength": 1313,
+                  "snippet": {
+                    "text": "{\n    /// Kind id (`K::ID`, ADR-0030 schema hash) the producer stamped.\n    pub kind: KindId,\n    /// Kind's registered name. Owned `String` so the handler can move\n    /// it into a downstream envelope without cloning.\n    pub kind_name: String,\n    /// Sending mailbox's registered name, if the mail came from a\n    /// component. `None` for substrate-core pushes with no sending\n    /// mailbox (ADR-0011).\n    pub origin: Option<String>,\n    /// Remote reply target of the mail (ADR-0008 / ADR-0037 /\n    /// ADR-0042). Carries the correlation id for reply-routing.\n    pub sender: ReplyTo,\n    /// Payload bytes (the kind's encoded representation per ADR-0019).\n    /// Owned `Vec<u8>` — handlers move this into the downstream\n    /// envelope rather than cloning the borrowed slice every\n    /// dispatch (the perf win called out in iamacoffeepot/aether#848).\n    pub payload: Vec<u8>,\n    /// Kind-implied item count.\n    pub count: u32,\n    /// ADR-0080 §1: the producer-minted identity of this mail.\n    /// `MailId::NONE` for legacy paths that haven't migrated.\n    pub mail_id: MailId,\n    /// ADR-0080 §5: the root of this mail's causal chain.\n    pub root: MailId,\n    /// ADR-0080 §5: the in-flight mail at the sender, or `None` for\n    /// chassis-root sends.\n    pub parent_mail: Option<MailId>,\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 149,
+                  "startColumn": 1,
+                  "charOffset": 6222,
+                  "charLength": 1338,
+                  "snippet": {
+                    "text": "pub struct OwnedDispatch {\n    /// Kind id (`K::ID`, ADR-0030 schema hash) the producer stamped.\n    pub kind: KindId,\n    /// Kind's registered name. Owned `String` so the handler can move\n    /// it into a downstream envelope without cloning.\n    pub kind_name: String,\n    /// Sending mailbox's registered name, if the mail came from a\n    /// component. `None` for substrate-core pushes with no sending\n    /// mailbox (ADR-0011).\n    pub origin: Option<String>,\n    /// Remote reply target of the mail (ADR-0008 / ADR-0037 /\n    /// ADR-0042). Carries the correlation id for reply-routing.\n    pub sender: ReplyTo,\n    /// Payload bytes (the kind's encoded representation per ADR-0019).\n    /// Owned `Vec<u8>` — handlers move this into the downstream\n    /// envelope rather than cloning the borrowed slice every\n    /// dispatch (the perf win called out in iamacoffeepot/aether#848).\n    pub payload: Vec<u8>,\n    /// Kind-implied item count.\n    pub count: u32,\n    /// ADR-0080 §1: the producer-minted identity of this mail.\n    /// `MailId::NONE` for legacy paths that haven't migrated.\n    pub mail_id: MailId,\n    /// ADR-0080 §5: the root of this mail's causal chain.\n    pub root: MailId,\n    /// ADR-0080 §5: the in-flight mail at the sender, or `None` for\n    /// chassis-root sends.\n    pub parent_mail: Option<MailId>,\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "74254f5dfd0077e9",
+            "equalIndicator/v1": "80aaf6850589af5778c3d54b8072d7ada715a45ea57a27ad10258075e9552b1c"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/wasm/component.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1247,
+                  "startColumn": 17,
+                  "charOffset": 55552,
+                  "charLength": 352,
+                  "snippet": {
+                    "text": "Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {\n                    captured_for_handler.lock().unwrap().push((\n                        dispatch.mail_id,\n                        dispatch.root,\n                        //noinspection DuplicatedCode\n                        dispatch.parent_mail,\n                    ));\n                })"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1247,
+                  "startColumn": 1,
+                  "charOffset": 55536,
+                  "charLength": 369,
+                  "snippet": {
+                    "text": "                Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {\n                    captured_for_handler.lock().unwrap().push((\n                        dispatch.mail_id,\n                        dispatch.root,\n                        //noinspection DuplicatedCode\n                        dispatch.parent_mail,\n                    ));\n                }),"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/wasm/component.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1316,
+                  "startColumn": 17,
+                  "charOffset": 58381,
+                  "charLength": 298,
+                  "snippet": {
+                    "text": "Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {\n                    captured_for_handler.lock().unwrap().push((\n                        dispatch.mail_id,\n                        dispatch.root,\n                        dispatch.parent_mail,\n                    ));\n                })"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1316,
+                  "startColumn": 1,
+                  "charOffset": 58365,
+                  "charLength": 315,
+                  "snippet": {
+                    "text": "                Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {\n                    captured_for_handler.lock().unwrap().push((\n                        dispatch.mail_id,\n                        dispatch.root,\n                        dispatch.parent_mail,\n                    ));\n                }),"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "daf7a17efb3c0912",
+            "equalIndicator/v1": "80e305e520c98032ea65d1113f14d9981869565f01fda7a1a127c701b110ef88"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/decode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 197,
+                  "startColumn": 9,
+                  "charOffset": 6917,
+                  "charLength": 257,
+                  "snippet": {
+                    "text": "SchemaType::Bool\n        | SchemaType::String\n        | SchemaType::Bytes\n        | SchemaType::Option(_)\n        | SchemaType::Vec(_)\n        | SchemaType::Enum { .. }\n        | SchemaType::Unit\n        | SchemaType::Ref(_)\n        | SchemaType::Map { .. }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 197,
+                  "startColumn": 1,
+                  "charOffset": 6909,
+                  "charLength": 328,
+                  "snippet": {
+                    "text": "        SchemaType::Bool\n        | SchemaType::String\n        | SchemaType::Bytes\n        | SchemaType::Option(_)\n        | SchemaType::Vec(_)\n        | SchemaType::Enum { .. }\n        | SchemaType::Unit\n        | SchemaType::Ref(_)\n        | SchemaType::Map { .. } => Err(DecodeError::UnsupportedSchema(NON_CAST_VARIANTS_MSG)),"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/encode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 720,
+                  "startColumn": 9,
+                  "charOffset": 29157,
+                  "charLength": 257,
+                  "snippet": {
+                    "text": "SchemaType::Bool\n        | SchemaType::String\n        | SchemaType::Bytes\n        | SchemaType::Option(_)\n        | SchemaType::Vec(_)\n        | SchemaType::Enum { .. }\n        | SchemaType::Unit\n        | SchemaType::Ref(_)\n        | SchemaType::Map { .. }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 720,
+                  "startColumn": 1,
+                  "charOffset": 29149,
+                  "charLength": 328,
+                  "snippet": {
+                    "text": "        SchemaType::Bool\n        | SchemaType::String\n        | SchemaType::Bytes\n        | SchemaType::Option(_)\n        | SchemaType::Vec(_)\n        | SchemaType::Enum { .. }\n        | SchemaType::Unit\n        | SchemaType::Ref(_)\n        | SchemaType::Map { .. } => Err(EncodeError::UnsupportedSchema(NON_CAST_VARIANTS_MSG)),"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "fc07817cb78d9b07",
+            "equalIndicator/v1": "825bb68a188d198dbe144b2c85ce1a960b74fe67f4a61a0950580785dbca74ed"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 764,
+                  "startColumn": 9,
+                  "charOffset": 29745,
+                  "charLength": 451,
+                  "snippet": {
+                    "text": "let vertices = vec![\n            pt(0.0, 0.0, 0.0), // 0: A bottom-left\n            pt(2.0, 0.0, 0.0), // 1: B bottom-right\n            pt(2.0, 2.0, 0.0), // 2: C top-right\n            pt(0.0, 2.0, 0.0), // 3: D top-left\n            pt(0.5, 0.5, 0.0), // 4: E hole bottom-left\n            pt(1.5, 0.5, 0.0), // 5: F hole bottom-right\n            pt(1.5, 1.5, 0.0), // 6: G hole top-right\n            pt(0.5, 1.5, 0.0), // 7: H hole top-left\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 764,
+                  "startColumn": 1,
+                  "charOffset": 29737,
+                  "charLength": 459,
+                  "snippet": {
+                    "text": "        let vertices = vec![\n            pt(0.0, 0.0, 0.0), // 0: A bottom-left\n            pt(2.0, 0.0, 0.0), // 1: B bottom-right\n            pt(2.0, 2.0, 0.0), // 2: C top-right\n            pt(0.0, 2.0, 0.0), // 3: D top-left\n            pt(0.5, 0.5, 0.0), // 4: E hole bottom-left\n            pt(1.5, 0.5, 0.0), // 5: F hole bottom-right\n            pt(1.5, 1.5, 0.0), // 6: G hole top-right\n            pt(0.5, 1.5, 0.0), // 7: H hole top-left\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/tessellate/cdt/triangulate.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 328,
+                  "startColumn": 9,
+                  "charOffset": 12238,
+                  "charLength": 395,
+                  "snippet": {
+                    "text": "let vertices = vec![\n            pt(0.0, 0.0, 0.0), // 0: outer BL\n            pt(2.0, 0.0, 0.0), // 1: outer BR\n            pt(2.0, 2.0, 0.0), // 2: outer TR\n            pt(0.0, 2.0, 0.0), // 3: outer TL\n            pt(0.5, 0.5, 0.0), // 4: hole BL\n            pt(1.5, 0.5, 0.0), // 5: hole BR\n            pt(1.5, 1.5, 0.0), // 6: hole TR\n            pt(0.5, 1.5, 0.0), // 7: hole TL\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 328,
+                  "startColumn": 1,
+                  "charOffset": 12230,
+                  "charLength": 403,
+                  "snippet": {
+                    "text": "        let vertices = vec![\n            pt(0.0, 0.0, 0.0), // 0: outer BL\n            pt(2.0, 0.0, 0.0), // 1: outer BR\n            pt(2.0, 2.0, 0.0), // 2: outer TR\n            pt(0.0, 2.0, 0.0), // 3: outer TL\n            pt(0.5, 0.5, 0.0), // 4: hole BL\n            pt(1.5, 0.5, 0.0), // 5: hole BR\n            pt(1.5, 1.5, 0.0), // 6: hole TR\n            pt(0.5, 1.5, 0.0), // 7: hole TL\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/tessellate/cdt/triangulate.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 365,
+                  "startColumn": 9,
+                  "charOffset": 13589,
+                  "charLength": 279,
+                  "snippet": {
+                    "text": "let vertices = vec![\n            pt(0.0, 0.0, 0.0),\n            pt(2.0, 0.0, 0.0),\n            pt(2.0, 2.0, 0.0),\n            pt(0.0, 2.0, 0.0),\n            pt(0.5, 0.5, 0.0),\n            pt(1.5, 0.5, 0.0),\n            pt(1.5, 1.5, 0.0),\n            pt(0.5, 1.5, 0.0),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 365,
+                  "startColumn": 1,
+                  "charOffset": 13581,
+                  "charLength": 287,
+                  "snippet": {
+                    "text": "        let vertices = vec![\n            pt(0.0, 0.0, 0.0),\n            pt(2.0, 0.0, 0.0),\n            pt(2.0, 2.0, 0.0),\n            pt(0.0, 2.0, 0.0),\n            pt(0.5, 0.5, 0.0),\n            pt(1.5, 0.5, 0.0),\n            pt(1.5, 1.5, 0.0),\n            pt(0.5, 1.5, 0.0),\n        ];"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "75ced28022d4fd5f",
+            "equalIndicator/v1": "83bdb4ef1da84c0df3bd9464ed138ce4f80a03285a4295e19b59e10e1657d07a"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 782,
+                  "startColumn": 9,
+                  "charOffset": 32651,
+                  "charLength": 370,
+                  "snippet": {
+                    "text": "write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 782,
+                  "startColumn": 1,
+                  "charOffset": 32643,
+                  "charLength": 378,
+                  "snippet": {
+                    "text": "        write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 843,
+                  "startColumn": 9,
+                  "charOffset": 35339,
+                  "charLength": 370,
+                  "snippet": {
+                    "text": "write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 843,
+                  "startColumn": 1,
+                  "charOffset": 35331,
+                  "charLength": 378,
+                  "snippet": {
+                    "text": "        write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 938,
+                  "startColumn": 9,
+                  "charOffset": 39386,
+                  "charLength": 370,
+                  "snippet": {
+                    "text": "write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 938,
+                  "startColumn": 1,
+                  "charOffset": 39378,
+                  "charLength": 378,
+                  "snippet": {
+                    "text": "        write_frame(\n            &mut stream,\n            &WireFrame::Hello(Hello {\n                wire_version: WIRE_VERSION,\n                peer: PeerKind::Client {\n                    client_name: \"test-client\".into(),\n                    client_version: \"0.0.1\".into(),\n                },\n            }),\n        )\n        .expect(\"test: write_frame Hello to rpc server\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2937b8c1223c78d1",
+            "equalIndicator/v1": "84210e7d944f64631b7fbb701e11a4d38edd16bfeeecf209bba9c2e535f21309"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/binding.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 708,
+                  "startColumn": 38,
+                  "charOffset": 32130,
+                  "charLength": 394,
+                  "snippet": {
+                    "text": "{\n                kind: dispatch.kind,\n                kind_name: dispatch.kind_name,\n                origin: dispatch.origin,\n                sender: dispatch.sender,\n                payload: dispatch.payload,\n                count: dispatch.count,\n                mail_id: dispatch.mail_id,\n                root: dispatch.root,\n                parent_mail: dispatch.parent_mail,\n            }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 708,
+                  "startColumn": 1,
+                  "charOffset": 32093,
+                  "charLength": 433,
+                  "snippet": {
+                    "text": "            let _ = tx.send(Envelope {\n                kind: dispatch.kind,\n                kind_name: dispatch.kind_name,\n                origin: dispatch.origin,\n                sender: dispatch.sender,\n                payload: dispatch.payload,\n                count: dispatch.count,\n                mail_id: dispatch.mail_id,\n                root: dispatch.root,\n                parent_mail: dispatch.parent_mail,\n            });"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/envelope.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 45,
+                  "startColumn": 14,
+                  "charOffset": 1837,
+                  "charLength": 354,
+                  "snippet": {
+                    "text": "{\n            kind: dispatch.kind,\n            kind_name: dispatch.kind_name,\n            origin: dispatch.origin,\n            sender: dispatch.sender,\n            payload: dispatch.payload,\n            count: dispatch.count,\n            mail_id: dispatch.mail_id,\n            root: dispatch.root,\n            parent_mail: dispatch.parent_mail,\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 45,
+                  "startColumn": 1,
+                  "charOffset": 1824,
+                  "charLength": 367,
+                  "snippet": {
+                    "text": "        Self {\n            kind: dispatch.kind,\n            kind_name: dispatch.kind_name,\n            origin: dispatch.origin,\n            sender: dispatch.sender,\n            payload: dispatch.payload,\n            count: dispatch.count,\n            mail_id: dispatch.mail_id,\n            root: dispatch.root,\n            parent_mail: dispatch.parent_mail,\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ae5b881c9d7efd82",
+            "equalIndicator/v1": "998456a235a5a52cd53f9abceebf7ce8ae034e23182f091b22a5d3fb9eb12b6a"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/handle_store.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1029,
+                  "startColumn": 5,
+                  "charOffset": 38823,
+                  "charLength": 454,
+                  "snippet": {
+                    "text": "fn note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"body\"),\n                    ty: SchemaType::String,\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1029,
+                  "startColumn": 1,
+                  "charOffset": 38819,
+                  "charLength": 458,
+                  "snippet": {
+                    "text": "    fn note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"body\"),\n                    ty: SchemaType::String,\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 602,
+                  "startColumn": 5,
+                  "charOffset": 27284,
+                  "charLength": 454,
+                  "snippet": {
+                    "text": "fn note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"body\"),\n                    ty: SchemaType::String,\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 602,
+                  "startColumn": 1,
+                  "charOffset": 27280,
+                  "charLength": 458,
+                  "snippet": {
+                    "text": "    fn note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"body\"),\n                    ty: SchemaType::String,\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "5aac7dde48c68479",
+            "equalIndicator/v1": "acae0d13832a92fb98de79a163c324505079c2419408b722606d7369ed251aa4"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/merge.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 212,
+                  "startColumn": 5,
+                  "charOffset": 8937,
+                  "charLength": 714,
+                  "snippet": {
+                    "text": "for (a, b) in keys {\n        let canonical = if a < b { (a, b) } else { (b, a) };\n        if !seen.insert(canonical) {\n            continue;\n        }\n\n        let forward = directed.get(&(a, b)).copied().unwrap_or(0);\n        let reverse = directed.get(&(b, a)).copied().unwrap_or(0);\n        match forward.cmp(&reverse) {\n            std::cmp::Ordering::Greater => {\n                for _ in 0..(forward - reverse) {\n                    edges.push((a, b));\n                }\n            }\n            std::cmp::Ordering::Less => {\n                for _ in 0..(reverse - forward) {\n                    edges.push((b, a));\n                }\n            }\n            std::cmp::Ordering::Equal => {}\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 212,
+                  "startColumn": 1,
+                  "charOffset": 8933,
+                  "charLength": 718,
+                  "snippet": {
+                    "text": "    for (a, b) in keys {\n        let canonical = if a < b { (a, b) } else { (b, a) };\n        if !seen.insert(canonical) {\n            continue;\n        }\n\n        let forward = directed.get(&(a, b)).copied().unwrap_or(0);\n        let reverse = directed.get(&(b, a)).copied().unwrap_or(0);\n        match forward.cmp(&reverse) {\n            std::cmp::Ordering::Greater => {\n                for _ in 0..(forward - reverse) {\n                    edges.push((a, b));\n                }\n            }\n            std::cmp::Ordering::Less => {\n                for _ in 0..(reverse - forward) {\n                    edges.push((b, a));\n                }\n            }\n            std::cmp::Ordering::Equal => {}\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/cleanup/provenance.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 130,
+                  "startColumn": 5,
+                  "charOffset": 5500,
+                  "charLength": 709,
+                  "snippet": {
+                    "text": "for (a, b) in keys {\n        let canonical = if a < b { (a, b) } else { (b, a) };\n        if !seen.insert(canonical) {\n            continue;\n        }\n        let forward = directed.get(&(a, b)).copied().unwrap_or(0);\n        let reverse = directed.get(&(b, a)).copied().unwrap_or(0);\n        match forward.cmp(&reverse) {\n            std::cmp::Ordering::Greater => {\n                for _ in 0..(forward - reverse) {\n                    out.push((a, b));\n                }\n            }\n            std::cmp::Ordering::Less => {\n                for _ in 0..(reverse - forward) {\n                    out.push((b, a));\n                }\n            }\n            std::cmp::Ordering::Equal => {}\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 130,
+                  "startColumn": 1,
+                  "charOffset": 5496,
+                  "charLength": 713,
+                  "snippet": {
+                    "text": "    for (a, b) in keys {\n        let canonical = if a < b { (a, b) } else { (b, a) };\n        if !seen.insert(canonical) {\n            continue;\n        }\n        let forward = directed.get(&(a, b)).copied().unwrap_or(0);\n        let reverse = directed.get(&(b, a)).copied().unwrap_or(0);\n        match forward.cmp(&reverse) {\n            std::cmp::Ordering::Greater => {\n                for _ in 0..(forward - reverse) {\n                    out.push((a, b));\n                }\n            }\n            std::cmp::Ordering::Less => {\n                for _ in 0..(reverse - forward) {\n                    out.push((b, a));\n                }\n            }\n            std::cmp::Ordering::Equal => {}\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0eaada78bde0161a",
+            "equalIndicator/v1": "b7503da8770256fef828456a11dac4d73d15898bfde3d33d9fb44ca0978e84d0"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/dispatch.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 91,
+                  "startColumn": 21,
+                  "charOffset": 4233,
+                  "charLength": 947,
+                  "snippet": {
+                    "text": "if actor\n                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)\n                        .is_none()\n                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)\n                    {\n                        // Issue 576: catch-all caps override\n                        // `__aether_dispatch_fallback` and return\n                        // `true` after their fallback runs,\n                        // suppressing this warn. Strict receivers\n                        // keep the default (returns `false`) and\n                        // surface the miss.\n                        tracing::warn!(\n                            target: \"aether_substrate::dispatch\",\n                            actor = A::NAMESPACE,\n                            kind = env.kind_name.as_str(),\n                            \"actor dispatch missed: kind not handled or decode failed\"\n                        );\n                    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 91,
+                  "startColumn": 1,
+                  "charOffset": 4213,
+                  "charLength": 967,
+                  "snippet": {
+                    "text": "                    if actor\n                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)\n                        .is_none()\n                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)\n                    {\n                        // Issue 576: catch-all caps override\n                        // `__aether_dispatch_fallback` and return\n                        // `true` after their fallback runs,\n                        // suppressing this warn. Strict receivers\n                        // keep the default (returns `false`) and\n                        // surface the miss.\n                        tracing::warn!(\n                            target: \"aether_substrate::dispatch\",\n                            actor = A::NAMESPACE,\n                            kind = env.kind_name.as_str(),\n                            \"actor dispatch missed: kind not handled or decode failed\"\n                        );\n                    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/dispatcher_slot.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 214,
+                  "startColumn": 21,
+                  "charOffset": 9696,
+                  "charLength": 579,
+                  "snippet": {
+                    "text": "if actor\n                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)\n                        .is_none()\n                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)\n                    {\n                        tracing::warn!(\n                            target: \"aether_substrate::dispatch\",\n                            actor = A::NAMESPACE,\n                            kind = env.kind_name.as_str(),\n                            \"actor dispatch missed: kind not handled or decode failed\"\n                        );\n                    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 214,
+                  "startColumn": 1,
+                  "charOffset": 9676,
+                  "charLength": 599,
+                  "snippet": {
+                    "text": "                    if actor\n                        .__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload)\n                        .is_none()\n                        && !actor.__aether_dispatch_fallback(&mut ctx, &env)\n                    {\n                        tracing::warn!(\n                            target: \"aether_substrate::dispatch\",\n                            actor = A::NAMESPACE,\n                            kind = env.kind_name.as_str(),\n                            \"actor dispatch missed: kind not handled or decode failed\"\n                        );\n                    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f5f00e437181a548",
+            "equalIndicator/v1": "c164a49aa43af5a655b273b6ad370aed55953c6751eb0330a3655c230625757c"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 706,
+                  "startColumn": 9,
+                  "charOffset": 29741,
+                  "charLength": 329,
+                  "snippet": {
+                    "text": "let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 706,
+                  "startColumn": 1,
+                  "charOffset": 29733,
+                  "charLength": 337,
+                  "snippet": {
+                    "text": "        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 761,
+                  "startColumn": 9,
+                  "charOffset": 31747,
+                  "charLength": 329,
+                  "snippet": {
+                    "text": "let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 761,
+                  "startColumn": 1,
+                  "charOffset": 31739,
+                  "charLength": 337,
+                  "snippet": {
+                    "text": "        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/rpc/server.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 988,
+                  "startColumn": 9,
+                  "charOffset": 41576,
+                  "charLength": 329,
+                  "snippet": {
+                    "text": "let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 988,
+                  "startColumn": 1,
+                  "charOffset": 41568,
+                  "charLength": 337,
+                  "snippet": {
+                    "text": "        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))\n            .with_actor::<RpcServerCapability>(RpcServerConfig {\n                bind_addr: \"127.0.0.1:0\".into(),\n                peer_kind: test_peer_kind(),\n            })\n            .build_passive()\n            .expect(\"rpc server boots\");"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b6dd0f6ce7486d1d",
+            "equalIndicator/v1": "d7a0c08d1575369af402ec39ecb7938dcb6088572ac22af1508c92a190dd7288"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/encode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 952,
+                  "startColumn": 9,
+                  "charOffset": 36813,
+                  "charLength": 240,
+                  "snippet": {
+                    "text": "let schema = cast_struct(vec![NamedField {\n            name: \"xs\".into(),\n            ty: SchemaType::Array {\n                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),\n                len: 4,\n            },\n        }]);"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 952,
+                  "startColumn": 1,
+                  "charOffset": 36805,
+                  "charLength": 248,
+                  "snippet": {
+                    "text": "        let schema = cast_struct(vec![NamedField {\n            name: \"xs\".into(),\n            ty: SchemaType::Array {\n                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),\n                len: 4,\n            },\n        }]);"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-codec/src/encode.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1023,
+                  "startColumn": 9,
+                  "charOffset": 39705,
+                  "charLength": 240,
+                  "snippet": {
+                    "text": "let schema = cast_struct(vec![NamedField {\n            name: \"xs\".into(),\n            ty: SchemaType::Array {\n                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),\n                len: 4,\n            },\n        }]);"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1023,
+                  "startColumn": 1,
+                  "charOffset": 39697,
+                  "charLength": 248,
+                  "snippet": {
+                    "text": "        let schema = cast_struct(vec![NamedField {\n            name: \"xs\".into(),\n            ty: SchemaType::Array {\n                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U8)),\n                len: 4,\n            },\n        }]);"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "7212ba13719a7692",
+            "equalIndicator/v1": "e46209beefc178b9d9b6492bfa6b070fd284c2ef674dde5b16c9bb1f6cccba21"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/handle_store.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1051,
+                  "startColumn": 5,
+                  "charOffset": 39436,
+                  "charLength": 490,
+                  "snippet": {
+                    "text": "fn held_note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"held\"),\n                    ty: SchemaType::Ref(SchemaCell::owned(note_schema())),\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1051,
+                  "startColumn": 1,
+                  "charOffset": 39432,
+                  "charLength": 494,
+                  "snippet": {
+                    "text": "    fn held_note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"held\"),\n                    ty: SchemaType::Ref(SchemaCell::owned(note_schema())),\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 618,
+                  "startColumn": 5,
+                  "charOffset": 27744,
+                  "charLength": 490,
+                  "snippet": {
+                    "text": "fn held_note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"held\"),\n                    ty: SchemaType::Ref(SchemaCell::owned(note_schema())),\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 618,
+                  "startColumn": 1,
+                  "charOffset": 27740,
+                  "charLength": 494,
+                  "snippet": {
+                    "text": "    fn held_note_schema() -> SchemaType {\n        SchemaType::Struct {\n            fields: Cow::Owned(vec![\n                NamedField {\n                    name: Cow::Borrowed(\"held\"),\n                    ty: SchemaType::Ref(SchemaCell::owned(note_schema())),\n                },\n                NamedField {\n                    name: Cow::Borrowed(\"seq\"),\n                    ty: SchemaType::Scalar(Primitive::U32),\n                },\n            ]),\n            repr_c: false,\n        }\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "64173f14df2b0e87",
+            "equalIndicator/v1": "eb0afc38030f7f2e1d1972ff9a7da957f043a5d765d6155bf9e4ce65c6a6f28e"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "DuplicatedCode",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Duplicated code",
+            "markdown": "Duplicated code"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-math/src/mat.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 136,
+                  "startColumn": 9,
+                  "charOffset": 4366,
+                  "charLength": 287,
+                  "snippet": {
+                    "text": "Self {\n            cols: [\n                Vec4::new(r0.x, r1.x, r2.x, 0.0),\n                Vec4::new(r0.y, r1.y, r2.y, 0.0),\n                Vec4::new(r0.z, r1.z, r2.z, 0.0),\n                Vec4::new(-row0.dot(t_xyz), -row1.dot(t_xyz), -row2.dot(t_xyz), 1.0),\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 136,
+                  "startColumn": 1,
+                  "charOffset": 4358,
+                  "charLength": 295,
+                  "snippet": {
+                    "text": "        Self {\n            cols: [\n                Vec4::new(r0.x, r1.x, r2.x, 0.0),\n                Vec4::new(r0.y, r1.y, r2.y, 0.0),\n                Vec4::new(r0.z, r1.z, r2.z, 0.0),\n                Vec4::new(-row0.dot(t_xyz), -row1.dot(t_xyz), -row2.dot(t_xyz), 1.0),\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-math/src/mat.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 157,
+                  "startColumn": 9,
+                  "charOffset": 5183,
+                  "charLength": 263,
+                  "snippet": {
+                    "text": "Self {\n            cols: [\n                Vec4::new(x.x, y.x, z.x, 0.0),\n                Vec4::new(x.y, y.y, z.y, 0.0),\n                Vec4::new(x.z, y.z, z.z, 0.0),\n                Vec4::new(-x.dot(eye), -y.dot(eye), -z.dot(eye), 1.0),\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 157,
+                  "startColumn": 1,
+                  "charOffset": 5175,
+                  "charLength": 271,
+                  "snippet": {
+                    "text": "        Self {\n            cols: [\n                Vec4::new(x.x, y.x, z.x, 0.0),\n                Vec4::new(x.y, y.y, z.y, 0.0),\n                Vec4::new(x.z, y.z, z.z, 0.0),\n                Vec4::new(-x.dot(eye), -y.dot(eye), -z.dot(eye), 1.0),\n            ],\n        }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "717c8d05e2ec4820",
+            "equalIndicator/v1": "fa47a6909a8cb8abecc622eab52fc63242e97f3dd8d1fa7678a251e856cc1b3e"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "DUPLICATES",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsConstantConditionIf",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "The condition is always false",
+            "markdown": "The condition is always false"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/builder.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 444,
+                  "startColumn": 31,
+                  "charOffset": 18044,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": "A::FRAME_BARRIER"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 442,
+                  "startColumn": 1,
+                  "charOffset": 17888,
+                  "charLength": 255,
+                  "snippet": {
+                    "text": "        // shutdown claim. Both share the same dispatcher trampoline\n        // shape apart from the post-dispatch decrement.\n        let claim_result = if A::FRAME_BARRIER {\n            ctx.claim_frame_bound_mailbox::<A>().map(|claim| {\n                ("
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "4e724b22b876a166",
+            "equalIndicator/v1": "cf3c3b2122a2a937d73ecb5137db2d5fd00455a49e56af5b962992410fb1f7ab"
+          },
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsThreadLocalStableMethodCanBeUsed",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Can be replaced with 'pipeline_tls::IN_LOG_PIPELINE.set(false)'",
+            "markdown": "Can be replaced with 'pipeline_tls::IN_LOG_PIPELINE.set(false)'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 259,
+                  "startColumn": 39,
+                  "charOffset": 10277,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "with"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 257,
+                  "startColumn": 1,
+                  "charOffset": 10184,
+                  "charLength": 130,
+                  "snippet": {
+                    "text": "impl Drop for PipelineGuard {\n    fn drop(&mut self) {\n        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(false));\n    }\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "678b42645c76d2e1",
+            "equalIndicator/v1": "05803e20879359671bccd9a2de68fe8263ca00c03b79d497ce7ee77a0c288835"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsThreadLocalStableMethodCanBeUsed",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Can be replaced with 'pipeline_tls::IN_LOG_PIPELINE.set(true)'",
+            "markdown": "Can be replaced with 'pipeline_tls::IN_LOG_PIPELINE.set(true)'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 252,
+                  "startColumn": 39,
+                  "charOffset": 10133,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "with"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 250,
+                  "startColumn": 1,
+                  "charOffset": 10049,
+                  "charLength": 131,
+                  "snippet": {
+                    "text": "impl PipelineGuard {\n    fn enter() -> Self {\n        pipeline_tls::IN_LOG_PIPELINE.with(|cell| cell.set(true));\n        Self\n    }"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "65da19cb4670f56a",
+            "equalIndicator/v1": "c670859c96d697d1700bfb674ca433cd83c97da8158aa7feb7d7fca36d3667b6"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/actor/ctx/sync_waiter.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 16,
+                  "startColumn": 7,
+                  "charOffset": 870,
+                  "charLength": 19,
+                  "snippet": {
+                    "text": "crate::mail::sync::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "charOffset": 721,
+                  "charLength": 278,
+                  "snippet": {
+                    "text": "//! `-1` = timeout, `-2` = payload exceeds buffer, `-3` = host tore the\n//! actor down mid-wait. The pure rc → `Result<K, E>` mapping lives in\n//! [`crate::mail::sync::decode_wait_reply`] for callers that want to\n//! reuse the sentinel decoding without going through the trait.\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "99c0760a5620c7b5",
+            "equalIndicator/v1": "0030bb7622debc80ac965564eb8f79ec1794098b290b41c3e7103affff93d8e5"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/runtime/log_install.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 66,
+                  "startColumn": 1,
+                  "charOffset": 3106,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "std::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 64,
+                  "startColumn": 1,
+                  "charOffset": 3103,
+                  "charLength": 127,
+                  "snippet": {
+                    "text": "}\n\nstd::thread_local! {\n    static ACTOR_DISPATCH: Cell<Option<&'static dyn MailDispatch>> =\n        const { Cell::new(None) };"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "51827692eaedabbf",
+            "equalIndicator/v1": "03eacd1bbfc2872c97804192b934df9d0496415bde250f55bbc6a21df80e7b4e"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 599,
+                  "startColumn": 19,
+                  "charOffset": 27203,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 597,
+                  "startColumn": 1,
+                  "charOffset": 27048,
+                  "charLength": 231,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.mailer_held_note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0003_0002);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e931ff6cfda58cf3",
+            "equalIndicator/v1": "059a5ace01f1cbcdc89be5aeeb440cd29f95cf152fd0872758a41aa2a36e488e"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/lib.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 37,
+                  "startColumn": 11,
+                  "charOffset": 2176,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "ffi::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 35,
+                  "startColumn": 1,
+                  "charOffset": 2046,
+                  "charLength": 316,
+                  "snippet": {
+                    "text": "//!     `actor::ctx::sync_waiter::wait_reply_via`.\n//!   - [`ffi`] — FFI binding layer: [`ffi::bridge`] dispatch ZSTs +\n//!     [`ffi::FfiActor`] trait + [`ffi::Replaceable`] hook trait +\n//!     [`ffi::FfiActorMailbox`] for the actor-typed sender chain +\n//!     the [`export!`] macro that pins `init` / `receive` /"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2e5fe267392ec209",
+            "equalIndicator/v1": "11e9ab43459498466e6808efea93bdc92a253910bb1ffc831c8c2870131e9b07"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-data/src/lib.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 526,
+                  "startColumn": 9,
+                  "charOffset": 22510,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 524,
+                  "startColumn": 1,
+                  "charOffset": 22358,
+                  "charLength": 195,
+                  "snippet": {
+                    "text": "    /// poisoned by a trait their `#[repr(C)]`-less layout can't satisfy.\n    pub fn encode_cast<T: bytemuck::NoUninit>(value: &T) -> Vec<u8> {\n        ::bytemuck::bytes_of(value).to_vec()\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "cdba26db8dbc5b24",
+            "equalIndicator/v1": "11ea436f37b9a67fde76ace4bf779cf9b278c8bdd8dd2c0344ea23f83bd9f4dd"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/mailbox.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 10,
+                  "startColumn": 17,
+                  "charOffset": 464,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "super::ctx::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 8,
+                  "startColumn": 1,
+                  "charOffset": 420,
+                  "charLength": 217,
+                  "snippet": {
+                    "text": "//! FFI-shaped wrapper.\n//!\n//! Built via [`super::ctx::NativeCtx::actor`] /\n//! [`super::ctx::NativeCtx::resolve_actor`] and their init variants.\n//! The compile-time `R: HandlesKind<K>` gate is the same as the prior"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e96c49b0b6373131",
+            "equalIndicator/v1": "11edb1f27f5563c70bb35b342035e9c49ff12faa81d0619d3b59492aacea0348"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/component.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 20,
+                  "startColumn": 22,
+                  "charOffset": 1134,
+                  "charLength": 25,
+                  "snippet": {
+                    "text": "aether_substrate::actor::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 18,
+                  "startColumn": 1,
+                  "charOffset": 1045,
+                  "charLength": 204,
+                  "snippet": {
+                    "text": "//! inside the trampoline, drop flows through `ctx.shutdown()`.\n//!\n//! [`NativeActor`]: aether_substrate::actor::native::NativeActor\n//!\n//! The cap is a `#[bridge] mod native { ... }` per the ADR-0076 /"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "a196f46b5588cd3f",
+            "equalIndicator/v1": "1363b9ce957130cd1b5d40a711e88c778740b8e48d5e346b0727edfe1c99fde1"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/binding.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 165,
+                  "startColumn": 41,
+                  "charOffset": 8601,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 163,
+                  "startColumn": 1,
+                  "charOffset": 8428,
+                  "charLength": 332,
+                  "snippet": {
+                    "text": "    /// `caller_frame_bound`, `frame_bound_set`, and `aborter` wire\n    /// the ADR-0074 §Decision 5 cross-class `wait_reply` guard.\n    /// Capabilities authored under a [`crate::ChassisCtx`] should\n    /// prefer [`Self::from_ctx`], which inherits the chassis's\n    /// shared set + aborter automatically; the explicit constructor"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e971d6b4733711fd",
+            "equalIndicator/v1": "139f88d0dd1528d69b78250e1a3a67d9d520b59ab1c8ad1f516e4246cf076e64"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 588,
+                  "startColumn": 19,
+                  "charOffset": 26790,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 586,
+                  "startColumn": 1,
+                  "charOffset": 26640,
+                  "charLength": 226,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.mailer_note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0003_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "cefe4ea40f15f375",
+            "equalIndicator/v1": "175b279cec563be61979dbe25bc15da194af49a379c019f75b14768aabe66fde"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 599,
+                  "startColumn": 43,
+                  "charOffset": 27227,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 597,
+                  "startColumn": 1,
+                  "charOffset": 27048,
+                  "charLength": 231,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.mailer_held_note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0003_0002);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d635f9e5af1e3be2",
+            "equalIndicator/v1": "1b3c5f23df71584796ae0bf7ac0e808b0db9af8f208b2784e30d6dcc1fdde364"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/ffi/mailbox.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 8,
+                  "charOffset": 511,
+                  "charLength": 20,
+                  "snippet": {
+                    "text": "crate::ffi::bridge::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 9,
+                  "startColumn": 1,
+                  "charOffset": 379,
+                  "charLength": 246,
+                  "snippet": {
+                    "text": "//! variant is lifetime-free — it carries no transport reference\n//! because the FFI imports are global to the loaded module\n//! ([`crate::ffi::bridge::MAIL_BRIDGE`] is the dispatch surface).\n//!\n//! Built via [`crate::ffi::ctx::FfiCtx::actor`] /"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2074d39116e6632a",
+            "equalIndicator/v1": "1c8bf81bec69cb4ccaaf86c901c27ad7ac34fef2058ff8b08935048358c1fe48"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-kinds/src/trace.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 313,
+                  "startColumn": 7,
+                  "charOffset": 11376,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 311,
+                  "startColumn": 1,
+                  "charOffset": 11268,
+                  "charLength": 297,
+                  "snippet": {
+                    "text": "/// (`TraceObserverCapability`) when a causal chain's `in_flight`\n/// counter hits zero, addressed to\n/// [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`]. The chassis-side\n/// dispatcher switch routes this kind into the gate-site\n/// notification map and signals every subscriber waiting on `root`."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "15abba0c8a63a5b2",
+            "equalIndicator/v1": "1d140f71d682f21fe0503cd1bb3940f49449bf33497b2d72669a0009bbb9754f"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 62,
+                  "startColumn": 19,
+                  "charOffset": 3071,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": "crate::chassis::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 60,
+                  "startColumn": 1,
+                  "charOffset": 2924,
+                  "charLength": 227,
+                  "snippet": {
+                    "text": "    /// Desktop's winit driver, headless's std-timer driver, hub's\n    /// listener-and-MCP driver. Passive chassis (test-bench)\n    /// declare [`crate::chassis::builder::NeverDriver`] here.\n    type Driver: DriverCapability;\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "7c712d314d6d527e",
+            "equalIndicator/v1": "1d2bb6b655a8bd5e9cd9c5002822e625fb823d0de1173c333c3f8ab93ea52703"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/spawn.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 63,
+                  "startColumn": 11,
+                  "charOffset": 2801,
+                  "charLength": 14,
+                  "snippet": {
+                    "text": "aether_actor::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 61,
+                  "startColumn": 1,
+                  "charOffset": 2682,
+                  "charLength": 257,
+                  "snippet": {
+                    "text": "    /// Subname is empty, contains `:`, has control / whitespace\n    /// chars, or exceeds the byte cap. See\n    /// [`aether_actor::NamespaceError`].\n    SubnameInvalid(NamespaceError),\n    /// `A::NAMESPACE` is already owned by a different `TypeId`. Trips"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "3dcb01be8b2c988b",
+            "equalIndicator/v1": "1f64e43dd7ea39a7bc45967f6f00c12129cbe9ebaba98a2f4185ad61409819a6"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 67,
+                  "startColumn": 22,
+                  "charOffset": 3181,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 65,
+                  "startColumn": 1,
+                  "charOffset": 3027,
+                  "charLength": 241,
+                  "snippet": {
+                    "text": "/// handler exit and on `WARN`/`ERROR` priority flush. Backed by\n/// issue #582's [`Local`] primitive — one slot per actor, accessed\n/// via TLS-routed [`crate::local::ActorSlots`].\n#[derive(Default)]\npub struct LogBuffer(pub Vec<LogEvent>);"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "dd53bb5e93f67c3e",
+            "equalIndicator/v1": "259970e69f6c2e3b007794aa8ab568279875bdb9d15daf18ed98438628476f20"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/ffi/bridge/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 9,
+                  "charOffset": 658,
+                  "charLength": 11,
+                  "snippet": {
+                    "text": "sync_wait::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 12,
+                  "startColumn": 1,
+                  "charOffset": 537,
+                  "charLength": 234,
+                  "snippet": {
+                    "text": "//! - [`persist::PersistBridge`] — migration-bundle deposit\n//!   (`save_state`), used during `on_replace` only.\n//! - [`sync_wait::SyncWaitBridge`] — blocking reply receive\n//!   (`wait_reply`), the ADR-0042 sync round-trip path.\n//!"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d2b4dd6a84dd942a",
+            "equalIndicator/v1": "27909b044a068efbc4463cecb46037475e2dfc4affd5841a4d6b329e17afe7d9"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/render/pipeline.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 48,
+                  "charOffset": 450,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "super::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 6,
+                  "startColumn": 1,
+                  "charOffset": 269,
+                  "charLength": 270,
+                  "snippet": {
+                    "text": "//! target + `Depth32Float` depth target with `LessEqual` testing.\n//! Desktop additionally builds its own wireframe-overlay pipeline\n//! (using [`super::vertex_buffer_layout`] + [`super::MAIN_SHADER_WGSL`])\n//! and runs it as an extra draw inside [`record_main_pass`].\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "738b932be7a66f9f",
+            "equalIndicator/v1": "285d2343668d92126e13764c576c2673cc308bb6aae96843efb922adaf44dc4c"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-data/src/lib.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 533,
+                  "startColumn": 9,
+                  "charOffset": 22809,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 531,
+                  "startColumn": 1,
+                  "charOffset": 22697,
+                  "charLength": 197,
+                  "snippet": {
+                    "text": "    /// independent of `serde`.\n    pub fn encode_postcard<T: serde::Serialize>(value: &T) -> Vec<u8> {\n        ::postcard::to_allocvec(value).expect(\"postcard encode to Vec is infallible\")\n    }\n}"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "bf95ab31151fbb73",
+            "equalIndicator/v1": "32bc35510e71b8f015dcde5b8c40b4b167b84f997b4d821b46462b07fd25915d"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/ctx.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 196,
+                  "startColumn": 49,
+                  "charOffset": 8660,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 194,
+                  "startColumn": 1,
+                  "charOffset": 8482,
+                  "charLength": 319,
+                  "snippet": {
+                    "text": "    /// when set, the trampoline drains any remaining inbox mail\n    /// synchronously, runs `NativeActor::unwire`, and exits the\n    /// dispatch loop. After exit the actor's [`crate::MailboxId`]\n    /// transitions from `Live` to `Dead` in the chassis's\n    /// [`crate::ActorRegistry`] and is added to `tombstones` —"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "c0d3842e115cebd1",
+            "equalIndicator/v1": "3f6d87fc9abfec00214fa8c86171f09f90a71d0b8e684c4e46339c21a57b5303"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/spawn.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 3,
+                  "startColumn": 17,
+                  "charOffset": 92,
+                  "charLength": 24,
+                  "snippet": {
+                    "text": "crate::actor::registry::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "charOffset": 0,
+                  "charLength": 286,
+                  "snippet": {
+                    "text": "//! Spawn primitive for instanced actors (ADR-0079, issue 607 Phase 3).\n//!\n//! Builds on [`crate::actor::registry::ActorRegistry`] (Phase 2) to add\n//! the atomic register-and-spawn dance: validate subname → check\n//! tombstones + name-owner uniqueness → call `A::init` on the caller's"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "a8613f615d41fa00",
+            "equalIndicator/v1": "422cb5098222bbfb9bb986d41423dcac4c3491c6752c29ca6d47b1019f288b6d"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/scheduler/pool.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 14,
+                  "charOffset": 159,
+                  "charLength": 27,
+                  "snippet": {
+                    "text": "crate::runtime::lifecycle::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 2,
+                  "startColumn": 1,
+                  "charOffset": 72,
+                  "charLength": 280,
+                  "snippet": {
+                    "text": "//!\n//! The pool's only inputs at construction time are a worker count, a\n//! shared [`crate::runtime::lifecycle::FatalAborter`], and an optional\n//! ready-queue capacity (today the queue is unbounded — backpressure\n//! happens at the per-actor inbox level, not at the scheduler)."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "9df5fe9dbc8379f6",
+            "equalIndicator/v1": "4cb3045aa8cffebd6ba833fff2652a03c12ea8e8c55bcda470225b86d4aac135"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 38,
+                  "startColumn": 7,
+                  "charOffset": 1515,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "ctx::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 36,
+                  "startColumn": 1,
+                  "charOffset": 1393,
+                  "charLength": 268,
+                  "snippet": {
+                    "text": "//! Cross-thread access from drivers / embedders flows through\n//! cap-exported sub-handles published in `init` via\n//! [`ctx::NativeInitCtx::publish_handle`] and retrieved via\n//! [`crate::DriverCtx::handle`]. The actor itself never escapes its\n//! dispatcher thread."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "227c67724e03b61d",
+            "equalIndicator/v1": "556df11b922ecf1786985dae482532d8cdb3210b1323dcdc7f9f16712ecbd8f3"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/mailbox.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 7,
+                  "charOffset": 503,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "super::ctx::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 9,
+                  "startColumn": 1,
+                  "charOffset": 444,
+                  "charLength": 264,
+                  "snippet": {
+                    "text": "//!\n//! Built via [`super::ctx::NativeCtx::actor`] /\n//! [`super::ctx::NativeCtx::resolve_actor`] and their init variants.\n//! The compile-time `R: HandlesKind<K>` gate is the same as the prior\n//! parametric form: `ctx.actor::<RenderCapability>().send(&triangle)`"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d0820bd1b4305e11",
+            "equalIndicator/v1": "605f7ea4dfea2a4f665ab2b0caef04dc9bc8db9ea11728934590e74ff96fd9d3"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-kinds/src/trace.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 310,
+                  "startColumn": 7,
+                  "charOffset": 11222,
+                  "charLength": 14,
+                  "snippet": {
+                    "text": "crate::trace::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 308,
+                  "startColumn": 1,
+                  "charOffset": 11163,
+                  "charLength": 206,
+                  "snippet": {
+                    "text": "\n/// ADR-0080 §6 settlement notification. Emitted by\n/// [`crate::trace::BatchedTraceEvents`]'s consumer\n/// (`TraceObserverCapability`) when a causal chain's `in_flight`\n/// counter hits zero, addressed to"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "175c652d52087f84",
+            "equalIndicator/v1": "629dc144c73a504b0b801cd4c0d1176af428889a8bebcb40324f34979dadbdda"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/runtime/trace.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 9,
+                  "charOffset": 234,
+                  "charLength": 17,
+                  "snippet": {
+                    "text": "crossbeam_queue::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 5,
+                  "startColumn": 1,
+                  "charOffset": 89,
+                  "charLength": 340,
+                  "snippet": {
+                    "text": "//! - **Producer-side helpers** (`record_sent` / `record_received` /\n//!   `record_finished`) push [`TraceEvent`]s onto a process-global\n//!   [`crossbeam_queue::SegQueue`]. The hooks live in\n//!   [`crate::actor::native::binding::NativeBinding::send_mail_with_lineage`]\n//!   (Sent), the native dispatcher trampoline (Received / Finished),"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2ad284f0bbe450d2",
+            "equalIndicator/v1": "74d593e65d6f4c6e2834e001f8852c66083d9205c91f3b65409f83efba33c1c2"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 438,
+                  "startColumn": 43,
+                  "charOffset": 17450,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 436,
+                  "startColumn": 1,
+                  "charOffset": 17328,
+                  "charLength": 174,
+                  "snippet": {
+                    "text": "    impl Kind for FakePod {\n        const NAME: &'static str = \"test.fake_pod\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0002);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "9ab6d3ba590bf6d4",
+            "equalIndicator/v1": "755f0ee5e60a7b022105e482a63e775e9f5c051fe6eced6b338881783c61467f"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/handle_store.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1026,
+                  "startColumn": 43,
+                  "charOffset": 38766,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1024,
+                  "startColumn": 1,
+                  "charOffset": 38599,
+                  "charLength": 219,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0002_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b996e72a012705ad",
+            "equalIndicator/v1": "798feb1d269b0cd9e4f8ec815f4511ccf2076b9d1558e0384ac0230960907397"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 426,
+                  "startColumn": 43,
+                  "charOffset": 17050,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 424,
+                  "startColumn": 1,
+                  "charOffset": 16931,
+                  "charLength": 171,
+                  "snippet": {
+                    "text": "    impl Kind for FakeKind {\n        const NAME: &'static str = \"test.fake\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0dd7b9fe9f3d5a16",
+            "equalIndicator/v1": "7b6a01ff871357308bff0ba57cc609f19cfaffbcf4c0a7f7b9f73db39440ed05"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/lib.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 38,
+                  "startColumn": 11,
+                  "charOffset": 2244,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "ffi::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 36,
+                  "startColumn": 1,
+                  "charOffset": 2097,
+                  "charLength": 328,
+                  "snippet": {
+                    "text": "//!   - [`ffi`] — FFI binding layer: [`ffi::bridge`] dispatch ZSTs +\n//!     [`ffi::FfiActor`] trait + [`ffi::Replaceable`] hook trait +\n//!     [`ffi::FfiActorMailbox`] for the actor-typed sender chain +\n//!     the [`export!`] macro that pins `init` / `receive` /\n//!     lifecycle FFI exports plus the `aether.kinds.inputs` /"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "57aeee293d5cc0b7",
+            "equalIndicator/v1": "7db90c79978834a805e030e36d3912d6c45fa2153a264db19ca53f5ba8d1740c"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/ffi/bridge/mail.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 19,
+                  "charOffset": 379,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "crate::ffi::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 7,
+                  "startColumn": 1,
+                  "charOffset": 289,
+                  "charLength": 282,
+                  "snippet": {
+                    "text": "//!\n//! ZST whose inherent methods forward to the matching `extern \"C\"`\n//! host fns in [`crate::ffi::raw`]. `send_mail` pushes a typed payload\n//! at a recipient mailbox; `reply_mail` routes to the originator of\n//! the mail currently being dispatched; `prev_correlation` reads the"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0618a2a8cc854838",
+            "equalIndicator/v1": "81803d50ce3bbfb801c3cd9b1aee0b1fb51242add49c3bd505a736f9b66cedc9"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-mesh/src/tessellate.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 22,
+                  "startColumn": 34,
+                  "charOffset": 1056,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 20,
+                  "startColumn": 1,
+                  "charOffset": 882,
+                  "charLength": 342,
+                  "snippet": {
+                    "text": "//! historically because both ran on the post-CSG polygon stream, but\n//! they answer different questions and have different consumers — the\n//! polygon-domain public API ([`crate::cleanup::run_to_loops`] +\n//! [`crate::polygon::mesh_polygons`]) skips tessellation entirely\n//! because n-gon polygons are the canonical mesh form per ADR-0057."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "6ddd0d4ed6dd237d",
+            "equalIndicator/v1": "83105f79ba69b839d82d318e23245b3242d8e7c97860cf18ae5417e7c2911aef"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/wasm/component.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1090,
+                  "startColumn": 30,
+                  "charOffset": 48859,
+                  "charLength": 23,
+                  "snippet": {
+                    "text": "crate::mail::outbound::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1088,
+                  "startColumn": 1,
+                  "charOffset": 48774,
+                  "charLength": 222,
+                  "snippet": {
+                    "text": "        use aether_data::{KindDescriptor, SchemaType};\n\n        let (outbound, rx) = crate::mail::outbound::HubOutbound::attached_loopback();\n        let registry = Arc::new(Registry::new());\n        let pong_id = registry"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "7ab4ee2c3e02a2c2",
+            "equalIndicator/v1": "8767517efb349ac3c6951c2819f51b095ecfd9194150aa2c1354f3283132e251"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/ctx.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 258,
+                  "startColumn": 55,
+                  "charOffset": 11813,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 256,
+                  "startColumn": 1,
+                  "charOffset": 11689,
+                  "charLength": 260,
+                  "snippet": {
+                    "text": "\n    /// Issue 607 Phase 3b (ADR-0079): spawn an instanced actor as a\n    /// child of the calling actor. The new actor's [`crate::ReplyTo`]\n    /// stamps the calling actor's mailbox so any reply addressed to\n    /// `ReplyTarget::Component` routes back here."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "910a375bb96e282f",
+            "equalIndicator/v1": "8d30b90bfac2c00b6fef07a5daa2d5413977d1a429a071a43a64a08bb138dcd0"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/builder.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 17,
+                  "startColumn": 24,
+                  "charOffset": 766,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": "crate::chassis::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 15,
+                  "startColumn": 1,
+                  "charOffset": 630,
+                  "charLength": 313,
+                  "snippet": {
+                    "text": "//! - Trait family + builder + ctx wiring.\n//! - [`Chassis::Driver`] / [`Chassis::Env`] / [`Chassis::build`] are\n//!   not yet on the [`crate::chassis::Chassis`] trait — they land\n//!   alongside the first real driver extraction (phase 3) so every\n//!   chassis can nominate a real driver type rather than a stub."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0469d78964def794",
+            "equalIndicator/v1": "91ded66a597da8fe564cc74fb05f8438e06b85d77dc82aa05418fb8566b174fd"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/mail/mailer.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 588,
+                  "startColumn": 43,
+                  "charOffset": 26814,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 586,
+                  "startColumn": 1,
+                  "charOffset": 26640,
+                  "charLength": 226,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.mailer_note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0003_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f30815c693075937",
+            "equalIndicator/v1": "92a3bbf54d7f523f1f178bbd73f9b7c0bd5abcd7546938fa2acb0e07569f72ee"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 438,
+                  "startColumn": 19,
+                  "charOffset": 17426,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 436,
+                  "startColumn": 1,
+                  "charOffset": 17328,
+                  "charLength": 174,
+                  "snippet": {
+                    "text": "    impl Kind for FakePod {\n        const NAME: &'static str = \"test.fake_pod\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0002);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f222f0736b536351",
+            "equalIndicator/v1": "93e251928d49d49d43b9e51ae825267f9b563dae7b0a817675263440ce2a8408"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/settlement.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 17,
+                  "startColumn": 7,
+                  "charOffset": 778,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 15,
+                  "startColumn": 1,
+                  "charOffset": 663,
+                  "charLength": 233,
+                  "snippet": {
+                    "text": "//! Both fire when the [`crate::actor::native`] dispatcher routes a\n//! `Settled { root }` mail addressed to\n//! [`aether_data::MailboxId::CHASSIS_MAILBOX_ID`] through the\n//! registry's [`SettlementRegistry::fire_settled`] hook.\n//!"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "1d0cbb5a1e3ccc45",
+            "equalIndicator/v1": "9472e4b54ffd186bf8185fc5294b3ecb681814ea59365c6a9f38d273fdce0dea"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/ffi/bridge/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 12,
+                  "startColumn": 9,
+                  "charOffset": 545,
+                  "charLength": 9,
+                  "snippet": {
+                    "text": "persist::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 10,
+                  "startColumn": 1,
+                  "charOffset": 447,
+                  "charLength": 263,
+                  "snippet": {
+                    "text": "//!   async-handles the reply — it's mail-level metadata, not a\n//!   sync-wait artifact.\n//! - [`persist::PersistBridge`] — migration-bundle deposit\n//!   (`save_state`), used during `on_replace` only.\n//! - [`sync_wait::SyncWaitBridge`] — blocking reply receive"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "30f6a3ca2ce17dcd",
+            "equalIndicator/v1": "97b1600c321a6cedf690683962396ab1abbee31266640c93cde8e70884c8f372"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/builder.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1084,
+                  "startColumn": 11,
+                  "charOffset": 44422,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1082,
+                  "startColumn": 1,
+                  "charOffset": 44294,
+                  "charLength": 300,
+                  "snippet": {
+                    "text": "    frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,\n    /// Membership view of the same set; shared with every\n    /// [`crate::NativeBinding`] booted under this chassis so the\n    /// cross-class `wait_reply` guard can classify recipients.\n    /// Populated alongside `frame_bound_pending` by"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "23e58a054e1f8ec2",
+            "equalIndicator/v1": "9a2a7bf6650c529379d6edd6f9a21cdd22c53816ecad836e2d265fbd4c5db77b"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/render/pipeline.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 14,
+                  "charOffset": 416,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "super::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 6,
+                  "startColumn": 1,
+                  "charOffset": 269,
+                  "charLength": 270,
+                  "snippet": {
+                    "text": "//! target + `Depth32Float` depth target with `LessEqual` testing.\n//! Desktop additionally builds its own wireframe-overlay pipeline\n//! (using [`super::vertex_buffer_layout`] + [`super::MAIN_SHADER_WGSL`])\n//! and runs it as an extra draw inside [`record_main_pass`].\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b07379e8ce643555",
+            "equalIndicator/v1": "a141e9d7c62d128ad1854e6b63876742c60d16ab8e11be98f186e84c6d99994a"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/lib.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 37,
+                  "startColumn": 37,
+                  "charOffset": 2202,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "ffi::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 35,
+                  "startColumn": 1,
+                  "charOffset": 2046,
+                  "charLength": 316,
+                  "snippet": {
+                    "text": "//!     `actor::ctx::sync_waiter::wait_reply_via`.\n//!   - [`ffi`] — FFI binding layer: [`ffi::bridge`] dispatch ZSTs +\n//!     [`ffi::FfiActor`] trait + [`ffi::Replaceable`] hook trait +\n//!     [`ffi::FfiActorMailbox`] for the actor-typed sender chain +\n//!     the [`export!`] macro that pins `init` / `receive` /"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ec8db9791923e5e1",
+            "equalIndicator/v1": "a3599da259a87361acbe65088a383cc4abcf81997b1f22401d92579f771c304c"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/monitor.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 7,
+                  "charOffset": 440,
+                  "charLength": 24,
+                  "snippet": {
+                    "text": "crate::actor::registry::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 7,
+                  "startColumn": 1,
+                  "charOffset": 380,
+                  "charLength": 143,
+                  "snippet": {
+                    "text": "//!\n//! See ADR-0079 for the lifecycle semantics; the\n//! [`crate::actor::registry::ActorRegistry`] holds the forward and\n//! reverse indices.\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f6dbaa7492f0872f",
+            "equalIndicator/v1": "a8b828088d8c9e7251d893244eae1b426b811fb42a3137a5c8eec30c7f310838"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/builder.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1623,
+                  "startColumn": 24,
+                  "charOffset": 66861,
+                  "charLength": 25,
+                  "snippet": {
+                    "text": "crate::chassis::builder::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1621,
+                  "startColumn": 1,
+                  "charOffset": 66710,
+                  "charLength": 318,
+                  "snippet": {
+                    "text": "    /// drivers) clone this once and feed it to\n    /// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`] each frame —\n    /// same role as [`crate::chassis::builder::DriverCtx::frame_bound_pending`]\n    /// on the driver-build path.\n    pub fn frame_bound_pending(&self) -> Vec<(MailboxId, Arc<AtomicU64>)> {"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d1d59458ec12c99a",
+            "equalIndicator/v1": "a90daccce37bed2d64aa65d4f9183db1e37555cd929def29928f71ee0cd03f39"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mailbox.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 161,
+                  "startColumn": 19,
+                  "charOffset": 5606,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 159,
+                  "startColumn": 1,
+                  "charOffset": 5511,
+                  "charLength": 171,
+                  "snippet": {
+                    "text": "    impl Kind for FakeKind {\n        const NAME: &'static str = \"test.fake\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "2ab1111c4458ba5e",
+            "equalIndicator/v1": "ac4f8dc66dbda1028e7242fd85092a755c836847f0693345669680d7ba95b0fb"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/actor/native/dispatcher_slot.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 16,
+                  "startColumn": 31,
+                  "charOffset": 756,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "charOffset": 602,
+                  "charLength": 327,
+                  "snippet": {
+                    "text": "//! 1. CAS `Ready → Running` on the [`SlotState`] (caller invariant:\n//!    the slot was just popped from the ready queue).\n//! 2. Drains envelopes via [`crate::NativeBinding::try_recv`] until\n//!    inbox is empty, the budget is exhausted, or shutdown fires.\n//!    Per-envelope wrapping is `local::with_stamped(slots, ...)` +"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f7f148b80d789c4b",
+            "equalIndicator/v1": "b1aa494b383e8a4f1e7278797713e65385c76911b021c9780d3c0e98970f80f5"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/handle_store.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1026,
+                  "startColumn": 19,
+                  "charOffset": 38742,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "::aether_data::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1024,
+                  "startColumn": 1,
+                  "charOffset": 38599,
+                  "charLength": 219,
+                  "snippet": {
+                    "text": "        const NAME: &'static str = \"test.note\";\n        // Stable test sentinel — distinct from real schema-hashed kind ids.\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0002_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "df21784b6fc706ec",
+            "equalIndicator/v1": "b2aa1fc67a3487c6b84ce308f67cccf3d50be58fc71888b21c8680cd9c3bd45a"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-substrate/src/chassis/builder.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1090,
+                  "startColumn": 11,
+                  "charOffset": 44771,
+                  "charLength": 7,
+                  "snippet": {
+                    "text": "crate::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 1088,
+                  "startColumn": 1,
+                  "charOffset": 44646,
+                  "charLength": 281,
+                  "snippet": {
+                    "text": "    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,\n    /// Cloned into every `ChassisCtx` and onto every booted\n    /// [`crate::NativeBinding`] so the cross-class `wait_reply`\n    /// guard has somewhere to abort to. Inherited from the\n    /// [`Builder`]'s configured aborter."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "3d61be88a096dfbf",
+            "equalIndicator/v1": "b835e37c1c40405297d85d2ff4d4ff7bde8c69068d3ba58c30ea8ca236f6bd8e"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 240,
+                  "startColumn": 21,
+                  "charOffset": 9818,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 238,
+                  "startColumn": 1,
+                  "charOffset": 9689,
+                  "charLength": 294,
+                  "snippet": {
+                    "text": "                let registry = Arc::new(Registry::new());\n                let store = ::std::sync::Arc::new(\n                    ::aether_substrate::handle_store::HandleStore::new(1024 * 1024),\n                );\n                let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "842c82f0930f066e",
+            "equalIndicator/v1": "c4624c471d40d43fe318c10267b6e6bfc72416e257d85449d7f3f746d4411d28"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 19,
+                  "charOffset": 536,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "crate::mail::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 9,
+                  "startColumn": 1,
+                  "charOffset": 416,
+                  "charLength": 229,
+                  "snippet": {
+                    "text": "//! [`Mailbox<K>`](crate::mail::mailbox) addressing token lives in\n//! the [`mailbox`] submodule; the\n//! [`WaitError`](crate::mail::sync::WaitError) trait + the rc-decode\n//! helper for `wait_reply` returns live in\n//! [`sync`]."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "39350824c1352df8",
+            "equalIndicator/v1": "da9a2717405bdf11dace8a7d895c958fec5cbd95cb87976d98a9e26883ee38be"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 426,
+                  "startColumn": 19,
+                  "charOffset": 17026,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 424,
+                  "startColumn": 1,
+                  "charOffset": 16931,
+                  "charLength": 171,
+                  "snippet": {
+                    "text": "    impl Kind for FakeKind {\n        const NAME: &'static str = \"test.fake\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ce2a49c989f96adf",
+            "equalIndicator/v1": "de34d3f1dcb282f10a8eae58383959c4851b185640d2cea46cc85f1cfa262808"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/ffi/bridge/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 9,
+                  "charOffset": 252,
+                  "charLength": 6,
+                  "snippet": {
+                    "text": "mail::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 5,
+                  "startColumn": 1,
+                  "charOffset": 180,
+                  "charLength": 266,
+                  "snippet": {
+                    "text": "//! `FfiTransport` ZST impl into one ZST per FFI op family:\n//!\n//! - [`mail::MailBridge`] — outbound mail (`send_mail`, `reply_mail`,\n//!   `prev_correlation`). Correlation lives here because every send\n//!   mints one regardless of whether the caller sync-waits or"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "7c3ffc518da8ccaf",
+            "equalIndicator/v1": "e5d1b61056ac9490bf217fecc17376a3b7f0468d6342db7b5ff16243ffd840c4"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mailbox.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 161,
+                  "startColumn": 43,
+                  "charOffset": 5630,
+                  "charLength": 2,
+                  "snippet": {
+                    "text": "::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 159,
+                  "startColumn": 1,
+                  "charOffset": 5511,
+                  "charLength": 171,
+                  "snippet": {
+                    "text": "    impl Kind for FakeKind {\n        const NAME: &'static str = \"test.fake\";\n        const ID: ::aether_data::KindId = ::aether_data::KindId(0xDEAD_BEEF_0001_0001);\n    }\n"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "a45c1be3ea79554d",
+            "equalIndicator/v1": "e9c87e10f8efc7e94e29d528baff295b9bb45818d35af7f09f538b5c3e72d5b7"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/mail/mod.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 20,
+                  "charOffset": 435,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "crate::mail::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 7,
+                  "startColumn": 1,
+                  "charOffset": 293,
+                  "charLength": 294,
+                  "snippet": {
+                    "text": "//! `PriorState` bundle, and `ReplyTo` opaque handle live here in\n//! `mod.rs` (pure decoders, no transport coupling). The\n//! [`Mailbox<K>`](crate::mail::mailbox) addressing token lives in\n//! the [`mailbox`] submodule; the\n//! [`WaitError`](crate::mail::sync::WaitError) trait + the rc-decode"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "1ae2475987c94cd3",
+            "equalIndicator/v1": "eeb8b6fb0351708b3ae1791e9d09a84f3293ef889024cc45bd47984de851eb95"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-capabilities/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 239,
+                  "startColumn": 29,
+                  "charOffset": 9775,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "::std::sync::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 237,
+                  "startColumn": 1,
+                  "charOffset": 9675,
+                  "charLength": 226,
+                  "snippet": {
+                    "text": "            {\n                let registry = Arc::new(Registry::new());\n                let store = ::std::sync::Arc::new(\n                    ::aether_substrate::handle_store::HandleStore::new(1024 * 1024),\n                );"
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b5c10c0633286c00",
+            "equalIndicator/v1": "ef42e58baa42417907155ff18512e5ad6efaea9df5fd3630fbf13e26313f9c18"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "RsUnnecessaryQualifications",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Path prefix not necessary",
+            "markdown": "Path prefix not necessary"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "crates/aether-actor/src/log.rs",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 240,
+                  "startColumn": 15,
+                  "charOffset": 9741,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "crate::log::"
+                  },
+                  "sourceLanguage": "Rust"
+                },
+                "contextRegion": {
+                  "startLine": 238,
+                  "startColumn": 1,
+                  "charOffset": 9660,
+                  "charLength": 254,
+                  "snippet": {
+                    "text": "\n/// `true` iff we're currently inside the drain / host-ship path.\n/// Read by [`crate::log::is_in_pipeline`] consumers (chiefly the\n/// actor-aware layer in `aether-substrate::log_install`); set + cleared\n/// by the internal `PipelineGuard` RAII helper."
+                  },
+                  "sourceLanguage": "Rust"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "5066c9bec703edaf",
+            "equalIndicator/v1": "fa98cf6f0fd690e2cd30f51b3aa1429703b4e6536ff7e92a04860b4722c6e7a2"
+          },
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "problemType": "REGULAR",
+            "tags": [
+              "Rust"
+            ]
+          }
+        },
+        {
+          "ruleId": "TomlUnresolvedReference",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Cannot resolve file '*'",
+            "markdown": "Cannot resolve file '\\*'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Cargo.toml",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 20,
+                  "charOffset": 695,
+                  "charLength": 1,
+                  "snippet": {
+                    "text": "*"
+                  },
+                  "sourceLanguage": "TOML"
+                },
+                "contextRegion": {
+                  "startLine": 21,
+                  "startColumn": 1,
+                  "charOffset": 552,
+                  "charLength": 167,
+                  "snippet": {
+                    "text": "# (see ADR-0003 §Consequences) and must be excluded so they aren't\n# auto-absorbed into this workspace via the parent-walk.\nexclude = [\"spikes/*\"]\n\n[workspace.package]"
+                  },
+                  "sourceLanguage": "TOML"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b37c53c291380948",
+            "equalIndicator/v1": "2a74efc6cee3857a958dc6898a1e9a22f003c71409d49f1ae2c2dd10ed1292c7"
+          },
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "problemType": "REGULAR",
+            "tags": [
+              "TOML"
+            ]
+          }
+        }
+      ],
+      "automationDetails": {
+        "id": "project/qodana/2026-05-18",
+        "guid": "665d5aaf-6708-409b-aff3-5d6371609ed4",
+        "properties": {
+          "jobUrl": "https://github.com/iamacoffeepot/aether/actions/runs/26023147698",
+          "analysisKind": "regular"
+        }
+      },
+      "newlineSequences": [
+        "\r\n",
+        "\n"
+      ],
+      "properties": {
+        "qodana.coverage.files.provided": false,
+        "configProfile": "recommended",
+        "deviceId": "200820300000000-b163-d8df-6be5-f02643189070",
+        "qodanaNewResultSummary": {
+          "high": 3,
+          "moderate": 85,
+          "total": 88
+        }
+      }
+    }
+  ]
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -39,3 +39,28 @@ exclude:
 # rationale on `args:` in .github/workflows/qodana.yml. Bootstrap
 # adds ~60-90s per run.
 bootstrap: apt-get update && apt-get install -y libasound2-dev && rustup install 1.95.0 --profile default --no-self-update && rustup default 1.95.0 && rustup component add rust-src rust-analyzer
+
+# Baseline absorbs the 88 remaining findings on main as of commit
+# abc9f38 (post the iamacoffeepot/aether#913 Phase 1-6 sweep). The
+# baseline file is a snapshot SARIF; Qodana suppresses anything
+# already present there. Only NEW findings beyond the baseline
+# surface as failures. The 88 are all known-acceptable patterns:
+# - 55 RsUnnecessaryQualifications: rustdoc / defensive leading
+#   `::` / cross-crate paths the rustc lint can't catch.
+# - 28 DuplicatedCode: trait-impl-facade and mirror patterns.
+#   //noinspection annotations from PR iamacoffeepot/aether#931
+#   serve as in-source documentation but Qodana CLI does not
+#   honour them (works only in the IDE).
+# - 2 RsThreadLocalStableMethodCanBeUsed: IN_LOG_PIPELINE pair
+#   intentionally retains `.with(|c| c.set(...))` because the
+#   wasm32 branch wraps Cell in a custom `Slot` type that lacks
+#   the LocalKey<Cell<T>>::set shortcut.
+# - 1 TomlUnresolvedReference: the workspace `exclude =
+#   ["spikes/*"]` glob; valid cargo syntax Qodana misparses.
+# - 1 CargoUnusedDependency: `anyhow` in aether-substrate kept
+#   per its Cargo.toml comment reserving it for the planned
+#   wasmtime::Result -> anyhow::Result rename (issue 571).
+# - 1 RsConstantConditionIf: generic trait const `A::FRAME_BARRIER`
+#   evaluated against trait default (false); concrete impls
+#   override it to true.
+baseline: qodana.sarif.json


### PR DESCRIPTION
## What

Closes the iamacoffeepot/aether#913 Qodana triage umbrella. The phase-by-phase sweep took main from **424 findings** (post the toolchain components fix iamacoffeepot/aether#916) down to **88 all-acceptable-pattern residuals**. This PR baselines those 88 and removes `continue-on-error: true` from the Qodana workflow so future PRs fail CI on any NEW finding.

## Baseline contents (88 residuals)

| Rule | Count | Why baselined |
|---|---|---|
| `RsUnnecessaryQualifications` | 55 | Rustdoc-style paths, defensive leading `::` in macro-callable consts, and cross-crate paths the rustc `unused_qualifications` lint cannot catch. |
| `DuplicatedCode` | 28 | Trait-impl-facade and mirror patterns (FfiCtx/FfiDropCtx, NativeCtx/NativeDropCtx, encoder/decoder twins, desktop/headless chassis scaffolding, math primitive mirrors, mesh cleanup validators). The `//noinspection` annotations applied in iamacoffeepot/aether#931 serve as in-source documentation but Qodana CLI does **not** honour them — they only work in the IDE. |
| `RsThreadLocalStableMethodCanBeUsed` | 2 | `pipeline_tls::IN_LOG_PIPELINE` pair intentionally retains `.with(\|c\| c.set(...))` because the wasm32 branch wraps `Cell` in a custom `Slot` type that lacks the `LocalKey<Cell<T>>::set` shortcut. |
| `TomlUnresolvedReference` | 1 | The workspace `exclude = ["spikes/*"]` glob; valid cargo syntax Qodana misparses. |
| `CargoUnusedDependency` | 1 | `anyhow` in `aether-substrate` kept per its `Cargo.toml` comment reserving it for the planned `wasmtime::Result → anyhow::Result` rename (issue 571). |
| `RsConstantConditionIf` | 1 | Generic trait const `A::FRAME_BARRIER` evaluated against the trait default (`false`); concrete impls override it to `true`. The audit-FP pattern previously documented during clippy adoption. |

## Changes

- **`qodana.sarif.json`** (new, ~819 KB) — baseline snapshot of the 88 residuals as of main commit `abc9f38`.
- **`qodana.yaml`** — add `baseline: qodana.sarif.json` + a comment block documenting the residual categories.
- **`.github/workflows/qodana.yml`** — drop `continue-on-error: true`. Qodana now exits non-zero (and fails the PR) on findings new relative to the baseline.

## Verification

This PR's own Qodana run exercises the flipped workflow — should pass cleanly because no new findings are introduced (diff is purely the baseline file + config). Future PRs that introduce a new Qodana finding will see the Qodana check go red on the PR itself.

## Lessons captured

- `//noinspection DuplicatedCode` works in the IntelliJ IDE but **not** in Qodana CLI / CI scans (worth a memory entry; the iamacoffeepot/aether#931 annotations now serve only as human documentation).
- Phase Final's "strictness flip" was deferrable until the baseline mechanism replaced source-level suppression as the integration with `--baseline qodana.sarif.json` — much cleaner than per-finding annotations.

## Closes

Closes iamacoffeepot/aether#913.
