### PR TITLE
refactor(test-bench): migrate sibling crate scenario tests onto execute

### DIFF
--- a/crates/aether-camera/tests/scenario.rs
+++ b/crates/aether-camera/tests/scenario.rs
@@ -21,7 +21,7 @@
 use aether_camera::CameraDestroy;
 use aether_kinds::{LoadComponent, LoadResult};
 use aether_substrate_bundle::test_bench::{
-    TestBench,
+    BenchOp, TestBench,
     test_helpers::require_runtime,
     visual::{decode_png, not_all_black},
 };
@@ -62,16 +62,22 @@ fn component_address() -> String {
 /// the error message rather than wedging on a missing subscription.
 fn load_camera(bench: &mut TestBench, wasm_path: &Path) {
     let wasm = fs::read(wasm_path).expect("read camera wasm");
-    let result: LoadResult = bench
-        .send_and_await_reply(
-            "aether.component",
-            &LoadComponent {
-                wasm,
-                name: Some(COMPONENT_NAME.to_owned()),
-            },
-        )
-        .expect("await load_component reply");
-    match result {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(COMPONENT_NAME.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
         LoadResult::Ok { .. } => {}
         LoadResult::Err { error } => panic!("load_component: {error}"),
     }
@@ -88,10 +94,14 @@ fn camera_component_lifecycle() {
 
     // A few ticks lets the component finish init, run on_tick, and
     // let the renderer cycle.
-    bench.advance(5).expect("advance");
-
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    let result = bench
+        .execute(vec![
+            ("advance", BenchOp::advance(5)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("advance + capture");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     not_all_black(&img).expect("camera scene should not be all black");
 }
 
@@ -113,7 +123,9 @@ fn camera_default_orbit_publishes_view_proj() {
     // Five ticks: enough for init + a handful of publishes to surface
     // on the camera sink. The component publishes on every tick after
     // init, so any non-zero count proves the path is alive.
-    bench.advance(5).expect("advance");
+    bench
+        .execute(vec![("advance", BenchOp::advance(5))])
+        .expect("advance");
 
     let observed = bench.count_observed("aether.camera");
     assert!(
@@ -140,7 +152,9 @@ fn camera_destroy_main_keeps_substrate_alive() {
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     load_camera(&mut bench, &wasm_path);
 
-    bench.advance(2).expect("pre-destroy advance");
+    bench
+        .execute(vec![("pre", BenchOp::advance(2))])
+        .expect("pre-destroy advance");
     // Baseline: default orbit was publishing before destroy.
     let pre_destroy = bench.count_observed("aether.camera");
     assert!(
@@ -149,24 +163,31 @@ fn camera_destroy_main_keeps_substrate_alive() {
         bench.observed_kinds(),
     );
 
-    // Drop the only camera the component was bootstrapped with. Per
-    // issue 634 Phase 4, agents address loaded components at the
-    // trampoline's full name (`aether.component.trampoline:NAME`).
-    bench
-        .send_mail(
-            &component_address(),
-            &CameraDestroy {
-                name: "main".to_owned(),
-            },
-        )
-        .expect("send camera.destroy");
-    bench.advance(5).expect("post-destroy advance");
-
+    // Drop the only camera the component was bootstrapped with (agents
+    // address loaded components at the trampoline's full name,
+    // `aether.component.trampoline:NAME`, per issue 634 Phase 4), then
+    // advance and capture.
+    //
     // Survivability: the chassis still renders its clear pass after
     // the active camera was removed. If the component panicked or the
     // substrate wedged, capture would fail or the frame would be
     // all-black.
-    let png = bench.capture().expect("capture after destroy");
-    let img = decode_png(&png).expect("decode capture png");
+    let result = bench
+        .execute(vec![
+            (
+                "destroy",
+                BenchOp::send_mail(
+                    component_address(),
+                    &CameraDestroy {
+                        name: "main".to_owned(),
+                    },
+                ),
+            ),
+            ("post", BenchOp::advance(5)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("destroy + advance + capture");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     not_all_black(&img).expect("frame should not be all black after camera destroy");
 }

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -23,7 +23,7 @@
 use aether_kinds::{LoadComponent, LoadResult};
 use aether_mesh_viewer::LoadMesh;
 use aether_substrate_bundle::test_bench::{
-    TestBench,
+    BenchOp, TestBench,
     test_helpers::{init_save_sandbox, require_runtime, test_namespace_roots, write_fixture},
     visual::{decode_png, differs_from_background},
 };
@@ -72,16 +72,22 @@ const BAD_DSL: &[u8] = b"(box not-a-number 1 1)\n";
 /// the error message rather than wedging on a missing subscription.
 fn load_viewer(bench: &mut TestBench, wasm_path: &Path) {
     let wasm = fs::read(wasm_path).expect("read mesh-viewer wasm");
-    let result: LoadResult = bench
-        .send_and_await_reply(
-            "aether.component",
-            &LoadComponent {
-                wasm,
-                name: Some(COMPONENT_NAME.to_owned()),
-            },
-        )
-        .expect("await load_component reply");
-    match result {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(COMPONENT_NAME.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
         LoadResult::Ok { .. } => {}
         LoadResult::Err { error } => panic!("load_component: {error}"),
     }
@@ -119,23 +125,29 @@ fn dsl_box_loads_and_renders() {
         .expect("boot");
     load_viewer(&mut bench, &wasm_path);
 
-    // First tick triggers the load; the read reply lands on a later
-    // tick. A handful of ticks ensures the cache is populated and
-    // several render-sink emissions land.
-    bench.advance(1).expect("priming advance");
-    bench
-        .send_mail(
-            &component_address(),
-            &LoadMesh {
-                namespace: "save".to_owned(),
-                path,
-            },
-        )
-        .expect("send mesh.load");
-    bench.advance(5).expect("post-load advance");
+    // Priming tick triggers the load; the read reply lands on a later
+    // tick, so a handful of post-load ticks populate the cache and
+    // emit several render-sink frames before the capture.
+    let result = bench
+        .execute(vec![
+            ("prime", BenchOp::advance(1)),
+            (
+                "load_mesh",
+                BenchOp::send_mail(
+                    component_address(),
+                    &LoadMesh {
+                        namespace: "save".to_owned(),
+                        path,
+                    },
+                ),
+            ),
+            ("post", BenchOp::advance(5)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("prime + load + advance + capture");
 
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     assert_draw_triangle_observed(&bench);
     differs_from_background(&img, 5).expect("captured frame should diverge from clear color");
 }
@@ -159,20 +171,26 @@ fn obj_quad_loads_and_renders() {
         .expect("boot");
     load_viewer(&mut bench, &wasm_path);
 
-    bench.advance(1).expect("priming advance");
-    bench
-        .send_mail(
-            &component_address(),
-            &LoadMesh {
-                namespace: "save".to_owned(),
-                path,
-            },
-        )
-        .expect("send mesh.load");
-    bench.advance(5).expect("post-load advance");
+    let result = bench
+        .execute(vec![
+            ("prime", BenchOp::advance(1)),
+            (
+                "load_mesh",
+                BenchOp::send_mail(
+                    component_address(),
+                    &LoadMesh {
+                        namespace: "save".to_owned(),
+                        path,
+                    },
+                ),
+            ),
+            ("post", BenchOp::advance(5)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("prime + load + advance + capture");
 
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     assert_draw_triangle_observed(&bench);
     differs_from_background(&img, 5).expect("captured frame should diverge from clear color");
 }
@@ -199,37 +217,47 @@ fn parse_failure_keeps_prior_mesh() {
         .expect("boot");
     load_viewer(&mut bench, &wasm_path);
 
-    bench.advance(1).expect("priming advance");
     bench
-        .send_mail(
-            &component_address(),
-            &LoadMesh {
-                namespace: "save".to_owned(),
-                path: good,
-            },
-        )
-        .expect("send good mesh.load");
-    bench.advance(5).expect("post-good-load advance");
+        .execute(vec![
+            ("prime", BenchOp::advance(1)),
+            (
+                "load_good",
+                BenchOp::send_mail(
+                    component_address(),
+                    &LoadMesh {
+                        namespace: "save".to_owned(),
+                        path: good,
+                    },
+                ),
+            ),
+            ("post_good", BenchOp::advance(5)),
+        ])
+        .expect("prime + good load");
 
     // Baseline: the good mesh is publishing.
     assert_draw_triangle_observed(&bench);
 
-    // Now hand the viewer something it can't parse.
-    bench
-        .send_mail(
-            &component_address(),
-            &LoadMesh {
-                namespace: "save".to_owned(),
-                path: bad,
-            },
-        )
-        .expect("send bad mesh.load");
-    bench.advance(5).expect("post-bad-load advance");
-
-    // The cached triangle list should be intact — the captured frame
-    // still has non-clear-color geometry.
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    // Now hand the viewer something it can't parse, then capture. The
+    // cached triangle list should be intact — the frame still has
+    // non-clear-color geometry.
+    let result = bench
+        .execute(vec![
+            (
+                "load_bad",
+                BenchOp::send_mail(
+                    component_address(),
+                    &LoadMesh {
+                        namespace: "save".to_owned(),
+                        path: bad,
+                    },
+                ),
+            ),
+            ("post_bad", BenchOp::advance(5)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("bad load + capture");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     differs_from_background(&img, 5)
         .expect("cached mesh should remain visible after parse failure");
 }

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -15,10 +15,9 @@
 //! gate) live in `aether_substrate_bundle::test_bench::test_helpers`
 //! (issues 460 + 821).
 
-use aether_data::Kind;
 use aether_kinds::{Key, LoadComponent, LoadResult, keycode};
 use aether_substrate_bundle::test_bench::{
-    TestBench,
+    BenchOp, TestBench,
     test_helpers::require_runtime,
     visual::{decode_png, differs_from_background},
 };
@@ -58,16 +57,22 @@ fn component_address() -> String {
 /// the error message rather than wedging on a missing subscription.
 fn load_sokoban(bench: &mut TestBench, wasm_path: &Path) {
     let wasm = fs::read(wasm_path).expect("read sokoban wasm");
-    let result: LoadResult = bench
-        .send_and_await_reply(
-            "aether.component",
-            &LoadComponent {
-                wasm,
-                name: Some(COMPONENT_NAME.to_owned()),
-            },
-        )
-        .expect("await load_component reply");
-    match result {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(COMPONENT_NAME.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
         LoadResult::Ok { .. } => {}
         LoadResult::Err { error } => panic!("load_component: {error}"),
     }
@@ -104,10 +109,14 @@ fn default_level_renders_grid_and_player() {
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     load_sokoban(&mut bench, &wasm_path);
 
-    bench.advance(3).expect("advance");
-
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    let result = bench
+        .execute(vec![
+            ("advance", BenchOp::advance(3)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("advance + capture");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     assert_draw_triangle_observed(&bench);
     differs_from_background(&img, 5).expect("default level should render visible geometry");
 }
@@ -125,24 +134,23 @@ fn key_press_keeps_render_path_alive() {
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     load_sokoban(&mut bench, &wasm_path);
 
-    bench.advance(2).expect("pre-key advance");
-
     // Press D — sokoban steps the player east; the WASD/arrow mapping
-    // lives in `step_delta` inside the demo's lib.rs. `send_bytes`
-    // is synchronous-on-settle (iamacoffeepot/aether#834), so the
-    // post-key advance below picks up the new player position
-    // structurally.
+    // lives in `step_delta` inside the demo's lib.rs. Each `execute`
+    // step is synchronous-on-settle (iamacoffeepot/aether#834), so the
+    // post-key advance picks up the new player position structurally.
     let key = Key {
         code: keycode::KEY_D,
     };
-    bench
-        .send_bytes(&component_address(), Key::ID, key.encode_into_bytes())
-        .expect("send key");
-
-    bench.advance(2).expect("post-key advance");
-
-    let png = bench.capture().expect("capture");
-    let img = decode_png(&png).expect("decode capture png");
+    let result = bench
+        .execute(vec![
+            ("pre", BenchOp::advance(2)),
+            ("key", BenchOp::send_mail(component_address(), &key)),
+            ("post", BenchOp::advance(2)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("pre-key advance + key + post-key advance + capture");
+    let png = result.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
     assert_draw_triangle_observed(&bench);
     differs_from_background(&img, 5).expect("frame should still render after key press");
 }


### PR DESCRIPTION
Phase 2 of consolidating every `TestBench` caller onto `execute` (issue 868). Migrates the component / demo scenario tests that drove the bench through the imperative primitives onto `BenchOp` sequences.

## Summary
- **`aether-camera`** — 3 tests + `load_camera` helper
- **`aether-mesh-viewer`** — 3 tests + `load_viewer` helper
- **`aether-demo-sokoban`** — 2 tests + `load_sokoban` helper

Step order is preserved exactly (e.g. mesh-viewer's `prime → load_mesh → post-advance → capture`), so behaviour is unchanged. Tests that asserted intermediate state — `parse_failure`'s mid-sequence draw-triangle check, `camera_destroy`'s pre-destroy baseline — split into two `execute` calls around the assertion. Sokoban's typed key send moves from the manual `send_bytes(Key::ID, encode_into_bytes())` to `BenchOp::send_mail(&key)`, dropping the now-unused `aether_data::Kind` import.

With every caller migrated, PR3 can fold spawn in and narrow the primitives to `pub(crate)`.

## Test plan
- [x] `scripts/preflight.sh` — 1019/1019 tests pass; workspace clippy + fmt + doc + wasm32 component cross-build clean
- [x] All 8 sibling scenario tests exercised under `AETHER_REQUIRE_RUNTIME=1` (run, not skipped) against freshly-built component wasm

Part of iamacoffeepot/aether#868