### PR TITLE
feat(substrate): settlement-gate frame submit, retire drain barrier calls (ADR-0082 §6)

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -18,11 +18,13 @@ use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use aether_actor::Actor;
-use aether_capabilities::InputCapability;
 use aether_capabilities::fs::NamespaceRoots;
-use aether_data::{encode_empty, mailbox_id_from_name};
-use aether_kinds::{AdvanceResult, CaptureFrameResult, Tick};
-use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId};
+use aether_data::{Kind, encode_empty, mailbox_id_from_name};
+use aether_kinds::{AdvanceResult, CaptureFrameResult, LifecycleAdvance};
+use aether_substrate::chassis::settlement::SettlementRegistry;
+use aether_substrate::{
+    Chassis, LifecycleDriverCapability, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId,
+};
 use aether_substrate_bundle::chassis_root::next_chassis_correlation;
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
@@ -120,11 +122,15 @@ fn drive_events_loop(
 ) {
     let queue = Arc::clone(&boot.queue);
     let outbound = Arc::clone(&boot.outbound);
-    let input_mailbox = mailbox_id_from_name(InputCapability::NAMESPACE);
-    let frame_bound_pending = passive.frame_bound_pending();
+    let _ = kind_tick; // PR 3c retired the direct Tick push; the bin now
+    // drives `LifecycleAdvance` and the lifecycle driver broadcasts Tick.
+    let lifecycle_mailbox =
+        mailbox_id_from_name(<LifecycleDriverCapability<()> as Actor>::NAMESPACE);
+    let kind_lifecycle_advance = <LifecycleAdvance as Kind>::ID;
+    let settlement_registry = Arc::clone(passive.settlement_registry());
     // ADR-0080 §6 chassis-root correlation counter (issue
     // iamacoffeepot/aether#723). Threaded through `run_frame` so each
-    // tick push carries observable lineage like the desktop and
+    // advance push carries observable lineage like the desktop and
     // headless drivers do.
     let chassis_correlation = AtomicU64::new(1);
 
@@ -136,10 +142,10 @@ fn drive_events_loop(
                         true,
                         &queue,
                         &outbound,
-                        input_mailbox,
-                        kind_tick,
+                        lifecycle_mailbox,
+                        kind_lifecycle_advance,
+                        &settlement_registry,
                         &capture_queue,
-                        &frame_bound_pending,
                         &mut gpu,
                         &chassis_correlation,
                     );
@@ -156,10 +162,10 @@ fn drive_events_loop(
                     false,
                     &queue,
                     &outbound,
-                    input_mailbox,
-                    kind_tick,
+                    lifecycle_mailbox,
+                    kind_lifecycle_advance,
+                    &settlement_registry,
                     &capture_queue,
-                    &frame_bound_pending,
                     &mut gpu,
                     &chassis_correlation,
                 );
@@ -179,28 +185,35 @@ fn run_frame(
     dispatch_tick: bool,
     queue: &Arc<aether_substrate::Mailer>,
     outbound: &Arc<aether_substrate::HubOutbound>,
-    input_mailbox: MailboxId,
-    kind_tick: aether_data::KindId,
+    lifecycle_mailbox: MailboxId,
+    kind_lifecycle_advance: aether_data::KindId,
+    settlement_registry: &Arc<SettlementRegistry>,
     capture_queue: &CaptureQueue,
-    frame_bound_pending: &[(MailboxId, Arc<AtomicU64>)],
     gpu: &mut Gpu,
     chassis_correlation: &AtomicU64,
 ) {
     if dispatch_tick {
-        queue.push_chassis_root_mail(
+        // ADR-0082 §6 / PR 3c: push LifecycleAdvance and wait for the
+        // frame chain to settle before submit. Settlement replaces the
+        // retired `drain_frame_bound_or_abort` pending-counter poll —
+        // it waits for the whole Tick → component → DrawTriangle →
+        // render chain rather than just render's inbox counter.
+        let advance_root = queue.push_chassis_root_mail(
             next_chassis_correlation(chassis_correlation),
-            input_mailbox,
-            kind_tick,
-            encode_empty::<Tick>(),
+            lifecycle_mailbox,
+            kind_lifecycle_advance,
+            encode_empty::<LifecycleAdvance>(),
             1,
         );
+        let rx = settlement_registry.subscribe_settlement(advance_root);
+        if rx.recv_timeout(frame_loop::DRAIN_BUDGET).is_err() {
+            tracing::error!(
+                target: "aether_substrate::lifecycle",
+                root = ?advance_root,
+                "frame chain did not settle within drain budget; submitting anyway",
+            );
+        }
     }
-    // ADR-0074 §Decision 5: render's inbox must quiesce before
-    // submit so any DrawTriangle / aether.camera mail this frame is
-    // integrated into the recorded pass. (The pre-Phase-4 component
-    // drain barrier is retired; trampoline traps fail-fast directly
-    // via `NativeBinding::fatal_abort`.)
-    frame_loop::drain_frame_bound_or_abort(frame_bound_pending, outbound);
 
     match capture_queue.take() {
         Some(req) => {

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -33,7 +33,12 @@ use aether_kinds::{
 use aether_substrate::actor::native::envelope::Envelope;
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{HubOutbound, Mailer, SubstrateBoot, chassis::frame_loop, mail::MailboxId};
+use aether_substrate::runtime::lifecycle;
+use aether_substrate::{
+    HubOutbound, Mailer, SubstrateBoot,
+    chassis::frame_loop,
+    mail::{MailId, MailboxId},
+};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -79,12 +84,6 @@ pub struct App {
     /// Hub outbound — shared with the log-capture layer and the
     /// capture-reply path.
     outbound: Arc<HubOutbound>,
-    /// Snapshot of every frame-bound capability's pending counter
-    /// (ADR-0074 §Decision 5). Today: render. Cloned out of
-    /// `DriverCtx::frame_bound_pending` at driver boot; `RedrawRequested`
-    /// hands it to `frame_loop::drain_frame_bound_or_abort` after the
-    /// component drain so render's inbox quiesces before submit.
-    frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
     pub(crate) started: Option<Instant>,
@@ -292,20 +291,22 @@ impl App {
     /// ADR-0080 §6 chassis-source push helper (issue
     /// iamacoffeepot/aether#723). Mints a fresh correlation, calls
     /// `push_chassis_root_mail` so the trace observer sees a `Sent`
-    /// event for every input/window/frame-stats emission.
+    /// event for every input/window/frame-stats emission. Returns the
+    /// minted chain-root [`MailId`] so frame-gating callers can
+    /// subscribe its settlement (ADR-0082 §6).
     fn push_chassis_root(
         &self,
         recipient: MailboxId,
         kind: aether_data::KindId,
         payload: Vec<u8>,
         count: u32,
-    ) {
+    ) -> MailId {
         let mut correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
         if correlation == 0 {
             correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
         }
         self.queue
-            .push_chassis_root_mail(correlation, recipient, kind, payload, count);
+            .push_chassis_root_mail(correlation, recipient, kind, payload, count)
     }
 
     fn apply_window_mode(
@@ -494,13 +495,17 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
-                // ADR-0082 PR 3b: redraw fires `LifecycleAdvance` to
-                // the lifecycle driver, which broadcasts Tick to
+                // ADR-0082 §6 / PR 3c: redraw fires `LifecycleAdvance`
+                // to the lifecycle driver, which broadcasts Tick to
                 // `aether.input` (via the chassis's `initial_subscribers`
-                // relay) plus any other subscribers. Settlement on the
-                // broadcast root replaces the prior
-                // `drain_frame_bound_or_abort` gate.
-                self.push_chassis_root(
+                // relay) plus any other subscribers. Components emit
+                // their `DrawTriangle` / `aether.camera` mail into render
+                // as descendants of this advance's chain root. Waiting
+                // for that root to settle before submit guarantees the
+                // frame's geometry is integrated — the causal-completion
+                // replacement for the retired `drain_frame_bound_or_abort`
+                // pending-counter poll.
+                let advance_root = self.push_chassis_root(
                     self.lifecycle_mailbox,
                     self.kind_lifecycle_advance,
                     encode_empty::<aether_kinds::LifecycleAdvance>(),
@@ -512,13 +517,23 @@ impl ApplicationHandler<UserEvent> for App {
                         self.publish_window_size(size.width, size.height);
                     }
                 }
-                // ADR-0074 §Decision 5: render's inbox must quiesce
-                // before submit so any DrawTriangle / aether.camera
-                // mail this frame is integrated into the recorded
-                // pass. (The pre-Phase-4 component drain barrier is
-                // retired; trampoline traps fail-fast directly via
-                // `NativeBinding::fatal_abort`.)
-                frame_loop::drain_frame_bound_or_abort(&self.frame_bound_pending, &self.outbound);
+                if let Some(registry) = self.queue.settlement_registry() {
+                    let rx = registry.subscribe_settlement(advance_root);
+                    if rx.recv_timeout(frame_loop::DRAIN_BUDGET).is_err() {
+                        // A frame chain that doesn't settle within the
+                        // drain budget is a wedged dispatcher — same
+                        // fail-fast disposition the old drain barrier
+                        // had (ADR-0063).
+                        lifecycle::fatal_abort(
+                            &self.outbound,
+                            format!(
+                                "frame chain wedged: LifecycleAdvance root {advance_root:?} did \
+                                 not settle within {:?}",
+                                frame_loop::DRAIN_BUDGET
+                            ),
+                        );
+                    }
+                }
                 if let Some(gpu) = self.gpu.as_mut() {
                     match pending_capture {
                         Some(req) => {
@@ -690,7 +705,6 @@ impl DriverCapability for DesktopDriverCapability {
             )))
         })?;
         let triangles_rendered = Arc::clone(&render_handles.triangles_rendered);
-        let frame_bound_pending = ctx.frame_bound_pending();
 
         let kind_tick = boot.registry.kind_id(Tick::NAME).expect("Tick registered");
         let kind_key = boot.registry.kind_id(Key::NAME).expect("Key registered");
@@ -745,7 +759,6 @@ impl DriverCapability for DesktopDriverCapability {
             render_handles,
             capture_queue,
             outbound: Arc::clone(&boot.outbound),
-            frame_bound_pending,
             window: None,
             gpu: None,
             started: None,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -42,7 +42,6 @@ use aether_substrate::{
     EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, ReplyTarget, ReplyTo,
     SubstrateBoot,
     capture::CaptureQueue,
-    chassis::frame_loop,
     mail::{Mail, MailboxId},
 };
 
@@ -152,13 +151,6 @@ pub struct TestBench {
     /// Kind id of [`LifecycleAdvance`], pre-resolved so the advance
     /// loop body stays alloc-free per tick.
     kind_lifecycle_advance: KindId,
-    /// Snapshot of every frame-bound capability's pending counter
-    /// (ADR-0074 §Decision 5). Today: render. Cloned out of
-    /// `PassiveChassis::frame_bound_pending` at boot; `advance` /
-    /// the bin's `run_frame` hand it to
-    /// `frame_loop::drain_frame_bound_or_abort` so render's inbox
-    /// quiesces before `record_frame`.
-    frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,
 
     frame: u64,
     next_correlation_id: AtomicU64,
@@ -329,7 +321,6 @@ impl TestBench {
         let kind_lifecycle_advance = <aether_kinds::LifecycleAdvance as Kind>::ID;
         let _ = kind_tick; // PR 3b retired direct Tick push; kept on the
         // build result for wire-compat with binaries that haven't migrated yet.
-        let frame_bound_pending = passive.frame_bound_pending();
 
         Ok(Self {
             queue,
@@ -341,7 +332,6 @@ impl TestBench {
             gpu,
             lifecycle_mailbox,
             kind_lifecycle_advance,
-            frame_bound_pending,
             frame: 0,
             next_correlation_id: AtomicU64::new(1),
             session: SessionToken(Uuid::from_u128(TESTBENCH_SESSION_UUID)),
@@ -806,16 +796,12 @@ impl TestBench {
                 });
             }
         }
-        // ADR-0074 §Decision 5: render's inbox must quiesce before
-        // submit so any DrawTriangle / aether.camera mail this frame
-        // is integrated into the recorded pass. Settlement above
-        // covers the causal-chain invariant; this preserves the
-        // separate per-frame ordering invariant for frame-bound caps.
-        // (The pre-Phase-4 component drain barrier is retired;
-        // trampoline traps fail-fast directly via
-        // `NativeBinding::fatal_abort`.)
-        frame_loop::drain_frame_bound_or_abort(&self.frame_bound_pending, &self.outbound);
-
+        // ADR-0082 §6 / PR 3c: the advance settlement above already
+        // waited for the whole frame chain (Tick → component →
+        // DrawTriangle → render cap accumulator) to drain, so render's
+        // inbox is quiesced by the time we reach submit. The prior
+        // `drain_frame_bound_or_abort` pending-counter poll is
+        // redundant under settlement gating and retired.
         match self.capture_queue.take() {
             Some(req) => {
                 // iamacoffeepot/aether#860: wait for each pre-mail's
@@ -846,13 +832,6 @@ impl TestBench {
                 self.gpu.render();
             }
         }
-
-        // ADR-0074 §Decision 5 ordering invariant: keep the frame-bound
-        // drain so render and any future frame-bound cap quiesces before
-        // the next frame. Pre-#775 this was paired with a periodic
-        // FrameStats settlement gate every `LOG_EVERY_FRAMES`; with the
-        // observation path retired the drain stands on its own.
-        frame_loop::drain_frame_bound_or_abort(&self.frame_bound_pending, &self.outbound);
 
         Ok(())
     }


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

PR 3c of the ADR-0082 migration (refs iamacoffeepot/aether#949). Replaces the per-frame `drain_frame_bound_or_abort` pending-counter poll with settlement gating on the `LifecycleAdvance` chain root.

- **Desktop `RedrawRequested`** captures the `LifecycleAdvance` root and waits for its settlement before GPU submit. The frame's `DrawTriangle` / `aether.camera` mail are descendants of that root, so settlement guarantees the geometry is integrated — the causal-completion replacement for the pending-counter drain. A chain that doesn't settle within `DRAIN_BUDGET` fatal-aborts (same disposition as the old drain barrier, ADR-0063).
- **`TestBench::advance`** already settles the advance root (PR 3b); both redundant `drain_frame_bound_or_abort` calls in `run_frame` are removed and the `frame_bound_pending` field retired.
- **Standalone test-bench bin** `run_frame` migrates from direct Tick push + drain to `LifecycleAdvance` + settlement wait.

The `FRAME_BARRIER` const + `claim_frame_bound_mailbox` machinery + the `drain_frame_bound_or_abort` helper itself are now logically dead; they retire in a follow-up cleanup PR (no behaviour change there) to keep this PR's diff focused on the gating swap.

## Caveat

The desktop render path can't be exercised by automated tests (no display in CI — scenario tests use the TestBench offscreen path, which IS covered here). The desktop settlement-gated submit needs an MCP-harness smoke before being relied on. The TestBench path (same settlement pattern) is fully covered by the 1026 passing tests.

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy --all-targets + nextest 1026/1026 + wasm32 cross-build).
- [ ] CI green, Qodana green.
- [ ] MCP smoke of desktop frame submit (manual, post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)