### PR TITLE
refactor(kinds): rename aether.tick to aether.lifecycle.tick (ADR-0082 §11)

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -27,8 +27,16 @@ use bytemuck::{Pod, Zeroable};
 // `aether.kinds` section carries and the `LABEL_NODE` sidecar — so
 // it's load-bearing on every build, not an optional enrichment.
 
-/// Per-frame signal from the substrate's frame loop. Empty payload —
-/// elapsed-time is parked until a subscriber actually needs it.
+// ADR-0082 lifecycle stage kinds. Empty payload — the broadcast is the
+// signal. Future revisions may add per-stage fields (frame_no on Tick,
+// vp matrix on Render) once stage payload semantics settle; v1 keeps
+// the wire shape minimal so the application-declared graph can drive
+// stage timing without committing to a fixed payload schema.
+
+/// Per-frame lifecycle stage (ADR-0082 §11). Empty payload —
+/// elapsed-time is parked until a subscriber actually needs it. The
+/// kind moved from `aether.tick` into the `aether.lifecycle.*` family
+/// in PR 4 so the lifecycle stage vocabulary reads as one namespace.
 ///
 /// ADR-0033 handler dispatch (`#[actor]` synthesized
 /// `__aether_dispatch`) decodes every typed handler via
@@ -48,16 +56,8 @@ use bytemuck::{Pod, Zeroable};
     aether_data::Kind,
     aether_data::Schema,
 )]
-#[kind(name = "aether.tick")]
+#[kind(name = "aether.lifecycle.tick")]
 pub struct Tick;
-
-// ADR-0082 lifecycle stage kinds. Empty payload — the broadcast is the
-// signal. Future revisions may add per-stage fields (frame_no on Tick,
-// vp matrix on Render) once stage payload semantics settle; v1 keeps
-// the wire shape minimal so the application-declared graph can drive
-// stage timing without committing to a fixed payload schema. The
-// existing `aether.tick` kind above stays in place for PR-4-deferred
-// renaming; the new kinds below add the rest of the lifecycle family.
 
 /// Lifecycle stage broadcast — capability init pass (ADR-0082 §5).
 /// Fires once at chassis boot, after every capability's actor-framework
@@ -2030,7 +2030,7 @@ mod tests {
 
     #[test]
     fn kind_names_are_stable() {
-        assert_eq!(Tick::NAME, "aether.tick");
+        assert_eq!(Tick::NAME, "aether.lifecycle.tick");
         assert_eq!(InitCaps::NAME, "aether.lifecycle.init_caps");
         assert_eq!(InitComponents::NAME, "aether.lifecycle.init_components");
         assert_eq!(Render::NAME, "aether.lifecycle.render");

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -28,7 +28,7 @@
 //! 3. On reply, the cached triangle list is replaced atomically. Any
 //!    parse or mesh failure leaves the prior cache intact (silent
 //!    drop; errors surface via `engine_logs`).
-//! 4. Every `aether.tick` re-emits the cached triangles to
+//! 4. Every `aether.lifecycle.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -197,8 +197,8 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
     // Capture's `run_frame` runs with `dispatch_tick=false`, so the
     // probe won't auto-tick during the captured frame. The pre-mail
     // bundle wires it up manually: set_render flips state to "visible
-    // red", and a synthesised `aether.tick` immediately drives the
-    // probe's on_tick to emit a `DrawTriangle` into the bench's
+    // red", and a synthesised `aether.lifecycle.tick` immediately drives
+    // the probe's on_tick to emit a `DrawTriangle` into the bench's
     // frame_vertices buffer right before the GPU readback.
     let pre = vec![
         envelope(
@@ -212,7 +212,7 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
         ),
         MailEnvelope {
             recipient_name: probe_address(),
-            kind_name: "aether.tick".to_owned(),
+            kind_name: "aether.lifecycle.tick".to_owned(),
             payload: Vec::new(),
             count: 1,
         },

--- a/crates/aether-substrate/src/lifecycle/mod.rs
+++ b/crates/aether-substrate/src/lifecycle/mod.rs
@@ -9,9 +9,9 @@
 //! enabling chassis main loops to drive the lifecycle cadence by mail
 //! without per-stage hand-rolled glue.
 //!
-//! See ADR-0082 for the full design. PR 2 of the migration ships the
-//! core types and synthetic-chassis tests; PR 3 wires the driver into
-//! production chassis main loops, PR 4 renames `aether.tick` into the
+//! See ADR-0082 for the full design. PR 2 of the migration shipped the
+//! core types and synthetic-chassis tests; PR 3 wired the driver into
+//! production chassis main loops; PR 4 renamed `aether.tick` into the
 //! `aether.lifecycle.*` family.
 
 mod driver;


### PR DESCRIPTION
<!-- pr-body-ok: b — intentional iamacoffeepot/aether# cross-issue refs -->

## Summary

PR 4 — the final ADR-0082 migration step (refs iamacoffeepot/aether#949). Moves the per-frame `Tick` kind from `aether.tick` into the `aether.lifecycle.*` family so the lifecycle stage vocabulary (`init_caps`, `init_components`, `tick`, `render`, `present`, `shutdown`) reads as one namespace — visually distinct from interrupt kinds (`aether.key`, `aether.mouse_move`) and content kinds (`aether.draw_triangle`).

- The Rust `Tick` type is unchanged — every subscriber resolves `Tick::ID` symbolically, so the rename propagates by recompilation. The kind id changes (FNV-1a hash of the new name), so all wasm components rebuild; CI pre-builds component wasm before tests and preflight's wasm32 cross-build covers the local path.
- Touch points beyond the kind definition: the `test_bench_scenario` pre-mail bundle that synthesises a Tick by name string (`"aether.tick"` → `"aether.lifecycle.tick"`), and prose doc-comments in the mesh-viewer + lifecycle module.
- Historical ADR references to `aether.tick` are left frozen (they record the state at their writing).

This completes the full ADR-0082 arc: PR 1 (ADR) → PR 2 (core types) → PR 3a/b/c/d (driver settlement → chassis port → settlement-gated submit → FRAME_BARRIER retirement) → PR 4 (Tick rename).

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy --all-targets + nextest 1019/1019 + wasm32 cross-build). One flake on `batched_ticks_preserve_per_mailbox_count` (pre-existing parallel-contention flake, also seen on PR 3c; passes isolated and on re-run — the rename is symbolic and doesn't touch the test's logic).
- [x] RustRover `get_file_problems` (errorsOnly: false) clean.
- [x] CI green, Qodana green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)