### PR TITLE
feat(kinds): dag descriptor wire kinds + dagid/transformid newtypes

### DIFF
--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -107,6 +107,10 @@ pub const fn tag_for_type_id(type_id: u64) -> Option<Tag> {
         Some(Tag::Kind)
     } else if type_id == HandleId::TYPE_ID {
         Some(Tag::Handle)
+    } else if type_id == DagId::TYPE_ID {
+        Some(Tag::Dag)
+    } else if type_id == TransformId::TYPE_ID {
+        Some(Tag::Transform)
     } else {
         None
     }
@@ -123,6 +127,10 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
         Some(KindId::TYPE_NAME)
     } else if type_id == HandleId::TYPE_ID {
         Some(HandleId::TYPE_NAME)
+    } else if type_id == DagId::TYPE_ID {
+        Some(DagId::TYPE_NAME)
+    } else if type_id == TransformId::TYPE_ID {
+        Some(TransformId::TYPE_NAME)
     } else {
         None
     }
@@ -260,6 +268,73 @@ impl<'de> Deserialize<'de> for HandleId {
     }
 }
 
+/// Substrate-minted reference to one submitted computation DAG
+/// (ADR-0047 §4). Carries the `Tag::Dag` discriminator + a 60-bit
+/// counter masked into the low bits — monotonic-per-substrate with a
+/// session salt, analogous to [`HandleId`] rather than a name hash.
+/// `#[repr(transparent)]` over `u64`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct DagId(pub u64);
+
+impl DagId {
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.dag_id");
+    pub const TYPE_NAME: &'static str = "aether.dag_id";
+}
+
+impl fmt::Display for DagId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Serialize for DagId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for DagId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Dag).map(DagId)
+    }
+}
+
+/// Global identity for a registered native transform (ADR-0048
+/// §1/§4). Carries the `Tag::Transform` discriminator + a 60-bit
+/// FNV-1a hash of the transform's canonical name. The value
+/// derivation (`fnv1a_64(TRANSFORM_DOMAIN ++ canonical("{crate}::\
+/// {module}::{fn}"))`) lives with the transform-registry macro work
+/// (iamacoffeepot/aether#979); this newtype defines only the wire
+/// shape so the descriptor's `Transform` node encodes/decodes.
+/// `#[repr(transparent)]` over `u64`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct TransformId(pub u64);
+
+impl TransformId {
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.transform_id");
+    pub const TYPE_NAME: &'static str = "aether.transform_id";
+}
+
+impl fmt::Display for TransformId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Serialize for TransformId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for TransformId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Transform).map(TransformId)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,5 +373,32 @@ mod tests {
         assert_eq!(MailboxId::NONE.0, 0);
         assert_eq!(tagged_id::tag_of(MailboxId::NONE.0), None);
         assert!(tagged_id::encode(MailboxId::NONE.0).is_none());
+    }
+
+    /// ADR-0047: a `DagId` carrying `Tag::Dag` bits encodes to the
+    /// `dag-XXXX-XXXX-XXXX` form and round-trips through `decode_with_tag`.
+    /// `tag_for_type_id(DagId::TYPE_ID)` resolves the codec arm.
+    #[test]
+    fn dag_id_is_tagged_and_resolves_codec_arm() {
+        assert_eq!(tag_for_type_id(DagId::TYPE_ID), Some(Tag::Dag));
+        let id = tagged_id::with_tag(Tag::Dag, 0x42);
+        let encoded = tagged_id::encode(id).expect("DagId tag-encodes");
+        assert!(encoded.starts_with("dag-"), "expected tagged: {encoded}");
+        let decoded =
+            tagged_id::decode_with_tag(&encoded, Tag::Dag).expect("DagId round-trips via decode");
+        assert_eq!(decoded, id);
+    }
+
+    /// ADR-0048: a `TransformId` carrying `Tag::Transform` bits encodes
+    /// to the `trn-XXXX-XXXX-XXXX` form and resolves its codec arm.
+    #[test]
+    fn transform_id_is_tagged_and_resolves_codec_arm() {
+        assert_eq!(tag_for_type_id(TransformId::TYPE_ID), Some(Tag::Transform));
+        let id = tagged_id::with_tag(Tag::Transform, 0x99);
+        let encoded = tagged_id::encode(id).expect("TransformId tag-encodes");
+        assert!(encoded.starts_with("trn-"), "expected tagged: {encoded}");
+        let decoded = tagged_id::decode_with_tag(&encoded, Tag::Transform)
+            .expect("TransformId round-trips via decode");
+        assert_eq!(decoded, id);
     }
 }

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -56,7 +56,9 @@ pub use hash::{
     KIND_DOMAIN, MAILBOX_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
     mailbox_id_from_name,
 };
-pub use ids::{HandleId, KindId, MailboxId, tag_for_type_id, type_name_for_type_id};
+pub use ids::{
+    DagId, HandleId, KindId, MailboxId, TransformId, tag_for_type_id, type_name_for_type_id,
+};
 pub use mail::{MailId, ReplyTarget, ReplyTo};
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};
@@ -164,6 +166,12 @@ impl CastEligible for KindId {
     const ELIGIBLE: bool = true;
 }
 impl CastEligible for HandleId {
+    const ELIGIBLE: bool = true;
+}
+impl CastEligible for DagId {
+    const ELIGIBLE: bool = true;
+}
+impl CastEligible for TransformId {
     const ELIGIBLE: bool = true;
 }
 
@@ -308,7 +316,7 @@ mod schema_impls {
     use alloc::vec::Vec;
 
     use crate::schema::{LabelCell, LabelNode, Primitive, SchemaCell, SchemaType};
-    use crate::{HandleId, KindId, MailboxId, Schema};
+    use crate::{DagId, HandleId, KindId, MailboxId, Schema, TransformId};
     use alloc::collections::BTreeMap;
 
     macro_rules! scalar {
@@ -393,6 +401,18 @@ mod schema_impls {
     }
 
     impl Schema for HandleId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+    }
+
+    impl Schema for DagId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+    }
+
+    impl Schema for TransformId {
         const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
         const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
         const LABEL_NODE: LabelNode = LabelNode::Anonymous;

--- a/crates/aether-data/src/tag_bits.rs
+++ b/crates/aether-data/src/tag_bits.rs
@@ -23,3 +23,11 @@ pub const TAG_KIND: u8 = 0x2;
 
 /// Tag value for reply-handle ids (ADR-0045).
 pub const TAG_HANDLE: u8 = 0x3;
+
+/// Tag value for DAG ids (ADR-0047). Substrate-minted, counter-backed
+/// per submitted DAG.
+pub const TAG_DAG: u8 = 0x4;
+
+/// Tag value for native-transform ids (ADR-0048). Name-hashed global
+/// identity for a registered transform.
+pub const TAG_TRANSFORM: u8 = 0x5;

--- a/crates/aether-data/src/tagged_id.rs
+++ b/crates/aether-data/src/tagged_id.rs
@@ -18,7 +18,9 @@
 use alloc::string::String;
 use core::fmt;
 
-pub use crate::tag_bits::{HASH_MASK, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT};
+pub use crate::tag_bits::{
+    HASH_MASK, TAG_DAG, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT, TAG_TRANSFORM,
+};
 
 /// Type tag identifying an id space. Encoded in the high 4 bits of
 /// every tagged id. `0x0` is reserved as an invalid sentinel — a
@@ -34,6 +36,12 @@ pub enum Tag {
     Kind = TAG_KIND,
     /// Handle id (ADR-0045) — entry in the substrate's handle store.
     Handle = TAG_HANDLE,
+    /// DAG id (ADR-0047) — substrate-minted, counter-backed handle for
+    /// one submitted computation DAG.
+    Dag = TAG_DAG,
+    /// Native-transform id (ADR-0048) — name-hashed global identity for
+    /// a registered transform.
+    Transform = TAG_TRANSFORM,
 }
 
 impl Tag {
@@ -46,18 +54,22 @@ impl Tag {
             Self::Mailbox => "mbx",
             Self::Kind => "knd",
             Self::Handle => "hdl",
+            Self::Dag => "dag",
+            Self::Transform => "trn",
         }
     }
 
     /// Decode a 4-bit tag value from the high nibble of a `u64`.
     /// Returns `None` for `0x0` (the reserved invalid sentinel) and
-    /// for any reserved-future value (`0x4..=0xF`).
+    /// for any reserved-future value (`0x6..=0xF`).
     #[must_use]
     pub const fn from_bits(bits: u8) -> Option<Self> {
         match bits {
             TAG_MAILBOX => Some(Self::Mailbox),
             TAG_KIND => Some(Self::Kind),
             TAG_HANDLE => Some(Self::Handle),
+            TAG_DAG => Some(Self::Dag),
+            TAG_TRANSFORM => Some(Self::Transform),
             _ => None,
         }
     }
@@ -158,6 +170,8 @@ pub fn decode(s: &str) -> Result<u64, DecodeError> {
         b"mbx" | b"MBX" => Tag::Mailbox,
         b"knd" | b"KND" => Tag::Kind,
         b"hdl" | b"HDL" => Tag::Handle,
+        b"dag" | b"DAG" => Tag::Dag,
+        b"trn" | b"TRN" => Tag::Transform,
         _ => return Err(DecodeError::Malformed),
     };
     if bytes[3] != b'-' || bytes[8] != b'-' || bytes[13] != b'-' {
@@ -203,7 +217,13 @@ mod tests {
 
     #[test]
     fn round_trip_all_tags() {
-        for &tag in &[Tag::Mailbox, Tag::Kind, Tag::Handle] {
+        for &tag in &[
+            Tag::Mailbox,
+            Tag::Kind,
+            Tag::Handle,
+            Tag::Dag,
+            Tag::Transform,
+        ] {
             for hash in [0u64, 0x1, 0x0FFF_FFFF_FFFF_FFFF, 0xDEAD_BEEF_CAFE_BABE] {
                 let id = with_tag(tag, hash);
                 assert_eq!(tag_of(id), Some(tag));
@@ -224,6 +244,26 @@ mod tests {
         assert_eq!(s.len(), 18);
         assert!(s.starts_with("mbx-"));
         assert_eq!(s, "mbx-aaaa-aaaa-aaaa");
+    }
+
+    #[test]
+    fn dag_tag_encoding_shape() {
+        let id = with_tag(Tag::Dag, 0);
+        let s = encode(id).expect("test setup: Dag id encodes (tag is non-zero)");
+        assert_eq!(s.len(), 18);
+        assert!(s.starts_with("dag-"));
+        assert_eq!(s, "dag-aaaa-aaaa-aaaa");
+        assert_eq!(decode(&s).expect("test setup: dag id decodes"), id);
+    }
+
+    #[test]
+    fn transform_tag_encoding_shape() {
+        let id = with_tag(Tag::Transform, 0);
+        let s = encode(id).expect("test setup: Transform id encodes (tag is non-zero)");
+        assert_eq!(s.len(), 18);
+        assert!(s.starts_with("trn-"));
+        assert_eq!(s, "trn-aaaa-aaaa-aaaa");
+        assert_eq!(decode(&s).expect("test setup: transform id decodes"), id);
     }
 
     #[test]

--- a/crates/aether-kinds/src/dag.rs
+++ b/crates/aether-kinds/src/dag.rs
@@ -1,0 +1,345 @@
+//! ADR-0047 computation-DAG wire vocabulary: the descriptor
+//! (`DagDescriptor` + `Node`/`Edge`), the `Bundle` meta-type, the
+//! three request kinds (`aether.dag.submit` / `cancel` / `status`),
+//! their reply kinds, and the structured `DagError` set.
+//!
+//! These kinds are postcard-shaped — `Vec<Node>` / `Vec<Edge>` make
+//! the descriptor non-cast — and register in the substrate descriptor
+//! inventory through `#[derive(Kind)]` exactly like the other reply
+//! enums (`LoadResult`, `ReadResult`).
+//!
+//! **Pair-element shape.** ADR-0047 §1/§2 describe `Bundle`'s elements
+//! and the submit/status output handles as ordered `(X, Y)` pairs. The
+//! schema vocabulary (`aether_data::SchemaType`) has no tuple arm, so
+//! the wire encodes each pair as a named two-field struct
+//! ([`BundleElement`], [`NodeHandle`]) — the standard idiom for
+//! structured collections in a reply enum (cf. `ListenerInfo`,
+//! `EngineDescriptor`). A `Vec` of two-field records is the ordered
+//! pair list the ADR specifies.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_data::{DagId, HandleId, KindId, MailboxId, TransformId};
+use serde::{Deserialize, Serialize};
+
+/// Descriptor-local node identifier (ADR-0047 §2). A `u32` index
+/// assigned by the submitter, unique within one `DagDescriptor` —
+/// **not** a globally-unique handle id. Two DAGs submitted in
+/// parallel can both carry a `NodeId(0)` without collision because
+/// the namespaces don't cross.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    aether_data::Schema,
+)]
+pub struct NodeId(pub u32);
+
+/// One node in a computation DAG (ADR-0047 §2). Variant ordering is
+/// wire-stable and additive-only: `Source` (root, effectful),
+/// `Transform` (mid-graph, pure — Phase 3 dispatch), `Call`
+/// (mid-graph, effectful — its output is a self-describing
+/// [`Bundle`]), `Observer` (terminal, effectful).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub enum Node {
+    /// Root node: dispatches `payload` to `mailbox` as the kind
+    /// `kind_id` and feeds the reply downstream. `payload` is opaque
+    /// bytes the substrate forwards unparsed (ADR-0047 §2), keeping
+    /// the descriptor capability-decoupled. Sources have no incoming
+    /// edges.
+    Source {
+        id: NodeId,
+        mailbox: MailboxId,
+        kind_id: KindId,
+        payload: Vec<u8>,
+    },
+    /// Mid-graph pure transform (ADR-0048 native-transform shape).
+    /// Identity is the global `transform_id`; `output_kind_id`
+    /// declares what the node produces. Dispatch lights up in Phase 3
+    /// (iamacoffeepot/aether#976) — Phase 2 reserves the wire shape.
+    Transform {
+        id: NodeId,
+        transform_id: TransformId,
+        output_kind_id: KindId,
+    },
+    /// Mid-graph effectful cap dispatch (ADR-0047 rev 2026-05-20). Its
+    /// request is assembled from incoming edges (the observer-side
+    /// slot-fill path), dispatched to `recipient`, and its correlated
+    /// replies accumulate into a [`Bundle`] that closes on settlement.
+    /// Replies are heterogeneous and self-describing, so a `Call`
+    /// declares **no** `output_kind_id` — its output handle is typed
+    /// as a `Bundle`.
+    Call {
+        id: NodeId,
+        recipient: MailboxId,
+        kind_id: KindId,
+    },
+    /// Terminal node: assembles `kind_id` from its incoming edges and
+    /// dispatches it to `recipient` (the slot-fill consumer). Observers
+    /// have no outgoing edges.
+    Observer {
+        id: NodeId,
+        recipient: MailboxId,
+        kind_id: KindId,
+    },
+}
+
+impl Node {
+    /// The descriptor-local id of this node, regardless of variant.
+    /// The validator (iamacoffeepot/aether#975) leans on this for the
+    /// uniqueness + edge-endpoint checks.
+    #[must_use]
+    pub const fn id(&self) -> NodeId {
+        match self {
+            Self::Source { id, .. }
+            | Self::Transform { id, .. }
+            | Self::Call { id, .. }
+            | Self::Observer { id, .. } => *id,
+        }
+    }
+}
+
+/// One directed edge in a computation DAG (ADR-0047 §2). `from` is the
+/// producing node, `to` the consuming node, and `slot` the
+/// consumer-side input index — for an `Observer` / `Call` it selects
+/// the `Ref<K>` field of the consumer's assembled-request schema the
+/// upstream output fills.
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, aether_data::Schema,
+)]
+pub struct Edge {
+    pub from: NodeId,
+    pub to: NodeId,
+    pub slot: u32,
+}
+
+/// A computation DAG (ADR-0047 §2). `version` is the first field — a
+/// decode-boundary guard rail (ADR-0047 §10): a substrate handed a
+/// version it doesn't implement rejects the submit with a clear
+/// [`DagError`] rather than mis-decoding an unknown node shape. The
+/// version check itself lives in the validator
+/// (iamacoffeepot/aether#975); this kind only carries the field.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.descriptor")]
+pub struct DagDescriptor {
+    pub version: u16,
+    pub nodes: Vec<Node>,
+    pub edges: Vec<Edge>,
+}
+
+/// One self-describing element of a [`Bundle`] — a single correlated
+/// reply, tagged with its own `kind_id`. The `payload` is opaque
+/// postcard bytes the element's own kind decodes downstream.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub struct BundleElement {
+    pub kind_id: KindId,
+    pub payload: Vec<u8>,
+}
+
+/// First-class meta-type whose value is an ordered list of
+/// self-describing reply elements (ADR-0047 §2, rev 2026-05-20). A
+/// [`Node::Call`]'s output handle resolves to a `Bundle`: a
+/// single-reply cap yields a 1-element bundle, zero replies an empty
+/// bundle, N replies an N-element bundle. The heterogeneity lives in
+/// the tagged `elements`, not in `Bundle`'s own fixed schema, so a
+/// downstream `Transform` / `Observer` simply declares a `Bundle`
+/// input and dispatches on each element's `kind_id` in its body.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.bundle")]
+pub struct Bundle {
+    pub elements: Vec<BundleElement>,
+}
+
+/// One terminal node's assigned output handle, returned in a submit /
+/// status reply (ADR-0047 §1). Handle ids are allocated at submit time
+/// so downstream `Ref::Handle` slots can be substituted before the
+/// values resolve.
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, aether_data::Schema,
+)]
+pub struct NodeHandle {
+    pub node_id: NodeId,
+    pub handle_id: HandleId,
+}
+
+/// `aether.dag.submit` — submit a computation DAG for validation and
+/// execution. The substrate replies synchronously with
+/// [`SubmitResult`] as soon as validation completes, before any source
+/// dispatches.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.submit")]
+pub struct Submit {
+    pub descriptor: DagDescriptor,
+}
+
+/// `aether.dag.cancel` — cancel an in-flight DAG by its substrate-minted
+/// [`DagId`]. Reply: [`CancelResult`].
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.cancel")]
+pub struct Cancel {
+    pub dag_id: DagId,
+}
+
+/// `aether.dag.status` — query an in-flight or completed DAG's
+/// progress. Reply: [`StatusResult`].
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.status")]
+pub struct Status {
+    pub dag_id: DagId,
+}
+
+/// Reply to [`Submit`] (ADR-0047 §1). `Ok` carries the minted
+/// [`DagId`] plus the full per-node output-handle list (handle ids
+/// assigned to terminal nodes) so a caller can hand them to downstream
+/// consumers immediately, even though the values aren't resolved yet.
+/// `Err` carries a structured [`DagError`] from the validator.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.submit_result")]
+pub enum SubmitResult {
+    Ok {
+        dag_id: DagId,
+        output_handles: Vec<NodeHandle>,
+    },
+    Err {
+        error: DagError,
+    },
+}
+
+/// Reply to [`Cancel`] (ADR-0047 §1). `Ok.cancelled` is `false` when
+/// the DAG had already completed (nothing to cancel); `Err` carries a
+/// human-readable reason (e.g. unknown `dag_id`).
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.cancel_result")]
+pub enum CancelResult {
+    Ok { cancelled: bool },
+    Err { error: String },
+}
+
+/// Per-node execution state in a [`StatusResult::Running`] progress
+/// list (ADR-0047 §6).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub enum NodeState {
+    Pending,
+    Resolved,
+    Failed,
+}
+
+/// One node's status in a [`StatusResult::Running`] progress list
+/// (ADR-0047 §1/§6).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub struct NodeStatus {
+    pub node_id: NodeId,
+    pub state: NodeState,
+}
+
+/// Reply to [`Status`] (ADR-0047 §1/§6). `Pending` — submitted, no
+/// source has resolved yet. `Running` — at least one node resolved,
+/// some haven't. `Complete` — all terminal handles resolved, with the
+/// same `(node, handle)` pairs the submit reply returned. `Failed` —
+/// a node failed, naming the node and a human-readable reason.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.status_result")]
+pub enum StatusResult {
+    Pending,
+    Running { progress: Vec<NodeStatus> },
+    Complete { outputs: Vec<NodeHandle> },
+    Failed { node_id: NodeId, error: String },
+}
+
+/// Structured validation / execution failure for a submitted DAG
+/// (ADR-0047 §3). The §3 code block is authoritative for the variant
+/// set; the validator (iamacoffeepot/aether#975) maps each rule
+/// violation to one variant and short-circuits on the first failure.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub enum DagError {
+    /// Two nodes share the same [`NodeId`].
+    DuplicateNodeId(NodeId),
+    /// An edge endpoint references a node id not present in `nodes`.
+    UnknownNodeId(NodeId),
+    /// The graph is not acyclic — the residual after Kahn's algorithm.
+    Cycle(Vec<NodeId>),
+    /// A `Source` node carries an incoming edge.
+    SourceWithIncomingEdge(NodeId),
+    /// An `Observer` node carries an outgoing edge.
+    ObserverWithOutgoingEdge(NodeId),
+    /// A `Source.mailbox` doesn't resolve to a live mailbox.
+    UnknownSink(String),
+    /// A `Call.recipient` / `Observer.recipient` doesn't resolve to a
+    /// live mailbox.
+    UnknownRecipient(String),
+    /// A dispatch target's accept set doesn't include the named kind.
+    KindNotAccepted {
+        node: NodeId,
+        kind_id: KindId,
+        mailbox_or_recipient: String,
+    },
+    /// A `Transform.transform_id` doesn't resolve to a registered
+    /// native transform.
+    UnknownTransform {
+        node: NodeId,
+        transform_id: TransformId,
+    },
+    /// A `Transform`'s declared `output_kind_id` disagrees with the
+    /// registered transform's manifest output kind.
+    TransformOutputMismatch {
+        node: NodeId,
+        declared: KindId,
+        manifest: KindId,
+    },
+    /// An edge wires an upstream output kind to a downstream input
+    /// slot that expects a different kind.
+    EdgeTypeMismatch {
+        edge_index: u32,
+        expected_kind: KindId,
+        got_kind: KindId,
+    },
+    /// The descriptor exceeds a structural cap (node / edge count or
+    /// serialized byte size), or names an unsupported descriptor
+    /// version (ADR-0047 §3/§8 wire-churn-avoiding reuse).
+    TooLarge { reason: String },
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -13,9 +13,12 @@
 
 extern crate alloc;
 
+pub mod dag;
 pub mod descriptors;
 pub mod keycode;
 pub mod trace;
+
+pub use dag::*;
 
 use alloc::string::String;
 use bytemuck::{Pod, Zeroable};

--- a/crates/aether-kinds/tests/dag_bundle_roundtrip.rs
+++ b/crates/aether-kinds/tests/dag_bundle_roundtrip.rs
@@ -1,0 +1,39 @@
+//! ADR-0047 §2 rev 2026-05-20: a `Bundle` with two heterogeneous
+//! `(KindId, payload)` elements encodes through the canonical `Kind`
+//! path and decodes back equal.
+
+use aether_data::{Kind, KindId};
+use aether_kinds::dag::{Bundle, BundleElement};
+
+#[test]
+fn bundle_with_heterogeneous_elements_roundtrips() {
+    let bundle = Bundle {
+        elements: vec![
+            BundleElement {
+                kind_id: KindId(0x1111),
+                payload: vec![0xDE, 0xAD],
+            },
+            BundleElement {
+                kind_id: KindId(0x2222),
+                payload: vec![0xBE, 0xEF, 0xCA, 0xFE],
+            },
+        ],
+    };
+
+    let bytes = bundle.encode_into_bytes();
+    let decoded =
+        Bundle::decode_from_bytes(&bytes).expect("Bundle decodes from its own canonical bytes");
+    assert_eq!(decoded, bundle);
+    assert_eq!(decoded.elements.len(), 2);
+    assert_eq!(decoded.elements[0].kind_id, KindId(0x1111));
+    assert_eq!(decoded.elements[1].payload, vec![0xBE, 0xEF, 0xCA, 0xFE]);
+}
+
+#[test]
+fn empty_bundle_roundtrips() {
+    let bundle = Bundle { elements: vec![] };
+    let bytes = bundle.encode_into_bytes();
+    let decoded = Bundle::decode_from_bytes(&bytes).expect("empty Bundle decodes");
+    assert_eq!(decoded, bundle);
+    assert!(decoded.elements.is_empty());
+}

--- a/crates/aether-kinds/tests/dag_descriptor_roundtrip.rs
+++ b/crates/aether-kinds/tests/dag_descriptor_roundtrip.rs
@@ -1,0 +1,39 @@
+//! ADR-0047 §2 Phase 2 happy path: a 3-node source → observer
+//! descriptor with a small inline payload encodes through the
+//! canonical `Kind` path and decodes back equal.
+
+use aether_data::{Kind, KindId, MailboxId};
+use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId, Submit};
+
+#[test]
+fn source_observer_descriptor_roundtrips() {
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: MailboxId(0x1000),
+                kind_id: KindId(0x2000),
+                payload: vec![1, 2, 3, 4],
+            },
+            Node::Observer {
+                id: NodeId(1),
+                recipient: MailboxId(0x3000),
+                kind_id: KindId(0x4000),
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let submit = Submit {
+        descriptor: descriptor.clone(),
+    };
+    let bytes = submit.encode_into_bytes();
+    let decoded =
+        Submit::decode_from_bytes(&bytes).expect("Submit decodes from its own canonical bytes");
+    assert_eq!(decoded.descriptor, descriptor);
+}

--- a/crates/aether-kinds/tests/dag_descriptor_with_call_node.rs
+++ b/crates/aether-kinds/tests/dag_descriptor_with_call_node.rs
@@ -1,0 +1,62 @@
+//! ADR-0047 rev 2026-05-20: a descriptor including a `Call { recipient,
+//! kind_id }` variant feeding an `Observer` encodes and decodes cleanly.
+//! The `Call` variant carries no `output_kind_id` — its output is a
+//! self-describing `Bundle`.
+
+use aether_data::{Kind, KindId, MailboxId};
+use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId, Submit};
+
+#[test]
+fn descriptor_with_call_node_roundtrips() {
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: MailboxId(0x1000),
+                kind_id: KindId(0x2000),
+                payload: vec![],
+            },
+            Node::Call {
+                id: NodeId(1),
+                recipient: MailboxId(0x9000),
+                kind_id: KindId(0xA000),
+            },
+            Node::Observer {
+                id: NodeId(2),
+                recipient: MailboxId(0xB000),
+                kind_id: KindId(0xC000),
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+        ],
+    };
+
+    let submit = Submit {
+        descriptor: descriptor.clone(),
+    };
+    let bytes = submit.encode_into_bytes();
+    let decoded = Submit::decode_from_bytes(&bytes).expect("Submit with Call node decodes cleanly");
+    assert_eq!(decoded.descriptor, descriptor);
+
+    // The Call variant declares no output kind — assert its shape so a
+    // future addition of an `output_kind_id` field would break here.
+    let Node::Call {
+        recipient, kind_id, ..
+    } = &decoded.descriptor.nodes[1]
+    else {
+        panic!("expected a Call node at index 1");
+    };
+    assert_eq!(*recipient, MailboxId(0x9000));
+    assert_eq!(*kind_id, KindId(0xA000));
+}

--- a/crates/aether-kinds/tests/dag_descriptor_with_transform_node.rs
+++ b/crates/aether-kinds/tests/dag_descriptor_with_transform_node.rs
@@ -1,0 +1,51 @@
+//! ADR-0047 §10 / ADR-0048 forward-compat: a descriptor including a
+//! `Transform { transform_id, .. }` variant encodes and decodes
+//! cleanly even though Phase 2 won't dispatch it.
+
+use aether_data::{Kind, KindId, MailboxId, TransformId};
+use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId, Submit};
+
+#[test]
+fn descriptor_with_transform_node_roundtrips() {
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: MailboxId(0x1000),
+                kind_id: KindId(0x2000),
+                payload: vec![9],
+            },
+            Node::Transform {
+                id: NodeId(1),
+                transform_id: TransformId(0x5000),
+                output_kind_id: KindId(0x6000),
+            },
+            Node::Observer {
+                id: NodeId(2),
+                recipient: MailboxId(0x7000),
+                kind_id: KindId(0x8000),
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+        ],
+    };
+
+    let submit = Submit {
+        descriptor: descriptor.clone(),
+    };
+    let bytes = submit.encode_into_bytes();
+    let decoded =
+        Submit::decode_from_bytes(&bytes).expect("Submit with Transform node decodes cleanly");
+    assert_eq!(decoded.descriptor, descriptor);
+}

--- a/crates/aether-kinds/tests/dag_error_variant_roundtrip.rs
+++ b/crates/aether-kinds/tests/dag_error_variant_roundtrip.rs
@@ -1,0 +1,46 @@
+//! ADR-0047 §3: every `DagError` variant postcard-roundtrips with
+//! structural equality. Catches accidental wire breakage when future
+//! variants are appended (postcard discriminants are positional).
+
+use aether_data::{KindId, TransformId};
+use aether_kinds::dag::{DagError, NodeId};
+
+fn roundtrip(error: &DagError) {
+    let bytes = postcard::to_allocvec(error).expect("DagError encodes via postcard");
+    let decoded: DagError =
+        postcard::from_bytes(&bytes).expect("DagError decodes from its own bytes");
+    assert_eq!(&decoded, error);
+}
+
+#[test]
+fn every_dag_error_variant_roundtrips() {
+    roundtrip(&DagError::DuplicateNodeId(NodeId(3)));
+    roundtrip(&DagError::UnknownNodeId(NodeId(99)));
+    roundtrip(&DagError::Cycle(vec![NodeId(0), NodeId(1), NodeId(2)]));
+    roundtrip(&DagError::SourceWithIncomingEdge(NodeId(0)));
+    roundtrip(&DagError::ObserverWithOutgoingEdge(NodeId(4)));
+    roundtrip(&DagError::UnknownSink("aether.bogus".into()));
+    roundtrip(&DagError::UnknownRecipient("aether.gone".into()));
+    roundtrip(&DagError::KindNotAccepted {
+        node: NodeId(2),
+        kind_id: KindId(0x1234),
+        mailbox_or_recipient: "aether.fs".into(),
+    });
+    roundtrip(&DagError::UnknownTransform {
+        node: NodeId(1),
+        transform_id: TransformId(0x5555),
+    });
+    roundtrip(&DagError::TransformOutputMismatch {
+        node: NodeId(1),
+        declared: KindId(0xAAAA),
+        manifest: KindId(0xBBBB),
+    });
+    roundtrip(&DagError::EdgeTypeMismatch {
+        edge_index: 7,
+        expected_kind: KindId(0xCCCC),
+        got_kind: KindId(0xDDDD),
+    });
+    roundtrip(&DagError::TooLarge {
+        reason: "256 nodes exceeds cap".into(),
+    });
+}


### PR DESCRIPTION
## Summary

- Adds the ADR-0047 §2 DAG descriptor wire vocabulary in a new `aether-kinds::dag` module: `DagDescriptor` (leading `version: u16`), `Node` (`Source` / `Transform` / `Call` / `Observer`, where the `Call` variant carries no `output_kind_id` since its output is a `Bundle`), `Edge`, the `Bundle` meta-type, the three request kinds (submit / cancel / status) plus their reply kinds, and the structured `DagError` set.
- Adds `DagId` and `TransformId` tagged-id newtypes in `aether-data` (`Tag::Dag` / `Tag::Transform`, `dag-` / `trn-` prefixes) following the `HandleId` template, wired through `tag_for_type_id` / `type_name_for_type_id` so the codec picks them up transparently.
- Bundle elements and submit/status output handles are described as ordered pairs in the ADR, but `aether_data::SchemaType` has no tuple arm, so each pair encodes as a named two-field struct (`BundleElement`, `NodeHandle`) — the existing codebase idiom for structured collections in a reply enum.

Closes iamacoffeepot/aether#974

## Test plan

- [x] `scripts/preflight.sh` green (fmt, clippy --workspace --all-targets -D warnings, doc, nextest --workspace --profile ci, wasm32 cross-build)
- [x] New roundtrip tests for the descriptor, Call/Transform node variants, Bundle, and DagError variants

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>