### PR TITLE
ci(repo): allow meta-scopes in issue titles

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -21,7 +21,11 @@ jobs:
             // Allowed types match the existing `type:*` label set.
             const TYPES = ['feat', 'fix', 'chore', 'docs', 'perf', 'refactor', 'flake'];
 
-            // {type}({crate}): <subject>  OR  {type}({crate}/{subfeat}): <subject>
+            // Meta-scopes: cross-cutting work that isn't a single crate.
+            // No `crate:*` label is applied for these.
+            const META_SCOPES = ['ci', 'docs', 'adr', 'qodana', 'repo', 'release', 'workflow'];
+
+            // {type}({scope}): <subject>  OR  {type}({scope}/{subfeat}): <subject>
             const titleRegex = new RegExp(
               '^(' + TYPES.join('|') + ')\\(([a-z0-9-]+)(?:/[a-z0-9-]+)?\\): .+$'
             );
@@ -57,19 +61,25 @@ jobs:
                 .map(l => l.name.slice('crate:'.length))
                 .sort();
 
-              if (!validCrates.includes(crateFromTitle)) {
+              const isCrate = validCrates.includes(crateFromTitle);
+              const isMeta = META_SCOPES.includes(crateFromTitle);
+
+              if (!isCrate && !isMeta) {
                 messages.push(
-                  'Scope `' + crateFromTitle + '` is not a known crate. ' +
-                  'Valid: ' + validCrates.join(', ') + '.'
+                  'Scope `' + crateFromTitle + '` is not a known crate or meta-scope. ' +
+                  'Valid crates: ' + validCrates.join(', ') + '. ' +
+                  'Valid meta-scopes: ' + META_SCOPES.join(', ') + '.'
                 );
                 if (!labels.includes('invalid-title')) {
                   labelsToAdd.push('invalid-title');
                 }
               } else {
                 const wantType = 'type:' + typeFromTitle;
-                const wantCrate = 'crate:' + crateFromTitle;
                 if (!labels.includes(wantType)) labelsToAdd.push(wantType);
-                if (!labels.includes(wantCrate)) labelsToAdd.push(wantCrate);
+                if (isCrate) {
+                  const wantCrate = 'crate:' + crateFromTitle;
+                  if (!labels.includes(wantCrate)) labelsToAdd.push(wantCrate);
+                }
                 if (labels.includes('invalid-title')) {
                   labelsToRemove.push('invalid-title');
                 }


### PR DESCRIPTION
## Summary

- The issue-label-bot derives valid scopes from `crate:*` repo labels only, so cross-cutting titles (`chore(ci): ...`, `fix(qodana): ...`, `docs(adr): ...`) always get flagged `invalid-title` — even though those scopes match the muscle memory the team already uses on commits and branches.
- Adds a `META_SCOPES` allowlist (`ci`, `docs`, `adr`, `qodana`, `repo`, `release`, `workflow`) checked alongside the crate set. Meta-scoped issues get the `type:*` label but no `crate:*` (they don't map to a single crate).
- Error message now lists both buckets so the bot self-documents the valid surface.

Context: surfaced on iamacoffeepot/aether#946, which was filed as `chore(ci): ...` and immediately flagged. The valid-scope set was strictly crate-derived; this restores the natural conventional-commits scope vocabulary.

## Test plan

- [ ] Edit a stale `invalid-title` issue (e.g. iamacoffeepot/aether#946) — the rolling bot comment should clear and `crate:*` should not be applied since the scope is meta.
- [ ] File a throwaway issue with title `foo(bar): test` — should still flag (unknown scope), and the error message should list both valid crates and valid meta-scopes.
- [ ] Existing crate-scoped issues remain unaffected (still get `crate:*` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)