### PR TITLE
ci(qodana): drop continue-on-error so new findings gate the merge

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -14,11 +14,14 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
-    # Report-only while the EAP linter beds in — Qodana action defaults
-    # to exit-non-zero on findings, which would fail PR CI on every
-    # false positive. Flip to required by removing this line once the
-    # noise floor is understood.
-    continue-on-error: true
+    # Strictness flip: PR 935 + 936 walked the 88-then-21 backlog
+    # down to zero baseline findings, so a new "N new problems" Qodana
+    # PR comment now gates the merge instead of just reporting. The
+    # earlier `continue-on-error: true` was kept while the EAP linter's
+    # false-positive floor was unknown; that argument retires once the
+    # baseline reaches zero (iamacoffeepot/aether#936). Re-add the flag
+    # only if a future linter bump regresses on confirmed false
+    # positives we can't suppress at source.
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The Qodana job has been report-only since CI bootstrap (the comment in qodana.yml literally said *"Flip to required by removing this line once the noise floor is understood."*). PR 935 (88-residual sweep) and PR 936 (21-residual main sweep) walked the backlog down to zero baseline; the noise-floor argument retires with them.

This also closes the second of two failures stacked on the invariants.rs DC fingerprint that walked into main on PR 936:

1. *My oversight* — I checked `gh pr checks 936` (saw Qodana "pass") instead of `gh pr view 936 --comments` where the diff actually surfaces. PR 937 closes the fingerprint cascade.
2. *Config gap* — even with the new-problem comment in plain sight, `continue-on-error: true` let the workflow return success regardless. Branch protection saw "Qodana scan: pass" and the PR merged.

With this flag gone, a future "N new problems" Qodana comment fails the check and blocks the merge. The two together close the loop: PR 937 brings the codebase back to zero, this PR makes sure the next regression actually blocks.

Re-add `continue-on-error: true` only if a future linter bump regresses on confirmed false positives we can't suppress at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)