### PR TITLE
feat(substrate/trace): settlement hold gates root until spawn_inherit threads exit

### DIFF
--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -59,9 +59,17 @@ mod native {
     /// settlement is the moment this hits zero (PR 3 wires the
     /// `Settled` mail emission). PR 2 keeps the count for tests and
     /// future consumers.
+    ///
+    /// `held_open` tracks ADR-0080 §12 settlement holds — currently
+    /// only `InheritCtx<A>` from `NativeCtx::spawn_inherit` produces
+    /// these via [`aether_substrate::runtime::trace::acquire_settlement_hold`].
+    /// `Settled` emission gates on `(in_flight == 0 && held_open == 0)`
+    /// so a worker thread that outlives its spawning handler keeps the
+    /// chain open until it drops.
     #[derive(Debug, Clone)]
     pub struct RootState {
         pub in_flight: u32,
+        pub held_open: u32,
         pub last_event_at: Instant,
     }
 
@@ -151,6 +159,7 @@ mod native {
                     let now = Instant::now();
                     let root_state = self.roots.entry(root).or_insert(RootState {
                         in_flight: 0,
+                        held_open: 0,
                         last_event_at: now,
                     });
                     root_state.in_flight = root_state.in_flight.saturating_add(1);
@@ -194,19 +203,54 @@ mod native {
                         if let Some(state) = self.roots.get_mut(&root) {
                             state.in_flight = state.in_flight.saturating_sub(1);
                             state.last_event_at = Instant::now();
-                            // ADR-0080 §6: settlement fires when the
-                            // chain's in-flight count transitions to
-                            // zero. We push `Settled { root }` to
-                            // `CHASSIS_MAILBOX_ID` via the bare mailer
-                            // so the outbound doesn't generate trace
-                            // events; the chassis-router decodes the
-                            // payload and signals every gate-site
-                            // subscriber waiting on this root.
-                            if state.in_flight == 0 {
+                            // ADR-0080 §6 / §12: settlement fires when
+                            // BOTH `in_flight` and `held_open` reach zero
+                            // (the latter gates thread-spawn primitives
+                            // — see iamacoffeepot/aether#716). We push
+                            // `Settled { root }` to `CHASSIS_MAILBOX_ID`
+                            // via the bare mailer so the outbound
+                            // doesn't generate trace events; the chassis-
+                            // router decodes the payload and signals every
+                            // gate-site subscriber waiting on this root.
+                            if state.in_flight == 0 && state.held_open == 0 {
                                 self.fire_settled(root);
                             }
                         }
                     }
+                }
+                // ADR-0080 §12 / iamacoffeepot/aether#716: spawn-thread
+                // primitives push HoldOpen on acquire and Release on the
+                // hold's Drop. Both ride the same trace queue as Sent /
+                // Received / Finished so ordering is preserved: a
+                // HoldOpen pushed by the parent thread before the worker
+                // starts is folded into the observer's state before the
+                // parent handler's Finished arrives.
+                TraceEvent::HoldOpen { root, t: _ } => {
+                    let now = Instant::now();
+                    let root_state = self.roots.entry(root).or_insert(RootState {
+                        in_flight: 0,
+                        held_open: 0,
+                        last_event_at: now,
+                    });
+                    root_state.held_open = root_state.held_open.saturating_add(1);
+                    root_state.last_event_at = now;
+                }
+                TraceEvent::Release { root, t: _ } => {
+                    if let Some(state) = self.roots.get_mut(&root) {
+                        state.held_open = state.held_open.saturating_sub(1);
+                        state.last_event_at = Instant::now();
+                        // Symmetric with Finished: re-check the joint
+                        // gate. A Release that brings held_open to 0
+                        // while in_flight is also 0 fires settlement
+                        // (the spawned thread outlived its handler).
+                        if state.in_flight == 0 && state.held_open == 0 {
+                            self.fire_settled(root);
+                        }
+                    }
+                    // Orphan Release (no matching HoldOpen ever observed
+                    // — trace queue not installed when the hold was
+                    // acquired, or the root was evicted) is dropped.
+                    // Eventual-consistency per ADR-0080 §6.
                 }
             }
         }
@@ -565,6 +609,7 @@ mod native {
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::{MailDispatch, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use std::sync::Mutex;
         use std::sync::mpsc::Receiver;
 
         /// Construct an observer for state-fold tests. Stash a fresh
@@ -842,6 +887,229 @@ mod native {
             let captured = captured.lock().expect("test stub: captured mutex poisoned");
             assert_eq!(captured.len(), 1);
             assert_eq!(captured[0].root, root);
+        }
+
+        /// ADR-0080 §12 / iamacoffeepot/aether#716 — shared fixture
+        /// for settlement-hold tests. Returns the observer +
+        /// `Mutex<Vec<Settled>>` capture (chassis-router-routed) +
+        /// the chassis-root `MailId` so the tests can apply events
+        /// against the same root the capture sees.
+        fn observer_with_settled_capture()
+        -> (TraceObserverCapability, Arc<Mutex<Vec<Settled>>>, MailId) {
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+            let captured: Arc<Mutex<Vec<Settled>>> = Arc::new(Mutex::new(Vec::new()));
+            let captured_for_router = Arc::clone(&captured);
+            let settled_kind = <Settled as aether_data::Kind>::ID;
+            mailer.install_chassis_router(Box::new(move |mail| {
+                if mail.kind == settled_kind
+                    && let Ok(notice) = postcard::from_bytes::<Settled>(&mail.payload)
+                {
+                    captured_for_router
+                        .lock()
+                        .expect("test stub: captured mutex poisoned")
+                        .push(notice);
+                }
+            }));
+
+            let obs = TraceObserverCapability {
+                roots: HashMap::new(),
+                mails: HashMap::new(),
+                t_sent_index: BTreeSet::new(),
+                retention: Duration::from_mins(1),
+                max_roots: 1000,
+                mailer: Arc::clone(&mailer),
+                settled_kind,
+                registry: Arc::clone(&registry),
+            };
+            (obs, captured, mail(1, 1))
+        }
+
+        /// Spawn completes before handler returns: `HoldOpen` +
+        /// `Release` land before `Finished`. Settlement fires when
+        /// `Finished` drops `in_flight` to 0 because `held_open` is
+        /// already 0 by then.
+        #[test]
+        fn hold_acquired_then_released_before_finished() {
+            let (mut obs, captured, root) = observer_with_settled_capture();
+
+            apply_sent_event(
+                &mut obs,
+                root,
+                root,
+                None,
+                MailboxId(1),
+                MailboxId(2),
+                KindId(0xABCD),
+                Nanos(100),
+            );
+            obs.apply_event(TraceEvent::HoldOpen {
+                root,
+                t: Nanos(150),
+            });
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(160),
+            });
+            // in_flight=1, held_open=0 — Release on its own doesn't fire.
+            assert!(
+                captured.lock().expect("captured mutex").is_empty(),
+                "Release with in_flight > 0 must not fire Settled"
+            );
+
+            obs.apply_event(TraceEvent::Finished {
+                mail_id: root,
+                t: Nanos(200),
+            });
+            let captured = captured.lock().expect("captured mutex");
+            assert_eq!(captured.len(), 1, "Finished with held_open=0 fires");
+            assert_eq!(captured[0].root, root);
+        }
+
+        /// The iamacoffeepot/aether#716 bug: spawn outlives handler.
+        /// `Finished` fires before `Release`. With the gate the
+        /// `Finished` event must NOT trigger `Settled`; only the
+        /// subsequent `Release` (which drops `held_open` to 0 while
+        /// `in_flight` is already 0) fires settlement.
+        #[test]
+        fn hold_outlives_finished_blocks_then_release_fires_settled() {
+            let (mut obs, captured, root) = observer_with_settled_capture();
+
+            apply_sent_event(
+                &mut obs,
+                root,
+                root,
+                None,
+                MailboxId(1),
+                MailboxId(2),
+                KindId(0xABCD),
+                Nanos(100),
+            );
+            obs.apply_event(TraceEvent::HoldOpen {
+                root,
+                t: Nanos(150),
+            });
+            obs.apply_event(TraceEvent::Finished {
+                mail_id: root,
+                t: Nanos(200),
+            });
+
+            // The bug: in_flight=0 but held_open=1, so Settled must NOT
+            // have fired yet. Pre-fix this assertion would fail (Settled
+            // would have been captured).
+            assert!(
+                captured.lock().expect("captured mutex").is_empty(),
+                "Settled must be gated by held_open > 0"
+            );
+
+            // Worker thread "drops" — Release event arrives.
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(300),
+            });
+            let captured = captured.lock().expect("captured mutex");
+            assert_eq!(
+                captured.len(),
+                1,
+                "Release with in_flight=0 fires the previously-gated Settled"
+            );
+            assert_eq!(captured[0].root, root);
+        }
+
+        /// Multiple concurrent spawns: each `InheritCtx` acquires its
+        /// own hold; the observer accumulates `held_open` to N. Only
+        /// the last Release brings both counters to zero, firing
+        /// exactly one Settled.
+        #[test]
+        fn multiple_holds_each_gate_settlement() {
+            let (mut obs, captured, root) = observer_with_settled_capture();
+
+            apply_sent_event(
+                &mut obs,
+                root,
+                root,
+                None,
+                MailboxId(1),
+                MailboxId(2),
+                KindId(0xABCD),
+                Nanos(100),
+            );
+            obs.apply_event(TraceEvent::HoldOpen {
+                root,
+                t: Nanos(110),
+            });
+            obs.apply_event(TraceEvent::HoldOpen {
+                root,
+                t: Nanos(120),
+            });
+            obs.apply_event(TraceEvent::HoldOpen {
+                root,
+                t: Nanos(130),
+            });
+            assert_eq!(
+                obs.roots.get(&root).expect("root").held_open,
+                3,
+                "three holds → counter at 3"
+            );
+
+            obs.apply_event(TraceEvent::Finished {
+                mail_id: root,
+                t: Nanos(200),
+            });
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(210),
+            });
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(220),
+            });
+            // Two of three holds released; held_open=1, in_flight=0.
+            assert!(
+                captured.lock().expect("captured mutex").is_empty(),
+                "partial release does not fire Settled"
+            );
+
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(230),
+            });
+            let captured = captured.lock().expect("captured mutex");
+            assert_eq!(captured.len(), 1, "last Release fires exactly one Settled");
+            assert_eq!(captured[0].root, root);
+        }
+
+        /// `HoldOpen` for a never-seen root creates the `RootState`
+        /// entry with `in_flight = 0`. A subsequent `Sent` ticks
+        /// `in_flight` up alongside the existing `held_open`. Order
+        /// `Sent`-before-`HoldOpen` vs `HoldOpen`-before-`Sent` is
+        /// producer-order-sensitive in practice but the observer is
+        /// symmetric.
+        #[test]
+        fn hold_open_creates_root_state_with_zero_in_flight() {
+            let mut obs = boot_observer();
+            let root = mail(1, 1);
+            obs.apply_event(TraceEvent::HoldOpen { root, t: Nanos(50) });
+            let state = obs.roots.get(&root).expect("HoldOpen creates root");
+            assert_eq!(state.in_flight, 0);
+            assert_eq!(state.held_open, 1);
+        }
+
+        /// Orphan `Release` (no matching `HoldOpen` — chassis didn't
+        /// have the trace queue installed when the hold was acquired,
+        /// or the root was evicted) drops silently. No state change,
+        /// no panic.
+        #[test]
+        fn orphan_release_drops_silently() {
+            let mut obs = boot_observer();
+            let root = mail(7, 7);
+            obs.apply_event(TraceEvent::Release {
+                root,
+                t: Nanos(100),
+            });
+            assert!(obs.roots.is_empty(), "orphan Release does not create state");
+            assert!(obs.mails.is_empty());
         }
 
         #[test]

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -828,40 +828,7 @@ mod native {
 
         #[test]
         fn finished_to_zero_fires_settled() {
-            use std::sync::Mutex;
-
-            // Build a Mailer with a chassis-router that records every
-            // chassis-addressed mail. The observer's `fire_settled`
-            // pushes through the Mailer; the router intercepts.
-            let registry = Arc::new(Registry::new());
-            let store = Arc::new(HandleStore::new(1024 * 1024));
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-            let captured: Arc<Mutex<Vec<Settled>>> = Arc::new(Mutex::new(Vec::new()));
-            let captured_for_router = Arc::clone(&captured);
-            let settled_kind = <Settled as aether_data::Kind>::ID;
-            mailer.install_chassis_router(Box::new(move |mail| {
-                if mail.kind == settled_kind
-                    && let Ok(notice) = postcard::from_bytes::<Settled>(&mail.payload)
-                {
-                    captured_for_router
-                        .lock()
-                        .expect("test stub: captured mutex poisoned")
-                        .push(notice);
-                }
-            }));
-
-            let mut obs = TraceObserverCapability {
-                roots: HashMap::new(),
-                mails: HashMap::new(),
-                t_sent_index: BTreeSet::new(),
-                retention: Duration::from_mins(1),
-                max_roots: 1000,
-                mailer: Arc::clone(&mailer),
-                settled_kind,
-                registry: Arc::clone(&registry),
-            };
-
-            let root = mail(1, 1);
+            let (mut obs, captured, root) = observer_with_settled_capture();
             apply_sent_event(
                 &mut obs,
                 root,
@@ -873,18 +840,13 @@ mod native {
                 Nanos(100),
             );
             // No Settled yet — in_flight is 1.
-            assert!(
-                captured
-                    .lock()
-                    .expect("test stub: captured mutex poisoned")
-                    .is_empty()
-            );
+            assert!(captured.lock().expect("captured mutex").is_empty());
             obs.apply_event(TraceEvent::Finished {
                 mail_id: root,
                 t: Nanos(200),
             });
             // Settled fired; chassis-router decoded the mail.
-            let captured = captured.lock().expect("test stub: captured mutex poisoned");
+            let captured = captured.lock().expect("captured mutex");
             assert_eq!(captured.len(), 1);
             assert_eq!(captured[0].root, root);
         }

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -96,6 +96,25 @@ pub enum TraceEvent {
         mail_id: MailId,
         t: Nanos,
     },
+    /// ADR-0080 §12 / iamacoffeepot/aether#716: a thread-spawn primitive
+    /// (currently `InheritCtx<A>` via `NativeCtx::spawn_inherit`) acquired
+    /// a `SettlementHold` against `root`. The observer increments the
+    /// root's `held_open` counter and gates `Settled` emission on
+    /// `(in_flight == 0 && held_open == 0)`. Pushed by the parent thread
+    /// before the worker thread is spawned, so by the time `Finished`
+    /// lands for the parent handler the hold is already visible.
+    HoldOpen {
+        root: MailId,
+        t: Nanos,
+    },
+    /// Companion to [`Self::HoldOpen`]. Pushed by `SettlementHold`'s
+    /// `Drop` impl when the worker thread exits; the observer decrements
+    /// the root's `held_open` counter and may fire `Settled` if both
+    /// counters reached zero.
+    Release {
+        root: MailId,
+        t: Nanos,
+    },
 }
 
 /// ADR-0080 §3: a batch of [`TraceEvent`]s the chassis drainer ships

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -25,12 +25,12 @@
 //!
 //! ADR-0080 §12 says "the spawning handler's tree does not settle
 //! until every spawned-thread send completes." Enforced here via the
-//! `SettlementHold` RAII guard from
-//! [`crate::runtime::trace::acquire_settlement_hold`]: `spawn_inherit`
-//! acquires a hold against the parent's `in_flight_root` BEFORE the
-//! worker thread is spawned (so the `HoldOpen` trace event lands ahead
-//! of the parent handler's `Finished`), then moves the hold into the
-//! `InheritCtx<A>` so the worker thread owns it. Drop fires `Release`.
+//! [`SettlementHold`] RAII guard from [`acquire_settlement_hold`]:
+//! `spawn_inherit` acquires a hold against the parent's
+//! `in_flight_root` BEFORE the worker thread is spawned (so the
+//! `HoldOpen` trace event lands ahead of the parent handler's
+//! `Finished`), then moves the hold into the `InheritCtx<A>` so the
+//! worker thread owns it. Drop fires `Release`.
 //! The observer gates `Settled` emission on
 //! `(in_flight == 0 && held_open == 0)`, so a worker thread that
 //! outlives its handler keeps the chain open until it exits.

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -21,18 +21,19 @@
 //!   shape for long-lived workers that respond to external events
 //!   with no caller context — TCP per-connection workers, etc.
 //!
-//! ## Settlement contract gap (issue iamacoffeepot/aether#716)
+//! ## Settlement contract (ADR-0080 §12, iamacoffeepot/aether#716)
 //!
 //! ADR-0080 §12 says "the spawning handler's tree does not settle
-//! until every spawned-thread send completes." The send semantics
-//! here are correct (every send carries the right `root` and
-//! `parent_mail`), but the settlement contract is **not enforced**:
-//! a parent chain can settle before the spawned thread's first
-//! send arrives. There's no in-tree consumer surfacing this today;
-//! future caps that use `spawn_inherit` for non-trivial work will
-//! need the enforcement landed via the synthetic Sent/Finished
-//! anchor (issue iamacoffeepot/aether#716 Option B) or the
-//! `SettlementRegistry::hold_open / release` mechanism (Option C).
+//! until every spawned-thread send completes." Enforced here via the
+//! `SettlementHold` RAII guard from
+//! [`crate::runtime::trace::acquire_settlement_hold`]: `spawn_inherit`
+//! acquires a hold against the parent's `in_flight_root` BEFORE the
+//! worker thread is spawned (so the `HoldOpen` trace event lands ahead
+//! of the parent handler's `Finished`), then moves the hold into the
+//! `InheritCtx<A>` so the worker thread owns it. Drop fires `Release`.
+//! The observer gates `Settled` emission on
+//! `(in_flight == 0 && held_open == 0)`, so a worker thread that
+//! outlives its handler keeps the chain open until it exits.
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -43,6 +44,7 @@ use aether_actor::{MailSender, Sender, Singleton};
 use aether_data::{Kind, MailId, mailbox_id_from_name};
 
 use super::binding::NativeBinding;
+use crate::runtime::trace::{SettlementHold, acquire_settlement_hold};
 
 /// ADR-0080 §12 spawn-context that captures the spawning handler's
 /// in-flight `(mail_id, root)`. Outbound sends from the worker
@@ -57,6 +59,15 @@ pub struct InheritCtx<A> {
     binding: Arc<NativeBinding>,
     inherited_mail_id: MailId,
     inherited_root: MailId,
+    /// ADR-0080 §12 settlement hold. Acquired on the parent thread
+    /// before the worker is spawned (so the `HoldOpen` trace event is
+    /// visible before the parent handler's `Finished` lands) and moved
+    /// into the worker via this field. The hold's `Drop` impl fires
+    /// `Release`, gated jointly with `in_flight` so the parent chain
+    /// stays open until the worker exits. `Option` so callers without
+    /// an in-flight root (`MailId::NONE`) skip the hold cleanly — no
+    /// chain to keep open.
+    _hold: Option<SettlementHold>,
     _phantom: PhantomData<fn() -> A>,
 }
 
@@ -67,11 +78,13 @@ impl<A> InheritCtx<A> {
         binding: Arc<NativeBinding>,
         inherited_mail_id: MailId,
         inherited_root: MailId,
+        hold: Option<SettlementHold>,
     ) -> Self {
         Self {
             binding,
             inherited_mail_id,
             inherited_root,
+            _hold: hold,
             _phantom: PhantomData,
         }
     }
@@ -306,10 +319,26 @@ where
     A: Actor + Singleton + 'static,
     F: FnOnce(InheritCtx<A>) + Send + 'static,
 {
+    // ADR-0080 §12 / iamacoffeepot/aether#716: acquire the settlement
+    // hold on the parent thread BEFORE spawning. The `HoldOpen` event
+    // hits the trace queue ahead of the parent handler's `Finished`,
+    // so by the time the observer sees `in_flight` reach zero the
+    // `held_open` counter is already non-zero. Move the hold into the
+    // spawned closure via the `InheritCtx<A>` so release fires on
+    // worker exit.
+    //
+    // `MailId::NONE` skips the hold: a ctx without an in-flight root
+    // has no chain to keep open. Symmetric with the `outbound_root`
+    // / `outbound_parent` `None` cases.
+    let hold = if in_flight_root == MailId::NONE {
+        None
+    } else {
+        Some(acquire_settlement_hold(in_flight_root))
+    };
     thread::Builder::new()
         .name(format!("aether-inherit-{}", A::NAMESPACE))
         .spawn(move || {
-            let ctx = InheritCtx::<A>::new(binding, in_flight_mail_id, in_flight_root);
+            let ctx = InheritCtx::<A>::new(binding, in_flight_mail_id, in_flight_root, hold);
             f(ctx);
         })
         .expect("spawn aether-inherit thread")
@@ -403,10 +432,10 @@ mod tests {
 
     /// `InheritCtx`-spawned thread's `send_to_named` carries the
     /// inherited root and stamps `parent_mail = inherited_mail_id`.
-    /// This is the load-bearing semantic in PR-5-without-anchor:
-    /// even though settlement may fire prematurely (issue iamacoffeepot/aether#716),
-    /// the trace graph correctly attributes the spawned-thread mail
-    /// to the parent chain.
+    /// Settlement is held open until the worker thread exits per
+    /// ADR-0080 §12 / iamacoffeepot/aether#716; see
+    /// `spawn_inherit_acquires_and_releases_settlement_hold` below
+    /// for the held-open verification.
     #[test]
     fn inherit_ctx_send_carries_root_and_parent_mail() {
         let (registry, mailer) = fresh_substrate();
@@ -587,6 +616,142 @@ mod tests {
         let dispatch = &captured[0];
         assert_eq!(dispatch.root, inherited_root);
         assert_eq!(dispatch.parent_mail, Some(inherited_mail_id));
+    }
+
+    /// ADR-0080 §12 / iamacoffeepot/aether#716: `spawn_inherit`
+    /// acquires a `SettlementHold` on the parent root before spawning
+    /// and drops it on thread exit. Both events ride the global trace
+    /// queue (installed by `install_trace_queue`).
+    ///
+    /// Test filters the queue by the unique sender mailbox id we
+    /// allocate locally so the assertion is robust against other
+    /// parallel tests sharing the queue (the same drain-and-restore
+    /// pattern `mailer::drain_events_for` uses).
+    #[test]
+    fn spawn_inherit_acquires_and_releases_settlement_hold() {
+        use aether_kinds::trace::TraceEvent;
+        use crossbeam_queue::SegQueue;
+
+        crate::runtime::trace::init_substrate_start();
+        let queue = Arc::new(SegQueue::<TraceEvent>::new());
+        crate::runtime::trace::install_trace_queue(Arc::clone(&queue));
+        // After install_trace_queue, the global may already point at a
+        // queue from a prior test. Read the live one and drain from
+        // there so we observe the same queue spawn_inherit pushes to.
+        let live = crate::runtime::trace::trace_queue()
+            .expect("trace queue installed")
+            .clone();
+
+        let (_registry, mailer) = fresh_substrate();
+        let producer_mailbox = MailboxId(0xC0FE_C0FE_C0FE_C0FE);
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            producer_mailbox,
+        ));
+        // Root the test cares about — sender prefix is unique so we can
+        // filter events out of a shared queue.
+        let inherited_root = MailId::new(MailboxId(0xC0FE_C0FE_C0FE_C0FE), 9001);
+        let inherited_mail_id = MailId::new(MailboxId(0xC0FE_C0FE_C0FE_C0FE), 9002);
+
+        let join = spawn_inherit::<StubActor, _>(
+            Arc::clone(&binding),
+            inherited_mail_id,
+            inherited_root,
+            move |_inherit| {
+                // No-op body — we're verifying the hold lifecycle, not
+                // outbound sends.
+            },
+        );
+        join.join().expect("inherit worker thread joins");
+
+        // Drain queue, partition into "ours" (root matches inherited_root)
+        // vs "others" (put back so other parallel tests aren't disturbed).
+        let mut ours: Vec<TraceEvent> = Vec::new();
+        let mut leftover: Vec<TraceEvent> = Vec::new();
+        while let Some(event) = live.pop() {
+            let belongs = match &event {
+                TraceEvent::HoldOpen { root, .. } | TraceEvent::Release { root, .. } => {
+                    *root == inherited_root
+                }
+                _ => false,
+            };
+            if belongs {
+                ours.push(event);
+            } else {
+                leftover.push(event);
+            }
+        }
+        for ev in leftover {
+            live.push(ev);
+        }
+
+        assert_eq!(ours.len(), 2, "expected one HoldOpen + one Release");
+        assert!(
+            matches!(ours[0], TraceEvent::HoldOpen { root, .. } if root == inherited_root),
+            "first event is HoldOpen for inherited root, got {:?}",
+            ours[0]
+        );
+        assert!(
+            matches!(ours[1], TraceEvent::Release { root, .. } if root == inherited_root),
+            "second event is Release for inherited root, got {:?}",
+            ours[1]
+        );
+    }
+
+    /// `MailId::NONE` inherited root skips the hold — there's no chain
+    /// to keep open. Verify no `HoldOpen` / `Release` events surface
+    /// from a `NONE`-rooted spawn.
+    #[test]
+    fn spawn_inherit_with_none_root_skips_hold() {
+        use aether_kinds::trace::TraceEvent;
+        use crossbeam_queue::SegQueue;
+
+        crate::runtime::trace::init_substrate_start();
+        let queue = Arc::new(SegQueue::<TraceEvent>::new());
+        crate::runtime::trace::install_trace_queue(Arc::clone(&queue));
+        let live = crate::runtime::trace::trace_queue()
+            .expect("trace queue installed")
+            .clone();
+
+        let (_registry, mailer) = fresh_substrate();
+        // Different unique sender so this test's filter doesn't catch
+        // the other hold-lifecycle test's events.
+        let producer_mailbox = MailboxId(0xC0FE_DEAD_C0FE_DEAD);
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            producer_mailbox,
+        ));
+
+        let join = spawn_inherit::<StubActor, _>(
+            Arc::clone(&binding),
+            MailId::NONE,
+            MailId::NONE,
+            move |_inherit| {},
+        );
+        join.join().expect("inherit worker thread joins");
+
+        // Drain and inspect — there should be ZERO HoldOpen/Release
+        // events for `MailId::NONE` since spawn_inherit short-circuits
+        // the hold acquisition for NONE roots.
+        let mut leftover: Vec<TraceEvent> = Vec::new();
+        let mut none_events = 0usize;
+        while let Some(event) = live.pop() {
+            match &event {
+                TraceEvent::HoldOpen { root, .. } | TraceEvent::Release { root, .. }
+                    if *root == MailId::NONE =>
+                {
+                    none_events += 1;
+                }
+                _ => leftover.push(event),
+            }
+        }
+        for ev in leftover {
+            live.push(ev);
+        }
+        assert_eq!(
+            none_events, 0,
+            "MailId::NONE root must not produce HoldOpen/Release"
+        );
     }
 
     /// Setup smoke: a `Mail` pushed bare via `Mailer` doesn't trigger

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -832,6 +832,9 @@ mod tests {
                 TraceEvent::Sent { mail_id, .. }
                 | TraceEvent::Received { mail_id, .. }
                 | TraceEvent::Finished { mail_id, .. } => mail_id.sender == sender,
+                TraceEvent::HoldOpen { root, .. } | TraceEvent::Release { root, .. } => {
+                    root.sender == sender
+                }
             };
             if belongs {
                 out.push(event);

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -169,6 +169,65 @@ pub fn record_finished(mail_id: MailId) {
     });
 }
 
+/// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a `SettlementHold`
+/// against `root`. The returned guard increments the root's `held_open`
+/// counter (via a [`TraceEvent::HoldOpen`] pushed inline) and decrements
+/// it again on `Drop` (via [`TraceEvent::Release`]). Settlement for
+/// `root` gates on `(in_flight == 0 && held_open == 0)`, so any thread
+/// that outlives its spawning handler (`InheritCtx<A>` from
+/// [`crate::actor::native::NativeCtx::spawn_inherit`]) keeps the chain
+/// open until it drops.
+///
+/// Acquired on the parent thread before the worker is spawned so the
+/// `HoldOpen` event is visible in the trace queue before the parent
+/// handler's `Finished` lands. Moving the guard into the worker thread
+/// (via the `InheritCtx<A>` ctor) ties release to the worker's lifetime.
+///
+/// No-op when the trace queue isn't installed (early-test paths,
+/// fixtures that bypass chassis boot). The returned guard still pushes
+/// `Release` on drop, but the observer simply ignores both events.
+#[must_use = "SettlementHold gates root settlement; storing _ silently fires Release"]
+pub fn acquire_settlement_hold(root: MailId) -> SettlementHold {
+    if let Some(queue) = TRACE_QUEUE.get() {
+        queue.push(TraceEvent::HoldOpen {
+            root,
+            t: now_nanos(),
+        });
+    }
+    SettlementHold { root }
+}
+
+/// RAII guard for an ADR-0080 §12 settlement hold. Construct via
+/// [`acquire_settlement_hold`]; drop fires [`TraceEvent::Release`] for
+/// the same root. The only public surface is the guard — `Release` is
+/// never a free function, so a paired `hold`/`release` mismatch is
+/// structurally impossible.
+#[derive(Debug)]
+pub struct SettlementHold {
+    root: MailId,
+}
+
+impl SettlementHold {
+    /// The root this hold gates. Exposed for diagnostics / tests; the
+    /// hold itself releases via `Drop`.
+    #[must_use]
+    pub fn root(&self) -> MailId {
+        self.root
+    }
+}
+
+impl Drop for SettlementHold {
+    fn drop(&mut self) {
+        let Some(queue) = TRACE_QUEUE.get() else {
+            return;
+        };
+        queue.push(TraceEvent::Release {
+            root: self.root,
+            t: now_nanos(),
+        });
+    }
+}
+
 /// ADR-0080 chassis-root push helper. Combines `MailId` minting,
 /// the `Sent` trace event emission, and the `Mailer::push` into one
 /// call so chassis-side mail (Tick fanout from the frame loop, hub-


### PR DESCRIPTION
Closes iamacoffeepot/aether#716.

## Summary

- Adds `SettlementHold` — an RAII guard that, on acquire, pushes a `HoldOpen` trace event for the chain root and, on `Drop`, pushes a `Release`. The only public surface is the guard; there is no bare `release` function, so paired acquire/release calls cannot mismatch (same idiom as `MutexGuard` / `tokio::JoinSet` task handles).
- Trace observer extends `RootState` with a `held_open` counter alongside `in_flight` and gates `Settled` emission on `(in_flight == 0 && held_open == 0)`.
- Wired through `InheritCtx<A>`: `spawn_inherit` acquires the hold on the parent thread before `thread::spawn`, so the `HoldOpen` event lands in the trace queue ahead of the parent handler's `Finished`. The hold moves into the worker via an `Option<SettlementHold>` field on the ctx, and the worker thread exit fires `Release`. `MailId::NONE` roots short-circuit (no chain to keep open).

## Location refresh from the design comment

The design comment on iamacoffeepot/aether#716 sketched the hold in `chassis/settlement.rs`. After tracing the actual `in_flight` counter to `TraceObserverCapability`, the implementation puts `held_open` next to `in_flight` and routes `HoldOpen` / `Release` through the existing trace ring (same path as `Sent` / `Received` / `Finished`). The Drop-RAII shape and gate semantics are unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps` with rustdoc lints denied
- [x] `cargo nextest run --workspace --all-features --profile ci` — 1011 tests pass
- [x] wasm32 component cross-build for every component crate
- [x] Observer-level tests: spawn-completes-before-handler, spawn-outlives-handler (the iamacoffeepot/aether#716 bug), multiple-concurrent-spawns, HoldOpen-creates-zero-in-flight, orphan-Release-drops-silently
- [x] Producer-level tests: `spawn_inherit` pushes one HoldOpen + one Release per worker; `MailId::NONE` roots skip the hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)