### PR TITLE
chore(hooks): spell out errorsOnly=false in pre-push prompt

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -74,7 +74,10 @@ done < <(git diff --name-only "$base..HEAD" 2>/dev/null || true)
     echo
     if [[ ${#rust_files[@]} -gt 0 ]]; then
         echo "Then run \`mcp__rustrover__get_file_problems\` over each changed .rs"
-        echo "file (the qodana-equivalent that preflight.sh can't run locally):"
+        echo "file (the qodana-equivalent that preflight.sh can't run locally)."
+        echo "IMPORTANT: pass \`errorsOnly: false\` — the default is errors-only"
+        echo "and Qodana CI flags NOTICE-level findings (Duplicated code"
+        echo "fragment, Unnecessary path prefix) that get missed otherwise:"
         echo
         for f in "${rust_files[@]}"; do
             echo "    - $f"


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

Bake the `errorsOnly: false` discipline directly into the pre-push hook's prompt. The MCP tool defaults to errors-only output, so calls without the flag silently miss NOTICE-level Qodana findings (`Duplicated code fragment`, `Unnecessary path prefix`). iamacoffeepot/aether#991 bounced twice through CI for exactly this gap — the local "5 files clean" report I gave was a false negative because I called the tool with default flags.

The memory `feedback_rustrover_mcp_for_qodana_preflight.md` already documents the `errorsOnly: false` rule, but the hook prompt didn't echo it; under attention pressure the rule gets missed. Spelling it out in the on-disk hook output makes it impossible to skip.

## Test plan

- [x] `scripts/preflight.sh` reports "CI/repo-config-only change; CI will self-validate" — the `.claude/hooks/` path is in the docs/CI exception class.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)