### PR TITLE
feat(mesh-viewer): structured load replies for mesh and scene

### DIFF
--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1022,6 +1022,7 @@ mod engine {
 }
 
 mod control_plane {
+    use alloc::collections::BTreeMap;
     use alloc::string::String;
     use alloc::vec::Vec;
 
@@ -1513,6 +1514,70 @@ mod control_plane {
             prefix: String,
             error: FsError,
         },
+    }
+
+    // Mesh-viewer structured load replies (issue 964). The mesh-viewer
+    // component's `aether.mesh.load` was fire-and-forget — failures
+    // warn-logged and the prior cache stayed, with no wire signal a
+    // scenario harness or MCP `send_mail` caller could read. These two
+    // reply kinds give the load path the same structured Ok/Err shape
+    // the `aether.fs.*_result` family carries (ADR-0041), echoing the
+    // request's `namespace` + `path` for correlation per the
+    // explicit-nulls convention (every `Option` addressed, never an
+    // absent field).
+    //
+    // Flat-struct shape (`ok: bool` + `error: Option<String>`) rather
+    // than an Ok/Err enum so a caller reads success/failure off one
+    // field without matching a variant, and so `warnings` rides along
+    // on a successful load (e.g. a clamped sphere subdivision) without
+    // forcing a third variant. The diagnostic *content* of `error` /
+    // `warnings` is a sibling issue — this kind ships only the shape.
+
+    /// `aether.mesh.load_result` — reply to `aether.mesh.load`
+    /// (`aether_mesh_viewer::LoadMesh`). Echoes the request's
+    /// `namespace` + `path` so the caller correlates the reply to its
+    /// source without a pending-op queue — operation identity comes
+    /// from the reply kind, target identity from the echoed fields.
+    /// `ok` is the single success/failure read; `error` is `Some` iff
+    /// `ok` is false (read / utf-8 / parse / mesh / unknown-extension
+    /// failure); `warnings` carries non-fatal notes (e.g. an
+    /// auto-clamped sphere subdivision) on an otherwise-successful
+    /// load. Whole-mesh atomic-replace semantics are preserved: a
+    /// failed load leaves the prior cached triangles intact.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.mesh.load_result")]
+    pub struct MeshLoadResult {
+        pub ok: bool,
+        pub namespace: String,
+        pub path: String,
+        pub error: Option<String>,
+        pub warnings: Vec<String>,
+    }
+
+    /// `aether.scene.load_result` — reply to a future `aether.scene.load`
+    /// (issue 964 ships the reply shape ahead of the multi-instance
+    /// scene loader; the wire is the bottleneck its sibling issues fill).
+    /// Echoes the request's `namespace` + `path`. Whole-scene
+    /// atomic-replace semantics are preserved — `ok` is the overall
+    /// verdict, `instances_loaded` counts the instances that landed,
+    /// and `instance_errors` maps each failed instance name to its
+    /// failure reason so a partial scene is diagnosable per-instance.
+    /// `error` carries a whole-scene failure (e.g. the scene file
+    /// itself failed to read / parse) distinct from the per-instance
+    /// `instance_errors`. `BTreeMap` rather than `HashMap` because
+    /// `aether-kinds` is `no_std` + `alloc` and the `Schema` derive
+    /// encodes `BTreeMap` as `SchemaType::Map` (it rejects `HashMap`);
+    /// the keyed-by-instance-name semantics are identical.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.scene.load_result")]
+    pub struct SceneLoadResult {
+        pub ok: bool,
+        pub namespace: String,
+        pub path: String,
+        pub error: Option<String>,
+        pub instance_errors: BTreeMap<String, String>,
+        pub instances_loaded: u32,
+        pub warnings: Vec<String>,
     }
 
     // ADR-0043 substrate HTTP egress. One request kind + one reply
@@ -2076,9 +2141,13 @@ mod tests {
         assert_eq!(Camera::NAME, "aether.camera");
         // ADR-0066: aether.camera.{create,destroy,set_active,set_mode,
         // orbit.set,topdown.set} kind-name asserts live in
-        // `aether-camera`'s tests; aether.mesh.load lives in
-        // `aether-mesh-viewer`'s tests. The view-proj sink contract
-        // (`aether.camera`) stays here as a chassis primitive.
+        // `aether-camera`'s tests; the `aether.mesh.load` *request*
+        // lives in `aether-mesh-viewer`'s tests. The view-proj sink
+        // contract (`aether.camera`) stays here as a chassis primitive.
+        // The structured load *reply* kinds (issue 964) live in this
+        // crate, so their names are pinned here.
+        assert_eq!(MeshLoadResult::NAME, "aether.mesh.load_result");
+        assert_eq!(SceneLoadResult::NAME, "aether.scene.load_result");
         assert_eq!(NoteOn::NAME, "aether.audio.note_on");
         assert_eq!(NoteOff::NAME, "aether.audio.note_off");
         assert_eq!(SetMasterGain::NAME, "aether.audio.set_master_gain");

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -31,12 +31,12 @@
 //! 4. Every `aether.lifecycle.tick` re-emits the cached triangles to
 //!    `"aether.render"`.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, ReplyTo, Resolver, actor};
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::{FsCapability, InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, ReadResult, Tick, Vertex};
+use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Tick, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
@@ -62,6 +62,18 @@ const OBJ_DEFAULT_COLOR: (f32, f32, f32) = PALETTE[0];
 
 pub struct MeshViewer {
     triangles: Vec<DrawTriangle>,
+    /// Reply target of the most recent `aether.mesh.load` request,
+    /// parked across the async `aether.fs.read` round-trip (issue 964).
+    /// `on_load` runs in the requester's reply context; the actual
+    /// parse + cache replace happens later in `on_read_result`, whose
+    /// reply context points at `FsCapability`, not the original
+    /// requester. Stashing the handle here lets the `MeshLoadResult`
+    /// route back to whoever sent the `LoadMesh` (the
+    /// parked-sender pattern; the handle stays valid for the instance
+    /// lifetime per the SDK `ReplyTo` contract). `None` when the load
+    /// was fire-and-forget (no reply target) or when no load is in
+    /// flight.
+    pending_reply: Option<ReplyTo>,
 }
 
 /// Mesh viewer component.
@@ -84,6 +96,7 @@ impl FfiActor for MeshViewer {
     {
         Ok(MeshViewer {
             triangles: Vec::new(),
+            pending_reply: None,
         })
     }
 
@@ -111,18 +124,27 @@ impl FfiActor for MeshViewer {
 
     /// Triggers an asynchronous mesh load. Reply arrives as
     /// `aether.fs.read_result`; the parser is picked from the file
-    /// extension at that point.
+    /// extension at that point. The `aether.mesh.load_result` reply to
+    /// the originator (issue 964) fires once the read settles and the
+    /// parse / mesh outcome is known — see `on_read_result`.
     ///
     /// # Agent
     /// `namespace` is the short prefix with no `://` — `"save"`,
     /// `"assets"`, `"config"`. `path` is relative to the namespace
-    /// root and must end in `.dsl` or `.obj`.
-    // `&mut self` and `msg: LoadMesh` match the dispatch ABI
-    // (ADR-0033 / ADR-0038); the load body delegates straight to
-    // `FsCapability` via `ctx`.
-    #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
+    /// root and must end in `.dsl` or `.obj`. Send-and-await the
+    /// `aether.mesh.load_result` reply to learn whether the load
+    /// succeeded (`ok`) and why it didn't (`error`).
+    // `msg: LoadMesh` matches the dispatch ABI (ADR-0033 / ADR-0038);
+    // the load body delegates straight to `FsCapability` via `ctx`.
+    #[allow(clippy::needless_pass_by_value)]
     #[handler]
     fn on_load(&mut self, ctx: &mut FfiCtx<'_>, msg: LoadMesh) {
+        // Park the requester's reply target across the async read.
+        // `on_read_result` answers it with the structured outcome.
+        // Overwriting any prior pending handle is intentional —
+        // loads are serialized through one read round-trip, and a
+        // fresh load supersedes an unanswered prior one.
+        self.pending_reply = ctx.reply_target();
         tracing::info!(
             target: "aether_mesh_viewer",
             namespace = %msg.namespace,
@@ -136,14 +158,27 @@ impl FfiActor for MeshViewer {
     /// `path`'s extension and replaces the cached triangle list on
     /// success. Any failure (read error, non-utf8, parse error,
     /// unknown extension) leaves the previous cache intact, with a
-    /// warn log explaining the failure.
+    /// warn log explaining the failure. Issue 964: after computing the
+    /// outcome, replies `aether.mesh.load_result` to the originator of
+    /// the `aether.mesh.load` request (parked in `on_load`), echoing
+    /// the request's `namespace` + `path` and carrying the structured
+    /// `ok` / `error` verdict so a scenario harness or MCP `send_mail`
+    /// caller has a wire signal instead of having to scrape
+    /// `engine_logs`.
     ///
     /// # Agent
     /// Substrate-driven; do not send manually.
     #[handler]
-    fn on_read_result(&mut self, _ctx: &mut FfiCtx<'_>, r: ReadResult) {
-        let (path, bytes) = match r {
-            ReadResult::Ok { path, bytes, .. } => (path, bytes),
+    fn on_read_result(&mut self, ctx: &mut FfiCtx<'_>, r: ReadResult) {
+        let (namespace, path, outcome) = match r {
+            ReadResult::Ok {
+                namespace,
+                path,
+                bytes,
+            } => {
+                let outcome = self.load_bytes(&path, &bytes);
+                (namespace, path, outcome)
+            }
             ReadResult::Err {
                 namespace,
                 path,
@@ -156,34 +191,96 @@ impl FfiActor for MeshViewer {
                     error = ?error,
                     "read failed; keeping prior mesh",
                 );
-                return;
+                let outcome = LoadOutcome::failed(format!("read failed: {error:?}"));
+                (namespace, path, outcome)
             }
         };
-        let Ok(text) = str::from_utf8(&bytes) else {
+        self.reply_load_result(ctx, namespace, path, outcome);
+    }
+}
+
+/// The result of a single load attempt, decoupled from where the bytes
+/// came from. `on_read_result` builds one of these, then turns it into
+/// the wire `MeshLoadResult` reply (issue 964). A failed load reports
+/// `error: Some(_)` and leaves the cache untouched; a succeeded load
+/// reports `error: None` and may carry non-fatal `warnings` (none are
+/// produced today — diagnostic content is a sibling issue — but the
+/// shape is plumbed so it rides along once the content lands).
+struct LoadOutcome {
+    error: Option<String>,
+    warnings: Vec<String>,
+}
+
+impl LoadOutcome {
+    fn ok() -> Self {
+        Self {
+            error: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    fn failed(error: String) -> Self {
+        Self {
+            error: Some(error),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+impl MeshViewer {
+    /// Parse `bytes` for `path`, replacing the cached triangle list on
+    /// success and leaving it intact on any failure. Returns the
+    /// structured outcome for the `MeshLoadResult` reply.
+    fn load_bytes(&mut self, path: &str, bytes: &[u8]) -> LoadOutcome {
+        let Ok(text) = str::from_utf8(bytes) else {
             tracing::warn!(
                 target: "aether_mesh_viewer",
                 path = %path,
                 "mesh file is not valid UTF-8; keeping prior mesh",
             );
-            return;
+            return LoadOutcome::failed("mesh file is not valid UTF-8".to_string());
         };
         let lower = path.rsplit('.').next().map(str::to_ascii_lowercase);
         if lower.as_deref() == Some("dsl") {
-            self.try_replace_dsl(text);
+            self.try_replace_dsl(text)
         } else if lower.as_deref() == Some("obj") {
-            self.try_replace_obj(text);
+            self.try_replace_obj(text)
         } else {
             tracing::warn!(
                 target: "aether_mesh_viewer",
                 path = %path,
                 "unsupported file extension; expected .dsl or .obj",
             );
+            LoadOutcome::failed("unsupported file extension; expected .dsl or .obj".to_string())
         }
     }
-}
 
-impl MeshViewer {
-    fn try_replace_dsl(&mut self, dsl: &str) {
+    /// Build and dispatch the `aether.mesh.load_result` reply to the
+    /// parked requester. No-op when no reply target was parked (the
+    /// load was fire-and-forget). Clears the parked handle either way
+    /// so a stale target can't leak into a later load's reply.
+    fn reply_load_result(
+        &mut self,
+        ctx: &mut FfiCtx<'_>,
+        namespace: String,
+        path: String,
+        outcome: LoadOutcome,
+    ) {
+        if let Some(sender) = self.pending_reply.take() {
+            ctx.reply_to(
+                sender,
+                &MeshLoadResult {
+                    ok: outcome.error.is_none(),
+                    namespace,
+                    path,
+                    error: outcome.error,
+                    warnings: outcome.warnings,
+                },
+            );
+        }
+    }
+
+    fn try_replace_dsl(&mut self, dsl: &str) -> LoadOutcome {
         let ast = match aether_mesh::parse(dsl) {
             Ok(ast) => ast,
             Err(error) => {
@@ -192,7 +289,7 @@ impl MeshViewer {
                     error = %error,
                     "DSL parse failed; keeping prior mesh",
                 );
-                return;
+                return LoadOutcome::failed(format!("DSL parse failed: {error}"));
             }
         };
         let polygons = match aether_mesh::mesh_polygons(&ast) {
@@ -203,7 +300,7 @@ impl MeshViewer {
                     error = %error,
                     "DSL mesh build failed; keeping prior mesh",
                 );
-                return;
+                return LoadOutcome::failed(format!("DSL mesh build failed: {error}"));
             }
         };
         let mut out = Vec::new();
@@ -222,9 +319,10 @@ impl MeshViewer {
             "DSL load complete; cache replaced",
         );
         self.triangles = out;
+        LoadOutcome::ok()
     }
 
-    fn try_replace_obj(&mut self, obj: &str) {
+    fn try_replace_obj(&mut self, obj: &str) -> LoadOutcome {
         match parse_obj(obj) {
             Ok(tris) => {
                 tracing::info!(
@@ -233,12 +331,16 @@ impl MeshViewer {
                     "OBJ load complete; cache replaced",
                 );
                 self.triangles = tris;
+                LoadOutcome::ok()
             }
-            Err(error) => tracing::warn!(
-                target: "aether_mesh_viewer",
-                error = ?error,
-                "OBJ parse failed; keeping prior mesh",
-            ),
+            Err(error) => {
+                tracing::warn!(
+                    target: "aether_mesh_viewer",
+                    error = ?error,
+                    "OBJ parse failed; keeping prior mesh",
+                );
+                LoadOutcome::failed(format!("OBJ parse failed: {error:?}"))
+            }
         }
     }
 }

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -20,7 +20,7 @@
 //! `TestBench::builder().namespace_roots(...)` rather than env-var
 //! mutation.
 
-use aether_kinds::{LoadComponent, LoadResult};
+use aether_kinds::{LoadComponent, LoadResult, MeshLoadResult};
 use aether_mesh_viewer::LoadMesh;
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
@@ -260,4 +260,93 @@ fn parse_failure_keeps_prior_mesh() {
     let img = decode_png(png).expect("decode capture png");
     differs_from_background(&img, 5)
         .expect("cached mesh should remain visible after parse failure");
+}
+
+/// Issue 964 acceptance: a good-DSL load replies `aether.mesh.load_result`
+/// with `ok: true`, no `error`, and no `warnings`, echoing the request's
+/// `namespace` + `path`. `send_and_await` blocks through the async
+/// `aether.fs.read` round-trip until the structured reply lands, so the
+/// reply is the wire signal a harness reads instead of inferring success
+/// from rendered geometry.
+#[test]
+fn good_dsl_load_replies_ok() {
+    let Some(wasm_path) = require_runtime("aether_mesh_viewer") else {
+        return;
+    };
+    let sandbox = init_save_sandbox("mesh-viewer");
+    let path = write_fixture("reply_good.dsl", BOX_DSL);
+
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+    load_viewer(&mut bench, &wasm_path);
+
+    let result = bench
+        .execute(vec![(
+            "load_mesh",
+            BenchOp::send_and_await(
+                component_address(),
+                &LoadMesh {
+                    namespace: "save".to_owned(),
+                    path: path.clone(),
+                },
+            ),
+        )])
+        .expect("load + reply");
+
+    let reply = result
+        .reply::<MeshLoadResult>("load_mesh")
+        .expect("decode MeshLoadResult");
+    assert!(reply.ok, "good DSL should load: {:?}", reply.error);
+    assert!(reply.error.is_none(), "good load carries no error");
+    assert!(
+        reply.warnings.is_empty(),
+        "good load carries no warnings; got {:?}",
+        reply.warnings,
+    );
+    assert_eq!(reply.namespace, "save", "reply echoes request namespace");
+    assert_eq!(reply.path, path, "reply echoes request path");
+}
+
+/// Issue 964 acceptance: a bad-DSL load replies `aether.mesh.load_result`
+/// with `ok: false` and `error.is_some()`. The prior cache (none here)
+/// is untouched; the failure surfaces on the wire rather than only in
+/// `engine_logs`.
+#[test]
+fn bad_dsl_load_replies_err() {
+    let Some(wasm_path) = require_runtime("aether_mesh_viewer") else {
+        return;
+    };
+    let sandbox = init_save_sandbox("mesh-viewer");
+    let path = write_fixture("reply_bad.dsl", BAD_DSL);
+
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+    load_viewer(&mut bench, &wasm_path);
+
+    let result = bench
+        .execute(vec![(
+            "load_mesh",
+            BenchOp::send_and_await(
+                component_address(),
+                &LoadMesh {
+                    namespace: "save".to_owned(),
+                    path: path.clone(),
+                },
+            ),
+        )])
+        .expect("load + reply");
+
+    let reply = result
+        .reply::<MeshLoadResult>("load_mesh")
+        .expect("decode MeshLoadResult");
+    assert!(!reply.ok, "bad DSL should not load");
+    assert!(reply.error.is_some(), "bad load carries a failure reason");
+    assert_eq!(reply.namespace, "save", "reply echoes request namespace");
+    assert_eq!(reply.path, path, "reply echoes request path");
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#964

## Summary

- Add two reply kinds in `aether-kinds`: `aether.mesh.load_result` and `aether.scene.load_result`, both flat structs (`ok` / `namespace` / `path` / `error` / `warnings`, plus `instance_errors` + `instances_loaded` on the scene variant) echoing the request's `namespace` + `path` for correlation per the explicit-nulls convention.
- Switch the mesh-viewer cap from fire-and-forget to reply-aware: `on_load` parks the requester's reply target across the async `aether.fs.read` round-trip; `on_read_result` computes the load outcome and replies `aether.mesh.load_result` to the parked sender (the parked-sender pattern). The reply routes back to the original session with the original correlation id, so `mcp__aether-hub__send_mail` and the scenario harness see the structured reply in the tool status instead of inferring success from rendered geometry.
- Existing fire-and-forget callers continue to work — when no reply target is parked, the reply is a no-op.

## Notes

- `instance_errors` uses `BTreeMap<String, String>` rather than `HashMap` because `aether-kinds` is `no_std` + `alloc` and the `Schema` derive encodes `BTreeMap` as `SchemaType::Map` (it rejects `HashMap`). The keyed-by-instance-name semantics are identical.
- `aether.scene.load_result` ships the reply shape ahead of the multi-instance scene loader (the wire is the bottleneck its sibling issues fill, per the issue's framing).
- Out-of-scope (sibling issues) honored: no diagnostic content beyond honest one-line error strings already produced by the load path, no `describe_component` surfacing, no vertex-cap growth. `warnings` is plumbed but always empty for now.

## Test plan

- [x] `aether-kinds`: new `kind_names_are_stable` asserts for both reply kinds; descriptor inventory auto-registers them via the `Kind` derive.
- [x] Scenario fixtures: `good_dsl_load_replies_ok` asserts `ok: true`, `error: None`, `warnings: []`, echoed `namespace`/`path`; `bad_dsl_load_replies_err` asserts `ok: false`, `error.is_some()`.
- [x] Existing scenario tests (`dsl_box_loads_and_renders`, `obj_quad_loads_and_renders`, `parse_failure_keeps_prior_mesh`) still pass — fire-and-forget path unchanged.
- [x] Full `scripts/preflight.sh` green (fmt, clippy `-D warnings`, doc, wasm32 component cross-build, `cargo nextest run --workspace --profile ci`): 1021 tests, 0 skipped. Scenarios ran the full chassis locally (wgpu adapter present); on CI's Linux runner Mesa drivers + pre-built component wasm exercise them the same way.
