### PR TITLE
refactor(substrate-bundle): make execute the sole public bench-driver API

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -49,7 +49,6 @@ use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use super::events::{ChassisEvent, EventReceiver, channel as event_channel};
 use super::render::Gpu;
 use serde::de::DeserializeOwned;
-use std::any;
 use std::error;
 use std::thread;
 
@@ -379,42 +378,20 @@ impl TestBench {
             .clone()
     }
 
-    /// Push a typed mail and block until the dispatched chain
-    /// settles (ADR-0080 §6). Recipient is resolved by name against
-    /// the registry; kind ids are pulled from `K::ID` so the caller
-    /// doesn't need to look anything up.
+    /// Bytes-level fire-and-settle send: resolve `recipient_name` in
+    /// the registry, push `(kind, bytes)` as a chassis-root mail, and
+    /// block until the dispatched chain settles (ADR-0080 §6). Backs
+    /// the `SendMail` op of [`Self::execute`].
     ///
-    /// Issue 834: this is synchronous-on-settle. The mail is minted
-    /// as a chassis-root via [`Mailer::push_chassis_root_mail`] so the trace
-    /// pipeline tracks the chain; the bench then subscribes to
-    /// `Settled { root }` and waits up to `SETTLEMENT_TIMEOUT` for
-    /// the chain (the recipient's handler + every descendant mail
-    /// it spawned) to drain. By the time this returns, any
-    /// subsequent observation (`capture()`, the next send, an
-    /// assertion) is causally after the producer's full chain —
-    /// no more nudge_tick-style band-aids needed for render-flush
-    /// races.
-    pub fn send_mail<K>(&self, recipient_name: &str, mail: &K) -> Result<(), TestBenchError>
-    where
-        K: Kind + serde::Serialize,
-    {
-        let mailbox = self
-            .registry
-            .lookup(recipient_name)
-            .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
-        let payload = encode_struct(mail);
-        self.push_and_settle(recipient_name, K::NAME, mailbox, K::ID, payload)
-    }
-
-    /// Bytes-level send for callers that resolve kind+payload at
-    /// runtime (the scenario library's descriptor-driven path). Same
-    /// recipient lookup as `send_mail` but takes a pre-encoded
-    /// `(kind, bytes)` tuple — the typed `send_mail<K>` is the
-    /// preferred path when `K` is known statically.
-    ///
-    /// Issue 834: synchronous-on-settle, same semantics as
-    /// [`Self::send_mail`].
-    pub fn send_bytes(
+    /// Issue 834: synchronous-on-settle. The mail is minted as a
+    /// chassis-root via [`Mailer::push_chassis_root_mail`] so the trace
+    /// pipeline tracks the chain; the bench subscribes to
+    /// `Settled { root }` and waits up to `SETTLEMENT_TIMEOUT` for the
+    /// chain (the recipient's handler + every descendant mail it
+    /// spawned) to drain. By the time this returns, any subsequent
+    /// observation is causally after the producer's full chain — no
+    /// nudge_tick-style band-aids needed for render-flush races.
+    pub(crate) fn send_bytes(
         &self,
         recipient_name: &str,
         kind: KindId,
@@ -427,11 +404,10 @@ impl TestBench {
         self.push_and_settle(recipient_name, "<bytes>", mailbox, kind, bytes)
     }
 
-    /// Shared body of [`Self::send_mail`] / [`Self::send_bytes`]:
-    /// push as a chassis-root mail (so the trace pipeline tracks
-    /// the chain) and block on `Settled { root }`. Returns
-    /// `SettlementTimeout` if the chain doesn't drain within
-    /// [`SETTLEMENT_TIMEOUT`].
+    /// Body of [`Self::send_bytes`]: push as a chassis-root mail (so
+    /// the trace pipeline tracks the chain) and block on
+    /// `Settled { root }`. Returns `SettlementTimeout` if the chain
+    /// doesn't drain within [`SETTLEMENT_TIMEOUT`].
     fn push_and_settle(
         &self,
         recipient_name: &str,
@@ -460,8 +436,11 @@ impl TestBench {
     /// the caller chains `after_init` / `finish` against — the same
     /// shape callers reach for from the chassis-builder scope. Used by
     /// integration tests that exercise the spawn lifecycle without
-    /// going through a parent-actor handler.
-    pub fn spawn_actor<'a, A>(
+    /// going through a parent-actor handler. Test-only: the spawn
+    /// lifecycle is exercised by the in-crate unit test, and `execute`
+    /// (the public driver) doesn't model spawning.
+    #[cfg(test)]
+    pub(crate) fn spawn_actor<'a, A>(
         &'a self,
         subname: aether_substrate::Subname<'a>,
         config: A::Config,
@@ -475,52 +454,25 @@ impl TestBench {
     }
 
     /// Borrow the bench's [`aether_substrate::ActorRegistry`]. Used
-    /// alongside `spawn_actor` so tests can inspect the live entry's
-    /// `MailboxId` directly.
-    pub fn actor_registry(&self) -> &Arc<aether_substrate::ActorRegistry> {
+    /// alongside `spawn_actor` so the in-crate spawn test can inspect
+    /// the live entry's `MailboxId` directly. Test-only, same
+    /// rationale as [`Self::spawn_actor`].
+    #[cfg(test)]
+    pub(crate) fn actor_registry(&self) -> &Arc<aether_substrate::ActorRegistry> {
         self.passive.actor_registry()
-    }
-
-    /// Send `mail` to `recipient_name` with this bench's session as
-    /// the reply target, then pump until a matching reply arrives and
-    /// decode it as `R`. The reply must be postcard-encoded — true
-    /// for every standard reply kind (`*Result` variants in
-    /// `aether-kinds`). Use this for any sink/component whose reply
-    /// pattern is "send → await → decode" — e.g. the `aether.fs`
-    /// `Read`/`Write`/`Delete`/`List` round trips. `advance` and
-    /// `capture` are specialisations of this same shape against the
-    /// `aether.component` mailbox.
-    pub fn send_and_await_reply<K, R>(
-        &mut self,
-        recipient_name: &str,
-        mail: &K,
-    ) -> Result<R, TestBenchError>
-    where
-        K: Kind + serde::Serialize,
-        R: DeserializeOwned,
-    {
-        let mailbox = self
-            .registry
-            .lookup(recipient_name)
-            .ok_or_else(|| TestBenchError::UnknownMailbox(recipient_name.to_owned()))?;
-        let cid = self.fresh_correlation_id();
-        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
-        let payload = encode_struct(mail);
-        self.queue
-            .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
-        self.pump_until_reply::<R>(cid, any::type_name::<R>())
     }
 
     /// Bytes-level request/reply: push `(kind, payload)` to
     /// `recipient_name` with this bench's session as the reply
     /// target, pump until the matching reply arrives, and return its
-    /// raw payload bytes. The bytes-level sibling of
-    /// [`Self::send_and_await_reply`] — used by the `SendAndAwait` op
-    /// of [`Self::execute`], where the reply type isn't known
-    /// statically and the caller decodes on demand. Decode the
-    /// returned bytes with `postcard::from_bytes` (every standard
-    /// `*Result` kind is postcard-encoded).
-    pub fn send_bytes_and_await(
+    /// raw payload bytes. Backs the `SendAndAwait` op of
+    /// [`Self::execute`], where the reply type isn't known statically
+    /// and the caller decodes on demand via
+    /// [`super::ExecutionResult::reply`]. Used for the
+    /// component load/replace/drop round trips and the `aether.fs`
+    /// `Read`/`Write`/`Delete`/`List` replies — every standard
+    /// `*Result` kind is postcard-encoded.
+    pub(crate) fn send_bytes_and_await(
         &mut self,
         recipient_name: &str,
         kind: KindId,
@@ -541,7 +493,7 @@ impl TestBench {
     /// dispatches `Tick` to subscribers, drains the queue, and
     /// renders. Returns once the substrate has replied with
     /// `AdvanceResult::Ok`.
-    pub fn advance(&mut self, ticks: u32) -> Result<u32, TestBenchError> {
+    pub(crate) fn advance(&mut self, ticks: u32) -> Result<u32, TestBenchError> {
         let cid = self.fresh_correlation_id();
         // Issue 603 Phase 4: advance migrated from `aether.control`
         // (chassis_handler closure) onto `aether.test_bench`
@@ -574,7 +526,7 @@ impl TestBench {
     /// rendered, which matches "what the user would see right now"
     /// in the same way wgpu / D3D / Vulkan swapchain front buffers
     /// behave.
-    pub fn capture(&mut self) -> Result<Vec<u8>, TestBenchError> {
+    pub(crate) fn capture(&mut self) -> Result<Vec<u8>, TestBenchError> {
         self.capture_with_mails(Vec::new(), Vec::new())
     }
 
@@ -584,7 +536,7 @@ impl TestBench {
     /// is dispatched *after* the readback — typically cleanup that
     /// restores state the caller flipped for the capture. Matches
     /// the wire shape of the MCP `capture_frame` tool.
-    pub fn capture_with_mails(
+    pub(crate) fn capture_with_mails(
         &mut self,
         pre: Vec<aether_kinds::MailEnvelope>,
         after: Vec<aether_kinds::MailEnvelope>,

--- a/crates/aether-substrate-bundle/src/test_bench/execute.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/execute.rs
@@ -43,17 +43,17 @@ use super::bench::{TestBench, TestBenchError};
 /// a loaded component's trampoline address) — mailbox ids are
 /// one-way name hashes, so every send resolves by name.
 pub enum BenchOp {
-    /// Run `ticks` complete frames. Maps to [`TestBench::advance`].
+    /// Run `ticks` complete frames. Build with [`BenchOp::advance`].
     Advance { ticks: u32 },
-    /// Fire-and-settle a mail; no reply is awaited. Maps to
-    /// [`TestBench::send_bytes`].
+    /// Fire-and-settle a mail; no reply is awaited. Build with the
+    /// typed [`BenchOp::send_mail`].
     SendMail {
         recipient: String,
         kind: KindId,
         payload: Vec<u8>,
     },
     /// Send a mail and block until a reply arrives, stashing the raw
-    /// reply bytes. Maps to [`TestBench::send_bytes_and_await`].
+    /// reply bytes. Build with the typed [`BenchOp::send_and_await`].
     /// Covers component load / replace / drop and the `aether.fs`
     /// read / write / delete / list round trips uniformly — decode
     /// the stored bytes downstream with [`ExecutionResult::reply`].
@@ -62,15 +62,15 @@ pub enum BenchOp {
         kind: KindId,
         payload: Vec<u8>,
     },
-    /// Capture the current frame as PNG bytes. Maps to
-    /// [`TestBench::capture`]. Does not dispatch a tick — sequence a
+    /// Capture the current frame as PNG bytes. Build with
+    /// [`BenchOp::capture`]. Does not dispatch a tick — sequence a
     /// [`BenchOp::Advance`] before it if the world must move first.
     Capture,
     /// Capture with pre/after mail bundles dispatched atomically
     /// around the readback (the `CaptureFrame` shape, ADR-0020): `pre`
     /// lands *before* the readback so its effects appear in the PNG,
-    /// `after` runs *after* (cleanup). Maps to
-    /// [`TestBench::capture_with_mails`]. Use this rather than
+    /// `after` runs *after* (cleanup). Build with
+    /// [`BenchOp::capture_with_mails`]. Use this rather than
     /// decomposing into separate `SendMail` + `Capture` ops when the
     /// pre-mail's geometry must land in the same frame as the
     /// readback.

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -21,7 +21,7 @@ use aether_actor::Actor;
 use aether_capabilities::ComponentHostCapability;
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{LoadComponent, LoadResult};
-use aether_substrate_bundle::test_bench::{TestBench, test_helpers::require_runtime};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 use aether_test_fixture_probe::TickObserved;
 use std::fs;
 
@@ -29,16 +29,22 @@ const PROBE_NAME: &str = "probe";
 
 fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
     let wasm = fs::read(wasm_path).expect("read fixture wasm");
-    let result: LoadResult = bench
-        .send_and_await_reply(
-            ComponentHostCapability::NAMESPACE,
-            &LoadComponent {
-                wasm,
-                name: Some(PROBE_NAME.to_owned()),
-            },
-        )
-        .expect("await load_component reply");
-    match result {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &LoadComponent {
+                    wasm,
+                    name: Some(PROBE_NAME.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
         LoadResult::Ok { mailbox_id, .. } => mailbox_id,
         LoadResult::Err { error } => panic!("load_component: {error}"),
     }
@@ -59,7 +65,9 @@ fn tick_roundtrip_component_to_sink() {
     let _mbox = load_probe(&mut bench, &wasm_path);
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(3).expect("advance 3");
+    bench
+        .execute(vec![("advance", BenchOp::advance(3))])
+        .expect("advance 3");
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -87,7 +95,9 @@ fn batched_ticks_preserve_per_mailbox_count() {
     let _mbox = load_probe(&mut bench, &wasm_path);
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(N).expect("advance N");
+    bench
+        .execute(vec![("advance", BenchOp::advance(N))])
+        .expect("advance N");
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -16,48 +16,66 @@ use aether_kinds::{
     DropComponent, DropResult, LoadComponent, LoadResult, SubscribeInputResult, Tick,
     UnsubscribeInput,
 };
-use aether_substrate_bundle::test_bench::{TestBench, test_helpers::require_runtime};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
 use aether_test_fixture_probe::TickObserved;
 use std::fs;
 
 fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId {
     let wasm = fs::read(wasm_path).expect("read fixture wasm");
-    let result: LoadResult = bench
-        .send_and_await_reply(
-            ComponentHostCapability::NAMESPACE,
-            &LoadComponent {
-                wasm,
-                name: Some(name.to_owned()),
-            },
-        )
-        .expect("await load_component reply");
-    match result {
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &LoadComponent {
+                    wasm,
+                    name: Some(name.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
         LoadResult::Ok { mailbox_id, .. } => mailbox_id,
         LoadResult::Err { error } => panic!("load_component({name}): {error}"),
     }
 }
 
 fn unsubscribe(bench: &mut TestBench, kind: KindId, mailbox: MailboxId) {
-    let r: SubscribeInputResult = bench
-        .send_and_await_reply(
-            InputCapability::NAMESPACE,
-            &UnsubscribeInput { kind, mailbox },
-        )
-        .expect("await unsubscribe reply");
-    match r {
+    let result = bench
+        .execute(vec![(
+            "unsub",
+            BenchOp::send_and_await(
+                InputCapability::NAMESPACE,
+                &UnsubscribeInput { kind, mailbox },
+            ),
+        )])
+        .expect("unsubscribe sequence");
+    match result
+        .reply::<SubscribeInputResult>("unsub")
+        .expect("decode SubscribeInputResult")
+    {
         SubscribeInputResult::Ok => {}
         SubscribeInputResult::Err { error } => panic!("unsubscribe failed: {error}"),
     }
 }
 
 fn drop_component(bench: &mut TestBench, mailbox_id: MailboxId) {
-    let r: DropResult = bench
-        .send_and_await_reply(
-            ComponentHostCapability::NAMESPACE,
-            &DropComponent { mailbox_id },
-        )
-        .expect("await drop reply");
-    match r {
+    let result = bench
+        .execute(vec![(
+            "drop",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &DropComponent { mailbox_id },
+            ),
+        )])
+        .expect("drop sequence");
+    match result
+        .reply::<DropResult>("drop")
+        .expect("decode DropResult")
+    {
         DropResult::Ok => {}
         DropResult::Err { error } => panic!("drop failed: {error}"),
     }
@@ -72,7 +90,9 @@ fn empty_subscribers_means_no_delivery() {
         return;
     }
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    bench.advance(2).expect("advance 2");
+    bench
+        .execute(vec![("advance", BenchOp::advance(2))])
+        .expect("advance 2");
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         0,
@@ -91,7 +111,9 @@ fn subscribed_component_receives_published_ticks() {
     let _mbox = load_probe_named(&mut bench, &wasm_path, "listener");
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(3).expect("advance 3");
+    bench
+        .execute(vec![("advance", BenchOp::advance(3))])
+        .expect("advance 3");
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -114,7 +136,9 @@ fn two_subscribers_each_receive_every_tick() {
     let _mbox_b = load_probe_named(&mut bench, &wasm_path, "b");
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(2).expect("advance 2");
+    bench
+        .execute(vec![("advance", BenchOp::advance(2))])
+        .expect("advance 2");
     let delta = bench.count_observed(TickObserved::NAME) - baseline;
     assert_eq!(
         delta,
@@ -136,7 +160,9 @@ fn unsubscribe_stops_delivery() {
     let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(1).expect("pre-unsubscribe advance");
+    bench
+        .execute(vec![("advance", BenchOp::advance(1))])
+        .expect("pre-unsubscribe advance");
     assert_eq!(
         bench.count_observed(TickObserved::NAME) - baseline,
         1,
@@ -146,7 +172,9 @@ fn unsubscribe_stops_delivery() {
     let pre_unsub = bench.count_observed(TickObserved::NAME);
 
     unsubscribe(&mut bench, Tick::ID, mbox);
-    bench.advance(2).expect("post-unsubscribe advance");
+    bench
+        .execute(vec![("advance", BenchOp::advance(2))])
+        .expect("post-unsubscribe advance");
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         pre_unsub,
@@ -168,7 +196,9 @@ fn drop_clears_subscriptions() {
     let mbox = load_probe_named(&mut bench, &wasm_path, "victim");
     let baseline = bench.count_observed(TickObserved::NAME);
 
-    bench.advance(1).expect("pre-drop advance");
+    bench
+        .execute(vec![("advance", BenchOp::advance(1))])
+        .expect("pre-drop advance");
     assert_eq!(
         bench.count_observed(TickObserved::NAME) - baseline,
         1,
@@ -178,7 +208,9 @@ fn drop_clears_subscriptions() {
     let pre_drop = bench.count_observed(TickObserved::NAME);
 
     drop_component(&mut bench, mbox);
-    bench.advance(2).expect("post-drop advance");
+    bench
+        .execute(vec![("advance", BenchOp::advance(2))])
+        .expect("post-drop advance");
     assert_eq!(
         bench.count_observed(TickObserved::NAME),
         pre_drop,


### PR DESCRIPTION
Phase 3 (final) of issue 868. With every caller migrated (PR1 + PR2), this narrows the imperative `TestBench` driving primitives so `execute` is the only **public** way to drive the bench.

## Summary
- **`pub(crate)`**: `advance`, `send_bytes`, `send_bytes_and_await`, `capture`, `capture_with_mails`.
- **Deletes** the now-dead typed `send_mail::<K>` and `send_and_await_reply::<K,R>` — superseded by the `BenchOp::send_mail` / `send_and_await` constructors, which `execute` resolves through the bytes-level primitives.
- **`spawn_actor` + `actor_registry` become `#[cfg(test)] pub(crate)`**: their only caller is the in-crate spawn smoke test, and `execute` doesn't model instanced-actor spawning. Folding spawn into a `BenchOp` turned out **unnecessary** — `pub(crate)` already keeps it off the public surface, so it'd be machinery for an in-crate-test-only path.
- **Migrates the two bundle integration test files PR1 missed** (`tests/input_subscriptions.rs`, `tests/end_to_end.rs`) onto `execute`. As external test crates they can't reach `pub(crate)` primitives, so this is what makes the privatization compile.
- `BenchOp` variant docs now point at the public `BenchOp` constructors instead of the privatized `TestBench` methods (rustdoc forbids public docs linking to private items).

End state: external consumers (this crate's integration tests + the three sibling component/demo crates) drive the bench exclusively through `execute`.

## Test plan
- [x] `scripts/preflight.sh` — 1019/1019 tests pass; workspace clippy + fmt + doc + wasm32 component cross-build clean
- [x] `cargo doc` with broken/private intra-doc-link denial — clean (caught the public→private variant-doc links)
- [x] RustRover inspection clean on all four changed files (no DuplicatedCode on the repetitive `execute([advance])` blocks)
- [x] Full bundle suite exercised under `AETHER_REQUIRE_RUNTIME=1`, including the migrated integration files and the in-crate spawn smoke test

Closes iamacoffeepot/aether#868