### PR TITLE
chore(ci): add pre-push pre-flight hook + claude-side gate

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Pre-flight gate for Claude-driven `git push` / `gh pr create` Bash calls.
+#
+# The git pre-push hook (.githooks/pre-push) does the same gating for any
+# pusher (CLI, IDE, Claude). What this Claude-side hook adds:
+#
+#   1. Earlier failure. The check fires before `git push` starts uploading,
+#      so a stale tree fails in milliseconds instead of after a slow push +
+#      pre-push pre-flight cycle.
+#
+#   2. The RustRover MCP nudge. The git hook can only run shell-callable
+#      checks (fmt / clippy / doc / nextest / wasm32). The qodana-equivalent
+#      surface lives in RustRover's IDE inspector, callable as the
+#      `mcp__rustrover__get_file_problems` MCP tool from Claude. This hook
+#      reminds Claude to run that tool over the diff before pushing.
+#
+# Reads the Bash tool-call JSON from stdin (Claude Code PreToolUse hook
+# protocol). Exits 0 to allow, 2 to block (stdout body returns to Claude).
+
+set -u
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+case "$command" in
+    *"git push"*|*"gh pr create"*) ;;
+    *) exit 0 ;;
+esac
+
+# User-elected bypass. The git pre-push hook will also see --no-verify.
+case "$command" in
+    *"--no-verify"*) exit 0 ;;
+esac
+
+if ! command -v git >/dev/null 2>&1; then
+    exit 0
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    exit 0
+fi
+
+head_sha=$(git rev-parse HEAD 2>/dev/null || true)
+[[ -z "$head_sha" ]] && exit 0
+
+stamp_file="$(git rev-parse --git-dir)/aether-preflight-passed"
+if [[ -f "$stamp_file" ]]; then
+    stamped_sha=$(awk '{print $1}' "$stamp_file" 2>/dev/null || echo)
+    if [[ "$stamped_sha" == "$head_sha" ]]; then
+        exit 0
+    fi
+fi
+
+# No matching stamp. Compute the diff vs origin/main so the message tells
+# Claude exactly which files to inspect.
+if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    base=$(git merge-base HEAD origin/main 2>/dev/null \
+        || git rev-parse origin/main)
+else
+    base=$(git rev-parse HEAD~1 2>/dev/null || echo "$head_sha")
+fi
+rust_files=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    [[ "$f" =~ \.rs$ ]] && rust_files+=("$f")
+done < <(git diff --name-only "$base..HEAD" 2>/dev/null || true)
+
+{
+    echo "[claude pre-push] no pre-flight stamp for HEAD ($head_sha)."
+    echo
+    echo "Before pushing, run the local pre-flight:"
+    echo
+    echo "    scripts/preflight.sh"
+    echo
+    if [[ ${#rust_files[@]} -gt 0 ]]; then
+        echo "Then run \`mcp__rustrover__get_file_problems\` over each changed .rs"
+        echo "file (the qodana-equivalent that preflight.sh can't run locally):"
+        echo
+        for f in "${rust_files[@]}"; do
+            echo "    - $f"
+        done
+        echo
+    fi
+    echo "Once preflight.sh exits 0 the stamp updates and the push proceeds."
+    echo "To bypass deliberately (e.g. emergency docs push), re-run the push"
+    echo "with --no-verify."
+} >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-pr-body.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-pre-push.sh"
           }
         ]
       },

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Pre-push hook: runs scripts/preflight.sh against the ref(s) being pushed.
+#
+# Enable with: scripts/setup-githooks.sh  (sets core.hooksPath -> .githooks)
+# Bypass once with: git push --no-verify
+#
+# Stamp short-circuit: if .git/aether-preflight-passed records the current
+# HEAD sha, the pre-flight is skipped (you just ran it). Any new commit
+# invalidates the stamp.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+z40=$(printf '%040d' 0)
+stamp_file="$(git rev-parse --git-dir)/aether-preflight-passed"
+
+if [[ -f "$stamp_file" ]]; then
+    head_sha=$(git rev-parse HEAD)
+    stamped_sha=$(awk '{print $1}' "$stamp_file" 2>/dev/null || echo)
+    if [[ "$stamped_sha" == "$head_sha" ]]; then
+        echo "[pre-push] HEAD $(git rev-parse --short HEAD) already passed; skipping."
+        exit 0
+    fi
+fi
+
+# Pre-push stdin: one line per ref being pushed.
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# Collect the changed-file union across all pushed refs.
+changed_files=()
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [[ -z "${local_sha:-}" ]] && continue
+    # Skip deletions (local_sha is all-zero).
+    [[ "$local_sha" == "$z40" ]] && continue
+
+    if [[ "${remote_sha:-}" == "$z40" || -z "${remote_sha:-}" ]]; then
+        # New branch: compare against origin/main if it exists.
+        if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            base=$(git merge-base "$local_sha" origin/main 2>/dev/null \
+                || git rev-parse origin/main)
+        else
+            base=$(git rev-parse "$local_sha"~1 2>/dev/null || echo "$local_sha")
+        fi
+    else
+        base="$remote_sha"
+    fi
+
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && changed_files+=("$f")
+    done < <(git diff --name-only "$base..$local_sha" 2>/dev/null || true)
+done
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+    echo "[pre-push] no refs / no changed files; allowing push."
+    exit 0
+fi
+
+# Dedupe and forward to preflight.sh.
+unique_files=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && unique_files+=("$f")
+done < <(printf '%s\n' "${changed_files[@]}" | sort -u)
+
+exec "$ROOT/scripts/preflight.sh" --files "${unique_files[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,22 @@ Components declare their receive-side kind vocabulary with `#[handlers]` on a si
 - Format: `cargo fmt` (check-only: `cargo fmt -- --check`)
 - Type/borrow check only: `cargo check`
 
+## Pre-push pre-flight
+
+`scripts/preflight.sh` runs the CI-equivalent local checks (fmt + clippy + doc + nextest + wasm32 component cross-build) over the workspace. The pre-push git hook at `.githooks/pre-push` invokes it automatically against the changed-file set for each push, and stamps `.git/aether-preflight-passed` with the HEAD sha on success so a re-push of the same commit short-circuits.
+
+Enable once per clone: `scripts/setup-githooks.sh` (sets `core.hooksPath -> .githooks`).
+
+Exception classes — pushes that skip the Rust pre-flight:
+
+- **Docs-only**: every changed path matches `docs/**` or `*.md` at the root.
+- **CI / repo-config-only**: every changed path is `.github/**`, `.claude/**`, `.githooks/**`, `scripts/**`, `qodana.{yaml,sarif.json}`, `.mcp.json`, `.gitignore`, `.gitattributes`, or `{rust-toolchain,rustfmt,clippy}.toml`. CI itself runs on workflow changes and validates the workflow shape.
+- A mixed push (e.g. one `.rs` + one `.md`) runs the full pre-flight; the exception only applies when every file matches the class.
+
+A Claude-side hook (`.claude/hooks/check-pre-push.sh`) checks the stamp ahead of `git push` / `gh pr create`. If HEAD doesn't have a matching stamp, the hook blocks the push and prompts Claude to run `scripts/preflight.sh` plus `mcp__rustrover__get_file_problems` over each changed `.rs` file — the qodana-equivalent surface the shell-only git hook can't reach.
+
+Bypass either layer with `git push --no-verify` (or omit the matching stamp deliberately and skip the Claude hook by tagging the override per the existing hook conventions).
+
 ## Qodana pre-flight (local)
 
 Qodana gates merges via the `ci-pass` aggregator (iamacoffeepot/aether#941), but running `qodana scan` locally is blocked: the container's cargo-metadata pass times out on the colima virtiofs bind mount. The local equivalent is RustRover's inspection set — Qodana's `qodana.recommended` profile rehosts most of its checks from the same IntelliJ inspector RustRover runs in-IDE.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Runs the CI-equivalent local pre-flight on the workspace.
+#
+# Mirrors the CI gates (.github/workflows/ci.yml) that are feasible
+# to run locally: fmt + clippy + doc + nextest + wasm32 component
+# cross-build. Qodana is omitted (running `qodana scan` locally is
+# blocked by colima virtiofs; see CLAUDE.md § "Qodana pre-flight").
+#
+# On success, writes `.git/aether-preflight-passed` with the current
+# HEAD sha + unix timestamp. The pre-push hook (.githooks/pre-push)
+# uses this stamp to skip pre-flight when HEAD already passed.
+#
+# Usage:
+#   scripts/preflight.sh                       # diff vs origin/main
+#   scripts/preflight.sh --files A B ...       # explicit changed-file set
+#                                              # (used by .githooks/pre-push)
+#   scripts/preflight.sh --force               # ignore exception classes,
+#                                              # run the full check set
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+force=0
+explicit=0
+explicit_files=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --files)
+            explicit=1
+            shift
+            while [[ $# -gt 0 && "$1" != --* ]]; do
+                explicit_files+=("$1")
+                shift
+            done
+            ;;
+        --force)
+            force=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "preflight: unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+stamp_pass() {
+    mkdir -p "$(git rev-parse --git-dir)"
+    echo "$(git rev-parse HEAD) $(date -u +%s)" \
+        > "$(git rev-parse --git-dir)/aether-preflight-passed"
+}
+
+if (( force )); then
+    needs_rust=1
+    needs_skip=0
+    bucket_msg="--force; running full pre-flight"
+else
+    if (( explicit )); then
+        changed=("${explicit_files[@]}")
+    else
+        if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            base=$(git merge-base HEAD origin/main 2>/dev/null \
+                || git rev-parse origin/main)
+        else
+            base=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+        fi
+        changed=()
+        while IFS= read -r f; do
+            [[ -n "$f" ]] && changed+=("$f")
+        done < <(git diff --name-only "$base..HEAD")
+    fi
+
+    if [[ ${#changed[@]} -eq 0 ]]; then
+        echo "[preflight] no changed files; nothing to check."
+        stamp_pass
+        exit 0
+    fi
+
+    docs_pat='^(docs/|.*\.md$)'
+    ci_pat='^(\.github/|\.claude/|\.githooks/|scripts/|qodana\.yaml$|qodana\.sarif\.json$|\.mcp\.json$|\.gitignore$|\.gitattributes$|rust-toolchain\.toml$|rustfmt\.toml$|clippy\.toml$)'
+    rust_pat='(\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$)'
+
+    all_docs=1
+    all_ci=1
+    any_rust=0
+    for f in "${changed[@]}"; do
+        [[ "$f" =~ $docs_pat ]] || all_docs=0
+        [[ "$f" =~ $ci_pat ]] || all_ci=0
+        [[ "$f" =~ $rust_pat ]] && any_rust=1
+    done
+
+    needs_skip=0
+    needs_rust=0
+    bucket_msg=""
+    if (( all_docs )); then
+        needs_skip=1
+        bucket_msg="docs-only change; skipping Rust pre-flight"
+    elif (( all_ci )); then
+        needs_skip=1
+        bucket_msg="CI/repo-config-only change; CI will self-validate"
+    elif (( any_rust )); then
+        needs_rust=1
+        bucket_msg="Rust source / Cargo manifest changed; running full pre-flight"
+    else
+        needs_skip=1
+        bucket_msg="no compile-path change; skipping Rust pre-flight"
+    fi
+fi
+
+echo "[preflight] $bucket_msg."
+
+if (( needs_skip )); then
+    stamp_pass
+    exit 0
+fi
+
+run_step() {
+    local label="$1"
+    shift
+    echo "  -> $label"
+    "$@"
+}
+
+run_step "cargo fmt --all -- --check" \
+    cargo fmt --all -- --check
+
+run_step "cargo clippy --workspace --all-targets -- -D warnings" \
+    cargo clippy --workspace --all-targets -- -D warnings
+
+run_step "cargo doc --workspace --no-deps (rustdoc lints denied)" \
+    env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
+    cargo doc --workspace --no-deps
+
+# Wasm32 component cross-build mirrors CI's pre-test step. Component
+# crates are discovered structurally (issue #439): cdylib lib target
+# AND a dep on `aether-actor`.
+echo "  -> wasm32 component cross-build"
+comp_pkgs=$(cargo metadata --format-version=1 --no-deps |
+    jq -r '.packages[]
+        | select(.targets[]?.kind | (. // []) | contains(["cdylib"]))
+        | select([.dependencies[]?.name] | contains(["aether-actor"]))
+        | .name' || true)
+if [[ -n "${comp_pkgs:-}" ]]; then
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        echo "     . $pkg"
+        cargo build --target wasm32-unknown-unknown -p "$pkg" --quiet
+    done <<< "$comp_pkgs"
+else
+    echo "     (no component crates discovered)"
+fi
+
+# Final, slowest step. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a
+# missing wasm artifact fails loudly rather than skipping silently.
+run_step "cargo nextest run --workspace --all-features --profile ci" \
+    env AETHER_REQUIRE_RUNTIME=1 \
+    cargo nextest run --workspace --all-features --profile ci
+
+stamp_pass
+echo "[preflight] OK."

--- a/scripts/setup-githooks.sh
+++ b/scripts/setup-githooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Wires up the repo's git hooks: sets core.hooksPath to .githooks so the
+# pre-push gate runs the local CI-equivalent pre-flight before each push.
+#
+# Idempotent. Re-run safely.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/preflight.sh
+
+echo "git hooks installed: core.hooksPath -> .githooks"
+echo
+echo "The pre-push hook runs scripts/preflight.sh against the changed file"
+echo "set for the push (fmt + clippy + doc + nextest + wasm32 cross-build)."
+echo "Skipped automatically for docs-only and CI-only pushes."
+echo
+echo "Bypass once with:   git push --no-verify"
+echo "Run pre-flight ad-hoc:  scripts/preflight.sh"


### PR DESCRIPTION
Closes iamacoffeepot/aether#946.

## Summary

- `scripts/preflight.sh` — runs the CI-equivalent local check set (`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo doc` with rustdoc lints denied, `cargo nextest run --workspace --all-features --profile ci`, wasm32 component cross-build). Buckets the changed-file set into docs-only / CI-repo-only / Rust-touched and skips the slow path when nothing under the compile surface changed. Stamps `.git/aether-preflight-passed` with HEAD sha + unix timestamp on success.
- `.githooks/pre-push` — reads the standard pre-push stdin protocol, builds the changed-file union across pushed refs, forwards to `scripts/preflight.sh --files`. Short-circuits when the stamp matches HEAD (re-push of the same commit is free).
- `.claude/hooks/check-pre-push.sh` — intercepts `git push` and `gh pr create` Bash tool-calls. If the stamp doesn't match HEAD, exits 2 with a message telling Claude to run `scripts/preflight.sh` plus `mcp__rustrover__get_file_problems` over each changed `.rs` file (the qodana-equivalent surface the shell-only git hook can't reach). `--no-verify` bypasses both layers.
- `scripts/setup-githooks.sh` — one-time per clone, sets `core.hooksPath -> .githooks` and chmods the scripts. Documented in CLAUDE.md.

Exception buckets (a push that matches one of these skips the Rust pre-flight):

- **Docs-only**: every changed path is `docs/**` or `*.md`.
- **CI/repo-config-only**: `.github/**`, `.claude/**`, `.githooks/**`, `scripts/**`, `qodana.{yaml,sarif.json}`, `.mcp.json`, `.gitignore`, `.gitattributes`, `{rust-toolchain,rustfmt,clippy}.toml`. CI itself runs unconditionally on workflow changes.
- Mixed (one `.rs` + one `.md`) runs the full pre-flight; exceptions only apply when every file matches the class.

## Test plan

- [x] Smoke-tested both bucket-skip paths (docs-only, CI-only) and the rust-bucket detection.
- [x] Claude hook: exit 2 without stamp, exit 0 with matching stamp, exit 0 on `--no-verify`.
- [x] Git pre-push: stdin protocol parsed correctly; stamp-match short-circuits.
- [x] This PR itself: `preflight.sh` correctly buckets the whole diff as no-compile-path and skips; the Claude hook saw the matching stamp and allowed the push.
- [ ] Run `scripts/setup-githooks.sh` in a clone and push a Rust-touching change to exercise the full pre-flight pipeline end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)