### PR TITLE
chore(substrate): enable clippy::absolute_paths + sweep (issue 951)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ unreadable_literal                  = "deny"
 unwrap_used                         = "warn"
 print_stdout                        = "warn"
 print_stderr                        = "warn"
+# absolute_paths — catches `crate::a::b::c::Thing` written inline at call sites
+# when a `use` would shorten it. See iamacoffeepot/aether#951. Starts at `warn`;
+# promotion to `deny` is a follow-up phase once any reintroduced hits stay green.
+# Default `absolute-paths-max-segments = 2` is sufficient — no override in clippy.toml.
+absolute_paths                      = "warn"
 
 # Disable — idiom fight / dispatcher contract / doc-burden. Rationale in iamacoffeepot/aether#854.
 float_cmp                    = "allow"

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -43,6 +43,10 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use std::mem;
+use syn::meta;
+use syn::parse::Parser;
+use syn::spanned::Spanned;
 use syn::{
     Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
     GenericArgument, ImplItem, Item, ItemImpl, ItemMod, Lit, Meta, PathArguments, Signature, Type,
@@ -604,7 +608,7 @@ fn parse_kind_attr(attrs: &[Attribute]) -> syn::Result<KindAttr> {
     Err(syn::Error::new(
         attrs
             .first()
-            .map_or_else(proc_macro2::Span::call_site, syn::spanned::Spanned::span),
+            .map_or_else(proc_macro2::Span::call_site, Spanned::span),
         "missing `#[kind(name = \"...\")]` attribute",
     ))
 }
@@ -759,7 +763,7 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
     if attr.is_empty() {
         return Ok(opts);
     }
-    let parser = syn::meta::parser(|meta| {
+    let parser = meta::parser(|meta| {
         if meta.path.is_ident("skip_markers") {
             opts.skip_markers = true;
             Ok(())
@@ -767,7 +771,7 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
             Err(meta.error("unrecognised #[actor] argument; only `skip_markers` is supported"))
         }
     });
-    syn::parse::Parser::parse2(parser, attr)?;
+    Parser::parse2(parser, attr)?;
     Ok(opts)
 }
 
@@ -851,7 +855,7 @@ fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
     if attr.is_empty() {
         return Ok(opts);
     }
-    let parser = syn::meta::parser(|meta| {
+    let parser = meta::parser(|meta| {
         if meta.path.is_ident("singleton") {
             if matches!(opts.cardinality, Some(BridgeCardinality::Instanced)) {
                 return Err(meta.error(
@@ -880,7 +884,7 @@ fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
                 .error("#[bridge] only accepts `singleton`, `instanced`, or `feature = \"name\"`"))
         }
     });
-    syn::parse::Parser::parse(parser, attr)?;
+    Parser::parse(parser, attr)?;
     Ok(opts)
 }
 
@@ -1178,7 +1182,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     // one it adds `feature = "X"` so the inner `mod native` only
     // compiles when both the target and the feature say to.
     item_mod.content = Some((brace, items));
-    let mod_attrs = std::mem::take(&mut item_mod.attrs);
+    let mod_attrs = mem::take(&mut item_mod.attrs);
     Ok(quote! {
         #stub_and_reexport
         #actor_marker

--- a/crates/aether-actor-derive/tests/derive.rs
+++ b/crates/aether-actor-derive/tests/derive.rs
@@ -17,6 +17,8 @@ use aether_data::{CastEligible, Kind, Ref, Schema};
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaCell, SchemaType};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
@@ -120,8 +122,7 @@ fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
         panic!("expected Struct schema");
     };
     assert!(!*repr_c);
-    let by_name: std::collections::HashMap<&str, &SchemaType> =
-        fields.iter().map(|f| (&*f.name, &f.ty)).collect();
+    let by_name: HashMap<&str, &SchemaType> = fields.iter().map(|f| (&*f.name, &f.ty)).collect();
     assert_eq!(by_name["body"], &SchemaType::String);
     assert!(matches!(by_name["tags"], SchemaType::Vec(inner) if **inner == SchemaType::String));
     assert!(
@@ -329,14 +330,14 @@ fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
 #[kind(name = "test.headers")]
 #[allow(dead_code)]
 struct Headers {
-    headers: std::collections::BTreeMap<String, String>,
+    headers: BTreeMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
 #[kind(name = "test.lookup")]
 #[allow(dead_code)]
 struct Lookup {
-    counters: std::collections::BTreeMap<u32, u64>,
+    counters: BTreeMap<u32, u64>,
 }
 
 #[test]

--- a/crates/aether-actor/src/actor/ctx/sync_waiter.rs
+++ b/crates/aether-actor/src/actor/ctx/sync_waiter.rs
@@ -22,6 +22,7 @@ use alloc::vec::Vec;
 use aether_data::Kind;
 
 use crate::mail::sync::{WaitError, decode_wait_reply};
+use serde::de::DeserializeOwned;
 
 /// Synchronous reply-receive surface every per-handler ctx that
 /// participates in ADR-0042 sync round trips exposes. Today FFI ctxs
@@ -49,7 +50,7 @@ pub trait SyncWaiter {
         expected_correlation: u64,
     ) -> Result<K, E>
     where
-        K: Kind + serde::de::DeserializeOwned,
+        K: Kind + DeserializeOwned,
         E: WaitError;
 }
 
@@ -64,7 +65,7 @@ pub fn wait_reply_via<K, E>(
     expected_correlation: u64,
 ) -> Result<K, E>
 where
-    K: Kind + serde::de::DeserializeOwned,
+    K: Kind + DeserializeOwned,
     E: WaitError,
 {
     let mut buf: Vec<u8> = vec![0u8; capacity];

--- a/crates/aether-actor/src/actor/slot.rs
+++ b/crates/aether-actor/src/actor/slot.rs
@@ -7,15 +7,16 @@
 //! `init` / `receive` shims that the substrate serializes.
 
 /// Macro-use backing store for the one component instance per guest.
+use core::cell::UnsafeCell;
 pub struct Slot<C> {
-    inner: core::cell::UnsafeCell<Option<C>>,
+    inner: UnsafeCell<Option<C>>,
 }
 
 impl<C> Slot<C> {
     /// Build an empty slot. `const` so it can live in a `static`.
     pub const fn new() -> Self {
         Self {
-            inner: core::cell::UnsafeCell::new(None),
+            inner: UnsafeCell::new(None),
         }
     }
 

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -24,6 +24,7 @@ use crate::actor::ctx::mail_sender::MailSender;
 use crate::actor::ctx::outbound_reply::OutboundReply;
 use crate::actor::ctx::persistence::Persistence;
 use crate::actor::ctx::resolver::Resolver;
+use crate::actor::ctx::sync_waiter;
 use crate::actor::ctx::sync_waiter::SyncWaiter;
 use crate::actor::sender::{MailCtx, Sender};
 use crate::actor::{Actor, HandlesKind, Singleton};
@@ -32,6 +33,8 @@ use crate::ffi::mailbox::FfiActorMailbox;
 use crate::mail::ReplyTo;
 use crate::mail::mailbox::{KindId, Mailbox, resolve, resolve_mailbox};
 use crate::mail::sync::WaitError;
+use alloc::string::String;
+use serde::de::DeserializeOwned;
 
 /// Init-only capability handle for FFI guests. Resolved during
 /// `FfiActor::init`; not available at runtime (the type split fences
@@ -180,7 +183,7 @@ impl FfiCtx<'_> {
     // — `reason` is owned because callers `format!(...)` inline and the
     // diverging body means no further use.
     #[allow(clippy::needless_pass_by_value)]
-    pub fn fatal_abort(&self, reason: alloc::string::String) -> ! {
+    pub fn fatal_abort(&self, reason: String) -> ! {
         panic!("aether-actor: fatal_abort: {reason}")
     }
 }
@@ -269,10 +272,10 @@ impl SyncWaiter for FfiCtx<'_> {
         expected_correlation: u64,
     ) -> Result<K, E>
     where
-        K: Kind + serde::de::DeserializeOwned,
+        K: Kind + DeserializeOwned,
         E: WaitError,
     {
-        crate::actor::ctx::sync_waiter::wait_reply_via::<K, E>(
+        sync_waiter::wait_reply_via::<K, E>(
             |kind, out, timeout, corr| SYNC_WAIT_BRIDGE.wait_reply(kind, out, timeout, corr),
             timeout_ms,
             capacity,

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -58,6 +58,7 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 
 use crate::actor::ctx::{MailSender, OutboundReply, Persistence, Resolver};
+use core::fmt;
 
 pub mod bridge;
 pub mod ctx;
@@ -108,8 +109,8 @@ impl BootError {
     }
 }
 
-impl core::fmt::Display for BootError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for BootError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
     }
 }

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -127,6 +127,7 @@ mod native_impl {
 
     use core::any::{Any, TypeId};
     use core::cell::{Cell, RefCell};
+    use core::ptr;
     use std::boxed::Box;
     use std::collections::HashMap;
 
@@ -177,7 +178,7 @@ mod native_impl {
             let entry = map
                 .entry(TypeId::of::<T>())
                 .or_insert_with(|| Box::new(RefCell::new(T::default())) as Box<dyn Any + Send>);
-            core::ptr::from_ref::<RefCell<T>>(
+            ptr::from_ref::<RefCell<T>>(
                 entry
                     .downcast_ref::<RefCell<T>>()
                     .expect("TypeId<T> ⇒ RefCell<T>"),
@@ -218,7 +219,7 @@ mod native_impl {
     }
 
     std::thread_local! {
-        static CURRENT_SLOTS: Cell<*const ActorSlots> = const { Cell::new(core::ptr::null()) };
+        static CURRENT_SLOTS: Cell<*const ActorSlots> = const { Cell::new(ptr::null()) };
     }
 
     /// RAII guard restoring the prior `CURRENT_SLOTS` value on
@@ -245,7 +246,7 @@ mod native_impl {
     pub fn with_stamped<R>(slots: &ActorSlots, f: impl FnOnce() -> R) -> R {
         let _guard = CURRENT_SLOTS.with(|slot| {
             let prev = slot.get();
-            slot.set(core::ptr::from_ref::<ActorSlots>(slots));
+            slot.set(ptr::from_ref::<ActorSlots>(slots));
             StampGuard { prev }
         });
         f()
@@ -387,6 +388,9 @@ mod tests {
     use crate::local;
     use alloc::boxed::Box;
     use alloc::string::String;
+    use std::panic;
+    use std::panic::AssertUnwindSafe;
+    use std::thread;
 
     // Probe newtypes via the `#[local]` attribute — exercises
     // the macro and keeps the test bodies focused on the storage
@@ -463,7 +467,7 @@ mod tests {
         with_stamped(&slots, || {
             Probe::with_mut(|outer| {
                 outer.0 = 1;
-                let inner = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let inner = panic::catch_unwind(AssertUnwindSafe(|| {
                     Probe::with_mut(|p| p.0 = 2);
                 }));
                 assert!(inner.is_err(), "nested same-type with_mut must panic");
@@ -488,12 +492,12 @@ mod tests {
         // an out-of-stamp access *after* a panicking stamp still
         // trips debug_assert.
         let slots = ActorSlots::new();
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
             with_stamped(&slots, || panic!("handler trapped"));
         }));
         assert!(outcome.is_err(), "inner panic propagates");
 
-        let outside = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let outside = panic::catch_unwind(AssertUnwindSafe(|| {
             Probe::with_mut(|p| p.0 = 1);
         }));
         assert!(
@@ -523,7 +527,7 @@ mod tests {
         // Move the Box into a freshly-spawned thread and read
         // back — same slots, same data, despite the thread
         // boundary.
-        let observed = std::thread::spawn(move || with_stamped(&slots, || Probe::with(|p| p.0)))
+        let observed = thread::spawn(move || with_stamped(&slots, || Probe::with(|p| p.0)))
             .join()
             .expect("worker thread joined cleanly");
 

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -60,6 +60,8 @@ use tracing::{
 use tracing::{Subscriber, span};
 
 use crate::{Local, local};
+use core::fmt;
+use core::mem;
 
 /// Per-actor log buffer, drained by the chassis dispatcher at
 /// handler exit and on `WARN`/`ERROR` priority flush. Backed by
@@ -125,9 +127,11 @@ pub type NativeLogShipper = fn(mailbox: MailboxId, kind: KindId, payload: &[u8])
 mod shipper {
     extern crate std;
     use super::NativeLogShipper;
+    use core::mem;
+    use core::ptr;
     use core::sync::atomic::{AtomicPtr, Ordering};
 
-    pub(super) static HOOK: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+    pub(super) static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
     pub(super) fn store(hook: NativeLogShipper) {
         HOOK.store(hook as *mut (), Ordering::Release);
@@ -142,7 +146,7 @@ mod shipper {
             // through `store(hook: NativeLogShipper)`, which casts a
             // valid `fn` pointer of that exact signature. Round-trips
             // through `*mut ()` for `AtomicPtr` storage.
-            Some(unsafe { core::mem::transmute::<*mut (), NativeLogShipper>(raw) })
+            Some(unsafe { mem::transmute::<*mut (), NativeLogShipper>(raw) })
         }
     }
 }
@@ -164,7 +168,7 @@ pub fn set_native_log_shipper(hook: NativeLogShipper) {
 /// `aether_substrate::runtime::log_install::with_actor_dispatch`
 /// envelope is active.
 pub fn drain_buffer() {
-    let Some(entries) = LogBuffer::try_with_mut(|b| core::mem::take(&mut b.0)) else {
+    let Some(entries) = LogBuffer::try_with_mut(|b| mem::take(&mut b.0)) else {
         return;
     };
     if entries.is_empty() {
@@ -336,7 +340,7 @@ impl MessageBuilder {
         truncate(self.fields)
     }
 
-    fn append_field(&mut self, name: &str, separator: &str, value: core::fmt::Arguments<'_>) {
+    fn append_field(&mut self, name: &str, separator: &str, value: fmt::Arguments<'_>) {
         if !self.fields.is_empty() {
             self.fields.push(' ');
         }
@@ -365,7 +369,7 @@ impl Visit for MessageBuilder {
         }
     }
 
-    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         if field.name() == "message" {
             let _ = write!(&mut self.message, "{value:?}");
         } else {

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -19,6 +19,8 @@
 //! the inherent methods on `aether_substrate::actor::native::binding::NativeBinding`
 //! (native).
 
+use core::slice;
+use serde::de::DeserializeOwned;
 pub mod mailbox;
 pub mod sync;
 
@@ -191,7 +193,7 @@ impl<'a> Mail<'a> {
         // which guarantees the substrate wrote `self.byte_len >=
         // size_of::<K>()` bytes valid at `self.ptr` for the lifetime
         // of this `Mail`. `'a` ties the borrow to that lifetime.
-        let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
+        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         Some(bytemuck::pod_read_unaligned(bytes))
     }
 
@@ -214,7 +216,7 @@ impl<'a> Mail<'a> {
         // the lifetime of this `Mail`. `'a` ties the returned slice
         // to that lifetime; `try_cast_slice` returns `None` on
         // alignment mismatch.
-        let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
+        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         bytemuck::try_cast_slice(bytes).ok()
     }
 
@@ -249,7 +251,7 @@ impl<'a> Mail<'a> {
         // substrate's receive ABI; the `byte_len` check above proves
         // the host promised exactly `size_of::<K>()` bytes valid at
         // `self.ptr` for this `Mail`'s lifetime.
-        let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
+        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         Some(bytemuck::pod_read_unaligned(bytes))
     }
 
@@ -269,7 +271,7 @@ impl<'a> Mail<'a> {
         // the host promised `size_of::<K>() * count` bytes valid at
         // `self.ptr` for this `Mail`'s lifetime. `try_cast_slice`
         // returns `None` on alignment mismatch.
-        let bytes = unsafe { core::slice::from_raw_parts(self.ptr as *const u8, byte_len) };
+        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
         bytemuck::try_cast_slice(bytes).ok()
     }
 
@@ -302,8 +304,7 @@ impl<'a> Mail<'a> {
         // lifetime. Bounding the slice by `byte_len` keeps
         // `K::decode_from_bytes` (cast or postcard) from running past
         // the substrate-written region into adjacent linear memory.
-        let bytes =
-            unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
+        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
         K::decode_from_bytes(bytes)
     }
 }
@@ -370,7 +371,7 @@ impl<'a> PriorState<'a> {
             // bytes valid at `self.ptr` for this `PriorState`'s
             // lifetime. The `len == 0` branch above avoids forming a
             // slice over a possibly-null pointer.
-            unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.len) }
+            unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
         }
     }
 
@@ -390,7 +391,7 @@ impl<'a> PriorState<'a> {
     #[must_use]
     pub fn as_kind<K>(&self) -> Option<K>
     where
-        K: Kind + Schema + serde::de::DeserializeOwned,
+        K: Kind + Schema + DeserializeOwned,
     {
         let bytes = self.bytes();
         if bytes.len() < 8 {
@@ -414,6 +415,7 @@ impl<'a> PriorState<'a> {
 mod tests {
     use super::*;
     use aether_data::KindId as DataKindId;
+    use alloc::string::String;
     use alloc::vec::Vec;
     use serde::{Deserialize, Serialize};
 
@@ -448,7 +450,7 @@ mod tests {
     )]
     #[kind(name = "test.fake_postcard")]
     struct FakePostcard {
-        tag: alloc::string::String,
+        tag: String,
         ids: Vec<u32>,
     }
 
@@ -616,7 +618,7 @@ mod tests {
     #[test]
     fn mail_decode_kind_postcard_roundtrip() {
         let value = FakePostcard {
-            tag: alloc::string::String::from("greet"),
+            tag: String::from("greet"),
             ids: alloc::vec![1, 2, 3, 4],
         };
         let bytes =
@@ -671,7 +673,7 @@ mod tests {
     #[test]
     fn mail_decode_kind_wrong_kind_returns_none() {
         let value = FakePostcard {
-            tag: alloc::string::String::from("x"),
+            tag: String::from("x"),
             ids: alloc::vec![],
         };
         let bytes =
@@ -693,7 +695,7 @@ mod tests {
     #[test]
     fn mail_decode_kind_wrong_count_returns_none() {
         let value = FakePostcard {
-            tag: alloc::string::String::from("x"),
+            tag: String::from("x"),
             ids: alloc::vec![],
         };
         let bytes =
@@ -715,7 +717,7 @@ mod tests {
     #[test]
     fn mail_decode_kind_truncated_bytes_returns_none() {
         let value = FakePostcard {
-            tag: alloc::string::String::from("longer"),
+            tag: String::from("longer"),
             ids: alloc::vec![1, 2, 3],
         };
         let bytes =
@@ -788,7 +790,7 @@ mod tests {
     #[kind(name = "test.state.struct")]
     struct StateStruct {
         tag: u32,
-        label: alloc::string::String,
+        label: String,
         items: Vec<u32>,
     }
 
@@ -820,7 +822,7 @@ mod tests {
     fn as_kind_roundtrip() {
         let value = StateStruct {
             tag: 11,
-            label: alloc::string::String::from("phase-2"),
+            label: String::from("phase-2"),
             items: alloc::vec![1, 2, 3],
         };
         let buf = frame_bundle(&value);

--- a/crates/aether-actor/src/mail/sync.rs
+++ b/crates/aether-actor/src/mail/sync.rs
@@ -20,6 +20,7 @@
 //! `-2` / `-3`) map onto the [`WaitError`] constructors below.
 
 use alloc::string::String;
+use serde::de::DeserializeOwned;
 
 /// Error contract every sync wrapper's error enum needs to implement
 /// so [`decode_wait_reply`] (and the per-target
@@ -40,7 +41,7 @@ pub trait WaitError {
 /// into the scratch buffer.
 pub fn decode_wait_reply<K, E>(rc: i32, buf: &[u8]) -> Result<K, E>
 where
-    K: serde::de::DeserializeOwned,
+    K: DeserializeOwned,
     E: WaitError,
 {
     match rc {

--- a/crates/aether-camera/tests/scenario.rs
+++ b/crates/aether-camera/tests/scenario.rs
@@ -36,6 +36,8 @@ use aether_substrate_bundle::test_bench::{
 // keep the anchor for parity with the other component scenario files.
 #[allow(unused_imports)]
 use aether_camera as _;
+use std::fs;
+use std::path::Path;
 
 /// Component name passed to `LoadComponent`. The full mailbox address
 /// the substrate registers is `aether.component.trampoline:cam`
@@ -58,8 +60,8 @@ fn component_address() -> String {
 /// Load this crate's pre-built wasm into the bench and await
 /// `LoadResult`. Panics on load failure so the calling test surfaces
 /// the error message rather than wedging on a missing subscription.
-fn load_camera(bench: &mut TestBench, wasm_path: &std::path::Path) {
-    let wasm = std::fs::read(wasm_path).expect("read camera wasm");
+fn load_camera(bench: &mut TestBench, wasm_path: &Path) {
+    let wasm = fs::read(wasm_path).expect("read camera wasm");
     let result: LoadResult = bench
         .send_and_await_reply(
             "aether.component",

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -80,6 +80,8 @@ mod native {
     use aether_substrate::chassis::error::BootError;
 
     use super::{NoteOff, NoteOn, SetMasterGain};
+    use core::fmt;
+    use std::env;
 
     /// Capacity of the event queue between the cap's handlers and the
     /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -113,9 +115,9 @@ mod native {
     impl AudioConfig {
         #[must_use]
         pub fn from_env() -> Self {
-            let disabled = std::env::var("AETHER_AUDIO_DISABLE")
+            let disabled = env::var("AETHER_AUDIO_DISABLE")
                 .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
-            let requested_sample_rate = std::env::var("AETHER_AUDIO_SAMPLE_RATE")
+            let requested_sample_rate = env::var("AETHER_AUDIO_SAMPLE_RATE")
                 .ok()
                 .and_then(|s| s.parse::<u32>().ok());
             Self {
@@ -564,8 +566,8 @@ mod native {
         StreamPlay(String),
     }
 
-    impl core::fmt::Display for AudioBuildError {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    impl fmt::Display for AudioBuildError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 Self::NoDevice => write!(f, "no default audio output device"),
                 Self::RateUnsupported(r) => write!(f, "requested sample rate {r} Hz unsupported"),
@@ -887,6 +889,7 @@ mod native {
         use aether_actor::Actor;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
+        use aether_substrate::mail::registry;
 
         #[test]
         fn builtin_registry_covers_five_patches() {
@@ -1044,10 +1047,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_inbox(
-                AudioCapability::NAMESPACE,
-                aether_substrate::mail::registry::noop_handler(),
-            );
+            registry.register_inbox(AudioCapability::NAMESPACE, registry::noop_handler());
 
             //noinspection DuplicatedCode
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -119,7 +119,9 @@ mod native {
     use aether_substrate::mail::registry::Registry;
     use aether_substrate::mail::{KindId, Mail, MailboxId};
 
+    use crate::input::InputCapability;
     use crate::trampoline::{WasmTrampoline, WasmTrampolineConfig};
+    use aether_actor::log;
 
     /// Configuration for [`ComponentHostCapability`]. `engine` and
     /// `linker` are the wasmtime instances every load instantiates
@@ -210,10 +212,9 @@ mod native {
             // trampoline from every fan-out set. Mail rather than
             // direct mutation post-issue-640 — `aether.input` is the
             // sole owner of the subscriber table.
-            ctx.actor::<crate::input::InputCapability>()
-                .send(&UnsubscribeAll {
-                    mailbox: payload.mailbox_id,
-                });
+            ctx.actor::<InputCapability>().send(&UnsubscribeAll {
+                mailbox: payload.mailbox_id,
+            });
             self.forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
         }
 
@@ -307,7 +308,7 @@ mod native {
             // spawned trampoline. The trampoline's `#[handlers]`-
             // emitted `ConfigureLogDrain` handler stamps its per-
             // actor slot. Issue #601.
-            if let Some(drain) = aether_actor::log::current_drain() {
+            if let Some(drain) = log::current_drain() {
                 let cfg = aether_kinds::ConfigureLogDrain { mailbox: drain };
                 let cfg_payload = bytemuck::bytes_of(&cfg).to_vec();
                 let kind = <aether_kinds::ConfigureLogDrain as Kind>::ID;

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -64,6 +64,7 @@ mod proxy_native {
     use std::io::ErrorKind;
     use std::process::Child;
     use std::sync::Arc;
+    use std::thread;
     use std::time::{Duration, Instant};
 
     /// Total time [`connect_proxy`] keeps retrying a refused dial when
@@ -290,7 +291,7 @@ mod proxy_native {
                 Ok(conn) => Ok(conn),
                 Err(e) => {
                     if retry && is_transient_connect_error(&e) && Instant::now() < deadline {
-                        std::thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
+                        thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
                         continue;
                     }
                     Err(e)
@@ -454,7 +455,9 @@ mod tests {
     use aether_substrate::Subname;
     use aether_substrate::chassis::builder::Builder;
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
+    use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
+    use std::thread;
     use std::time::{Duration, Instant};
 
     fn substrate_peer_kind() -> PeerKind {
@@ -555,7 +558,7 @@ mod tests {
                 Instant::now() < deadline,
                 "reply did not route back through the proxy within 5s",
             );
-            std::thread::sleep(Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
         }
     }
 
@@ -570,7 +573,7 @@ mod tests {
             .expect("empty chassis boots");
 
         // Bind then drop a listener to get a definitely-closed port.
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("local_addr").port();
         drop(listener);
 

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -38,6 +38,8 @@
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
 use aether_kinds::{ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine};
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
 
 #[aether_actor::bridge(singleton)]
 mod server_native {
@@ -56,6 +58,7 @@ mod server_native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{ReplyTarget, ReplyTo};
     use std::collections::HashMap;
+    use std::io;
     use std::net::TcpListener;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
@@ -332,7 +335,7 @@ mod server_native {
     /// rebinds the port, but on localhost it's negligible — and this
     /// sidesteps both a wire change to report an ephemeral port back
     /// from the substrate and an un-recycled incrementing port pool.
-    fn free_local_port() -> std::io::Result<u16> {
+    fn free_local_port() -> io::Result<u16> {
         let listener = TcpListener::bind("127.0.0.1:0")?;
         let port = listener.local_addr()?.port();
         drop(listener);
@@ -357,9 +360,9 @@ use aether_kinds::{ListEnginesResult, SpawnEngineResult, TerminateEngineResult};
 #[cfg(test)]
 #[derive(Clone, Default)]
 pub struct ReplyCells {
-    pub list: std::sync::Arc<std::sync::Mutex<Option<ListEnginesResult>>>,
-    pub spawn: std::sync::Arc<std::sync::Mutex<Option<SpawnEngineResult>>>,
-    pub terminate: std::sync::Arc<std::sync::Mutex<Option<TerminateEngineResult>>>,
+    pub list: Arc<Mutex<Option<ListEnginesResult>>>,
+    pub spawn: Arc<Mutex<Option<SpawnEngineResult>>>,
+    pub terminate: Arc<Mutex<Option<TerminateEngineResult>>>,
 }
 
 #[cfg(test)]
@@ -418,6 +421,7 @@ mod tests {
     use crate::test_chassis::TestChassis;
     use aether_actor::Actor;
     use aether_data::{Kind, mailbox_id_from_name};
+    use aether_kinds::descriptors;
     use aether_kinds::{
         ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine, TerminateEngineResult,
     };
@@ -428,6 +432,7 @@ mod tests {
     use aether_substrate::mail::registry::Registry;
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
     use std::sync::Arc;
+    use std::thread;
     use std::time::{Duration, Instant};
 
     /// Boot a passive chassis hosting `EngineServer` + the reply sink.
@@ -435,7 +440,7 @@ mod tests {
     /// mailer to push requests through, and the sink's cells.
     fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
         let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
+        for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
         let (outbound, _rx) = HubOutbound::attached_loopback();
@@ -470,7 +475,7 @@ mod tests {
                 return value;
             }
             assert!(Instant::now() < deadline, "no reply within deadline");
-            std::thread::sleep(Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
         }
     }
 

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -631,13 +631,9 @@ mod native {
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::registry::Registry;
 
         use crate::test_chassis::{TestChassis, fresh_substrate};
-        use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::ReplyTarget;
-        use aether_substrate::mail::outbound::HubOutbound;
         use aether_substrate::mail::registry;
         use serde::de::DeserializeOwned;
         use std::fs;
@@ -933,15 +929,7 @@ mod native {
             ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
         }
 
-        /// Build a fully-wired `Mailer` connected to a fresh test
-        /// outbound channel.
-        fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
-            let (outbound, rx) = HubOutbound::attached_loopback();
-            let registry = Arc::new(Registry::new());
-            let store = Arc::new(HandleStore::new(1024 * 1024));
-            let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
-            (mailer, rx)
-        }
+        use crate::test_chassis::test_mailer_and_rx;
 
         fn decode_reply<K: aether_data::Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
             let event = rx

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -24,6 +24,9 @@ use aether_actor::FfiActorMailbox;
 use aether_kinds::{Delete, FsError, List, Read, Write};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
+use std::fs;
+use std::io;
+use std::process;
 
 /// Result shape used throughout the adapter layer. The variants of
 /// `FsError` map directly onto ADR-0041 §1's reply enums, so the
@@ -120,8 +123,8 @@ impl LocalFileAdapter {
     // of `dirs::data_dir()` / a `PathBuf::from(env)` straight in and
     // we shadow-rebind to the canonicalised form.
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(root: PathBuf, writable: bool) -> std::io::Result<Self> {
-        std::fs::create_dir_all(&root)?;
+    pub fn new(root: PathBuf, writable: bool) -> io::Result<Self> {
+        fs::create_dir_all(&root)?;
         let root = root.canonicalize()?;
         Ok(Self { root, writable })
     }
@@ -149,7 +152,7 @@ impl LocalFileAdapter {
 impl FileAdapter for LocalFileAdapter {
     fn read(&self, path: &str) -> FsResult<Vec<u8>> {
         let resolved = self.resolve(path)?;
-        match std::fs::read(&resolved) {
+        match fs::read(&resolved) {
             Ok(bytes) => Ok(bytes),
             Err(e) => Err(fs_error_from_std(e)),
         }
@@ -161,7 +164,7 @@ impl FileAdapter for LocalFileAdapter {
         }
         let resolved = self.resolve(path)?;
         if let Some(parent) = resolved.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| FsError::AdapterError(e.to_string()))?;
+            fs::create_dir_all(parent).map_err(|e| FsError::AdapterError(e.to_string()))?;
         }
         let mut tmp = resolved.clone();
         let existing = tmp
@@ -169,12 +172,12 @@ impl FileAdapter for LocalFileAdapter {
             .and_then(|s| s.to_str())
             .ok_or_else(|| FsError::AdapterError("non-utf8 filename".into()))?
             .to_string();
-        tmp.set_file_name(format!("{existing}.tmp-{}", std::process::id()));
-        std::fs::write(&tmp, bytes).map_err(|e| FsError::AdapterError(e.to_string()))?;
-        match std::fs::rename(&tmp, &resolved) {
+        tmp.set_file_name(format!("{existing}.tmp-{}", process::id()));
+        fs::write(&tmp, bytes).map_err(|e| FsError::AdapterError(e.to_string()))?;
+        match fs::rename(&tmp, &resolved) {
             Ok(()) => Ok(()),
             Err(e) => {
-                let _ = std::fs::remove_file(&tmp);
+                let _ = fs::remove_file(&tmp);
                 Err(FsError::AdapterError(e.to_string()))
             }
         }
@@ -185,7 +188,7 @@ impl FileAdapter for LocalFileAdapter {
             return Err(FsError::Forbidden);
         }
         let resolved = self.resolve(path)?;
-        match std::fs::remove_file(&resolved) {
+        match fs::remove_file(&resolved) {
             Ok(()) => Ok(()),
             Err(e) => Err(fs_error_from_std(e)),
         }
@@ -193,7 +196,7 @@ impl FileAdapter for LocalFileAdapter {
 
     fn list(&self, prefix: &str) -> FsResult<Vec<String>> {
         let resolved = self.resolve(prefix)?;
-        let entries = std::fs::read_dir(&resolved).map_err(fs_error_from_std)?;
+        let entries = fs::read_dir(&resolved).map_err(fs_error_from_std)?;
         let mut names = Vec::new();
         for entry in entries {
             let entry = entry.map_err(|e| FsError::AdapterError(e.to_string()))?;
@@ -212,7 +215,7 @@ impl FileAdapter for LocalFileAdapter {
 // `to_string()` both borrow, so technically `&Error` would work, but
 // it'd force ad-hoc closures at every call site.
 #[allow(clippy::needless_pass_by_value)]
-fn fs_error_from_std(err: std::io::Error) -> FsError {
+fn fs_error_from_std(err: io::Error) -> FsError {
     match err.kind() {
         ErrorKind::NotFound => FsError::NotFound,
         ErrorKind::PermissionDenied => FsError::Forbidden,
@@ -237,9 +240,7 @@ pub struct NamespaceRoots {
 /// read-only. Returns the populated registry along with the roots
 /// echoed back (cloned) so the chassis can log what it actually
 /// wired.
-pub fn build_registry(
-    roots: NamespaceRoots,
-) -> std::io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
+pub fn build_registry(roots: NamespaceRoots) -> io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
     let mut registry = AdapterRegistry::new();
     let save = Arc::new(LocalFileAdapter::new(roots.save.clone(), true)?);
     let assets = Arc::new(LocalFileAdapter::new(roots.assets.clone(), false)?);
@@ -258,10 +259,10 @@ impl NamespaceRoots {
     /// builders that want to surface root-validity as a "skip the
     /// `aether.fs` cap and continue" decision rather than letting
     /// init failure abort the whole boot.
-    pub fn ensure_dirs(&self) -> std::io::Result<()> {
-        std::fs::create_dir_all(&self.save)?;
-        std::fs::create_dir_all(&self.assets)?;
-        std::fs::create_dir_all(&self.config)?;
+    pub fn ensure_dirs(&self) -> io::Result<()> {
+        fs::create_dir_all(&self.save)?;
+        fs::create_dir_all(&self.assets)?;
+        fs::create_dir_all(&self.config)?;
         self.save.canonicalize()?;
         self.assets.canonicalize()?;
         self.config.canonicalize()?;
@@ -388,6 +389,7 @@ mod native {
     use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use std::env;
 
     impl NamespaceRoots {
         /// Resolve each root from its env-var override, falling back to
@@ -415,22 +417,22 @@ mod native {
         pub fn from_env() -> Self {
             let save = env_or_default("AETHER_SAVE_DIR", || {
                 dirs::data_dir()
-                    .unwrap_or_else(std::env::temp_dir)
+                    .unwrap_or_else(env::temp_dir)
                     .join("aether")
                     .join("save")
             });
             let assets = env_or_default("AETHER_ASSETS_DIR", || {
-                std::env::current_exe()
+                env::current_exe()
                     .ok()
                     .and_then(|p| p.parent().map(Path::to_path_buf))
                     .map_or_else(
-                        || std::env::temp_dir().join("aether").join("assets"),
+                        || env::temp_dir().join("aether").join("assets"),
                         |p| p.join("assets"),
                     )
             });
             let config = env_or_default("AETHER_CONFIG_DIR", || {
                 dirs::config_dir()
-                    .unwrap_or_else(std::env::temp_dir)
+                    .unwrap_or_else(env::temp_dir)
                     .join("aether")
             });
             Self {
@@ -442,7 +444,7 @@ mod native {
     }
 
     fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
-        match std::env::var(var) {
+        match env::var(var) {
             Ok(s) if !s.is_empty() => PathBuf::from(s),
             _ => default(),
         }
@@ -633,12 +635,23 @@ mod native {
         use aether_substrate::mail::registry::Registry;
 
         use crate::test_chassis::{TestChassis, fresh_substrate};
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::ReplyTarget;
+        use aether_substrate::mail::outbound::HubOutbound;
+        use aether_substrate::mail::registry;
+        use serde::de::DeserializeOwned;
+        use std::fs;
+        use std::process;
+        use std::sync::mpsc::Receiver;
+        use std::time::Duration;
+        use std::time::SystemTime;
+        use std::time::UNIX_EPOCH;
 
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.
         struct TestFixture {
             cap: FsCapability,
-            rx: std::sync::mpsc::Receiver<EgressEvent>,
+            rx: Receiver<EgressEvent>,
             transport: Arc<NativeBinding>,
         }
 
@@ -666,9 +679,9 @@ mod native {
         /// Manual tempdir helper to avoid pulling in the `tempfile`
         /// crate. Caller cleans up via [`cleanup`] after the test asserts.
         fn scratch_root(tag: &str) -> PathBuf {
-            let pid = std::process::id();
-            let nonce: u64 = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
+            let pid = process::id();
+            let nonce: u64 = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
                 // Nanosecond clock fits comfortably in u64 for the next ~584 years.
                 .map_or(0, |d| {
                     #[allow(clippy::cast_possible_truncation)]
@@ -676,12 +689,12 @@ mod native {
                     nanos
                 });
             let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
-            std::fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+            fs::create_dir_all(&path).expect("test setup: scratch dir creates");
             path
         }
 
         fn cleanup(path: &Path) {
-            let _ = std::fs::remove_dir_all(path);
+            let _ = fs::remove_dir_all(path);
         }
 
         fn roots_under(root: &Path) -> NamespaceRoots {
@@ -690,9 +703,9 @@ mod native {
                 assets: root.join("assets"),
                 config: root.join("config"),
             };
-            std::fs::create_dir_all(&r.save).expect("test setup: save root creates");
-            std::fs::create_dir_all(&r.assets).expect("test setup: assets root creates");
-            std::fs::create_dir_all(&r.config).expect("test setup: config root creates");
+            fs::create_dir_all(&r.save).expect("test setup: save root creates");
+            fs::create_dir_all(&r.assets).expect("test setup: assets root creates");
+            fs::create_dir_all(&r.config).expect("test setup: config root creates");
             r
         }
 
@@ -773,7 +786,7 @@ mod native {
                 .expect("test setup: LocalFileAdapter constructs on scratch root");
             a.write("slot.bin", &[0u8; 16])
                 .expect("test setup: adapter accepts atomic write");
-            let siblings: Vec<String> = std::fs::read_dir(a.root())
+            let siblings: Vec<String> = fs::read_dir(a.root())
                 .expect("test setup: adapter root is readable")
                 .filter_map(Result::ok)
                 .filter_map(|e| e.file_name().to_str().map(ToString::to_string))
@@ -917,28 +930,22 @@ mod native {
         }
 
         fn session_sender() -> ReplyTo {
-            ReplyTo::to(aether_substrate::mail::ReplyTarget::Session(SessionToken(
-                Uuid::nil(),
-            )))
+            ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
         }
 
         /// Build a fully-wired `Mailer` connected to a fresh test
         /// outbound channel.
-        fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
-            let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
+        fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
+            let (outbound, rx) = HubOutbound::attached_loopback();
             let registry = Arc::new(Registry::new());
-            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
+            let store = Arc::new(HandleStore::new(1024 * 1024));
             let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
             (mailer, rx)
         }
 
-        fn decode_reply<K: aether_data::Kind + serde::de::DeserializeOwned>(
-            rx: &std::sync::mpsc::Receiver<EgressEvent>,
-        ) -> K {
+        fn decode_reply<K: aether_data::Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
             let event = rx
-                .recv_timeout(std::time::Duration::from_secs(1))
+                .recv_timeout(Duration::from_secs(1))
                 .expect("test: egress event arrives within 1s deadline");
             let EgressEvent::ToSession {
                 kind_name, payload, ..
@@ -976,15 +983,15 @@ mod native {
         fn cap_init_fails_when_adapter_init_fails() {
             let root = scratch_root("init-fails");
             let save_path = root.join("save_is_actually_a_file");
-            std::fs::write(&save_path, b"not a dir")
+            fs::write(&save_path, b"not a dir")
                 .expect("test setup: write save_path as a regular file");
             let roots = NamespaceRoots {
                 save: save_path,
                 assets: root.join("assets"),
                 config: root.join("config"),
             };
-            std::fs::create_dir_all(&roots.assets).expect("test setup: assets root creates");
-            std::fs::create_dir_all(&roots.config).expect("test setup: config root creates");
+            fs::create_dir_all(&roots.assets).expect("test setup: assets root creates");
+            fs::create_dir_all(&roots.config).expect("test setup: config root creates");
 
             let (registry, mailer) = fresh_substrate();
             let result = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
@@ -1000,10 +1007,7 @@ mod native {
         fn duplicate_claim_rejects_with_typed_error() {
             let root = scratch_root("collide");
             let (registry, mailer) = fresh_substrate();
-            registry.register_inbox(
-                FsCapability::NAMESPACE,
-                aether_substrate::mail::registry::noop_handler(),
-            );
+            registry.register_inbox(FsCapability::NAMESPACE, registry::noop_handler());
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<FsCapability>(roots_under(&root))

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -158,9 +158,14 @@ mod native {
             Arc, BootError, HandleCapability, HandlePublish, HandlePublishResult, HandleStore,
         };
         use crate::test_chassis::{TestChassis, boot_test_chassis_with};
+        use aether_kinds::descriptors;
         use aether_substrate::chassis::builder::Builder;
+        use aether_substrate::mail::MailId;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::EgressEvent;
+        use aether_substrate::mail::outbound::HubOutbound;
+        use aether_substrate::mail::registry;
+        use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
 
@@ -172,10 +177,10 @@ mod native {
         ) {
             let store = Arc::new(HandleStore::new(64 * 1024));
             let registry = Arc::new(Registry::new());
-            for d in aether_kinds::descriptors::all() {
+            for d in descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
-            let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
+            let (outbound, rx) = HubOutbound::attached_loopback();
             let mailer = Arc::new(
                 Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
             );
@@ -211,15 +216,15 @@ mod native {
             };
             let bytes = postcard::to_allocvec(&req)
                 .expect("test setup: HandlePublish serializes via postcard");
-            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+            handler.enqueue(OwnedDispatch {
                 kind: <HandlePublish as Kind>::ID,
                 kind_name: "aether.handle.publish".to_owned(),
                 origin: None,
                 sender: session_reply_to(),
                 payload: bytes,
                 count: 1,
-                mail_id: aether_substrate::mail::MailId::NONE,
-                root: aether_substrate::mail::MailId::NONE,
+                mail_id: MailId::NONE,
+                root: MailId::NONE,
                 parent_mail: None,
             });
 
@@ -284,10 +289,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (_store, mailer, registry, _rx) = fresh_substrate();
-            registry.register_inbox(
-                HandleCapability::NAMESPACE,
-                aether_substrate::mail::registry::noop_handler(),
-            );
+            registry.register_inbox(HandleCapability::NAMESPACE, registry::noop_handler());
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<HandleCapability>(())

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -22,6 +22,7 @@ use aether_actor::FfiActorMailbox;
 use aether_kinds::{Fetch, HttpError, HttpHeader, HttpMethod};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
+use std::env;
 
 /// Default response-body cap when `AETHER_HTTP_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -126,16 +127,15 @@ impl HttpConfig {
 }
 
 fn disable_flag_env() -> bool {
-    std::env::var("AETHER_HTTP_DISABLE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    env::var("AETHER_HTTP_DISABLE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 fn https_flag_env() -> bool {
-    std::env::var("AETHER_HTTP_REQUIRE_HTTPS")
-        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    env::var("AETHER_HTTP_REQUIRE_HTTPS").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 fn parse_allowlist_env() -> HashSet<String> {
-    std::env::var("AETHER_HTTP_ALLOWLIST")
+    env::var("AETHER_HTTP_ALLOWLIST")
         .ok()
         .map(|s| {
             s.split(',')
@@ -148,14 +148,14 @@ fn parse_allowlist_env() -> HashSet<String> {
 }
 
 fn parse_max_body_bytes_env() -> usize {
-    std::env::var("AETHER_HTTP_MAX_BODY_BYTES")
+    env::var("AETHER_HTTP_MAX_BODY_BYTES")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(DEFAULT_MAX_BODY_BYTES)
 }
 
 fn parse_default_timeout_env() -> Duration {
-    let ms = std::env::var("AETHER_HTTP_TIMEOUT_MS")
+    let ms = env::var("AETHER_HTTP_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
         .unwrap_or(DEFAULT_TIMEOUT_MS);
@@ -259,6 +259,8 @@ mod native {
     use aether_kinds::FetchResult;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use ureq::http::Method;
+    use ureq::http::Request;
 
     /// `ureq`-backed adapter. Holds the shared agent, the allowlist
     /// (empty = deny all), the response cap, and the `require_https`
@@ -321,7 +323,7 @@ mod native {
                 return Err(HttpError::BodyTooLarge);
             }
 
-            let mut builder = ureq::http::Request::builder()
+            let mut builder = Request::builder()
                 .method(http_method_to_http_crate(req.method))
                 .uri(&req.url);
 
@@ -396,15 +398,15 @@ mod native {
         }
     }
 
-    fn http_method_to_http_crate(m: HttpMethod) -> ureq::http::Method {
+    fn http_method_to_http_crate(m: HttpMethod) -> Method {
         match m {
-            HttpMethod::Get => ureq::http::Method::GET,
-            HttpMethod::Post => ureq::http::Method::POST,
-            HttpMethod::Put => ureq::http::Method::PUT,
-            HttpMethod::Delete => ureq::http::Method::DELETE,
-            HttpMethod::Patch => ureq::http::Method::PATCH,
-            HttpMethod::Head => ureq::http::Method::HEAD,
-            HttpMethod::Options => ureq::http::Method::OPTIONS,
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Delete => Method::DELETE,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Head => Method::HEAD,
+            HttpMethod::Options => Method::OPTIONS,
         }
     }
 
@@ -542,6 +544,12 @@ mod native {
         use aether_substrate::mail::mailer::Mailer;
 
         use crate::test_chassis::{TestChassis, fresh_substrate};
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::outbound::HubOutbound;
+        use aether_substrate::mail::registry;
+        use aether_substrate::mail::registry::Registry;
+        use serde::de::DeserializeOwned;
+        use std::sync::mpsc::Receiver;
 
         struct StubAdapter {
             response: Mutex<Option<Result<FetchResponse, HttpError>>>,
@@ -585,19 +593,15 @@ mod native {
             ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
         }
 
-        fn test_mailer_and_rx() -> (Arc<Mailer>, std::sync::mpsc::Receiver<EgressEvent>) {
-            let (outbound, rx) = aether_substrate::mail::outbound::HubOutbound::attached_loopback();
-            let registry = Arc::new(aether_substrate::mail::registry::Registry::new());
-            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
+        fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
+            let (outbound, rx) = HubOutbound::attached_loopback();
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
             let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
             (mailer, rx)
         }
 
-        fn decode_reply<K: Kind + serde::de::DeserializeOwned>(
-            rx: &std::sync::mpsc::Receiver<EgressEvent>,
-        ) -> K {
+        fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
             let event = rx
                 .recv_timeout(Duration::from_secs(1))
                 .expect("test: egress event arrives within 1s deadline");
@@ -635,10 +639,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_inbox(
-                HttpCapability::NAMESPACE,
-                aether_substrate::mail::registry::noop_handler(),
-            );
+            registry.register_inbox(HttpCapability::NAMESPACE, registry::noop_handler());
             let config = HttpConfig {
                 disabled: true,
                 ..HttpConfig::default()

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -541,13 +541,9 @@ mod native {
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::ReplyTo;
-        use aether_substrate::mail::mailer::Mailer;
 
         use crate::test_chassis::{TestChassis, fresh_substrate};
-        use aether_substrate::handle_store::HandleStore;
-        use aether_substrate::mail::outbound::HubOutbound;
         use aether_substrate::mail::registry;
-        use aether_substrate::mail::registry::Registry;
         use serde::de::DeserializeOwned;
         use std::sync::mpsc::Receiver;
 
@@ -593,13 +589,7 @@ mod native {
             ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())))
         }
 
-        fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
-            let (outbound, rx) = HubOutbound::attached_loopback();
-            let registry = Arc::new(Registry::new());
-            let store = Arc::new(HandleStore::new(1024 * 1024));
-            let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
-            (mailer, rx)
-        }
+        use crate::test_chassis::test_mailer_and_rx;
 
         fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
             let event = rx

--- a/crates/aether-capabilities/src/log.rs
+++ b/crates/aether-capabilities/src/log.rs
@@ -231,7 +231,11 @@ mod native {
         use aether_kinds::LogEvent;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::MailId;
+        use aether_substrate::mail::ReplyTo;
         use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::mail::registry;
+        use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
@@ -289,15 +293,15 @@ mod native {
                 entries: vec![event(3, "parse failed: missing close paren")],
             };
             let bytes = postcard::to_allocvec(&batch).expect("encode");
-            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+            handler.enqueue(OwnedDispatch {
                 kind: <LogBatch as Kind>::ID,
                 kind_name: "aether.log".to_owned(),
                 origin: None,
-                sender: aether_substrate::mail::ReplyTo::NONE,
+                sender: ReplyTo::NONE,
                 payload: bytes,
                 count: 1,
-                mail_id: aether_substrate::mail::MailId::NONE,
-                root: aether_substrate::mail::MailId::NONE,
+                mail_id: MailId::NONE,
+                root: MailId::NONE,
                 parent_mail: None,
             });
 
@@ -308,10 +312,7 @@ mod native {
         #[test]
         fn duplicate_claim_rejects_with_typed_error() {
             let (registry, mailer) = fresh_substrate();
-            registry.register_inbox(
-                LogCapability::NAMESPACE,
-                aether_substrate::mail::registry::noop_handler(),
-            );
+            registry.register_inbox(LogCapability::NAMESPACE, registry::noop_handler());
 
             let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
                 .with_actor::<LogCapability>(())

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -70,6 +70,8 @@ mod native {
     };
 
     use super::{Camera, CaptureFrame, DrawTriangle};
+    use aether_substrate::render::VERTEX_BUFFER_BYTES;
+    use std::mem;
 
     /// Configuration for [`RenderCapability`]. `vertex_buffer_bytes` is
     /// the maximum bytes the render accumulator will hold before
@@ -103,7 +105,7 @@ mod native {
     impl Default for RenderConfig {
         fn default() -> Self {
             Self {
-                vertex_buffer_bytes: aether_substrate::render::VERTEX_BUFFER_BYTES,
+                vertex_buffer_bytes: VERTEX_BUFFER_BYTES,
                 observed_kinds: None,
                 capture_backend: None,
             }
@@ -534,7 +536,7 @@ mod native {
                     .expect("mutex poisoned; fail-fast per ADR-0063");
                 if !live.is_empty() {
                     // Producer emitted: swap into cache.
-                    std::mem::swap(&mut *live, &mut *last);
+                    mem::swap(&mut *live, &mut *last);
                     // Post-swap, `live` holds what `last` held before
                     // — stale geometry from however many frames ago.
                     // Clear (preserves capacity) so the next tick's
@@ -736,18 +738,20 @@ mod native {
         use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::MailId;
         use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{KindId, ReplyTo};
+        use std::thread;
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
             let registry = Arc::new(Registry::new());
             // Issue 603 Phase 2: `RenderCapability::init` reads
             // `mailer.registry()` to keep the substrate registry handle
             // for `capture_frame`'s resolve-bundle path.
-            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
+            let store = Arc::new(HandleStore::new(1024 * 1024));
             let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
             (registry, mailer)
         }
@@ -770,15 +774,15 @@ mod native {
             let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
                 panic!("expected mailbox entry for {name}");
             };
-            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+            handler.enqueue(OwnedDispatch {
                 kind,
                 kind_name: "test.kind".to_owned(),
                 origin: None,
                 sender: ReplyTo::NONE,
                 payload: payload.to_vec(),
                 count: 1,
-                mail_id: aether_substrate::mail::MailId::NONE,
-                root: aether_substrate::mail::MailId::NONE,
+                mail_id: MailId::NONE,
+                root: MailId::NONE,
                 parent_mail: None,
             });
         }
@@ -821,7 +825,7 @@ mod native {
                 if pending.is_empty() || pending[0].1.load(Ordering::Acquire) == 0 {
                     break;
                 }
-                std::thread::sleep(Duration::from_millis(5));
+                thread::sleep(Duration::from_millis(5));
             }
             // The pending counter must have hit zero — the dispatcher
             // ran the handler.
@@ -867,7 +871,7 @@ mod native {
                 &[1u8; 16],
             );
 
-            std::thread::sleep(Duration::from_millis(50));
+            thread::sleep(Duration::from_millis(50));
             // No further assertion on internal state — passive chassis
             // doesn't expose `Arc<RenderCapability>`. Decode failure is
             // observable via the macro miss path's warn-log; this test
@@ -889,6 +893,7 @@ mod native_headless {
     use aether_substrate::mail::outbound::HubOutbound;
 
     use super::{Camera, CaptureFrame, DrawTriangle};
+    use std::io;
 
     /// Chassis-without-GPU companion to [`super::RenderCapability`].
     /// Claims the same `aether.render` mailbox so desktop-designed
@@ -914,7 +919,7 @@ mod native_headless {
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
+                BootError::Other(Box::new(io::Error::other(
                     "HubOutbound must be wired on Mailer before \
                          HeadlessRenderCapability::init (chassis main connects the hub before \
                          the Builder chain)",

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -738,7 +738,6 @@ mod native {
         use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
-        use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::MailId;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::OwnedDispatch;
@@ -746,15 +745,7 @@ mod native {
         use aether_substrate::mail::{KindId, ReplyTo};
         use std::thread;
 
-        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-            let registry = Arc::new(Registry::new());
-            // Issue 603 Phase 2: `RenderCapability::init` reads
-            // `mailer.registry()` to keep the substrate registry handle
-            // for `capture_frame`'s resolve-bundle path.
-            let store = Arc::new(HandleStore::new(1024 * 1024));
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-            (registry, mailer)
-        }
+        use crate::test_chassis::fresh_substrate;
 
         /// Boots a passive `TestChassis` with a default `RenderCapability`.
         /// Collapses the four-line `Builder::<TestChassis>::new(...)` chain

--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -21,12 +21,14 @@
 
 use crate::rpc::wire::{Hello, HelloAck, MailEnvelope, PeerKind, WIRE_VERSION, WireFrame};
 use aether_codec::frame::{FrameError, read_frame, write_frame};
+use std::error;
 use std::fmt;
 use std::io::{self, BufReader};
 use std::net::{Shutdown, TcpStream};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::thread;
 use std::thread::JoinHandle;
 
 /// The outbound half of a live RPC connection: the write socket plus a
@@ -105,8 +107,8 @@ impl fmt::Display for RpcClientError {
     }
 }
 
-impl std::error::Error for RpcClientError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl error::Error for RpcClientError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::Connect(e) => Some(e),
             Self::Frame(e) => Some(e),
@@ -178,7 +180,7 @@ impl RpcClient {
         let shutdown_for_thread = Arc::clone(&shutdown);
         let (inbound_tx, inbound_rx) = mpsc::channel::<WireFrame>();
 
-        let thread = std::thread::Builder::new()
+        let thread = thread::Builder::new()
             .name("aether-rpc-client-reader".into())
             .spawn(move || {
                 loop {
@@ -280,6 +282,7 @@ mod tests {
     use std::io::BufReader;
     use std::net::{TcpListener, TcpStream};
     use std::sync::Arc;
+    use std::thread;
     use std::thread::JoinHandle;
     use std::time::Duration;
 
@@ -307,7 +310,7 @@ mod tests {
     fn fake_server(handle: impl FnOnce(TcpStream) + Send + 'static) -> (u16, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
         let port = listener.local_addr().expect("local_addr").port();
-        let thread = std::thread::spawn(move || {
+        let thread = thread::spawn(move || {
             let (stream, _) = listener.accept().expect("fake server accept");
             handle(stream);
         });

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -40,6 +40,7 @@ mod server_native {
         Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
     };
     use aether_actor::actor;
+    use aether_codec::frame::FrameError;
     use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
     use aether_kinds::{CallSettled, RouteEnvelope};
@@ -51,10 +52,12 @@ mod server_native {
     use aether_substrate::mail::mailer::Mailer;
     use std::collections::HashMap;
     use std::io::{self, BufReader};
+    use std::net::Shutdown;
     use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
+    use std::thread;
     use std::thread::JoinHandle;
     use std::time::Duration;
 
@@ -174,7 +177,7 @@ mod server_native {
             let self_id = ctx.self_id();
             let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
 
-            let thread = std::thread::Builder::new()
+            let thread = thread::Builder::new()
                 .name(format!("aether-rpc-accept-{port}"))
                 .spawn(move || {
                     while !accept_shutdown_for_thread.load(Ordering::Acquire) {
@@ -236,7 +239,7 @@ mod server_native {
             // shutdown flag and exits.
             for conn in self.connections.values_mut() {
                 conn.shutdown.store(true, Ordering::Release);
-                let _ = conn.write_half.shutdown(std::net::Shutdown::Read);
+                let _ = conn.write_half.shutdown(Shutdown::Read);
                 if let Some(t) = conn.reader_thread.take() {
                     let _ = t.join();
                 }
@@ -400,7 +403,7 @@ mod server_native {
             let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
             let inbound_tx = self.inbound_tx.clone();
 
-            let thread = match std::thread::Builder::new()
+            let thread = match thread::Builder::new()
                 .name(format!("aether-rpc-reader-{conn_id}"))
                 .spawn(move || {
                     let mut reader = BufReader::new(read_half);
@@ -410,7 +413,7 @@ mod server_native {
                         }
                         let frame: WireFrame = match read_frame(&mut reader) {
                             Ok(f) => f,
-                            Err(aether_codec::frame::FrameError::Io(io_err))
+                            Err(FrameError::Io(io_err))
                                 if io_err.kind() == io::ErrorKind::UnexpectedEof =>
                             {
                                 let _ = inbound_tx.send(InboundEvent::ReaderClosed {
@@ -618,7 +621,7 @@ mod server_native {
                 return;
             };
             conn.shutdown.store(true, Ordering::Release);
-            let _ = conn.write_half.shutdown(std::net::Shutdown::Both);
+            let _ = conn.write_half.shutdown(Shutdown::Both);
             // Drop reader_thread without joining inline — the
             // dispatcher must not block on the reader. The thread sees
             // the shutdown flag (or its own EOF) and exits; the
@@ -642,7 +645,7 @@ mod server_native {
             };
             if let Err(e) = write_frame(&mut conn.write_half, frame) {
                 let reason = match &e {
-                    aether_codec::frame::FrameError::Io(io_err)
+                    FrameError::Io(io_err)
                         if matches!(
                             io_err.kind(),
                             io::ErrorKind::BrokenPipe
@@ -652,7 +655,7 @@ mod server_native {
                     {
                         "peer hung up"
                     }
-                    aether_codec::frame::FrameError::Io(_) => "write error",
+                    FrameError::Io(_) => "write error",
                     _ => "frame encode error",
                 };
                 tracing::debug!(
@@ -684,6 +687,7 @@ mod tests {
     use crate::test_chassis::{TestChassis, fresh_substrate};
     use aether_codec::frame::{read_frame, write_frame};
     use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::chassis::builder::PassiveChassis;
     use std::net::TcpStream;
     use std::sync::Arc;
     use std::time::Duration;
@@ -703,12 +707,7 @@ mod tests {
     /// chassis and reach for [`connect_to_rpc_server`] for the
     /// connect / timeout half. Returns `(chassis, stream)`; both must
     /// stay alive for the listener to keep accepting.
-    fn boot_with_rpc_server_only(
-        timeout: Duration,
-    ) -> (
-        aether_substrate::chassis::builder::PassiveChassis<TestChassis>,
-        TcpStream,
-    ) {
+    fn boot_with_rpc_server_only(timeout: Duration) -> (PassiveChassis<TestChassis>, TcpStream) {
         let (registry, mailer) = fresh_substrate();
         let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<RpcServerCapability>(RpcServerConfig {
@@ -725,7 +724,7 @@ mod tests {
     /// `TcpStream`, set `read_timeout`. Shared by every test whose
     /// boot path is more elaborate than `boot_with_rpc_server_only`.
     fn connect_to_rpc_server(
-        chassis: &aether_substrate::chassis::builder::PassiveChassis<TestChassis>,
+        chassis: &PassiveChassis<TestChassis>,
         timeout: Duration,
     ) -> TcpStream {
         let port = chassis

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -39,6 +39,7 @@ mod listener_native {
     use std::time::Duration;
 
     use crate::tcp::session::{TcpSessionActor, TcpSessionConfig};
+    use std::thread;
 
     /// Init config for [`TcpListenerActor`]. `TcpCapability::on_bind`
     /// binds the socket on the dispatcher thread (so addr-parse / port-
@@ -102,7 +103,7 @@ mod listener_native {
             let self_id = ctx.self_id();
             let connection_ready_kind = KindId(<ConnectionReady as Kind>::ID.0);
 
-            let thread = std::thread::Builder::new()
+            let thread = thread::Builder::new()
                 .name(format!("aether-tcp-accept-{port}"))
                 .spawn(move || {
                     while !shutdown_for_thread.load(Ordering::Acquire) {

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -555,21 +555,24 @@ mod cap_native {
         use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
         use aether_data::{Kind, SessionToken, Uuid};
+        use aether_kinds::descriptors;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::MailId;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use serde::de::DeserializeOwned;
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
             let registry = Arc::new(Registry::new());
-            for d in aether_kinds::descriptors::all() {
+            for d in descriptors::all() {
                 let _ = registry.register_kind_with_descriptor(d);
             }
             let (outbound, rx) = HubOutbound::attached_loopback();
-            let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
-                1024 * 1024,
-            ));
+            let store = Arc::new(HandleStore::new(1024 * 1024));
             let mailer =
                 Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
             (registry, mailer, rx)
@@ -613,7 +616,7 @@ mod cap_native {
         ) -> R
         where
             K: Kind + serde::Serialize,
-            R: serde::de::DeserializeOwned,
+            R: DeserializeOwned,
         {
             let id = registry
                 .lookup(cap_namespace)
@@ -622,15 +625,15 @@ mod cap_native {
                 panic!("expected mailbox entry");
             };
             let bytes = postcard::to_allocvec(mail).expect("encode");
-            handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+            handler.enqueue(OwnedDispatch {
                 kind: K::ID,
                 kind_name: K::NAME.to_owned(),
                 origin: None,
                 sender: session_reply(),
                 payload: bytes,
                 count: 1,
-                mail_id: aether_substrate::mail::MailId::NONE,
-                root: aether_substrate::mail::MailId::NONE,
+                mail_id: MailId::NONE,
+                root: MailId::NONE,
                 parent_mail: None,
             });
 

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -52,6 +52,7 @@ mod session_native {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
+    use std::thread;
     use std::thread::JoinHandle;
 
     /// Default per-read buffer size. 64 KiB matches the typical
@@ -122,7 +123,7 @@ mod session_native {
             let data_ready_kind = KindId(<SessionDataReady as Kind>::ID.0);
 
             let thread_name = format!("aether-tcp-read-{}", config.session_name);
-            let thread = std::thread::Builder::new()
+            let thread = thread::Builder::new()
                 .name(thread_name)
                 .spawn(move || {
                     let mut read_half = read_half;

--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -28,6 +28,7 @@ mod native {
     use aether_substrate::mail::outbound::HubOutbound;
 
     use super::Advance;
+    use std::io;
 
     /// Stub cap for `aether.test_bench` on chassis without test-bench
     /// drive (desktop, headless). Replies `AdvanceResult::Err` so MCP
@@ -45,7 +46,7 @@ mod native {
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
+                BootError::Other(Box::new(io::Error::other(
                     "HubOutbound must be wired on Mailer before \
                      UnsupportedTestBenchCapability::init (chassis main connects the hub before \
                      the Builder chain)",

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -13,6 +13,7 @@
 
 use std::sync::Arc;
 
+use aether_kinds::descriptors;
 use aether_substrate::actor::native::{NativeActor, NativeDispatch};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -47,7 +48,7 @@ impl Chassis for TestChassis {
 /// (rpc, engine proxy) get the connected backend they need.
 pub fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
     let registry = Arc::new(Registry::new());
-    for d in aether_kinds::descriptors::all() {
+    for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
     }
     let (outbound, _rx) = HubOutbound::attached_loopback();

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -12,6 +12,7 @@
 //! `(Arc<Registry>, Arc<Mailer>)` seed for `Builder::new`.
 
 use std::sync::Arc;
+use std::sync::mpsc::Receiver;
 
 use aether_kinds::descriptors;
 use aether_substrate::actor::native::{NativeActor, NativeDispatch};
@@ -20,7 +21,7 @@ use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, Pas
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::mailer::Mailer;
-use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
 use aether_substrate::mail::registry::Registry;
 
 /// Canonical test chassis. `build()` is unreachable — every consumer
@@ -80,4 +81,19 @@ where
         .with_actor::<A>(config)
         .build_passive()
         .expect("test chassis boots")
+}
+
+/// Build a `(Arc<Mailer>, Receiver<EgressEvent>)` pair where the
+/// mailer's outbound is wired to a loopback channel whose receiver
+/// the caller can drain. Mirrors [`fresh_substrate`] but exposes the
+/// egress side for tests that need to observe `ReplyTarget::Session`
+/// sends (the cap-level reply path used by `aether.fs` / `aether.http`
+/// / `aether.audio`). The registry is bare — no kind descriptors —
+/// so tests can register only what they exercise.
+pub fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
+    let (outbound, rx) = HubOutbound::attached_loopback();
+    let registry = Arc::new(Registry::new());
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+    (mailer, rx)
 }

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -44,6 +44,9 @@ mod native {
     use aether_substrate::mail::helpers::resolve_bundle;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::registry::Registry;
+    use aether_substrate::runtime::trace;
+    use std::cmp::Reverse;
+    use std::env;
 
     /// ADR-0080 §11 retention defaults. Override via env vars.
     /// `AETHER_TRACE_RETENTION_MS` — drop roots older than this many
@@ -309,7 +312,7 @@ mod native {
                     })
                 })
                 .collect();
-            summaries.sort_by_key(|s| std::cmp::Reverse(s.t_sent));
+            summaries.sort_by_key(|s| Reverse(s.t_sent));
             summaries.truncate(max);
             ListActiveRootsResult { roots: summaries }
         }
@@ -446,14 +449,14 @@ mod native {
     }
 
     fn parse_env_u64(name: &str, default: u64) -> u64 {
-        std::env::var(name)
+        env::var(name)
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(default)
     }
 
     fn parse_env_usize(name: &str, default: usize) -> usize {
-        std::env::var(name)
+        env::var(name)
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(default)
@@ -542,7 +545,7 @@ mod native {
         /// Issue 718 / ADR-0080 Phase 2.
         #[handler]
         fn on_list_active_roots(&mut self, ctx: &mut NativeCtx<'_>, request: ListActiveRoots) {
-            let now = aether_substrate::runtime::trace::now_nanos();
+            let now = trace::now_nanos();
             let result = self.build_list_active_roots(request, now);
             ctx.reply(&result);
         }
@@ -559,7 +562,7 @@ mod native {
         /// root via `describe_tree` for full chain context. Issue 735.
         #[handler]
         fn on_describe_window(&mut self, ctx: &mut NativeCtx<'_>, request: DescribeWindow) {
-            let now = aether_substrate::runtime::trace::now_nanos();
+            let now = trace::now_nanos();
             let result = self.build_describe_window(request, now);
             ctx.reply(&result);
         }
@@ -609,8 +612,11 @@ mod native {
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::{MailDispatch, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use std::collections::HashSet;
+        use std::env;
         use std::sync::Mutex;
         use std::sync::mpsc::Receiver;
+        use std::thread;
 
         /// Construct an observer for state-fold tests. Stash a fresh
         /// `Mailer` so `fire_settled` has somewhere to push (the
@@ -625,8 +631,8 @@ mod native {
             // write. `std::env::set_var` only requires "no other thread
             // is reading or writing the environment simultaneously."
             unsafe {
-                std::env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
-                std::env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");
+                env::set_var("AETHER_TRACE_RETENTION_MS", "60000");
+                env::set_var("AETHER_TRACE_MAX_ROOTS", "1000");
             }
             observer_with(Duration::from_mins(1), 1000)
         }
@@ -816,7 +822,7 @@ mod native {
                 );
                 // Tiny delay so `Instant::now()` advances across
                 // each insert — cheap-enough for a 5-root test.
-                std::thread::sleep(Duration::from_millis(2));
+                thread::sleep(Duration::from_millis(2));
             }
             obs.evict();
             assert_eq!(obs.roots.len(), 3);
@@ -1132,8 +1138,7 @@ mod native {
                     assert_eq!(r, root);
                     assert_eq!(in_flight, 3);
                     assert_eq!(mails.len(), 3);
-                    let ids: std::collections::HashSet<MailId> =
-                        mails.iter().map(|m| m.mail_id).collect();
+                    let ids: HashSet<MailId> = mails.iter().map(|m| m.mail_id).collect();
                     assert!(ids.contains(&root));
                     assert!(ids.contains(&a));
                     assert!(ids.contains(&b));
@@ -1250,7 +1255,7 @@ mod native {
                 Nanos(100),
             );
             assert_eq!(obs.t_sent_index.len(), 1);
-            std::thread::sleep(Duration::from_millis(80));
+            thread::sleep(Duration::from_millis(80));
             obs.evict();
             assert!(obs.t_sent_index.is_empty(), "secondary index out of sync");
         }
@@ -1273,7 +1278,7 @@ mod native {
                     KindId(0xABCD),
                     Nanos(cid * 100),
                 );
-                std::thread::sleep(Duration::from_millis(2));
+                thread::sleep(Duration::from_millis(2));
             }
             obs.evict();
             assert_eq!(obs.roots.len(), 3);
@@ -1455,8 +1460,7 @@ mod native {
             match result {
                 DescribeWindowResult::Ok { mails } => {
                     assert_eq!(mails.len(), 2);
-                    let ids: std::collections::HashSet<MailId> =
-                        mails.iter().map(|m| m.mail_id).collect();
+                    let ids: HashSet<MailId> = mails.iter().map(|m| m.mail_id).collect();
                     assert!(ids.contains(&mail(1, 2)));
                     assert!(ids.contains(&mail(1, 3)));
                 }
@@ -1509,7 +1513,7 @@ mod native {
                 Nanos(100),
             );
             assert_eq!(obs.roots.len(), 1);
-            std::thread::sleep(Duration::from_millis(80));
+            thread::sleep(Duration::from_millis(80));
             obs.evict();
             assert!(obs.roots.is_empty());
             assert!(obs.mails.is_empty());

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -92,6 +92,7 @@ mod native {
     use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
     use aether_substrate::mail::{Mail, MailboxId};
+    use std::io;
 
     /// Configuration handed to [`WasmTrampoline::init`] by the spawn
     /// path. Carries the wasmtime engine / linker plus the parsed
@@ -175,9 +176,7 @@ mod native {
                 substrate_ctx,
             )
             .map_err(|e| {
-                BootError::Other(
-                    std::io::Error::other(format!("wasm instantiation failed: {e}")).into(),
-                )
+                BootError::Other(io::Error::other(format!("wasm instantiation failed: {e}")).into())
             })?;
             Ok(Self {
                 component: Some(component),

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -24,6 +24,7 @@ mod native {
     use aether_substrate::mail::outbound::HubOutbound;
 
     use super::{SetWindowMode, SetWindowTitle};
+    use std::io;
 
     /// Chassis-without-window companion to the desktop driver's
     /// driver-as-actor `aether.window` claim. Mirrors
@@ -46,7 +47,7 @@ mod native {
 
         fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
+                BootError::Other(Box::new(io::Error::other(
                     "HubOutbound must be wired on Mailer before \
                      HeadlessWindowCapability::init (chassis main connects the hub before \
                      the Builder chain)",

--- a/crates/aether-capabilities/tests/log_pool_stress.rs
+++ b/crates/aether-capabilities/tests/log_pool_stress.rs
@@ -31,11 +31,14 @@ use std::time::{Duration, Instant};
 use aether_data::{Kind, ReplyTo};
 use aether_kinds::LogBatch;
 
+use aether_substrate::mail::MailId;
+use aether_substrate::mail::registry::OwnedDispatch;
 use aether_substrate::{
     Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, NativeActor, NativeCtx,
     NativeInitCtx, NeverDriver, PassiveChassis, Registry, handle_store::HandleStore,
     mail::registry::MailboxEntry,
 };
+use std::thread;
 
 const STRESS_BATCHES: u32 = 10_000;
 /// Pooled-vs-dedicated wallclock ratio cap. Issue 635 Phase 2 spec is
@@ -134,15 +137,15 @@ fn push_log_batch(registry: &Registry, recipient: &str, payload: &[u8]) {
     let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
-    handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+    handler.enqueue(OwnedDispatch {
         kind: <LogBatch as Kind>::ID,
         kind_name: LogBatch::NAME.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
         payload: payload.to_vec(),
         count: 1,
-        mail_id: aether_substrate::mail::MailId::NONE,
-        root: aether_substrate::mail::MailId::NONE,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
         parent_mail: None,
     });
 }
@@ -157,7 +160,7 @@ fn await_counter(counter: &AtomicU64, target: u64) -> u64 {
         if value >= target || Instant::now() >= deadline {
             return value;
         }
-        std::thread::yield_now();
+        thread::yield_now();
     }
 }
 

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -31,6 +31,9 @@ use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::{Map, Value};
 
 use crate::cast::{align_of_primitive, non_cast_variant_error};
+use aether_data::tagged_id;
+use std::error;
+use std::str;
 
 #[derive(Debug)]
 pub enum DecodeError {
@@ -91,7 +94,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
-impl std::error::Error for DecodeError {}
+impl error::Error for DecodeError {}
 
 /// ADR-0020: decode `bytes` against a `SchemaType` descriptor into a
 /// JSON value symmetric to what `encode_schema` would accept.
@@ -217,7 +220,7 @@ fn decode_cast_field(
 fn render_type_id_value(id: u64, type_id: u64, _path: &str) -> Result<Value, DecodeError> {
     let _expected = aether_data::tag_for_type_id(type_id)
         .ok_or(DecodeError::UnsupportedSchema("unknown TypeId in schema"))?;
-    Ok(aether_data::tagged_id::encode(id).map_or_else(|| Value::from(id), Value::String))
+    Ok(tagged_id::encode(id).map_or_else(|| Value::from(id), Value::String))
 }
 
 fn read_primitive_cast(
@@ -292,7 +295,7 @@ fn decode_postcard(
         SchemaType::String => {
             let len = read_varint_u64(cur, path)? as usize;
             let bytes = cur.take_slice(len, path)?;
-            let s = std::str::from_utf8(bytes)
+            let s = str::from_utf8(bytes)
                 .map_err(|_| DecodeError::InvalidUtf8 { path: path.into() })?;
             Ok(Value::String(s.into()))
         }
@@ -622,6 +625,7 @@ mod tests {
     use crate::encode_schema;
     use crate::test_fixtures::{cast_struct, pending_ok_err_variants, postcard_struct, scalar};
     use aether_data::SchemaCell;
+    use aether_data::tagged_id;
     use serde_json::json;
 
     /// Local alias preserving the decode-side spelling that the test
@@ -1036,8 +1040,7 @@ mod tests {
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
         let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let s = aether_data::tagged_id::encode(mailbox.0)
-            .expect("test setup: encode tagged mailbox id");
+        let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         roundtrip(json!({ "mailbox": s }), &schema);
     }
 
@@ -1056,8 +1059,7 @@ mod tests {
             },
         ]);
         let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let s = aether_data::tagged_id::encode(mailbox.0)
-            .expect("test setup: encode tagged mailbox id");
+        let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         roundtrip(json!({ "stream": 1, "mailbox": s }), &schema);
     }
 
@@ -1073,11 +1075,10 @@ mod tests {
         // match what the substrate expects.
         use aether_data::Kind;
         let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let mailbox_str = aether_data::tagged_id::encode(mailbox.0)
-            .expect("test setup: encode tagged mailbox id");
+        let mailbox_str =
+            tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         let kind_id = aether_kinds::Tick::ID;
-        let kind_str =
-            aether_data::tagged_id::encode(kind_id.0).expect("test setup: encode tagged kind id");
+        let kind_str = tagged_id::encode(kind_id.0).expect("test setup: encode tagged kind id");
         let json_in = json!({ "kind": kind_str, "mailbox": mailbox_str });
 
         let bytes = encode_schema(
@@ -1099,7 +1100,7 @@ mod tests {
         // `with_tag` discipline holds through the schema-bytes
         // change).
         assert_eq!(
-            aether_data::tagged_id::tag_of(aether_kinds::SubscribeInput::ID.0),
+            tagged_id::tag_of(aether_kinds::SubscribeInput::ID.0),
             Some(aether_data::Tag::Kind),
         );
     }

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -43,6 +43,7 @@ use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::Value;
 
 use crate::cast::{align_of_primitive, non_cast_variant_error};
+use std::error;
 
 #[derive(Debug)]
 pub enum EncodeError {
@@ -97,7 +98,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
-impl std::error::Error for EncodeError {}
+impl error::Error for EncodeError {}
 
 /// ADR-0019: encode `params` against a `SchemaType` descriptor.
 /// Dispatches on the schema's wire shape:
@@ -852,6 +853,7 @@ mod tests {
     };
     use aether_data::SchemaCell;
     use serde_json::json;
+    use std::collections::BTreeMap;
 
     fn enum_schema(variants: Vec<EnumVariant>) -> SchemaType {
         SchemaType::Enum {
@@ -1352,8 +1354,7 @@ mod tests {
             ty: map_schema(SchemaType::String, SchemaType::String),
         }]);
 
-        let mut reference: std::collections::BTreeMap<String, String> =
-            std::collections::BTreeMap::new();
+        let mut reference: BTreeMap<String, String> = BTreeMap::new();
         reference.insert("content-type".into(), "application/json".into());
         reference.insert("x-trace".into(), "abc123".into());
 
@@ -1388,8 +1389,7 @@ mod tests {
     fn map_u32_keys_match_postcard_btreemap() {
         let schema = map_schema(SchemaType::Scalar(Primitive::U32), SchemaType::String);
 
-        let mut reference: std::collections::BTreeMap<u32, String> =
-            std::collections::BTreeMap::new();
+        let mut reference: BTreeMap<u32, String> = BTreeMap::new();
         reference.insert(1, "one".into());
         reference.insert(42, "answer".into());
         reference.insert(255, "max-u8".into());
@@ -1408,8 +1408,7 @@ mod tests {
     #[test]
     fn map_bool_keys_match_postcard_btreemap() {
         let schema = map_schema(SchemaType::Bool, SchemaType::Scalar(Primitive::U32));
-        let mut reference: std::collections::BTreeMap<bool, u32> =
-            std::collections::BTreeMap::new();
+        let mut reference: BTreeMap<bool, u32> = BTreeMap::new();
         reference.insert(false, 0);
         reference.insert(true, 1);
         let expected = postcard::to_allocvec(&reference)

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -25,6 +25,7 @@ use std::fmt;
 use std::io::{self, Read, Write};
 
 use serde::{Serialize, de::DeserializeOwned};
+use std::error;
 
 /// Maximum accepted frame body size. Bounded so a malformed length
 /// prefix cannot drive a reader into an OOM. 16 MiB is comfortably
@@ -53,7 +54,7 @@ impl fmt::Display for FrameError {
     }
 }
 
-impl std::error::Error for FrameError {}
+impl error::Error for FrameError {}
 
 impl From<io::Error> for FrameError {
     fn from(e: io::Error) -> Self {

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -69,6 +69,7 @@ mod tests {
         primitives::write_varint_u64,
         schema::{KIND_DOMAIN, fnv1a_64_prefixed},
     };
+    use crate::ids::KindId;
     use crate::schema::{
         EnumVariant, KindLabels, KindShape, LabelCell, LabelNode, NamedField, Primitive,
         SchemaCell, SchemaShape, SchemaType, VariantLabel, VariantShape,
@@ -328,7 +329,7 @@ mod tests {
     };
 
     static TRIANGLE_LABELS: KindLabels = KindLabels {
-        kind_id: crate::ids::KindId(0),
+        kind_id: KindId(0),
         kind_label: Cow::Borrowed("my_crate::Triangle"),
         root: LabelNode::Struct {
             type_label: Some(Cow::Borrowed("my_crate::Triangle")),
@@ -346,7 +347,7 @@ mod tests {
     }
 
     static RESULT_LABELS: KindLabels = KindLabels {
-        kind_id: crate::ids::KindId(0),
+        kind_id: KindId(0),
         kind_label: Cow::Borrowed("my_crate::Result"),
         root: LabelNode::Enum {
             type_label: Some(Cow::Borrowed("my_crate::Result")),
@@ -382,7 +383,7 @@ mod tests {
     // on either side breaks `describe_kinds`.
 
     static REF_VERTEX_LABELS: KindLabels = KindLabels {
-        kind_id: crate::ids::KindId(0),
+        kind_id: KindId(0),
         kind_label: Cow::Borrowed("my_crate::HeldVertex"),
         root: LabelNode::Ref(LabelCell::Static(&VERTEX_LABELS)),
     };
@@ -410,7 +411,7 @@ mod tests {
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         match decoded {
             InputsRecord::Handler { id, name, doc } => {
-                assert_eq!(id, crate::ids::KindId(ID));
+                assert_eq!(id, KindId(ID));
                 assert_eq!(name, NAME);
                 assert_eq!(doc.as_deref(), DOC);
             }
@@ -429,7 +430,7 @@ mod tests {
         assert_eq!(
             decoded,
             InputsRecord::Handler {
-                id: crate::ids::KindId(ID),
+                id: KindId(ID),
                 name: NAME.into(),
                 doc: None,
             }

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -15,6 +15,12 @@ use super::primitives::{
     cow_enum_variants, cow_named_fields, cow_schema_types, str_len, varint_u32_len, varint_u64_len,
     varint_usize_len, write_str, write_varint_u32, write_varint_u64, write_varint_usize,
 };
+use crate::schema::KindShape;
+use crate::schema::SchemaShape;
+use crate::schema::VariantShape;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 const SCHEMA_UNIT: u8 = 0;
 const SCHEMA_BOOL: u8 = 1;
@@ -191,15 +197,15 @@ pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &Schem
 /// per ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot
 /// fail for `KindShape`, so a failure indicates a serializer bug.
 #[must_use]
-pub fn canonical_kind_bytes(name: &str, schema: &SchemaType) -> alloc::vec::Vec<u8> {
-    let shape = crate::schema::KindShape {
-        name: alloc::borrow::Cow::Owned(name.into()),
+pub fn canonical_kind_bytes(name: &str, schema: &SchemaType) -> Vec<u8> {
+    let shape = KindShape {
+        name: Cow::Owned(name.into()),
         schema: schema_to_shape(schema),
     };
     postcard::to_allocvec(&shape).expect("canonical KindShape serialization is infallible")
 }
 
-fn schema_to_shape(s: &SchemaType) -> crate::schema::SchemaShape {
+fn schema_to_shape(s: &SchemaType) -> SchemaShape {
     use crate::schema::SchemaShape;
     match s {
         SchemaType::Unit => SchemaShape::Unit,
@@ -207,12 +213,10 @@ fn schema_to_shape(s: &SchemaType) -> crate::schema::SchemaShape {
         SchemaType::Scalar(p) => SchemaShape::Scalar(*p),
         SchemaType::String => SchemaShape::String,
         SchemaType::Bytes => SchemaShape::Bytes,
-        SchemaType::Option(cell) => {
-            SchemaShape::Option(alloc::boxed::Box::new(schema_to_shape(cell)))
-        }
-        SchemaType::Vec(cell) => SchemaShape::Vec(alloc::boxed::Box::new(schema_to_shape(cell))),
+        SchemaType::Option(cell) => SchemaShape::Option(Box::new(schema_to_shape(cell))),
+        SchemaType::Vec(cell) => SchemaShape::Vec(Box::new(schema_to_shape(cell))),
         SchemaType::Array { element, len } => SchemaShape::Array {
-            element: alloc::boxed::Box::new(schema_to_shape(element)),
+            element: Box::new(schema_to_shape(element)),
             len: *len,
         },
         SchemaType::Struct { fields, repr_c } => SchemaShape::Struct {
@@ -222,16 +226,16 @@ fn schema_to_shape(s: &SchemaType) -> crate::schema::SchemaShape {
         SchemaType::Enum { variants } => SchemaShape::Enum {
             variants: variants.iter().map(variant_to_shape).collect(),
         },
-        SchemaType::Ref(cell) => SchemaShape::Ref(alloc::boxed::Box::new(schema_to_shape(cell))),
+        SchemaType::Ref(cell) => SchemaShape::Ref(Box::new(schema_to_shape(cell))),
         SchemaType::Map { key, value } => SchemaShape::Map {
-            key: alloc::boxed::Box::new(schema_to_shape(key)),
-            value: alloc::boxed::Box::new(schema_to_shape(value)),
+            key: Box::new(schema_to_shape(key)),
+            value: Box::new(schema_to_shape(value)),
         },
         SchemaType::TypeId(id) => SchemaShape::TypeId(*id),
     }
 }
 
-fn variant_to_shape(v: &EnumVariant) -> crate::schema::VariantShape {
+fn variant_to_shape(v: &EnumVariant) -> VariantShape {
     use crate::schema::VariantShape;
     match v {
         EnumVariant::Unit { discriminant, .. } => VariantShape::Unit {
@@ -291,7 +295,7 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 /// ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot fail
 /// for `KindShape`, so a failure indicates a serializer bug.
 #[must_use]
-pub fn kind_id_from_shape(shape: &crate::schema::KindShape) -> u64 {
+pub fn kind_id_from_shape(shape: &KindShape) -> u64 {
     let bytes =
         postcard::to_allocvec(shape).expect("canonical KindShape serialization is infallible");
     (u64::from(TAG_KIND) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -38,8 +38,11 @@
 
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
+use serde::de::DeserializeOwned;
 
 pub mod canonical;
 pub mod hash;
@@ -176,7 +179,7 @@ impl<T: CastEligible, const N: usize> CastEligible for [T; N] {
 // Listing them here is the price of not having stable Rust
 // specialization; new "definitely not eligible" types can be added
 // as the kind vocabulary reaches for them.
-impl CastEligible for alloc::string::String {
+impl CastEligible for String {
     const ELIGIBLE: bool = false;
 }
 impl<T> CastEligible for Vec<T> {
@@ -190,7 +193,7 @@ impl<K> CastEligible for Ref<K> {
 }
 // Issue #232: `BTreeMap<K, V>` is variable-length and disqualifies a
 // parent struct from `repr_c`, same as `Vec`/`String`/`Option`.
-impl<K, V> CastEligible for alloc::collections::BTreeMap<K, V> {
+impl<K, V> CastEligible for BTreeMap<K, V> {
     const ELIGIBLE: bool = false;
 }
 
@@ -306,6 +309,7 @@ mod schema_impls {
 
     use crate::schema::{LabelCell, LabelNode, Primitive, SchemaCell, SchemaType};
     use crate::{HandleId, KindId, MailboxId, Schema};
+    use alloc::collections::BTreeMap;
 
     macro_rules! scalar {
         ($t:ty, $p:ident) => {
@@ -416,7 +420,7 @@ mod schema_impls {
     // type level. `HashMap<K, V>` is rejected at the derive layer
     // (mail-derive) because its iteration order is platform-
     // dependent and would diverge canonical bytes across builds.
-    impl<K: Schema + Ord + 'static, V: Schema + 'static> Schema for alloc::collections::BTreeMap<K, V> {
+    impl<K: Schema + Ord + 'static, V: Schema + 'static> Schema for BTreeMap<K, V> {
         const SCHEMA: SchemaType = SchemaType::Map {
             key: SchemaCell::Static(&K::SCHEMA),
             value: SchemaCell::Static(&V::SCHEMA),
@@ -478,6 +482,7 @@ pub mod __derive_runtime {
     };
     pub use alloc::borrow::Cow;
     pub use alloc::vec::Vec;
+    use serde::de::DeserializeOwned;
 
     /// Cast-shape decode helper. Routes through `bytemuck::pod_read_unaligned`
     /// after a length check so the Kind derive can emit a uniform call
@@ -513,7 +518,7 @@ pub mod __derive_runtime {
     /// this helper rather than on `Kind` so cast kinds stay
     /// independent of `serde`.
     #[must_use]
-    pub fn decode_postcard<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+    pub fn decode_postcard<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
         postcard::from_bytes(bytes).ok()
     }
 
@@ -628,9 +633,7 @@ pub fn encode_struct<T: Kind + serde::Serialize>(value: &T) -> Vec<u8> {
 }
 
 /// Decode a structural value via postcard. Returns owned `T`.
-pub fn decode_struct<T: Kind + serde::de::DeserializeOwned>(
-    bytes: &[u8],
-) -> Result<T, DecodeError> {
+pub fn decode_struct<T: Kind + DeserializeOwned>(bytes: &[u8]) -> Result<T, DecodeError> {
     postcard::from_bytes(bytes).map_err(DecodeError::from)
 }
 
@@ -645,6 +648,7 @@ pub fn encode_empty<T: Kind>() -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::String;
     use bytemuck::{Pod, Zeroable};
     use serde::{Deserialize, Serialize};
 
@@ -677,7 +681,7 @@ mod tests {
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     struct TestStruct {
         tag: u32,
-        label: alloc::string::String,
+        label: String,
     }
     impl Kind for TestStruct {
         const NAME: &'static str = "test.struct";
@@ -727,7 +731,7 @@ mod tests {
     fn struct_roundtrip() {
         let v = TestStruct {
             tag: 7,
-            label: alloc::string::String::from("hello"),
+            label: String::from("hello"),
         };
         let bytes = encode_struct(&v);
         let back: TestStruct =
@@ -782,7 +786,7 @@ mod tests {
     fn ref_inline_wraps_value() {
         let v = TestStruct {
             tag: 7,
-            label: alloc::string::String::from("hi"),
+            label: String::from("hi"),
         };
         let r = Ref::inline(v.clone());
         match r {
@@ -795,7 +799,7 @@ mod tests {
     fn ref_predicates_and_handle_id() {
         let inline: Ref<TestStruct> = Ref::Inline(TestStruct {
             tag: 1,
-            label: alloc::string::String::from("a"),
+            label: String::from("a"),
         });
         let handle: Ref<TestStruct> = Ref::handle(99);
         assert!(inline.is_inline());
@@ -810,7 +814,7 @@ mod tests {
     fn ref_inline_postcard_roundtrip() {
         let v = TestStruct {
             tag: 42,
-            label: alloc::string::String::from("hello"),
+            label: String::from("hello"),
         };
         let r = Ref::Inline(v);
         let bytes = postcard::to_allocvec(&r).expect("test setup: postcard encodes Inline Ref");
@@ -835,7 +839,7 @@ mod tests {
     fn ref_inline_and_handle_have_distinct_wire_discriminants() {
         let inline: Ref<TestStruct> = Ref::Inline(TestStruct {
             tag: 1,
-            label: alloc::string::String::from("x"),
+            label: String::from("x"),
         });
         let handle: Ref<TestStruct> = Ref::Handle { id: 1, kind_id: 1 };
         let inline_bytes =

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::ids::{KindId, MailboxId};
+use core::ops::Deref;
 
 /// One entry in `Hello.kinds`: a kind-name plus its schema. The hub
 /// uses the schema to encode agent-supplied params into the exact
@@ -167,7 +168,7 @@ impl SchemaCell {
     }
 }
 
-impl core::ops::Deref for SchemaCell {
+impl Deref for SchemaCell {
     type Target = SchemaType;
     fn deref(&self) -> &SchemaType {
         match self {
@@ -439,7 +440,7 @@ impl LabelCell {
     }
 }
 
-impl core::ops::Deref for LabelCell {
+impl Deref for LabelCell {
     type Target = LabelNode;
     fn deref(&self) -> &LabelNode {
         match self {

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -28,6 +28,7 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use aether_data::__inventory::DescriptorEntry;
 use aether_data::KindDescriptor;
 
 /// Every kind the substrate exposes. Order is unspecified — names are
@@ -35,7 +36,7 @@ use aether_data::KindDescriptor;
 /// hub `Hello` handshake) are order-independent.
 #[must_use]
 pub fn all() -> Vec<KindDescriptor> {
-    inventory::iter::<aether_data::__inventory::DescriptorEntry>()
+    inventory::iter::<DescriptorEntry>()
         .map(|e| KindDescriptor {
             name: e.name.to_string(),
             schema: e.schema.clone(),

--- a/crates/aether-math/src/lib.rs
+++ b/crates/aether-math/src/lib.rs
@@ -43,5 +43,18 @@ pub use mat::Mat4;
 pub use quat::Quat;
 pub use vec::{Vec2, Vec3, Vec4};
 
+// Re-export the standard math constants under our own crate root so
+// downstream code can write `aether_math::PI` without rooting at
+// `core::f32::consts`. The absolute path is intentional: importing
+// `PI` / `TAU` at the crate root would shadow these re-exports and
+// create a name cycle.
+#[expect(
+    clippy::absolute_paths,
+    reason = "re-export would shadow itself if imported"
+)]
 pub const PI: f32 = core::f32::consts::PI;
+#[expect(
+    clippy::absolute_paths,
+    reason = "re-export would shadow itself if imported"
+)]
 pub const TAU: f32 = core::f32::consts::TAU;

--- a/crates/aether-math/src/vec.rs
+++ b/crates/aether-math/src/vec.rs
@@ -348,6 +348,7 @@ impl_vec_ops!(Vec4 { x, y, z, w });
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::f32::consts::FRAC_PI_2;
 
     #[test]
     fn vec3_dot_cross() {
@@ -428,7 +429,7 @@ mod tests {
 
     #[test]
     fn vec3_rotate_axis_angle_y_quarter_turn_takes_x_to_negz() {
-        let r = Vec3::X.rotate_axis_angle(Vec3::Y, core::f32::consts::FRAC_PI_2);
+        let r = Vec3::X.rotate_axis_angle(Vec3::Y, FRAC_PI_2);
         assert!(r.x.abs() < 1e-6);
         assert!(r.y.abs() < 1e-6);
         assert!((r.z + 1.0).abs() < 1e-6);

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -10,6 +10,9 @@
 //! server keeps running on its own port; this binary is additive and
 //! defaults to a distinct port so the two coexist.
 
+use std::env;
+use tokio::net::TcpListener;
+use tokio::task;
 mod args;
 mod rpc;
 #[cfg(test)]
@@ -41,8 +44,8 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
     let hub_addr =
-        std::env::var("AETHER_HUB_RPC_ADDR").unwrap_or_else(|_| DEFAULT_HUB_RPC_ADDR.to_owned());
-    let mcp_port: u16 = std::env::var("AETHER_MCP_PORT")
+        env::var("AETHER_HUB_RPC_ADDR").unwrap_or_else(|_| DEFAULT_HUB_RPC_ADDR.to_owned());
+    let mcp_port: u16 = env::var("AETHER_MCP_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_MCP_PORT);
@@ -51,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
     // Dial the hub. The handshake is blocking, so run it on a
     // blocking-pool thread rather than stalling a runtime worker.
     tracing::info!(target: "aether_mcp", hub = %hub_addr, "dialing hub rpc server");
-    let session = tokio::task::spawn_blocking({
+    let session = task::spawn_blocking({
         let hub_addr = hub_addr.clone();
         move || RpcSession::connect(&hub_addr)
     })
@@ -83,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let app = axum::Router::new().nest_service("/mcp", service);
-    let listener = tokio::net::TcpListener::bind(&mcp_addr).await?;
+    let listener = TcpListener::bind(&mcp_addr).await?;
     let bound = listener.local_addr()?;
     tracing::info!(target: "aether_mcp", "mcp listener bound on http://{bound}/mcp");
     axum::serve(listener, app).await?;

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -13,6 +13,8 @@ use std::sync::{Arc, Mutex};
 use aether_capabilities::rpc::{
     MailEnvelope, PeerKind, RpcClient, RpcConnection, RpcReaderHandle, WireFrame,
 };
+use std::thread;
+use std::thread::JoinHandle;
 use tokio::sync::mpsc;
 
 /// One outbound RPC connection to the hub, shared across every MCP
@@ -36,7 +38,7 @@ pub struct RpcSession {
     _reader: RpcReaderHandle,
     /// The demux thread. Detached on drop — it exits on its own once
     /// `_reader`'s teardown closes `inbound`.
-    _router: std::thread::JoinHandle<()>,
+    _router: JoinHandle<()>,
 }
 
 impl RpcSession {
@@ -63,7 +65,7 @@ impl RpcSession {
         let pending: Arc<Mutex<HashMap<u64, mpsc::UnboundedSender<WireFrame>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let router_pending = Arc::clone(&pending);
-        let router = std::thread::Builder::new()
+        let router = thread::Builder::new()
             .name("aether-mcp-rpc-router".into())
             .spawn(move || {
                 // `inbound.recv()` ends with `Err` once the reader

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -36,6 +36,9 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 
+use crate::args::EngineLogEntry;
+use crate::args::EngineLogsArgs;
+use crate::args::EngineLogsResponse;
 use crate::args::{
     CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, EngineInfo, LoadComponentArgs,
     MailIdJson, MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs,
@@ -43,6 +46,11 @@ use crate::args::{
     TracedMailSpec,
 };
 use crate::rpc::RpcSession;
+use aether_kinds::descriptors;
+use base64::engine::general_purpose::STANDARD;
+use std::time::Duration;
+use tokio::fs;
+use tokio::time;
 
 /// Mailbox name of the hub's engines cap — the `engine = None` target
 /// for the engine-management tools.
@@ -176,7 +184,7 @@ impl Mcp {
     ) -> Result<String, McpError> {
         // Snapshot the substrate descriptor inventory once for the
         // whole batch rather than per item.
-        let descriptors = aether_kinds::descriptors::all();
+        let descriptors = descriptors::all();
         let mut statuses = Vec::with_capacity(args.mails.len());
         for (index, spec) in args.mails.into_iter().enumerate() {
             let status = match self.deliver_one(&descriptors, spec).await {
@@ -196,7 +204,7 @@ impl Mcp {
         Parameters(args): Parameters<SendMailTracedArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
-        let descriptors = aether_kinds::descriptors::all();
+        let descriptors = descriptors::all();
         // Encode the batch before sending — a bad spec produces a
         // clean invalid-params error and never touches the wire.
         // Same shape `CaptureFrame` carries: `Vec<MailEnvelope>` with
@@ -213,8 +221,8 @@ impl Mcp {
 
         // Round 1: ack carries the chassis-root MailId; ReplyEnd
         // closes when the chain settles substrate-side.
-        let ack_reply = match tokio::time::timeout(
-            std::time::Duration::from_millis(u64::from(timeout_ms)),
+        let ack_reply = match time::timeout(
+            Duration::from_millis(u64::from(timeout_ms)),
             self.session.call_one(dispatch_envelope),
         )
         .await
@@ -280,7 +288,7 @@ impl Mcp {
         Parameters(args): Parameters<LoadComponentArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
-        let wasm = tokio::fs::read(&args.binary_path).await.map_err(|e| {
+        let wasm = fs::read(&args.binary_path).await.map_err(|e| {
             McpError::invalid_params(
                 format!("reading binary_path {:?}: {e}", args.binary_path),
                 None,
@@ -328,7 +336,7 @@ impl Mcp {
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
         let mailbox_id = parse_mailbox_id(&args.mailbox_id)?;
-        let wasm = tokio::fs::read(&args.binary_path).await.map_err(|e| {
+        let wasm = fs::read(&args.binary_path).await.map_err(|e| {
             McpError::invalid_params(
                 format!("reading binary_path {:?}: {e}", args.binary_path),
                 None,
@@ -370,7 +378,7 @@ impl Mcp {
         let engine = parse_engine_id(&args.engine_id)?;
         // Encode both bundles before sending — a bad entry produces a
         // clean invalid-params error and never touches the wire.
-        let descriptors = aether_kinds::descriptors::all();
+        let descriptors = descriptors::all();
         let mails = encode_capture_bundle(&descriptors, &args.mails).map_err(|e| {
             McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
         })?;
@@ -388,7 +396,7 @@ impl Mcp {
             .map_err(internal)?;
         match CaptureFrameResult::decode_from_bytes(&reply.payload) {
             Some(CaptureFrameResult::Ok { png }) => {
-                let encoded = base64::engine::general_purpose::STANDARD.encode(&png);
+                let encoded = STANDARD.encode(&png);
                 Ok(CallToolResult::success(vec![Content::image(
                     encoded,
                     "image/png",
@@ -403,7 +411,7 @@ impl Mcp {
         description = "List the substrate kind vocabulary — every aether.* kind with its full schema, enough to build send_mail params. This is the static vocabulary aether-mcp ships with, not a per-engine query; component-defined kinds aren't included (use describe_component for a loaded component's handlers)."
     )]
     pub async fn describe_kinds(&self) -> Result<String, McpError> {
-        json(&aether_kinds::descriptors::all())
+        json(&descriptors::all())
     }
 
     #[tool(
@@ -446,7 +454,7 @@ impl Mcp {
     )]
     pub async fn engine_logs(
         &self,
-        Parameters(args): Parameters<crate::args::EngineLogsArgs>,
+        Parameters(args): Parameters<EngineLogsArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
         let engine_id_str = args.engine_id.clone();
@@ -470,11 +478,11 @@ impl Mcp {
                 next_since,
                 truncated_before,
             }) => {
-                let response = crate::args::EngineLogsResponse {
+                let response = EngineLogsResponse {
                     engine_id: engine_id_str,
                     entries: entries
                         .into_iter()
-                        .map(|e| crate::args::EngineLogEntry {
+                        .map(|e| EngineLogEntry {
                             timestamp_unix_ms: e.timestamp_unix_ms,
                             level: level_to_str(e.level).to_owned(),
                             target: e.target,
@@ -750,7 +758,9 @@ mod tests {
     use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
 
+    use crate::args::EngineLogsArgs;
     use crate::test_chassis::TestChassis;
+    use aether_kinds::descriptors;
 
     /// Boot a hub-shaped passive chassis: a forwarding
     /// `RpcServerCapability` + the engines cap + `TraceObserver` (so
@@ -759,7 +769,7 @@ mod tests {
     /// port an `RpcSession` dials.
     fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
         let registry = Arc::new(Registry::new());
-        for d in aether_kinds::descriptors::all() {
+        for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
         let (outbound, _rx) = HubOutbound::attached_loopback();
@@ -1067,7 +1077,7 @@ mod tests {
         let (_chassis, port) = boot_hub();
         let mcp = connect_mcp(port);
         let result = mcp
-            .engine_logs(Parameters(crate::args::EngineLogsArgs {
+            .engine_logs(Parameters(EngineLogsArgs {
                 engine_id: "not-a-uuid".to_owned(),
                 max: None,
                 level: None,
@@ -1087,7 +1097,7 @@ mod tests {
         let (_chassis, port) = boot_hub();
         let mcp = connect_mcp(port);
         let result = mcp
-            .engine_logs(Parameters(crate::args::EngineLogsArgs {
+            .engine_logs(Parameters(EngineLogsArgs {
                 engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
                 max: None,
                 level: Some("verbose".to_owned()),

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -41,6 +41,7 @@ use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
 use crate::LoadMesh;
+use core::str;
 
 const OUTLINE_WIDTH: f32 = 0.012;
 const OUTLINE_LIFT: f32 = 0.002;
@@ -158,7 +159,7 @@ impl FfiActor for MeshViewer {
                 return;
             }
         };
-        let Ok(text) = core::str::from_utf8(&bytes) else {
+        let Ok(text) = str::from_utf8(&bytes) else {
             tracing::warn!(
                 target: "aether_mesh_viewer",
                 path = %path,

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -35,6 +35,8 @@ use aether_substrate_bundle::test_bench::{
 // kinds the test code doesn't statically reference.
 #[allow(unused_imports)]
 use aether_mesh_viewer as _;
+use std::fs;
+use std::path::Path;
 
 /// User-facing component name passed to `LoadComponent`.
 const COMPONENT_NAME: &str = "mv";
@@ -68,8 +70,8 @@ const BAD_DSL: &[u8] = b"(box not-a-number 1 1)\n";
 /// Load this crate's pre-built wasm into the bench and await
 /// `LoadResult`. Panics on load failure so the calling test surfaces
 /// the error message rather than wedging on a missing subscription.
-fn load_viewer(bench: &mut TestBench, wasm_path: &std::path::Path) {
-    let wasm = std::fs::read(wasm_path).expect("read mesh-viewer wasm");
+fn load_viewer(bench: &mut TestBench, wasm_path: &Path) {
+    let wasm = fs::read(wasm_path).expect("read mesh-viewer wasm");
     let result: LoadResult = bench
         .send_and_await_reply(
             "aether.component",

--- a/crates/aether-mesh/examples/dsl_to_obj.rs
+++ b/crates/aether-mesh/examples/dsl_to_obj.rs
@@ -9,16 +9,18 @@
 // (see the usage line above).
 #![allow(clippy::print_stdout)]
 
+use std::env;
+use std::fs;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = env::args().collect();
     let Some(path) = args.get(1) else {
         eprintln!("usage: {} <path-to-.dsl>", args[0]);
         return ExitCode::from(2);
     };
 
-    let text = match std::fs::read_to_string(path) {
+    let text = match fs::read_to_string(path) {
         Ok(t) => t,
         Err(e) => {
             eprintln!("read {path}: {e}");

--- a/crates/aether-mesh/src/cleanup/merge.rs
+++ b/crates/aether-mesh/src/cleanup/merge.rs
@@ -77,7 +77,9 @@
 use super::mesh::{IndexedMesh, IndexedPolygon, VertexId};
 use crate::plane::{Plane3, project_2d};
 use crate::point::Point3;
+use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 type PlaneKey = (i64, i64, i64, i128);
 type BucketKey = (PlaneKey, u32);
@@ -414,8 +416,7 @@ fn extract_loops(
     let mut starts: Vec<(VertexId, VertexId)> = boundary.to_vec();
     starts.sort_unstable();
 
-    let mut visited: std::collections::HashSet<(VertexId, VertexId)> =
-        std::collections::HashSet::new();
+    let mut visited: HashSet<(VertexId, VertexId)> = HashSet::new();
     let mut loops = Vec::new();
 
     for &(start_a, start_b) in &starts {
@@ -459,7 +460,7 @@ fn pick_continuation(
     vertices: &[Point3],
     axes: (usize, usize),
     outgoing: &HashMap<VertexId, Vec<VertexId>>,
-    visited: &std::collections::HashSet<(VertexId, VertexId)>,
+    visited: &HashSet<(VertexId, VertexId)>,
     prev: VertexId,
     cur: VertexId,
 ) -> Option<VertexId> {
@@ -483,13 +484,13 @@ fn pick_continuation(
     let mut best = unvisited[0];
     for &cand in &unvisited[1..] {
         match cmp_turn(in_dx, in_dy, cur_2d, vertices, axes, cand, best) {
-            std::cmp::Ordering::Less => best = cand,
-            std::cmp::Ordering::Equal => {
+            Ordering::Less => best = cand,
+            Ordering::Equal => {
                 if cand < best {
                     best = cand;
                 }
             }
-            std::cmp::Ordering::Greater => {}
+            Ordering::Greater => {}
         }
     }
     Some(best)
@@ -524,7 +525,7 @@ fn cmp_turn(
     axes: (usize, usize),
     a: VertexId,
     b: VertexId,
-) -> std::cmp::Ordering {
+) -> Ordering {
     let a_2d = project_2d(vertices[a], axes);
     let b_2d = project_2d(vertices[b], axes);
     let a_dx = a_2d.0 - cur.0;
@@ -558,7 +559,7 @@ fn cmp_turn(
                 rhs.cmp(&lhs)
             }
         }
-        _ => std::cmp::Ordering::Equal,
+        _ => Ordering::Equal,
     }
 }
 
@@ -585,6 +586,7 @@ mod tests {
     use super::*;
     use crate::loop_polygon::Polygon;
     use crate::test_helpers::{indexed_mesh_on, pt, triangle_fan};
+    use std::collections::BTreeSet;
 
     fn weld_then_merge(polys: Vec<Polygon>) -> Vec<Polygon> {
         IndexedMesh::weld(polys).merge_coplanar().into_polygons()
@@ -613,8 +615,8 @@ mod tests {
         let out = weld_then_merge(vec![t1, t2]);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].vertices.len(), 4);
-        let covered: std::collections::BTreeSet<Point3> = out[0].vertices.iter().copied().collect();
-        let expect: std::collections::BTreeSet<Point3> = [
+        let covered: BTreeSet<Point3> = out[0].vertices.iter().copied().collect();
+        let expect: BTreeSet<Point3> = [
             pt(0.0, 0.0, 0.0),
             pt(1.0, 0.0, 0.0),
             pt(1.0, 1.0, 0.0),
@@ -688,8 +690,7 @@ mod tests {
         );
         let out = weld_then_merge(polys);
         assert_eq!(out.len(), 3);
-        let lens: std::collections::BTreeSet<usize> =
-            out.iter().map(|p| p.vertices.len()).collect();
+        let lens: BTreeSet<usize> = out.iter().map(|p| p.vertices.len()).collect();
         assert_eq!(lens, [3, 4].into_iter().collect());
     }
 
@@ -887,8 +888,7 @@ mod tests {
             2,
             "different colors must stay in separate buckets and not merge"
         );
-        let colors: std::collections::BTreeSet<u32> =
-            merged.polygons.iter().map(|p| p.color).collect();
+        let colors: BTreeSet<u32> = merged.polygons.iter().map(|p| p.color).collect();
         assert_eq!(colors, [11, 22].into_iter().collect());
     }
 
@@ -1149,8 +1149,7 @@ mod tests {
             "X-junction at J must extract 2 loops, got {}",
             merged.polygons.len()
         );
-        let lens: std::collections::BTreeSet<usize> =
-            merged.polygons.iter().map(|p| p.vertices.len()).collect();
+        let lens: BTreeSet<usize> = merged.polygons.iter().map(|p| p.vertices.len()).collect();
         assert_eq!(
             lens,
             [3, 5].into_iter().collect(),
@@ -1287,7 +1286,7 @@ mod tests {
         // After collapsing 14 and 10, only 11, 12, 13 survive (in some
         // rotation; rotate_left makes 11 the head).
         assert_eq!(out.len(), 3);
-        let as_set: std::collections::BTreeSet<VertexId> = out.iter().copied().collect();
+        let as_set: BTreeSet<VertexId> = out.iter().copied().collect();
         assert_eq!(as_set, [11, 12, 13].into_iter().collect());
     }
 

--- a/crates/aether-mesh/src/cleanup/tjunctions.rs
+++ b/crates/aether-mesh/src/cleanup/tjunctions.rs
@@ -194,6 +194,7 @@ mod tests {
     use crate::test_helpers::pt;
 
     use super::super::mesh::IndexedPolygon;
+    use std::collections::BTreeSet;
 
     fn xy_plane() -> Plane3 {
         Plane3 {
@@ -569,13 +570,12 @@ mod tests {
         // simple loops sharing w. Compare loops as multisets to
         // tolerate rotation / order-of-emission differences.
         assert_eq!(repaired.polygons.len(), 3);
-        let actual_loops: std::collections::BTreeSet<std::collections::BTreeSet<VertexId>> =
-            repaired
-                .polygons
-                .iter()
-                .map(|p| p.vertices.iter().copied().collect())
-                .collect();
-        let expected_loops: std::collections::BTreeSet<std::collections::BTreeSet<VertexId>> =
+        let actual_loops: BTreeSet<BTreeSet<VertexId>> = repaired
+            .polygons
+            .iter()
+            .map(|p| p.vertices.iter().copied().collect())
+            .collect();
+        let expected_loops: BTreeSet<BTreeSet<VertexId>> =
             [vec![0, 3, 4], vec![0, 3, 4, 5, 6], vec![3, 1, 2]]
                 .into_iter()
                 .map(|v| v.into_iter().collect())

--- a/crates/aether-mesh/src/cleanup/twin_edges.rs
+++ b/crates/aether-mesh/src/cleanup/twin_edges.rs
@@ -12,6 +12,7 @@
 //! the correct cancellation.
 
 use super::mesh::VertexId;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
 /// Collect surviving directed edges after twin-pair cancellation.
@@ -32,17 +33,17 @@ pub(super) fn surviving_directed_edges(
         let forward = directed.get(&(a, b)).copied().unwrap_or(0);
         let reverse = directed.get(&(b, a)).copied().unwrap_or(0);
         match forward.cmp(&reverse) {
-            std::cmp::Ordering::Greater => {
+            Ordering::Greater => {
                 for _ in 0..(forward - reverse) {
                     out.push((a, b));
                 }
             }
-            std::cmp::Ordering::Less => {
+            Ordering::Less => {
                 for _ in 0..(reverse - forward) {
                     out.push((b, a));
                 }
             }
-            std::cmp::Ordering::Equal => {}
+            Ordering::Equal => {}
         }
     }
     out

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -57,7 +57,7 @@ pub enum MeshError {
 /// Wire entry: evaluate `node` polygon-domain, run the cleanup +
 /// CDT-tessellation pipeline, then fan back to wire `Triangle`s.
 ///
-/// Runs [`crate::simplify::simplify`] as a pre-pass so identity
+/// Runs [`simplify::simplify`] as a pre-pass so identity
 /// transforms collapse before they reach the mesher.
 pub fn mesh(node: &Node) -> Result<Vec<Triangle>, MeshError> {
     let simplified = simplify::simplify(node);

--- a/crates/aether-mesh/src/mesh.rs
+++ b/crates/aether-mesh/src/mesh.rs
@@ -28,11 +28,17 @@
 //! face-normal-direction tests.
 
 use crate::ast::{Axis, Node};
+use crate::cleanup;
 use crate::fixed::FixedError;
 use crate::loop_polygon::Polygon as LoopPolygon;
 use crate::plane::Plane3;
 use crate::point::Point3;
+use crate::simplify;
+use crate::tessellate;
 use aether_math::Vec3;
+use std::f32::consts::FRAC_PI_2;
+use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Triangle {
@@ -54,20 +60,20 @@ pub enum MeshError {
 /// Runs [`crate::simplify::simplify`] as a pre-pass so identity
 /// transforms collapse before they reach the mesher.
 pub fn mesh(node: &Node) -> Result<Vec<Triangle>, MeshError> {
-    let simplified = crate::simplify::simplify(node);
+    let simplified = simplify::simplify(node);
     let mut polys = Vec::new();
     mesh_into_polygons(&mut polys, &simplified, Vec3::ZERO)?;
-    Ok(polygons_to_triangles(&crate::tessellate::run(polys)))
+    Ok(polygons_to_triangles(&tessellate::run(polys)))
 }
 
 /// Polygon-domain entry: same composition as [`mesh`] but stops at the
 /// n-gon boundary loops cleanup produces (no triangulation). The public
 /// polygon API in `crate::polygon` is the consumer.
 pub fn mesh_polygons_internal(node: &Node) -> Result<Vec<LoopPolygon>, MeshError> {
-    let simplified = crate::simplify::simplify(node);
+    let simplified = simplify::simplify(node);
     let mut polys = Vec::new();
     mesh_into_polygons(&mut polys, &simplified, Vec3::ZERO)?;
-    Ok(crate::cleanup::run_to_loops(polys))
+    Ok(cleanup::run_to_loops(polys))
 }
 
 /// Fan-triangulate a convex polygon list to wire `Triangle`s. Each
@@ -393,7 +399,7 @@ fn mesh_lathe(
         return Ok(());
     }
     let segments = segments as usize;
-    let two_pi = std::f32::consts::TAU;
+    let two_pi = TAU;
     let cos_sin: Vec<(f32, f32)> = (0..segments)
         .map(|i| {
             let theta = two_pi * (i as f32) / (segments as f32);
@@ -443,7 +449,7 @@ fn mesh_torus(
     }
     let m = major_segments as usize;
     let n = minor_segments as usize;
-    let two_pi = std::f32::consts::TAU;
+    let two_pi = TAU;
     let position = |i: usize, j: usize| -> Vec3 {
         let alpha = two_pi * (i as f32) / (m as f32);
         let beta = two_pi * (j as f32) / (n as f32);
@@ -620,7 +626,7 @@ fn mesh_sphere(
     let n = subdivisions as usize;
     let mut profile: Vec<[f32; 2]> = Vec::with_capacity(n + 1);
     for i in 0..=n {
-        let theta = -std::f32::consts::FRAC_PI_2 + (i as f32) * std::f32::consts::PI / (n as f32);
+        let theta = -FRAC_PI_2 + (i as f32) * PI / (n as f32);
         profile.push([radius * theta.cos(), radius * theta.sin()]);
     }
     mesh_lathe(out, &profile, subdivisions, color, offset)

--- a/crates/aether-mesh/src/obj.rs
+++ b/crates/aether-mesh/src/obj.rs
@@ -11,6 +11,7 @@ use std::fmt::Write;
 
 use crate::mesh::Triangle;
 use aether_math::Vec3;
+use std::collections::BTreeMap;
 
 #[must_use]
 pub fn to_obj(triangles: &[Triangle]) -> String {
@@ -40,7 +41,7 @@ pub fn to_obj(triangles: &[Triangle]) -> String {
         writeln!(out, "v {} {} {}", v.x, v.y, v.z).expect("writeln! into String never fails");
     }
 
-    let mut faces_by_color = std::collections::BTreeMap::<u32, Vec<[usize; 3]>>::new();
+    let mut faces_by_color = BTreeMap::<u32, Vec<[usize; 3]>>::new();
     for (_, indices, color) in faces {
         faces_by_color.entry(color).or_default().push(indices);
     }

--- a/crates/aether-mesh/src/parse.rs
+++ b/crates/aether-mesh/src/parse.rs
@@ -7,11 +7,14 @@ use lexpr::Value;
 
 use crate::ast::{Axis, Node};
 use aether_math::Vec3;
+use lexpr::parse;
+use lexpr::parse::KeywordSyntax;
+use lexpr::parse::Options;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
     #[error("lexpr read error: {0}")]
-    Read(#[from] lexpr::parse::Error),
+    Read(#[from] parse::Error),
     #[error("expected a list, got {0}")]
     NotAList(String),
     #[error("expected a proper list (nil-terminated), got dotted pair")]
@@ -60,8 +63,7 @@ pub enum ParseError {
 }
 
 pub fn parse(text: &str) -> Result<Node, ParseError> {
-    let opts = lexpr::parse::Options::default()
-        .with_keyword_syntax(lexpr::parse::KeywordSyntax::ColonPrefix);
+    let opts = Options::default().with_keyword_syntax(KeywordSyntax::ColonPrefix);
     let mut parser = lexpr::Parser::from_str_custom(text, opts);
     let value = parser
         .next_value()?

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -74,7 +74,7 @@ pub struct Polygon {
 
 /// Mesh `node` and return the result as n-gon polygons.
 ///
-/// Goes directly through [`crate::mesh::mesh_polygons_internal`] —
+/// Goes directly through [`mesh::mesh_polygons_internal`] —
 /// the polygon-domain mesh evaluator that operates polygon-in /
 /// polygon-out throughout (no triangle round-trip). This is the fix
 /// for the `protruding_sphere` `SingularEdges`: the previous path went

--- a/crates/aether-mesh/src/polygon.rs
+++ b/crates/aether-mesh/src/polygon.rs
@@ -47,11 +47,14 @@
 //! selection and face-normal lighting; small noise there doesn't
 //! affect topology.
 
+use crate::ast::Node;
 use crate::loop_polygon;
+use crate::mesh;
 use crate::mesh::MeshError;
 use crate::plane;
 use crate::plane::project_2d;
 use crate::point::Point3;
+use crate::tessellate;
 use aether_math::Vec3;
 use std::collections::HashMap;
 
@@ -80,8 +83,8 @@ pub struct Polygon {
 /// CDT-output sliver triangles. Skipping the triangle hop avoids the
 /// re-derivation entirely — n-gon loops travel from CSG cleanup
 /// straight into the crate-internal `group_loops` step.
-pub fn mesh_polygons(node: &crate::ast::Node) -> Result<Vec<Polygon>, MeshError> {
-    let loops = crate::mesh::mesh_polygons_internal(node)?;
+pub fn mesh_polygons(node: &Node) -> Result<Vec<Polygon>, MeshError> {
+    let loops = mesh::mesh_polygons_internal(node)?;
     Ok(group_loops(loops))
 }
 
@@ -440,17 +443,15 @@ fn fan_triangulate(vertices: &[Point3]) -> Vec<[Point3; 3]> {
 }
 
 fn cdt_tessellate(polygon: &Polygon) -> Option<Vec<[Point3; 3]>> {
-    crate::tessellate::tessellate_polygon_integer(
-        &polygon.vertices,
-        &polygon.holes,
-        polygon.plane_normal,
-    )
+    tessellate::tessellate_polygon_integer(&polygon.vertices, &polygon.holes, polygon.plane_normal)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ast::Node;
+    use core::f32::consts::FRAC_1_SQRT_2;
+    use std::f32::consts::PI;
 
     fn p(x: f32, y: f32, z: f32) -> Point3 {
         Point3::from_f32(Vec3::new(x, y, z)).expect("in range")
@@ -525,7 +526,7 @@ mod tests {
         for n in 3..=8 {
             let vertices: Vec<Point3> = (0..n)
                 .map(|i| {
-                    let theta = 2.0 * std::f32::consts::PI * (i as f32) / (n as f32);
+                    let theta = 2.0 * PI * (i as f32) / (n as f32);
                     p(theta.cos(), theta.sin(), 0.0)
                 })
                 .collect();
@@ -609,11 +610,7 @@ mod tests {
             p(0.199_996_95, 0.453_582_76, 0.346_405_03),
             p(0.199_996_95, 1.0, 0.346_405_03),
         ];
-        let normal = Vec3::new(
-            -core::f32::consts::FRAC_1_SQRT_2,
-            0.0,
-            -core::f32::consts::FRAC_1_SQRT_2,
-        );
+        let normal = Vec3::new(-FRAC_1_SQRT_2, 0.0, -FRAC_1_SQRT_2);
         assert!(
             is_convex(&verts, &normal),
             "snap-rounded near-collinear vertex should not flip convex classification"

--- a/crates/aether-mesh/src/serialize.rs
+++ b/crates/aether-mesh/src/serialize.rs
@@ -7,6 +7,9 @@ use lexpr::{Cons, Number, Value};
 
 use crate::ast::Node;
 use aether_math::Vec3;
+use lexpr::parse::KeywordSyntax;
+use lexpr::print;
+use lexpr::print::Options;
 
 /// Serialize a typed mesh AST to its canonical Lisp s-expression form.
 ///
@@ -18,10 +21,9 @@ use aether_math::Vec3;
 #[must_use]
 pub fn serialize(node: &Node) -> String {
     let value = node_to_value(node);
-    let opts = lexpr::print::Options::default()
-        .with_keyword_syntax(lexpr::parse::KeywordSyntax::ColonPrefix);
+    let opts = Options::default().with_keyword_syntax(KeywordSyntax::ColonPrefix);
     let mut buf = Vec::new();
-    lexpr::print::to_writer_custom(&mut buf, &value, opts).expect("writing to Vec never fails");
+    print::to_writer_custom(&mut buf, &value, opts).expect("writing to Vec never fails");
     String::from_utf8(buf).expect("lexpr emits utf-8")
 }
 

--- a/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/bowyer_watson.rs
@@ -60,6 +60,8 @@
 //! relies on; it is also where degenerate-input handling lands.
 
 use super::predicates::{Point2, in_circle, orient2d};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 pub(super) type VertId = usize;
 pub(super) type TriId = usize;
@@ -264,10 +266,7 @@ impl Mesh {
     /// the constraint may not be locally Delaunay — leaving slivers in
     /// the output even though the topology is correct. This pass cleans
     /// them up.
-    pub(super) fn lawson_redelaunize(
-        &mut self,
-        constraints: &std::collections::HashSet<(VertId, VertId)>,
-    ) {
+    pub(super) fn lawson_redelaunize(&mut self, constraints: &HashSet<(VertId, VertId)>) {
         const MAX_LAWSON_ITERATIONS: usize = 4096;
         for _ in 0..MAX_LAWSON_ITERATIONS {
             let mut flipped = false;
@@ -655,10 +654,8 @@ impl Mesh {
         // whose b is this triangle's a, and "across edge opposite b" =
         // the new triangle whose a is this triangle's b.
         // Build a vertex → (new_tid, "is this vert the `a` slot"?) map.
-        let mut by_a: std::collections::HashMap<VertId, TriId> =
-            std::collections::HashMap::with_capacity(n_new);
-        let mut by_b: std::collections::HashMap<VertId, TriId> =
-            std::collections::HashMap::with_capacity(n_new);
+        let mut by_a: HashMap<VertId, TriId> = HashMap::with_capacity(n_new);
+        let mut by_b: HashMap<VertId, TriId> = HashMap::with_capacity(n_new);
         for (k, &(a, b, _)) in boundary.iter().enumerate() {
             let tid = first_new_tid + k;
             by_a.insert(a, tid);
@@ -686,6 +683,8 @@ impl Mesh {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f64::consts::PI;
+    use std::f64::consts::TAU;
 
     fn count_alive(mesh: &Mesh) -> usize {
         mesh.alive_triangles().count()
@@ -791,7 +790,7 @@ mod tests {
         // checker exercises both `assert_all_ccw` and `assert_delaunay`.
         let pts: Vec<(i64, i64)> = (0..6)
             .map(|i| {
-                let theta = i as f64 * std::f64::consts::PI / 3.0;
+                let theta = i as f64 * PI / 3.0;
                 ((1000.0 * theta.cos()) as i64, (1000.0 * theta.sin()) as i64)
             })
             .collect();
@@ -867,7 +866,7 @@ mod tests {
     fn flip_edge_preserves_neighbor_symmetry_and_winding() {
         let pts: Vec<(i64, i64)> = (0..12)
             .map(|i| {
-                let theta = i as f64 * std::f64::consts::TAU / 12.0;
+                let theta = i as f64 * TAU / 12.0;
                 ((1000.0 * theta.cos()) as i64, (1000.0 * theta.sin()) as i64)
             })
             .collect();

--- a/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
+++ b/crates/aether-mesh/src/tessellate/cdt/triangulate.rs
@@ -24,6 +24,9 @@ use super::predicates::orient2d;
 use crate::cleanup::mesh::VertexId;
 use crate::plane::{Axis, Plane3, projection_axes};
 use crate::point::Point3;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::hash_map::Entry;
 
 fn project_point(p: Point3, axis_a: Axis, axis_b: Axis) -> Point2 {
     let pick = |a: Axis| -> i64 {
@@ -56,11 +59,10 @@ pub(in crate::tessellate) fn triangulate(
     // first appearance. Build the index translation table.
     let (axis_a, axis_b) = projection_axes(plane);
     let mut input_ids: Vec<VertexId> = Vec::new();
-    let mut id_to_local: std::collections::HashMap<VertexId, usize> =
-        std::collections::HashMap::new();
+    let mut id_to_local: HashMap<VertexId, usize> = HashMap::new();
     for loop_ in loops {
         for &vid in loop_ {
-            if let std::collections::hash_map::Entry::Vacant(e) = id_to_local.entry(vid) {
+            if let Entry::Vacant(e) = id_to_local.entry(vid) {
                 e.insert(input_ids.len());
                 input_ids.push(vid);
             }
@@ -81,8 +83,7 @@ pub(in crate::tessellate) fn triangulate(
     let super_count = mesh.super_count;
 
     // 3. Convert each loop edge to a constraint and enforce it.
-    let mut constraints: std::collections::HashSet<(usize, usize)> =
-        std::collections::HashSet::new();
+    let mut constraints: HashSet<(usize, usize)> = HashSet::new();
     for loop_ in loops {
         let n = loop_.len();
         for i in 0..n {

--- a/crates/aether-mesh/tests/mesh_box.rs
+++ b/crates/aether-mesh/tests/mesh_box.rs
@@ -6,6 +6,7 @@
 //! Verify the box mesher produces 12 triangles at the expected corners.
 
 use aether_mesh::{mesh, parse};
+use std::collections::BTreeSet;
 
 #[test]
 fn unit_box_has_twelve_triangles() {
@@ -18,7 +19,7 @@ fn unit_box_has_twelve_triangles() {
 fn unit_box_corners_are_at_half_extents() {
     let ast = parse("(box 2 2 2 :color 5)").expect("test setup: box DSL parses");
     let tris = mesh(&ast).expect("test setup: box meshes");
-    let mut seen_corners = std::collections::BTreeSet::<[i32; 3]>::new();
+    let mut seen_corners = BTreeSet::<[i32; 3]>::new();
     for tri in &tris {
         for v in tri.vertices {
             // box 2 2 2 → corners at ±1 on each axis

--- a/crates/aether-mesh/tests/mesh_v1_remaining.rs
+++ b/crates/aether-mesh/tests/mesh_v1_remaining.rs
@@ -12,6 +12,7 @@
 
 use aether_math::Vec3;
 use aether_mesh::{mesh, parse};
+use std::collections::BTreeSet;
 
 fn tri_normal(tri: &aether_mesh::Triangle) -> Vec3 {
     let a = tri.vertices[0];
@@ -135,7 +136,7 @@ fn wedge_outward_normals() {
 fn wedge_uses_six_unique_vertices() {
     let ast = parse("(wedge 2 2 2 :color 0)").expect("test setup: wedge DSL parses");
     let tris = mesh(&ast).expect("test setup: wedge meshes");
-    let mut seen = std::collections::BTreeSet::<[i32; 3]>::new();
+    let mut seen = BTreeSet::<[i32; 3]>::new();
     for tri in &tris {
         for v in tri.vertices {
             seen.insert([v.x as i32, v.y as i32, v.z as i32]);
@@ -304,7 +305,7 @@ fn array_copies_are_translated_correctly() {
     let ast =
         parse("(array 3 (2 0 0) (box 1 1 1 :color 0))").expect("test setup: array DSL parses");
     let tris = mesh(&ast).expect("test setup: array meshes");
-    let mut x_centers = std::collections::BTreeSet::<i32>::new();
+    let mut x_centers = BTreeSet::<i32>::new();
     for tri in &tris {
         let c = tri_centroid(tri);
         x_centers.insert(c.x.round() as i32);

--- a/crates/aether-mesh/tests/mesh_v2.rs
+++ b/crates/aether-mesh/tests/mesh_v2.rs
@@ -2,6 +2,7 @@
 
 use aether_math::Vec3;
 use aether_mesh::{ParseError, mesh, parse};
+use std::f32::consts::SQRT_2;
 
 #[test]
 fn torus_triangle_count_is_two_per_quad() {
@@ -107,7 +108,7 @@ fn sweep_curved_path_keeps_profile_perpendicular() {
                 }
             }
             assert!(
-                min_dist <= radius.mul_add(std::f32::consts::SQRT_2, 1e-4),
+                min_dist <= radius.mul_add(SQRT_2, 1e-4),
                 "swept vertex too far from any waypoint: {v:?} (dist {min_dist})"
             );
         }

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -28,7 +28,8 @@ use aether_substrate_bundle::test_bench::{
 };
 use std::env;
 use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
+
+use aether_substrate_bundle::chassis_root::next_chassis_correlation;
 use std::time::Duration;
 
 /// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
@@ -187,14 +188,7 @@ fn run_frame(
     gpu: &mut Gpu,
     chassis_correlation: &AtomicU64,
 ) {
-    let next_correlation = || -> u64 {
-        let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
-        if id == 0 {
-            chassis_correlation.fetch_add(1, Ordering::Relaxed)
-        } else {
-            id
-        }
-    };
+    let next_correlation = || -> u64 { next_chassis_correlation(chassis_correlation) };
 
     if dispatch_tick {
         trace::push_chassis_root_mail(

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -16,21 +16,27 @@ use std::sync::Arc;
 
 use aether_actor::Actor;
 use aether_capabilities::InputCapability;
+use aether_capabilities::fs::NamespaceRoots;
 use aether_data::{encode_empty, mailbox_id_from_name};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
+use aether_substrate::runtime::trace;
 use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId};
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
     render::Gpu,
 };
+use std::env;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 /// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
 /// missing/unparseable input with a warn log so scenario scripts can
 /// see what dimensions they actually got.
 fn parse_size_env() -> (u32, u32) {
     use aether_substrate_bundle::test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH};
-    let Ok(raw) = std::env::var("AETHER_TEST_BENCH_SIZE") else {
+    let Ok(raw) = env::var("AETHER_TEST_BENCH_SIZE") else {
         return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
     };
     if let Some((w, h)) = raw.split_once('x') {
@@ -60,7 +66,7 @@ fn main() -> anyhow::Result<()> {
     let (events_tx, events_rx) = events::channel();
 
     // Per issue 464, this `main()` is the env-reading edge.
-    let namespace_roots = aether_capabilities::fs::NamespaceRoots::from_env();
+    let namespace_roots = NamespaceRoots::from_env();
 
     let env = TestBenchEnv {
         name: "test-bench".to_owned(),
@@ -121,7 +127,7 @@ fn drive_events_loop(
     // iamacoffeepot/aether#723). Threaded through `run_frame` so each
     // tick push carries observable lineage like the desktop and
     // headless drivers do.
-    let chassis_correlation = std::sync::atomic::AtomicU64::new(1);
+    let chassis_correlation = AtomicU64::new(1);
 
     while let Ok(event) = events_rx.recv() {
         match event {
@@ -177,21 +183,21 @@ fn run_frame(
     input_mailbox: MailboxId,
     kind_tick: aether_data::KindId,
     capture_queue: &CaptureQueue,
-    frame_bound_pending: &[(MailboxId, Arc<std::sync::atomic::AtomicU64>)],
+    frame_bound_pending: &[(MailboxId, Arc<AtomicU64>)],
     gpu: &mut Gpu,
-    chassis_correlation: &std::sync::atomic::AtomicU64,
+    chassis_correlation: &AtomicU64,
 ) {
     let next_correlation = || -> u64 {
-        let id = chassis_correlation.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
         if id == 0 {
-            chassis_correlation.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            chassis_correlation.fetch_add(1, Ordering::Relaxed)
         } else {
             id
         }
     };
 
     if dispatch_tick {
-        aether_substrate::runtime::trace::push_chassis_root_mail(
+        trace::push_chassis_root_mail(
             queue,
             next_correlation(),
             input_mailbox,
@@ -215,7 +221,7 @@ fn run_frame(
             // bailing out of the frame loop.
             let mut pre_failed: Option<String> = None;
             for rx in req.pre_settlements {
-                if rx.recv_timeout(std::time::Duration::from_secs(5)).is_err() {
+                if rx.recv_timeout(Duration::from_secs(5)).is_err() {
                     pre_failed = Some(
                         "capture pre-mail chain failed to settle within 5s — \
                          a downstream cap is wedged"

--- a/crates/aether-substrate-bundle/src/chassis_root.rs
+++ b/crates/aether-substrate-bundle/src/chassis_root.rs
@@ -1,0 +1,20 @@
+//! Tiny shared helper for the chassis-root mail correlation counter
+//! (ADR-0080 §6). Both the headless driver and the test-bench bin
+//! own an `AtomicU64` that hands out `correlation_id`s for synthetic
+//! chassis-root mail, skipping 0 (reserved sentinel). Extracted from
+//! a duplicated closure across both sites — see PR 952's qodana
+//! follow-up.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Atomically advance `counter` and return the next non-zero id.
+/// Symmetric with the per-actor counter on `NativeBinding`; zero
+/// stays reserved as the `MailId::NONE` sentinel.
+pub fn next_chassis_correlation(counter: &AtomicU64) -> u64 {
+    let id = counter.fetch_add(1, Ordering::Relaxed);
+    if id == 0 {
+        counter.fetch_add(1, Ordering::Relaxed)
+    } else {
+        id
+    }
+}

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -28,6 +28,11 @@ use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 use crate::chassis_common::{CommonBoot, maybe_with_rpc_server, with_common_caps};
+use crate::hub;
+use aether_substrate::runtime::lifecycle::FatalAborter;
+use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
+use std::env;
+use winit::event_loop::ControlFlow;
 
 /// Event the event-loop thread consumes from the desktop chassis.
 /// Just one variant today: a wake-up so the loop picks up a queued
@@ -96,7 +101,7 @@ impl DesktopEnv {
     /// than the historic catch-all `wasmtime::Result` (issue #571).
     pub fn from_env() -> Result<Self, EventLoopError> {
         let event_loop = EventLoop::<UserEvent>::with_user_event().build()?;
-        event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
+        event_loop.set_control_flow(ControlFlow::Poll);
         let capture_queue = CaptureQueue::new();
 
         let http = HttpConf::from_env();
@@ -106,7 +111,7 @@ impl DesktopEnv {
         // nested matches read clearer than `map_or_else` here because both
         // arms have multi-line bodies (warn-log path on parse failure).
         #[allow(clippy::option_if_let_else)]
-        let (boot_mode, boot_size) = match std::env::var("AETHER_WINDOW_MODE") {
+        let (boot_mode, boot_size) = match env::var("AETHER_WINDOW_MODE") {
             Ok(s) => match parse_window_mode_env(&s) {
                 Ok(parsed) => parsed,
                 Err(e) => {
@@ -121,15 +126,13 @@ impl DesktopEnv {
             },
             Err(_) => (WindowMode::Windowed, None),
         };
-        let boot_title =
-            std::env::var("AETHER_WINDOW_TITLE").unwrap_or_else(|_| "aether".to_owned());
+        let boot_title = env::var("AETHER_WINDOW_TITLE").unwrap_or_else(|_| "aether".to_owned());
 
         // `AETHER_RPC_PORT` has no default — absent means RpcServer
         // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
         let rpc_addr = {
             use std::net::{IpAddr, Ipv4Addr};
-            crate::hub::rpc_port_from_env()
-                .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
+            hub::rpc_port_from_env().map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
         };
 
         let workers = parse_workers_env();
@@ -155,7 +158,7 @@ impl DesktopEnv {
 /// `Some(n)`; `0` → `Some(1)` with a warn (the pool requires at least
 /// one worker); unparseable → `None` with a warn. Issue 745.
 fn parse_workers_env() -> Option<usize> {
-    let raw = std::env::var("AETHER_WORKERS").ok()?;
+    let raw = env::var("AETHER_WORKERS").ok()?;
     match raw.trim().parse::<usize>() {
         Ok(0) => {
             tracing::warn!(
@@ -238,11 +241,8 @@ impl DesktopChassis {
         // cross-class `wait_reply` aborter so the substrate exits via
         // `lifecycle::fatal_abort` instead of unwinding. Built before
         // `boot` moves into the driver.
-        let aborter: Arc<dyn aether_substrate::runtime::lifecycle::FatalAborter> = Arc::new(
-            aether_substrate::runtime::lifecycle::OutboundFatalAborter::new(Arc::clone(
-                &boot.outbound,
-            )),
-        );
+        let aborter: Arc<dyn FatalAborter> =
+            Arc::new(OutboundFatalAborter::new(Arc::clone(&boot.outbound)));
 
         // Issue 552 stage 2d: render is a NativeActor. The chassis
         // builder constructs the cap inside `init` (called from

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -46,6 +46,11 @@ use winit::window::{Fullscreen, Window, WindowId};
 
 use super::chassis::UserEvent;
 use super::render::Gpu;
+use aether_substrate::capture::CaptureQueue;
+use std::io;
+use std::sync::mpsc::Receiver;
+use std::time::Duration;
+use winit::dpi::PhysicalSize;
 
 pub struct App {
     queue: Arc<Mailer>,
@@ -68,7 +73,7 @@ pub struct App {
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
     /// `render_and_capture`, then reply-to-sender on `outbound`.
-    capture_queue: aether_substrate::capture::CaptureQueue,
+    capture_queue: CaptureQueue,
     /// Hub outbound — shared with the log-capture layer and the
     /// capture-reply path.
     outbound: Arc<HubOutbound>,
@@ -110,7 +115,7 @@ pub struct App {
     /// occludes) `about_to_wait` only fires after a winit event, so
     /// window-kind mail can stall briefly until the user nudges the
     /// window — accepted limitation for v1.
-    window_inbox: std::sync::mpsc::Receiver<Envelope>,
+    window_inbox: Receiver<Envelope>,
     kind_set_window_mode: aether_data::KindId,
     kind_set_window_title: aether_data::KindId,
     /// ADR-0080 §6 chassis-root correlation counter (issue
@@ -320,7 +325,7 @@ impl App {
         if matches!(mode, WindowMode::Windowed)
             && let (Some(w), Some(h)) = (width, height)
         {
-            let _ = window.request_inner_size(winit::dpi::PhysicalSize::new(w, h));
+            let _ = window.request_inner_size(PhysicalSize::new(w, h));
         }
 
         self.current_mode = mode.clone();
@@ -429,7 +434,7 @@ impl ApplicationHandler<UserEvent> for App {
         }
         let mut attrs = Window::default_attributes().with_title(&self.boot_title);
         if let Some((w, h)) = self.boot_size {
-            attrs = attrs.with_inner_size(winit::dpi::PhysicalSize::new(w, h));
+            attrs = attrs.with_inner_size(PhysicalSize::new(w, h));
         }
         match resolve_fullscreen(&self.boot_mode, event_loop.primary_monitor().as_ref()) {
             Ok(fs) => attrs = attrs.with_fullscreen(fs),
@@ -519,7 +524,7 @@ impl ApplicationHandler<UserEvent> for App {
                             // the chassis).
                             let mut pre_failed: Option<String> = None;
                             for rx in req.pre_settlements {
-                                if rx.recv_timeout(std::time::Duration::from_secs(5)).is_err() {
+                                if rx.recv_timeout(Duration::from_secs(5)).is_err() {
                                     pre_failed = Some(
                                         "capture pre-mail chain failed to settle within 5s — \
                                          a downstream cap is wedged"
@@ -632,7 +637,7 @@ impl ApplicationHandler<UserEvent> for App {
 pub struct DesktopDriverCapability {
     pub event_loop: EventLoop<UserEvent>,
     pub boot: SubstrateBoot,
-    pub capture_queue: aether_substrate::capture::CaptureQueue,
+    pub capture_queue: CaptureQueue,
     pub boot_mode: WindowMode,
     pub boot_size: Option<(u32, u32)>,
     pub boot_title: String,
@@ -670,7 +675,7 @@ impl DriverCapability for DesktopDriverCapability {
         // the FRAME_BARRIER claim machinery and surfaces via
         // `ctx.frame_bound_pending()`.
         let render_handles: RenderHandles = ctx.handle::<RenderHandles>().ok_or_else(|| {
-            BootError::Other(Box::new(std::io::Error::other(
+            BootError::Other(Box::new(io::Error::other(
                 "DesktopDriverCapability::boot: RenderHandles must be published before the driver \
                  (verify the chassis builder calls `with_actor::<RenderCapability>(config)` before `driver(...)`)",
             )))

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -20,6 +20,9 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 pub use render::VERTEX_BUFFER_BYTES;
+use std::env;
+use std::iter;
+use std::slice;
 
 /// Wireframe-overlay shader: same vertex layout as the main shader so
 /// the pipeline shares the existing vertex buffer. The fragment stage
@@ -80,7 +83,7 @@ enum WireframeMode {
 
 impl WireframeMode {
     fn from_env() -> Self {
-        match std::env::var("AETHER_WIREFRAME").ok().as_deref() {
+        match env::var("AETHER_WIREFRAME").ok().as_deref() {
             None | Some("" | "0" | "off") => Self::Off,
             Some("line") => Self::Line,
             Some(_) => Self::Overlay, // "1", "overlay", etc.
@@ -225,7 +228,7 @@ impl Gpu {
                         module: &wire_shader,
                         entry_point: Some("vs_main"),
                         compilation_options: wgpu::PipelineCompilationOptions::default(),
-                        buffers: std::slice::from_ref(&vertex_layout),
+                        buffers: slice::from_ref(&vertex_layout),
                     },
                     fragment: Some(wgpu::FragmentState {
                         module: &wire_shader,
@@ -375,7 +378,7 @@ impl Gpu {
             });
         }
 
-        queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(iter::once(encoder.finish()));
         if let Some(tex) = surface_tex {
             tex.present();
         }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -30,6 +30,11 @@ use aether_substrate::{Chassis, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{CommonBoot, maybe_with_rpc_server, with_common_caps};
+use crate::hub;
+use aether_substrate::mail::registry::MailDispatch;
+use aether_substrate::runtime::lifecycle::FatalAborter;
+use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
+use std::env;
 
 /// Marker type for the headless chassis. Carries no fields — the
 /// chassis instance is the [`BuiltChassis<HeadlessChassis>`] returned
@@ -78,8 +83,8 @@ impl HeadlessEnv {
         let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
         // `AETHER_RPC_PORT` has no default — absent means RpcServer
         // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
-        let rpc_addr = crate::hub::rpc_port_from_env()
-            .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
+        let rpc_addr =
+            hub::rpc_port_from_env().map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
         let workers = parse_workers_env();
         Self {
             namespace_roots,
@@ -97,7 +102,7 @@ impl HeadlessEnv {
 /// `Some(n)`; `0` → `Some(1)` with a warn (the pool requires at least
 /// one worker); unparseable → `None` with a warn. Issue 745.
 fn parse_workers_env() -> Option<usize> {
-    let raw = std::env::var("AETHER_WORKERS").ok()?;
+    let raw = env::var("AETHER_WORKERS").ok()?;
     match raw.trim().parse::<usize>() {
         Ok(0) => {
             tracing::warn!(
@@ -166,19 +171,16 @@ impl HeadlessChassis {
         let outbound_for_audio_sink = Arc::clone(&boot.outbound);
         boot.registry.register_inline(
             "aether.audio",
-            Arc::new(
-                move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {
-                    if dispatch.kind == kind_set_master_gain {
-                        outbound_for_audio_sink.send_reply(
-                            dispatch.sender,
-                            &SetMasterGainResult::Err {
-                                error: "unsupported on headless chassis — no audio device"
-                                    .to_owned(),
-                            },
-                        );
-                    }
-                },
-            ),
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                if dispatch.kind == kind_set_master_gain {
+                    outbound_for_audio_sink.send_reply(
+                        dispatch.sender,
+                        &SetMasterGainResult::Err {
+                            error: "unsupported on headless chassis — no audio device".to_owned(),
+                        },
+                    );
+                }
+            }),
         );
 
         // Tick rates are bounded well below `u32::MAX` Hz (typically
@@ -197,11 +199,8 @@ impl HeadlessChassis {
         // ADR-0074 §Decision 5: production chassis configures the
         // cross-class `wait_reply` aborter so the substrate exits via
         // `lifecycle::fatal_abort` instead of unwinding.
-        let aborter: Arc<dyn aether_substrate::runtime::lifecycle::FatalAborter> = Arc::new(
-            aether_substrate::runtime::lifecycle::OutboundFatalAborter::new(Arc::clone(
-                &boot.outbound,
-            )),
-        );
+        let aborter: Arc<dyn FatalAborter> =
+            Arc::new(OutboundFatalAborter::new(Arc::clone(&boot.outbound)));
 
         let driver = HeadlessTimerCapability {
             boot,
@@ -236,7 +235,9 @@ impl HeadlessChassis {
 #[cfg(test)]
 mod tests {
     use super::parse_workers_env;
+    use std::env;
     use std::sync::Mutex;
+    use std::sync::PoisonError;
 
     /// Process-wide guard around `AETHER_WORKERS` env mutation —
     /// `cargo test` parallelises within a binary, so each parser test
@@ -246,9 +247,7 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         // Safety: this test owns the AETHER_WORKERS slot for the
         // duration of the closure via ENV_LOCK; no other thread inside
         // the same test binary mutates it concurrently. Edition-2024
@@ -256,15 +255,15 @@ mod tests {
         // races that don't apply here.
         unsafe {
             match value {
-                Some(v) => std::env::set_var("AETHER_WORKERS", v),
-                None => std::env::remove_var("AETHER_WORKERS"),
+                Some(v) => env::set_var("AETHER_WORKERS", v),
+                None => env::remove_var("AETHER_WORKERS"),
             }
         }
         let out = f();
         // SAFETY: same justification as the prior block — this test
         // still owns the `AETHER_WORKERS` slot via `ENV_LOCK`.
         unsafe {
-            std::env::remove_var("AETHER_WORKERS");
+            env::remove_var("AETHER_WORKERS");
         }
         out
     }

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -15,7 +15,9 @@
 //! Builder→BuiltChassis→run path applies all the same).
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
+
+use crate::chassis_root::next_chassis_correlation;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -115,14 +117,7 @@ impl DriverRunning for HeadlessTimerRunning {
         // per-actor counter on `NativeBinding`. Skipping 0 keeps the
         // sentinel slot reserved.
         let chassis_correlation = AtomicU64::new(1);
-        let next_correlation = || -> u64 {
-            let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
-            if id == 0 {
-                chassis_correlation.fetch_add(1, Ordering::Relaxed)
-            } else {
-                id
-            }
-        };
+        let next_correlation = || -> u64 { next_chassis_correlation(&chassis_correlation) };
 
         let mut next_deadline = Instant::now() + tick_period;
         loop {

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -28,6 +28,7 @@ use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
     Mailer, SubstrateBoot, mail::MailboxId, runtime::trace::push_chassis_root_mail,
 };
+use std::env;
 
 pub const DEFAULT_TICK_HZ: u32 = 60;
 
@@ -39,7 +40,7 @@ pub fn parse_tick_hz_env() -> u32 {
     // Match arms read cleaner than `map_or` here because the Ok arm
     // is a chained iterator/closure that warn-logs on parse failure.
     #[allow(clippy::option_if_let_else)]
-    match std::env::var("AETHER_TICK_HZ") {
+    match env::var("AETHER_TICK_HZ") {
         Ok(s) => s
             .trim()
             .parse::<u32>()

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -23,6 +23,7 @@ use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
 use crate::hub::DEFAULT_RPC_PORT;
+use std::thread;
 
 /// ADR-0071 marker for the hub chassis. Carries no fields — the
 /// chassis instance is the [`BuiltChassis<HubChassis>`] returned by
@@ -143,7 +144,7 @@ fn shutdown_signal() -> &'static str {
                 "aether-substrate-hub: signal handler install failed: {e}; \
                  parking thread — SIGKILL is the only exit"
             );
-            std::thread::park();
+            thread::park();
             return "park";
         }
     };

--- a/crates/aether-substrate-bundle/src/hub/mod.rs
+++ b/crates/aether-substrate-bundle/src/hub/mod.rs
@@ -14,6 +14,7 @@
 //! vocabulary that supported it — the forward-model RPC architecture
 //! never used those paths and they were unreachable in practice.
 
+use std::env;
 mod chassis;
 
 pub use aether_substrate::Chassis;
@@ -32,7 +33,7 @@ pub const DEFAULT_RPC_PORT: u16 = 8901;
 /// server" instead.
 #[must_use]
 pub fn rpc_port_from_env() -> Option<u16> {
-    std::env::var("AETHER_RPC_PORT")
+    env::var("AETHER_RPC_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
 }

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -25,6 +25,7 @@
 //! chassis surface.
 
 mod chassis_common;
+pub mod chassis_root;
 pub mod desktop;
 pub mod headless;
 pub mod hub;

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -48,6 +48,10 @@ use aether_substrate::{
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use super::events::{ChassisEvent, EventReceiver, channel as event_channel};
 use super::render::Gpu;
+use serde::de::DeserializeOwned;
+use std::any;
+use std::error;
+use std::thread;
 
 /// Default offscreen target dimensions when the caller picks
 /// `start()` (no explicit size). 800x600 matches the scenario harness
@@ -116,7 +120,7 @@ impl fmt::Display for TestBenchError {
 /// dispatcher wake under nextest CPU contention.
 const SETTLEMENT_TIMEOUT: Duration = Duration::from_secs(5);
 
-impl std::error::Error for TestBenchError {}
+impl error::Error for TestBenchError {}
 
 /// In-process test-bench driver. Owns the substrate, runs the
 /// chassis events loop synchronously inside its API methods, routes
@@ -492,7 +496,7 @@ impl TestBench {
     ) -> Result<R, TestBenchError>
     where
         K: Kind + serde::Serialize,
-        R: serde::de::DeserializeOwned,
+        R: DeserializeOwned,
     {
         let mailbox = self
             .registry
@@ -503,7 +507,7 @@ impl TestBench {
         let payload = encode_struct(mail);
         self.queue
             .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
-        self.pump_until_reply::<R>(cid, std::any::type_name::<R>())
+        self.pump_until_reply::<R>(cid, any::type_name::<R>())
     }
 
     /// Run `ticks` complete frames synchronously. Each frame
@@ -614,7 +618,7 @@ impl TestBench {
     /// `WriteResult`) can't beat the bail-out check.
     fn pump_until_reply<R>(&mut self, cid: u64, expected: &'static str) -> Result<R, TestBenchError>
     where
-        R: serde::de::DeserializeOwned,
+        R: DeserializeOwned,
     {
         const MAX_ITERATIONS: u32 = 8_192;
         // Sleep per quiet iteration. 10 ms × QUIET_BUDGET caps total
@@ -682,7 +686,7 @@ impl TestBench {
                     });
                 }
                 // Yield to capability dispatcher threads (ADR-0070).
-                std::thread::sleep(QUIET_SLEEP);
+                thread::sleep(QUIET_SLEEP);
             }
         }
         Err(TestBenchError::Timeout {
@@ -693,7 +697,7 @@ impl TestBench {
 
     fn decode_reply<R>(event: EgressEvent, expected: &'static str) -> Result<R, TestBenchError>
     where
-        R: serde::de::DeserializeOwned,
+        R: DeserializeOwned,
     {
         match event {
             EgressEvent::ToSession {
@@ -857,6 +861,8 @@ fn correlation_of(event: &EgressEvent) -> Option<u64> {
 #[allow(clippy::too_many_lines, clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
+    use std::thread;
+    use std::time::Instant;
 
     /// Boot, advance one tick, capture, sanity-check the PNG.
     /// The default scene is empty so the captured frame is the
@@ -1099,9 +1105,9 @@ mod tests {
 
         // Wait briefly for the two pre-loaded `Bump` mails to land in
         // the first instance's dispatcher.
-        let deadline = std::time::Instant::now() + Duration::from_millis(500);
-        while received.load(AtomicOrdering::SeqCst) < 2 && std::time::Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while received.load(AtomicOrdering::SeqCst) < 2 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             received.load(AtomicOrdering::SeqCst),

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -40,6 +40,7 @@ mod native {
 
     use super::Advance;
     use crate::test_bench::events::{ChassisEvent, EventSender};
+    use std::io;
 
     /// Configuration for [`TestBenchCapability`]. Carries the
     /// `EventSender` the embedder loop reads on, so the handler can
@@ -68,7 +69,7 @@ mod native {
             ctx: &mut NativeInitCtx<'_>,
         ) -> Result<Self, BootError> {
             let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(std::io::Error::other(
+                BootError::Other(Box::new(io::Error::other(
                     "HubOutbound must be wired on Mailer before \
                      TestBenchCapability::init (test-bench attaches its loopback before \
                      the Builder chain)",

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -27,6 +27,8 @@ use aether_substrate::{
 
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
 use super::events::{ChassisEvent, EventSender};
+use aether_substrate::mail::registry::MailDispatch;
+use std::io;
 
 /// Wire-stable `EngineInfo.workers` value (ADR-0038: post actor-per-
 /// component, the scheduler doesn't read this — it's retained on the
@@ -81,7 +83,7 @@ impl Chassis for TestBenchChassis {
     /// `Builder<TestBenchChassis, _>` can still parameterise over
     /// `Chassis` per ADR-0071.
     fn build(_env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
-        Err(BootError::Other(Box::new(std::io::Error::other(
+        Err(BootError::Other(Box::new(io::Error::other(
             "TestBenchChassis has no driver; use TestBenchChassis::build_passive(env) instead \
              (the binary main() loops on events_rx; the in-process TestBench dispatches per-call)",
         ))))
@@ -271,17 +273,15 @@ impl TestBenchChassis {
             let observed_for_handler = sink;
             boot.registry.register_inline(
                 TEST_BENCH_OBSERVER_MAILBOX_NAME,
-                Arc::new(
-                    move |dispatch: aether_substrate::mail::registry::MailDispatch<'_>| {
-                        if dispatch.kind_name.is_empty() {
-                            return;
-                        }
-                        observed_for_handler
-                            .lock()
-                            .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
-                            .push(dispatch.kind_name.to_owned());
-                    },
-                ),
+                Arc::new(move |dispatch: MailDispatch<'_>| {
+                    if dispatch.kind_name.is_empty() {
+                        return;
+                    }
+                    observed_for_handler
+                        .lock()
+                        .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
+                        .push(dispatch.kind_name.to_owned());
+                }),
             );
         }
 

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -11,6 +11,7 @@ use aether_capabilities::{RenderGpu, RenderHandles};
 use aether_substrate::render::RenderError;
 
 pub use aether_substrate::render::VERTEX_BUFFER_BYTES;
+use std::iter;
 
 /// Render target format. Test-bench commits to RGBA at init since
 /// there's no surface to query, which keeps the readback path swizzle-
@@ -107,7 +108,7 @@ impl Gpu {
             Ok(()) => {}
             Err(RenderError::VertexBufferOverflow { .. }) => return,
         }
-        queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(iter::once(encoder.finish()));
     }
 
     /// Variant of `render` that also copies the offscreen texture
@@ -138,7 +139,7 @@ impl Gpu {
             }
         }
         let meta = self.render_handles.record_capture_copy(&mut encoder);
-        queue.submit(std::iter::once(encoder.finish()));
+        queue.submit(iter::once(encoder.finish()));
         self.render_handles.finish_capture(&meta)
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
@@ -42,6 +42,9 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use crate::capabilities::fs::NamespaceRoots;
+use std::env;
+use std::fs;
+use std::process;
 
 /// Process-wide test sandbox. Single `OnceLock` so repeat calls
 /// across a binary's tests resolve to the same dir — handy for
@@ -125,7 +128,7 @@ pub fn locate_component_wasm(crate_name: &str) -> Option<PathBuf> {
 // and surfaces it on failure (issue 891).
 #[allow(clippy::print_stderr)]
 pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
-    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     if !has_wgpu_adapter() {
         assert!(
             !strict,
@@ -170,11 +173,8 @@ pub fn require_runtime(crate_name: &str) -> Option<PathBuf> {
 /// a test that can't reserve its sandbox can't proceed.
 pub fn init_save_sandbox(label: &str) -> &'static Path {
     TEST_SAVE_DIR.get_or_init(|| {
-        let dir = std::env::temp_dir().join(format!(
-            "aether-{label}-tests-{pid}",
-            pid = std::process::id(),
-        ));
-        std::fs::create_dir_all(&dir).expect("create test save dir");
+        let dir = env::temp_dir().join(format!("aether-{label}-tests-{pid}", pid = process::id()));
+        fs::create_dir_all(&dir).expect("create test save dir");
         dir
     })
 }
@@ -212,6 +212,6 @@ pub fn write_fixture(name: &str, bytes: &[u8]) -> String {
     let dir = TEST_SAVE_DIR
         .get()
         .expect("init_save_sandbox must run before write_fixture");
-    std::fs::write(dir.join(name), bytes).expect("write fixture");
+    fs::write(dir.join(name), bytes).expect("write fixture");
     name.to_owned()
 }

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -23,11 +23,12 @@ use aether_data::{Kind, MailboxId};
 use aether_kinds::{LoadComponent, LoadResult};
 use aether_substrate_bundle::test_bench::{TestBench, test_helpers::require_runtime};
 use aether_test_fixture_probe::TickObserved;
+use std::fs;
 
 const PROBE_NAME: &str = "probe";
 
 fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
-    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
     let result: LoadResult = bench
         .send_and_await_reply(
             ComponentHostCapability::NAMESPACE,

--- a/crates/aether-substrate-bundle/tests/engine_logs.rs
+++ b/crates/aether-substrate-bundle/tests/engine_logs.rs
@@ -25,6 +25,7 @@
 
 use aether_kinds::{LogBatch, LogEvent, LogRead, LogReadResult};
 use aether_substrate_bundle::test_bench::{TestBench, test_helpers::has_wgpu_adapter};
+use std::env;
 
 const LOG_MAILBOX: &str = "aether.log";
 
@@ -32,7 +33,7 @@ fn require_wgpu_only() -> bool {
     if has_wgpu_adapter() {
         return true;
     }
-    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     assert!(
         !strict,
         "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -12,6 +12,7 @@
 use aether_actor::Actor;
 use aether_capabilities::EngineServer;
 use aether_data::{Kind, mailbox_id_from_name};
+use aether_kinds::descriptors;
 use aether_kinds::{
     ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
     TerminateEngineResult,
@@ -25,6 +26,7 @@ use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 struct TestChassis;
@@ -101,7 +103,7 @@ mod sink {
 
 fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     let registry = Arc::new(Registry::new());
-    for d in aether_kinds::descriptors::all() {
+    for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
     }
     let (outbound, _rx) = HubOutbound::attached_loopback();
@@ -136,7 +138,7 @@ fn drive<K: Kind + serde::Serialize, T>(
             return value;
         }
         assert!(Instant::now() < until, "no reply within {deadline:?}");
-        std::thread::sleep(Duration::from_millis(25));
+        thread::sleep(Duration::from_millis(25));
     }
 }
 

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -18,9 +18,10 @@ use aether_kinds::{
 };
 use aether_substrate_bundle::test_bench::{TestBench, test_helpers::require_runtime};
 use aether_test_fixture_probe::TickObserved;
+use std::fs;
 
 fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId {
-    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
     let result: LoadResult = bench
         .send_and_await_reply(
             ComponentHostCapability::NAMESPACE,

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -17,6 +17,7 @@
 // were rejected with `RpcError::UnsupportedTarget`.
 
 use aether_capabilities::EngineServer;
+use aether_capabilities::rpc::RpcServerHandle;
 use aether_capabilities::rpc::{
     Hello, HelloAck, MailEnvelope, MailboxAddress, PeerKind, RpcServerCapability, RpcServerConfig,
     WIRE_VERSION, WireFrame,
@@ -24,6 +25,7 @@ use aether_capabilities::rpc::{
 use aether_capabilities::trace::TraceObserverCapability;
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
+use aether_kinds::descriptors;
 use aether_kinds::{List, ListResult, SpawnEngine, SpawnEngineResult, TerminateEngine};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -52,7 +54,7 @@ impl Chassis for TestChassis {
 /// (`spawn`, `terminate`) settle and close.
 fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     let registry = Arc::new(Registry::new());
-    for d in aether_kinds::descriptors::all() {
+    for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
     }
     let (outbound, _rx) = HubOutbound::attached_loopback();
@@ -72,7 +74,7 @@ fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
         .build_passive()
         .expect("hub caps boot");
     let port = chassis
-        .handle::<aether_capabilities::rpc::RpcServerHandle>()
+        .handle::<RpcServerHandle>()
         .expect("RpcServerHandle published")
         .local_port;
     (chassis, port)

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -47,6 +47,8 @@ use aether_test_fixture_probe::SetRender;
 // and `aether_kinds::descriptors::all()` won't see fixture kinds.
 #[allow(unused_imports)]
 use aether_test_fixture_probe as _;
+use std::env;
+use std::fs;
 
 /// Caller-supplied component name passed to `LoadComponent`.
 const PROBE_NAME: &str = "probe";
@@ -86,7 +88,7 @@ fn envelope<K: Kind>(recipient: &str, mail: &K) -> MailEnvelope {
 /// `aether.test_bench`, so load is no longer naturally ordered ahead
 /// of advance — the test must await `LoadResult` explicitly.
 fn load_probe(bench: &mut TestBench, wasm_path: &Path) {
-    let wasm = std::fs::read(wasm_path).expect("read fixture wasm");
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
     let result: aether_kinds::LoadResult = bench
         .send_and_await_reply(
             "aether.component",
@@ -276,7 +278,7 @@ fn replace_component_preserves_mailbox_identity() {
     // replace mail no longer naturally orders ahead of the next
     // advance. Await `ReplaceResult` explicitly.
     let probe_mbox = mailbox_id_from_name(&probe_address());
-    let wasm = std::fs::read(&wasm_path).expect("re-read fixture wasm");
+    let wasm = fs::read(&wasm_path).expect("re-read fixture wasm");
     let replace_result: aether_kinds::ReplaceResult = bench
         .send_and_await_reply(
             "aether.component",
@@ -313,7 +315,7 @@ fn require_wgpu_only() -> bool {
     if has_wgpu_adapter() {
         return true;
     }
-    let strict = std::env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
     assert!(
         !strict,
         "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -49,6 +49,7 @@ use crate::chassis::ctx::ChassisCtx;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTarget, ReplyTo};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
+use crate::runtime::trace;
 
 /// Per-actor binding state every native capability owns. Each
 /// capability constructs one at boot via [`NativeBinding::new`] and
@@ -466,7 +467,7 @@ impl NativeBinding {
         // mail. No-op when the global trace queue isn't installed
         // (test fixtures bypassing the chassis); the drainer is the
         // only consumer.
-        crate::runtime::trace::record_sent(
+        trace::record_sent(
             mail_id,
             root,
             parent_mail,
@@ -682,12 +683,15 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
 )]
 mod tests {
     use super::*;
+    use crate::handle_store::HandleStore;
+    use crate::mail::registry::InboxHandler;
+    use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
     use std::sync::mpsc;
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         (registry, mailer)
     }
@@ -696,14 +700,12 @@ mod tests {
     /// it receives onto `tx` as an owned [`Envelope`]. Used by tests
     /// that need a registered recipient but only care about
     /// observing — or just not warn-dropping — the mail.
-    fn forward_to_envelope_sender(
-        tx: mpsc::Sender<Envelope>,
-    ) -> Arc<dyn crate::mail::registry::InboxHandler> {
+    fn forward_to_envelope_sender(tx: mpsc::Sender<Envelope>) -> Arc<dyn InboxHandler> {
         // iamacoffeepot/aether#848: the helper takes
         // [`OwnedDispatch`] directly so payload + kind_name move
         // into the forwarded [`Envelope`] without `to_vec()` /
         // `to_owned()` clones.
-        Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+        Arc::new(move |dispatch: OwnedDispatch| {
             // `Envelope` is now a type alias for `OwnedDispatch`, so
             // the inbox-handler value moves straight onto the actor
             // mpsc with no field-by-field translation.

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -683,18 +683,10 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
 )]
 mod tests {
     use super::*;
-    use crate::handle_store::HandleStore;
     use crate::mail::registry::InboxHandler;
     use crate::mail::registry::OwnedDispatch;
-    use crate::mail::registry::Registry;
+    use crate::test_util::fresh_substrate;
     use std::sync::mpsc;
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-        (registry, mailer)
-    }
 
     /// Build a registry handler that forwards every [`MailDispatch`]
     /// it receives onto `tx` as an owned [`Envelope`]. Used by tests

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -93,7 +93,7 @@ impl<'a> NativeCtx<'a> {
     /// ADR-0080 §12 spawn primitive: launch a worker thread that
     /// inherits this handler's in-flight `(mail_id, root)` so its
     /// sends fold into the current causal chain. The closure `f`
-    /// receives a [`crate::actor::native::InheritCtx<A>`] — sends
+    /// receives a [`InheritCtx<A>`] — sends
     /// from inside `f` carry `parent_mail = self.in_flight_mail_id()`
     /// and `root = self.in_flight_root()` automatically.
     ///
@@ -123,7 +123,7 @@ impl<'a> NativeCtx<'a> {
 
     /// ADR-0080 §12 spawn primitive: launch a worker thread with no
     /// in-flight inheritance. The closure `f` receives a
-    /// [`crate::actor::native::RootCtx<A>`] — each send mints a
+    /// [`RootCtx<A>`] — each send mints a
     /// fresh root chain with `A`'s mailbox as the producer.
     ///
     /// Use for long-lived workers that respond to external events

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -35,6 +35,13 @@ use crate::mail::ReplyTo;
 use crate::mail::mailer::Mailer;
 
 use super::{NativeActor, NativeDispatch};
+use crate::actor::native::InheritCtx;
+use crate::actor::native::RootCtx;
+use crate::actor::native::spawn_thread;
+use crate::mail::ReplyTarget;
+use aether_actor::actor::ctx::sync_waiter;
+use serde::de::DeserializeOwned;
+use std::thread::JoinHandle;
 
 /// Per-mail context for a [`NativeActor`] handler. Borrows the
 /// actor's [`NativeBinding`] for outbound mail and carries the
@@ -101,12 +108,12 @@ impl<'a> NativeCtx<'a> {
     /// arrives; callers gate-sensitive to settlement should not
     /// rely on the parent chain staying open for the worker's
     /// lifetime today.
-    pub fn spawn_inherit<A, F>(&self, f: F) -> std::thread::JoinHandle<()>
+    pub fn spawn_inherit<A, F>(&self, f: F) -> JoinHandle<()>
     where
         A: Actor + Singleton + 'static,
-        F: FnOnce(crate::actor::native::InheritCtx<A>) + Send + 'static,
+        F: FnOnce(InheritCtx<A>) + Send + 'static,
     {
-        crate::actor::native::spawn_thread::spawn_inherit::<A, F>(
+        spawn_thread::spawn_inherit::<A, F>(
             Arc::clone(self.binding),
             self.in_flight_mail_id,
             self.in_flight_root,
@@ -123,12 +130,12 @@ impl<'a> NativeCtx<'a> {
     /// (TCP per-connection workers, pollers). For short-burst CPU
     /// offload that is part of the current handler's causal closure,
     /// use [`Self::spawn_inherit`].
-    pub fn spawn_detached<A, F>(&self, f: F) -> std::thread::JoinHandle<()>
+    pub fn spawn_detached<A, F>(&self, f: F) -> JoinHandle<()>
     where
         A: Actor + Singleton + 'static,
-        F: FnOnce(crate::actor::native::RootCtx<A>) + Send + 'static,
+        F: FnOnce(RootCtx<A>) + Send + 'static,
     {
-        crate::actor::native::spawn_thread::spawn_detached::<A, F>(Arc::clone(self.binding), f)
+        spawn_thread::spawn_detached::<A, F>(Arc::clone(self.binding), f)
     }
 
     /// ADR-0080 §5: the [`MailId`] of the mail currently being
@@ -169,7 +176,7 @@ impl<'a> NativeCtx<'a> {
     #[must_use]
     pub fn origin(&self) -> Option<MailboxId> {
         match self.sender.target {
-            crate::mail::ReplyTarget::Component(id) => Some(id),
+            ReplyTarget::Component(id) => Some(id),
             _ => None,
         }
     }
@@ -282,7 +289,7 @@ impl<'a> NativeCtx<'a> {
             .spawner()
             .expect("NativeCtx::spawn_child requires a chassis-built binding (no spawner installed — likely a `new_for_test` binding)");
         let sender = ReplyTo {
-            target: crate::mail::ReplyTarget::Component(self.binding.self_mailbox()),
+            target: ReplyTarget::Component(self.binding.self_mailbox()),
             correlation_id: ReplyTo::NO_CORRELATION,
         };
         super::spawn::SpawnBuilder::new(Arc::clone(spawner), subname, config, sender)
@@ -674,7 +681,7 @@ impl OutboundReply for NativeCtx<'_> {
 
     fn origin(&self) -> Option<MailboxId> {
         match self.sender.target {
-            crate::mail::ReplyTarget::Component(id) => Some(id),
+            ReplyTarget::Component(id) => Some(id),
             _ => None,
         }
     }
@@ -696,10 +703,10 @@ impl SyncWaiter for NativeCtx<'_> {
         expected_correlation: u64,
     ) -> Result<K, E>
     where
-        K: Kind + serde::de::DeserializeOwned,
+        K: Kind + DeserializeOwned,
         E: WaitError,
     {
-        aether_actor::actor::ctx::sync_waiter::wait_reply_via::<K, E>(
+        sync_waiter::wait_reply_via::<K, E>(
             |kind, out, timeout, corr| self.binding.wait_reply(kind, out, timeout, corr),
             timeout_ms,
             capacity,

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -43,6 +43,12 @@ use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
+use crate::runtime::log_install;
+use crate::runtime::log_install::MailDispatch;
+use crate::runtime::trace;
+use aether_actor::local;
+use aether_actor::log;
+use std::thread;
 
 /// Try the typed `#[handler]` dispatch; if no typed arm matches and
 /// the actor's `#[fallback]` also returns `false`, warn that the kind
@@ -107,17 +113,14 @@ pub fn dispatch_loop_run<A>(
         // the default `Pooled` scheduler (issue 635) this surfaces as
         // `aether-worker-N` shared across actors; `Thread`-scheduled
         // actors get per-actor names.
-        let thread_name = std::thread::current().name().map(str::to_owned);
-        crate::runtime::trace::record_received(inbound_mail_id, thread_name);
-        aether_actor::local::with_stamped(slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &**binding as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-                    typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        let thread_name = thread::current().name().map(str::to_owned);
+        trace::record_received(inbound_mail_id, thread_name);
+        local::with_stamped(slots, || {
+            log_install::with_actor_dispatch(&**binding as &dyn MailDispatch, || {
+                let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
+                typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
+                log::drain_buffer();
+            });
         });
         // ADR-0080 §2 producer hook: `Finished` at handler exit. PR 2
         // does not bracket the panic-unwind path; if a handler panics
@@ -125,7 +128,7 @@ pub fn dispatch_loop_run<A>(
         // the substrate down anyway, so a missing `Finished` is
         // moot. A future PR may add `catch_unwind` here for graceful
         // settlement-on-panic.
-        crate::runtime::trace::record_finished(inbound_mail_id);
+        trace::record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -138,19 +141,16 @@ pub fn dispatch_loop_run<A>(
     // the full inbox.
     while let Some(env) = binding.try_recv() {
         let inbound_mail_id = env.mail_id;
-        let thread_name = std::thread::current().name().map(str::to_owned);
-        crate::runtime::trace::record_received(inbound_mail_id, thread_name);
-        aether_actor::local::with_stamped(slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &**binding as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-                    let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        let thread_name = thread::current().name().map(str::to_owned);
+        trace::record_received(inbound_mail_id, thread_name);
+        local::with_stamped(slots, || {
+            log_install::with_actor_dispatch(&**binding as &dyn MailDispatch, || {
+                let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
+                let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
+                log::drain_buffer();
+            });
         });
-        crate::runtime::trace::record_finished(inbound_mail_id);
+        trace::record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -158,16 +158,12 @@ pub fn dispatch_loop_run<A>(
 
     // Phase 3: last-chance close hook. ReplyTo is None — no inbound
     // envelope produced this call.
-    aether_actor::local::with_stamped(slots, || {
-        crate::runtime::log_install::with_actor_dispatch(
-            &**binding as &dyn crate::runtime::log_install::MailDispatch,
-            || {
-                let mut close_ctx =
-                    NativeCtx::new(binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
-                actor.unwire(&mut close_ctx);
-                aether_actor::log::drain_buffer();
-            },
-        );
+    local::with_stamped(slots, || {
+        log_install::with_actor_dispatch(&**binding as &dyn MailDispatch, || {
+            let mut close_ctx = NativeCtx::new(binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+            actor.unwire(&mut close_ctx);
+            log::drain_buffer();
+        });
     });
 
     // Phase 4: close in the registry — drains `monitors_of[id]` for

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -42,7 +42,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use crate::actor::native::Envelope;
+use crate::runtime::log_install;
+use crate::runtime::log_install::MailDispatch;
+use crate::runtime::trace;
+use aether_actor::local;
 use aether_actor::local::ActorSlots;
+use aether_actor::log;
+use std::ops::Deref;
+use std::sync::PoisonError;
+use std::thread;
 
 /// `ActorSlots` uses `RefCell` internally because the dedicated-thread
 /// dispatcher path only ever reaches it from one OS thread. Worker-pool
@@ -60,7 +69,7 @@ struct PooledSlots(Box<ActorSlots>);
 // single-threaded across the Pooled dispatch path.
 unsafe impl Sync for PooledSlots {}
 
-impl std::ops::Deref for PooledSlots {
+impl Deref for PooledSlots {
     type Target = ActorSlots;
     fn deref(&self) -> &ActorSlots {
         &self.0
@@ -177,7 +186,7 @@ where
         let tx = self
             .close_done_tx
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(PoisonError::into_inner)
             .take();
         if let Some(tx) = tx {
             // Receiver may have hung up if the wait already timed out.
@@ -195,7 +204,7 @@ where
     // (reply_to, payload) into the actor; the helper here doesn't
     // happen to, but the surface mirrors the owning dispatch loop.
     #[allow(clippy::needless_pass_by_value)]
-    fn dispatch_one(&self, actor: &mut Box<A>, env: crate::actor::native::Envelope) {
+    fn dispatch_one(&self, actor: &mut Box<A>, env: Envelope) {
         let inbound_mail_id = env.mail_id;
         // Issue 734: capture the OS thread name at the dispatcher's
         // receive hook so the trace renderer can stamp each event
@@ -203,19 +212,16 @@ where
         // `Pooled` default scheduler (issue 635) this is the worker's
         // `aether-worker-N` name (shared across actors); `Thread`-
         // scheduled actors land on a per-actor name.
-        let thread_name = std::thread::current().name().map(str::to_owned);
-        crate::runtime::trace::record_received(inbound_mail_id, thread_name);
-        aether_actor::local::with_stamped(&self.slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
-                    super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        let thread_name = thread::current().name().map(str::to_owned);
+        trace::record_received(inbound_mail_id, thread_name);
+        local::with_stamped(&self.slots, || {
+            log_install::with_actor_dispatch(&*self.binding as &dyn MailDispatch, || {
+                let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
+                super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
+                log::drain_buffer();
+            });
         });
-        crate::runtime::trace::record_finished(inbound_mail_id);
+        trace::record_finished(inbound_mail_id);
         if let Some(p) = &self.pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -226,20 +232,17 @@ where
     /// final tracing event from the close hook still routes to
     /// `LogCapability`.
     fn run_close_hook(&self, actor: &mut Box<A>) {
-        aether_actor::local::with_stamped(&self.slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &*self.binding as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut close_ctx = NativeCtx::new(
-                        &self.binding,
-                        ReplyTo::NONE,
-                        aether_data::MailId::NONE,
-                        aether_data::MailId::NONE,
-                    );
-                    actor.unwire(&mut close_ctx);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        local::with_stamped(&self.slots, || {
+            log_install::with_actor_dispatch(&*self.binding as &dyn MailDispatch, || {
+                let mut close_ctx = NativeCtx::new(
+                    &self.binding,
+                    ReplyTo::NONE,
+                    aether_data::MailId::NONE,
+                    aether_data::MailId::NONE,
+                );
+                actor.unwire(&mut close_ctx);
+                log::drain_buffer();
+            });
         });
     }
 
@@ -280,10 +283,7 @@ where
             return CycleResult::Idle;
         }
 
-        let mut actor_guard = self
-            .actor
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut actor_guard = self.actor.lock().unwrap_or_else(PoisonError::into_inner);
         let Some(actor) = actor_guard.as_mut() else {
             // Slot already finalized. Nothing to do.
             drop(actor_guard);
@@ -396,10 +396,7 @@ where
     /// predicate stays available for diagnostics + the fast-path
     /// already-closed check inside `set_close_done_tx`.
     fn is_closed(&self) -> bool {
-        let guard = self
-            .actor
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = self.actor.lock().unwrap_or_else(PoisonError::into_inner);
         guard.is_none()
     }
 
@@ -418,7 +415,7 @@ where
         let prior = self
             .close_done_tx
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(PoisonError::into_inner)
             .replace(tx);
         // Defensive: if a prior sender was installed (shouldn't happen
         // — `shutdown_instanced` runs once per chassis), drop it. The

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -109,13 +109,13 @@ pub struct Spawner {
     /// chassis runs its own sequence; not shared across substrates.
     counter: AtomicU64,
     /// Issue 635 PR C: chassis worker pool's ready-queue sender.
-    /// Cloned into [`crate::scheduler::WakeHandle`]s when the
+    /// Cloned into [`WakeHandle`]s when the
     /// Pooled spawn branch lands a slot.
     pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
     /// Issue 635 Phase 3: strong-Arc store for instanced
-    /// [`crate::scheduler::Drainable`] slots spawned via the Pooled
+    /// [`Drainable`] slots spawned via the Pooled
     /// branch. Without this the slot dropped at end of `spawn_actor`
-    /// and the [`crate::scheduler::WakeHandle`]'s `Weak` failed to
+    /// and the [`WakeHandle`]'s `Weak` failed to
     /// upgrade — every wake after spawn would silently no-op.
     /// Slots live until the Spawner itself drops (chassis teardown);
     /// self-closing actors leave their slot Arc here as a small
@@ -131,7 +131,7 @@ pub struct Spawner {
 
 /// One entry in [`Spawner::instanced_slots`]. Holds both the strong
 /// `Arc<dyn Drainable>` (so the wake handle's `Weak` upgrades) and a
-/// [`crate::scheduler::WakeHandle`] clone (so the chassis-teardown
+/// [`WakeHandle`] clone (so the chassis-teardown
 /// path can wake the slot after signaling shutdown). Issue 685.
 struct InstancedSlotEntry {
     slot: Arc<dyn Drainable>,
@@ -183,7 +183,7 @@ impl Spawner {
     /// workers can drain the close cycles we just queued.
     ///
     /// Issue 714: the original implementation polled
-    /// [`crate::scheduler::Drainable::is_closed`] every 2 ms with a
+    /// [`Drainable::is_closed`] every 2 ms with a
     /// `timeout`-bounded loop. Under nextest contention the worker that
     /// observed the wake could be scheduled out long enough that the
     /// 2 s deadline elapsed before the close cycle ran, surfacing as

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -26,14 +26,29 @@ use aether_actor::{HandlesKind, Instanced, NamespaceError, validate_namespace_se
 use aether_data::{Kind, mailbox_id_from_name};
 
 use crate::actor::native::binding::NativeBinding;
+use crate::actor::native::dispatch;
+use crate::actor::native::dispatcher_slot::DispatcherSlot;
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::{NativeActor, NativeDispatch, NativeInitCtx};
 use crate::actor::registry::ActorRegistry;
+use crate::chassis::ctx::MailboxWakeSlot;
 use crate::chassis::error::BootError;
 use crate::mail::mailer::Mailer;
+use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{NameConflict, Registry};
 use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
+use crate::runtime::log_install;
+use crate::runtime::log_install::MailDispatch;
+use crate::scheduler::Drainable;
+use crate::scheduler::WakeHandle;
+use aether_actor::local;
+use aether_actor::local::ActorSlots;
+use aether_actor::log;
+use std::sync::Weak;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
 
 /// How to derive the subname for a [`SpawnBuilder::finish`] call. The
 /// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
@@ -96,7 +111,7 @@ pub struct Spawner {
     /// Issue 635 PR C: chassis worker pool's ready-queue sender.
     /// Cloned into [`crate::scheduler::WakeHandle`]s when the
     /// Pooled spawn branch lands a slot.
-    pool_ready_tx: crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>>,
+    pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
     /// Issue 635 Phase 3: strong-Arc store for instanced
     /// [`crate::scheduler::Drainable`] slots spawned via the Pooled
     /// branch. Without this the slot dropped at end of `spawn_actor`
@@ -119,8 +134,8 @@ pub struct Spawner {
 /// [`crate::scheduler::WakeHandle`] clone (so the chassis-teardown
 /// path can wake the slot after signaling shutdown). Issue 685.
 struct InstancedSlotEntry {
-    slot: Arc<dyn crate::scheduler::Drainable>,
-    wake: crate::scheduler::WakeHandle,
+    slot: Arc<dyn Drainable>,
+    wake: WakeHandle,
 }
 
 impl Spawner {
@@ -130,7 +145,7 @@ impl Spawner {
         mailer: Arc<Mailer>,
         frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
         aborter: Arc<dyn FatalAborter>,
-        pool_ready_tx: crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>>,
+        pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
     ) -> Self {
         Self {
             registry,
@@ -147,9 +162,7 @@ impl Spawner {
     /// Borrow the chassis worker pool's ready-queue sender. PR D
     /// reaches for this when a Pooled instanced actor spawns.
     #[allow(dead_code)] // wired in PR D
-    pub(crate) fn pool_ready_tx(
-        &self,
-    ) -> &crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>> {
+    pub(crate) fn pool_ready_tx(&self) -> &crossbeam_channel::Sender<Arc<dyn Drainable>> {
         &self.pool_ready_tx
     }
 
@@ -183,7 +196,7 @@ impl Spawner {
     /// drained out of `instanced_slots` will then drop, and any actor
     /// whose close cycle didn't run misses its `unwire` (matches
     /// the today behavior pre-685).
-    pub(crate) fn shutdown_instanced(&self, timeout: std::time::Duration) {
+    pub(crate) fn shutdown_instanced(&self, timeout: Duration) {
         let entries: Vec<InstancedSlotEntry> = {
             let mut guard = self
                 .instanced_slots
@@ -213,10 +226,10 @@ impl Spawner {
             // we just need *some* worker to pick the slot up.
             let _ = entry.wake.wake();
         }
-        let deadline = std::time::Instant::now() + timeout;
+        let deadline = Instant::now() + timeout;
         let mut stuck = 0usize;
         for rx in &waiters {
-            let now = std::time::Instant::now();
+            let now = Instant::now();
             let remaining = deadline.saturating_duration_since(now);
             // `remaining == 0` means the deadline has passed; pass
             // `Duration::ZERO` to `recv_timeout` and treat as a
@@ -342,7 +355,7 @@ impl Spawner {
         // slots) can reach `Local::with_mut` without threading a
         // ctx through. Mirrors the singleton path in
         // `chassis::builder::make_native_actor_boot` (issue 672).
-        let slots = Box::new(aether_actor::local::ActorSlots::new());
+        let slots = Box::new(ActorSlots::new());
 
         let actor = {
             // Instanced actors don't publish driver-facing sub-handles
@@ -358,15 +371,12 @@ impl Spawner {
             // sender attribution when init returns. Singletons get
             // this through `make_native_actor_boot`; instanced
             // actors join the pattern in issue 672.
-            let init_result = aether_actor::local::with_stamped(&slots, || {
-                crate::runtime::log_install::with_actor_dispatch(
-                    &*transport as &dyn crate::runtime::log_install::MailDispatch,
-                    || {
-                        let r = A::init(config, &mut init_ctx);
-                        aether_actor::log::drain_buffer();
-                        r
-                    },
-                )
+            let init_result = local::with_stamped(&slots, || {
+                log_install::with_actor_dispatch(&*transport as &dyn MailDispatch, || {
+                    let r = A::init(config, &mut init_ctx);
+                    log::drain_buffer();
+                    r
+                })
             });
             match init_result {
                 Ok(a) => a,
@@ -404,8 +414,7 @@ impl Spawner {
         // Populated post-init by the `Pooled` branch below; left empty
         // for `Dedicated` (today's only path) so the closure's `get()`
         // is a single relaxed atomic load.
-        let wake_slot: Arc<crate::chassis::ctx::MailboxWakeSlot> =
-            Arc::new(crate::chassis::ctx::MailboxWakeSlot::default());
+        let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
         // iamacoffeepot/aether#848 PR 3: closure takes `OwnedDispatch`
         // directly. Payload + kind_name + origin all move into the
@@ -416,7 +425,7 @@ impl Spawner {
         // since `dispatch` was already moved into `env`.
         let registered = self.registry.try_register_inbox(
             full_name.clone(),
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 let Some(tx) = weak_for_handler.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::spawn",
@@ -498,20 +507,17 @@ impl Spawner {
         // already steady-state when `Spawner::spawn_actor` runs — the
         // child wire→dispatcher transition is sequential within this
         // ctx, peers are running, all mailboxes claimed.
-        aether_actor::local::with_stamped(&slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &*transport as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut wire_ctx = crate::actor::native::NativeCtx::new(
-                        &transport,
-                        ReplyTo::NONE,
-                        MailId::NONE,
-                        MailId::NONE,
-                    );
-                    actor.wire(&mut wire_ctx);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        local::with_stamped(&slots, || {
+            log_install::with_actor_dispatch(&*transport as &dyn MailDispatch, || {
+                let mut wire_ctx = crate::actor::native::NativeCtx::new(
+                    &transport,
+                    ReplyTo::NONE,
+                    MailId::NONE,
+                    MailId::NONE,
+                );
+                actor.wire(&mut wire_ctx);
+                log::drain_buffer();
+            });
         });
 
         // Pre-load bootstrap mail. tx is alive (rx is held by the
@@ -540,10 +546,10 @@ impl Spawner {
                 let mailer_for_thread = Arc::clone(&self.mailer);
                 let pending_for_thread = Arc::clone(&pending);
                 let thread_name = alloc_instanced_thread_name(&full_name);
-                let _ = std::thread::Builder::new()
+                let _ = thread::Builder::new()
                     .name(thread_name)
                     .spawn(move || {
-                        crate::actor::native::dispatch::dispatch_loop_run::<A>(
+                        dispatch::dispatch_loop_run::<A>(
                             &transport_for_thread,
                             &mut actor,
                             &slots,
@@ -560,7 +566,7 @@ impl Spawner {
                 // with the chassis worker pool. No per-actor thread.
                 // The wake hook on the closure pushes the slot to the
                 // ready queue when an envelope lands.
-                let slot = crate::actor::native::dispatcher_slot::DispatcherSlot::<A>::new(
+                let slot = DispatcherSlot::<A>::new(
                     actor,
                     Arc::clone(&transport),
                     slots,
@@ -569,14 +575,10 @@ impl Spawner {
                     Arc::clone(&self.mailer),
                     id,
                 );
-                let slot_dyn: Arc<dyn crate::scheduler::Drainable> = slot.clone();
-                let weak: std::sync::Weak<dyn crate::scheduler::Drainable> =
-                    Arc::downgrade(&slot_dyn);
-                let wake = crate::scheduler::WakeHandle::new(
-                    Arc::clone(slot.state()),
-                    weak,
-                    self.pool_ready_tx.clone(),
-                );
+                let slot_dyn: Arc<dyn Drainable> = slot.clone();
+                let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+                let wake =
+                    WakeHandle::new(Arc::clone(slot.state()), weak, self.pool_ready_tx.clone());
                 // Stash the slot's strong Arc so wakes can upgrade their
                 // `Weak`. PR C dropped it here, which broke every wake
                 // after spawn (the registry only holds the inbox

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -379,8 +379,10 @@ mod tests {
     use aether_data::{KindId, MailboxId};
 
     use crate::handle_store::HandleStore;
+    use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
     use crate::mail::{Mail, Mailer};
+    use crate::runtime::trace;
 
     /// Stub actor used as the `A` phantom marker on [`InheritCtx`] /
     /// [`RootCtx`]. Must impl `Singleton` because the spawn helpers
@@ -418,7 +420,7 @@ mod tests {
         // Copy).
         let _ = registry.try_register_inbox(
             name.to_owned(),
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 captured_for_handler.lock().unwrap().push(CapturedDispatch {
                     mail_id: dispatch.mail_id,
                     root: dispatch.root,
@@ -632,15 +634,13 @@ mod tests {
         use aether_kinds::trace::TraceEvent;
         use crossbeam_queue::SegQueue;
 
-        crate::runtime::trace::init_substrate_start();
+        trace::init_substrate_start();
         let queue = Arc::new(SegQueue::<TraceEvent>::new());
-        crate::runtime::trace::install_trace_queue(Arc::clone(&queue));
+        trace::install_trace_queue(Arc::clone(&queue));
         // After install_trace_queue, the global may already point at a
         // queue from a prior test. Read the live one and drain from
         // there so we observe the same queue spawn_inherit pushes to.
-        let live = crate::runtime::trace::trace_queue()
-            .expect("trace queue installed")
-            .clone();
+        let live = trace::trace_queue().expect("trace queue installed").clone();
 
         let (_registry, mailer) = fresh_substrate();
         let producer_mailbox = MailboxId(0xC0FE_C0FE_C0FE_C0FE);
@@ -706,12 +706,10 @@ mod tests {
         use aether_kinds::trace::TraceEvent;
         use crossbeam_queue::SegQueue;
 
-        crate::runtime::trace::init_substrate_start();
+        trace::init_substrate_start();
         let queue = Arc::new(SegQueue::<TraceEvent>::new());
-        crate::runtime::trace::install_trace_queue(Arc::clone(&queue));
-        let live = crate::runtime::trace::trace_queue()
-            .expect("trace queue installed")
-            .clone();
+        trace::install_trace_queue(Arc::clone(&queue));
+        let live = trace::trace_queue().expect("trace queue installed").clone();
 
         let (_registry, mailer) = fresh_substrate();
         // Different unique sender so this test's filter doesn't catch

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -378,11 +378,11 @@ mod tests {
     use aether_actor::Singleton;
     use aether_data::{KindId, MailboxId};
 
-    use crate::handle_store::HandleStore;
+    use crate::mail::Mail;
     use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
-    use crate::mail::{Mail, Mailer};
     use crate::runtime::trace;
+    use crate::test_util::fresh_substrate;
 
     /// Stub actor used as the `A` phantom marker on [`InheritCtx`] /
     /// [`RootCtx`]. Must impl `Singleton` because the spawn helpers
@@ -402,13 +402,6 @@ mod tests {
         root: MailId,
         parent_mail: Option<MailId>,
         sender: aether_data::ReplyTo,
-    }
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-        (registry, mailer)
     }
 
     fn register_capture(registry: &Registry, name: &str) -> Arc<Mutex<Vec<CapturedDispatch>>> {

--- a/crates/aether-substrate/src/actor/registry.rs
+++ b/crates/aether-substrate/src/actor/registry.rs
@@ -29,6 +29,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::actor::native::envelope::Envelope;
 use crate::mail::MailboxId;
+use std::any::Any;
 
 /// One actor slot in the registry. `Live` carries the inbox sender
 /// (for direct mail routing into the dispatcher), the actor's
@@ -340,7 +341,7 @@ impl ActorRegistry {
     /// lock drops before the caller iterates.
     pub(crate) fn live_subnames_of_type<T>(&self) -> Vec<(String, MailboxId)>
     where
-        T: std::any::Any + 'static,
+        T: Any + 'static,
     {
         let actors = self
             .actors
@@ -544,6 +545,7 @@ impl ActorRegistry {
 )]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
 
     #[test]
     fn fresh_registry_is_empty() {
@@ -562,7 +564,7 @@ mod tests {
     /// doesn't drag in `NativeActor`.
     fn insert_live_stub(r: &ActorRegistry, id: MailboxId) {
         struct Stub;
-        let (tx, _rx) = std::sync::mpsc::channel::<Envelope>();
+        let (tx, _rx) = mpsc::channel::<Envelope>();
         r.insert_live(id, Arc::new(tx), TypeId::of::<Stub>(), String::new())
             .expect("fresh slot");
     }

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -18,8 +18,11 @@ use crate::actor::native::binding::NativeBinding;
 use crate::actor::wasm::reply_table::{NO_REPLY_HANDLE, ReplyEntry, ReplyTable};
 use crate::mail::mailer::Mailer;
 use crate::mail::outbound::HubOutbound;
+use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{MailboxEntry, Registry};
 use crate::mail::{Mail, MailId, MailKind, MailboxId, ReplyTarget, ReplyTo};
+use crate::runtime::trace;
+use std::thread;
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -214,14 +217,7 @@ impl ComponentCtx {
             id => Some(id),
         };
         let root = inherited_root.unwrap_or(mail_id);
-        crate::runtime::trace::record_sent(
-            mail_id,
-            root,
-            parent_mail,
-            self.sender,
-            recipient,
-            kind,
-        );
+        trace::record_sent(mail_id, root, parent_mail, self.sender, recipient, kind);
 
         // Closure-bound (actor-enqueue) and Sink-bound (synchronous
         // handler) recipients dispatch inline here, bypassing the
@@ -247,7 +243,7 @@ impl ComponentCtx {
                 // flow straight into the downstream cap's mpsc
                 // envelope without a `to_vec()` clone.
                 let origin = self.registry.mailbox_name(self.sender);
-                handler.enqueue(crate::mail::registry::OwnedDispatch {
+                handler.enqueue(OwnedDispatch {
                     kind,
                     kind_name,
                     origin,
@@ -263,8 +259,8 @@ impl ComponentCtx {
             Some(MailboxEntry::Inline(handler)) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 let origin = self.registry.mailbox_name(self.sender);
-                let thread_name = std::thread::current().name().map(str::to_owned);
-                crate::runtime::trace::record_received(mail_id, thread_name);
+                let thread_name = thread::current().name().map(str::to_owned);
+                trace::record_received(mail_id, thread_name);
                 handler.dispatch(crate::mail::registry::MailDispatch {
                     kind,
                     kind_name: &kind_name,
@@ -276,7 +272,7 @@ impl ComponentCtx {
                     root,
                     parent_mail,
                 });
-                crate::runtime::trace::record_finished(mail_id);
+                trace::record_finished(mail_id);
                 return;
             }
             Some(MailboxEntry::Dropped) | None => {
@@ -688,10 +684,16 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+    use crate::actor::wasm::host_fns;
+    use crate::handle_store::HandleStore;
     use crate::mail::MailboxId;
     use crate::mail::mailer::Mailer;
     use crate::mail::outbound::{EgressEvent, HubOutbound};
+    use crate::mail::registry;
+    use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
+    use aether_data::tagged_id::Tag;
+    use std::sync::mpsc::Receiver;
 
     /// Captured `(mail_id, root, parent_mail)` triple for the
     /// lineage-propagation tests in this module.
@@ -710,7 +712,7 @@ mod tests {
         let sink_id = registry
             .try_register_inbox(
                 name,
-                Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+                Arc::new(move |dispatch: OwnedDispatch| {
                     captured_for_handler.lock().unwrap().push((
                         dispatch.mail_id,
                         dispatch.root,
@@ -724,7 +726,7 @@ mod tests {
 
     fn ctx() -> ComponentCtx {
         let registry = Arc::new(Registry::new());
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         ComponentCtx::new(
             MailboxId(0),
             Arc::clone(&registry),
@@ -736,7 +738,7 @@ mod tests {
     fn instantiate(wat: &str) -> Component {
         let engine = Engine::default();
         let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
-        crate::actor::wasm::host_fns::register(&mut linker).expect("register host fns");
+        host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).expect("compile WAT");
         let module = Module::new(&engine, &wasm).expect("compile module");
         Component::instantiate(&engine, &linker, &module, ctx()).expect("instantiate")
@@ -1110,11 +1112,7 @@ mod tests {
         );
     }
 
-    fn plane_ctx_for_reply() -> (
-        ComponentCtx,
-        std::sync::mpsc::Receiver<EgressEvent>,
-        aether_data::KindId,
-    ) {
+    fn plane_ctx_for_reply() -> (ComponentCtx, Receiver<EgressEvent>, aether_data::KindId) {
         use crate::mail::MailboxId as M;
         use aether_data::{KindDescriptor, SchemaType};
 
@@ -1126,7 +1124,7 @@ mod tests {
                 schema: SchemaType::Unit,
             })
             .expect("register kind");
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         let ctx = ComponentCtx::new(M(0), registry, mailer, outbound);
         (ctx, rx, pong_id)
@@ -1135,7 +1133,7 @@ mod tests {
     fn instantiate_with_ctx(wat: &str, ctx: ComponentCtx) -> Component {
         let engine = Engine::default();
         let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
-        crate::actor::wasm::host_fns::register(&mut linker).expect("register host fns");
+        host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).unwrap();
         let module = Module::new(&engine, &wasm).unwrap();
         Component::instantiate(&engine, &linker, &module, ctx).unwrap()
@@ -1189,10 +1187,10 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_inbox("client", crate::mail::registry::noop_handler())
+            .try_register_inbox("client", registry::noop_handler())
             .expect("register client mailbox");
 
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(
             Mailer::new(Arc::clone(&registry), store).with_outbound(Arc::clone(&outbound)),
         );
@@ -1231,10 +1229,10 @@ mod tests {
         let (outbound, outbound_rx) = HubOutbound::attached_loopback();
         let registry = Arc::new(Registry::new());
         let sender = registry
-            .try_register_inbox("client", crate::mail::registry::noop_handler())
+            .try_register_inbox("client", registry::noop_handler())
             .expect("register client mailbox");
 
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         // Deliberately no `with_outbound` — exercises the local warn-drop path.
 
@@ -1265,12 +1263,9 @@ mod tests {
         let registry = Arc::new(Registry::new());
         let (captured, sink_id) = register_lineage_capture_sink(&registry, "issue_722_sink");
 
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-        let sender = MailboxId(aether_data::with_tag(
-            aether_data::tagged_id::Tag::Mailbox,
-            0x42,
-        ));
+        let sender = MailboxId(aether_data::with_tag(Tag::Mailbox, 0x42));
         let ctx = ComponentCtx::new(
             sender,
             Arc::clone(&registry),
@@ -1281,13 +1276,7 @@ mod tests {
         // Inbound lineage: the chassis-driven tick chain we're "in"
         // when the wasm guest's on_tick handler fires its outbound.
         let inbound_root = MailId::new(MailboxId::CHASSIS_MAILBOX_ID, 7);
-        let inbound_mail = MailId::new(
-            MailboxId(aether_data::with_tag(
-                aether_data::tagged_id::Tag::Mailbox,
-                0x99,
-            )),
-            42,
-        );
+        let inbound_mail = MailId::new(MailboxId(aether_data::with_tag(Tag::Mailbox, 0x99)), 42);
         ctx.set_in_flight(inbound_mail, inbound_root);
 
         ctx.send(sink_id, aether_data::KindId(0xABCD), vec![1, 2, 3], 1);
@@ -1317,12 +1306,9 @@ mod tests {
         let (captured, sink_id) =
             register_lineage_capture_sink(&registry, "issue_722_fresh_root_sink");
 
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-        let sender = MailboxId(aether_data::with_tag(
-            aether_data::tagged_id::Tag::Mailbox,
-            0x33,
-        ));
+        let sender = MailboxId(aether_data::with_tag(Tag::Mailbox, 0x33));
         let ctx = ComponentCtx::new(
             sender,
             Arc::clone(&registry),

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -49,6 +49,8 @@ use aether_data::{
     canonical::kind_id_from_shape,
 };
 use aether_kinds::{ComponentCapabilities, FallbackCapability, HandlerCapability};
+use serde::de::DeserializeOwned;
+use std::str;
 use wasmparser::{Parser, Payload};
 
 /// Section name the derive writes to for canonical schema bytes.
@@ -178,7 +180,7 @@ pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> 
             continue;
         };
         if reader.name() == NAMESPACE_SECTION {
-            return std::str::from_utf8(reader.data())
+            return str::from_utf8(reader.data())
                 .map(|s| Some(s.to_owned()))
                 .map_err(|e| format!("{NAMESPACE_SECTION}: invalid UTF-8: {e}"));
         }
@@ -277,7 +279,7 @@ fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(),
 /// the section is exhausted. Abort on unknown version or postcard
 /// decode error. Per-section version allowlists are passed in so the
 /// shape and labels sections can evolve independently.
-fn decode_records<T: serde::de::DeserializeOwned>(
+fn decode_records<T: DeserializeOwned>(
     section_name: &str,
     supported_versions: &[u8],
     data: &[u8],
@@ -495,6 +497,7 @@ fn merge_variant(shape: &aether_data::VariantShape, label: Option<&VariantLabel>
 mod tests {
     use super::*;
     use aether_data::{LabelCell, LabelNode, Primitive, SchemaShape, VariantShape};
+    use std::fs;
     fn wasm_with_section(section_name: &str, section: &[u8]) -> Vec<u8> {
         use core::fmt::Write as _;
         let mut escaped = String::with_capacity(section.len() * 3);
@@ -761,7 +764,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../../target/wasm32-unknown-unknown/release/aether_demo_sokoban.wasm"
         );
-        let Ok(bytes) = std::fs::read(path) else {
+        let Ok(bytes) = fs::read(path) else {
             eprintln!("skipping: sokoban wasm not built at {path}");
             return;
         };
@@ -1006,7 +1009,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../../target/wasm32-unknown-unknown/release/examples/hello.wasm"
         );
-        let Ok(bytes) = std::fs::read(path) else {
+        let Ok(bytes) = fs::read(path) else {
             eprintln!("skipping: hello example wasm not built at {path}");
             return;
         };

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -40,10 +40,14 @@ use std::sync::Arc;
 use aether_data::KindDescriptor;
 use wasmtime::{Engine, Linker};
 
+use crate::mail::registry::MailDispatch;
+use crate::runtime::log_install;
+use crate::runtime::panic_hook;
 use crate::{
     AETHER_DIAGNOSTICS, ComponentCtx, HubOutbound, Mailer, Registry, actor::wasm::host_fns,
     handle_store::HandleStore,
 };
+use aether_kinds::descriptors;
 
 /// Everything a chassis needs after shared boot setup. Fields are
 /// `pub` so chassis code destructures and takes ownership of the
@@ -123,16 +127,16 @@ impl SubstrateBootBuilder<'_> {
         // crashes surface in `engine_logs` instead of vanishing to
         // stderr. Idempotent — chassis re-entries / repeated builds in
         // tests are safe.
-        crate::runtime::panic_hook::init_panic_hook();
+        panic_hook::init_panic_hook();
 
         let outbound = HubOutbound::disconnected();
         // Issue #581: install the actor-aware tracing subscriber stack.
-        crate::runtime::log_install::init_subscriber();
+        log_install::init_subscriber();
 
         let engine = Arc::new(Engine::default());
         let registry = Arc::new(Registry::new());
 
-        let boot_descriptors = aether_kinds::descriptors::all();
+        let boot_descriptors = descriptors::all();
         for d in &boot_descriptors {
             registry
                 .register_kind_with_descriptor(d.clone())
@@ -156,7 +160,7 @@ impl SubstrateBootBuilder<'_> {
         // chain's `in_flight` would leak.
         registry.register_inline(
             AETHER_DIAGNOSTICS,
-            Arc::new(|dispatch: crate::mail::registry::MailDispatch<'_>| {
+            Arc::new(|dispatch: MailDispatch<'_>| {
                 let kind_name = dispatch.kind_name;
                 let bytes = dispatch.payload;
                 if kind_name == <aether_kinds::UnresolvedMail as aether_data::Kind>::NAME

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -26,19 +26,44 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
 
 use crate::actor::native::binding::NativeBinding;
+use crate::actor::native::dispatch;
+use crate::actor::native::dispatcher_slot::DispatcherSlot;
 use crate::actor::native::{ExportedHandles, NativeActor, NativeDispatch, NativeInitCtx};
 use crate::chassis::Chassis;
+use crate::chassis::ctx::MailboxSender;
+use crate::chassis::ctx::MailboxWakeSlot;
 use crate::chassis::ctx::{ChassisCtx, FallbackRouter, MailboxClaim};
 use crate::chassis::error::BootError;
+use crate::chassis::settlement::SettlementRegistry;
+use crate::mail::Mail;
 use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
+use crate::runtime::log_install;
+use crate::runtime::log_install::MailDispatch;
+use crate::runtime::trace;
+use crate::runtime::trace::TraceDrainerHandle;
+use crate::scheduler::Drainable;
+use crate::scheduler::WakeHandle;
 use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 use aether_actor::Actor;
 use aether_actor::HandlesKind;
+use aether_actor::local;
+use aether_actor::local::ActorSlots;
+use aether_actor::log;
 use aether_data::mailbox_id_from_name;
+use aether_kinds::trace::Settled;
+use aether_kinds::trace::TraceEvent;
 use aether_kinds::{ConfigureLogDrain, LogBatch};
+use std::any::Any;
+use std::any::TypeId;
+use std::io;
+use std::mem;
+use std::sync::Weak;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 /// Failure mode raised by [`DriverRunning::run`].
 #[derive(Debug)]
@@ -199,7 +224,7 @@ impl<'a> DriverCtx<'a> {
     /// driver-facing sub-handle bundles without reaching for the cap
     /// itself.
     #[must_use]
-    pub fn handle<H: std::any::Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
+    pub fn handle<H: Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
         self.handles.get::<H>()
     }
 }
@@ -337,10 +362,10 @@ impl PassiveBoot for FallbackRouterBoot {
 struct ClaimResources {
     mailbox_id: MailboxId,
     transport: Arc<NativeBinding>,
-    mailbox_sender: crate::chassis::ctx::MailboxSender,
+    mailbox_sender: MailboxSender,
     pending: Option<Arc<AtomicU64>>,
-    wake_slot: Arc<crate::chassis::ctx::MailboxWakeSlot>,
-    slots: Box<aether_actor::local::ActorSlots>,
+    wake_slot: Arc<MailboxWakeSlot>,
+    slots: Box<ActorSlots>,
 }
 
 /// Phase state of a [`NativeActorBoot`] — variants carry exactly the
@@ -407,8 +432,7 @@ impl<A: NativeActor + NativeDispatch> NativeActorBoot<A> {
 
 impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
     fn claim(&mut self, ctx: &mut ChassisCtx<'_>) -> Result<(), BootError> {
-        let BootState::Pending { config } =
-            std::mem::replace(&mut self.state, BootState::Transitioning)
+        let BootState::Pending { config } = mem::replace(&mut self.state, BootState::Transitioning)
         else {
             panic!("PassiveBoot::claim called in non-Pending state");
         };
@@ -423,14 +447,14 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         if ctx
             .spawner_arc()
             .actor_registry()
-            .try_claim_namespace(A::NAMESPACE, std::any::TypeId::of::<A>())
+            .try_claim_namespace(A::NAMESPACE, TypeId::of::<A>())
             .is_err()
         {
             // The other claim is on the same namespace by a different
             // TypeId — a chassis-build collision. State stays
             // `Transitioning` (no resources held); cleanup_after_failure
             // sees that and does nothing.
-            return Err(BootError::Other(Box::new(std::io::Error::other(format!(
+            return Err(BootError::Other(Box::new(io::Error::other(format!(
                 "namespace {:?} already owned by a different TypeId — fix the conflicting actor's NAMESPACE const",
                 A::NAMESPACE
             )))));
@@ -477,7 +501,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 // claiming the same namespace can't (issue 607 Phase 7).
                 ctx.spawner_arc()
                     .actor_registry()
-                    .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+                    .release_namespace(A::NAMESPACE, TypeId::of::<A>());
                 // State stays `Transitioning` — no further cleanup
                 // for the rollback loop to do.
                 return Err(e);
@@ -495,7 +519,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // `init`, `wire`, and each handler dispatch so library code
         // inside the actor (e.g., the issue-581 log buffer) can reach
         // `Local::with_mut` without threading a ctx through.
-        let slots = Box::new(aether_actor::local::ActorSlots::new());
+        let slots = Box::new(ActorSlots::new());
 
         self.state = BootState::Claimed {
             resources: ClaimResources {
@@ -517,7 +541,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         handles: &mut ExportedHandles,
     ) -> Result<(), BootError> {
         let BootState::Claimed { resources, config } =
-            std::mem::replace(&mut self.state, BootState::Transitioning)
+            mem::replace(&mut self.state, BootState::Transitioning)
         else {
             panic!("PassiveBoot::init called in non-Claimed state");
         };
@@ -529,15 +553,12 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         let init_result = {
             let mailer_clone = ctx.mail_send_handle();
             let mut init_ctx = NativeInitCtx::new(&resources.transport, handles, mailer_clone);
-            aether_actor::local::with_stamped(&resources.slots, || {
-                crate::runtime::log_install::with_actor_dispatch(
-                    &*resources.transport as &dyn crate::runtime::log_install::MailDispatch,
-                    || {
-                        let r = A::init(config, &mut init_ctx);
-                        aether_actor::log::drain_buffer();
-                        r
-                    },
-                )
+            local::with_stamped(&resources.slots, || {
+                log_install::with_actor_dispatch(&*resources.transport as &dyn MailDispatch, || {
+                    let r = A::init(config, &mut init_ctx);
+                    log::drain_buffer();
+                    r
+                })
             })
         };
         let actor = match init_result {
@@ -551,7 +572,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 ctx.unclaim_mailbox(resources.mailbox_id);
                 ctx.spawner_arc()
                     .actor_registry()
-                    .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+                    .release_namespace(A::NAMESPACE, TypeId::of::<A>());
                 drop(resources);
                 // State stays `Transitioning` — no further work for
                 // the rollback loop to do.
@@ -571,7 +592,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         let BootState::Initialized {
             resources,
             mut actor,
-        } = std::mem::replace(&mut self.state, BootState::Transitioning)
+        } = mem::replace(&mut self.state, BootState::Transitioning)
         else {
             panic!("PassiveBoot::wire called in non-Initialized state");
         };
@@ -584,20 +605,17 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // `with_stamped` + `with_actor_dispatch` envelope as `init`
         // and per-envelope dispatch so `Local<T>` and `tracing::*`
         // route identically.
-        aether_actor::local::with_stamped(&resources.slots, || {
-            crate::runtime::log_install::with_actor_dispatch(
-                &*resources.transport as &dyn crate::runtime::log_install::MailDispatch,
-                || {
-                    let mut wire_ctx = crate::actor::native::NativeCtx::new(
-                        &resources.transport,
-                        aether_data::ReplyTo::NONE,
-                        aether_data::MailId::NONE,
-                        aether_data::MailId::NONE,
-                    );
-                    actor.wire(&mut wire_ctx);
-                    aether_actor::log::drain_buffer();
-                },
-            );
+        local::with_stamped(&resources.slots, || {
+            log_install::with_actor_dispatch(&*resources.transport as &dyn MailDispatch, || {
+                let mut wire_ctx = crate::actor::native::NativeCtx::new(
+                    &resources.transport,
+                    aether_data::ReplyTo::NONE,
+                    aether_data::MailId::NONE,
+                    aether_data::MailId::NONE,
+                );
+                actor.wire(&mut wire_ctx);
+                log::drain_buffer();
+            });
         });
 
         self.state = BootState::Wired { resources, actor };
@@ -626,10 +644,10 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 let mailer_for_thread = ctx.mail_send_handle();
                 let self_id_for_thread = mailbox_id;
                 let thread_name = alloc_native_actor_thread_name::<A>();
-                let thread = std::thread::Builder::new()
+                let thread = thread::Builder::new()
                     .name(thread_name)
                     .spawn(move || {
-                        crate::actor::native::dispatch::dispatch_loop_run::<A>(
+                        dispatch::dispatch_loop_run::<A>(
                             &transport_for_thread,
                             &mut actor,
                             &slots,
@@ -653,7 +671,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 // pool wake hook on every accepted send.
                 let actor_registry = Arc::clone(ctx.spawner_arc().actor_registry());
                 let mailer_clone = ctx.mail_send_handle();
-                let slot = crate::actor::native::dispatcher_slot::DispatcherSlot::<A>::new(
+                let slot = DispatcherSlot::<A>::new(
                     actor,
                     Arc::clone(&transport),
                     slots,
@@ -662,15 +680,11 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                     mailer_clone,
                     mailbox_id,
                 );
-                let slot_dyn: Arc<dyn crate::scheduler::Drainable> = slot.clone();
-                let weak: std::sync::Weak<dyn crate::scheduler::Drainable> =
-                    Arc::downgrade(&slot_dyn);
+                let slot_dyn: Arc<dyn Drainable> = slot.clone();
+                let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
                 drop(slot_dyn);
-                let wake = crate::scheduler::WakeHandle::new(
-                    Arc::clone(slot.state()),
-                    weak,
-                    ctx.pool_ready_tx().clone(),
-                );
+                let wake =
+                    WakeHandle::new(Arc::clone(slot.state()), weak, ctx.pool_ready_tx().clone());
                 // Issue 697 multi-pass: mail addressed at this actor
                 // during the wire pass landed in its inbox before the
                 // wake hook was installed, so the closure-side wake
@@ -710,7 +724,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 ctx.unclaim_mailbox(resources.mailbox_id);
                 ctx.spawner_arc()
                     .actor_registry()
-                    .release_namespace(A::NAMESPACE, std::any::TypeId::of::<A>());
+                    .release_namespace(A::NAMESPACE, TypeId::of::<A>());
             }
         }
     }
@@ -734,8 +748,8 @@ struct PooledActorShutdown<A>
 where
     A: NativeActor + NativeDispatch,
 {
-    slot: Option<Arc<crate::actor::native::dispatcher_slot::DispatcherSlot<A>>>,
-    mailbox_sender: Option<crate::chassis::ctx::MailboxSender>,
+    slot: Option<Arc<DispatcherSlot<A>>>,
+    mailbox_sender: Option<MailboxSender>,
 }
 
 impl<A> DynShutdown for PooledActorShutdown<A>
@@ -769,8 +783,8 @@ fn alloc_native_actor_thread_name<A: Actor>() -> String {
 /// to disconnect the channel (the dispatcher's `recv_blocking` returns
 /// `None` and the thread exits), then joins the thread.
 struct NativeActorShutdown {
-    thread: Option<std::thread::JoinHandle<()>>,
-    mailbox_sender: Option<crate::chassis::ctx::MailboxSender>,
+    thread: Option<JoinHandle<()>>,
+    mailbox_sender: Option<MailboxSender>,
 }
 
 impl DynShutdown for NativeActorShutdown {
@@ -1126,14 +1140,14 @@ struct BootedPassives {
     /// order, so the last batch may target an already-dead
     /// `TraceObserver` mailbox — that's acceptable: the observer cap
     /// drained its inbox during its own dispatcher's phase-2 drain.
-    _trace_drainer: crate::runtime::trace::TraceDrainerHandle,
+    _trace_drainer: TraceDrainerHandle,
     /// ADR-0080 §6 settlement registry. Cloned into the Mailer's
     /// chassis-router closure (which decodes `Settled { root }`
     /// mail addressed to `CHASSIS_MAILBOX_ID` and signals
     /// subscribers); reachable from `BootedPassives`-holders via
     /// [`Self::settlement_registry`] for PR 4 gate-site
     /// `subscribe_settlement` calls.
-    settlement_registry: Arc<super::settlement::SettlementRegistry>,
+    settlement_registry: Arc<SettlementRegistry>,
 }
 
 /// Issue #601: dispatch a `ConfigureLogDrain { mailbox: drain }` mail
@@ -1161,7 +1175,7 @@ fn dispatch_configure_log_drain(
     for target in targets {
         let cfg = ConfigureLogDrain { mailbox: drain };
         let payload = bytemuck::bytes_of(&cfg).to_vec();
-        let mail = crate::mail::Mail::new(*target, kind, payload, 1);
+        let mail = Mail::new(*target, kind, payload, 1);
         mailer.push(mail);
     }
 }
@@ -1171,7 +1185,7 @@ impl BootedPassives {
     /// PR 4 gate-site code (lifecycle drains, the per-frame Tick
     /// barrier, `replace_component` drain) reaches for this to call
     /// `subscribe_settlement(root)` and wait on the returned receiver.
-    pub fn settlement_registry(&self) -> &Arc<super::settlement::SettlementRegistry> {
+    pub fn settlement_registry(&self) -> &Arc<SettlementRegistry> {
         &self.settlement_registry
     }
 
@@ -1183,8 +1197,7 @@ impl BootedPassives {
         // point (drops via `_pool` field order after this method
         // returns), so workers can drain the close cycles the
         // `shutdown_instanced` wakes queue.
-        self.spawner
-            .shutdown_instanced(std::time::Duration::from_secs(2));
+        self.spawner.shutdown_instanced(Duration::from_secs(2));
         while let Some(s) = self.shutdowns.pop() {
             s.shutdown_dyn();
         }
@@ -1241,12 +1254,11 @@ fn boot_passives(
     // owns the thread that batches events into mail addressed to the
     // `aether.trace` sink. The handle in `BootedPassives` joins the
     // thread on chassis tear down.
-    crate::runtime::trace::init_substrate_start();
-    let trace_queue: Arc<crossbeam_queue::SegQueue<aether_kinds::trace::TraceEvent>> =
+    trace::init_substrate_start();
+    let trace_queue: Arc<crossbeam_queue::SegQueue<TraceEvent>> =
         Arc::new(crossbeam_queue::SegQueue::new());
-    crate::runtime::trace::install_trace_queue(Arc::clone(&trace_queue));
-    let trace_drainer =
-        crate::runtime::trace::start_drainer(Arc::clone(&trace_queue), Arc::clone(mailer));
+    trace::install_trace_queue(Arc::clone(&trace_queue));
+    let trace_drainer = trace::start_drainer(Arc::clone(&trace_queue), Arc::clone(mailer));
 
     // ADR-0080 §6 settlement registry + chassis-mail router. The
     // registry owns the gate-site notification map; the router
@@ -1255,14 +1267,13 @@ fn boot_passives(
     // Other chassis-internal kinds (none today; future debugger /
     // describe_tree replies could land here) add matching arms inside
     // the router closure without touching the Mailer's surface.
-    let settlement_registry: Arc<super::settlement::SettlementRegistry> =
-        Arc::new(crate::chassis::settlement::SettlementRegistry::new());
+    let settlement_registry: Arc<SettlementRegistry> = Arc::new(SettlementRegistry::new());
     mailer.install_settlement_registry(Arc::clone(&settlement_registry));
     let registry_for_router = Arc::clone(&settlement_registry);
-    let settled_kind = <aether_kinds::trace::Settled as aether_data::Kind>::ID;
+    let settled_kind = <Settled as aether_data::Kind>::ID;
     mailer.install_chassis_router(Box::new(move |mail| {
         if mail.kind == settled_kind {
-            match postcard::from_bytes::<aether_kinds::trace::Settled>(&mail.payload) {
+            match postcard::from_bytes::<Settled>(&mail.payload) {
                 Ok(notice) => registry_for_router.fire_settled(notice.root),
                 Err(e) => tracing::warn!(
                     target: "aether_substrate::chassis::settlement",
@@ -1508,7 +1519,7 @@ impl<C: Chassis> BuiltChassis<C> {
         let full_name = format!("{}:{}", A::NAMESPACE, subname);
         let id = MailboxId(mailbox_id_from_name(&full_name).0);
         let type_id = self.booted.actor_registry.type_id_at(id)?;
-        if type_id != std::any::TypeId::of::<A>() {
+        if type_id != TypeId::of::<A>() {
             return None;
         }
         Some(id)
@@ -1610,7 +1621,7 @@ impl<C: Chassis> PassiveChassis<C> {
     /// that drive a `PassiveChassis` directly (`TestBench`, integration
     /// harnesses). `None` if no booted cap published a handle of that
     /// type.
-    pub fn handle<H: std::any::Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
+    pub fn handle<H: Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
         self.booted.handles.get::<H>()
     }
 
@@ -1619,7 +1630,7 @@ impl<C: Chassis> PassiveChassis<C> {
     /// for this to call `subscribe_settlement(root)`; PR 3 surfaces
     /// the accessor for tests that pump synthetic events through the
     /// trace pipeline and wait on the resulting `Settled` signal.
-    pub fn settlement_registry(&self) -> &Arc<super::settlement::SettlementRegistry> {
+    pub fn settlement_registry(&self) -> &Arc<SettlementRegistry> {
         self.booted.settlement_registry()
     }
 
@@ -1655,7 +1666,7 @@ impl<C: Chassis> PassiveChassis<C> {
         let full_name = format!("{}:{}", A::NAMESPACE, subname);
         let id = MailboxId(mailbox_id_from_name(&full_name).0);
         let type_id = self.booted.actor_registry.type_id_at(id)?;
-        if type_id != std::any::TypeId::of::<A>() {
+        if type_id != TypeId::of::<A>() {
             return None;
         }
         Some(id)
@@ -1714,6 +1725,17 @@ impl<C: Chassis> PassiveChassis<C> {
 )]
 mod tests {
     use super::*;
+    use crate::actor::monitor::MonitorHandle;
+    use crate::actor::native::ctx::NativeCtx;
+    use crate::handle_store::HandleStore;
+    use crate::mail::KindId;
+    use crate::mail::registry;
+    use std::io;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::thread;
+    use std::time::Duration;
+    use std::time::Instant;
 
     /// Lightweight passive-cap fixture for chassis-level boot tests.
     /// The chassis-builder tests don't care about handler dispatch
@@ -1735,8 +1757,8 @@ mod tests {
     impl NativeDispatch for StubLog {
         fn __aether_dispatch_envelope(
             &mut self,
-            _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-            _kind: crate::mail::KindId,
+            _ctx: &mut NativeCtx<'_>,
+            _kind: KindId,
             _payload: &[u8],
         ) -> Option<()> {
             None
@@ -1769,11 +1791,11 @@ mod tests {
 
     /// Test driver: records that it ran, then exits.
     struct RanDriver {
-        ran: Arc<std::sync::atomic::AtomicBool>,
+        ran: Arc<AtomicBool>,
     }
 
     struct RanDriverRunning {
-        ran: Arc<std::sync::atomic::AtomicBool>,
+        ran: Arc<AtomicBool>,
     }
 
     impl DriverCapability for RanDriver {
@@ -1785,14 +1807,14 @@ mod tests {
 
     impl DriverRunning for RanDriverRunning {
         fn run(self: Box<Self>) -> Result<(), RunError> {
-            self.ran.store(true, std::sync::atomic::Ordering::SeqCst);
+            self.ran.store(true, Ordering::SeqCst);
             Ok(())
         }
     }
 
     fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
         let registry = Arc::new(Registry::new());
-        let store = Arc::new(crate::handle_store::HandleStore::new(1024 * 1024));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         (registry, mailer)
     }
@@ -1804,7 +1826,7 @@ mod tests {
     #[test]
     fn driver_build_runs_driver_and_tears_down_passives() {
         let (registry, mailer) = fresh_substrate();
-        let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ran = Arc::new(AtomicBool::new(false));
 
         let chassis = Builder::<DrivenTestChassis<RanDriver>>::new(registry, mailer)
             .with_actor::<StubLog>(())
@@ -1815,7 +1837,7 @@ mod tests {
             .expect("build succeeds");
 
         chassis.run().expect("driver run succeeds");
-        assert!(ran.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(ran.load(Ordering::SeqCst));
     }
 
     /// Boot-time mailbox-claim collision aborts the build (and runs
@@ -1853,7 +1875,7 @@ mod tests {
         impl NativeActor for FailingCap {
             type Config = ();
             fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Err(BootError::Other(Box::new(std::io::Error::other(
+                Err(BootError::Other(Box::new(io::Error::other(
                     "intentional init failure for Phase 7 cleanup test",
                 ))))
             }
@@ -1861,8 +1883,8 @@ mod tests {
         impl NativeDispatch for FailingCap {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -1912,7 +1934,7 @@ mod tests {
         }
         impl Kind for Ping {
             const NAME: &'static str = "test.with_actor.ping";
-            const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0001);
+            const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0001);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != size_of::<Self>() {
                     return None;
@@ -1948,8 +1970,8 @@ mod tests {
         impl NativeDispatch for ProbeCap {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Ping::ID.0 {
@@ -1986,7 +2008,7 @@ mod tests {
 
         let payload = Ping { tag: 0xDEAD_BEEF };
         let bytes = payload.encode_into_bytes();
-        handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        handler.enqueue(registry::test_owned_dispatch(
             <Ping as Kind>::ID,
             Ping::NAME,
             &bytes,
@@ -1994,9 +2016,9 @@ mod tests {
         ));
 
         // Wait briefly for the dispatcher thread to dispatch.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while received.load(AtomicOrdering::SeqCst) == 0 && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             received.load(AtomicOrdering::SeqCst),
@@ -2033,8 +2055,8 @@ mod tests {
         impl NativeDispatch for FrameBoundProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -2075,7 +2097,7 @@ mod tests {
         }
         impl Kind for Tick {
             const NAME: &'static str = "test.local.tick";
-            const ID: aether_data::KindId = aether_data::KindId(0xA1B2_C3D4_E5F6_0002);
+            const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0002);
             fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
                 if bytes.len() != size_of::<Self>() {
                     return None;
@@ -2123,8 +2145,8 @@ mod tests {
         impl NativeDispatch for LocalProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Tick::ID.0 {
@@ -2160,7 +2182,7 @@ mod tests {
         for seq in 0..3 {
             let payload = Tick { seq };
             let bytes = payload.encode_into_bytes();
-            handler.enqueue(crate::mail::registry::test_owned_dispatch(
+            handler.enqueue(registry::test_owned_dispatch(
                 <Tick as Kind>::ID,
                 Tick::NAME,
                 &bytes,
@@ -2168,9 +2190,9 @@ mod tests {
             ));
         }
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while observed.load(AtomicOrdering::SeqCst) != 103 && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while observed.load(AtomicOrdering::SeqCst) != 103 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             observed.load(AtomicOrdering::SeqCst),
@@ -2250,8 +2272,8 @@ mod tests {
         impl NativeDispatch for ChildCap {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Ping::ID.0 {
@@ -2287,8 +2309,8 @@ mod tests {
         impl NativeDispatch for ParentCap {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Hatch::ID.0 {
@@ -2324,18 +2346,16 @@ mod tests {
             panic!("expected mailbox entry");
         };
         let bytes = (Hatch { tag: 1 }).encode_into_bytes();
-        handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        handler.enqueue(registry::test_owned_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
             &bytes,
             1,
         ));
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while child_received.load(AtomicOrdering::SeqCst) < 1
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while child_received.load(AtomicOrdering::SeqCst) < 1 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             spawn_count.load(AtomicOrdering::SeqCst),
@@ -2405,15 +2425,15 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for Closer {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Quit::ID.0 {
@@ -2444,7 +2464,7 @@ mod tests {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
-        handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        handler.enqueue(registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &bytes,
@@ -2452,11 +2472,9 @@ mod tests {
         ));
 
         // Wait for unwire to run + the registry slot to flip Dead.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while close_observed.load(AtomicOrdering::SeqCst) == 0
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             close_observed.load(AtomicOrdering::SeqCst),
@@ -2467,9 +2485,9 @@ mod tests {
         // thread runs `mark_dead` after `unwire`, so there's a
         // small window between the close-observed bump above and the
         // registry update.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().is_live(id) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().is_live(id) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert!(
             !chassis.actor_registry().is_live(id),
@@ -2524,15 +2542,15 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for Quiet {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -2595,15 +2613,15 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for Quiet {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -2715,8 +2733,8 @@ mod tests {
         impl NativeDispatch for Target {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Quit::ID.0 {
@@ -2734,7 +2752,7 @@ mod tests {
         struct Watcher {
             notice_count: Arc<AtomicU32>,
             last_target: Arc<AtomicU64>,
-            handle: Mutex<Option<crate::actor::monitor::MonitorHandle>>,
+            handle: Mutex<Option<MonitorHandle>>,
         }
         impl Actor for Watcher {
             const NAMESPACE: &'static str = "test.monitor.watcher";
@@ -2755,8 +2773,8 @@ mod tests {
         impl NativeDispatch for Watcher {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == WatchOrder::ID.0 {
@@ -2812,7 +2830,7 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        watcher_handler.enqueue(registry::test_owned_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
             &order.encode_into_bytes(),
@@ -2820,11 +2838,9 @@ mod tests {
         ));
 
         // Wait until the registry sees the monitor entry.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().monitor_count(target_id) == 0
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().monitor_count(target_id) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             chassis.actor_registry().monitor_count(target_id),
@@ -2845,7 +2861,7 @@ mod tests {
         else {
             panic!("expected mailbox entry for target");
         };
-        target_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        target_handler.enqueue(registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -2853,10 +2869,9 @@ mod tests {
         ));
 
         // Wait for the notice to land at the watcher.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while notice_count.load(AtomicOrdering::SeqCst) == 0 && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while notice_count.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             notice_count.load(AtomicOrdering::SeqCst),
@@ -2871,9 +2886,9 @@ mod tests {
 
         // Wait for target slot to flip Dead (the close path runs
         // close_actor → mark_dead after fan-out).
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().is_live(target_id) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().is_live(target_id) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert!(
             !chassis.actor_registry().is_live(target_id),
@@ -2958,8 +2973,8 @@ mod tests {
         impl NativeDispatch for Target {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -2967,7 +2982,7 @@ mod tests {
         }
 
         struct Watcher {
-            handle: Mutex<Option<crate::actor::monitor::MonitorHandle>>,
+            handle: Mutex<Option<MonitorHandle>>,
             close_observed: Arc<AtomicU32>,
         }
         impl Actor for Watcher {
@@ -2984,15 +2999,15 @@ mod tests {
                     close_observed: config,
                 })
             }
-            fn unwire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for Watcher {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == WatchOrder::ID.0 {
@@ -3035,7 +3050,7 @@ mod tests {
         let order = WatchOrder {
             target_id: target_id.0,
         };
-        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        watcher_handler.enqueue(registry::test_owned_dispatch(
             <WatchOrder as Kind>::ID,
             WatchOrder::NAME,
             &order.encode_into_bytes(),
@@ -3043,28 +3058,24 @@ mod tests {
         ));
 
         // Wait for register to land.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().monitor_count(target_id) == 0
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().monitor_count(target_id) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(chassis.actor_registry().monitor_count(target_id), 1);
 
         // Quit watcher — its close path walks `monitoring[watcher]` and
         // prunes watcher from `monitors_of[target]`.
-        watcher_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        watcher_handler.enqueue(registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
             1,
         ));
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while close_observed.load(AtomicOrdering::SeqCst) == 0
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             close_observed.load(AtomicOrdering::SeqCst),
@@ -3074,9 +3085,9 @@ mod tests {
 
         // Watcher slot tombstones; target slot still Live; target's
         // forward index drained of the dead watcher.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().is_live(watcher_id) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().is_live(watcher_id) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert!(
             chassis.actor_registry().is_tombstoned(watcher_id),
@@ -3153,8 +3164,8 @@ mod tests {
         impl NativeDispatch for Member {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Quit::ID.0 {
@@ -3219,7 +3230,7 @@ mod tests {
         let MailboxEntry::Inbox(handler) = registry.entry(id_c).expect("c sink registered") else {
             panic!("expected mailbox entry for c");
         };
-        handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        handler.enqueue(registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -3227,9 +3238,9 @@ mod tests {
         ));
 
         // Wait for c's slot to flip Dead.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().is_live(id_c) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().is_live(id_c) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
 
         assert!(
@@ -3279,8 +3290,8 @@ mod tests {
         impl NativeDispatch for Foo {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -3301,8 +3312,8 @@ mod tests {
         impl NativeDispatch for Bar {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -3435,8 +3446,8 @@ mod tests {
         impl NativeDispatch for Grandchild {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Ping::ID.0 {
@@ -3468,8 +3479,8 @@ mod tests {
         impl NativeDispatch for Parent {
             fn __aether_dispatch_envelope(
                 &mut self,
-                ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == Hatch::ID.0 {
@@ -3514,7 +3525,7 @@ mod tests {
         else {
             panic!("expected mailbox entry for parent");
         };
-        parent_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        parent_handler.enqueue(registry::test_owned_dispatch(
             <Hatch as Kind>::ID,
             Hatch::NAME,
             &(Hatch { tag: 1 }).encode_into_bytes(),
@@ -3524,11 +3535,9 @@ mod tests {
         // Wait for the grandchild's after_init Ping to dispatch (proves
         // the recursive spawn happened AND the after_init plumbing
         // works through it).
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while grandchild_received.load(AtomicOrdering::SeqCst) == 0
-            && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while grandchild_received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             grandchild_received.load(AtomicOrdering::SeqCst),
@@ -3562,7 +3571,7 @@ mod tests {
         // Closing the parent does NOT cascade-close the grandchild.
         // Parent-child shutdown coupling is opt-in via monitor; without
         // it, the grandchild keeps running.
-        parent_handler.enqueue(crate::mail::registry::test_owned_dispatch(
+        parent_handler.enqueue(registry::test_owned_dispatch(
             <Quit as Kind>::ID,
             Quit::NAME,
             &(Quit { tag: 1 }).encode_into_bytes(),
@@ -3570,9 +3579,9 @@ mod tests {
         ));
 
         // Wait for parent slot to flip Dead.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while chassis.actor_registry().is_live(parent_id) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while chassis.actor_registry().is_live(parent_id) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert!(
             chassis.actor_registry().is_tombstoned(parent_id),
@@ -3610,15 +3619,15 @@ mod tests {
             fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_count: config })
             }
-            fn wire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn wire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for WireProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -3698,7 +3707,7 @@ mod tests {
             fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_ran: config })
             }
-            fn wire(&mut self, ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn wire(&mut self, ctx: &mut NativeCtx<'_>) {
                 ctx.send_to_named::<WireBarrierPing>(
                     Ponger::NAMESPACE,
                     &WireBarrierPing { tag: 1 },
@@ -3709,8 +3718,8 @@ mod tests {
         impl NativeDispatch for Pinger {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -3734,8 +3743,8 @@ mod tests {
         impl NativeDispatch for Ponger {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {
                 if kind.0 == WireBarrierPing::ID.0 {
@@ -3770,9 +3779,9 @@ mod tests {
         );
 
         // Wait for Ponger's dispatcher to drain the wire-emitted ping.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        while received.load(AtomicOrdering::SeqCst) == 0 && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
         }
         assert_eq!(
             received.load(AtomicOrdering::SeqCst),
@@ -3807,15 +3816,15 @@ mod tests {
             fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
                 Ok(Self { wire_count: config })
             }
-            fn wire(&mut self, _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>) {
+            fn wire(&mut self, _ctx: &mut NativeCtx<'_>) {
                 self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
             }
         }
         impl NativeDispatch for WireSpawnProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut crate::actor::native::ctx::NativeCtx<'_>,
-                _kind: crate::mail::KindId,
+                _ctx: &mut NativeCtx<'_>,
+                _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
                 None
@@ -3876,7 +3885,7 @@ mod tests {
     #[test]
     fn with_workers_survives_driver_transition() {
         let (registry, mailer) = fresh_substrate();
-        let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ran = Arc::new(AtomicBool::new(false));
         let builder = Builder::<DrivenTestChassis<RanDriver>>::new(registry, mailer)
             .with_workers(Some(3))
             .driver(RanDriver {

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1727,9 +1727,9 @@ mod tests {
     use super::*;
     use crate::actor::monitor::MonitorHandle;
     use crate::actor::native::ctx::NativeCtx;
-    use crate::handle_store::HandleStore;
     use crate::mail::KindId;
     use crate::mail::registry;
+    use crate::test_util::fresh_substrate;
     use std::io;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
@@ -1810,13 +1810,6 @@ mod tests {
             self.ran.store(true, Ordering::SeqCst);
             Ok(())
         }
-    }
-
-    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
-        let registry = Arc::new(Registry::new());
-        let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
-        (registry, mailer)
     }
 
     /// Driver build path: passives boot, driver runs, passives tear

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -735,7 +735,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
 /// 1. Sets the binding's `should_shutdown` flag so the next
 ///    [`crate::scheduler::DispatcherSlot::run_cycle`] observes the
 ///    signal and runs `unwire` + registry finalize.
-/// 2. Drops the [`crate::chassis::ctx::MailboxSender`] so subsequent
+/// 2. Drops the [`MailboxSender`] so subsequent
 ///    sends warn-and-discard.
 /// 3. Drops the slot Arc — the chassis-held strong ref. The pool
 ///    worker's strong ref (via the ready queue) drops at end of the
@@ -779,7 +779,7 @@ fn alloc_native_actor_thread_name<A: Actor>() -> String {
 }
 
 /// Shutdown adapter for a [`NativeActor`] booted through
-/// [`Builder::with_actor`]. Drops the [`crate::chassis::ctx::MailboxSender`]
+/// [`Builder::with_actor`]. Drops the [`MailboxSender`]
 /// to disconnect the channel (the dispatcher's `recv_blocking` returns
 /// `None` and the thread exits), then joins the thread.
 struct NativeActorShutdown {
@@ -2078,7 +2078,7 @@ mod tests {
     }
 
     /// Issue 582: the chassis dispatcher trampoline stamps the
-    /// per-actor [`aether_actor::local::ActorSlots`] into TLS
+    /// per-actor [`ActorSlots`] into TLS
     /// for the duration of `init` and each handler call. A cap that
     /// reaches for `Local::with_mut` from inside both lifecycle
     /// stages must see its own state — verified end-to-end here so

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -63,7 +63,7 @@ pub struct DropOnShutdownClaim {
     /// Issue 635 PR C: optional wake hook for `Pooled` actors. The
     /// mailbox closure invokes this after a successful inbox push so
     /// the chassis worker pool re-queues the actor's
-    /// [`Drainable`](crate::scheduler::Drainable) slot. `Dedicated` actors
+    /// [`Drainable`] slot. `Dedicated` actors
     /// (today: every cap) leave this empty — the closure's `get()`
     /// is a single atomic load, ~free.
     ///
@@ -76,7 +76,7 @@ pub struct DropOnShutdownClaim {
 /// Cell holding the optional wake hook a `Pooled` mailbox fires after
 /// each accepted send. The mailbox closure captures `Arc<MailboxWakeSlot>`
 /// at registration time; the spawn path populates it once the
-/// [`Drainable`](crate::scheduler::Drainable) slot exists.
+/// [`Drainable`] slot exists.
 #[derive(Default)]
 pub struct MailboxWakeSlot {
     inner: OnceLock<MailboxWakeFn>,

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -17,8 +17,12 @@ use crate::actor::native::envelope::Envelope;
 use crate::chassis::error::BootError;
 use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
+use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::FatalAborter;
+use crate::scheduler::Drainable;
+use std::fmt;
+use std::sync::OnceLock;
 
 // iamacoffeepot/aether#848 PR 3: the `build_envelope(&MailDispatch)`
 // helper retired. Production cap registration closures now take
@@ -75,11 +79,11 @@ pub struct DropOnShutdownClaim {
 /// [`Drainable`](crate::scheduler::Drainable) slot exists.
 #[derive(Default)]
 pub struct MailboxWakeSlot {
-    inner: std::sync::OnceLock<MailboxWakeFn>,
+    inner: OnceLock<MailboxWakeFn>,
 }
 
-impl std::fmt::Debug for MailboxWakeSlot {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for MailboxWakeSlot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MailboxWakeSlot")
             .field("installed", &self.inner.get().is_some())
             .finish()
@@ -295,7 +299,7 @@ impl<'a> ChassisCtx<'a> {
             // path. `SendError` returns the envelope on failure so
             // the warn-log reads `env.kind_name` (the owned String)
             // without needing to clone ahead of the send.
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 let env: Envelope = dispatch;
                 if let Err(mpsc::SendError(env)) = tx.send(env) {
                     tracing::warn!(
@@ -354,7 +358,7 @@ impl<'a> ChassisCtx<'a> {
             // logs `dispatch.kind_name` (still owned by the closure
             // at that point); the post-send fail branch reads
             // `env.kind_name` out of the `SendError` payload.
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",
@@ -435,7 +439,7 @@ impl<'a> ChassisCtx<'a> {
             // the only change is that `dispatch` is `OwnedDispatch`
             // (moved into `env` via `From`) and the failure branch
             // reads `env.kind_name` out of the `SendError`.
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 let Some(tx) = weak.upgrade() else {
                     tracing::warn!(
                         target: "aether_substrate::capability",
@@ -590,9 +594,7 @@ impl<'a> ChassisCtx<'a> {
     /// sender. The `Pooled` branch of `make_native_actor_boot` clones
     /// this into the [`crate::scheduler::WakeHandle`] that fires when
     /// the actor's mailbox accepts a send.
-    pub(crate) fn pool_ready_tx(
-        &self,
-    ) -> &crossbeam_channel::Sender<Arc<dyn crate::scheduler::Drainable>> {
+    pub(crate) fn pool_ready_tx(&self) -> &crossbeam_channel::Sender<Arc<dyn Drainable>> {
         self.spawner.pool_ready_tx()
     }
 

--- a/crates/aether-substrate/src/chassis/error.rs
+++ b/crates/aether-substrate/src/chassis/error.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use crate::mail::MailboxId;
 use crate::mail::registry::NameConflict;
+use std::io;
 
 /// Failure modes capability boot can raise. Per ADR-0063, any boot
 /// error aborts the chassis before user code runs — no partial boots.
@@ -67,7 +68,7 @@ impl From<NameConflict> for BootError {
 /// errors directly without per-call `.map_err` glue.
 impl From<wasmtime::Error> for BootError {
     fn from(e: wasmtime::Error) -> Self {
-        Self::Other(Box::new(std::io::Error::other(format!("{e}"))))
+        Self::Other(Box::new(io::Error::other(format!("{e}"))))
     }
 }
 

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -34,6 +34,7 @@ use std::time::{Duration, Instant};
 use crate::mail::MailboxId;
 use crate::mail::outbound::HubOutbound;
 use crate::runtime::lifecycle;
+use std::thread;
 
 /// ADR-0063 fail-fast budget for the per-frame drain barrier. A
 /// dispatcher that doesn't quiesce within this window is treated as
@@ -77,7 +78,7 @@ pub fn drain_frame_bound_or_abort(pending: &[(MailboxId, Arc<AtomicU64>)], outbo
                     );
                     lifecycle::fatal_abort(outbound, reason);
                 }
-                std::thread::sleep(Duration::from_micros(50));
+                thread::sleep(Duration::from_micros(50));
             }
         }
     }

--- a/crates/aether-substrate/src/chassis/helpers.rs
+++ b/crates/aether-substrate/src/chassis/helpers.rs
@@ -7,6 +7,7 @@
 /// Postcard-decode a control-plane payload with the one error-message
 /// shape every handler uses. Handlers wrap the `String` in their own
 /// `*Result::Err` variant — the shape is uniform, the enum differs.
-pub fn decode_payload<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, String> {
+use serde::de::DeserializeOwned;
+pub fn decode_payload<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, String> {
     postcard::from_bytes(bytes).map_err(|e| format!("postcard decode failed: {e}"))
 }

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -48,7 +48,7 @@ use crossbeam_channel::{Receiver, Sender, bounded};
 
 /// Chassis-owned settlement notification registry. Owned by the
 /// chassis (one per substrate); cloned via `Arc` into the
-/// [`crate::mail::Mailer`]'s chassis-router closure so the
+/// [`Mailer`]'s chassis-router closure so the
 /// dispatcher's `Settled` switch can fire.
 #[derive(Default)]
 pub struct SettlementRegistry {
@@ -91,7 +91,7 @@ enum SettlementSubscriber {
 impl SettlementSubscriber {
     /// Fire this subscriber for the settled `root`. Channel sends are
     /// non-blocking (`try_send`, so a closed receiver doesn't panic);
-    /// mail sends go through the chassis [`crate::mail::mailer::Mailer`]
+    /// mail sends go through the chassis [`Mailer`]
     /// which resolves the recipient inline on the firing thread.
     fn fire(self, root: MailId) {
         match self {
@@ -155,7 +155,7 @@ impl SettlementRegistry {
     }
 
     /// Subscribe a mailbox to receive a notification mail when `root`
-    /// settles. The notification is a [`crate::mail::Mail`] with the
+    /// settles. The notification is a [`Mail`] with the
     /// given `kind`, the [`MailId`] of the settled root postcard-encoded
     /// as payload, and `count = 1`. Pre-fires immediately (synchronously
     /// pushes the mail) if `root` has already settled at least once.

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -41,6 +41,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use crate::mail::Mail;
+use crate::mail::mailer::Mailer;
 use aether_data::{KindId, MailId, MailboxId};
 use crossbeam_channel::{Receiver, Sender, bounded};
 
@@ -82,7 +84,7 @@ enum SettlementSubscriber {
     Mail {
         target: MailboxId,
         kind: KindId,
-        mailer: Arc<crate::mail::mailer::Mailer>,
+        mailer: Arc<Mailer>,
     },
 }
 
@@ -169,7 +171,7 @@ impl SettlementRegistry {
         root: MailId,
         target: MailboxId,
         kind: KindId,
-        mailer: Arc<crate::mail::mailer::Mailer>,
+        mailer: Arc<Mailer>,
     ) {
         let mut inner = self
             .inner
@@ -269,12 +271,7 @@ impl SettlementRegistry {
 /// the notification is dropped (logged at error) — `MailId` is a small
 /// `repr(C)` postcard-shaped struct, so encode failure here is a "this
 /// should never happen" path rather than a recoverable condition.
-fn push_settlement_notice(
-    mailer: &crate::mail::mailer::Mailer,
-    target: MailboxId,
-    kind: KindId,
-    root: MailId,
-) {
+fn push_settlement_notice(mailer: &Mailer, target: MailboxId, kind: KindId, root: MailId) {
     let payload = match postcard::to_allocvec(&root) {
         Ok(p) => p,
         Err(e) => {
@@ -286,7 +283,7 @@ fn push_settlement_notice(
             return;
         }
     };
-    mailer.push(crate::mail::Mail::new(target, kind, payload, 1));
+    mailer.push(Mail::new(target, kind, payload, 1));
 }
 
 #[cfg(test)]
@@ -302,6 +299,7 @@ mod tests {
     use super::*;
     use crate::handle_store::HandleStore;
     use crate::mail::mailer::Mailer;
+    use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
     use std::sync::Mutex as StdMutex;
 
@@ -339,7 +337,7 @@ mod tests {
             // directly and move payload into the captured row
             // (was: `payload.to_vec()` clone via the legacy
             // borrowed-dispatch shape).
-            Arc::new(move |dispatch: crate::mail::registry::OwnedDispatch| {
+            Arc::new(move |dispatch: OwnedDispatch| {
                 captured_clone.lock().unwrap().push(CapturedDispatch {
                     kind: dispatch.kind,
                     payload: dispatch.payload,

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -45,6 +45,7 @@ use std::sync::RwLock;
 use crate::mail::Mail;
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
+use std::env;
 
 /// Default byte cap for the handle store.
 pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
@@ -158,7 +159,7 @@ impl HandleStore {
     pub fn from_env() -> Self {
         // Nested match keeps the warn-log path readable.
         #[allow(clippy::option_if_let_else)]
-        let max_bytes = match std::env::var(ENV_MAX_BYTES) {
+        let max_bytes = match env::var(ENV_MAX_BYTES) {
             Ok(raw) => match raw.parse::<usize>() {
                 Ok(n) => n,
                 Err(e) => {
@@ -835,6 +836,7 @@ mod tests {
     use aether_data::{NamedField, SchemaCell};
 
     use super::*;
+    use aether_data::tagged_id;
 
     // ------------------------------------------------------------
     // HandleStore unit tests
@@ -907,12 +909,9 @@ mod tests {
         // ADR-0064: counter occupies the low 60 bits; the high 4
         // bits carry `Tag::Handle`. Strip the tag to assert on the
         // raw counter value.
-        assert_eq!(aether_data::tagged_id::body_of(a.0), 1);
-        assert_eq!(aether_data::tagged_id::body_of(b.0), 2);
-        assert_eq!(
-            aether_data::tagged_id::tag_of(a.0),
-            Some(aether_data::Tag::Handle)
-        );
+        assert_eq!(tagged_id::body_of(a.0), 1);
+        assert_eq!(tagged_id::body_of(b.0), 2);
+        assert_eq!(tagged_id::tag_of(a.0), Some(aether_data::Tag::Handle));
         assert_ne!(a, HandleId(0));
     }
 

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -49,6 +49,8 @@ pub mod mail;
 pub mod render;
 pub mod runtime;
 pub mod scheduler;
+#[cfg(test)]
+mod test_util;
 
 pub use actor::monitor::MonitorHandle;
 pub use actor::native::binding::NativeBinding;

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -124,7 +124,7 @@ impl Mailer {
     }
 
     /// Borrow the wired
-    /// [`SettlementRegistry`](crate::chassis::settlement::SettlementRegistry),
+    /// [`SettlementRegistry`],
     /// or `None` if no registry was installed (test fixtures, chassis
     /// that don't bring up the trace pipeline). Capabilities subscribe
     /// via

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -25,12 +25,15 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use crate::chassis::settlement::SettlementRegistry;
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
+use crate::runtime::trace;
 use aether_data::{HandleId, KindId};
 use std::sync::OnceLock;
+use std::thread;
 
 pub struct Mailer {
     /// Registry handle for resolving recipients on `push`. Owned for
@@ -83,7 +86,7 @@ pub struct Mailer {
     /// / chassis that don't bring up the trace pipeline; callers that
     /// expect to subscribe must check for the presence and surface a
     /// clear error otherwise.
-    settlement_registry: OnceLock<Arc<crate::chassis::settlement::SettlementRegistry>>,
+    settlement_registry: OnceLock<Arc<SettlementRegistry>>,
 }
 
 impl Mailer {
@@ -116,10 +119,7 @@ impl Mailer {
     /// so capability handlers can reach the registry via
     /// `ctx.mailer().settlement_registry()`. Single-claim; subsequent
     /// calls are no-ops.
-    pub fn install_settlement_registry(
-        &self,
-        registry: Arc<crate::chassis::settlement::SettlementRegistry>,
-    ) {
+    pub fn install_settlement_registry(&self, registry: Arc<SettlementRegistry>) {
         let _ = self.settlement_registry.set(registry);
     }
 
@@ -129,9 +129,7 @@ impl Mailer {
     /// that don't bring up the trace pipeline). Capabilities subscribe
     /// via
     /// [`crate::chassis::settlement::SettlementRegistry::subscribe_settlement_mail`].
-    pub fn settlement_registry(
-        &self,
-    ) -> Option<&Arc<crate::chassis::settlement::SettlementRegistry>> {
+    pub fn settlement_registry(&self) -> Option<&Arc<SettlementRegistry>> {
         self.settlement_registry.get()
     }
 
@@ -307,8 +305,8 @@ fn route_mail(
         // replies) get the symmetric `Received`/`Finished` bracket.
         let inbound_mail_id = mail.mail_id;
         if let Some(router) = chassis_router {
-            let thread_name = std::thread::current().name().map(str::to_owned);
-            crate::runtime::trace::record_received(inbound_mail_id, thread_name);
+            let thread_name = thread::current().name().map(str::to_owned);
+            trace::record_received(inbound_mail_id, thread_name);
             router(mail);
         } else {
             tracing::warn!(
@@ -317,7 +315,7 @@ fn route_mail(
                 "chassis-addressed mail dropped — no chassis router installed",
             );
         }
-        crate::runtime::trace::record_finished(inbound_mail_id);
+        trace::record_finished(inbound_mail_id);
         return;
     }
 
@@ -355,7 +353,7 @@ fn route_mail(
                 // drain (issue 838). Parked mail (the `Ok(WalkOutcome::Parked)`
                 // arm above) is deliberately NOT finished — it's held
                 // for replay when the handle resolves.
-                crate::runtime::trace::record_finished(mail.mail_id);
+                trace::record_finished(mail.mail_id);
                 return;
             }
         }
@@ -415,8 +413,8 @@ fn route_mail(
             // above — see that arm's doc for the
             // double-count-prematurely-settle hazard the split
             // avoids.
-            let thread_name = std::thread::current().name().map(str::to_owned);
-            crate::runtime::trace::record_received(inbound_mail_id, thread_name);
+            let thread_name = thread::current().name().map(str::to_owned);
+            trace::record_received(inbound_mail_id, thread_name);
             handler.dispatch(MailDispatch {
                 kind: mail.kind,
                 kind_name: &kind_name,
@@ -428,7 +426,7 @@ fn route_mail(
                 root: mail.root,
                 parent_mail: mail.parent_mail,
             });
-            crate::runtime::trace::record_finished(inbound_mail_id);
+            trace::record_finished(inbound_mail_id);
         }
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
@@ -438,7 +436,7 @@ fn route_mail(
             );
             // ADR-0080 §2: balance the `Sent` so settlement chains
             // drain (issue 838). No `Received` — no handler ran.
-            crate::runtime::trace::record_finished(inbound_mail_id);
+            trace::record_finished(inbound_mail_id);
         }
         None => {
             // ADR-0037 Phase 1: unknown-locally mailboxes bubble up
@@ -482,7 +480,7 @@ fn route_mail(
                 // bubbled-up mail on its own settlement domain; no
                 // wire signal exists today for federated cross-engine
                 // settlement (and the issue body parks that design).
-                crate::runtime::trace::record_finished(inbound_mail_id);
+                trace::record_finished(inbound_mail_id);
                 return;
             }
             tracing::warn!(
@@ -495,7 +493,7 @@ fn route_mail(
             // unloaded `"camera"` mailbox every tick; without this
             // every Tick chain has an orphaned `Sent` and never
             // settles.
-            crate::runtime::trace::record_finished(inbound_mail_id);
+            trace::record_finished(inbound_mail_id);
         }
     }
 }
@@ -517,6 +515,9 @@ mod tests {
     use crate::handle_store::HandleStore;
     use crate::mail::MailboxId;
     use crate::mail::outbound::EgressEvent;
+    use crate::mail::registry::InboxHandler;
+    use crate::mail::registry::InlineHandler;
+    use crate::runtime::trace;
     use aether_data::{Kind, Ref};
     use aether_data::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
 
@@ -647,7 +648,7 @@ mod tests {
         /// Inline-variant handler: synchronous capture body. Used by
         /// the `register_inline` test sites; mailer brackets the
         /// call so settlement balances.
-        fn inline_handler(&self) -> Arc<dyn crate::mail::registry::InlineHandler> {
+        fn inline_handler(&self) -> Arc<dyn InlineHandler> {
             let captured = Arc::clone(&self.captured);
             let count = Arc::clone(&self.delivery_count);
             Arc::new(move |dispatch: MailDispatch<'_>| {
@@ -663,7 +664,7 @@ mod tests {
         /// — these tests don't subscribe to settlement so the
         /// "downstream never finishes" path is intentional and
         /// harmless.
-        fn inbox_handler(&self) -> Arc<dyn crate::mail::registry::InboxHandler> {
+        fn inbox_handler(&self) -> Arc<dyn InboxHandler> {
             let captured = Arc::clone(&self.captured);
             let count = Arc::clone(&self.delivery_count);
             Arc::new(move |dispatch: OwnedDispatch| {
@@ -813,12 +814,12 @@ mod tests {
     /// these tests don't assume ownership, they filter their own
     /// events out of whatever's in flight.
     fn ensure_trace_queue() -> Arc<SegQueue<TraceEvent>> {
-        if let Some(q) = crate::runtime::trace::trace_queue() {
+        if let Some(q) = trace::trace_queue() {
             return Arc::clone(q);
         }
         let q = Arc::new(SegQueue::<TraceEvent>::new());
-        crate::runtime::trace::install_trace_queue(Arc::clone(&q));
-        crate::runtime::trace::trace_queue().cloned().unwrap_or(q)
+        trace::install_trace_queue(Arc::clone(&q));
+        trace::trace_queue().cloned().unwrap_or(q)
     }
 
     /// Drain the trace queue and return only events whose `mail_id`

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -64,7 +64,7 @@ pub struct Mailer {
     /// [`MailboxId::CHASSIS_MAILBOX_ID`], `route_mail` short-circuits
     /// the registry lookup and invokes this closure instead. Today
     /// the chassis installs a router that decodes `Settled { root }`
-    /// and signals the [`crate::chassis::settlement::SettlementRegistry`]
+    /// and signals the [`SettlementRegistry`]
     /// — keeping the Mailer ignorant of trace kinds while still
     /// providing the dispatch surface those kinds need.
     ///
@@ -128,7 +128,7 @@ impl Mailer {
     /// or `None` if no registry was installed (test fixtures, chassis
     /// that don't bring up the trace pipeline). Capabilities subscribe
     /// via
-    /// [`crate::chassis::settlement::SettlementRegistry::subscribe_settlement_mail`].
+    /// [`SettlementRegistry::subscribe_settlement_mail`].
     pub fn settlement_registry(&self) -> Option<&Arc<SettlementRegistry>> {
         self.settlement_registry.get()
     }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
+use std::error;
 
 /// Test-only helper that builds a [`MailDispatch`] with empty
 /// `origin` / `ReplyTo::NONE` / `MailId::NONE` defaults from the
@@ -387,7 +388,7 @@ impl fmt::Display for KindConflict {
     }
 }
 
-impl std::error::Error for KindConflict {}
+impl error::Error for KindConflict {}
 
 /// A runtime mailbox registration lost to name collision. Returned
 /// from `try_register_inbox` (ADR-0010) so a runtime caller can
@@ -405,7 +406,7 @@ impl fmt::Display for NameConflict {
     }
 }
 
-impl std::error::Error for NameConflict {}
+impl error::Error for NameConflict {}
 
 /// Reasons `Registry::drop_mailbox` can refuse. Distinct from the
 /// post-drop dispatch log, which the scheduler handles independently.
@@ -424,7 +425,7 @@ impl fmt::Display for DropError {
     }
 }
 
-impl std::error::Error for DropError {}
+impl error::Error for DropError {}
 
 impl Registry {
     #[must_use]
@@ -1048,6 +1049,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use super::*;
+    use std::sync::Mutex;
 
     #[test]
     fn register_and_lookup_closure_mailbox() {
@@ -1561,7 +1563,7 @@ mod tests {
     /// called out in iamacoffeepot/aether#848.
     #[test]
     fn inbox_handler_blanket_impl_moves_owned_payload() {
-        let collected = Arc::new(std::sync::Mutex::new(Vec::<Vec<u8>>::new()));
+        let collected = Arc::new(Mutex::new(Vec::<Vec<u8>>::new()));
         let collected_for_handler = Arc::clone(&collected);
         let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: OwnedDispatch| {
             // Payload moves straight into the captured Vec — no clone

--- a/crates/aether-substrate/src/render/capture.rs
+++ b/crates/aether-substrate/src/render/capture.rs
@@ -6,6 +6,7 @@
 
 use super::COPY_ROW_ALIGN;
 use super::targets::{Readback, Targets, align_up};
+use std::sync::mpsc;
 
 /// Dimensions + wire-format info captured at `copy_texture_to_buffer`
 /// time and consumed after the buffer is mapped. Owned by the caller
@@ -117,7 +118,7 @@ pub fn finish_capture(
         .ok_or_else(|| "readback buffer missing".to_owned())?;
 
     let slice = readback.buffer.slice(..);
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = mpsc::channel();
     slice.map_async(wgpu::MapMode::Read, move |res| {
         let _ = tx.send(res);
     });

--- a/crates/aether-substrate/src/render/pipeline.rs
+++ b/crates/aether-substrate/src/render/pipeline.rs
@@ -13,6 +13,7 @@ use super::{
     CAMERA_UNIFORM_BYTES, DEPTH_FORMAT, IDENTITY_VIEW_PROJ, MAIN_SHADER_WGSL, VERTEX_BUFFER_BYTES,
     VERTEX_STRIDE, vertex_buffer_layout,
 };
+use std::slice;
 
 /// Surfaceable failures from `record_main_pass`. Today there's only
 /// the buffer-overflow case (frame dropped); reified as a `Result`
@@ -112,7 +113,7 @@ pub fn build_main_pipeline(
             module: &shader,
             entry_point: Some("vs_main"),
             compilation_options: wgpu::PipelineCompilationOptions::default(),
-            buffers: std::slice::from_ref(&vertex_layout),
+            buffers: slice::from_ref(&vertex_layout),
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,

--- a/crates/aether-substrate/src/runtime/lifecycle.rs
+++ b/crates/aether-substrate/src/runtime/lifecycle.rs
@@ -28,6 +28,8 @@
 use std::sync::Arc;
 
 use crate::mail::outbound::HubOutbound;
+use aether_actor::log;
+use std::process;
 
 /// Process exit code on fatal abort. Distinct from `0` (clean exit)
 /// and `1` (which Rust uses for panics from `main`).
@@ -63,9 +65,9 @@ pub fn fatal_abort(_outbound: &HubOutbound, reason: String) -> ! {
     // ring retired, `aether-actor::log::drain_buffer` is the
     // closest equivalent — it hands buffered events to the cap
     // via the actor's transport.)
-    aether_actor::log::drain_buffer();
+    log::drain_buffer();
 
-    std::process::exit(FATAL_EXIT_CODE);
+    process::exit(FATAL_EXIT_CODE);
 }
 
 /// Indirection over [`fatal_abort`] for call sites that don't

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -27,6 +27,9 @@ use aether_actor::log::{LogBuffer, NativeLogShipper, drain_buffer, encode_event}
 use aether_data::{KindId, MailboxId};
 
 use crate::actor::native::binding::NativeBinding;
+use aether_actor::log;
+use core::mem;
+use std::io;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::{Context, SubscriberExt};
@@ -100,7 +103,7 @@ pub fn with_actor_dispatch<R>(dispatch: &dyn MailDispatch, f: impl FnOnce() -> R
     // by the `DispatchGuard` drop, so no `'static` reference escapes
     // past `with_actor_dispatch`'s return.
     let static_ref: &'static dyn MailDispatch =
-        unsafe { core::mem::transmute::<&dyn MailDispatch, &'static dyn MailDispatch>(dispatch) };
+        unsafe { mem::transmute::<&dyn MailDispatch, &'static dyn MailDispatch>(dispatch) };
     let _guard = ACTOR_DISPATCH.with(|slot| {
         let prev = slot.get();
         slot.set(Some(static_ref));
@@ -140,7 +143,7 @@ where
         // (e.g. the `capability mailbox sender dropped` warn fired
         // during shutdown) would otherwise loop the pipeline. Stderr
         // fmt still receives the event via the registered fmt::Layer.
-        if aether_actor::log::is_in_pipeline() {
+        if log::is_in_pipeline() {
             return;
         }
         let entry = encode_event(event);
@@ -170,8 +173,8 @@ pub fn init_subscriber() {
     let filter = EnvFilter::try_from_env(FILTER_ENV).unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::registry()
         .with(filter)
-        .with(tsfmt::layer().with_writer(std::io::stderr))
+        .with(tsfmt::layer().with_writer(io::stderr))
         .with(ActorAwareLayer)
         .try_init();
-    aether_actor::log::set_native_log_shipper(ship_via_stamped_dispatch as NativeLogShipper);
+    log::set_native_log_shipper(ship_via_stamped_dispatch as NativeLogShipper);
 }

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -6,7 +6,7 @@
 //! `fmt::Layer` for operator visibility but do not enter the mail
 //! system. Until those code paths run as actors, their events stay
 //! out of `engine_logs`. The chassis-pushed `ConfigureLogDrain` mail
-//! and per-actor [`aether_actor::log::LogDrainSlot`] handle every
+//! and per-actor [`log::LogDrainSlot`] handle every
 //! actor-bound case.
 //!
 //! Two entry points:

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -18,9 +18,12 @@
 // `RUST_BACKTRACE` if set — so existing toolchain conventions still
 // work.
 
+use std::any::Any;
 use std::backtrace::{Backtrace, BacktraceStatus};
+use std::env;
 use std::panic::{self, PanicHookInfo};
 use std::sync::OnceLock;
+use std::thread;
 
 /// Env var that forces backtrace capture without flipping
 /// `RUST_BACKTRACE` for the whole process (which would change every
@@ -58,7 +61,7 @@ fn make_hook(
 }
 
 fn emit_event(info: &PanicHookInfo<'_>) {
-    let thread = std::thread::current();
+    let thread = thread::current();
     let thread_name = thread.name().unwrap_or("<unnamed>");
     let location = info.location().map_or_else(
         || "<unknown>".to_string(),
@@ -99,7 +102,7 @@ fn emit_event(info: &PanicHookInfo<'_>) {
 // Chained if-let on disjoint downcasts reads cleaner than a deep
 // `map_or_else` ladder over two Options.
 #[allow(clippy::option_if_let_else)]
-fn payload_string(payload: &(dyn std::any::Any + Send)) -> String {
+fn payload_string(payload: &(dyn Any + Send)) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()
     } else if let Some(s) = payload.downcast_ref::<String>() {
@@ -110,7 +113,7 @@ fn payload_string(payload: &(dyn std::any::Any + Send)) -> String {
 }
 
 fn capture_backtrace() -> Option<Backtrace> {
-    capture_backtrace_with(std::env::var_os(ENV_BACKTRACE).is_some())
+    capture_backtrace_with(env::var_os(ENV_BACKTRACE).is_some())
 }
 
 /// Pure-fn factor of `capture_backtrace` so tests can exercise both
@@ -140,18 +143,25 @@ mod tests {
     use tracing::field::{Field, Visit};
 
     use super::*;
+    use std::any::Any;
+    use std::fmt;
+    use std::thread;
+    use tracing::span::Attributes;
+    use tracing::span::Id;
+    use tracing::span::Record;
+    use tracing::subscriber;
 
     /// `&'static str` payload (the common `panic!("literal")` case).
     #[test]
     fn payload_string_handles_static_str() {
-        let payload: Box<dyn std::any::Any + Send> = Box::new("static reason");
+        let payload: Box<dyn Any + Send> = Box::new("static reason");
         assert_eq!(payload_string(payload.as_ref()), "static reason");
     }
 
     /// `String` payload (the common `panic!("{}", x)` case).
     #[test]
     fn payload_string_handles_owned_string() {
-        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("owned reason"));
+        let payload: Box<dyn Any + Send> = Box::new(String::from("owned reason"));
         assert_eq!(payload_string(payload.as_ref()), "owned reason");
     }
 
@@ -159,7 +169,7 @@ mod tests {
     /// at least identifies the payload shape.
     #[test]
     fn payload_string_handles_unknown_type() {
-        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let payload: Box<dyn Any + Send> = Box::new(42i32);
         let out = payload_string(payload.as_ref());
         assert!(
             out.starts_with("<non-string panic payload"),
@@ -205,12 +215,12 @@ mod tests {
     /// assertion stable under parallel test execution.
     #[test]
     fn make_hook_chains_to_previous() {
-        let test_thread = std::thread::current().id();
+        let test_thread = thread::current().id();
         let counter = Arc::new(AtomicUsize::new(0));
         let counter_for_prev = Arc::clone(&counter);
         let prev: Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static> =
             Box::new(move |_info| {
-                if std::thread::current().id() == test_thread {
+                if thread::current().id() == test_thread {
                     counter_for_prev.fetch_add(1, Ordering::SeqCst);
                 }
             });
@@ -248,7 +258,7 @@ mod tests {
             events: Arc::clone(&captured),
         };
 
-        tracing::subscriber::with_default(subscriber, || {
+        subscriber::with_default(subscriber, || {
             let _ = panic::catch_unwind(|| {
                 panic!("e2e probe 8e3a");
             });
@@ -299,11 +309,11 @@ mod tests {
         fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
             true
         }
-        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-            tracing::span::Id::from_u64(1)
+        fn new_span(&self, _: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
         }
-        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
-        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn record(&self, _: &Id, _: &Record<'_>) {}
+        fn record_follows_from(&self, _: &Id, _: &Id) {}
         fn event(&self, event: &tracing::Event<'_>) {
             let mut buf = String::new();
             let mut visitor = StringVisit(&mut buf);
@@ -313,8 +323,8 @@ mod tests {
                 fields: buf,
             });
         }
-        fn enter(&self, _: &tracing::span::Id) {}
-        fn exit(&self, _: &tracing::span::Id) {}
+        fn enter(&self, _: &Id) {}
+        fn exit(&self, _: &Id) {}
     }
 
     struct StringVisit<'a>(&'a mut String);
@@ -323,7 +333,7 @@ mod tests {
         fn record_str(&mut self, field: &Field, value: &str) {
             let _ = write!(self.0, "{}={};", field.name(), value);
         }
-        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
             let _ = write!(self.0, "{}={:?};", field.name(), value);
         }
     }

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -42,6 +42,7 @@ use crossbeam_queue::SegQueue;
 
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
+use crate::mail::registry::MailboxEntry;
 
 /// Monotonic-since-boot reference. Set once at chassis boot via
 /// [`init_substrate_start`]; producer-side hooks subtract from it to
@@ -376,7 +377,7 @@ fn ship_batch(
     if !mailer
         .registry()
         .entry(recipient)
-        .is_some_and(|e| matches!(e, crate::mail::registry::MailboxEntry::Inbox(_)))
+        .is_some_and(|e| matches!(e, MailboxEntry::Inbox(_)))
     {
         // Observer not registered (or dropped); silently discard the
         // batch. Test isolation: a chassis without

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -35,6 +35,9 @@ use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
 
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
+use std::mem;
+use std::panic;
+use std::time::Duration;
 
 /// Configuration for [`Pool::start`]. Defaults via [`PoolConfig::default`]
 /// give `num_cpus`-derived sizing; chassis mains override per
@@ -79,7 +82,7 @@ impl BudgetTemplate {
             Self::Custom {
                 max_mails,
                 max_usec,
-            } => BatchBudget::custom(max_mails, std::time::Duration::from_micros(max_usec)),
+            } => BatchBudget::custom(max_mails, Duration::from_micros(max_usec)),
         }
     }
 }
@@ -138,7 +141,7 @@ impl PoolHandle {
         // (empty) workers Vec and returns an empty Vec.
         self.shutdown_tx.take();
         self.ready_tx.take();
-        std::mem::take(&mut self.workers)
+        mem::take(&mut self.workers)
             .into_iter()
             .map(|w| w.handle.join())
             .collect()
@@ -243,7 +246,7 @@ fn worker_loop(
             }
         };
         let budget = template.build();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| slot.run_cycle(budget)));
+        let result = panic::catch_unwind(AssertUnwindSafe(|| slot.run_cycle(budget)));
         match result {
             Ok(CycleResult::Idle | CycleResult::Closed) => {
                 // Slot done for now; drop the popped Arc. The chassis
@@ -297,10 +300,12 @@ fn format_panic_payload(payload: &Box<dyn Any + Send>, actor_label: &str) -> Str
 mod tests {
     use super::*;
     use crate::runtime::lifecycle::PanicAborter;
+    use crate::scheduler::slot::BATCH_MAX_USEC;
     use crate::scheduler::slot::tests::CounterSlot;
     use crate::scheduler::{SlotStateLabel, WakeHandle};
     use std::sync::Weak;
     use std::time::Duration;
+    use std::time::Instant;
 
     fn standard_handle(workers: usize) -> PoolHandle {
         Pool::start(
@@ -313,7 +318,7 @@ mod tests {
     }
 
     fn wait_until<F: Fn() -> bool>(timeout: Duration, f: F) -> bool {
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         while start.elapsed() < timeout {
             if f() {
                 return true;
@@ -522,5 +527,5 @@ mod tests {
     // Reuse the standard wallclock budget for fairness tests — 200µs
     // is enough for the test harness to dispatch a handful of
     // counters before yielding.
-    const BATCH_MAX_USEC_TEST: u64 = crate::scheduler::slot::BATCH_MAX_USEC;
+    const BATCH_MAX_USEC_TEST: u64 = BATCH_MAX_USEC;
 }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -355,13 +355,16 @@ pub mod tests {
     use std::time::Duration;
 
     use crossbeam_channel::unbounded;
+    use std::collections::VecDeque;
+    use std::hint;
+    use std::thread;
 
     /// Test fixture: a slot with a `Vec<u32>` inbox and a counter
     /// incremented per dispatch. Exercises the [`Drainable`] surface
     /// without dragging in the real chassis machinery.
     pub struct CounterSlot {
         pub state: Arc<SlotState>,
-        pub inbox: Mutex<std::collections::VecDeque<u32>>,
+        pub inbox: Mutex<VecDeque<u32>>,
         pub closed: AtomicBool,
         pub dispatched: AtomicU32,
         /// If `Some(n)`, the n-th dispatch (1-indexed) panics. Used by
@@ -376,7 +379,7 @@ pub mod tests {
         pub fn new(label: &'static str) -> Arc<Self> {
             Arc::new(Self {
                 state: Arc::new(SlotState::new()),
-                inbox: Mutex::new(std::collections::VecDeque::new()),
+                inbox: Mutex::new(VecDeque::new()),
                 closed: AtomicBool::new(false),
                 dispatched: AtomicU32::new(0),
                 panic_at: None,
@@ -418,9 +421,9 @@ pub mod tests {
                 self.panic_at,
                 "CounterSlot panic at envelope #{n} (test-induced)"
             );
-            std::hint::black_box(env);
+            hint::black_box(env);
             if !self.work_per_env.is_zero() {
-                std::thread::sleep(self.work_per_env);
+                thread::sleep(self.work_per_env);
             }
         }
     }

--- a/crates/aether-substrate/src/test_util.rs
+++ b/crates/aether-substrate/src/test_util.rs
@@ -1,0 +1,29 @@
+//! Substrate-internal test helpers.
+//!
+//! The cross-crate canonical `(Arc<Registry>, Arc<Mailer>)` fixture lives
+//! at `aether_capabilities::test_chassis::fresh_substrate`. Substrate
+//! itself can't depend on `aether-capabilities` (wrong direction of the
+//! dep graph), so the same minimal seed lives here for substrate's own
+//! `#[cfg(test)] mod tests` modules. Intentionally narrower than the
+//! capabilities version: no kind descriptors registered, no outbound
+//! wired — substrate-internal tests don't exercise descriptor lookup or
+//! the unknown-mailbox bubble-up path (ADR-0037).
+//!
+//! Folded out of three identical `fn fresh_substrate()` copies under
+//! `actor/native/binding.rs`, `actor/native/spawn_thread.rs`, and
+//! `chassis/builder.rs` (Qodana `DuplicatedCode` notice).
+
+use std::sync::Arc;
+
+use crate::handle_store::HandleStore;
+use crate::mail::mailer::Mailer;
+use crate::mail::registry::Registry;
+
+/// Build the `(Arc<Registry>, Arc<Mailer>)` seed substrate-internal
+/// tests feed to `Builder::<...>::new` and `NativeBinding::new_for_test`.
+pub fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+    let registry = Arc::new(Registry::new());
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+    (registry, mailer)
+}

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -24,10 +24,14 @@ use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};
 
 use aether_data::{Kind, ReplyTo};
+use aether_substrate::handle_store::HandleStore;
+use aether_substrate::mail::MailId;
+use aether_substrate::mail::registry::OwnedDispatch;
 use aether_substrate::{
     Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, NativeActor, NativeCtx,
     NativeInitCtx, NeverDriver, PassiveChassis, Registry, mail::MailboxId,
 };
+use std::thread;
 
 /// Postcard-shape kind via the derive — exercises the
 /// `decode_from_bytes` postcard path the macro's dispatch arm uses.
@@ -120,9 +124,7 @@ impl Chassis for TestChassis {
 fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
     {
         let registry = Arc::new(Registry::new());
-        let store = Arc::new(aether_substrate::handle_store::HandleStore::new(
-            1024 * 1024,
-        ));
+        let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
         (registry, mailer)
     }
@@ -135,15 +137,15 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
         panic!("expected mailbox entry under {recipient}");
     };
     let bytes = payload.encode_into_bytes();
-    handler.enqueue(aether_substrate::mail::registry::OwnedDispatch {
+    handler.enqueue(OwnedDispatch {
         kind: <K as Kind>::ID,
         kind_name: K::NAME.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
         payload: bytes,
         count: 1,
-        mail_id: aether_substrate::mail::MailId::NONE,
-        root: aether_substrate::mail::MailId::NONE,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
         parent_mail: None,
     });
 }
@@ -151,7 +153,7 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
 fn wait_for(target: u32, counter: &AtomicU32, budget: Duration) -> bool {
     let deadline = Instant::now() + budget;
     while counter.load(AtomicOrdering::SeqCst) < target && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(5));
+        thread::sleep(Duration::from_millis(5));
     }
     counter.load(AtomicOrdering::SeqCst) >= target
 }
@@ -262,7 +264,7 @@ fn macro_emitted_cap_drops_unknown_kind_via_dispatch() {
     // Settle: give the dispatcher time to observe + drop the envelope.
     // The macro-emitted dispatch returns None; the chassis-side
     // dispatcher logs a warn but doesn't increment any handler counter.
-    std::thread::sleep(Duration::from_millis(50));
+    thread::sleep(Duration::from_millis(50));
     assert_eq!(greet_total.load(AtomicOrdering::SeqCst), 0);
     assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
 

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -31,6 +31,8 @@ use aether_substrate_bundle::test_bench::{
 // PR 432 / PR 434 used for the trunk-rlib pattern.
 #[allow(unused_imports)]
 use aether_demo_sokoban as _;
+use std::fs;
+use std::path::Path;
 
 /// User-facing component name passed to `LoadComponent`.
 const COMPONENT_NAME: &str = "world";
@@ -54,8 +56,8 @@ fn component_address() -> String {
 /// Load this crate's pre-built wasm into the bench and await
 /// `LoadResult`. Panics on load failure so the calling test surfaces
 /// the error message rather than wedging on a missing subscription.
-fn load_sokoban(bench: &mut TestBench, wasm_path: &std::path::Path) {
-    let wasm = std::fs::read(wasm_path).expect("read sokoban wasm");
+fn load_sokoban(bench: &mut TestBench, wasm_path: &Path) {
+    let wasm = fs::read(wasm_path).expect("read sokoban wasm");
     let result: LoadResult = bench
         .send_and_await_reply(
             "aether.component",


### PR DESCRIPTION
## Summary

- Add `absolute_paths = "warn"` to `[workspace.lints.clippy]` in root `Cargo.toml`. Lint stays at `warn`, not `deny` — promotion is the follow-up phase per issue 951's phased pattern (mirrors iamacoffeepot/aether#854).
- Sweep ~792 inline `crate::a::b::c::Thing` sites across 109 files into `use` declarations at the appropriate scope (file or nested-mod). Heuristic: leaves like `Result` / `Error` / `Formatter` / `Builder` (and other prelude-conflict-prone names) drop to 2-segment form (e.g. `fmt::Result`) instead of importing bare; everything else uses the 1-segment form (`Duration`, `Instant`).
- Two `pub const` re-exports in `aether-math/src/lib.rs` (`PI` / `TAU`) keep their inline `core::f32::consts::*` paths under `#[expect(clippy::absolute_paths)]` — importing the constant would shadow the re-export and create a name cycle.
- Drop two `[`X`](crate::a::b::X)` doc-link targets that became redundant after the sweep imported `Drainable` and `SettlementRegistry` (rustdoc resolves `[`X`]` via the new import map).
- Default `absolute-paths-max-segments = 2` is sufficient — no `clippy.toml` override needed.

`cargo clippy --workspace --all-targets -- -D warnings` is green at warn level. `-D warnings` from iamacoffeepot/aether#854 keeps the lint enforced workspace-wide today; the explicit promotion to `"deny"` is a separate follow-up diff once the warn count holds at zero across a few merges.

Closes iamacoffeepot/aether#951

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo nextest run --workspace` — 1011/1011 pass
- [x] `cargo doc --workspace --no-deps` clean (after dropping the two now-redundant explicit link targets)
- [x] `cargo check -p aether-camera --target wasm32-unknown-unknown` builds (pre-existing unused-import warnings in `aether-capabilities` are unchanged from main)
- [x] `cargo check -p aether-mesh-viewer --target wasm32-unknown-unknown` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)