### PR TITLE
feat(substrate): release-flow tooling — schema, skills, bootstrap

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: approve
+description: Plan → Ready gate. Validates that an issue's scope artifacts are complete and any drafted ADR has merged, then sets AgentReady=Yes and advances Phase to Ready. Does NOT dispatch implementation — that's /delegate's job. Idempotent on re-run.
+---
+
+# /approve — Plan → Ready gate
+
+The primary human review point of the release flow. The user invokes `/approve <issue>` after reading the scope artifacts that `/scope` produced. The skill validates the gates and flips the issue to Ready; from there `/delegate` (or the Phase C orchestrator) picks it up.
+
+## Invocation
+
+```
+/approve <issue>                    standard
+/approve <issue> --note "<text>"    adds the text to the audit comment
+/approve <issue> --skip-adr         bypass the ADR-merged check (emergency override)
+```
+
+## Preconditions
+
+1. `.claude/release-state.json` exists and is readable. If not, abort with *"Run `/release-init <version>` first."*
+2. Issue must be in the active project. If not, abort with *"Issue #N is not in project <project-number>. Add it first."*
+
+## Gate checks
+
+Run all of these. **Refuse** if any fail; list every failure in the refusal comment, don't stop at the first.
+
+| Gate | Check | Refusal message |
+|------|-------|-----------------|
+| Phase | `Phase == Plan` | "Issue is at <current>, not Plan. Use `/scope` or `/bounce` first." |
+| Problem statement | body has `## Problem statement` and the section is non-empty | "Missing or empty §Problem statement." |
+| Design notes | body has `## Design notes` and is non-empty | "Missing or empty §Design notes." |
+| Implementation plan | body has `## Implementation plan` and is non-empty | "Missing or empty §Implementation plan." |
+| ADR merged | if §Design notes references an ADR PR, that PR's `mergedAt` is non-null | "ADR PR #M is not merged. Merge it or pass `--skip-adr` to override." |
+| AgentReady allowed | `AgentReady` field is settable (not blocked by labels like `blocked`, `wontfix`, `duplicate`) | "Issue carries label '<label>' which blocks approval." |
+
+If **all** gates pass, proceed.
+
+## Actions on pass
+
+1. Set the project item's `AgentReady` field to `Yes`.
+2. Set the project item's `Phase` field to `Ready`.
+3. Post an audit comment:
+
+   ```
+   [approve] Plan approved by <user>. Phase → Ready, AgentReady=Yes.
+   <--note text if passed>
+   ```
+
+4. Print a summary to the user:
+
+   ```
+   ✓ #N approved.
+   Phase: Plan → Ready
+   AgentReady: No → Yes
+   Next: /delegate <N>   (or wait for the orchestrator)
+   ```
+
+## Idempotency
+
+If `/approve` is re-run on an issue that already has `Phase=Ready` and `AgentReady=Yes`:
+
+- Re-validate the gates (catches drift if anyone hand-edited the body).
+- If gates still pass: no-op, print *"Already approved — Phase=Ready, AgentReady=Yes."* No new comment.
+- If gates now fail: refuse and list failures. Don't auto-bounce — let the user decide whether to fix the body or `/bounce` the issue.
+
+## Side findings
+
+`/approve` is intentionally **not the place to triage side findings**. The §Side findings section is informational at this gate. Side findings get triaged via `/scope-spinoff <issue>` before or after approval — the user's call when. Approving an issue with un-triaged side findings is fine and common; the findings stay in the body for the next reviewer (or a future maintenance pass).
+
+## Multi-PR umbrella issues
+
+If §Sub-issues lists children, the umbrella's `/approve` means "the overall plan is approved, children are split correctly". Each child still goes through its own `/scope` → `/approve` flow. The umbrella itself may not be `/delegate`-able (no code to write at this level); leaving it at `Phase=Ready` is correct — it advances to `Done` only when every child is `Done`.
+
+A future `/release-promote-umbrella <parent>` skill can auto-close the umbrella when all children are Done. Out of scope for v1.
+
+## ADR gate, in detail
+
+Parse §Design notes for a URL or reference matching one of:
+
+- `https://github.com/<owner>/<repo>/pull/<N>`
+- `Closes <owner>/<repo>#<N>` (the cross-repo close form per the user's memory)
+- A bare `#<N>` paired with an "ADR" mention nearby
+
+For each such reference, run `gh pr view <N> --json mergedAt,state` and require `state == MERGED`. List every unmerged ADR PR in the refusal.
+
+`--skip-adr` exists for cases where:
+
+- The ADR is intentionally drafted in the same release but lands separately (e.g. ADR-NNNN cluster work).
+- The change is small enough that ADR-by-the-time-Ready is overkill in retrospect.
+
+When `--skip-adr` is used, the audit comment is verbose:
+
+```
+[approve] Plan approved by <user> with --skip-adr override.
+   Unmerged ADRs at approval time: #M
+   Reason: <required note text>
+```
+
+`--skip-adr` requires `--note "<reason>"`. Don't allow silent ADR bypasses.
+
+## Failure modes
+
+- **Issue not in project**: instruct user to add it via `gh project item-add`.
+- **`release-state.json` stale (field IDs invalid)**: re-run `/release-init <version> --reuse <num>` to rebuild the cache. Same advice as `/scope`.
+- **GitHub API rate limit**: retry with backoff. If still failing, abort and tell the user the rate-limit reset time.
+- **Hand-edits during validation**: if the issue body changes between the gate read and the field update, re-read and re-validate before committing the Phase transition. Don't write a partial transition.
+
+## What `/approve` does NOT do
+
+- Dispatch implementation. Run `/delegate <issue>` (or wait for the Phase C orchestrator) after approval.
+- Edit the issue body. Even if a gate fails because a section is missing, /approve doesn't write the missing section — that's `/scope`'s job.
+- Auto-resolve side findings.
+- Close umbrella issues when children complete. Future work.
+- Notify anyone. The audit comment is the notification surface.

--- a/.claude/skills/bounce/SKILL.md
+++ b/.claude/skills/bounce/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: bounce
+description: Explicit phase regression. Move an issue from its current Phase back to an earlier one (Plan / Design / Define), record the reason as a comment, and set the BounceTo field so /scope can resume from the right place. Required reason — no silent bounces. For env/tooling halts, use Phase=Stalled manually (no skill in v1).
+---
+
+# /bounce — explicit phase regression
+
+The user invokes `/bounce` when reviewing scope artifacts (or watching execution) and concludes an upstream phase needs rework. The skill records the regression as a `Phase=Bounced` + `BounceTo=<phase>` state with an audit comment. `/scope` then resumes from the target phase on next invocation.
+
+Self-bounces by other skills (`/scope` hitting a wall, `/delegate` discovering a design flaw) use the same mechanism — this skill is the explicit user-driven wrapper.
+
+## Invocation
+
+```
+/bounce <issue> <to-phase> --reason "<text>"
+```
+
+`<to-phase>` is one of: `Define`, `Design`, `Plan`. `--reason` is required.
+
+## Preconditions
+
+1. `.claude/release-state.json` exists. If not, abort with the standard pointer.
+2. Issue must be in the active project.
+3. `--reason` is non-empty (no silent bounces — the corpus shows bounces without context are the hardest to triage later).
+
+## Validation
+
+| Check | Refusal |
+|-------|---------|
+| Target phase is `Define`, `Design`, or `Plan` | "Cannot bounce to <phase>. Valid: Define, Design, Plan." |
+| Target phase is earlier than current phase in the flow | "Issue is at <current>; bouncing to <target> would advance, not regress. Use `/scope` to advance." |
+| Issue is not already at `Phase=Bounced` | "Issue is already Bounced (BounceTo=<x>). Resolve that bounce first, or re-scope." |
+| Issue is not at `Phase=Done` | "Issue is Done; bouncing a closed issue is a no-op. File a fresh issue if work needs to resume." |
+
+Phase ordering for "is earlier" check:
+
+```
+Backlog (0) → Define (1) → Design (2) → Plan (3) → Ready (4) → Executing (5) → Refine (6) → Done (7)
+```
+
+A bounce from `Ready` to `Plan` is valid (target=3 < current=4). A bounce from `Plan` to `Plan` is invalid (no-op). A bounce from `Design` to `Plan` is invalid (advancing).
+
+## Actions on pass
+
+1. Set the project item's `Phase` field to `Bounced`.
+2. Set the project item's `BounceTo` field to the target phase.
+3. Post an audit comment:
+
+   ```
+   [bounce] Phase regression by <user>: <previous-phase> → Bounced (BounceTo=<target>).
+
+   Reason: <text>
+   ```
+
+4. Print summary:
+
+   ```
+   ✓ #N bounced.
+   Phase: <previous> → Bounced
+   BounceTo: <target>
+   Next: address the reason in the issue body or comments, then /scope #N
+         (or /scope #N --phase <target> to force redo of that section)
+   ```
+
+## Resume contract with `/scope`
+
+When `/scope <issue>` runs on a Bounced issue, it must:
+
+1. Read `BounceTo` from the project item.
+2. Set `Phase=<BounceTo>` (clears the Bounced state).
+3. Run from that phase forward — redoing the bounced phase and every downstream phase.
+
+If the user passes `/scope <issue> --phase <name>` while bounced and `<name>` matches `BounceTo`, behavior is identical (the flag is the explicit form of the same intent). If `<name>` differs from `BounceTo`, honor `<name>` (the user is overriding) but post a comment noting the override.
+
+## Self-bounce by other skills
+
+Skills that detect their own wall conditions (`/scope` hitting a vague issue body, `/delegate` discovering a broken assumption) call into the same logic: set `Phase=Bounced`, set `BounceTo=<phase>`, post a comment. The audit comment prefix changes to identify the source:
+
+```
+[scope] Self-bounce: <previous> → Bounced (BounceTo=Design).
+   Question: <the blocker>
+
+[delegate] Self-bounce: Executing → Bounced (BounceTo=Plan).
+   Discovered during implementation: <the issue>
+```
+
+Same skill mechanism, different invocation site. `/bounce` is the user-driven variant.
+
+## Stalled (separate semantic)
+
+`Phase=Stalled` is a different signal — env/tooling failure, not a phase regression. Examples: qodana CI service down, GitHub API rate-limited mid-batch, `gh` token expired. The issue's scoping is fine; the *environment* is the problem.
+
+v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
+
+## Failure modes
+
+- **`release-state.json` stale**: rebuild via `/release-init <version> --reuse <num>`.
+- **GitHub API failure mid-transition**: don't write a partial state. If the field-edit succeeds but the comment fails, retry the comment with backoff. If the field-edit fails, abort without retrying the comment.
+- **Rate limits**: retry with backoff.
+
+## What `/bounce` does NOT do
+
+- Edit the issue body. The bounce reason is in a comment, not the body. `/scope` is the only skill that touches body sections.
+- Decide *what* needs fixing. The `--reason` text is the user's framing; the skill records it verbatim. If the issue body needs new information for the bounce to be addressable, the user adds it (in a comment or body edit) before re-invoking `/scope`.
+- Resume the issue. The user re-invokes `/scope` (or the orchestrator picks it up) once the reason is addressed.
+- Cascade to dependent issues. If a bounced issue blocks other Plan/Ready issues, the user is responsible for triaging them too. A future skill could auto-bounce-cascade, but v1 keeps it manual.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: implement
+description: Execute an approved release issue end-to-end. Cuts a branch in an isolated worktree, implements per the issue's §Implementation plan, opens a PR, then loops on CI feedback until green or self-bounce. Does NOT merge — stops at "PR open, CI green" awaiting user or orchestrator. Requires Phase=Ready, AgentReady=Yes.
+---
+
+# /implement — release-flow execution skill
+
+The execution side of the release flow. Pairs with `/scope` and `/approve`: where those produce a vetted plan, `/implement` carries it out. Loops the Execute⇄Refine cycle internally until CI is green, then stops and waits for merge (does *not* auto-merge — `/delegate` does, this doesn't).
+
+Distinct from `/delegate`. `/delegate` is for ad-hoc agent-labeled work outside the Project flow; `/implement` is purpose-built for issues that have passed `/approve`. Both share worktree isolation; everything else differs.
+
+## Invocation
+
+```
+/implement <issue>                       run with defaults (retry-cap=3, wall=30min)
+/implement <issue> --retry-cap <N>       override retry cap
+/implement <issue> --wall-clock <mins>   override wall-clock budget
+/implement <issue> --resume              continue an in-flight execution (rare)
+```
+
+## Preconditions
+
+| Check | Refusal |
+|-------|---------|
+| `.claude/release-state.json` exists | "Run `/release-init <version>` first." |
+| Issue in active project | "Issue #N is not in project <project-number>. Add it first." |
+| `Phase == Ready` | "Issue is at <current>, not Ready. Use `/scope` + `/approve` first." |
+| `AgentReady == Yes` | "Approval gate not met. Run `/approve <issue>` first." |
+| §Sub-issues section absent or empty | "Issue is an umbrella with sub-issues. Delegate the children, not the parent." |
+| Issue body has `## Implementation plan` | "Missing implementation plan — issue isn't fully scoped. Re-run `/scope`." |
+| `gh auth status` has `repo`+`project` scopes | "Run `gh auth refresh -s project` (repo scope is standard)." |
+
+## Worktree setup
+
+```bash
+# branch name derived from issue: <type>/issue-<N>-<slug>
+git worktree add /tmp/aether-impl-<N> -b <type>/issue-<N>-<slug> main
+cd /tmp/aether-impl-<N>
+```
+
+Worktree path is `/tmp/aether-impl-<N>` so concurrent `/implement` runs on different issues don't collide. Branch is cut from `main` (not the current branch) per the user's memory rule.
+
+Type comes from the project item's `Type` field. Slug is the issue title sanitized: lowercased, alnum + dashes, max 30 chars.
+
+## Execute phase
+
+1. Set project item's `Phase = Executing`. Post audit comment: `[implement] Executing — branched <type>/issue-<N>-<slug> off main, worktree /tmp/aether-impl-<N>`.
+
+2. Implement per the issue body's `## Implementation plan` section. The agent follows the plan literally: same files, same sequence, same test coverage. Deviations are bounces, not freelancing.
+
+3. Run local pre-flight before pushing:
+   - `cargo fmt`
+   - `cargo clippy --workspace --all-targets -- -D warnings`
+   - `cargo nextest run --workspace`
+   - `cargo doc --workspace --no-deps`
+   - wasm32 cross-build for component crates (`cargo metadata` → packages with `crate-type = cdylib` and `aether-component` dep)
+   - `scripts/preflight.sh` if present (writes the stamp file expected by the pre-push hook)
+
+4. Push the branch and open the PR:
+   ```bash
+   git push -u origin <branch>
+   gh pr create --title "<conventional-commit title>" --body "<see PR body template below>"
+   ```
+
+5. Audit comment on issue: `[implement] PR opened: #<pr-number>`.
+
+## Refine loop (the spin-until-green part)
+
+After PR open, enter the loop. On each iteration:
+
+1. Wait for CI to complete (`gh pr checks <pr> --watch`).
+
+2. **CI green** → goto "Done condition" below.
+
+3. **CI failed** → pull logs (`gh run view <run-id> --log-failed`), classify, act:
+
+   ```
+   Classification → Action
+   ─────────────────────────────────────────────────────────────────
+   Format / clippy / doc           → always real, mechanical fix
+   Build error                     → always real, mechanical fix
+   Same test fails twice in a row  → real failure, fix the cause
+   Different test each attempt     → likely flake, rerun without push
+   Scenario runner regression      → real, fix or bounce-to-Design
+   Pre-existing test breaks        → likely scope expansion needed
+                                     bounce-to-Plan with the test name
+   Build env failure (qodana down,
+   gh api rate limit, network)     → Stalled, abort loop, set
+                                     Phase=Stalled, exit
+   ```
+
+4. If real failure, fix in the worktree, push to the same branch, increment attempt counter, goto step 1.
+
+5. Set project item's `Phase` to `Refine` during fix-and-wait, back to `Executing` when pushing the fix. (Flicker is intentional — gives the board honest visibility.)
+
+6. Audit comment per attempt: `[implement] CI failed (attempt <N>/<retry-cap>): <one-line summary>` and `[implement] Fix pushed for attempt <N>`.
+
+7. **Retry cap hit** → self-bounce. `Phase=Bounced`, `BounceTo=Plan`, comment with the full attempt history.
+
+8. **Wall-clock hit** → self-bounce. Same as retry cap with the elapsed time noted.
+
+9. **Design-level discovery** at any attempt → self-bounce. `Phase=Bounced`, `BounceTo=Design`, comment with the specific finding. Examples:
+   - "Approach X doesn't work because Y; needs alternative."
+   - "Test Z passes only if we also change A, which is outside §Implementation plan."
+
+## Flake detection (v1, simple)
+
+Per-test counter. If test `foo::bar` fails on attempt 1, store it. If it fails again on attempt 2, real failure — fix the underlying cause. If different tests fail each attempt with no common cause, treat as flake — rerun CI (no push) up to 2 times before counting against retry budget.
+
+Format/clippy/build are never flakes — always real, always immediate fix.
+
+## Done condition
+
+CI green:
+
+1. Audit comment: `[implement] CI green on attempt <N>. PR #<pr-number> ready for merge.`
+2. Project item: leave `Phase = Refine` and `AgentReady = Yes`. The issue is now in the "PR open + green" state; the merge is a separate human or orchestrator decision.
+3. Do not merge. Do not close. Do not auto-set Phase=Done.
+4. Print to user:
+
+   ```
+   ✓ #<N> implemented and CI-green.
+   PR: <pr-url>
+   Branch: <type>/issue-<N>-<slug>
+   Worktree: /tmp/aether-impl-<N>  (clean up after merge with `git worktree remove`)
+   Next: review and merge the PR; Phase will go to Done at merge.
+   ```
+
+Phase moves to `Done` either:
+- When the user merges and a post-merge hook (or `/release-promote`) detects it, **or**
+- When the Phase C orchestrator (future) merges under bounded auth.
+
+For v1, that final transition is manual: the user merges via `gh pr merge` or the UI, then optionally runs `/release-promote <issue>` to mark Phase=Done. (Or it could just be inferred by Phase D tooling that reconciles state.)
+
+## Self-bounce mechanics
+
+Uses the same machinery as `/bounce` — see that skill's "Self-bounce by other skills" section. Audit comment prefix is `[implement]`:
+
+```
+[implement] Self-bounce after attempt <N>: Executing → Bounced (BounceTo=Plan).
+   Reason: <retry cap hit | wall clock hit | scope expansion needed | ...>
+   Attempts history:
+     1. <failure summary>
+     2. <failure summary>
+     3. <failure summary>
+```
+
+The worktree stays on disk until the user cleans up — useful for inspecting the failed state. Worktree cleanup is *not* part of self-bounce.
+
+## PR body template
+
+```markdown
+Closes iamacoffeepot/aether#<issue>.
+
+## Summary
+
+<extracted from issue body — the §Problem statement + chosen approach from §Design notes, condensed>
+
+## Test plan
+
+<extracted from §Implementation plan's test-coverage notes>
+
+## Generated by
+
+`/implement` — agent execution of [scoped issue #<issue>](<issue-url>).
+```
+
+The cross-repo close form (`Closes iamacoffeepot/aether#N`) is required because the bare `#N` form gets stripped by the user's PR-body hook. See `feedback_close_keyword_hook_strips_hash.md`.
+
+## Auth budget (v1, will grow in Phase C)
+
+| Budget | Default | Override |
+|--------|---------|----------|
+| Retry cap | 3 attempts after a real failure | `--retry-cap <N>` |
+| Wall clock | 30 minutes total | `--wall-clock <mins>` |
+| Token cost | not enforced in v1 | future `--token-cap <N>` |
+
+Both caps trigger self-bounce to Plan with the budget breach noted. The `AuthBudget` field on the project item is the persistent record; for v1 it's a free-text note ("retry=3, wall=30m"). Phase C orchestrator will read this field to apply per-issue budgets.
+
+## Failure modes
+
+- **`release-state.json` stale**: rebuild via `/release-init <version> --reuse <num>`.
+- **PR creation fails** (e.g. duplicate branch from prior aborted run): clean up the stale branch (`git branch -D`), retry. If repeated failure, self-bounce to Plan.
+- **Pre-flight CI failure on first push** (formatting, build): fix in-worktree and push. Doesn't count against retry budget — local-equivalent failures are pre-CI.
+- **Worktree creation fails** (path already exists from prior aborted run): `git worktree remove` the stale one, retry. If `git worktree list` is stuck, instruct the user to clean it up manually.
+- **Phase regression while running** (someone hand-bounces the issue mid-execution): detect on next field-update, abort the loop, leave the branch and PR as-is, post a comment noting the abort.
+- **PR gets reviewer comments mid-loop**: ignore in v1. `/implement` only listens to CI signal. Reviewer feedback is a separate human concern — they can `/bounce` or comment on the PR directly.
+
+## What `/implement` does NOT do
+
+- Merge the PR (manual or Phase C orchestrator).
+- Edit the issue body (only `/scope` does).
+- Re-scope the issue when CI surfaces problems — bounce instead.
+- Address reviewer feedback on the PR. Reviewers comment; `/bounce` if the feedback requires re-scoping; manual handling otherwise.
+- Notify anyone. Audit comments are the surface.
+- Run on issues that aren't in the active project. Use `/delegate` for ad-hoc agent-labeled work outside the Project flow.
+- Clean up worktrees after success or bounce. Leaves them for inspection; `git worktree remove /tmp/aether-impl-<N>` is the user's call.
+
+## Comparison: `/delegate` vs `/implement`
+
+| Concern | `/delegate` | `/implement` |
+|---------|-------------|--------------|
+| Required state | `agent` label | `Phase=Ready`, `AgentReady=Yes` |
+| Project board awareness | none | full |
+| CI loop | none (one-shot) | spins until green or bounce |
+| Self-bounce | no | yes (to Plan or Design) |
+| Auth budget | none | retry-cap + wall-clock |
+| Auto-merge | no | no (parity) |
+| Worktree | yes | yes |
+| Use case | quick fixes, hot-takes | release-flow execution |

--- a/.claude/skills/release-init/SKILL.md
+++ b/.claude/skills/release-init/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: release-init
+description: Bootstrap a new aether release. Creates a GitHub Project with the canonical schema (Phase column + Type/Size/AgentReady/BounceTo/ADR/AuthBudget custom fields), populates .claude/release-state.json with the project ID + field/option ID cache, optionally seeds the project with starter issues. Required before /scope works.
+---
+
+# /release-init — release bootstrap skill
+
+Bootstraps the GitHub Project + local config that the other release skills depend on. Idempotent only when `--reuse` is passed; otherwise creates a fresh project each call.
+
+## Invocation
+
+```
+/release-init <version>                            create new project "aether <version>"
+/release-init <version> --reuse <project-number>   adopt an existing project (no creation)
+/release-init <version> --import #N,#M,#...        add listed issues to project, set Phase=Backlog
+/release-init <version> --owner <owner>            override default owner (iamacoffeepot)
+```
+
+Combinable: `/release-init 0.4 --reuse 2 --import #297,#694`.
+
+## Preconditions
+
+1. `gh auth status` must include `project` scope. If not, instruct the user to run `gh auth refresh -s project` and abort.
+2. The bootstrap script must exist at `scripts/release-project-init.sh` (committed in repo). If missing, abort with a pointer.
+3. `.claude/release-state.json` should not already exist (the file is the active-release marker; only one at a time). If it exists, ask the user to confirm overwrite before proceeding.
+
+## Steps
+
+### 1. Create or adopt the project
+
+If `--reuse <num>` was not passed:
+
+```bash
+bash scripts/release-project-init.sh <version> --owner <owner>
+```
+
+Capture the project number from the script's output (`Project N created.`).
+
+If `--reuse <num>` was passed, skip creation and use `<num>` directly. Verify the project exists and has the expected fields by running the next step's `field-list` and checking that Phase, Type, Size, AgentReady, BounceTo, ADR, AuthBudget are present. If any are missing, abort with a message naming the missing fields.
+
+### 2. Query the field cache
+
+```bash
+gh project field-list <project-number> --owner <owner> --format json
+gh project view <project-number> --owner <owner> --format json
+```
+
+Extract:
+- The project's GraphQL node ID (from `view`, `.id`).
+- For each of Phase, Type, Size, AgentReady, BounceTo: the field ID and, for single-select fields, every option's ID.
+- For ADR and AuthBudget: just the field ID (text fields, no options).
+
+### 3. Write `.claude/release-state.json`
+
+Schema (formatted, no trailing comma):
+
+```json
+{
+  "active_project": <number>,
+  "project_node_id": "PVT_...",
+  "release_version": "<version>",
+  "owner": "<owner>",
+  "field_cache": {
+    "Phase": {
+      "id": "PVTSSF_...",
+      "options": {
+        "Backlog": "<id>",
+        "Define": "<id>",
+        "Design": "<id>",
+        "Plan": "<id>",
+        "Ready": "<id>",
+        "Executing": "<id>",
+        "Refine": "<id>",
+        "Done": "<id>",
+        "Bounced": "<id>",
+        "Stalled": "<id>"
+      }
+    },
+    "Type":       { "id": "...", "options": { "feat": "...", "fix": "...", ... } },
+    "Size":       { "id": "...", "options": { "S": "...", "M": "...", "L": "..." } },
+    "AgentReady": { "id": "...", "options": { "No": "...", "Yes": "..." } },
+    "BounceTo":   { "id": "...", "options": { "Plan": "...", "Design": "...", "Define": "..." } },
+    "ADR":        { "id": "...", "options": null },
+    "AuthBudget": { "id": "...", "options": null }
+  }
+}
+```
+
+Write atomically: temp file then rename. Set permissions to user-only (`chmod 600`) since this is operational state, not source.
+
+### 4. Ensure `.gitignore` covers it
+
+Append `.claude/release-state.json` to `.gitignore` if not already present. This file is per-machine operational state, not project source. Do not commit.
+
+### 5. Import issues if `--import` was given
+
+For each issue in the comma-separated list:
+
+```bash
+gh project item-add <project-number> --owner <owner> --url https://github.com/<owner>/aether/issues/<number>
+```
+
+Then set `Phase=Backlog` on each (using the now-cached field/option IDs). Don't set Type/Size/AgentReady yet — those are `/scope`'s responsibility per-issue.
+
+### 6. Print summary
+
+```
+✓ aether <version> bootstrapped
+  Project: https://github.com/users/<owner>/projects/<number>
+  Local state: .claude/release-state.json
+  Imported: <N> issue(s)
+
+Next:
+  1. Open the project URL above, switch board view → group by Phase.
+  2. Add more issues: gh project item-add <project-number> --owner <owner> --url <issue-url>
+  3. Scope an issue: /scope <issue-number>
+```
+
+## Failure modes
+
+- **`gh` lacks `project` scope**: abort with the refresh command.
+- **Bootstrap script fails partway**: leave whatever was created on the GH side, report the error, do not write `release-state.json`. The user can `gh project delete` and retry.
+- **`field-list` returns fewer fields than expected** (e.g. someone hand-deleted a field): abort and report the missing fields by name.
+- **`.claude/release-state.json` already exists and `--force` not passed**: ask the user to confirm overwrite before proceeding.
+- **`--import` issue doesn't exist or is in a different repo**: skip with a warning comment; continue with the rest.
+
+## What `/release-init` does NOT do
+
+- Configure the board view layout (group-by, sort, sub-grouping). That's a UI-only step today. The CLI prints instructions; the user does it once.
+- Add Type/Size/AgentReady values to imported issues — `/scope` handles that.
+- Migrate items from an older release project. If you want to move issues from `aether 0.3` to `aether 0.4`, use `gh project item-archive` on the old + `--import` on the new.
+- Mark the project as a template. Possible future refinement: `/release-init --as-template` followed by `gh project copy` per release. Not yet.
+- Delete or close old release projects. The user does that manually when they're done with a release.
+
+## Notes on `release-state.json`
+
+- The file is the **active-release marker**. Only one exists at a time per repo. Switching releases means re-running `/release-init <newversion>` (after archiving the old).
+- The `field_cache` is invalidated if anyone hand-edits fields/options in the UI. If `/scope` or another skill ever fails with a "field ID not found" error, run `/release-init <version> --reuse <num>` to rebuild the cache against the same project.
+- The file is `chmod 600` because it carries operational state; not sensitive per se, but personal to the machine.

--- a/.claude/skills/scope-spinoff/SKILL.md
+++ b/.claude/skills/scope-spinoff/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: scope-spinoff
+description: Triage §Side findings into child GitHub issues. Reads the parent issue's §Side findings section, lets the user pick which entries to spin off, files each as a new Backlog-Phase issue with a conventional-commit title and a link back to the parent, then removes the spun-off entries from the parent body. Audit-comment trail on the parent records what was spun.
+---
+
+# /scope-spinoff — side findings → child issues
+
+`/scope` populates `## Side findings` on an issue with unrelated stuff it notices while reading the code (dead code, undocumented invariants, latent bugs, drift). At review time the user decides which of those deserve their own issues. `/scope-spinoff` handles the filing mechanics.
+
+## Invocation
+
+```
+/scope-spinoff <issue>                  interactive — list findings, prompt for picks
+/scope-spinoff <issue> <indices>        non-interactive — e.g. "1,3,5"
+/scope-spinoff <issue> --all            spin off every finding
+/scope-spinoff <issue> --dry-run        show what would be filed, change nothing
+```
+
+`<indices>` are 1-based, matching the order findings appear in the §Side findings section.
+
+## Preconditions
+
+1. `.claude/release-state.json` exists.
+2. Parent issue is in the active project (no Phase restriction — even Done parents can spin off informational findings).
+3. Parent's body has a `## Side findings` section with at least one bullet.
+
+## Interactive mode
+
+Read `## Side findings` from the parent's body. Print a numbered list:
+
+```
+Found 4 side findings on #<parent>:
+  1. <text>
+  2. <text>
+  3. <text>
+  4. <text>
+
+Pick which to spin off (comma-separated, "all", or empty to cancel):
+```
+
+Wait for the user's response. Parse "1,3,4" into a set of indices.
+
+## Per-finding actions
+
+For each selected finding:
+
+1. **Generate a conventional-commit title** from the finding text. The agent applies its judgment for the type prefix:
+   - "dead code", "unused", "drift" → `chore(<crate>)`
+   - "missing test", "test gap" → `test(<crate>)`
+   - "doc gap", "missing rustdoc" → `docs(<crate>)`
+   - "bug", "regression" → `fix(<crate>)`
+   - "missing feature", "extension" → `feat(<crate>)`
+   - Default if ambiguous → `chore(<crate>)`
+
+   The `<crate>` comes from the file pointer in the finding (e.g. `aether-substrate/dispatch.rs:142` → `substrate`). If the pointer is missing or ambiguous, ask the user inline.
+
+2. **File the child issue:**
+
+   ```bash
+   gh issue create --title "<conventional-title>" --body "<body>"
+   ```
+
+   Body template:
+
+   ```markdown
+   <!-- pr-body-ok: e — auto-filed from scope-spinoff, scope is parent-issue context -->
+
+   ## Description
+
+   <expanded finding text — keep the original line, add any context the agent already has from reading the code>
+
+   ## Found during
+
+   Spun off from #<parent> §Side findings during `/scope-spinoff` on <date>.
+   ```
+
+3. **Add the child to the active project** at `Phase=Backlog`:
+
+   ```bash
+   gh project item-add <active-project> --owner <owner> --url <child-url>
+   ```
+
+   Don't set Type/Size/AgentReady — `/scope` handles those when the child gets scoped.
+
+4. **Audit comment on parent:**
+
+   ```
+   [scope-spinoff] Filed #<child> from finding "<one-line finding text>".
+   ```
+
+   One comment per spin-off, not a batched list — makes the timeline legible per-finding.
+
+After all selected findings are filed, **rewrite the parent's body** to remove the spun-off entries from §Side findings. Remaining findings keep their original numbering shifted to fill gaps (1, 2, 3 after removing original 2 means new 1, 2 — the user re-runs `/scope-spinoff` with fresh indices).
+
+If §Side findings becomes empty after removal, delete the section header too.
+
+## Dry-run
+
+`--dry-run` prints the planned actions without executing:
+
+```
+Would file:
+  - "chore(substrate): drop unreferenced drop_handler" (from finding 1)
+  - "test(actor): add coverage for ReplaceResult error path" (from finding 3)
+
+Would remove findings 1, 3 from #<parent> §Side findings.
+Would add 2 audit comments to #<parent>.
+
+(no changes made — re-run without --dry-run to file)
+```
+
+## Failure modes
+
+- **No §Side findings on parent**: refuse with *"No side findings on #N to spin off."*
+- **Index out of range**: refuse with valid range, e.g. *"Index 5 is out of range — valid: 1-4."*
+- **Filing partway through fails** (e.g. GitHub rate limit between findings 2 and 3): commit completed work — already-filed issues stay filed, already-removed entries stay removed. Report which indices succeeded and which failed. The user re-runs with the failed indices once the cause is resolved.
+- **Conventional-commit scope unknown** (file pointer ambiguous): ask the user inline:
+
+  ```
+  Finding 3 has no clear crate scope: "<text>"
+  Use which scope? (e.g. substrate, actor, mesh, or "skip" to omit this finding)
+  ```
+
+- **Parent issue closed**: still allowed — informational findings can be filed against a closed parent. Add a note in the audit comment that the parent is closed.
+
+## What `/scope-spinoff` does NOT do
+
+- Scope the child issues. They're filed at `Phase=Backlog` with a title + description; running `/scope <child>` is a separate operation.
+- Auto-link as dependencies. The §Found during line in the body and the `[scope-spinoff]` audit comment on the parent are the connection. GitHub's native `--add-dependency` feature could be added in v2 if the dependency graph view becomes load-bearing.
+- Modify §Problem statement, §Design notes, or §Implementation plan on the parent. Only §Side findings is touched.
+- Reorder remaining findings. Index reuse means re-run = different number for the same item; user is expected to re-read after a partial spin-off.
+
+## Why removal, not strikethrough
+
+Two alternatives considered for handling spun-off entries:
+
+- **Strikethrough**: visually clear what was spun, preserves history in-body. But clutters the section over time and competes with future spin-off runs.
+- **Move to a §Spun off subsection**: keeps the body as the canonical record. But duplicates the audit-comment trail and bloats the body.
+
+**Removal** is cleanest: the §Side findings section stays a live to-triage list; the audit comments are the historical record; the child issue itself carries the long-form context. The body shouldn't be a log.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: scope
+description: Walk a GitHub issue Define → Design → Plan and update the release Project board. Stops at Plan with AgentReady=No, awaiting user approval via /approve. Aggressive (agent makes design calls) and resumable (per-phase updates to the board).
+---
+
+# /scope — release scoping skill
+
+Walk a single issue from Backlog through Define → Design → Plan, producing a problem statement, design rationale, and implementation plan as structured body sections. Updates the active release Project's `Phase` field as it advances. Stops at `Plan` with `AgentReady=No`, awaiting user review via `/approve`.
+
+This skill produces **scoping artifacts only**. It does not write production code (that's `/delegate`), open implementation PRs, or set `AgentReady=Yes` (that's `/approve`).
+
+## Invocation
+
+```
+/scope <issue-number>                fresh run, or resume from current Phase
+/scope <issue-number> --phase define rewrite Define section, redo downstream
+/scope <issue-number> --phase design rewrite Design section, redo Plan
+/scope <issue-number> --phase plan   rewrite Plan section only
+```
+
+## Configuration
+
+Reads `.claude/release-state.json` at the repo root:
+
+```json
+{
+  "active_project": 2,
+  "project_node_id": "PVT_kwHOC4r7e84BYJmX",
+  "release_version": "0.4",
+  "owner": "iamacoffeepot",
+  "field_cache": {
+    "Phase":      { "id": "PVTSSF_...", "options": { "Backlog": "...", "Define": "...", ... } },
+    "Type":       { "id": "...", "options": { ... } },
+    "Size":       { "id": "...", "options": { ... } },
+    "AgentReady": { "id": "...", "options": { ... } },
+    "BounceTo":   { "id": "...", "options": { ... } }
+  }
+}
+```
+
+If the file is missing, abort with: *"No active release state. Run `/release-init <version>` first or create `.claude/release-state.json`."*
+
+The cache is populated by `/release-init`; this skill never writes it.
+
+## Phase walk
+
+For each sub-phase: read inputs, write the corresponding body section, post a brief progress comment, advance the `Phase` field on the project board. If a sub-phase has nothing to do (already complete on a resumed run), skip it.
+
+### Define
+
+- **Inputs**: issue body, comments, linked issues (`gh issue view <n> --json body,comments,closingIssuesReferences`).
+- **Output**: replaces or adds `## Problem statement` section in the body. Two short paragraphs:
+  1. *What's being solved.* The concrete problem in plain language.
+  2. *Why now / success criteria.* Why this release; what "done" looks like observably.
+- **Bounce**: if the body is too vague to frame a problem (e.g. one-line title, no description, no linked context), self-bounce with `Phase=Bounced`, `BounceTo=Define`, and a comment asking the specific clarifying question. Don't guess.
+- **Project board**: set `Phase=Design` on success.
+
+### Design
+
+- **Inputs**: this issue's body so far, related ADRs in `docs/adr/`, the auto-memory directory, relevant code in the affected crates (read via Read tool, not just grep).
+- **Posture**: aggressive — the agent picks between roughly-equal options and notes the rejected one. Self-bounce only when options are truly tied *or* the right answer needs information only the user has.
+- **Output**: replaces or adds `## Design notes` section. Structure:
+  ```
+  ### Chosen approach
+  <one paragraph: what we'll do and why>
+
+  ### Rejected options
+  - **<option A name>** — why not (one line)
+  - **<option B name>** — why not (one line)
+
+  ### Affected surfaces
+  <crates, public traits, wire formats, ADRs touched>
+  ```
+- **ADR drafting**: if the chosen approach is load-bearing (touches public traits, wire formats, lifecycle, dispatch, or otherwise looks architectural), scaffold an ADR via the `/adr` skill on a `docs/adr-NNNN-<slug>` branch and open a PR. Link the ADR PR in the Design notes section. The issue is not eligible for `/approve` until the ADR PR is merged.
+- **Bounce**: rare. Use only when truly stuck on a value-judgment the user must make.
+- **Project board**: set `Phase=Plan` on success.
+
+### Plan
+
+- **Inputs**: this issue's body (Define + Design must be present), the affected files (deeper read than Design — look at the actual code that will change).
+- **Output**: replaces or adds two sections:
+
+  ```
+  ## Implementation plan
+
+  1. <step> — <files touched> — <test coverage>
+  2. <step> — ...
+  ```
+
+  And, if the work spans multiple PRs:
+
+  ```
+  ## Sub-issues
+
+  - #NNN <child issue title>
+  - #MMM <child issue title>
+  ```
+
+- **Multi-PR split** triggers when:
+  - More than 3 logically-separable changes, *or*
+  - More than 2 crates with logically-separable work
+  - In that case, file each sub-issue (Phase=Backlog initially, link parent), update §Sub-issues, and scope each child in a follow-up `/scope` run.
+- **Size estimation** — set the `Size` custom field on the project item:
+  - **S**: single file, single concept, <100 LOC change
+  - **M**: single crate, multiple files, <500 LOC change
+  - **L**: cross-crate, architectural, or >500 LOC change
+- **Project board**: leave `Phase=Plan`; set `AgentReady=No` (default, but explicit). This is the resting state awaiting `/approve`.
+
+## Side findings
+
+During Design and Plan reads, the agent will inevitably notice unrelated issues — dead code, undocumented invariants, latent bugs in adjacent files. Don't chase them. Add a body section:
+
+```
+## Side findings
+
+- <one-line description> — <pointer: file:line or crate>
+- ...
+```
+
+These are *not auto-filed* as child issues. The user reviews them at `/approve` time and chooses which to spin off via `/scope-spinoff <issue>` (separate skill).
+
+## Comments (audit trail)
+
+After each sub-phase completes, post a brief comment so the timeline is legible:
+
+```
+[scope] Define complete — see body §Problem statement
+[scope] Design complete — chose A over B because <one-line reason>
+[scope] Plan complete — Size=M, sub-issues filed: #NNN, #MMM
+```
+
+Bounces are full comments with the question/blocker. Don't pad them with summaries of the section.
+
+## Body editing mechanics
+
+`gh issue edit <n> --body <text>` replaces the entire body. To avoid clobbering user-written content:
+
+1. Read the current body.
+2. Identify scope-managed sections by their H2 headers: `## Problem statement`, `## Design notes`, `## Implementation plan`, `## Sub-issues`, `## Side findings`. Everything else is user content; preserve verbatim.
+3. Insert or replace the managed sections, preserving user content above and below them.
+4. Write back via `gh issue edit`.
+
+The agent must be careful here — the body is the canonical scope artifact and clobbering user-written background notes will erode trust.
+
+## Project board mechanics
+
+To update a single-select field on a project item:
+
+```
+gh project item-edit \
+    --id <item-id> \
+    --project-id <project-node-id> \
+    --field-id <field-id> \
+    --single-select-option-id <option-id>
+```
+
+All four IDs come from `.claude/release-state.json`'s `field_cache`. The item ID for a given issue:
+
+```
+gh project item-list <active_project> --owner <owner> --format json \
+  | jq '.items[] | select(.content.number == <issue-number>) | .id'
+```
+
+Cache item IDs per-issue per-run to avoid repeated lookups.
+
+## Restart and resume semantics
+
+- **Fresh `/scope <issue>`**: detect current `Phase` from the board. Run only the sub-phases that haven't completed. A completed sub-phase is one whose body section is present and non-empty.
+- **`/scope <issue> --phase <name>`**: force rewrite of that sub-phase's section regardless of completion. Downstream sub-phases re-run because their inputs changed. (E.g. redoing Design implies redoing Plan because Design choices drive Plan steps.)
+- **After a bounce**: the user resolves the bounce (clarifies the issue, picks the tied option), then re-invokes `/scope <issue>` to resume from the bounced phase.
+
+## What `/scope` does NOT do
+
+- Write production code (use `/delegate` after `/approve`).
+- Open implementation PRs (use `/delegate`).
+- Merge anything.
+- Auto-file side findings as child issues (use `/scope-spinoff`).
+- Set `AgentReady=Yes` (use `/approve`).
+- Set `Type` — that should come from the issue title's conventional-commit prefix (`feat:` → `feat`, `fix:` → `fix`, etc.). If unset, infer from title; if title has no prefix, leave unset and surface in a Plan-phase comment.
+
+## Failure modes to handle gracefully
+
+- **`.claude/release-state.json` missing**: abort with the helpful message above.
+- **Issue not in active project**: add it (`gh project item-add`), then proceed.
+- **`gh` lacks `project` scope**: abort with *"Run `gh auth refresh -s project`"*.
+- **Issue already at Phase=Done or Phase=Executing**: refuse with *"Issue is past Plan — use `/bounce` to regress or work in a fresh issue."*
+- **ADR drafting failure**: keep the issue at Design, post a comment explaining, don't advance to Plan.
+- **Body-edit collision (user edited body mid-run)**: re-read, re-merge, post a comment if there are conflicts in managed sections.

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,14 @@ spikes/*/target/
 .claude/worktrees/
 .claude/skills/*
 !.claude/skills/adr/
+!.claude/skills/approve/
 !.claude/skills/audit/
+!.claude/skills/bounce/
 !.claude/skills/delegate/
+!.claude/skills/implement/
+!.claude/skills/release-init/
+!.claude/skills/scope/
+!.claude/skills/scope-spinoff/
 !.claude/skills/sweep/
 # Agent audit artifacts — runs of an audit workflow that examines
 # the repo and emits findings. Outputs are per-run and per-machine,
@@ -30,3 +36,4 @@ spikes/*/target/
 # discoverable; everything else under it is ignored.
 /traces/*
 !/traces/.gitkeep
+.claude/release-state.json

--- a/docs/release/schema.md
+++ b/docs/release/schema.md
@@ -1,0 +1,59 @@
+# Release project schema
+
+Each aether release lives in its own GitHub Project (`aether 0.4`, `aether 0.5`, …). The schema is created by `release-project-init.sh <version>` and used by future `/release-*` skills.
+
+## Phase (custom single-select field — board's grouping column)
+
+We use a custom `Phase` field rather than the default `Status` because we need to set its options programmatically; `Status`'s options aren't editable via `gh project field-create`. Group the board view by Phase and ignore Status.
+
+| Phase     | Meaning                                                    | Advances by  |
+|-----------|------------------------------------------------------------|--------------|
+| Backlog   | Not yet picked up for this release                         | User         |
+| Define    | Problem framing in progress                                | User + Claude |
+| Design    | Tradeoffs / options / ADR drafting                         | User + Claude |
+| Plan      | Sequencing, dependencies, sub-issues                       | User + Claude |
+| Ready     | Agent-ready; awaiting dispatch                             | Gate: `AgentReady=Yes` |
+| Executing | Agent has the issue; PR in flight                          | Auto         |
+| Refine    | CI-feedback loop, agent-driven                             | Auto         |
+| Done      | PR merged                                                  | Auto         |
+| Bounced   | Phase regression — see `BounceTo`                          | User triage  |
+| Stalled   | Env/tooling failure, blocks dispatch                       | User triage  |
+
+## Custom fields
+
+| Field        | Type           | Values / shape                                | Notes |
+|--------------|----------------|-----------------------------------------------|-------|
+| `Phase`      | single-select  | (see above)                                   | Board column |
+| `Type`       | single-select  | feat / fix / chore / docs / refactor / ci / test | Mirrors conventional-commit type |
+| `Size`       | single-select  | S / M / L                                     | Caps parallelism in Phase C executor |
+| `AgentReady` | single-select  | No (default) / Yes                            | Gate to `Ready` |
+| `BounceTo`   | single-select  | Plan / Design / Define                        | Only meaningful when `Phase=Bounced` |
+| `ADR`        | text           | e.g. "ADR-0072"                               | Non-null in `Design` if architectural |
+| `AuthBudget` | text           | freeform                                      | Phase C placeholder (cost/time/retry caps) |
+
+## Native fields used
+
+- `Repository`: auto-populated when issues are added.
+- Issue dependencies: GH's native feature, not a custom field. `gh issue edit <n> --add-dependency <m>` and the dependency graph view.
+
+## Phase-transition rules (enforced socially in Phase B; codified in `/release-promote` in Phase C)
+
+```
+Backlog  → Define     body has a problem statement
+Define   → Design     if multi-PR, umbrella issue exists; if architectural, ADR drafted
+Design   → Plan       tradeoffs aired in comments; ADR merged if applicable
+Plan     → Ready      dependencies declared, AgentReady=Yes, one concept per issue
+Ready    → Executing  agent dispatched (via /delegate or fleet executor)
+Executing → Refine    PR opened, CI running
+Refine   → Done       CI green, merged
+Executing/Refine → Bounced   agent surfaced an upstream-phase issue (BounceTo set)
+Any      → Stalled    env/tooling failure (not the issue's fault)
+```
+
+## Operations
+
+- **Create release project:** `release-project-init.sh 0.4`
+- **Add issue to project:** `gh project item-add <project> --owner iamacoffeepot --url <issue-url>`
+- **Set a field on an issue:** `gh project item-edit --id <item-id> --field-id <field-id> --single-select-option-id <option-id>` (or `--text` / `--number` etc.)
+
+Field and option IDs aren't human-readable; future `/release-*` skills will cache them at project-create time so callers can use field names directly.

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# release-project-init.sh — create a GitHub Project v2 for an aether release.
+#
+# Usage:
+#   release-project-init.sh <version> [--owner <owner>]
+#
+# Example:
+#   release-project-init.sh 0.4
+#   release-project-init.sh 0.4-sandbox --owner iamacoffeepot
+#
+# Idempotent? No. Creates a fresh project each call.
+
+set -euo pipefail
+
+VERSION="${1:?usage: $0 <version> [--owner <owner>]}"
+shift || true
+
+OWNER="iamacoffeepot"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --owner) OWNER="$2"; shift 2;;
+        *) echo "unknown arg: $1" >&2; exit 64;;
+    esac
+done
+
+TITLE="aether ${VERSION}"
+
+echo "→ Creating project: ${TITLE} (owner: ${OWNER})"
+PROJECT_JSON=$(gh project create --owner "$OWNER" --title "$TITLE" --format json)
+PROJECT_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
+PROJECT_NUMBER=$(echo "$PROJECT_JSON" | jq -r '.number')
+echo "  ${PROJECT_URL}"
+
+create_select() {
+    local name="$1" options="$2"
+    echo "  + ${name} (single-select)"
+    gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+        --name "$name" --data-type SINGLE_SELECT \
+        --single-select-options "$options" >/dev/null
+}
+
+create_text() {
+    local name="$1"
+    echo "  + ${name} (text)"
+    gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+        --name "$name" --data-type TEXT >/dev/null
+}
+
+create_select "Phase"      "Backlog,Define,Design,Plan,Ready,Executing,Refine,Done,Bounced,Stalled"
+create_select "Type"       "feat,fix,chore,docs,refactor,ci,test"
+create_select "Size"       "S,M,L"
+create_select "AgentReady" "No,Yes"
+create_select "BounceTo"   "Plan,Design,Define"
+create_text   "ADR"
+create_text   "AuthBudget"
+
+cat <<EOF
+
+✓ Project ${PROJECT_NUMBER} created.
+
+Next steps (manual, in the UI):
+  1. Open ${PROJECT_URL}
+  2. Board view → group by Phase (not the default Status)
+  3. Optionally hide the default Status field
+
+Programmatic next:
+  gh project item-add ${PROJECT_NUMBER} --owner ${OWNER} --url <issue-url>
+  gh project field-list ${PROJECT_NUMBER} --owner ${OWNER} --format json  # for field/option IDs
+EOF


### PR DESCRIPTION
Phase B foundation for the release-execution model from iamacoffeepot/aether#957. All inert until invoked — no `settings.json` changes, no auto-runs, no PR-flow impact today.

## Summary

- `docs/release/schema.md` — GH Project schema (Phase column + Type/Size/AgentReady/BounceTo/ADR/AuthBudget custom fields)
- `scripts/release-project-init.sh` — bootstrap script; creates the project, seeds all fields
- `.claude/skills/release-init/` — wraps the script, writes the per-user `.claude/release-state.json` field cache
- `.claude/skills/scope/` — Backlog → Define → Design → Plan walker, with §Side findings + ADR drafting
- `.claude/skills/approve/` — Plan → Ready gate with ADR-merged check
- `.claude/skills/implement/` — Ready → PR-green executor with CI feedback loop, retry cap, structured self-bounce
- `.claude/skills/bounce/` — explicit phase regression (user-driven; internal skills self-bounce via the same mechanism)
- `.claude/skills/scope-spinoff/` — interactive side-findings → child-issues triage

## How it stays inert

Every skill checks for `.claude/release-state.json` and refuses with a pointer if absent. The file is per-user, gitignored, populated only by `/release-init <version>`. Nothing fires implicitly.

## Replaces nothing

`/delegate` stays in place for ad-hoc agent-tagged work outside the project flow. See the comparison table at the end of `/implement`'s SKILL.md for the difference in scope.

## Test plan

- [ ] Read each SKILL.md for consistency (cross-skill contracts, audit-comment prefixes, error-message style)
- [ ] `/release-init 0.5-sandbox --reuse 2` against the existing sandbox project — verifies state cache write
- [ ] `/scope <small-test-issue>` end-to-end on a low-risk issue
- [ ] `/approve` the resulting Plan state
- [ ] `/implement` against a trivial fix, verify the CI loop classifies correctly
- [ ] `/bounce` from Plan back to Design with `--reason`
- [ ] `/scope-spinoff --dry-run` on an issue with §Side findings

Refs iamacoffeepot/aether#957.