### PR TITLE
fix(substrate/trace): retire process-global queue, per-chassis TraceHandle

### DIFF
--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -29,11 +29,16 @@ mod native {
         DispatchTraced, DispatchTracedAck, ListActiveRoots, ListActiveRootsResult, MailNodeWire,
         RootSummaryWire, TraceWindow,
     };
+    use std::cmp::Reverse;
+    #[cfg(test)]
+    use std::collections::HashSet;
     use std::collections::{BTreeSet, HashMap};
+    use std::env;
     use std::ops::Bound;
-    use std::time::{Duration, Instant};
-
     use std::sync::Arc;
+    #[cfg(test)]
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     use aether_actor::{MailCtx, actor};
     use aether_data::{KindId, MailId, MailboxId};
@@ -44,9 +49,6 @@ mod native {
     use aether_substrate::mail::helpers::resolve_bundle;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::registry::Registry;
-    use aether_substrate::runtime::trace;
-    use std::cmp::Reverse;
-    use std::env;
 
     /// ADR-0080 §11 retention defaults. Override via env vars.
     /// `AETHER_TRACE_RETENTION_MS` — drop roots older than this many
@@ -545,7 +547,7 @@ mod native {
         /// Issue 718 / ADR-0080 Phase 2.
         #[handler]
         fn on_list_active_roots(&mut self, ctx: &mut NativeCtx<'_>, request: ListActiveRoots) {
-            let now = trace::now_nanos();
+            let now = ctx.mailer().now_nanos();
             let result = self.build_list_active_roots(request, now);
             ctx.reply(&result);
         }
@@ -562,7 +564,7 @@ mod native {
         /// root via `describe_tree` for full chain context. Issue 735.
         #[handler]
         fn on_describe_window(&mut self, ctx: &mut NativeCtx<'_>, request: DescribeWindow) {
-            let now = trace::now_nanos();
+            let now = ctx.mailer().now_nanos();
             let result = self.build_describe_window(request, now);
             ctx.reply(&result);
         }
@@ -612,11 +614,8 @@ mod native {
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::{MailDispatch, Registry};
         use aether_substrate::mail::{ReplyTarget, ReplyTo};
-        use std::collections::HashSet;
-        use std::env;
         use std::sync::Mutex;
         use std::sync::mpsc::Receiver;
-        use std::thread;
 
         /// Construct an observer for state-fold tests. Stash a fresh
         /// `Mailer` so `fire_settled` has somewhere to push (the

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -12,25 +12,22 @@
 // (the `TestBench::start()` API ADR-0067 introduced); both paths
 // share `TestBenchChassis::build_passive`.
 
+use std::env;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use aether_actor::Actor;
 use aether_capabilities::InputCapability;
 use aether_capabilities::fs::NamespaceRoots;
 use aether_data::{encode_empty, mailbox_id_from_name};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
-use aether_substrate::runtime::trace;
 use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId};
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
     render::Gpu,
 };
-use std::env;
-use std::sync::atomic::AtomicU64;
-
-use aether_substrate_bundle::chassis_root::next_chassis_correlation;
-use std::time::Duration;
 
 /// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
 /// missing/unparseable input with a warn log so scenario scripts can
@@ -188,11 +185,17 @@ fn run_frame(
     gpu: &mut Gpu,
     chassis_correlation: &AtomicU64,
 ) {
-    let next_correlation = || -> u64 { next_chassis_correlation(chassis_correlation) };
+    let next_correlation = || -> u64 {
+        let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
+        if id == 0 {
+            chassis_correlation.fetch_add(1, Ordering::Relaxed)
+        } else {
+            id
+        }
+    };
 
     if dispatch_tick {
-        trace::push_chassis_root_mail(
-            queue,
+        queue.push_chassis_root_mail(
             next_correlation(),
             input_mailbox,
             kind_tick,

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -14,7 +14,7 @@
 
 use std::env;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use aether_actor::Actor;
@@ -23,6 +23,7 @@ use aether_capabilities::fs::NamespaceRoots;
 use aether_data::{encode_empty, mailbox_id_from_name};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
 use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId};
+use aether_substrate_bundle::chassis_root::next_chassis_correlation;
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
@@ -185,18 +186,9 @@ fn run_frame(
     gpu: &mut Gpu,
     chassis_correlation: &AtomicU64,
 ) {
-    let next_correlation = || -> u64 {
-        let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
-        if id == 0 {
-            chassis_correlation.fetch_add(1, Ordering::Relaxed)
-        } else {
-            id
-        }
-    };
-
     if dispatch_tick {
         queue.push_chassis_root_mail(
-            next_correlation(),
+            next_chassis_correlation(chassis_correlation),
             input_mailbox,
             kind_tick,
             encode_empty::<Tick>(),

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -33,10 +33,7 @@ use aether_kinds::{
 use aether_substrate::actor::native::envelope::Envelope;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{
-    HubOutbound, Mailer, SubstrateBoot, chassis::frame_loop, mail::MailboxId,
-    runtime::trace::push_chassis_root_mail,
-};
+use aether_substrate::{HubOutbound, Mailer, SubstrateBoot, chassis::frame_loop, mail::MailboxId};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -302,7 +299,8 @@ impl App {
         if correlation == 0 {
             correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
         }
-        push_chassis_root_mail(&self.queue, correlation, recipient, kind, payload, count);
+        self.queue
+            .push_chassis_root_mail(correlation, recipient, kind, payload, count);
     }
 
     fn apply_window_mode(

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -14,10 +14,9 @@
 //! winit, but the `chassis_builder`'s single-threaded
 //! Builder→BuiltChassis→run path applies all the same).
 
+use std::env;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-
-use crate::chassis_root::next_chassis_correlation;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -27,10 +26,7 @@ use aether_data::{KindId, encode_empty, mailbox_id_from_name};
 use aether_kinds::Tick;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{
-    Mailer, SubstrateBoot, mail::MailboxId, runtime::trace::push_chassis_root_mail,
-};
-use std::env;
+use aether_substrate::{Mailer, SubstrateBoot, mail::MailboxId};
 
 pub const DEFAULT_TICK_HZ: u32 = 60;
 
@@ -117,7 +113,14 @@ impl DriverRunning for HeadlessTimerRunning {
         // per-actor counter on `NativeBinding`. Skipping 0 keeps the
         // sentinel slot reserved.
         let chassis_correlation = AtomicU64::new(1);
-        let next_correlation = || -> u64 { next_chassis_correlation(&chassis_correlation) };
+        let next_correlation = || -> u64 {
+            let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
+            if id == 0 {
+                chassis_correlation.fetch_add(1, Ordering::Relaxed)
+            } else {
+                id
+            }
+        };
 
         let mut next_deadline = Instant::now() + tick_period;
         loop {
@@ -132,8 +135,7 @@ impl DriverRunning for HeadlessTimerRunning {
             // backlog, which would just compound the stall.
             next_deadline = Instant::now() + tick_period;
 
-            push_chassis_root_mail(
-                &queue,
+            queue.push_chassis_root_mail(
                 next_correlation(),
                 input_mailbox,
                 kind_tick,

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -16,7 +16,7 @@
 
 use std::env;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -27,6 +27,8 @@ use aether_kinds::Tick;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Mailer, SubstrateBoot, mail::MailboxId};
+
+use crate::chassis_root::next_chassis_correlation;
 
 pub const DEFAULT_TICK_HZ: u32 = 60;
 
@@ -113,14 +115,6 @@ impl DriverRunning for HeadlessTimerRunning {
         // per-actor counter on `NativeBinding`. Skipping 0 keeps the
         // sentinel slot reserved.
         let chassis_correlation = AtomicU64::new(1);
-        let next_correlation = || -> u64 {
-            let id = chassis_correlation.fetch_add(1, Ordering::Relaxed);
-            if id == 0 {
-                chassis_correlation.fetch_add(1, Ordering::Relaxed)
-            } else {
-                id
-            }
-        };
 
         let mut next_deadline = Instant::now() + tick_period;
         loop {
@@ -136,7 +130,7 @@ impl DriverRunning for HeadlessTimerRunning {
             next_deadline = Instant::now() + tick_period;
 
             queue.push_chassis_root_mail(
-                next_correlation(),
+                next_chassis_correlation(&chassis_correlation),
                 input_mailbox,
                 kind_tick,
                 encode_empty::<Tick>(),

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -42,7 +42,6 @@ use aether_substrate::{
     capture::CaptureQueue,
     chassis::frame_loop,
     mail::{Mail, MailboxId},
-    runtime::trace::push_chassis_root_mail,
 };
 
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
@@ -386,7 +385,7 @@ impl TestBench {
     /// doesn't need to look anything up.
     ///
     /// Issue 834: this is synchronous-on-settle. The mail is minted
-    /// as a chassis-root via [`push_chassis_root_mail`] so the trace
+    /// as a chassis-root via [`Mailer::push_chassis_root_mail`] so the trace
     /// pipeline tracks the chain; the bench then subscribes to
     /// `Settled { root }` and waits up to `SETTLEMENT_TIMEOUT` for
     /// the chain (the recipient's handler + every descendant mail
@@ -443,7 +442,9 @@ impl TestBench {
     ) -> Result<(), TestBenchError> {
         let cid = self.fresh_correlation_id();
         let registry = self.passive.settlement_registry();
-        let root = push_chassis_root_mail(&self.queue, cid, mailbox, kind, payload, 1);
+        let root = self
+            .queue
+            .push_chassis_root_mail(cid, mailbox, kind, payload, 1);
         let rx = registry.subscribe_settlement(root);
         match rx.recv_timeout(SETTLEMENT_TIMEOUT) {
             Ok(()) => Ok(()),
@@ -773,8 +774,7 @@ impl TestBench {
             // test name the actual cause instead of timing out
             // generically on the reply pump.
             let registry = self.passive.settlement_registry();
-            let tick_root = push_chassis_root_mail(
-                &self.queue,
+            let tick_root = self.queue.push_chassis_root_mail(
                 self.fresh_correlation_id(),
                 self.input_mailbox,
                 self.kind_tick,

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -49,7 +49,6 @@ use crate::chassis::ctx::ChassisCtx;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTarget, ReplyTo};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
-use crate::runtime::trace;
 
 /// Per-actor binding state every native capability owns. Each
 /// capability constructs one at boot via [`NativeBinding::new`] and
@@ -260,6 +259,15 @@ impl NativeBinding {
         self.self_mailbox
     }
 
+    /// Borrow the wired `Mailer`. Surfaced so cross-file producer
+    /// hooks (`dispatch`, `dispatcher_slot`, `spawn_thread`) can
+    /// reach the trace handle via `binding.mailer().record_*(...)`
+    /// without the field having to be `pub(crate)`. Filed under
+    /// iamacoffeepot/aether#953 (per-chassis trace state).
+    pub fn mailer(&self) -> &Arc<Mailer> {
+        &self.mailer
+    }
+
     /// The chassis's [`crate::Spawner`], if one was wired in at
     /// construction. `Some` for production transports built through
     /// [`Self::from_ctx`] (the chassis builds + threads its `Spawner`
@@ -464,10 +472,10 @@ impl NativeBinding {
         let mail_id = MailId::new(self.self_mailbox, correlation);
         let root = inherited_root.unwrap_or(mail_id);
         // ADR-0080 §2 producer hook: emit `Sent` before pushing the
-        // mail. No-op when the global trace queue isn't installed
-        // (test fixtures bypassing the chassis); the drainer is the
-        // only consumer.
-        trace::record_sent(
+        // mail. Every `Mailer` carries a trace handle by default
+        // (per-chassis post iamacoffeepot/aether#953), so producer
+        // calls are unconditional; the drainer is the optional piece.
+        self.mailer.record_sent(
             mail_id,
             root,
             parent_mail,
@@ -683,8 +691,7 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
 )]
 mod tests {
     use super::*;
-    use crate::mail::registry::InboxHandler;
-    use crate::mail::registry::OwnedDispatch;
+    use crate::mail::registry::{InboxHandler, OwnedDispatch};
     use crate::test_util::fresh_substrate;
     use std::sync::mpsc;
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -90,6 +90,17 @@ impl<'a> NativeCtx<'a> {
         }
     }
 
+    /// Borrow the wired `Mailer`. Issue 953: surfaced so cap handlers
+    /// (`TraceObserverCapability` is the motivating consumer) can
+    /// reach the per-chassis trace handle for `now_nanos` without
+    /// going through `binding()`. Mirrors the `NativeInitCtx::mailer`
+    /// accessor but returns a borrow rather than a clone — handler
+    /// paths usually just need a `&Mailer` for one call.
+    #[must_use]
+    pub fn mailer(&self) -> &Arc<Mailer> {
+        self.binding.mailer()
+    }
+
     /// ADR-0080 §12 spawn primitive: launch a worker thread that
     /// inherits this handler's in-flight `(mail_id, root)` so its
     /// sends fold into the current causal chain. The closure `f`

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -45,7 +45,6 @@ use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
 use crate::runtime::log_install;
 use crate::runtime::log_install::MailDispatch;
-use crate::runtime::trace;
 use aether_actor::local;
 use aether_actor::log;
 use std::thread;
@@ -114,7 +113,9 @@ pub fn dispatch_loop_run<A>(
         // `aether-worker-N` shared across actors; `Thread`-scheduled
         // actors get per-actor names.
         let thread_name = thread::current().name().map(str::to_owned);
-        trace::record_received(inbound_mail_id, thread_name);
+        binding
+            .mailer()
+            .record_received(inbound_mail_id, thread_name);
         local::with_stamped(slots, || {
             log_install::with_actor_dispatch(&**binding as &dyn MailDispatch, || {
                 let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
@@ -128,7 +129,7 @@ pub fn dispatch_loop_run<A>(
         // the substrate down anyway, so a missing `Finished` is
         // moot. A future PR may add `catch_unwind` here for graceful
         // settlement-on-panic.
-        trace::record_finished(inbound_mail_id);
+        binding.mailer().record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -142,7 +143,9 @@ pub fn dispatch_loop_run<A>(
     while let Some(env) = binding.try_recv() {
         let inbound_mail_id = env.mail_id;
         let thread_name = thread::current().name().map(str::to_owned);
-        trace::record_received(inbound_mail_id, thread_name);
+        binding
+            .mailer()
+            .record_received(inbound_mail_id, thread_name);
         local::with_stamped(slots, || {
             log_install::with_actor_dispatch(&**binding as &dyn MailDispatch, || {
                 let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
@@ -150,7 +153,7 @@ pub fn dispatch_loop_run<A>(
                 log::drain_buffer();
             });
         });
-        trace::record_finished(inbound_mail_id);
+        binding.mailer().record_finished(inbound_mail_id);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -45,7 +45,6 @@ use std::time::Instant;
 use crate::actor::native::Envelope;
 use crate::runtime::log_install;
 use crate::runtime::log_install::MailDispatch;
-use crate::runtime::trace;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use aether_actor::log;
@@ -213,7 +212,9 @@ where
         // `aether-worker-N` name (shared across actors); `Thread`-
         // scheduled actors land on a per-actor name.
         let thread_name = thread::current().name().map(str::to_owned);
-        trace::record_received(inbound_mail_id, thread_name);
+        self.binding
+            .mailer()
+            .record_received(inbound_mail_id, thread_name);
         local::with_stamped(&self.slots, || {
             log_install::with_actor_dispatch(&*self.binding as &dyn MailDispatch, || {
                 let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
@@ -221,7 +222,7 @@ where
                 log::drain_buffer();
             });
         });
-        trace::record_finished(inbound_mail_id);
+        self.binding.mailer().record_finished(inbound_mail_id);
         if let Some(p) = &self.pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -25,7 +25,8 @@
 //!
 //! ADR-0080 §12 says "the spawning handler's tree does not settle
 //! until every spawned-thread send completes." Enforced here via the
-//! [`SettlementHold`] RAII guard from [`acquire_settlement_hold`]:
+//! [`SettlementHold`] RAII guard from
+//! [`crate::Mailer::acquire_settlement_hold`]:
 //! `spawn_inherit` acquires a hold against the parent's
 //! `in_flight_root` BEFORE the worker thread is spawned (so the
 //! `HoldOpen` trace event lands ahead of the parent handler's
@@ -44,7 +45,7 @@ use aether_actor::{MailSender, Sender, Singleton};
 use aether_data::{Kind, MailId, mailbox_id_from_name};
 
 use super::binding::NativeBinding;
-use crate::runtime::trace::{SettlementHold, acquire_settlement_hold};
+use crate::runtime::trace::SettlementHold;
 
 /// ADR-0080 §12 spawn-context that captures the spawning handler's
 /// in-flight `(mail_id, root)`. Outbound sends from the worker
@@ -333,7 +334,7 @@ where
     let hold = if in_flight_root == MailId::NONE {
         None
     } else {
-        Some(acquire_settlement_hold(in_flight_root))
+        Some(binding.mailer().acquire_settlement_hold(in_flight_root))
     };
     thread::Builder::new()
         .name(format!("aether-inherit-{}", A::NAMESPACE))
@@ -378,11 +379,9 @@ mod tests {
     use aether_actor::Singleton;
     use aether_data::{KindId, MailboxId};
 
-    use crate::mail::Mail;
-    use crate::mail::registry::OwnedDispatch;
-    use crate::mail::registry::Registry;
-    use crate::runtime::trace;
-    use crate::test_util::fresh_substrate;
+    use crate::handle_store::HandleStore;
+    use crate::mail::registry::{OwnedDispatch, Registry};
+    use crate::mail::{Mail, Mailer};
 
     /// Stub actor used as the `A` phantom marker on [`InheritCtx`] /
     /// [`RootCtx`]. Must impl `Singleton` because the spawn helpers
@@ -402,6 +401,13 @@ mod tests {
         root: MailId,
         parent_mail: Option<MailId>,
         sender: aether_data::ReplyTo,
+    }
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        (registry, mailer)
     }
 
     fn register_capture(registry: &Registry, name: &str) -> Arc<Mutex<Vec<CapturedDispatch>>> {
@@ -615,27 +621,17 @@ mod tests {
 
     /// ADR-0080 §12 / iamacoffeepot/aether#716: `spawn_inherit`
     /// acquires a `SettlementHold` on the parent root before spawning
-    /// and drops it on thread exit. Both events ride the global trace
-    /// queue (installed by `install_trace_queue`).
-    ///
-    /// Test filters the queue by the unique sender mailbox id we
-    /// allocate locally so the assertion is robust against other
-    /// parallel tests sharing the queue (the same drain-and-restore
-    /// pattern `mailer::drain_events_for` uses).
+    /// and drops it on thread exit. Both events ride the per-mailer
+    /// trace queue (iamacoffeepot/aether#953 retired the
+    /// process-global queue).
     #[test]
     fn spawn_inherit_acquires_and_releases_settlement_hold() {
         use aether_kinds::trace::TraceEvent;
-        use crossbeam_queue::SegQueue;
-
-        trace::init_substrate_start();
-        let queue = Arc::new(SegQueue::<TraceEvent>::new());
-        trace::install_trace_queue(Arc::clone(&queue));
-        // After install_trace_queue, the global may already point at a
-        // queue from a prior test. Read the live one and drain from
-        // there so we observe the same queue spawn_inherit pushes to.
-        let live = trace::trace_queue().expect("trace queue installed").clone();
 
         let (_registry, mailer) = fresh_substrate();
+        // Per-mailer queue (post #953): tests are isolated naturally
+        // — no shared global, no sender-prefix filter needed.
+        let live = Arc::clone(mailer.trace_handle().queue());
         let producer_mailbox = MailboxId(0xC0FE_C0FE_C0FE_C0FE);
         let binding = Arc::new(NativeBinding::new_for_test(
             Arc::clone(&mailer),
@@ -697,16 +693,9 @@ mod tests {
     #[test]
     fn spawn_inherit_with_none_root_skips_hold() {
         use aether_kinds::trace::TraceEvent;
-        use crossbeam_queue::SegQueue;
-
-        trace::init_substrate_start();
-        let queue = Arc::new(SegQueue::<TraceEvent>::new());
-        trace::install_trace_queue(Arc::clone(&queue));
-        let live = trace::trace_queue().expect("trace queue installed").clone();
 
         let (_registry, mailer) = fresh_substrate();
-        // Different unique sender so this test's filter doesn't catch
-        // the other hold-lifecycle test's events.
+        let live = Arc::clone(mailer.trace_handle().queue());
         let producer_mailbox = MailboxId(0xC0FE_DEAD_C0FE_DEAD);
         let binding = Arc::new(NativeBinding::new_for_test(
             Arc::clone(&mailer),

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -21,7 +21,6 @@ use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{MailboxEntry, Registry};
 use crate::mail::{Mail, MailId, MailKind, MailboxId, ReplyTarget, ReplyTo};
-use crate::runtime::trace;
 use std::thread;
 
 const MAIL_OFFSET: u32 = 1024;
@@ -217,7 +216,8 @@ impl ComponentCtx {
             id => Some(id),
         };
         let root = inherited_root.unwrap_or(mail_id);
-        trace::record_sent(mail_id, root, parent_mail, self.sender, recipient, kind);
+        self.queue
+            .record_sent(mail_id, root, parent_mail, self.sender, recipient, kind);
 
         // Closure-bound (actor-enqueue) and Sink-bound (synchronous
         // handler) recipients dispatch inline here, bypassing the
@@ -260,7 +260,7 @@ impl ComponentCtx {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 let origin = self.registry.mailbox_name(self.sender);
                 let thread_name = thread::current().name().map(str::to_owned);
-                trace::record_received(mail_id, thread_name);
+                self.queue.record_received(mail_id, thread_name);
                 handler.dispatch(crate::mail::registry::MailDispatch {
                     kind,
                     kind_name: &kind_name,
@@ -272,7 +272,7 @@ impl ComponentCtx {
                     root,
                     parent_mail,
                 });
-                trace::record_finished(mail_id);
+                self.queue.record_finished(mail_id);
                 return;
             }
             Some(MailboxEntry::Dropped) | None => {

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -54,7 +54,6 @@ use aether_actor::local::ActorSlots;
 use aether_actor::log;
 use aether_data::mailbox_id_from_name;
 use aether_kinds::trace::Settled;
-use aether_kinds::trace::TraceEvent;
 use aether_kinds::{ConfigureLogDrain, LogBatch};
 use std::any::Any;
 use std::any::TypeId;
@@ -1248,17 +1247,17 @@ fn boot_passives(
     });
     let pool = Pool::start(pool_config, Arc::clone(aborter));
 
-    // ADR-0080 §3 trace pipeline. `init_substrate_start` pins the
-    // monotonic-since-boot reference; `install_trace_queue` makes the
-    // global queue visible to producer-side hooks; `start_drainer`
-    // owns the thread that batches events into mail addressed to the
-    // `aether.trace` sink. The handle in `BootedPassives` joins the
-    // thread on chassis tear down.
-    trace::init_substrate_start();
-    let trace_queue: Arc<crossbeam_queue::SegQueue<TraceEvent>> =
-        Arc::new(crossbeam_queue::SegQueue::new());
-    trace::install_trace_queue(Arc::clone(&trace_queue));
-    let trace_drainer = trace::start_drainer(Arc::clone(&trace_queue), Arc::clone(mailer));
+    // ADR-0080 §3 trace pipeline. The `Mailer` already carries a
+    // per-chassis `TraceHandle` allocated by `Mailer::new` (issue 953
+    // retired the process-global queue); pull its queue and hand a
+    // clone to `start_drainer`, which owns the thread that batches
+    // events into mail addressed to the `aether.trace` sink. The
+    // handle in `BootedPassives` joins the thread on chassis tear
+    // down.
+    let trace_drainer = trace::start_drainer(
+        Arc::clone(mailer.trace_handle().queue()),
+        Arc::clone(mailer),
+    );
 
     // ADR-0080 §6 settlement registry + chassis-mail router. The
     // registry owns the gate-site notification map; the router

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -24,16 +24,17 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::thread;
 
 use crate::chassis::settlement::SettlementRegistry;
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
-use crate::runtime::trace;
+use crate::runtime::trace::{SettlementHold, TraceHandle};
 use aether_data::{HandleId, KindId};
+use aether_kinds::trace::Nanos;
 use std::sync::OnceLock;
-use std::thread;
 
 pub struct Mailer {
     /// Registry handle for resolving recipients on `push`. Owned for
@@ -87,6 +88,21 @@ pub struct Mailer {
     /// expect to subscribe must check for the presence and surface a
     /// clear error otherwise.
     settlement_registry: OnceLock<Arc<SettlementRegistry>>,
+    /// ADR-0080 per-chassis trace handle. Holds the trace event queue
+    /// and the boot-time anchor for `Nanos` timestamps. Producer-side
+    /// hooks (`record_sent` / `record_received` / `record_finished`,
+    /// `acquire_settlement_hold`) reach for it via the shortcut
+    /// methods on this `Mailer`.
+    ///
+    /// Per-`Mailer` (not process-global) since iamacoffeepot/aether#953
+    /// — see the module doc on [`crate::runtime::trace`]. Always
+    /// present (allocated by [`Self::new`] with a fresh `SegQueue` +
+    /// boot anchor); chassis that want to share a queue across
+    /// multiple `Mailer`s swap in via [`Self::with_trace_handle`]
+    /// before the `Arc` wrap. Tests get a real handle for free;
+    /// `start_drainer` is independent — without it, events accumulate
+    /// in the queue but aren't shipped.
+    trace_handle: TraceHandle,
 }
 
 impl Mailer {
@@ -103,6 +119,7 @@ impl Mailer {
             outbound: None,
             chassis_router: OnceLock::new(),
             settlement_registry: OnceLock::new(),
+            trace_handle: TraceHandle::new(),
         }
     }
 
@@ -123,14 +140,117 @@ impl Mailer {
         let _ = self.settlement_registry.set(registry);
     }
 
-    /// Borrow the wired
-    /// [`SettlementRegistry`],
-    /// or `None` if no registry was installed (test fixtures, chassis
+    /// Borrow the wired [`SettlementRegistry`], or `None` if no
+    /// registry was installed (test fixtures, chassis
     /// that don't bring up the trace pipeline). Capabilities subscribe
     /// via
     /// [`SettlementRegistry::subscribe_settlement_mail`].
     pub fn settlement_registry(&self) -> Option<&Arc<SettlementRegistry>> {
         self.settlement_registry.get()
+    }
+
+    /// Swap in a non-default [`TraceHandle`].
+    /// Production chassis use the default handle that [`Self::new`]
+    /// allocates (fresh `SegQueue` + boot anchor). Tests that need
+    /// multiple `Mailer`s to share a queue construct one with
+    /// [`TraceHandle::with_queue`] and pass
+    /// it here before the `Arc` wrap. Filed under
+    /// iamacoffeepot/aether#953 — per-chassis trace state.
+    #[must_use]
+    pub fn with_trace_handle(mut self, handle: TraceHandle) -> Self {
+        self.trace_handle = handle;
+        self
+    }
+
+    /// Borrow the [`TraceHandle`]. Always
+    /// present — `Mailer::new` allocates a default handle, and
+    /// chassis swap in via [`Self::with_trace_handle`] if they want a
+    /// non-default queue. Producer-side call sites usually reach for
+    /// the shortcut methods on this `Mailer` instead (`record_sent` /
+    /// `record_received` / `record_finished` /
+    /// `acquire_settlement_hold` / `now_nanos`).
+    pub fn trace_handle(&self) -> &TraceHandle {
+        &self.trace_handle
+    }
+
+    /// ADR-0080 §2 producer hook for the `Sent` event. Always pushes
+    /// — every `Mailer` carries a trace handle; the drainer is the
+    /// optional piece (without [`crate::runtime::trace::start_drainer`]
+    /// events accumulate in the queue but aren't shipped).
+    pub fn record_sent(
+        &self,
+        mail_id: aether_data::MailId,
+        root: aether_data::MailId,
+        parent_mail: Option<aether_data::MailId>,
+        sender: aether_data::MailboxId,
+        recipient: aether_data::MailboxId,
+        kind: KindId,
+    ) {
+        self.trace_handle
+            .record_sent(mail_id, root, parent_mail, sender, recipient, kind);
+    }
+
+    /// ADR-0080 §2 producer hook for the `Received` event.
+    pub fn record_received(&self, mail_id: aether_data::MailId, thread_name: Option<String>) {
+        self.trace_handle.record_received(mail_id, thread_name);
+    }
+
+    /// ADR-0080 §2 producer hook for the `Finished` event.
+    pub fn record_finished(&self, mail_id: aether_data::MailId) {
+        self.trace_handle.record_finished(mail_id);
+    }
+
+    /// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a settlement
+    /// hold on `root`. The returned guard fires `Release` on drop;
+    /// every `Mailer` carries a real handle so the contract is
+    /// structural.
+    #[must_use = "SettlementHold gates root settlement; storing _ silently fires Release"]
+    pub fn acquire_settlement_hold(&self, root: aether_data::MailId) -> SettlementHold {
+        self.trace_handle.acquire_settlement_hold(root)
+    }
+
+    /// Current monotonic `Nanos` timestamp relative to the trace
+    /// handle's boot anchor.
+    #[must_use]
+    pub fn now_nanos(&self) -> Nanos {
+        self.trace_handle.now_nanos()
+    }
+
+    /// ADR-0080 chassis-root push helper. Combines `MailId` minting,
+    /// the `Sent` trace event emission, and the [`Mailer::push`]
+    /// into one call so chassis-side mail (Tick fanout from the
+    /// frame loop, hub-bridged inbound, MCP-bridged) gets observable
+    /// lineage without duplicating the producer-side hook in
+    /// `NativeBinding::send_mail_with_lineage`.
+    ///
+    /// Returns the freshly minted `MailId` so the caller can
+    /// subscribe to its settlement via the chassis
+    /// [`SettlementRegistry`] before
+    /// waiting on the chain.
+    ///
+    /// `correlation_id` is allocated by the caller (the chassis
+    /// owns its own `AtomicU64` counter, symmetric with each
+    /// per-actor `NativeBinding`'s counter).
+    pub fn push_chassis_root_mail(
+        &self,
+        correlation_id: u64,
+        recipient: aether_data::MailboxId,
+        kind: KindId,
+        payload: Vec<u8>,
+        count: u32,
+    ) -> aether_data::MailId {
+        let mail_id =
+            aether_data::MailId::new(aether_data::MailboxId::CHASSIS_MAILBOX_ID, correlation_id);
+        self.record_sent(
+            mail_id,
+            mail_id,
+            None,
+            aether_data::MailboxId::CHASSIS_MAILBOX_ID,
+            recipient,
+            kind,
+        );
+        self.push(Mail::new(recipient, kind, payload, count).with_lineage(mail_id, mail_id, None));
+        mail_id
     }
 
     /// Attach a `HubOutbound` so mail to unknown mailbox ids bubbles
@@ -182,6 +302,7 @@ impl Mailer {
             self.outbound.as_ref(),
             &self.handle_store,
             self.chassis_router.get().map(|b| &**b),
+            &self.trace_handle,
         );
     }
 
@@ -214,6 +335,7 @@ impl Mailer {
                 outbound,
                 &self.handle_store,
                 chassis_router,
+                &self.trace_handle,
             );
         }
         Ok(())
@@ -288,6 +410,7 @@ fn route_mail(
     outbound: Option<&Arc<HubOutbound>>,
     store: &Arc<HandleStore>,
     chassis_router: Option<&(dyn Fn(Mail) + Send + Sync)>,
+    trace_handle: &TraceHandle,
 ) {
     // ADR-0080 §5 chassis-mail switch — routed ahead of the registry
     // lookup so mail to `CHASSIS_MAILBOX_ID` reaches the chassis-
@@ -306,7 +429,7 @@ fn route_mail(
         let inbound_mail_id = mail.mail_id;
         if let Some(router) = chassis_router {
             let thread_name = thread::current().name().map(str::to_owned);
-            trace::record_received(inbound_mail_id, thread_name);
+            trace_handle.record_received(inbound_mail_id, thread_name);
             router(mail);
         } else {
             tracing::warn!(
@@ -315,7 +438,7 @@ fn route_mail(
                 "chassis-addressed mail dropped — no chassis router installed",
             );
         }
-        trace::record_finished(inbound_mail_id);
+        trace_handle.record_finished(inbound_mail_id);
         return;
     }
 
@@ -353,7 +476,7 @@ fn route_mail(
                 // drain (issue 838). Parked mail (the `Ok(WalkOutcome::Parked)`
                 // arm above) is deliberately NOT finished — it's held
                 // for replay when the handle resolves.
-                trace::record_finished(mail.mail_id);
+                trace_handle.record_finished(mail.mail_id);
                 return;
             }
         }
@@ -414,7 +537,7 @@ fn route_mail(
             // double-count-prematurely-settle hazard the split
             // avoids.
             let thread_name = thread::current().name().map(str::to_owned);
-            trace::record_received(inbound_mail_id, thread_name);
+            trace_handle.record_received(inbound_mail_id, thread_name);
             handler.dispatch(MailDispatch {
                 kind: mail.kind,
                 kind_name: &kind_name,
@@ -426,7 +549,7 @@ fn route_mail(
                 root: mail.root,
                 parent_mail: mail.parent_mail,
             });
-            trace::record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id);
         }
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
@@ -436,7 +559,7 @@ fn route_mail(
             );
             // ADR-0080 §2: balance the `Sent` so settlement chains
             // drain (issue 838). No `Received` — no handler ran.
-            trace::record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id);
         }
         None => {
             // ADR-0037 Phase 1: unknown-locally mailboxes bubble up
@@ -480,7 +603,7 @@ fn route_mail(
                 // bubbled-up mail on its own settlement domain; no
                 // wire signal exists today for federated cross-engine
                 // settlement (and the issue body parks that design).
-                trace::record_finished(inbound_mail_id);
+                trace_handle.record_finished(inbound_mail_id);
                 return;
             }
             tracing::warn!(
@@ -493,7 +616,7 @@ fn route_mail(
             // unloaded `"camera"` mailbox every tick; without this
             // every Tick chain has an orphaned `Sent` and never
             // settles.
-            trace::record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id);
         }
     }
 }
@@ -515,9 +638,7 @@ mod tests {
     use crate::handle_store::HandleStore;
     use crate::mail::MailboxId;
     use crate::mail::outbound::EgressEvent;
-    use crate::mail::registry::InboxHandler;
-    use crate::mail::registry::InlineHandler;
-    use crate::runtime::trace;
+    use crate::mail::registry::{InboxHandler, InlineHandler};
     use aether_data::{Kind, Ref};
     use aether_data::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
 
@@ -808,18 +929,14 @@ mod tests {
     use aether_kinds::trace::TraceEvent;
     use crossbeam_queue::SegQueue;
 
-    /// Install a fresh process-global trace queue if none is wired
-    /// yet (e.g. when this test runs in isolation), otherwise return
-    /// the existing one. Either way the queue is ready for `push` —
-    /// these tests don't assume ownership, they filter their own
-    /// events out of whatever's in flight.
-    fn ensure_trace_queue() -> Arc<SegQueue<TraceEvent>> {
-        if let Some(q) = trace::trace_queue() {
-            return Arc::clone(q);
-        }
-        let q = Arc::new(SegQueue::<TraceEvent>::new());
-        trace::install_trace_queue(Arc::clone(&q));
-        trace::trace_queue().cloned().unwrap_or(q)
+    /// Borrow the queue Arc from a `Mailer`'s default trace handle.
+    /// `Mailer::new` allocates a fresh handle per construction
+    /// (iamacoffeepot/aether#953 retired the process-global), so each
+    /// test's queue is naturally isolated. The `drain_events_for`
+    /// filter by `sender` is no longer strictly necessary but kept
+    /// to match the original assertion shape.
+    fn install_test_trace_handle(mailer: &Mailer) -> Arc<SegQueue<TraceEvent>> {
+        Arc::clone(mailer.trace_handle().queue())
     }
 
     /// Drain the trace queue and return only events whose `mail_id`
@@ -854,13 +971,13 @@ mod tests {
     /// subscribers don't hang.
     #[test]
     fn unknown_mailbox_warn_drop_records_finished() {
-        let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0002_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Mailer::new(Arc::clone(&registry), store);
+        let queue = install_test_trace_handle(&mailer);
 
         let unknown = MailboxId(0xDEAD_BEEF_BABE);
         let mail = Mail::new(unknown, KindId(0xABCD), vec![], 1).with_lineage(
@@ -883,7 +1000,6 @@ mod tests {
     /// doesn't exist on the wire today.
     #[test]
     fn unknown_mailbox_egress_records_finished_locally() {
-        let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0003_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
@@ -891,6 +1007,7 @@ mod tests {
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Mailer::new(Arc::clone(&registry), store).with_outbound(Arc::clone(&outbound));
+        let queue = install_test_trace_handle(&mailer);
 
         let unknown = MailboxId(0xDEAD_BEEF_F00D);
         let mail = Mail::new(unknown, KindId(0xABCD), vec![9, 9], 1).with_lineage(
@@ -920,11 +1037,11 @@ mod tests {
     /// for `Inbox` recipients, but on the pushing thread.
     #[test]
     fn inline_arm_brackets_handler_with_received_and_finished() {
-        let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0004_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let (registry, mailer, _store) = make_mailer();
+        let queue = install_test_trace_handle(&mailer);
         let sink = CapturingSink::new();
         let sink_id = registry.register_inline("test.838.sink", sink.inline_handler());
 
@@ -969,11 +1086,11 @@ mod tests {
     /// loudly.
     #[test]
     fn inbox_arm_does_not_bracket_in_mailer() {
-        let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0005_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let (registry, mailer, _store) = make_mailer();
+        let queue = install_test_trace_handle(&mailer);
         let sink = CapturingSink::new();
         // Register as `register_inbox` (the actor-enqueue
         // contract), NOT `register_inline`.
@@ -1022,11 +1139,11 @@ mod tests {
     fn ref_walk_parked_defers_finished_until_handle_publish() {
         use aether_data::HandleId;
 
-        let queue = ensure_trace_queue();
         let sender = MailboxId(0x8380_0006_0000_0000);
         let inbound_mail_id = MailId::new(sender, 1);
 
         let (registry, mailer, store) = make_mailer();
+        let queue = install_test_trace_handle(&mailer);
         // Register both kinds so the mailer walks the outer schema
         // and the handle store recognises the inner one. The
         // registry-derived kind id is what `Ref::Handle.kind_id`
@@ -1160,18 +1277,21 @@ mod tests {
         struct Case {
             name: &'static str,
             expect: Expect,
-            // Returns the `MailId` to filter the trace queue on.
-            run: Box<dyn FnOnce() -> MailId>,
+            // Returns the stamped `MailId` plus the filtered trace
+            // events for that case. Each case builds its own
+            // `Mailer` whose default trace handle holds the queue
+            // we drain at the end of the closure (per-mailer queues
+            // post iamacoffeepot/aether#953 — no process-global).
+            run: Box<dyn FnOnce() -> (MailId, Vec<TraceEvent>)>,
         }
 
         // Touch the helper so the compiler considers it live.
         let _ = dispatch_path_for_entry(&MailboxEntry::Dropped);
 
-        let queue = ensure_trace_queue();
         // Each case: (case-name, expectation, push-fn that returns
-        // the stamped mail_id to filter on). Cases construct their
-        // own Mailer fixtures so chassis-router / outbound / handle-
-        // store-Parked setups can vary independently.
+        // the stamped mail_id + drained events). Cases construct
+        // their own Mailer fixtures so chassis-router / outbound /
+        // handle-store-Parked setups can vary independently.
 
         let cases: Vec<Case> = vec![
             // 1. Inline arm — bracket.
@@ -1182,13 +1302,14 @@ mod tests {
                     let sender = MailboxId(0x8380_DD01_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     let sink = CapturingSink::new();
                     let id = registry.register_inline("test.meta.sink", sink.inline_handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 2. Inbox arm — no bracket from Mailer (regression
@@ -1200,13 +1321,14 @@ mod tests {
                     let sender = MailboxId(0x8380_DD02_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     let sink = CapturingSink::new();
                     let id = registry.register_inbox("test.meta.closure", sink.inbox_handler());
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 3. Dropped arm — Finished only.
@@ -1217,13 +1339,14 @@ mod tests {
                     let sender = MailboxId(0x8380_DD03_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     let id = registry.register_inbox("test.meta.dropped", Arc::new(|_| {}));
                     let _ = registry.drop_mailbox(id).expect("drop");
                     mailer.push(
                         Mail::new(id, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 4. None warn-drop (no outbound) — Finished only.
@@ -1234,11 +1357,12 @@ mod tests {
                     let sender = MailboxId(0x8380_DD04_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (_registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     mailer.push(
                         Mail::new(MailboxId(0xDEAD_BEEF_0001), KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 5. None egress to hub — Finished only (per-engine
@@ -1253,11 +1377,12 @@ mod tests {
                     let registry = Arc::new(Registry::new());
                     let store = Arc::new(HandleStore::new(64 * 1024));
                     let mailer = Mailer::new(registry, store).with_outbound(outbound);
+                    let queue = install_test_trace_handle(&mailer);
                     mailer.push(
                         Mail::new(MailboxId(0xDEAD_BEEF_0002), KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 6. Ref-walk Err (malformed payload, terminal drop) —
@@ -1269,6 +1394,7 @@ mod tests {
                     let sender = MailboxId(0x8380_DD06_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     let kind_id = registry
                         .register_kind_with_descriptor(KindDescriptor {
                             name: HeldNote::NAME.into(),
@@ -1283,7 +1409,7 @@ mod tests {
                         Mail::new(id, kind_id, vec![0u8; 1], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 7. Ref-walk Parked (held for handle publish) — neither.
@@ -1294,6 +1420,7 @@ mod tests {
                     let sender = MailboxId(0x8380_DD07_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     let outer_kind_id = registry
                         .register_kind_with_descriptor(KindDescriptor {
                             name: HeldNote::NAME.into(),
@@ -1321,7 +1448,7 @@ mod tests {
                         Mail::new(id, outer_kind_id, payload, 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 8. CHASSIS_MAILBOX_ID with router installed — bracket.
@@ -1332,12 +1459,13 @@ mod tests {
                     let sender = MailboxId(0x8380_DD08_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (_registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     mailer.install_chassis_router(Box::new(|_| {}));
                     mailer.push(
                         Mail::new(MailboxId::CHASSIS_MAILBOX_ID, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
             // 9. CHASSIS_MAILBOX_ID with no router — Finished only.
@@ -1348,11 +1476,12 @@ mod tests {
                     let sender = MailboxId(0x8380_DD09_0000_0000);
                     let mail_id = MailId::new(sender, 1);
                     let (_registry, mailer, _store) = make_mailer();
+                    let queue = install_test_trace_handle(&mailer);
                     mailer.push(
                         Mail::new(MailboxId::CHASSIS_MAILBOX_ID, KindId(0xFEED), vec![], 1)
                             .with_lineage(mail_id, mail_id, None),
                     );
-                    mail_id
+                    (mail_id, drain_events_for(&queue, sender))
                 }),
             },
         ];
@@ -1360,8 +1489,7 @@ mod tests {
         for case in cases {
             let name = case.name;
             let expect = case.expect;
-            let mail_id = (case.run)();
-            let events = drain_events_for(&queue, mail_id.sender);
+            let (mail_id, events) = (case.run)();
             let received = events
                 .iter()
                 .any(|e| matches!(e, TraceEvent::Received { mail_id: m, .. } if *m == mail_id));

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -2,15 +2,15 @@
 //!
 //! Two pieces:
 //!
-//! - **Producer-side helpers** (`record_sent` / `record_received` /
-//!   `record_finished`) push [`TraceEvent`]s onto a process-global
-//!   [`SegQueue`]. The hooks live in
-//!   [`NativeBinding::send_mail_with_lineage`](crate::NativeBinding::send_mail_with_lineage)
-//!   (Sent), the native dispatcher trampoline (Received / Finished),
-//!   and the wasm trampoline forwarder (Received / Finished). Calls
-//!   are no-ops until the chassis [`install_trace_queue`]s the
-//!   queue at boot — silent drop is the right shape for tests that
-//!   don't bring up the chassis.
+//! - **Producer-side helpers** ([`TraceHandle::record_sent`] /
+//!   [`TraceHandle::record_received`] / [`TraceHandle::record_finished`])
+//!   push [`TraceEvent`]s onto the per-chassis [`SegQueue`] held in
+//!   the [`TraceHandle`]. The handle is owned by the chassis
+//!   [`Mailer`] and reached via [`Mailer::trace_handle`]; producer-side
+//!   call sites usually reach for the `mailer.record_sent(...)`
+//!   shortcuts. Calls are no-ops when the chassis hasn't installed a
+//!   handle — silent drop is the right shape for tests that don't
+//!   bring up the chassis.
 //!
 //! - **[`start_drainer`]** spawns the chassis-owned drainer thread.
 //!   The thread loop-drains up to `BATCH_MAX` events and ships a
@@ -20,19 +20,21 @@
 //!   [`TraceDrainerHandle`] — its `Drop` signals the thread and
 //!   joins.
 //!
-//! Why global rather than chassis-owned: producer-side hooks are
-//! reached from every actor's send path; threading an
-//! `Arc<SegQueue<TraceEvent>>` through every binding constructor is
-//! invasive churn for a feature that runs at most once per process.
-//! The global is initialised exactly once at chassis boot and never
-//! reset — multi-chassis test fixtures (`TestBench`) share the queue
-//! across their substrates, which is fine because each `TraceEvent`
-//! carries the producer's [`MailboxId`] so the observer can attribute
-//! events even if the queue is shared.
+//! Why per-chassis rather than process-global: the trace pipeline is
+//! per-chassis everywhere else (drainer is per-`build_passive`,
+//! observer is a regular cap actor, queue is allocated fresh each
+//! boot). A process-global `OnceLock` for the queue pinned the *first*
+//! chassis's queue forever — subsequent chassis boots in the same
+//! process silently wired their drainer to a fresh empty Arc while
+//! producers kept pushing into the orphaned first Arc, so trace events
+//! never reached the second chassis's observer. The handle now rides
+//! on the Mailer (one per chassis), which makes the lifecycle
+//! structurally correct and unlocks future in-process multi-substrate
+//! workflows. Filed as iamacoffeepot/aether#953.
 
-use std::sync::OnceLock;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -44,167 +46,173 @@ use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::MailboxEntry;
 
-/// Monotonic-since-boot reference. Set once at chassis boot via
-/// [`init_substrate_start`]; producer-side hooks subtract from it to
-/// produce a [`Nanos`] for each event.
-static SUBSTRATE_START: OnceLock<Instant> = OnceLock::new();
-
-/// Process-global trace queue. Set by [`install_trace_queue`] at
-/// chassis boot; producer-side hooks push when present, no-op when
-/// absent. Wrapped in `OnceLock<Arc<SegQueue>>` so the drainer thread
-/// can hold a clone for `pop` without contending on the `OnceLock`
-/// itself on every read.
-static TRACE_QUEUE: OnceLock<Arc<SegQueue<TraceEvent>>> = OnceLock::new();
-
-/// Initialise the crate-internal `SUBSTRATE_START` reference. Called
-/// once during chassis boot before any actor is wired so every
-/// subsequent timestamp has a stable origin. Safe to call multiple
-/// times — the `OnceLock` ignores subsequent calls.
-pub fn init_substrate_start() {
-    let _ = SUBSTRATE_START.set(Instant::now());
-}
-
-/// Install the process-global trace queue. The chassis builder
-/// constructs the queue + drainer pair at boot via
-/// [`start_drainer`]; this function exposes the queue handle so
-/// producer-side hooks can find it. Safe to call multiple times —
-/// subsequent calls return the existing queue.
-pub fn install_trace_queue(queue: Arc<SegQueue<TraceEvent>>) {
-    let _ = TRACE_QUEUE.set(queue);
-}
-
-/// Read the process-global trace queue, if installed. Returns `None`
-/// before chassis boot or in tests that bypass the chassis.
-pub fn trace_queue() -> Option<&'static Arc<SegQueue<TraceEvent>>> {
-    TRACE_QUEUE.get()
-}
-
-/// Compute the current [`Nanos`] timestamp relative to the
-/// crate-internal `SUBSTRATE_START` reference. `0` if `SUBSTRATE_START`
-/// was not initialised (the producer hooks early-out before this in
-/// that case, but the guard makes the function safe to call standalone).
-pub fn now_nanos() -> Nanos {
-    let start = match SUBSTRATE_START.get() {
-        Some(s) => *s,
-        None => return Nanos(0),
-    };
-    let elapsed = Instant::now().saturating_duration_since(start);
-    // u128 → u64: trace timestamps overflow after ~584 years; the
-    // substrate's `SUBSTRATE_START` is set at boot, so realistic
-    // runtimes are well within u64 range.
-    #[allow(clippy::cast_possible_truncation)]
-    Nanos(elapsed.as_nanos() as u64)
-}
-
-/// ADR-0080 §2 producer hook for the `Sent` event. No-op if the
-/// global queue isn't installed yet (early-test paths, tests that
-/// bypass chassis boot). Allocates and pushes only when the queue
-/// is live.
-pub fn record_sent(
-    mail_id: MailId,
-    root: MailId,
-    parent_mail: Option<MailId>,
-    sender: MailboxId,
-    recipient: MailboxId,
-    kind: KindId,
-) {
-    let Some(queue) = TRACE_QUEUE.get() else {
-        return;
-    };
-    queue.push(TraceEvent::Sent {
-        mail_id,
-        root,
-        parent_mail,
-        sender,
-        recipient,
-        kind,
-        t: now_nanos(),
-    });
-}
-
-/// ADR-0080 §2 producer hook for the `Received` event. Pushed by the
-/// native dispatcher trampoline at handler entry. No-op when
-/// `mail_id == MailId::NONE` — that's the structural recursion break
-/// per ADR-0080 §7: the drainer's own outbound `BatchedTraceEvents`
-/// mail is pushed bare through the `Mailer` (skipping
-/// `NativeBinding::send_mail_with_lineage`), so it carries the
-/// default `MailId::NONE`. Suppressing `Received`/`Finished` for
-/// `NONE`-stamped mail prevents the observer's own dispatch from
-/// generating events that would re-feed the drainer.
+/// Per-chassis trace-pipeline handle. Owned by the chassis [`Mailer`];
+/// producer-side hooks reach it via `mailer.trace_handle()` or the
+/// `mailer.record_*` shortcuts that wrap the methods on this type.
 ///
-/// Issue 734: dispatchers pass `std::thread::current().name()
-/// .map(str::to_owned)` as `thread_name` so the trace renderer
-/// (`hub::mcp::trace`) can stamp each event with a per-thread row. The
-/// default `Pooled` scheduler (post-issue-635) names worker threads
-/// `aether-worker-N`, so one tid commonly serves multiple actors;
-/// actors on the `Thread` scheduler get the per-actor names from
-/// `actor::native::spawn` (`aether-instanced-<full_name>`,
-/// `aether-root-<NAMESPACE>`). Anonymous test threads pass `None`.
-pub fn record_received(mail_id: MailId, thread_name: Option<String>) {
-    if mail_id == MailId::NONE {
-        return;
+/// Cloning shares the underlying [`SegQueue`] (Arc) and copies the
+/// boot-time anchor (Copy), so the chassis drainer and every producer
+/// site can hold an independent `TraceHandle` cheaply.
+#[derive(Clone, Debug)]
+pub struct TraceHandle {
+    queue: Arc<SegQueue<TraceEvent>>,
+    boot_time: Instant,
+}
+
+impl TraceHandle {
+    /// Build a fresh handle: empty queue, `Instant::now()` boot
+    /// anchor. The chassis builder calls this once per `build_passive`;
+    /// the returned handle is installed on the chassis [`Mailer`] and
+    /// its queue is handed to [`start_drainer`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_queue(Arc::new(SegQueue::new()))
     }
-    let Some(queue) = TRACE_QUEUE.get() else {
-        return;
-    };
-    queue.push(TraceEvent::Received {
-        mail_id,
-        t: now_nanos(),
-        thread_name,
-    });
-}
 
-/// ADR-0080 §2 producer hook for the `Finished` event. Pushed by the
-/// native dispatcher trampoline at handler exit (normal return).
-/// Symmetric `MailId::NONE` short-circuit (see [`record_received`]).
-pub fn record_finished(mail_id: MailId) {
-    if mail_id == MailId::NONE {
-        return;
+    /// Build a handle that wraps an existing queue Arc. Used by tests
+    /// that boot multiple `Mailer`s pointing at the same queue so the
+    /// test body can drain a single shared event stream and filter by
+    /// `mail_id.sender`. Production chassis use [`Self::new`] instead;
+    /// the queue is allocated fresh per chassis.
+    #[must_use]
+    pub fn with_queue(queue: Arc<SegQueue<TraceEvent>>) -> Self {
+        Self {
+            queue,
+            boot_time: Instant::now(),
+        }
     }
-    let Some(queue) = TRACE_QUEUE.get() else {
-        return;
-    };
-    queue.push(TraceEvent::Finished {
-        mail_id,
-        t: now_nanos(),
-    });
-}
 
-/// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a `SettlementHold`
-/// against `root`. The returned guard increments the root's `held_open`
-/// counter (via a [`TraceEvent::HoldOpen`] pushed inline) and decrements
-/// it again on `Drop` (via [`TraceEvent::Release`]). Settlement for
-/// `root` gates on `(in_flight == 0 && held_open == 0)`, so any thread
-/// that outlives its spawning handler (`InheritCtx<A>` from
-/// [`crate::actor::native::NativeCtx::spawn_inherit`]) keeps the chain
-/// open until it drops.
-///
-/// Acquired on the parent thread before the worker is spawned so the
-/// `HoldOpen` event is visible in the trace queue before the parent
-/// handler's `Finished` lands. Moving the guard into the worker thread
-/// (via the `InheritCtx<A>` ctor) ties release to the worker's lifetime.
-///
-/// No-op when the trace queue isn't installed (early-test paths,
-/// fixtures that bypass chassis boot). The returned guard still pushes
-/// `Release` on drop, but the observer simply ignores both events.
-#[must_use = "SettlementHold gates root settlement; storing _ silently fires Release"]
-pub fn acquire_settlement_hold(root: MailId) -> SettlementHold {
-    if let Some(queue) = TRACE_QUEUE.get() {
-        queue.push(TraceEvent::HoldOpen {
+    /// Borrow the queue Arc so the chassis builder can pass it to
+    /// [`start_drainer`]. Internal: producer-side call sites go
+    /// through the `record_*` methods on this type.
+    #[must_use]
+    pub fn queue(&self) -> &Arc<SegQueue<TraceEvent>> {
+        &self.queue
+    }
+
+    /// Boot-time anchor for [`Self::now_nanos`]. Exposed for fixtures
+    /// that want to reconstruct timestamps for asserting.
+    #[must_use]
+    pub fn boot_time(&self) -> Instant {
+        self.boot_time
+    }
+
+    /// Compute the current [`Nanos`] timestamp relative to this
+    /// handle's boot anchor. Sub-microsecond resolution; saturates to
+    /// `u64::MAX` after ~584 years of substrate uptime.
+    #[must_use]
+    pub fn now_nanos(&self) -> Nanos {
+        let elapsed = Instant::now().saturating_duration_since(self.boot_time);
+        // u128 → u64: trace timestamps overflow after ~584 years; the
+        // handle's boot anchor is set at chassis boot, so realistic
+        // runtimes are well within u64 range.
+        #[allow(clippy::cast_possible_truncation)]
+        Nanos(elapsed.as_nanos() as u64)
+    }
+
+    /// ADR-0080 §2 producer hook for the `Sent` event.
+    pub fn record_sent(
+        &self,
+        mail_id: MailId,
+        root: MailId,
+        parent_mail: Option<MailId>,
+        sender: MailboxId,
+        recipient: MailboxId,
+        kind: KindId,
+    ) {
+        self.queue.push(TraceEvent::Sent {
+            mail_id,
             root,
-            t: now_nanos(),
+            parent_mail,
+            sender,
+            recipient,
+            kind,
+            t: self.now_nanos(),
         });
     }
-    SettlementHold { root }
+
+    /// ADR-0080 §2 producer hook for the `Received` event. Pushed by
+    /// the native dispatcher trampoline at handler entry. No-op when
+    /// `mail_id == MailId::NONE` — that's the structural recursion
+    /// break per ADR-0080 §7: the drainer's own outbound
+    /// `BatchedTraceEvents` mail is pushed bare through the `Mailer`
+    /// (skipping `NativeBinding::send_mail_with_lineage`), so it
+    /// carries the default `MailId::NONE`. Suppressing
+    /// `Received`/`Finished` for `NONE`-stamped mail prevents the
+    /// observer's own dispatch from generating events that would
+    /// re-feed the drainer.
+    ///
+    /// Issue 734: dispatchers pass `std::thread::current().name()
+    /// .map(str::to_owned)` as `thread_name` so the trace renderer
+    /// (`hub::mcp::trace`) can stamp each event with a per-thread row.
+    pub fn record_received(&self, mail_id: MailId, thread_name: Option<String>) {
+        if mail_id == MailId::NONE {
+            return;
+        }
+        self.queue.push(TraceEvent::Received {
+            mail_id,
+            t: self.now_nanos(),
+            thread_name,
+        });
+    }
+
+    /// ADR-0080 §2 producer hook for the `Finished` event. Pushed by
+    /// the native dispatcher trampoline at handler exit (normal
+    /// return). Symmetric `MailId::NONE` short-circuit (see
+    /// [`Self::record_received`]).
+    pub fn record_finished(&self, mail_id: MailId) {
+        if mail_id == MailId::NONE {
+            return;
+        }
+        self.queue.push(TraceEvent::Finished {
+            mail_id,
+            t: self.now_nanos(),
+        });
+    }
+
+    /// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a
+    /// [`SettlementHold`] against `root`. The returned guard increments
+    /// the root's `held_open` counter (via a [`TraceEvent::HoldOpen`]
+    /// pushed inline) and decrements it again on `Drop` (via
+    /// [`TraceEvent::Release`]). Settlement for `root` gates on
+    /// `(in_flight == 0 && held_open == 0)`, so any thread that
+    /// outlives its spawning handler (`InheritCtx<A>` from
+    /// [`crate::actor::native::NativeCtx::spawn_inherit`]) keeps the
+    /// chain open until it drops.
+    ///
+    /// Acquired on the parent thread before the worker is spawned so
+    /// the `HoldOpen` event is visible in the trace queue before the
+    /// parent handler's `Finished` lands. Moving the guard into the
+    /// worker thread (via the `InheritCtx<A>` ctor) ties release to
+    /// the worker's lifetime.
+    #[must_use = "SettlementHold gates root settlement; storing _ silently fires Release"]
+    pub fn acquire_settlement_hold(&self, root: MailId) -> SettlementHold {
+        self.queue.push(TraceEvent::HoldOpen {
+            root,
+            t: self.now_nanos(),
+        });
+        SettlementHold {
+            handle: self.clone(),
+            root,
+        }
+    }
+}
+
+impl Default for TraceHandle {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// RAII guard for an ADR-0080 §12 settlement hold. Construct via
-/// [`acquire_settlement_hold`]; drop fires [`TraceEvent::Release`] for
-/// the same root. The only public surface is the guard — `Release` is
-/// never a free function, so a paired `hold`/`release` mismatch is
-/// structurally impossible.
+/// [`TraceHandle::acquire_settlement_hold`] (or
+/// [`Mailer::acquire_settlement_hold`]); drop fires
+/// [`TraceEvent::Release`] for the same root. The only public surface
+/// is the guard — `Release` is never a free function, so a paired
+/// `hold`/`release` mismatch is structurally impossible.
 #[derive(Debug)]
 pub struct SettlementHold {
+    handle: TraceHandle,
     root: MailId,
 }
 
@@ -219,50 +227,11 @@ impl SettlementHold {
 
 impl Drop for SettlementHold {
     fn drop(&mut self) {
-        let Some(queue) = TRACE_QUEUE.get() else {
-            return;
-        };
-        queue.push(TraceEvent::Release {
+        self.handle.queue.push(TraceEvent::Release {
             root: self.root,
-            t: now_nanos(),
+            t: self.handle.now_nanos(),
         });
     }
-}
-
-/// ADR-0080 chassis-root push helper. Combines `MailId` minting,
-/// the `Sent` trace event emission, and the `Mailer::push` into one
-/// call so chassis-side mail (Tick fanout from the frame loop, hub-
-/// bridged inbound, MCP-bridged) gets observable lineage without
-/// duplicating the producer-side hook in `NativeBinding::send_mail_with_lineage`.
-///
-/// Returns the freshly minted `MailId` so the caller can subscribe
-/// to its settlement via the chassis [`crate::chassis::settlement::SettlementRegistry`]
-/// before waiting on the chain.
-///
-/// `correlation_id` is allocated by the caller (the chassis owns its
-/// own `AtomicU64` counter, symmetric with each per-actor `NativeBinding`'s
-/// counter). Pre-PR 4 the test bench / hub minters were the only
-/// chassis-side counters; this helper shapes them as ADR-0080 §1
-/// chassis-root `MailId`s.
-pub fn push_chassis_root_mail(
-    mailer: &Mailer,
-    correlation_id: u64,
-    recipient: MailboxId,
-    kind: KindId,
-    payload: Vec<u8>,
-    count: u32,
-) -> MailId {
-    let mail_id = MailId::new(MailboxId::CHASSIS_MAILBOX_ID, correlation_id);
-    record_sent(
-        mail_id,
-        mail_id,
-        None,
-        MailboxId::CHASSIS_MAILBOX_ID,
-        recipient,
-        kind,
-    );
-    mailer.push(Mail::new(recipient, kind, payload, count).with_lineage(mail_id, mail_id, None));
-    mail_id
 }
 
 /// ADR-0080 §3 batch parameters: drain at most this many events per
@@ -305,10 +274,6 @@ impl Drop for TraceDrainerHandle {
 /// every `BATCH_INTERVAL` (also crate-internal) and ships a
 /// [`BatchedTraceEvents`] mail to the [`TRACE_OBSERVER_MAILBOX_NAME`]
 /// sink. Returns a handle whose `Drop` joins the thread.
-///
-/// Idempotent in the sense that calling [`install_trace_queue`]
-/// twice with the same `queue` Arc is a no-op; the chassis builder
-/// installs the queue exactly once and pairs it with one drainer.
 ///
 /// # Panics
 /// Panics if the OS refuses to spawn the drainer thread — fail-fast


### PR DESCRIPTION
## Summary

- The trace pipeline's `TRACE_QUEUE: OnceLock<Arc<SegQueue<TraceEvent>>>` and `SUBSTRATE_START: OnceLock<Instant>` statics pinned the *first* chassis's queue + boot anchor forever — subsequent chassis boots in the same process silently wired their drainer to a fresh empty `Arc` while producers kept pushing into the orphaned first `Arc`. Trace events never reached the second chassis's observer; tests waiting on `Settled` would hang the full timeout.
- Surfaced as `cargo test --workspace` flakes on `call_echo_round_trips_over_the_socket` and `call_echo_round_trip_event_then_end` (iamacoffeepot/aether#953). CI was unaffected — nextest isolates per-process.
- Restructured around a per-chassis `TraceHandle` carried on the `Mailer`. Tracing is no longer "optional" in the bolt-on sense — every `Mailer` allocates a default handle, the drainer is the optional piece. Decision made jointly with the user: settlement, `send_mail_traced`, and `RpcServerCapability` already depend on trace events flowing, so the always-present handle matches the reality.

## Shape

- `TraceHandle { queue: Arc<SegQueue<TraceEvent>>, boot_time: Instant }` — clone-able. `record_sent` / `record_received` / `record_finished` / `acquire_settlement_hold` / `now_nanos` move from free functions to methods on this type.
- `Mailer.trace_handle: TraceHandle` (not `Option`, not `OnceLock`) — initialised by `Mailer::new` with fresh queue + anchor. `Mailer::with_trace_handle(handle)` swaps in a non-default handle for tests that need a shared queue across multiple `Mailer`s.
- `Mailer` gains shortcut methods (`record_sent`, `record_received`, `record_finished`, `acquire_settlement_hold`, `now_nanos`) plus `push_chassis_root_mail` (was a free function).
- `SettlementHold` carries the handle directly (no `Option`); the `SettlementHold::empty` escape hatch retires.
- `NativeBinding::mailer()` accessor surfaced for cross-file producer sites (`dispatch`, `dispatcher_slot`, `spawn_thread`); `NativeCtx::mailer` added for `TraceObserverCapability::now_nanos`.

## Test plan

- [x] `scripts/preflight.sh` green: fmt + clippy + doc + nextest (1011/1011 pass) + wasm32 component cross-build.
- [x] **The originally-flaky tests now pass under `cargo test --workspace`**: `call_echo_round_trips_over_the_socket` + `call_echo_round_trip_event_then_end` complete in milliseconds with per-`Mailer` queues. The bisect agent on iamacoffeepot/aether#953 confirmed those tests reproduced the flake 25/25 against the previous code; this PR retires the root cause.
- [x] CI Qodana / clippy / nextest re-run on PR.

## References

- Closes iamacoffeepot/aether#953 (diagnosis at iamacoffeepot/aether#953#issuecomment-4485240051).
- Built atop iamacoffeepot/aether#716 / iamacoffeepot/aether#950's `SettlementHold` shape — the guard now carries a `TraceHandle` directly.