### PR TITLE
fix(substrate): dedupe now_unix_ms() across runtime modules

### DIFF
--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -17,8 +17,8 @@
 
 use aether_actor::Local;
 use aether_actor::log::{ActorLogRing, render_event};
-use std::time::{SystemTime, UNIX_EPOCH};
 
+use super::now_unix_ms;
 use std::io;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
@@ -71,14 +71,6 @@ pub fn emit_host_event(level: u32, target: &str, message: &str) {
     let _ = ActorLogRing::try_with_mut(|ring| {
         ring.push(level_u8, target, message, timestamp);
     });
-}
-
-fn now_unix_ms() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-        #[allow(clippy::cast_possible_truncation)]
-        let ms = d.as_millis() as u64;
-        ms
-    })
 }
 
 const FILTER_ENV: &str = "AETHER_LOG_FILTER";

--- a/crates/aether-substrate/src/runtime/mod.rs
+++ b/crates/aether-substrate/src/runtime/mod.rs
@@ -10,3 +10,13 @@ pub mod panic_hook;
 pub mod trace;
 
 pub use panic_hook::init_panic_hook;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn now_unix_ms() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
+        #[allow(clippy::cast_possible_truncation)]
+        let ms = d.as_millis() as u64;
+        ms
+    })
+}

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -39,11 +39,12 @@ use std::panic::{self, PanicHookInfo};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_actor::Local;
 use aether_actor::log::ActorLogRing;
 use aether_kinds::LogEntry;
+
+use super::now_unix_ms;
 
 /// Env var that forces backtrace capture without flipping
 /// `RUST_BACKTRACE` for the whole process (which would change every
@@ -140,14 +141,6 @@ fn emit_event(thread_name: &str, location: &str, payload: &str, backtrace: Optio
             "panic on substrate thread",
         );
     }
-}
-
-fn now_unix_ms() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-        #[allow(clippy::cast_possible_truncation)]
-        let ms = d.as_millis() as u64;
-        ms
-    })
 }
 
 /// ADR-0081 §4 crash dump. Reads the panicking actor's


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

- Qodana DuplicatedCode flagged identical bodies of `now_unix_ms()` in `runtime/log_install.rs` and `runtime/panic_hook.rs` (both shipped via iamacoffeepot/aether#961 / iamacoffeepot/aether#962 for ADR-0081). Leaked through because each PR only added one copy.
- Lift the helper to `runtime/mod.rs` as `pub(crate) fn now_unix_ms`; route both call sites through `super::now_unix_ms`.

Net diff: -18 / +13 (one new module-level helper, two locals retired).

## Test plan

- [x] `scripts/preflight.sh` green locally (fmt + clippy + nextest 1012/1012 + wasm32 cross-build).
- [x] Qodana green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)