### PR TITLE
feat(substrate): port chassis main loops onto lifecycle driver (ADR-0082 PR 3b)

### DIFF
--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -14,15 +14,50 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_actor::Actor;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     ComponentHostCapability, ComponentHostConfig, FsCapability, HandleCapability, HttpCapability,
     InputCapability, InputConfig, TcpCapability, fs::NamespaceRoots, http::HttpConfig,
     trace::TraceObserverCapability,
 };
+use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
+use aether_kinds::{Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::runtime::lifecycle::FatalAborter;
+use aether_substrate::{LifecycleDriverConfig, LifecycleGraph};
+
+/// Build the standard single-stage lifecycle config every Tick-driven
+/// chassis shares today (ADR-0082 PR 3b): a `Tick` self-loop with a
+/// `Quit` escape to a `Shutdown` terminal, relaying `Tick` to
+/// `aether.input` so the existing `InputCapability::on_tick` fan-out
+/// keeps routing to component subscribers. Headless / `test_bench` /
+/// desktop all use this identical shape; a chassis that adds
+/// `Render` / `Present` stages (ADR-0082 §11) builds its own graph
+/// instead.
+///
+/// # Panics
+/// Panics if the (compile-time-fixed) graph fails to build — it can't,
+/// the shape is structurally valid; the `expect` documents the
+/// invariant.
+#[must_use]
+pub fn tick_only_lifecycle_config() -> LifecycleDriverConfig<()> {
+    let graph = LifecycleGraph::<()>::builder()
+        .state::<Tick, _>(|()| Tick {})
+        .next::<Tick>()
+        .quit::<Shutdown>()
+        .terminal::<Shutdown, _>(|()| Shutdown {})
+        .start::<Tick>()
+        .build()
+        .expect("tick-only lifecycle graph is structurally valid");
+    let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
+    LifecycleDriverConfig {
+        graph,
+        context: (),
+        initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+    }
+}
 
 /// Args every full-stack chassis hands to [`with_common_caps`]. Kept
 /// as a flat struct (no defaults) so an added cap forces the chassis

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -14,15 +14,20 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_actor::Actor;
 use aether_capabilities::{
-    AudioCapability, CaptureBackend, ComponentHostConfig, InputConfig, RenderCapability,
-    RenderConfig, UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf,
-    fs::NamespaceRoots, http::HttpConfig as HttpConf,
+    AudioCapability, CaptureBackend, ComponentHostConfig, InputCapability, InputConfig,
+    RenderCapability, RenderConfig, UnsupportedTestBenchCapability,
+    audio::AudioConfig as AudioConf, fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
-use aether_kinds::WindowMode;
+use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
+use aether_kinds::{Shutdown, Tick, WindowMode};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{Chassis, SubstrateBoot, capture::CaptureQueue};
+use aether_substrate::{
+    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
+    capture::CaptureQueue,
+};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 
@@ -270,10 +275,32 @@ impl DesktopChassis {
             namespace_roots,
             http,
         };
+        // ADR-0082 §1 / PR 3b: desktop lifecycle graph mirrors the
+        // headless / test_bench shape today — Tick self-loops, Quit
+        // escapes to Shutdown. A future PR adds `Render` / `Present`
+        // states so the render cap subscribes per ADR-0082 §11; for
+        // now Tick is the only stage and `aether.input` relays it as
+        // before.
+        let lifecycle_graph = LifecycleGraph::<()>::builder()
+            .state::<Tick, _>(|()| Tick {})
+            .next::<Tick>()
+            .quit::<Shutdown>()
+            .terminal::<Shutdown, _>(|()| Shutdown {})
+            .start::<Tick>()
+            .build()
+            .expect("desktop lifecycle graph is structurally valid");
+        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
+        let lifecycle_config = LifecycleDriverConfig {
+            graph: lifecycle_graph,
+            context: (),
+            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+        };
+
         let builder = with_common_caps(Builder::<Self>::new(registry, Arc::clone(&mailer)), common)
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
-            .with_actor::<UnsupportedTestBenchCapability>(());
+            .with_actor::<UnsupportedTestBenchCapability>(())
+            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-desktop");
         builder.driver(driver).build()
     }

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -14,25 +14,22 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aether_actor::Actor;
 use aether_capabilities::{
-    AudioCapability, CaptureBackend, ComponentHostConfig, InputCapability, InputConfig,
-    RenderCapability, RenderConfig, UnsupportedTestBenchCapability,
-    audio::AudioConfig as AudioConf, fs::NamespaceRoots, http::HttpConfig as HttpConf,
+    AudioCapability, CaptureBackend, ComponentHostConfig, InputConfig, RenderCapability,
+    RenderConfig, UnsupportedTestBenchCapability, audio::AudioConfig as AudioConf,
+    fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
-use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
-use aether_kinds::{Shutdown, Tick, WindowMode};
+use aether_kinds::WindowMode;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{
-    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
-    capture::CaptureQueue,
-};
+use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
-use crate::chassis_common::{CommonBoot, maybe_with_rpc_server, with_common_caps};
+use crate::chassis_common::{
+    CommonBoot, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+};
 use crate::hub;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
@@ -275,32 +272,14 @@ impl DesktopChassis {
             namespace_roots,
             http,
         };
-        // ADR-0082 §1 / PR 3b: desktop lifecycle graph mirrors the
-        // headless / test_bench shape today — Tick self-loops, Quit
-        // escapes to Shutdown. A future PR adds `Render` / `Present`
-        // states so the render cap subscribes per ADR-0082 §11; for
-        // now Tick is the only stage and `aether.input` relays it as
-        // before.
-        let lifecycle_graph = LifecycleGraph::<()>::builder()
-            .state::<Tick, _>(|()| Tick {})
-            .next::<Tick>()
-            .quit::<Shutdown>()
-            .terminal::<Shutdown, _>(|()| Shutdown {})
-            .start::<Tick>()
-            .build()
-            .expect("desktop lifecycle graph is structurally valid");
-        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
-        let lifecycle_config = LifecycleDriverConfig {
-            graph: lifecycle_graph,
-            context: (),
-            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
-        };
-
+        // ADR-0082 §1 / PR 3b: desktop's lifecycle is the shared Tick-
+        // only graph today. A future PR adds `Render` / `Present`
+        // states so the render cap subscribes per ADR-0082 §11.
         let builder = with_common_caps(Builder::<Self>::new(registry, Arc::clone(&mailer)), common)
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<UnsupportedTestBenchCapability>(())
-            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
+            .with_actor::<LifecycleDriverCapability<()>>(tick_only_lifecycle_config());
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-desktop");
         builder.driver(driver).build()
     }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -56,7 +56,12 @@ pub struct App {
     /// `InputCapability` actor owns the subscriber table and fans
     /// out per-subscriber on its own dispatcher (issue 640).
     input_mailbox: MailboxId,
-    kind_tick: aether_data::KindId,
+    /// `aether.lifecycle` mailbox id, cached at boot. Each redraw
+    /// fires one `LifecycleAdvance` here; the driver broadcasts
+    /// Tick to `aether.input` via the chassis's `initial_subscribers`
+    /// relay, then waits for settlement before submitting the frame.
+    lifecycle_mailbox: MailboxId,
+    kind_lifecycle_advance: aether_data::KindId,
     kind_key: aether_data::KindId,
     kind_key_release: aether_data::KindId,
     kind_mouse_button: aether_data::KindId,
@@ -489,10 +494,16 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
+                // ADR-0082 PR 3b: redraw fires `LifecycleAdvance` to
+                // the lifecycle driver, which broadcasts Tick to
+                // `aether.input` (via the chassis's `initial_subscribers`
+                // relay) plus any other subscribers. Settlement on the
+                // broadcast root replaces the prior
+                // `drain_frame_bound_or_abort` gate.
                 self.push_chassis_root(
-                    self.input_mailbox,
-                    self.kind_tick,
-                    encode_empty::<Tick>(),
+                    self.lifecycle_mailbox,
+                    self.kind_lifecycle_advance,
+                    encode_empty::<aether_kinds::LifecycleAdvance>(),
                     1,
                 );
                 if let Some(window) = &self.window {
@@ -713,10 +724,19 @@ impl DriverCapability for DesktopDriverCapability {
         // `App` and `about_to_wait` drains it inline between frames.
         let window_claim = ctx.claim_mailbox("aether.window")?;
 
+        let lifecycle_mailbox = mailbox_id_from_name(
+            <aether_substrate::LifecycleDriverCapability<()> as Actor>::NAMESPACE,
+        );
+        let kind_lifecycle_advance = <aether_kinds::LifecycleAdvance as Kind>::ID;
+        let _ = kind_tick; // PR 3b retired direct Tick push; the
+        // chassis still resolves the kind id via `boot.registry` for
+        // compatibility but the redraw handler no longer reads it.
+
         let app = App {
             queue: Arc::clone(&boot.queue),
             input_mailbox: mailbox_id_from_name(InputCapability::NAMESPACE),
-            kind_tick,
+            lifecycle_mailbox,
+            kind_lifecycle_advance,
             kind_key,
             kind_key_release,
             kind_mouse_button,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -22,8 +22,8 @@ use aether_capabilities::{
     ComponentHostConfig, HeadlessRenderCapability, HeadlessWindowCapability, InputCapability,
     InputConfig, UnsupportedTestBenchCapability, fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
-use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_data::Kind;
+use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{SetMasterGain, SetMasterGainResult, Shutdown, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -17,22 +17,20 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aether_actor::Actor;
 use aether_capabilities::{
-    ComponentHostConfig, HeadlessRenderCapability, HeadlessWindowCapability, InputCapability,
-    InputConfig, UnsupportedTestBenchCapability, fs::NamespaceRoots, http::HttpConfig as HttpConf,
+    ComponentHostConfig, HeadlessRenderCapability, HeadlessWindowCapability, InputConfig,
+    UnsupportedTestBenchCapability, fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
 use aether_data::Kind;
-use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
-use aether_kinds::{SetMasterGain, SetMasterGainResult, Shutdown, Tick};
+use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{
-    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
-};
+use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
-use crate::chassis_common::{CommonBoot, maybe_with_rpc_server, with_common_caps};
+use crate::chassis_common::{
+    CommonBoot, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+};
 use crate::hub;
 use aether_substrate::mail::registry::MailDispatch;
 use aether_substrate::runtime::lifecycle::FatalAborter;
@@ -223,37 +221,15 @@ impl HeadlessChassis {
             namespace_roots,
             http,
         };
-        // ADR-0082 §1 / PR 3b: headless lifecycle graph — Tick self-loops
-        // until Quit fires, at which point the next advance takes the
-        // quit edge to Shutdown. Today the chassis emits the timer ticks
-        // and the lifecycle driver broadcasts Tick to subscribers
-        // (including `aether.input` so the existing component fan-out
-        // path stays intact).
-        let lifecycle_graph = LifecycleGraph::<()>::builder()
-            .state::<Tick, _>(|()| Tick {})
-            .next::<Tick>()
-            .quit::<Shutdown>()
-            .terminal::<Shutdown, _>(|()| Shutdown {})
-            .start::<Tick>()
-            .build()
-            .expect("headless lifecycle graph is structurally valid");
-        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
-        let lifecycle_config = LifecycleDriverConfig {
-            graph: lifecycle_graph,
-            context: (),
-            // Relay Tick from the lifecycle driver to `aether.input` so
-            // the existing `InputCapability::on_tick` fan-out path keeps
-            // routing Tick to component subscribers (issue 640 phase 2)
-            // until PR 4's component migration moves them onto the
-            // lifecycle subscriber table directly.
-            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
-        };
-
+        // ADR-0082 §1 / PR 3b: headless uses the shared Tick-only
+        // lifecycle graph (Tick self-loops, Quit escapes to Shutdown);
+        // the timer pushes `LifecycleAdvance` and the driver broadcasts
+        // Tick to `aether.input` via the relay subscriber.
         let builder = with_common_caps(Builder::<Self>::new(registry, Arc::clone(&mailer)), common)
             .with_actor::<HeadlessRenderCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<UnsupportedTestBenchCapability>(())
-            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
+            .with_actor::<LifecycleDriverCapability<()>>(tick_only_lifecycle_config());
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-headless");
         builder.driver(driver).build()
     }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -17,15 +17,19 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aether_actor::Actor;
 use aether_capabilities::{
-    ComponentHostConfig, HeadlessRenderCapability, HeadlessWindowCapability, InputConfig,
-    UnsupportedTestBenchCapability, fs::NamespaceRoots, http::HttpConfig as HttpConf,
+    ComponentHostConfig, HeadlessRenderCapability, HeadlessWindowCapability, InputCapability,
+    InputConfig, UnsupportedTestBenchCapability, fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
+use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_data::Kind;
-use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
+use aether_kinds::{SetMasterGain, SetMasterGainResult, Shutdown, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{Chassis, SubstrateBoot};
+use aether_substrate::{
+    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
+};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{CommonBoot, maybe_with_rpc_server, with_common_caps};
@@ -219,10 +223,37 @@ impl HeadlessChassis {
             namespace_roots,
             http,
         };
+        // ADR-0082 §1 / PR 3b: headless lifecycle graph — Tick self-loops
+        // until Quit fires, at which point the next advance takes the
+        // quit edge to Shutdown. Today the chassis emits the timer ticks
+        // and the lifecycle driver broadcasts Tick to subscribers
+        // (including `aether.input` so the existing component fan-out
+        // path stays intact).
+        let lifecycle_graph = LifecycleGraph::<()>::builder()
+            .state::<Tick, _>(|()| Tick {})
+            .next::<Tick>()
+            .quit::<Shutdown>()
+            .terminal::<Shutdown, _>(|()| Shutdown {})
+            .start::<Tick>()
+            .build()
+            .expect("headless lifecycle graph is structurally valid");
+        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
+        let lifecycle_config = LifecycleDriverConfig {
+            graph: lifecycle_graph,
+            context: (),
+            // Relay Tick from the lifecycle driver to `aether.input` so
+            // the existing `InputCapability::on_tick` fan-out path keeps
+            // routing Tick to component subscribers (issue 640 phase 2)
+            // until PR 4's component migration moves them onto the
+            // lifecycle subscriber table directly.
+            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+        };
+
         let builder = with_common_caps(Builder::<Self>::new(registry, Arc::clone(&mailer)), common)
             .with_actor::<HeadlessRenderCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
-            .with_actor::<UnsupportedTestBenchCapability>(());
+            .with_actor::<UnsupportedTestBenchCapability>(())
+            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-headless");
         builder.driver(driver).build()
     }

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -20,11 +20,12 @@ use std::sync::atomic::AtomicU64;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use aether_actor::Actor;
 use aether_data::{Kind, KindId, encode_empty, mailbox_id_from_name};
 use aether_kinds::LifecycleAdvance;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{Mailer, SubstrateBoot, mail::MailboxId};
+use aether_substrate::{LifecycleDriverCapability, Mailer, SubstrateBoot, mail::MailboxId};
 
 use crate::chassis_root::next_chassis_correlation;
 
@@ -104,7 +105,9 @@ impl DriverCapability for HeadlessTimerCapability {
 
         Ok(HeadlessTimerRunning {
             queue: Arc::clone(&boot.queue),
-            lifecycle_mailbox: mailbox_id_from_name("aether.lifecycle"),
+            lifecycle_mailbox: mailbox_id_from_name(
+                <LifecycleDriverCapability<()> as Actor>::NAMESPACE,
+            ),
             kind_lifecycle_advance: <LifecycleAdvance as Kind>::ID,
             tick_period,
             _boot: boot,

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -20,10 +20,8 @@ use std::sync::atomic::AtomicU64;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use aether_actor::Actor;
-use aether_capabilities::InputCapability;
-use aether_data::{KindId, encode_empty, mailbox_id_from_name};
-use aether_kinds::Tick;
+use aether_data::{Kind, KindId, encode_empty, mailbox_id_from_name};
+use aether_kinds::LifecycleAdvance;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Mailer, SubstrateBoot, mail::MailboxId};
@@ -61,19 +59,33 @@ pub fn parse_tick_hz_env() -> u32 {
 /// ADR-0071 driver capability for the headless chassis. Owns the
 /// pieces the timer loop needs at construction time, then `boot()`
 /// captures them on a [`HeadlessTimerRunning`] that drives the loop.
+///
+/// Pre-ADR-0082 this drove `Tick` mail directly to `aether.input`;
+/// PR 3b reroutes through `LifecycleDriverCapability` so the driver
+/// owns the broadcast vocabulary and the substrate observes a
+/// labelled `aether.lifecycle` root for every frame chain.
 pub struct HeadlessTimerCapability {
     pub boot: SubstrateBoot,
+    /// Field kept for wire compatibility; the timer body no longer
+    /// touches `Tick` directly post-ADR-0082, but chassis builders
+    /// resolve the kind id from `SubstrateBoot::registry` once and
+    /// hand it through this struct. Removing the field would touch
+    /// every chassis call site; left as a no-op.
+    #[allow(dead_code)]
     pub kind_tick: KindId,
     pub tick_period: Duration,
 }
 
 pub struct HeadlessTimerRunning {
     queue: Arc<Mailer>,
-    /// `aether.input` mailbox id, cached at boot. Each generated tick
-    /// pushes one mail here and the input cap fans out per
-    /// subscriber (issue 640).
-    input_mailbox: MailboxId,
-    kind_tick: KindId,
+    /// `aether.lifecycle` mailbox id, cached at boot. Each tick fires
+    /// one `LifecycleAdvance` here; the lifecycle driver broadcasts
+    /// the current stage (Tick) to its subscriber set, including
+    /// `aether.input` per the chassis's `initial_subscribers`.
+    lifecycle_mailbox: MailboxId,
+    /// Kind id of [`LifecycleAdvance`], pre-resolved so the timer
+    /// loop body stays alloc-free per tick.
+    kind_lifecycle_advance: KindId,
     tick_period: Duration,
     /// `SubstrateBoot` drops at the end of `run()` so its scheduler
     /// joins workers before the chassis exits.
@@ -86,14 +98,14 @@ impl DriverCapability for HeadlessTimerCapability {
     fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
         let Self {
             boot,
-            kind_tick,
+            kind_tick: _,
             tick_period,
         } = self;
 
         Ok(HeadlessTimerRunning {
             queue: Arc::clone(&boot.queue),
-            input_mailbox: mailbox_id_from_name(InputCapability::NAMESPACE),
-            kind_tick,
+            lifecycle_mailbox: mailbox_id_from_name("aether.lifecycle"),
+            kind_lifecycle_advance: <LifecycleAdvance as Kind>::ID,
             tick_period,
             _boot: boot,
         })
@@ -104,8 +116,8 @@ impl DriverRunning for HeadlessTimerRunning {
     fn run(self: Box<Self>) -> Result<(), RunError> {
         let Self {
             queue,
-            input_mailbox,
-            kind_tick,
+            lifecycle_mailbox,
+            kind_lifecycle_advance,
             tick_period,
             _boot,
         } = *self;
@@ -129,11 +141,15 @@ impl DriverRunning for HeadlessTimerRunning {
             // backlog, which would just compound the stall.
             next_deadline = Instant::now() + tick_period;
 
+            // Fire-and-forget LifecycleAdvance. The driver's settlement
+            // gating tracks one pending advance at a time — frames that
+            // overlap (settlement still pending when the next deadline
+            // hits) warn-drop at the driver per ADR-0082 §6.
             queue.push_chassis_root_mail(
                 next_chassis_correlation(&chassis_correlation),
-                input_mailbox,
-                kind_tick,
-                encode_empty::<Tick>(),
+                lifecycle_mailbox,
+                kind_lifecycle_advance,
+                encode_empty::<LifecycleAdvance>(),
                 1,
             );
         }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -31,7 +31,9 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty, encode_struct};
-use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult, Tick};
+#[cfg(test)]
+use aether_kinds::Tick;
+use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_actor::Actor;
@@ -321,7 +323,9 @@ impl TestBench {
         let queue = Arc::clone(&boot.queue);
         let outbound = Arc::clone(&boot.outbound);
         let registry = Arc::clone(&boot.registry);
-        let lifecycle_mailbox = aether_data::mailbox_id_from_name("aether.lifecycle");
+        let lifecycle_mailbox = aether_data::mailbox_id_from_name(
+            <aether_substrate::LifecycleDriverCapability<()> as Actor>::NAMESPACE,
+        );
         let kind_lifecycle_advance = <aether_kinds::LifecycleAdvance as Kind>::ID;
         let _ = kind_tick; // PR 3b retired direct Tick push; kept on the
         // build result for wire-compat with binaries that haven't migrated yet.
@@ -795,7 +799,9 @@ impl TestBench {
             let rx = registry.subscribe_settlement(advance_root);
             if rx.recv_timeout(SETTLEMENT_TIMEOUT).is_err() {
                 return Err(TestBenchError::SettlementTimeout {
-                    recipient: "aether.lifecycle".to_owned(),
+                    recipient:
+                        <aether_substrate::LifecycleDriverCapability<()> as Actor>::NAMESPACE
+                            .to_owned(),
                     kind_name: aether_kinds::LifecycleAdvance::NAME,
                 });
             }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -141,11 +141,15 @@ pub struct TestBench {
 
     gpu: Gpu,
 
-    /// `aether.input` mailbox id, cached at boot. `advance()` ticks
-    /// fan through this single push and the input cap re-fans per
-    /// subscriber (issue 640).
-    input_mailbox: MailboxId,
-    kind_tick: KindId,
+    /// `aether.lifecycle` mailbox id, cached at boot. `advance()`
+    /// fires one `LifecycleAdvance` here per requested tick; the
+    /// lifecycle driver broadcasts `Tick` to `aether.input` (relayed
+    /// via the chassis's `initial_subscribers`) and the rest of the
+    /// subscriber set per ADR-0082.
+    lifecycle_mailbox: MailboxId,
+    /// Kind id of [`LifecycleAdvance`], pre-resolved so the advance
+    /// loop body stays alloc-free per tick.
+    kind_lifecycle_advance: KindId,
     /// Snapshot of every frame-bound capability's pending counter
     /// (ADR-0074 §Decision 5). Today: render. Cloned out of
     /// `PassiveChassis::frame_bound_pending` at boot; `advance` /
@@ -317,9 +321,10 @@ impl TestBench {
         let queue = Arc::clone(&boot.queue);
         let outbound = Arc::clone(&boot.outbound);
         let registry = Arc::clone(&boot.registry);
-        let input_mailbox = aether_data::mailbox_id_from_name(
-            <aether_capabilities::InputCapability as Actor>::NAMESPACE,
-        );
+        let lifecycle_mailbox = aether_data::mailbox_id_from_name("aether.lifecycle");
+        let kind_lifecycle_advance = <aether_kinds::LifecycleAdvance as Kind>::ID;
+        let _ = kind_tick; // PR 3b retired direct Tick push; kept on the
+        // build result for wire-compat with binaries that haven't migrated yet.
         let frame_bound_pending = passive.frame_bound_pending();
 
         Ok(Self {
@@ -330,8 +335,8 @@ impl TestBench {
             capture_queue,
             events_rx,
             gpu,
-            input_mailbox,
-            kind_tick,
+            lifecycle_mailbox,
+            kind_lifecycle_advance,
             frame_bound_pending,
             frame: 0,
             next_correlation_id: AtomicU64::new(1),
@@ -774,18 +779,24 @@ impl TestBench {
             // test name the actual cause instead of timing out
             // generically on the reply pump.
             let registry = self.passive.settlement_registry();
-            let tick_root = self.queue.push_chassis_root_mail(
+            // ADR-0082 PR 3b: TestBench pushes `LifecycleAdvance` to the
+            // lifecycle driver, which broadcasts Tick to `aether.input`
+            // (relayed via the chassis's `initial_subscribers`) plus any
+            // other subscribers. Settlement on the broadcast root waits
+            // for the whole subtree — same property the prior direct-
+            // push path had.
+            let advance_root = self.queue.push_chassis_root_mail(
                 self.fresh_correlation_id(),
-                self.input_mailbox,
-                self.kind_tick,
-                encode_empty::<Tick>(),
+                self.lifecycle_mailbox,
+                self.kind_lifecycle_advance,
+                encode_empty::<aether_kinds::LifecycleAdvance>(),
                 1,
             );
-            let rx = registry.subscribe_settlement(tick_root);
+            let rx = registry.subscribe_settlement(advance_root);
             if rx.recv_timeout(SETTLEMENT_TIMEOUT).is_err() {
                 return Err(TestBenchError::SettlementTimeout {
-                    recipient: "aether.input".to_owned(),
-                    kind_name: Tick::NAME,
+                    recipient: "aether.lifecycle".to_owned(),
+                    kind_name: aether_kinds::LifecycleAdvance::NAME,
                 });
             }
         }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -10,7 +10,6 @@
 
 use std::sync::{Arc, Mutex};
 
-use aether_actor::Actor;
 use aether_capabilities::{
     CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability, InputCapability,
     InputConfig, RenderCapability, RenderConfig, RenderHandles, TcpCapability, fs::NamespaceRoots,
@@ -19,17 +18,17 @@ use aether_capabilities::{
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
 use aether_data::KindId;
-use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
-use aether_kinds::{Shutdown, Tick};
+use aether_kinds::Tick;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
-    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
-    capture::CaptureQueue, render::VERTEX_BUFFER_BYTES,
+    Chassis, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue,
+    render::VERTEX_BUFFER_BYTES,
 };
 
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
 use super::events::{ChassisEvent, EventSender};
+use crate::chassis_common::tick_only_lifecycle_config;
 use aether_substrate::mail::registry::MailDispatch;
 use std::io;
 
@@ -289,26 +288,10 @@ impl TestBenchChassis {
             );
         }
 
-        // ADR-0082 §1 / PR 3b: test-bench lifecycle graph — Tick self-
-        // loops, Quit escapes to Shutdown. Same shape as headless;
-        // the embedder pushes `LifecycleAdvance` via TestBench's
-        // own pumping logic, the driver broadcasts Tick to
-        // `aether.input` per the relay registered below.
-        let lifecycle_graph = LifecycleGraph::<()>::builder()
-            .state::<Tick, _>(|()| Tick {})
-            .next::<Tick>()
-            .quit::<Shutdown>()
-            .terminal::<Shutdown, _>(|()| Shutdown {})
-            .start::<Tick>()
-            .build()
-            .expect("test-bench lifecycle graph is structurally valid");
-        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
-        let lifecycle_config = LifecycleDriverConfig {
-            graph: lifecycle_graph,
-            context: (),
-            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
-        };
-
+        // ADR-0082 §1 / PR 3b: test-bench uses the shared Tick-only
+        // lifecycle graph. The embedder pushes `LifecycleAdvance` via
+        // TestBench's own pumping logic; the driver broadcasts Tick to
+        // `aether.input` via the relay subscriber.
         let mut builder = Builder::<Self>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
             .with_actor::<HandleCapability>(())
             .with_actor::<TraceObserverCapability>(())
@@ -318,7 +301,7 @@ impl TestBenchChassis {
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<TestBenchCapability>(test_bench_cap_config)
-            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
+            .with_actor::<LifecycleDriverCapability<()>>(tick_only_lifecycle_config());
         if let Some(roots) = io_roots {
             builder = builder.with_actor::<FsCapability>(roots);
         }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -10,6 +10,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use aether_actor::Actor;
 use aether_capabilities::{
     CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability, InputCapability,
     InputConfig, RenderCapability, RenderConfig, RenderHandles, TcpCapability, fs::NamespaceRoots,
@@ -18,11 +19,13 @@ use aether_capabilities::{
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
 use aether_data::KindId;
-use aether_kinds::Tick;
+use aether_data::{MailboxId as DataMailboxId, mailbox_id_from_name};
+use aether_kinds::{Shutdown, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
-    Chassis, SubstrateBoot, capture::CaptureQueue, render::VERTEX_BUFFER_BYTES,
+    Chassis, LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph, SubstrateBoot,
+    capture::CaptureQueue, render::VERTEX_BUFFER_BYTES,
 };
 
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
@@ -285,6 +288,26 @@ impl TestBenchChassis {
             );
         }
 
+        // ADR-0082 §1 / PR 3b: test-bench lifecycle graph — Tick self-
+        // loops, Quit escapes to Shutdown. Same shape as headless;
+        // the embedder pushes `LifecycleAdvance` via TestBench's
+        // own pumping logic, the driver broadcasts Tick to
+        // `aether.input` per the relay registered below.
+        let lifecycle_graph = LifecycleGraph::<()>::builder()
+            .state::<Tick, _>(|()| Tick {})
+            .next::<Tick>()
+            .quit::<Shutdown>()
+            .terminal::<Shutdown, _>(|()| Shutdown {})
+            .start::<Tick>()
+            .build()
+            .expect("test-bench lifecycle graph is structurally valid");
+        let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
+        let lifecycle_config = LifecycleDriverConfig {
+            graph: lifecycle_graph,
+            context: (),
+            initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+        };
+
         let mut builder = Builder::<Self>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
             .with_actor::<HandleCapability>(())
             .with_actor::<TraceObserverCapability>(())
@@ -293,7 +316,8 @@ impl TestBenchChassis {
             .with_actor::<TcpCapability>(())
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<HeadlessWindowCapability>(())
-            .with_actor::<TestBenchCapability>(test_bench_cap_config);
+            .with_actor::<TestBenchCapability>(test_bench_cap_config)
+            .with_actor::<LifecycleDriverCapability<()>>(lifecycle_config);
         if let Some(roots) = io_roots {
             builder = builder.with_actor::<FsCapability>(roots);
         }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -177,6 +177,7 @@ impl TestBenchChassis {
     /// vocabulary the substrate registers from
     /// `aether_kinds::descriptors::all()`, so a missing entry indicates
     /// a substrate-build bug.
+    #[allow(clippy::too_many_lines)] // PR 3b growth from lifecycle graph + relay wiring.
     pub fn build_passive(env: TestBenchEnv) -> anyhow::Result<TestBenchBuild> {
         let TestBenchEnv {
             name,

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -73,11 +73,11 @@ pub use chassis::ctx::{
     MailboxSender,
 };
 pub use chassis::error::{BootError, WedgedFrameBound};
+pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::mailer::Mailer;
 pub use mail::outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend,
 };
-pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use runtime::panic_hook::init_panic_hook;

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -77,6 +77,7 @@ pub use mail::mailer::Mailer;
 pub use mail::outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend,
 };
+pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};
 pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
 pub use runtime::panic_hook::init_panic_hook;

--- a/crates/aether-substrate/src/lifecycle/driver.rs
+++ b/crates/aether-substrate/src/lifecycle/driver.rs
@@ -363,7 +363,7 @@ impl<C: 'static + Send + Sync> NativeActor for LifecycleDriverCapability<C> {
         if let Some(registry) = self.mailer.settlement_registry() {
             registry.subscribe_settlement_mail(
                 root,
-                mailbox_id_from_name("aether.lifecycle"),
+                mailbox_id_from_name(<Self as aether_actor::Actor>::NAMESPACE),
                 <Settled as Kind>::ID,
                 Arc::clone(&self.mailer),
             );

--- a/crates/aether-substrate/src/lifecycle/driver.rs
+++ b/crates/aether-substrate/src/lifecycle/driver.rs
@@ -77,6 +77,15 @@ pub struct LifecycleDriverConfig<C> {
     /// timer, window handle, render queue) — see the `'static` bound
     /// requirement on `C`.
     pub context: C,
+    /// Initial `(stage_kind, mailbox)` pairs to populate the
+    /// subscriber table at boot. Chassis builders use this to wire
+    /// the relay (e.g. `(Tick::ID, aether.input)`) without round-
+    /// tripping a `LifecycleSubscribe` mail through the dispatcher.
+    /// Each pair must reference a stage kind declared by `graph` —
+    /// the boot path verifies this and returns `BootError` otherwise,
+    /// so misconfiguration fails fast at chassis-build rather than
+    /// silently dropping mail at runtime.
+    pub initial_subscribers: Vec<(KindId, DataMailboxId)>,
 }
 
 /// The `aether.lifecycle` capability — ADR-0082's first-class actor
@@ -156,13 +165,34 @@ impl<C: 'static + Send + Sync> NativeActor for LifecycleDriverCapability<C> {
         config: LifecycleDriverConfig<C>,
         ctx: &mut NativeInitCtx<'_>,
     ) -> Result<Self, BootError> {
-        let LifecycleDriverConfig { graph, context } = config;
+        let LifecycleDriverConfig {
+            graph,
+            context,
+            initial_subscribers,
+        } = config;
         let current_state = graph.start();
         let mailer = ctx.mailer();
+        let mut subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>> = BTreeMap::new();
+        for (stage, mailbox) in initial_subscribers {
+            // Reject unknown-stage subscriptions at boot rather than
+            // silently dropping mail at runtime — ADR-0082 §7's
+            // fail-fast contract applies to compile-site config too,
+            // not just LifecycleSubscribe mail.
+            if graph.state(stage).is_none() && graph.terminal(stage).is_none() {
+                return Err(BootError::Other(
+                    format!(
+                        "aether.lifecycle: initial subscriber references stage {stage:?} not \
+                         declared by graph"
+                    )
+                    .into(),
+                ));
+            }
+            subscribers.entry(stage).or_default().insert(mailbox);
+        }
         Ok(Self {
             graph,
             context,
-            subscribers: BTreeMap::new(),
+            subscribers,
             current_state,
             terminal_reached: false,
             quit_pending: false,


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

PR 3b of the ADR-0082 migration (refs iamacoffeepot/aether#949). Migrates the headless, test_bench, and desktop chassis main loops onto `LifecycleDriverCapability`. Hub chassis intentionally unchanged (no frame loop). FRAME_BARRIER retirement and ctrlc → Quit bridges land as PR 3c.

- Extends `LifecycleDriverConfig` with `initial_subscribers` so each chassis pre-populates the driver's subscriber table at boot. Unknown stage targets fail boot fast per ADR-0082 §7.
- Each migrated chassis registers `LifecycleDriverCapability<()>` with a `Tick`-self-loops / `Quit`-escapes-to-`Shutdown` graph and relays `(Tick::ID, aether.input)` so the existing `InputCapability::on_tick` fan-out keeps routing Tick to component subscribers.
- **Headless timer** swaps the per-tick `push_chassis_root_mail(Tick → aether.input)` for `LifecycleAdvance → aether.lifecycle` fire-and-forget. The driver's settlement gating handles overlap if a frame overruns.
- **`TestBench::advance`** pushes `LifecycleAdvance` and subscribes settlement on the resulting root (replacing the prior Tick-direct settle-on-root). The broadcast subtree is part of the same chain so the back-pressure property is preserved.
- **Desktop `RedrawRequested`** swaps direct Tick push for `LifecycleAdvance`. `drain_frame_bound_or_abort` stays in place for one more PR so FRAME_BARRIER retirement lands atomically.
- Removes every `mailbox_id_from_name("aether.lifecycle")` magic-string call site — call sites now route through `<LifecycleDriverCapability<()> as Actor>::NAMESPACE` (or `<Self as Actor>::NAMESPACE` inside the cap itself).
- Re-exports `aether_substrate::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph}` from the crate root so chassis consumers don't reach for the inner module path.

PR 3c (next): FRAME_BARRIER + `drain_frame_bound_or_abort` retirement across the workspace, plus ctrlc / winit-close → Quit bridges.

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy --all-targets + nextest 1026/1026 + wasm32 cross-build). One flake on the first run of `batched_ticks_preserve_per_mailbox_count`; re-ran clean.
- [x] All `input_subscription` and `test_bench_scenario` integration tests pass — exercises the relay path end-to-end (chassis → LifecycleAdvance → driver broadcasts Tick → `aether.input` fan-out → component subscriber).
- [x] CI green, Qodana green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)