### PR TITLE
refactor(substrate): retire FRAME_BARRIER const + claim machinery + cross-class guard

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -929,16 +929,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
 
     // Collect everything we need from the inner actor impl into owned
     // values so the borrow on `items` ends before we mutate it below.
-    let (
-        self_ty,
-        type_ident,
-        generics,
-        namespace_expr,
-        frame_barrier_expr,
-        scheduling_expr,
-        handler_kinds,
-        catch_all,
-    ) = {
+    let (self_ty, type_ident, generics, namespace_expr, scheduling_expr, handler_kinds, catch_all) = {
         let Item::Impl(actor_impl) = &items[actor_idx] else {
             unreachable!("actor_idx points to an Item::Impl by construction");
         };
@@ -991,7 +982,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         let mut handler_kinds: Vec<Type> = Vec::new();
         let mut has_fallback = false;
         let mut namespace_expr: Option<Expr> = None;
-        let mut frame_barrier_expr: Option<Expr> = None;
         let mut scheduling_expr: Option<Expr> = None;
         for impl_item in &actor_impl.items {
             match impl_item {
@@ -1005,8 +995,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
                 ImplItem::Const(c) => {
                     if c.ident == "NAMESPACE" {
                         namespace_expr = Some(c.expr.clone());
-                    } else if c.ident == "FRAME_BARRIER" {
-                        frame_barrier_expr = Some(c.expr.clone());
                     } else if c.ident == "SCHEDULING" {
                         scheduling_expr = Some(c.expr.clone());
                     }
@@ -1044,7 +1032,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
             type_ident,
             actor_impl.generics.clone(),
             namespace_expr,
-            frame_barrier_expr,
             scheduling_expr,
             handler_kinds,
             has_fallback,
@@ -1066,9 +1053,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     //   (chassis builders, tests in sibling mods) keep working.
     // - Singleton, Actor, and HandlesKind impls are always-on so wasm
     //   consumers compile typed sends without the substrate runtime.
-    let frame_barrier_const = frame_barrier_expr.map(|expr| {
-        quote! { const FRAME_BARRIER: bool = #expr; }
-    });
     // Self-contained emission: the bridge lifts the user's expression
     // from inside `mod native` (where `Scheduling` is in scope via an
     // inner-mod import) to a sibling `impl Actor` at file root (where
@@ -1116,7 +1100,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     let actor_marker = quote! {
         impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
             const NAMESPACE: &'static str = #namespace_expr;
-            #frame_barrier_const
             #scheduling_const
         }
     };

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -38,16 +38,6 @@ pub trait Actor: Sized + Send + 'static {
     /// under when the load payload omits an explicit override.
     const NAMESPACE: &'static str;
 
-    /// ADR-0074 §Decision 5 scheduling class. `true` means this actor
-    /// participates in the per-frame drain barrier — the chassis frame
-    /// loop waits for the dispatcher's inbox to quiesce before
-    /// submitting the next render frame, so any mail a peer sent this
-    /// frame is integrated before submit. Defaults to `false`
-    /// (free-running). Today only `RenderCapability` overrides; future
-    /// drawing-side capabilities and any wasm component that wants
-    /// per-frame coupling will too.
-    const FRAME_BARRIER: bool = false;
-
     /// Issue 635 dispatch placement. `Pooled` (the default) registers
     /// a dispatcher slot with the chassis worker pool so many actors
     /// share a small thread set. `Dedicated` is the opt-in escape
@@ -62,10 +52,6 @@ pub trait Actor: Sized + Send + 'static {
     /// `tokio::Runtime::block_on` to coordinate child-process
     /// lifecycle) opts back into `Dedicated`.
     ///
-    /// `FRAME_BARRIER` and `SCHEDULING` are orthogonal: a frame-bound
-    /// actor can be either `Pooled` or `Dedicated`; the per-actor
-    /// `pending` counter is read by the chassis frame loop regardless
-    /// of where the dispatch happens.
     const SCHEDULING: Scheduling = Scheduling::Pooled;
 }
 

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -134,7 +134,7 @@ impl From<String> for BootError {
 /// from `#[actor]`.
 ///
 /// Issue 525 Phase 4 split the trait surface: the [`crate::Actor`]
-/// super-trait owns the symmetric bits (`NAMESPACE`, `FRAME_BARRIER`)
+/// super-trait owns the symmetric bits (`NAMESPACE`, `SCHEDULING`)
 /// shared with the substrate-side `NativeActor`; `FfiActor` adds the
 /// FFI lifecycle methods (`init`, `wire`, `unwire`). Hot-swap hooks
 /// (`on_replace`, `on_rehydrate`) moved to the opt-in [`Replaceable`]

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -1,8 +1,10 @@
 //! `aether.render` cap. Owns the render mailbox surface plus the
 //! driver-facing accumulator state ([`RenderHandles`]) and GPU bundle
-//! ([`RenderGpu`]). `FRAME_BARRIER` = true so the chassis frame loop's
-//! drain-or-abort sees the per-mailbox pending counter before recording
-//! a frame (ADR-0074 §Decision 5).
+//! ([`RenderGpu`]). Post-ADR-0082 the chassis gates frame submit on
+//! settlement of the `LifecycleAdvance` chain root — render's
+//! `DrawTriangle` / `aether.camera` mail are descendants of that root,
+//! so they're integrated before submit without a per-mailbox drain
+//! counter.
 //!
 //! Driver-side state (wgpu device, queue, pipeline, offscreen
 //! targets, accumulator buffers) lives on [`RenderHandles`]. The
@@ -173,16 +175,6 @@ mod native {
         /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
         /// folded the camera mailbox into render under this name.
         const NAMESPACE: &'static str = "aether.render";
-
-        /// Render is the one chassis-owned actor that participates in the
-        /// per-frame drain barrier (ADR-0074 §Decision 7). Without this,
-        /// a `DrawTriangle` mail in flight when the chassis driver records
-        /// the frame would land in the *next* frame's `frame_vertices`,
-        /// dropping a triangle the component meant for this frame. The
-        /// `Builder::with_actor` boot path checks this const and claims
-        /// through the frame-bound path so the cap's `pending` counter
-        /// registers in the chassis's `frame_bound_pending` Vec.
-        const FRAME_BARRIER: bool = true;
 
         /// Allocate the accumulator state up front. Idempotent on the
         /// driver-facing side: every chassis main passes a fresh
@@ -788,65 +780,11 @@ mod native {
             assert!(registry.lookup("aether.sink.camera").is_none());
         }
 
-        /// Boots render through `Builder::with_actor` and asserts a
-        /// `DrawTriangle` mail accumulates into the `frame_vertices`
-        /// buffer. The `RenderHandles` here is reached via the chassis
-        /// post-build by waiting on the per-mailbox pending counter
-        /// the `FRAME_BARRIER` claim populates. Coverage of the
-        /// `handles` accessor is in the desktop chassis path.
-        #[test]
-        fn render_dispatcher_appends_triangles_to_frame_vertices() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = build_render_chassis(&registry, &mailer);
-
-            let one_triangle = vec![0u8; DRAW_TRIANGLE_BYTES];
-            deliver(
-                &registry,
-                RenderCapability::NAMESPACE,
-                <DrawTriangle as Kind>::ID,
-                &one_triangle,
-            );
-
-            // Wait briefly for the dispatcher thread to drain. The
-            // test waits on the per-mailbox pending counter the
-            // FRAME_BARRIER claim populates and treats a drain-to-zero
-            // as the dispatch happening.
-            for _ in 0..50 {
-                let pending = chassis.frame_bound_pending();
-                if pending.is_empty() || pending[0].1.load(Ordering::Acquire) == 0 {
-                    break;
-                }
-                thread::sleep(Duration::from_millis(5));
-            }
-            // The pending counter must have hit zero — the dispatcher
-            // ran the handler.
-            let pending = chassis.frame_bound_pending();
-            assert_eq!(pending.len(), 1);
-            assert_eq!(
-                pending[0].1.load(Ordering::Acquire),
-                0,
-                "dispatcher should have processed the DrawTriangle"
-            );
-
-            drop(chassis);
-        }
-
-        /// Frame-bound claim populates the chassis's `frame_bound_pending`
-        /// Vec. Direct render-internal-state assertions live on
-        /// integration tests in the bundle, where the chassis-side
-        /// actors map exposes `Arc<RenderCapability>` for `handles()`
-        /// access.
-        #[test]
-        fn render_registers_frame_bound_pending_counter() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = build_render_chassis(&registry, &mailer);
-            assert_eq!(
-                chassis.frame_bound_pending().len(),
-                1,
-                "render claimed through frame-bound path"
-            );
-            drop(chassis);
-        }
+        // ADR-0082 retired the frame-bound pending counter; the
+        // DrawTriangle → render dispatch path is now covered end-to-end
+        // by the bundle scenario tests (`tick_roundtrip_component_to_sink`
+        // and the `test_bench_scenario` suite), which exercise it through
+        // real settlement rather than a per-mailbox counter poll.
 
         #[test]
         fn camera_kind_drops_wrong_length_payload() {

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -37,11 +37,11 @@
 //! traits in `aether_actor::actor::ctx` are the only cross-target
 //! abstraction.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::actor::native::envelope::Envelope;
@@ -92,36 +92,11 @@ pub struct NativeBinding {
     /// Monotonic correlation counter — atomic so `&self` can mint
     /// new ids without `&mut`.
     correlation: AtomicU64,
-    /// ADR-0074 §Decision 5 cross-class `wait_reply` guard. `true`
-    /// means this transport's owning capability declared
-    /// `Capability::FRAME_BARRIER = true`; combined with the
-    /// `frame_bound_set` lookup below, [`Self::wait_reply`] aborts
-    /// when a frame-bound caller blocks on a free-running recipient
-    /// (which would wedge the per-frame drain barrier waiting on a
-    /// thread that doesn't synchronize with frames).
-    caller_frame_bound: bool,
-    /// Membership view of the chassis's frame-bound mailbox set.
-    /// Read on each [`Self::wait_reply`] to classify the recipient
-    /// of the prior `send_mail`. Cloned from
-    /// [`ChassisCtx::frame_bound_set`] at boot; the chassis adds
-    /// entries as additional frame-bound capabilities boot, so this
-    /// view stays current across the chassis lifetime.
-    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
-    /// Indirection over [`crate::runtime::lifecycle::fatal_abort`] — invoked
-    /// by [`Self::wait_reply`] on cross-class violation. Cloned from
+    /// Indirection over [`crate::runtime::lifecycle::fatal_abort`] —
+    /// invoked by [`Self::fatal_abort`] when a wasm guest traps so a
+    /// faulty component brings the substrate down cleanly. Cloned from
     /// [`ChassisCtx::fatal_aborter`] at boot.
     aborter: Arc<dyn FatalAborter>,
-    /// Tracks `correlation_id → recipient_mailbox` for outbound
-    /// requests so [`Self::wait_reply`] can resolve the recipient
-    /// when checking the cross-class guard. Populated by
-    /// [`Self::send_mail`] (every send, since fire-and-forget vs
-    /// request/reply isn't distinguishable at this layer); pruned
-    /// by [`Self::wait_reply`] when the matching reply arrives or
-    /// the deadline expires. Bounded by the cleanup pass in
-    /// `wait_reply`'s exit paths plus an opportunistic cap (see
-    /// `MAX_PENDING_RECIPIENTS`); a runaway sender that never paired
-    /// a wait would otherwise leak entries here.
-    pending_recipients: Mutex<HashMap<u64, MailboxId>>,
     /// Issue 607 Phase 3b (ADR-0079): the chassis's [`crate::Spawner`]
     /// cloned into every booted actor's transport so per-handler
     /// `NativeCtx::spawn_child` can reach the spawn machinery without
@@ -138,19 +113,6 @@ pub struct NativeBinding {
     shutdown_flag: Arc<AtomicBool>,
 }
 
-/// Soft cap on [`NativeBinding::pending_recipients`]. A
-/// fire-and-forget `send_mail` (one with no paired `wait_reply`)
-/// leaves an entry in the map indefinitely; the cap stops a runaway
-/// sender from growing the map without bound. Picked large enough
-/// to comfortably exceed any realistic burst of in-flight requests
-/// from a single capability — the cross-class guard is preventive,
-/// not load-bearing for normal traffic. When the cap is hit the
-/// oldest entry is dropped (insertion order; we accept that the
-/// pruned correlation will silently skip the guard if its reply
-/// ever lands, which is strictly less safe than aborting but no
-/// worse than the pre-guard baseline).
-const MAX_PENDING_RECIPIENTS: usize = 1024;
-
 impl NativeBinding {
     /// Build a fresh transport. Pair `self_mailbox` with the id the
     /// `MailboxClaim` returned (the substrate routes replies back
@@ -160,19 +122,16 @@ impl NativeBinding {
     /// build the transport before pulling the receiver out of their
     /// claim aren't forced into a specific construction order.
     ///
-    /// `caller_frame_bound`, `frame_bound_set`, and `aborter` wire
-    /// the ADR-0074 §Decision 5 cross-class `wait_reply` guard.
-    /// Capabilities authored under a [`ChassisCtx`] should
-    /// prefer [`Self::from_ctx`], which inherits the chassis's
-    /// shared set + aborter automatically; the explicit constructor
-    /// is for harnesses that don't go through a chassis (`TestBench`
+    /// `aborter` backs [`Self::fatal_abort`] (wasm trap → clean
+    /// substrate exit). Capabilities authored under a [`ChassisCtx`]
+    /// should prefer [`Self::from_ctx`], which inherits the chassis's
+    /// aborter + spawner automatically; the explicit constructor is
+    /// for harnesses that don't go through a chassis (`TestBench`
     /// internals) or for tests that want to substitute a custom
     /// aborter.
     pub fn new(
         mailer: Arc<Mailer>,
         self_mailbox: MailboxId,
-        caller_frame_bound: bool,
-        frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
         aborter: Arc<dyn FatalAborter>,
         spawner: Option<Arc<crate::Spawner>>,
     ) -> Self {
@@ -182,58 +141,36 @@ impl NativeBinding {
             inbox: OnceLock::new(),
             overflow: Mutex::new(VecDeque::new()),
             correlation: AtomicU64::new(0),
-            caller_frame_bound,
-            frame_bound_set,
             aborter,
-            pending_recipients: Mutex::new(HashMap::new()),
             spawner,
             shutdown_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Convenience constructor that pulls the cross-class guard
-    /// state (frame-bound set + aborter) from a [`ChassisCtx`]. The
-    /// natural call site is inside a
+    /// Convenience constructor that pulls the aborter + spawner from a
+    /// [`ChassisCtx`]. The natural call site is inside a
     /// [`crate::DriverCapability::boot`] body:
     ///
     /// ```ignore
     /// let claim = ctx.claim_mailbox_drop_on_shutdown(NAME)?;
-    /// let transport = NativeBinding::from_ctx(ctx, claim.id, Self::FRAME_BARRIER);
+    /// let transport = NativeBinding::from_ctx(ctx, claim.id);
     /// ```
-    ///
-    /// Capabilities that don't migrate to this constructor in the
-    /// same PR keep using [`Self::new_for_test`] (or call
-    /// [`Self::new`] explicitly with their chosen guard state); the
-    /// guard is a no-op for non-frame-bound callers and the
-    /// `PanicAborter` default is harmless for production caps that
-    /// never call `wait_reply`.
     #[must_use]
-    pub fn from_ctx(ctx: &ChassisCtx<'_>, self_mailbox: MailboxId, frame_bound: bool) -> Self {
+    pub fn from_ctx(ctx: &ChassisCtx<'_>, self_mailbox: MailboxId) -> Self {
         Self::new(
             ctx.mail_send_handle(),
             self_mailbox,
-            frame_bound,
-            ctx.frame_bound_set(),
             ctx.fatal_aborter(),
             Some(Arc::clone(ctx.spawner_arc())),
         )
     }
 
-    /// Test-only constructor that disables the cross-class guard
-    /// (non-frame-bound caller, empty set, [`PanicAborter`]). Lets
-    /// existing unit tests construct a transport without naming
-    /// every guard parameter; not appropriate for production
-    /// capabilities, which should go through [`Self::from_ctx`] so
-    /// the guard wires to the chassis's shared state.
+    /// Test-only constructor with a [`PanicAborter`] and no spawner.
+    /// Lets unit tests build a transport without a chassis; not
+    /// appropriate for production capabilities, which should go
+    /// through [`Self::from_ctx`].
     pub fn new_for_test(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
-        Self::new(
-            mailer,
-            self_mailbox,
-            false,
-            Arc::new(RwLock::new(HashSet::new())),
-            Arc::new(PanicAborter),
-            None,
-        )
+        Self::new(mailer, self_mailbox, Arc::new(PanicAborter), None)
     }
 
     /// Install the receiver half of the actor's inbox so
@@ -486,23 +423,6 @@ impl NativeBinding {
         let mail = Mail::new(recipient_id, KindId(kind), bytes.to_vec(), count)
             .with_reply_to(reply_to)
             .with_lineage(mail_id, root, parent_mail);
-        // Record `correlation -> recipient` for the cross-class
-        // `wait_reply` guard. We record on every send (the FFI here
-        // can't tell fire-and-forget from request/reply) and let
-        // `wait_reply` prune. The opportunistic cap below stops a
-        // runaway sender that never paired a wait from leaking.
-        {
-            let mut pending = self
-                .pending_recipients
-                .lock()
-                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063");
-            if pending.len() >= MAX_PENDING_RECIPIENTS
-                && let Some(&drop_key) = pending.keys().next()
-            {
-                pending.remove(&drop_key);
-            }
-            pending.insert(correlation, recipient_id);
-        }
         self.mailer.push(mail);
         mail_id
     }
@@ -519,11 +439,8 @@ impl NativeBinding {
     /// transport-specific sentinel (e.g. `-100` no-inbox).
     ///
     /// # Panics
-    /// Panics if any of the internal mutexes (overflow, pending
-    /// recipients, frame-bound set) are poisoned, or if the cross-class
-    /// guard fires (ADR-0074 §Decision 5: a frame-bound caller blocking
-    /// on a free-running recipient triggers `fatal_abort`) — both are
-    /// fail-fast per ADR-0063.
+    /// Panics if the overflow mutex is poisoned — fail-fast per
+    /// ADR-0063.
     pub fn wait_reply(
         &self,
         expected_kind: u64,
@@ -539,43 +456,10 @@ impl NativeBinding {
             return -ERR_NO_INBOX_I32;
         };
 
-        // ADR-0074 §Decision 5 cross-class guard: a frame-bound
-        // caller blocking on a free-running recipient would wedge
-        // the per-frame drain barrier waiting on a thread that
-        // doesn't synchronize with frames. Detect at the call site
-        // and abort with a specific diagnostic instead of letting
-        // `drain_frame_bound_or_abort` time out further downstream
-        // with a less actionable "dispatcher wedged" reason. The
-        // guard is preventive — today no in-tree capability calls
-        // `wait_reply` cross-class — so the early return path is
-        // for future-cap correctness, not current behavior.
-        if self.caller_frame_bound
-            && expected_correlation != ReplyTo::NO_CORRELATION
-            && let Some(recipient) = self
-                .pending_recipients
-                .lock()
-                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063")
-                .get(&expected_correlation)
-                .copied()
-            && !self
-                .frame_bound_set
-                .read()
-                .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
-                .contains(&recipient)
-        {
-            self.aborter.abort(format!(
-                "frame-bound actor {} attempted wait_reply on free-running recipient {} \
-                 (correlation {expected_correlation}, expected_kind {expected_kind}) — \
-                 forbidden by ADR-0074 §Decision 5: blocking on a free-running actor would \
-                 wedge the per-frame drain barrier",
-                self.self_mailbox, recipient,
-            ));
-        }
-
         let timeout = Duration::from_millis(timeout_ms as u64);
         let deadline = Instant::now() + timeout;
 
-        let rc = loop {
+        loop {
             // Drain overflow first — a previous `wait_reply` may
             // have parked envelopes that match this kind /
             // correlation.
@@ -638,19 +522,7 @@ impl NativeBinding {
                 Err(RecvTimeoutError::Timeout) => break -1,
                 Err(RecvTimeoutError::Disconnected) => break -3,
             }
-        };
-
-        // Whatever the outcome, drop the recipient tracking entry
-        // for this correlation — we won't need it again. (Keeps the
-        // `pending_recipients` map bounded by the actual rate of
-        // unpaired sends rather than total send volume.)
-        if expected_correlation != ReplyTo::NO_CORRELATION {
-            self.pending_recipients
-                .lock()
-                .expect("pending_recipients mutex poisoned; fail-fast per ADR-0063")
-                .remove(&expected_correlation);
         }
-        rc
     }
 
     /// Correlation id the substrate minted for this actor's most
@@ -767,139 +639,6 @@ mod tests {
         // 1ms is enough — no sender ever pushes.
         let rc = transport.wait_reply(0, &mut buf, 1, 0);
         assert_eq!(rc, -1);
-    }
-
-    /// Build a transport with the cross-class guard wired: caller
-    /// classification is configurable, and the chassis's
-    /// frame-bound set is shared so tests can pre-populate it to
-    /// classify recipients. Aborter is [`PanicAborter`] so a
-    /// triggered abort surfaces as `should_panic` rather than
-    /// `process::exit`-ing the test runner.
-    fn transport_with_guard(
-        mailer: Arc<Mailer>,
-        self_mailbox: MailboxId,
-        caller_frame_bound: bool,
-        frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
-    ) -> NativeBinding {
-        NativeBinding::new(
-            mailer,
-            self_mailbox,
-            caller_frame_bound,
-            frame_bound_set,
-            Arc::new(PanicAborter),
-            None,
-        )
-    }
-
-    /// ADR-0074 §Decision 5: a frame-bound caller blocking on a
-    /// free-running recipient must abort. Verified via the
-    /// `PanicAborter` — the panic message names both mailboxes plus
-    /// the ADR.
-    #[test]
-    #[should_panic(expected = "forbidden by ADR-0074")]
-    fn cross_class_wait_reply_aborts_when_caller_frame_bound_and_recipient_free_running() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_inbox("test.free.running", forward_to_envelope_sender(tx));
-        let recipient = registry.lookup("test.free.running").unwrap();
-
-        // Empty frame-bound set => recipient classifies as free-running.
-        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
-        let transport =
-            transport_with_guard(Arc::clone(&mailer), MailboxId(99), true, frame_bound_set);
-        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
-        transport.install_inbox(rx_inbox);
-
-        // Send first to record the recipient against a correlation id.
-        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
-        let correlation = transport.prev_correlation();
-
-        // wait_reply should abort before timing out.
-        let mut buf = [0u8; 16];
-        transport.wait_reply(1, &mut buf, 1, correlation);
-    }
-
-    /// Same shape as the abort test, but the recipient is
-    /// pre-registered as frame-bound. Guard sees same-class and
-    /// lets `wait_reply` proceed to its normal `-1` timeout.
-    #[test]
-    fn cross_class_wait_reply_does_not_abort_when_recipient_also_frame_bound() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_inbox("test.frame.bound", forward_to_envelope_sender(tx));
-        let recipient = registry.lookup("test.frame.bound").unwrap();
-
-        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
-        // Pre-populate recipient as frame-bound (mirroring what
-        // `claim_frame_bound_mailbox` would do).
-        frame_bound_set.write().unwrap().insert(recipient);
-
-        let transport = transport_with_guard(
-            Arc::clone(&mailer),
-            MailboxId(99),
-            true,
-            Arc::clone(&frame_bound_set),
-        );
-        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
-        transport.install_inbox(rx_inbox);
-
-        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
-        let correlation = transport.prev_correlation();
-
-        let mut buf = [0u8; 16];
-        // Same-class: no abort, just normal timeout (1ms).
-        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
-        assert_eq!(rc, -1);
-    }
-
-    /// Free-running caller never trips the guard regardless of
-    /// recipient class — only frame-bound callers care about being
-    /// blocked across a class boundary.
-    #[test]
-    fn cross_class_wait_reply_does_not_abort_when_caller_free_running() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_inbox("test.any", forward_to_envelope_sender(tx));
-        let recipient = registry.lookup("test.any").unwrap();
-
-        // Empty set — recipient is free-running. Caller is also
-        // free-running. Guard must be inert.
-        let frame_bound_set = Arc::new(RwLock::new(HashSet::new()));
-        let transport =
-            transport_with_guard(Arc::clone(&mailer), MailboxId(99), false, frame_bound_set);
-        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
-        transport.install_inbox(rx_inbox);
-
-        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
-        let correlation = transport.prev_correlation();
-
-        let mut buf = [0u8; 16];
-        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
-        assert_eq!(rc, -1);
-    }
-
-    /// `pending_recipients` is cleaned up after `wait_reply` exits
-    /// (success, timeout, disconnect) so fire-and-forget senders
-    /// don't leak entries past their correlation horizon.
-    #[test]
-    fn wait_reply_prunes_pending_recipient_on_timeout() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, _rx) = mpsc::channel::<Envelope>();
-        registry.register_inbox("test.prune", forward_to_envelope_sender(tx));
-        let recipient = registry.lookup("test.prune").unwrap();
-
-        let transport = NativeBinding::new_for_test(Arc::clone(&mailer), MailboxId(99));
-        let (_tx_inbox, rx_inbox) = mpsc::channel::<Envelope>();
-        transport.install_inbox(rx_inbox);
-
-        assert_eq!(transport.send_mail(recipient.0, 1, &[], 1), 0);
-        let correlation = transport.prev_correlation();
-        assert_eq!(transport.pending_recipients.lock().unwrap().len(), 1);
-
-        let mut buf = [0u8; 16];
-        let rc = transport.wait_reply(1, &mut buf, 1, correlation);
-        assert_eq!(rc, -1);
-        assert_eq!(transport.pending_recipients.lock().unwrap().len(), 0);
     }
 
     fn make_envelope(kind: u64, payload: Vec<u8>, correlation: u64) -> Envelope {

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -116,11 +116,11 @@ pub fn dispatch_log_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) ->
 /// lifecycle.
 ///
 /// `pending` is decremented after every dispatched envelope when
-/// `Some` — singletons pass it for `FRAME_BARRIER` caps (the chassis
-/// frame-loop drain barrier reads it); instanced actors pass their
-/// per-actor counter (no live consumer post-PR-4: `wait_instanced_quiesce`
-/// retired in favour of ADR-0080 settlement gating, but the counter
-/// stays plumbed for the trampoline's `tx.send` accounting).
+/// `Some`. Singletons now always pass `None` — ADR-0082 retired the
+/// frame-bound drain barrier that was the singleton consumer.
+/// Instanced actors pass their per-actor counter, which
+/// `Spawner::shutdown_instanced` reads to coordinate teardown (issue
+/// 685).
 pub fn dispatch_loop_run<A>(
     binding: &Arc<NativeBinding>,
     actor: &mut Box<A>,

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -103,9 +103,11 @@ where
     /// envelope dispatch. Wrapped in [`PooledSlots`] for the `Sync`
     /// safety story — see that type's doc-comment.
     slots: PooledSlots,
-    /// `FRAME_BARRIER` counter for this actor's mailbox. `None` for
-    /// free-running caps; `Some` for frame-bound. Decremented after
-    /// every successful dispatch.
+    /// Per-actor inbox-pending counter, decremented after every
+    /// successful dispatch. `None` for singleton caps (ADR-0082 retired
+    /// the frame-bound drain that was the singleton consumer); `Some`
+    /// for instanced actors, where `Spawner::shutdown_instanced` reads
+    /// it to coordinate teardown (issue 685).
     pending: Option<Arc<AtomicU64>>,
     /// Chassis-level actor registry. Used by [`Self::finalize_registry`]
     /// to drain `monitors_of[id]` and prune `monitoring[id]` from each

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -16,11 +16,11 @@
 //! primitive + tombstone population.
 
 use std::any::TypeId;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 use aether_actor::{HandlesKind, Instanced, NamespaceError, validate_namespace_segment};
 use aether_data::{Kind, mailbox_id_from_name};
@@ -100,7 +100,6 @@ pub struct Spawner {
     registry: Arc<Registry>,
     actor_registry: Arc<ActorRegistry>,
     mailer: Arc<Mailer>,
-    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
     aborter: Arc<dyn FatalAborter>,
     /// Monotonic counter for [`Subname::Counter`]. Per-Spawner so each
     /// chassis runs its own sequence; not shared across substrates.
@@ -140,7 +139,6 @@ impl Spawner {
         registry: Arc<Registry>,
         actor_registry: Arc<ActorRegistry>,
         mailer: Arc<Mailer>,
-        frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
         aborter: Arc<dyn FatalAborter>,
         pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
     ) -> Self {
@@ -148,7 +146,6 @@ impl Spawner {
             registry,
             actor_registry,
             mailer,
-            frame_bound_set,
             aborter,
             counter: AtomicU64::new(0),
             pool_ready_tx,
@@ -332,11 +329,6 @@ impl Spawner {
         let transport = Arc::new(NativeBinding::new(
             Arc::clone(&self.mailer),
             id,
-            // Phase 3 instanced actors are free-running. Frame-barrier
-            // semantics for instanced types arrive when (if) a
-            // forcing function emerges; until then, false.
-            false,
-            Arc::clone(&self.frame_bound_set),
             Arc::clone(&self.aborter),
             // Pass the chassis's `Spawner` through so the spawned
             // actor can in turn `ctx.spawn_child` from its own

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -18,12 +18,11 @@
 //!   alongside the first real driver extraction (phase 3) so every
 //!   chassis can nominate a real driver type rather than a stub.
 
-use std::collections::HashSet;
 use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, RwLock};
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::dispatch;
@@ -196,20 +195,6 @@ impl<'a> DriverCtx<'a> {
 
     pub fn claim_fallback_router(&mut self, handler: FallbackRouter) -> Result<(), BootError> {
         self.inner.claim_fallback_router(handler)
-    }
-
-    /// Snapshot of every frame-bound mailbox's pending counter
-    /// collected during passive boot. Drivers stash this clone and
-    /// hand it to [`crate::chassis::frame_loop::drain_frame_bound_or_abort`]
-    /// each frame so render submit waits for inbound mail to drain
-    /// alongside component drains (ADR-0074 §Decision 5).
-    ///
-    /// Returns an empty vec on chassis with no frame-bound
-    /// capabilities (today: the headless chassis without render); in
-    /// that case the per-frame call is a fast no-op.
-    #[must_use]
-    pub fn frame_bound_pending(&self) -> Vec<(MailboxId, Arc<AtomicU64>)> {
-        self.inner.frame_bound_pending().to_vec()
     }
 
     /// Issue 629 / Phase A: retrieve a clone of a cap-published handle
@@ -405,14 +390,10 @@ enum BootState<A: NativeActor + NativeDispatch> {
 /// the sum dispatch trait the `#[actor] impl NativeActor for A`
 /// macro emits.
 ///
-/// Stage 2d: `FRAME_BARRIER` caps go through this path too. The
-/// frame-bound claim (`claim_frame_bound_mailbox_with_override`)
-/// registers the per-mailbox `pending` counter into the chassis's
-/// `frame_bound_pending` Vec; the dispatcher thread decrements after
-/// each successful handler dispatch so
-/// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`]
-/// (ADR-0074 §Decision 5) sees the counter drop to zero alongside
-/// component drains.
+/// ADR-0082 retired the frame-bound claim variant: every cap takes the
+/// drop-on-shutdown claim, and settlement gating on the
+/// `LifecycleAdvance` chain root (not a per-mailbox pending counter) is
+/// the frame-integration gate now.
 struct NativeActorBoot<A: NativeActor + NativeDispatch> {
     state: BootState<A>,
 }
@@ -461,33 +442,20 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // shutdown claim. Both share the same dispatcher trampoline
         // shape apart from the post-dispatch decrement.
         //
-        // The const is read through a local binding rather than used
-        // directly in the `if` so Qodana's `RsConstantConditionIf`
-        // inspector doesn't evaluate it against the trait default
-        // (false) and report "always false" — concrete `impl Actor`
-        // for frame-bound caps overrides it to `true`.
-        let frame_bound = A::FRAME_BARRIER;
-        let claim_result = if frame_bound {
-            ctx.claim_frame_bound_mailbox::<A>().map(|claim| {
-                (
-                    claim.id,
-                    claim.receiver,
-                    claim.mailbox_sender,
-                    Some(claim.pending),
-                    claim.wake_slot,
-                )
-            })
-        } else {
-            ctx.claim_mailbox_drop_on_shutdown::<A>().map(|claim| {
-                (
-                    claim.id,
-                    claim.receiver,
-                    claim.mailbox_sender,
-                    None,
-                    claim.wake_slot,
-                )
-            })
-        };
+        // ADR-0082: every cap takes the drop-on-shutdown claim. The
+        // FRAME_BARRIER frame-bound claim variant retired with the
+        // per-frame drain barrier — settlement gating on the
+        // LifecycleAdvance chain root is the frame-integration gate
+        // now, so no cap needs a pending-counter registration.
+        let claim_result = ctx.claim_mailbox_drop_on_shutdown::<A>().map(|claim| {
+            (
+                claim.id,
+                claim.receiver,
+                claim.mailbox_sender,
+                None,
+                claim.wake_slot,
+            )
+        });
         let (mailbox_id, receiver, mailbox_sender, pending, wake_slot) = match claim_result {
             Ok(c) => c,
             Err(e) => {
@@ -504,9 +472,8 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         };
 
         // Per-cap transport. `NativeBinding::from_ctx` pulls the
-        // chassis's frame-bound set + aborter so the cross-class
-        // wait_reply guard wires automatically.
-        let transport = Arc::new(NativeBinding::from_ctx(ctx, mailbox_id, A::FRAME_BARRIER));
+        // chassis's aborter + spawner.
+        let transport = Arc::new(NativeBinding::from_ctx(ctx, mailbox_id));
         transport.install_inbox(receiver);
 
         // Per-actor scratch storage (issue 582 / ADR-0074). Stamped
@@ -989,8 +956,6 @@ impl<C: Chassis> Builder<C, HasDriver> {
                 &registry,
                 &mailer,
                 &mut booted.fallback,
-                &mut booted.frame_bound_pending,
-                &booted.frame_bound_set,
                 &booted.aborter,
                 &mut booted.claimed_actor_mailboxes,
                 &booted.spawner,
@@ -1018,22 +983,10 @@ struct BootedPassives {
     /// type-keyed actor map; the actor itself never escapes its
     /// dispatcher thread.
     handles: ExportedHandles,
-    /// Per-mailbox pending counters from
-    /// [`ChassisCtx::claim_frame_bound_mailbox`] calls — collected
-    /// during passive boot, exposed to the driver via
-    /// [`DriverCtx::frame_bound_pending`] (the driver stashes a clone
-    /// for its frame loop).
-    frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)>,
-    /// Membership view of the same set; shared with every
-    /// [`NativeBinding`] booted under this chassis so the
-    /// cross-class `wait_reply` guard can classify recipients.
-    /// Populated alongside `frame_bound_pending` by
-    /// [`ChassisCtx::claim_frame_bound_mailbox`].
-    frame_bound_set: Arc<RwLock<HashSet<MailboxId>>>,
     /// Cloned into every `ChassisCtx` and onto every booted
-    /// [`NativeBinding`] so the cross-class `wait_reply`
-    /// guard has somewhere to abort to. Inherited from the
-    /// [`Builder`]'s configured aborter.
+    /// [`NativeBinding`] so a wasm-guest trap can fatal-abort the
+    /// substrate cleanly. Inherited from the [`Builder`]'s configured
+    /// aborter.
     aborter: Arc<dyn FatalAborter>,
     /// Issue #601: every actor mailbox claimed during passive boot.
     /// `Builder::build` / `build_passive` reads this list to dispatch
@@ -1045,8 +998,8 @@ struct BootedPassives {
     /// lifecycle registry, plus the spawn machinery that writes into
     /// it. Both built once at boot; `Spawner` carries `Arc` clones of
     /// the chassis-level handles (registry, `actor_registry`, mailer,
-    /// `frame_bound_set`, aborter) so future per-handler `spawn_child`
-    /// reaches them without separate plumbing.
+    /// aborter) so future per-handler `spawn_child` reaches them
+    /// without separate plumbing.
     actor_registry: Arc<crate::ActorRegistry>,
     spawner: Arc<crate::Spawner>,
     /// Issue 635 PR C: chassis-owned worker pool. Boots empty in
@@ -1119,8 +1072,6 @@ fn boot_passives(
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
     let mut fallback: Option<FallbackRouter> = None;
     let mut handles = ExportedHandles::new();
-    let mut frame_bound_pending: Vec<(MailboxId, Arc<AtomicU64>)> = Vec::new();
-    let frame_bound_set: Arc<RwLock<HashSet<MailboxId>>> = Arc::new(RwLock::new(HashSet::new()));
     let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
     let actor_registry: Arc<crate::ActorRegistry> = Arc::new(crate::ActorRegistry::new());
     // Issue 635 PR C: stand up the worker pool before any cap boots.
@@ -1186,7 +1137,6 @@ fn boot_passives(
         Arc::clone(registry),
         Arc::clone(&actor_registry),
         Arc::clone(mailer),
-        Arc::clone(&frame_bound_set),
         Arc::clone(aborter),
         pool.ready_tx(),
     ));
@@ -1199,15 +1149,13 @@ fn boot_passives(
 
     // Helper: build a fresh `ChassisCtx` borrowing from the locals.
     // Each phase re-takes the borrow because methods may mutate the
-    // borrowed slots (e.g., claim pushes into `frame_bound_pending`).
+    // borrowed slots (e.g., claim pushes into `claimed_actor_mailboxes`).
     macro_rules! build_ctx {
         () => {
             ChassisCtx::new(
                 registry,
                 mailer,
                 &mut fallback,
-                &mut frame_bound_pending,
-                &frame_bound_set,
                 aborter,
                 &mut claimed_actor_mailboxes,
                 &spawner,
@@ -1226,8 +1174,6 @@ fn boot_passives(
         registry: &Arc<Registry>,
         mailer: &Arc<Mailer>,
         fallback: &mut Option<FallbackRouter>,
-        frame_bound_pending: &mut Vec<(MailboxId, Arc<AtomicU64>)>,
-        frame_bound_set: &Arc<RwLock<HashSet<MailboxId>>>,
         aborter: &Arc<dyn FatalAborter>,
         claimed_actor_mailboxes: &mut Vec<MailboxId>,
         spawner: &Arc<crate::Spawner>,
@@ -1242,8 +1188,6 @@ fn boot_passives(
                 registry,
                 mailer,
                 fallback,
-                frame_bound_pending,
-                frame_bound_set,
                 aborter,
                 claimed_actor_mailboxes,
                 spawner,
@@ -1265,8 +1209,6 @@ fn boot_passives(
                     registry,
                     mailer,
                     &mut fallback,
-                    &mut frame_bound_pending,
-                    &frame_bound_set,
                     aborter,
                     &mut claimed_actor_mailboxes,
                     &spawner,
@@ -1286,8 +1228,6 @@ fn boot_passives(
                 registry,
                 mailer,
                 &mut fallback,
-                &mut frame_bound_pending,
-                &frame_bound_set,
                 aborter,
                 &mut claimed_actor_mailboxes,
                 &spawner,
@@ -1305,8 +1245,6 @@ fn boot_passives(
                 registry,
                 mailer,
                 &mut fallback,
-                &mut frame_bound_pending,
-                &frame_bound_set,
                 aborter,
                 &mut claimed_actor_mailboxes,
                 &spawner,
@@ -1334,8 +1272,6 @@ fn boot_passives(
                     registry,
                     mailer,
                     &mut fallback,
-                    &mut frame_bound_pending,
-                    &frame_bound_set,
                     aborter,
                     &mut claimed_actor_mailboxes,
                     &spawner,
@@ -1350,8 +1286,6 @@ fn boot_passives(
         shutdowns,
         fallback,
         handles,
-        frame_bound_pending,
-        frame_bound_set,
         aborter: Arc::clone(aborter),
         claimed_actor_mailboxes,
         actor_registry,
@@ -1525,16 +1459,6 @@ impl<C: Chassis> PassiveChassis<C> {
     /// trace pipeline and wait on the resulting `Settled` signal.
     pub fn settlement_registry(&self) -> &Arc<SettlementRegistry> {
         self.booted.settlement_registry()
-    }
-
-    /// Snapshot of every frame-bound mailbox's pending counter
-    /// collected during passive boot. Embedders (`TestBench`, bin
-    /// drivers) clone this once and feed it to
-    /// [`super::frame_loop::drain_frame_bound_or_abort`] each frame —
-    /// same role as [`DriverCtx::frame_bound_pending`]
-    /// on the driver-build path.
-    pub fn frame_bound_pending(&self) -> Vec<(MailboxId, Arc<AtomicU64>)> {
-        self.booted.frame_bound_pending.clone()
     }
 
     /// Issue 607 Phase 5 (ADR-0079): mirror of
@@ -1912,54 +1836,6 @@ mod tests {
             "dispatcher should have routed Ping → on_ping within the wait budget"
         );
 
-        drop(chassis);
-    }
-
-    /// Issue 552 stage 2d: `with_actor` accepts `FRAME_BARRIER` caps.
-    /// The chassis claims through `claim_frame_bound_mailbox`, the
-    /// pending counter feeds the chassis's `frame_bound_pending` Vec,
-    /// and the dispatcher decrements after each handler dispatch so
-    /// the per-frame drain barrier sees the counter drop in lock-step.
-    /// Pre-2d the entry point hard-rejected; the prior reject-test
-    /// retired alongside that branch.
-    #[test]
-    fn with_actor_supports_frame_barrier_caps() {
-        struct FrameBoundProbe;
-        impl Actor for FrameBoundProbe {
-            const NAMESPACE: &'static str = "test.with_actor.frame_bound";
-            const FRAME_BARRIER: bool = true;
-        }
-        impl aether_actor::Singleton for FrameBoundProbe {}
-
-        impl NativeActor for FrameBoundProbe {
-            type Config = ();
-            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
-            }
-        }
-
-        impl NativeDispatch for FrameBoundProbe {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                _kind: KindId,
-                _payload: &[u8],
-            ) -> Option<()> {
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(registry, mailer)
-            .with_actor::<FrameBoundProbe>(())
-            .build_passive()
-            .expect("FRAME_BARRIER caps boot through with_actor");
-        // Frame-bound claim populated the chassis's pending Vec.
-        assert_eq!(
-            chassis.frame_bound_pending().len(),
-            1,
-            "FRAME_BARRIER cap registered its pending counter for the drain barrier"
-        );
         drop(chassis);
     }
 

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -1,15 +1,12 @@
 //! Boot machinery shared by the chassis builder (`chassis::builder::Builder`,
 //! ADR-0071): mailbox claim helpers, the per-cap [`MailboxClaim`] /
-//! [`FrameBoundClaim`] / [`DropOnShutdownClaim`] result shapes, and
-//! the [`ChassisCtx`] threaded through every cap's boot. Sibling
-//! modules: error types live in `chassis::error`; the cross-flavour
-//! [`Envelope`] shape lives
+//! [`DropOnShutdownClaim`] result shapes, and the [`ChassisCtx`]
+//! threaded through every cap's boot. Sibling modules: error types
+//! live in `chassis::error`; the cross-flavour [`Envelope`] shape lives
 //! in `actor::native::envelope`.
 
-use std::collections::HashSet;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::sync::mpsc;
-use std::sync::{Arc, RwLock};
 
 use aether_actor::Actor;
 
@@ -124,39 +121,10 @@ pub struct MailboxSender {
 
 impl MailboxSender {
     /// Internal constructor — only
-    /// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] /
-    /// [`ChassisCtx::claim_frame_bound_mailbox`] build these.
+    /// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] builds these.
     pub(crate) fn new(inner: Arc<mpsc::Sender<Envelope>>) -> Self {
         Self { _inner: inner }
     }
-}
-
-/// Result returned from [`ChassisCtx::claim_frame_bound_mailbox`].
-///
-/// Same as [`DropOnShutdownClaim`] plus a `pending` counter that the
-/// sink registration handler increments on every accepted send and
-/// the capability's dispatcher decrements after each processed
-/// envelope. The chassis collects this counter so
-/// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`] can wait
-/// on it as part of the per-frame drain barrier (ADR-0074 §Decision 5).
-///
-/// Capabilities authored with `Capability::FRAME_BARRIER = true`
-/// must claim through this method instead of
-/// [`ChassisCtx::claim_mailbox_drop_on_shutdown`] — otherwise the
-/// chassis has no counter to wait on and the barrier degrades to
-/// "components only", reintroducing the race the `FRAME_BARRIER`
-/// classification exists to close.
-#[derive(Debug)]
-pub struct FrameBoundClaim {
-    pub id: MailboxId,
-    pub receiver: mpsc::Receiver<Envelope>,
-    pub mailbox_sender: MailboxSender,
-    /// Shared with the registry's sink handler. The handler increments
-    /// before pushing into the mpsc; the capability's dispatcher must
-    /// decrement after each `dispatch()` returns.
-    pub pending: Arc<AtomicU64>,
-    /// Issue 635 PR C: see [`DropOnShutdownClaim::wake_slot`].
-    pub wake_slot: Arc<MailboxWakeSlot>,
 }
 
 /// Generic fallback-router handler: invoked by substrate dispatch when a
@@ -185,44 +153,21 @@ pub struct ChassisCtx<'a> {
     registry: &'a Arc<Registry>,
     mailer: &'a Arc<Mailer>,
     fallback: &'a mut Option<FallbackRouter>,
-    /// Per-mailbox pending counters collected from
-    /// [`ChassisCtx::claim_frame_bound_mailbox`] calls. The chassis
-    /// builder hands these to the resulting `PassiveChassis` /
-    /// `BuiltChassis` so the frame loop can wait on them via
-    /// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`].
-    frame_bound_pending: &'a mut Vec<(MailboxId, Arc<AtomicU64>)>,
-    /// Membership view of the same set the `frame_bound_pending` Vec
-    /// covers, shared with every [`crate::NativeBinding`] built
-    /// against this chassis. Capabilities clone the [`Arc`] into their
-    /// transport at boot; the transport's cross-class `wait_reply`
-    /// guard reads it (with a brief read-lock) to classify the
-    /// recipient of an outbound request as frame-bound or
-    /// free-running. [`Self::claim_frame_bound_mailbox`] inserts the
-    /// claimed mailbox id here in addition to pushing onto the
-    /// pending-counter list.
-    frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
-    /// Indirection over [`crate::runtime::lifecycle::fatal_abort`] cloned into
-    /// every [`crate::NativeBinding`] this ctx builds, so the
-    /// cross-class `wait_reply` guard (ADR-0074 §Decision 5) can
-    /// abort without each capability needing to plumb
-    /// [`crate::HubOutbound`] itself. Defaults to
-    /// [`crate::runtime::lifecycle::PanicAborter`] when the chassis
-    /// builder doesn't override — production drivers swap in
+    /// Indirection over [`crate::runtime::lifecycle::fatal_abort`]
+    /// cloned into every [`crate::NativeBinding`] this ctx builds, so a
+    /// wasm-guest trap can fatal-abort the substrate cleanly without
+    /// each capability needing to plumb [`crate::HubOutbound`] itself.
+    /// Defaults to [`crate::runtime::lifecycle::PanicAborter`] when the
+    /// chassis builder doesn't override — production drivers swap in
     /// [`crate::runtime::lifecycle::OutboundFatalAborter`] via
     /// [`crate::chassis::builder::Builder::with_aborter`].
     aborter: &'a Arc<dyn FatalAborter>,
-    /// Issue #601: every actor-mailbox claim (`claim_mailbox_*`,
-    /// `claim_frame_bound_mailbox_*`, `claim_mailbox_drop_on_shutdown_*`)
-    /// appends its `MailboxId` here. The chassis builder reads the
-    /// list after `boot_passives` to dispatch
-    /// `aether.log.configure_drain` mail to each booted actor
-    /// so its `LogDrainSlot` resolves to the chassis's declared drain
-    /// (`Builder::with_log_drain<T>()`).
+    /// Issue #601: every actor-mailbox claim appends its `MailboxId`
+    /// here. The chassis builder reads the list after `boot_passives`.
     ///
     /// Synchronous-handler registrations (e.g. `AETHER_DIAGNOSTICS`)
     /// go through `Registry::register_inline` directly and do *not*
-    /// land here — they're not actors and have no `LogDrainSlot` to
-    /// install.
+    /// land here — they're not actors.
     claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
     /// Issue 607 Phase 3b (ADR-0079): the chassis's
     /// [`crate::Spawner`], cloned into every booted actor's
@@ -235,18 +180,11 @@ pub struct ChassisCtx<'a> {
 
 impl<'a> ChassisCtx<'a> {
     /// Internal constructor used by the ADR-0071
-    /// [`crate::chassis::builder::Builder`]. Eight refs is one
-    /// over clippy's default; the alternative — a builder-of-the-builder
-    /// — pays the same plumbing cost without adding clarity, since
-    /// every chassis path that constructs a `ChassisCtx` already has
-    /// every ref in scope.
-    #[allow(clippy::too_many_arguments)]
+    /// [`crate::chassis::builder::Builder`].
     pub(crate) fn new(
         registry: &'a Arc<Registry>,
         mailer: &'a Arc<Mailer>,
         fallback: &'a mut Option<FallbackRouter>,
-        frame_bound_pending: &'a mut Vec<(MailboxId, Arc<AtomicU64>)>,
-        frame_bound_set: &'a Arc<RwLock<HashSet<MailboxId>>>,
         aborter: &'a Arc<dyn FatalAborter>,
         claimed_actor_mailboxes: &'a mut Vec<MailboxId>,
         spawner: &'a Arc<crate::Spawner>,
@@ -255,8 +193,6 @@ impl<'a> ChassisCtx<'a> {
             registry,
             mailer,
             fallback,
-            frame_bound_pending,
-            frame_bound_set,
             aborter,
             claimed_actor_mailboxes,
             spawner,
@@ -394,132 +330,16 @@ impl<'a> ChassisCtx<'a> {
         })
     }
 
-    /// Variant of [`Self::claim_mailbox_drop_on_shutdown`] for
-    /// frame-bound capabilities. Claims under `C::NAMESPACE`. See
-    /// [`Self::claim_frame_bound_mailbox_with_override`] for the
-    /// arbitrary-name escape hatch.
-    pub fn claim_frame_bound_mailbox<C: Actor>(&mut self) -> Result<FrameBoundClaim, BootError> {
-        self.claim_frame_bound_mailbox_with_override(C::NAMESPACE)
-    }
-
-    /// Variant of [`Self::claim_mailbox_drop_on_shutdown_with_override`]
-    /// for frame-bound capabilities (ADR-0074 §Decision 5). In addition
-    /// to the channel-drop shutdown machinery, the registered sink
-    /// handler increments a `pending` counter on every accepted send;
-    /// the capability's dispatcher must decrement after each
-    /// processed envelope so the counter reflects "envelopes accepted
-    /// by the sink but not yet drained by the dispatcher."
-    ///
-    /// The chassis collects the counter so
-    /// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`] can
-    /// wait for it to hit zero before render submit. Pair this with
-    /// `FRAME_BARRIER = true` on the [`Actor`] impl. See
-    /// `aether_capabilities::RenderCapability` for the reference shape.
-    ///
-    /// # Panics
-    /// Panics if the `frame_bound_set` `RwLock` is poisoned — fail-fast
-    /// per ADR-0063: a poisoned lock means a prior writer panicked
-    /// under the guard, a substrate-level invariant violation.
-    pub fn claim_frame_bound_mailbox_with_override(
-        &mut self,
-        name: &str,
-    ) -> Result<FrameBoundClaim, BootError> {
-        let (tx, rx) = mpsc::channel::<Envelope>();
-        let tx = Arc::new(tx);
-        let weak = Arc::downgrade(&tx);
-        let pending = Arc::new(AtomicU64::new(0));
-        let pending_for_handler = Arc::clone(&pending);
-        let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
-        let wake_for_handler = Arc::clone(&wake_slot);
-        let id = self.registry.try_register_inbox(
-            name.to_owned(),
-            // iamacoffeepot/aether#848 PR 3: see `claim_mailbox_with_override`
-            // for the rationale. Pre-send increment + post-fail
-            // decrement bracket the `tx.send` exactly as before;
-            // the only change is that `dispatch` is `OwnedDispatch`
-            // (moved into `env` via `From`) and the failure branch
-            // reads `env.kind_name` out of the `SendError`.
-            Arc::new(move |dispatch: OwnedDispatch| {
-                let Some(tx) = weak.upgrade() else {
-                    tracing::warn!(
-                        target: "aether_substrate::capability",
-                        kind = %dispatch.kind_name,
-                        "frame-bound capability sender dropped — mail discarded"
-                    );
-                    return;
-                };
-                let env: Envelope = dispatch;
-                // Increment before send so the dispatcher's
-                // matching decrement-after-dispatch sees a count
-                // > 0 by the time it tries to decrement. If the
-                // send itself fails (receiver dropped between the
-                // upgrade and the send — shutdown race), undo
-                // the increment so the counter doesn't drift up.
-                pending_for_handler.fetch_add(1, Ordering::AcqRel);
-                if let Err(mpsc::SendError(env)) = tx.send(env) {
-                    pending_for_handler.fetch_sub(1, Ordering::AcqRel);
-                    tracing::warn!(
-                        target: "aether_substrate::capability",
-                        kind = %env.kind_name,
-                        "frame-bound capability receiver dropped — mail discarded"
-                    );
-                    return;
-                }
-                // Issue 635 PR C: fire the `Pooled` wake hook (if
-                // installed). Frame-bound + pool-scheduled is a
-                // valid combination per the issue's section 5
-                // ("FRAME_BARRIER and SCHEDULING are orthogonal");
-                // the chassis frame loop reads `pending` regardless
-                // of where the dispatch happens.
-                if let Some(wake) = wake_for_handler.get() {
-                    wake();
-                }
-            }),
-        )?;
-        self.frame_bound_pending.push((id, Arc::clone(&pending)));
-        // Mirror the membership into the shared set so each
-        // capability's [`crate::NativeBinding`] can resolve "is the
-        // recipient of this `wait_reply` frame-bound?" with a single
-        // read-lock — without each transport having to scan the
-        // pending-counter Vec on every check.
-        self.frame_bound_set
-            .write()
-            .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
-            .insert(id);
-        self.claimed_actor_mailboxes.push(id);
-        Ok(FrameBoundClaim {
-            id,
-            receiver: rx,
-            mailbox_sender: MailboxSender::new(tx),
-            pending,
-            wake_slot,
-        })
-    }
-
     /// Issue 607 Phase 7: undo a previous `claim_*_mailbox` call.
-    /// Removes the sink from the chassis registry, the (id, counter)
-    /// entry from `frame_bound_pending`, the id from
-    /// `frame_bound_set`, and the id from `claimed_actor_mailboxes`.
-    /// Idempotent: calling on an id that wasn't claimed is a no-op.
+    /// Removes the sink from the chassis registry and the id from
+    /// `claimed_actor_mailboxes`. Idempotent: calling on an id that
+    /// wasn't claimed is a no-op.
     ///
-    /// Used in the singleton-boot unwind path (`chassis_builder` /
-    /// capability) when `init` fails after the cap mailbox was
-    /// claimed. Without this, the failed cap leaves a sink registered
-    /// against its namespace and a stuck counter in
-    /// `frame_bound_pending` that the chassis frame loop would wait
-    /// for forever.
-    ///
-    /// # Panics
-    /// Panics if the `frame_bound_set` `RwLock` is poisoned — fail-fast
-    /// per ADR-0063: a poisoned lock means a prior writer panicked
-    /// under the guard, a substrate-level invariant violation.
+    /// Used in the singleton-boot unwind path when `init` fails after
+    /// the cap mailbox was claimed. Without this, the failed cap leaves
+    /// a sink registered against its namespace.
     pub fn unclaim_mailbox(&mut self, id: MailboxId) {
         self.registry.remove_closure(id);
-        self.frame_bound_pending.retain(|(i, _)| *i != id);
-        self.frame_bound_set
-            .write()
-            .expect("frame_bound_set lock poisoned; fail-fast per ADR-0063")
-            .remove(&id);
         self.claimed_actor_mailboxes.retain(|i| *i != id);
     }
 
@@ -550,26 +370,6 @@ impl<'a> ChassisCtx<'a> {
     #[must_use]
     pub fn mailer(&self) -> &Arc<Mailer> {
         self.mailer
-    }
-
-    /// Read the list of frame-bound pending counters collected so far
-    /// from earlier `claim_frame_bound_mailbox` calls. Used by
-    /// [`crate::chassis::builder::DriverCtx::frame_bound_pending`] to
-    /// snapshot the list at driver-boot time; capabilities that just
-    /// want their own counter should hold the `Arc<AtomicU64>` from
-    /// their [`FrameBoundClaim`] directly instead.
-    #[must_use]
-    pub fn frame_bound_pending(&self) -> &[(MailboxId, Arc<AtomicU64>)] {
-        self.frame_bound_pending
-    }
-
-    /// Clone the chassis's shared frame-bound membership set. Read by
-    /// [`crate::NativeBinding::from_ctx`] so the cross-class
-    /// `wait_reply` guard can classify each outbound recipient.
-    /// Capabilities that just want to send mail don't need this.
-    #[must_use]
-    pub fn frame_bound_set(&self) -> Arc<RwLock<HashSet<MailboxId>>> {
-        Arc::clone(self.frame_bound_set)
     }
 
     /// Clone the chassis's [`FatalAborter`]. Read by

--- a/crates/aether-substrate/src/chassis/error.rs
+++ b/crates/aether-substrate/src/chassis/error.rs
@@ -3,15 +3,10 @@
 //! `BootError` is what every `Capability::boot` / `NativeActor::init` /
 //! `Chassis::build` returns on failure (per ADR-0063 a boot error
 //! aborts the chassis before user code runs — no partial boots).
-//! `WedgedFrameBound` is the diagnostic the per-frame drain barrier
-//! returns when a frame-bound capability's inbox didn't drain within
-//! the budget.
 
 use std::error::Error as StdError;
 use std::fmt;
-use std::time::Duration;
 
-use crate::mail::MailboxId;
 use crate::mail::registry::NameConflict;
 use std::io;
 
@@ -69,27 +64,5 @@ impl From<NameConflict> for BootError {
 impl From<wasmtime::Error> for BootError {
     fn from(e: wasmtime::Error) -> Self {
         Self::Other(Box::new(io::Error::other(format!("{e}"))))
-    }
-}
-
-/// Diagnostic returned from
-/// [`crate::chassis::frame_loop::drain_frame_bound_or_abort`] when a
-/// frame-bound capability's inbox didn't drain within the budget. The
-/// chassis frame loop routes this through `lifecycle::fatal_abort`
-/// the same way component-side wedges do.
-#[derive(Debug, Clone, Copy)]
-pub struct WedgedFrameBound {
-    pub mailbox: MailboxId,
-    pub pending: u64,
-    pub waited: Duration,
-}
-
-impl fmt::Display for WedgedFrameBound {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "frame-bound dispatcher wedged: mailbox={} pending={} waited={:?}",
-            self.mailbox, self.pending, self.waited,
-        )
     }
 }

--- a/crates/aether-substrate/src/chassis/frame_loop.rs
+++ b/crates/aether-substrate/src/chassis/frame_loop.rs
@@ -1,85 +1,29 @@
-//! Shared frame-loop policy helpers (issue 427).
+//! Shared frame-loop policy constants (issue 427).
 //!
-//! One helper, invariant across chassis: the per-frame frame-bound
-//! drain barrier (ADR-0074 §Decision 5). `drain_frame_bound_or_abort`
-//! waits on each frame-bound cap's pending counter under
-//! `DRAIN_BUDGET`; a counter that doesn't reach zero is treated as
-//! wedged and routes through `lifecycle::fatal_abort`.
+//! Pre-ADR-0082 this module also held `drain_frame_bound_or_abort`,
+//! the per-frame frame-bound drain barrier (ADR-0074 §Decision 5):
+//! it polled each frame-bound cap's pending counter under
+//! `DRAIN_BUDGET` and routed a counter that wouldn't reach zero
+//! through `lifecycle::fatal_abort`. ADR-0082 §6 replaced that poll
+//! with settlement gating on the `LifecycleAdvance` chain root — the
+//! chassis waits for the frame chain to settle before submit, which
+//! covers the same "geometry integrated before submit" invariant via
+//! causal completion rather than a pending-counter sweep. The helper
+//! (and the `FRAME_BARRIER` machinery that fed it) retired in PR 3c /
+//! 3d; `DRAIN_BUDGET` survives as the timeout the settlement wait
+//! fatal-aborts against.
 //!
-//! Issue 775 retired the second helper, `emit_frame_stats`, that
-//! pushed a `FrameStats` cast every `LOG_EVERY_FRAMES` to the
-//! `hub.claude.broadcast` mailbox: with `BroadcastCapability` gone
-//! the fan-out has nowhere to land.
-//!
-//! Pre-Phase-4 there was a third helper, `drain_or_abort`, that
-//! polled a per-component pending-counter aggregate to detect dead /
-//! wedged wasm dispatchers. Issue 634 Phase 4 PR 1 retired the
-//! per-component routing path; PR 2 retired the polling barrier in
-//! favour of direct trap-abort at the trampoline (the trampoline
-//! holds a `FatalAborter` and aborts on `Component::deliver` Err).
-//! Wedge detection (CPU-loop wasm guests) waits on a future
-//! epoch-deadline ADR — symmetric with native actors, which have
-//! no wedge guard either.
-//!
-//! `WORKERS` deliberately stays chassis-side. Post-ADR-0038 it's
-//! declarative (the wire-stable `EngineInfo.workers` field, retained
-//! for compatibility — the scheduler doesn't read it). It's not
-//! actual loop policy and shouldn't be promoted into a shared
-//! module just because every chassis happens to set the same value.
+//! Issue 775 retired `emit_frame_stats`; issue 634 Phase 4 retired
+//! the earlier per-component `drain_or_abort`. `WORKERS` stays
+//! chassis-side — post-ADR-0038 it's the declarative wire-stable
+//! `EngineInfo.workers` field, not loop policy.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use crate::mail::MailboxId;
-use crate::mail::outbound::HubOutbound;
-use crate::runtime::lifecycle;
-use std::thread;
-
-/// ADR-0063 fail-fast budget for the per-frame drain barrier. A
-/// dispatcher that doesn't quiesce within this window is treated as
-/// wedged: the substrate logs and exits via `lifecycle::fatal_abort`.
-/// 5 s is patient enough that ordinary frames don't trip it even on
-/// slow first-load compiles, short enough that an operator staring
-/// at a frozen window gets a clean exit instead of a multi-minute
-/// wait.
+/// ADR-0063 fail-fast budget for the per-frame settlement wait. A
+/// frame chain that doesn't settle within this window is treated as
+/// wedged: the chassis loop exits via `lifecycle::fatal_abort`. 5 s
+/// is patient enough that ordinary frames don't trip it even on slow
+/// first-load compiles, short enough that an operator staring at a
+/// frozen window gets a clean exit instead of a multi-minute wait.
 pub const DRAIN_BUDGET: Duration = Duration::from_secs(5);
-
-/// Wait for every frame-bound capability's inbox to drain under
-/// `DRAIN_BUDGET` (ADR-0074 §Decision 5). Works on the per-mailbox
-/// pending counters
-/// [`crate::ChassisCtx::claim_frame_bound_mailbox`] collected for the
-/// chassis (snapshotted by drivers via
-/// [`crate::chassis::builder::DriverCtx::frame_bound_pending`]).
-///
-/// Empty `pending` is a fast no-op — chassis without frame-bound
-/// capabilities (today: headless, hub) call this every frame at
-/// zero cost.
-pub fn drain_frame_bound_or_abort(pending: &[(MailboxId, Arc<AtomicU64>)], outbound: &HubOutbound) {
-    if pending.is_empty() {
-        return;
-    }
-    let deadline = Instant::now() + DRAIN_BUDGET;
-    loop {
-        let mut still_pending: Option<(MailboxId, u64)> = None;
-        for (mbox, counter) in pending {
-            let v = counter.load(Ordering::Acquire);
-            if v > 0 {
-                still_pending = Some((*mbox, v));
-                break;
-            }
-        }
-        match still_pending {
-            None => return,
-            Some((mbox, count)) => {
-                if Instant::now() >= deadline {
-                    let reason = format!(
-                        "frame-bound dispatcher wedged: mailbox={mbox} pending={count} waited={DRAIN_BUDGET:?}"
-                    );
-                    lifecycle::fatal_abort(outbound, reason);
-                }
-                thread::sleep(Duration::from_micros(50));
-            }
-        }
-    }
-}

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -69,10 +69,9 @@ pub use chassis::builder::{
     NeverDriver, NeverDriverRunning, NoDriver, PassiveChassis, RunError,
 };
 pub use chassis::ctx::{
-    ActorErased, ChassisCtx, DropOnShutdownClaim, FallbackRouter, FrameBoundClaim, MailboxClaim,
-    MailboxSender,
+    ActorErased, ChassisCtx, DropOnShutdownClaim, FallbackRouter, MailboxClaim, MailboxSender,
 };
-pub use chassis::error::{BootError, WedgedFrameBound};
+pub use chassis::error::BootError;
 pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::mailer::Mailer;
 pub use mail::outbound::{


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

PR 3d of the ADR-0082 migration (refs iamacoffeepot/aether#949) — the final cleanup. Now that settlement gating (PR 3c, iamacoffeepot/aether#996) is the frame-integration gate, the FRAME_BARRIER machinery is dead. **No behaviour change for any in-tree actor.**

- Remove `Actor::FRAME_BARRIER` const + the `#[actor]` / `#[bridge]` macro codegen that re-emitted it.
- Remove the chassis frame-bound claim path: `ChassisCtx::claim_frame_bound_mailbox{,_with_override}`, `FrameBoundClaim`, the `frame_bound_pending` Vec + `frame_bound_set` membership view threaded through `ChassisCtx` / `BootedPassives` / `DriverCtx` / `PassiveChassis` / `Spawner`. Every cap now takes the drop-on-shutdown claim.
- Remove `drain_frame_bound_or_abort` (callers retired in PR 3c); `DRAIN_BUDGET` stays as the settlement-wait timeout.
- Remove the `NativeBinding` cross-class `wait_reply` guard (`caller_frame_bound` / `frame_bound_set` / `pending_recipients`) + its 4 tests. **User-approved**: preventive-only (no in-tree cross-class `wait_reply` caller), its premise was the now-retired drain barrier, and a frame-bound caller blocking on a free-running recipient still fatal-aborts via the settlement-wait timeout — just with a more generic message.
- Remove `WedgedFrameBound` + render's `FRAME_BARRIER = true` + the two render tests keyed on the pending counter (DrawTriangle→render coverage lives in the bundle scenario suite).

The dispatcher's `pending: Option<Arc<AtomicU64>>` **stays** — still live for instanced-actor shutdown coordination (`Spawner::shutdown_instanced`, issue 685); singletons just pass `None` now.

This completes the ADR-0082 PR 3 arc (3a settlement → 3b chassis port → 3c settlement-gated submit → 3d machinery retirement). PR 4 (rename `aether.tick` → `aether.lifecycle.tick` + component migration) is the remaining piece.

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy --all-targets + nextest 1019/1019 + wasm32 cross-build). Test count dropped 1026→1019: the 4 cross-class guard tests + 2 render pending-counter tests + 1 prune test retired with the machinery.
- [x] RustRover `get_file_problems` (errorsOnly: false) clean on changed files.
- [ ] CI green, Qodana green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)