### PR TITLE
fix(substrate): crash-time JSONL log dump on panic (ADR-0081 §4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "png",
  "postcard",
  "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
  "wasmparser 0.249.0",

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -34,6 +34,10 @@ aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"
 postcard = { version = "1.1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
+# ADR-0081 §4 crash dump: serialize the panicking actor's ring as
+# JSONL on a panic-hook write path. Read-side consumers (operator
+# `jq` queries) match.
+serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wasmtime = "44"

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -1,10 +1,21 @@
-// Substrate panic-hook plumbing (issue #321 Phase 1).
+// Substrate panic-hook plumbing.
 //
-// Installs a process-global panic hook that routes panics through
-// `tracing::error!` so they surface in `engine_logs` via the existing
-// ADR-0023 capture path. Without this, panics on dispatcher threads
-// (`std::thread::Builder::spawn` in `scheduler.rs`) print to stderr
-// only — and stderr is not what the capture layer reads.
+// Two responsibilities, layered in order:
+//
+// 1. **Tracing event.** Routes panics through `tracing::error!` so
+//    the panicking actor's own `ActorLogRing` (ADR-0081 §1) captures
+//    the panic in-band — `engine_logs` callers see the panic the
+//    same way they see any other event from that actor. Without
+//    this, panics on dispatcher threads (`std::thread::Builder::spawn`
+//    in `scheduler.rs`) print to stderr only.
+//
+// 2. **JSONL crash dump (ADR-0081 §4).** Synchronously reads the
+//    panicking actor's `ActorLogRing` snapshot, writes a panic
+//    header + ring contents to `<crash-dir>/<unix_ms>/<thread>.jsonl`
+//    before the process tears down. Restores the post-mortem
+//    retention property ADR-0023 §3 originally committed to (gone
+//    silently after iamacoffeepot/aether#776 retired the hub-side
+//    store). Closes iamacoffeepot/aether#825.
 //
 // Chains the previous hook (`take_hook` -> closure-wraps it ->
 // `set_hook`) so the test harness's panic formatter, color_eyre /
@@ -21,14 +32,35 @@
 use std::any::Any;
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::env;
+use std::fs;
+use std::io;
+use std::io::Write as _;
 use std::panic::{self, PanicHookInfo};
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_actor::Local;
+use aether_actor::log::ActorLogRing;
+use aether_kinds::LogEntry;
 
 /// Env var that forces backtrace capture without flipping
 /// `RUST_BACKTRACE` for the whole process (which would change every
 /// other crate's panic output).
 pub const ENV_BACKTRACE: &str = "AETHER_BACKTRACE";
+
+/// Disables the JSONL crash-dump path entirely. Anything truthy
+/// (`"1"`, `"true"`, any non-empty value other than `"0"` / `"false"`)
+/// skips the file write; the tracing event still fires.
+pub const ENV_CRASH_LOG_DISABLE: &str = "AETHER_CRASH_LOG_DISABLE";
+
+/// Override the crash-dump base directory. Each crash gets a
+/// `<base>/<unix_ms>/` subdirectory; the panicking actor's ring
+/// lands at `<base>/<unix_ms>/<thread>.jsonl`. Unset → default per
+/// ADR-0081 §4 (`$XDG_DATA_HOME/aether/crash/`, falling back to
+/// `$HOME/.local/share/aether/crash/`).
+pub const ENV_CRASH_LOG_DIR: &str = "AETHER_CRASH_LOG_DIR";
 
 static INIT: OnceLock<()> = OnceLock::new();
 
@@ -55,24 +87,40 @@ fn make_hook(
     prev: Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>,
 ) -> Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static> {
     Box::new(move |info| {
-        emit_event(info);
+        // Order matters: snapshot the ring + write the JSONL dump
+        // *before* the tracing event so the dump captures the
+        // panicking actor's history without the panic event itself
+        // appearing inside it (the event lands on the ring through
+        // the `ActorAwareLayer` push). Both paths swallow their own
+        // failures — a panic during the panic hook is the worst-
+        // case-scenario; we never want to obscure the original
+        // payload by panicking again here.
+        let timestamp_unix_ms = now_unix_ms();
+        let thread = thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>").to_owned();
+        let location = info.location().map_or_else(
+            || "<unknown>".to_string(),
+            |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
+        );
+        let payload = payload_string(info.payload());
+        let backtrace = capture_backtrace();
+
+        write_crash_dump(
+            timestamp_unix_ms,
+            &thread_name,
+            &location,
+            &payload,
+            backtrace.as_ref(),
+        );
+        emit_event(&thread_name, &location, &payload, backtrace.as_ref());
         prev(info);
     })
 }
 
-fn emit_event(info: &PanicHookInfo<'_>) {
-    let thread = thread::current();
-    let thread_name = thread.name().unwrap_or("<unnamed>");
-    let location = info.location().map_or_else(
-        || "<unknown>".to_string(),
-        |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
-    );
-    let payload = payload_string(info.payload());
-    let backtrace = capture_backtrace();
-
+fn emit_event(thread_name: &str, location: &str, payload: &str, backtrace: Option<&Backtrace>) {
     // The current `tracing::Span` is auto-captured by the dispatcher
     // (subscriber-side concern), so component / mailbox / kind ride
-    // along when the panic happens inside `dispatcher_loop` without
+    // along when the panic happens inside the dispatch loop without
     // having to thread them in here.
     if let Some(bt) = backtrace {
         tracing::error!(
@@ -92,6 +140,158 @@ fn emit_event(info: &PanicHookInfo<'_>) {
             "panic on substrate thread",
         );
     }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
+        #[allow(clippy::cast_possible_truncation)]
+        let ms = d.as_millis() as u64;
+        ms
+    })
+}
+
+/// ADR-0081 §4 crash dump. Reads the panicking actor's
+/// [`ActorLogRing`] snapshot via the thread-local `ActorSlots` stamp
+/// the dispatch loop opened, writes a panic header line followed by
+/// one JSONL record per ring entry to `<crash-dir>/<unix_ms>/<thread>.jsonl`.
+///
+/// Best-effort: any failure (env-var-unparseable, no ring stamped,
+/// fs write failure) silently returns. The panic itself is still
+/// surfaced via the tracing event that follows; the JSONL file is
+/// the *forensic* surface, not the primary signal.
+///
+/// Skipped entirely when `AETHER_CRASH_LOG_DISABLE` is truthy.
+fn write_crash_dump(
+    timestamp_unix_ms: u64,
+    thread_name: &str,
+    location: &str,
+    payload: &str,
+    backtrace: Option<&Backtrace>,
+) {
+    if crash_log_disabled() {
+        return;
+    }
+    let Some(dir) = resolve_crash_dir(timestamp_unix_ms) else {
+        return;
+    };
+    if let Err(e) = fs::create_dir_all(&dir) {
+        // Stderr only — the panic itself is the load-bearing
+        // signal; failure to write the forensic dump should not
+        // obscure it with extra noise on the normal logging path.
+        let _ = writeln!(
+            io::stderr(),
+            "aether-substrate: failed to create crash dir {}: {e}",
+            dir.display(),
+        );
+        return;
+    }
+    let path = dir.join(format!("{}.jsonl", sanitize_filename(thread_name)));
+    // Snapshot the ring on the panicking thread — `try_with` reads
+    // the actor's `ActorSlots` stamp, which is live for the
+    // duration of the dispatch loop's `local::with_stamped`. Out-of-
+    // actor panics (substrate boot, scheduler init) see `None` and
+    // we write only the header.
+    let ring = ActorLogRing::try_with(ActorLogRing::snapshot);
+    let backtrace_text = backtrace
+        .map(|bt| matches!(bt.status(), BacktraceStatus::Captured).then(|| format!("{bt}")))
+        .and_then(|opt| opt);
+    if let Err(e) = write_jsonl(
+        &path,
+        timestamp_unix_ms,
+        thread_name,
+        location,
+        payload,
+        backtrace_text.as_deref(),
+        ring.as_deref(),
+    ) {
+        let _ = writeln!(
+            io::stderr(),
+            "aether-substrate: failed to write crash dump {}: {e}",
+            path.display(),
+        );
+    }
+}
+
+fn crash_log_disabled() -> bool {
+    env::var(ENV_CRASH_LOG_DISABLE).is_ok_and(|v| {
+        let v = v.trim();
+        !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+    })
+}
+
+/// `$AETHER_CRASH_LOG_DIR/<unix_ms>/` if set; else
+/// `$XDG_DATA_HOME/aether/crash/<unix_ms>/`; else
+/// `$HOME/.local/share/aether/crash/<unix_ms>/`. `None` only when
+/// neither override nor `$HOME` is available (rare — typically
+/// containerised env with neither set).
+fn resolve_crash_dir(timestamp_unix_ms: u64) -> Option<PathBuf> {
+    let base = if let Ok(dir) = env::var(ENV_CRASH_LOG_DIR) {
+        PathBuf::from(dir)
+    } else if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+        PathBuf::from(xdg).join("aether").join("crash")
+    } else {
+        let home = env::var("HOME").ok()?;
+        PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("aether")
+            .join("crash")
+    };
+    Some(base.join(timestamp_unix_ms.to_string()))
+}
+
+/// Replace path-unfriendly characters in the thread name so it
+/// survives as a filename component. Thread names in aether tend to
+/// look like `aether-worker-2` (pool) or `aether.audio` (per-actor
+/// Thread scheduling); only `:` shows up via the trampoline format
+/// `aether.component.trampoline:NAME` and the dispatcher trims it
+/// before naming the thread anyway. Keep the routine defensive for
+/// future scheduler shapes.
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '\0' => '-',
+            c => c,
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_jsonl(
+    path: &Path,
+    timestamp_unix_ms: u64,
+    thread_name: &str,
+    location: &str,
+    payload: &str,
+    backtrace: Option<&str>,
+    ring: Option<&[LogEntry]>,
+) -> io::Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+
+    // Header line — one JSON object capturing the panic context.
+    let header = serde_json::json!({
+        "kind": "panic",
+        "timestamp_unix_ms": timestamp_unix_ms,
+        "thread": thread_name,
+        "location": location,
+        "payload": payload,
+        "backtrace": backtrace,
+        "ring_entries": ring.map_or(0, <[LogEntry]>::len),
+    });
+    writeln!(file, "{header}")?;
+
+    // Ring entries — one JSON object per line, in push order.
+    if let Some(entries) = ring {
+        for entry in entries {
+            let line = serde_json::to_string(entry).map_err(io::Error::other)?;
+            writeln!(file, "{line}")?;
+        }
+    }
+    Ok(())
 }
 
 /// Stringify the panic payload. Std supports two common shapes —
@@ -336,5 +536,146 @@ mod tests {
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
             let _ = write!(self.0, "{}={:?};", field.name(), value);
         }
+    }
+
+    // ADR-0081 §4 crash-dump unit tests. The env-var-reading paths
+    // (`crash_log_disabled`, `resolve_crash_dir`) are deliberately
+    // not unit-tested in this module: cargo's parallel test execution
+    // shares the process env, and setting `AETHER_CRASH_LOG_DIR` /
+    // `AETHER_CRASH_LOG_DISABLE` here would race other tests in the
+    // same binary. The pure-fn write path (`write_jsonl`) and the
+    // filename-sanitisation routine cover the load-bearing logic
+    // without touching env state.
+
+    use aether_kinds::LogEntry;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process;
+
+    fn tempdir(suffix: &str) -> PathBuf {
+        let mut dir = env::temp_dir();
+        dir.push(format!(
+            "aether-panic-hook-test-{}-{}",
+            suffix,
+            process::id(),
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("tempdir creates");
+        dir
+    }
+
+    fn entry(level: u8, sequence: u64, message: &str) -> LogEntry {
+        LogEntry {
+            timestamp_unix_ms: 1_700_000_000_000 + sequence,
+            level,
+            target: "panic_hook_test".to_owned(),
+            message: message.to_owned(),
+            sequence,
+            origin: None,
+        }
+    }
+
+    /// `sanitize_filename` rewrites `/`, `\`, `:`, and NUL to `-`,
+    /// leaves other characters alone. The trampoline-style
+    /// `aether.component.trampoline:NAME` produces a `:`-containing
+    /// thread name today; the sanitiser keeps the file shape sane.
+    #[test]
+    fn sanitize_filename_rewrites_path_chars() {
+        assert_eq!(
+            sanitize_filename("aether.component.trampoline:camera"),
+            "aether.component.trampoline-camera",
+        );
+        assert_eq!(sanitize_filename("a/b\\c"), "a-b-c");
+        assert_eq!(sanitize_filename("aether.audio"), "aether.audio");
+    }
+
+    /// `write_jsonl` produces a header object on line 1 + one JSON
+    /// object per ring entry on subsequent lines. Verifies the
+    /// load-bearing shape — every consumer of the crash dump reads
+    /// this byte format.
+    #[test]
+    fn write_jsonl_emits_header_then_entries() {
+        let dir = tempdir("write_jsonl");
+        let path = dir.join("aether.audio.jsonl");
+        let ring = vec![entry(2, 1, "before crash a"), entry(3, 2, "before crash b")];
+        write_jsonl(
+            &path,
+            1_700_000_001_234,
+            "aether.audio",
+            "src/audio.rs:42:8",
+            "panic payload",
+            Some("backtrace text"),
+            Some(&ring),
+        )
+        .expect("write succeeds");
+
+        let contents = fs::read_to_string(&path).expect("readback");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 entries");
+
+        let header: serde_json::Value = serde_json::from_str(lines[0]).expect("header is json");
+        assert_eq!(header["kind"], "panic");
+        assert_eq!(header["timestamp_unix_ms"], 1_700_000_001_234u64);
+        assert_eq!(header["thread"], "aether.audio");
+        assert_eq!(header["location"], "src/audio.rs:42:8");
+        assert_eq!(header["payload"], "panic payload");
+        assert_eq!(header["backtrace"], "backtrace text");
+        assert_eq!(header["ring_entries"], 2);
+
+        let e0: LogEntry = serde_json::from_str(lines[1]).expect("entry 0 round-trips");
+        let e1: LogEntry = serde_json::from_str(lines[2]).expect("entry 1 round-trips");
+        assert_eq!(e0.message, "before crash a");
+        assert_eq!(e0.sequence, 1);
+        assert_eq!(e1.message, "before crash b");
+        assert_eq!(e1.sequence, 2);
+    }
+
+    /// With no ring stamped (out-of-actor panic), the header is
+    /// still written and `ring_entries` is 0 — the dump file
+    /// exists, just with no per-actor history.
+    #[test]
+    fn write_jsonl_with_no_ring_emits_header_only() {
+        let dir = tempdir("write_jsonl_no_ring");
+        let path = dir.join("scheduler-thread.jsonl");
+        write_jsonl(
+            &path,
+            1_700_000_002_000,
+            "scheduler-thread",
+            "src/scheduler.rs:1:1",
+            "host-thread panic",
+            None,
+            None,
+        )
+        .expect("write succeeds");
+        let contents = fs::read_to_string(&path).expect("readback");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1, "header only");
+        let header: serde_json::Value = serde_json::from_str(lines[0]).expect("header is json");
+        assert_eq!(header["ring_entries"], 0);
+        assert!(
+            header["backtrace"].is_null(),
+            "no backtrace → null in the JSON",
+        );
+    }
+
+    /// Empty ring (actor stamped but no events emitted) round-trips
+    /// the same way as a missing ring — header only, no entries.
+    /// Confirms the empty-slice branch in `write_jsonl`.
+    #[test]
+    fn write_jsonl_with_empty_ring_emits_header_only() {
+        let dir = tempdir("write_jsonl_empty_ring");
+        let path = dir.join("aether.idle.jsonl");
+        write_jsonl(
+            &path,
+            0,
+            "aether.idle",
+            "<unknown>",
+            "boom",
+            None,
+            Some(&[]),
+        )
+        .expect("write succeeds");
+        let contents = fs::read_to_string(&path).expect("readback");
+        assert_eq!(contents.lines().count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

ADR-0081 P2: synchronous JSONL crash dump on panic, restoring the post-mortem retention property ADR-0023 §3 originally committed to (regressed silently when iamacoffeepot/aether#776 retired the hub-side store).

On panic, `runtime::panic_hook` now:

1. Snapshots the panicking actor's `ActorLogRing` via the thread-local `ActorSlots` stamp the dispatch loop opens.
2. Writes a header line (timestamp, thread, location, payload, optional backtrace, ring entry count) followed by one JSON object per ring entry, to `<crash-dir>/<unix_ms>/<thread>.jsonl`.
3. Then emits the existing `tracing::error!` event, then calls the chained previous hook.

The dump runs *before* the tracing event so the file captures the actor's history without the panic event itself appearing inside it (the event lands via the `ActorAwareLayer` push). Both paths swallow their own failures — never panic-in-panic-hook.

## Crash dir resolution

| Env | Path |
|---|---|
| `AETHER_CRASH_LOG_DISABLE` truthy | skip the file write (tracing event still fires) |
| `AETHER_CRASH_LOG_DIR=<dir>` | `<dir>/<unix_ms>/<thread>.jsonl` |
| (default with `XDG_DATA_HOME` set) | `$XDG_DATA_HOME/aether/crash/<unix_ms>/<thread>.jsonl` |
| (default with only `HOME` set) | `$HOME/.local/share/aether/crash/<unix_ms>/<thread>.jsonl` |
| neither override nor `HOME` | skip silently |

## Filename naming

Uses the OS thread name (sanitised: `:` → `-` etc.). With the default `Pooled` scheduler workers share one thread name across actors, so the filename degrades to `aether-worker-N` — but the panic header carries location + payload + in-flight tracing-span fields, so per-actor attribution rides in the file's content. Precise per-actor file naming becomes available when an actor opts into `Thread` scheduling.

## What's not covered (yet)

- **End-to-end test that drives a panic and asserts file contents.** Skipped because cargo's parallel test execution shares the process env: setting `AETHER_CRASH_LOG_DIR` in one test races other panic-hook tests in the same binary. Unit tests cover the pure write path (`write_jsonl` + `sanitize_filename`); manual verification is `AETHER_CRASH_LOG_DIR=/tmp/aether-crash cargo run -p aether-substrate-bundle --bin aether-substrate-headless` + a deliberate panic.
- **Per-actor file naming under Pooled scheduling.** Documented degraded-mode; a follow-up could thread the actor's mailbox name through a `Local<ActorIdentity>` slot.

## Test plan

- [x] `cargo nextest run --workspace` — 1012/1012 pass (4 new panic-hook tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo doc` — clean
- [x] wasm32 cross-build — clean (`scripts/preflight.sh`)
- [ ] Manual: `AETHER_CRASH_LOG_DIR=/tmp/aether-crash` + deliberate panic, confirm file lands with expected JSONL

## New dependency

Adds `serde_json = "1"` to `aether-substrate` for JSONL encoding. The crate already pulls `serde` + `postcard`; `serde_json` is the natural pair for the JSONL on-disk surface.

Closes iamacoffeepot/aether#825

🤖 Generated with [Claude Code](https://claude.com/claude-code)