### PR TITLE
feat(substrate): persistent handle store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "crossbeam-queue",
+ "dirs",
  "png",
  "postcard",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "dirs",
+ "libc",
  "png",
  "postcard",
  "serde",

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -30,7 +30,9 @@ mod native {
     };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
-    use aether_substrate::handle_store::{HandleStore, PutError};
+    use aether_substrate::handle_store::{
+        HandleStore, HandleStoreSnapshot, HandleSummary as StoreSummary, PutError,
+    };
 
     /// `aether.handle` mailbox cap. Owns the substrate's `HandleStore`.
     pub struct HandleCapability {
@@ -160,7 +162,7 @@ mod native {
         n as usize
     }
 
-    fn summary_to_wire(s: &aether_substrate::handle_store::HandleSummary) -> HandleSummary {
+    fn summary_to_wire(s: &StoreSummary) -> HandleSummary {
         HandleSummary {
             handle_id: s.handle_id,
             kind_id: s.kind_id,
@@ -171,9 +173,7 @@ mod native {
         }
     }
 
-    fn snapshot_to_result(
-        snap: &aether_substrate::handle_store::HandleStoreSnapshot,
-    ) -> HandleDescribeResult {
+    fn snapshot_to_result(snap: &HandleStoreSnapshot) -> HandleDescribeResult {
         let cast = |n: usize| u32::try_from(n).unwrap_or(u32::MAX);
         HandleDescribeResult {
             total_entries: cast(snap.total_entries),
@@ -328,9 +328,15 @@ mod native {
 
             let (store, mailer, registry, rx) = fresh_substrate();
             // Pre-populate the store: 3 entries, 1 pinned.
-            store.put(HandleId(1), KindId(0xA), vec![0u8; 100]).unwrap();
-            store.put(HandleId(2), KindId(0xB), vec![0u8; 200]).unwrap();
-            store.put(HandleId(3), KindId(0xC), vec![0u8; 50]).unwrap();
+            store
+                .put(HandleId(1), KindId(0xA), vec![0u8; 100])
+                .expect("put 1");
+            store
+                .put(HandleId(2), KindId(0xB), vec![0u8; 200])
+                .expect("put 2");
+            store
+                .put(HandleId(3), KindId(0xC), vec![0u8; 50])
+                .expect("put 3");
             store.pin(HandleId(2));
 
             let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -16,16 +16,17 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
-use aether_kinds::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
+use aether_kinds::{HandleDescribe, HandlePin, HandlePublish, HandleRelease, HandleUnpin};
 
 #[aether_actor::bridge(singleton)]
 mod native {
     use std::sync::Arc;
 
-    use super::{HandlePin, HandlePublish, HandleRelease, HandleUnpin};
+    use super::{HandleDescribe, HandlePin, HandlePublish, HandleRelease, HandleUnpin};
     use aether_actor::{MailCtx, actor};
     use aether_kinds::{
-        HandleError, HandlePinResult, HandlePublishResult, HandleReleaseResult, HandleUnpinResult,
+        HandleDescribeResult, HandleError, HandlePinResult, HandlePublishResult,
+        HandleReleaseResult, HandleSummary, HandleUnpinResult,
     };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -129,6 +130,61 @@ mod native {
                     error: HandleError::UnknownHandle,
                 });
             }
+        }
+
+        /// Summarize the persistent handle store (ADR-0049 §10). `max`
+        /// caps the top-N lists; the handler clamps it to `[1, 256]`
+        /// (a 0 / absent request lands on the v1 default of 16).
+        ///
+        /// # Agent
+        /// Reply: `HandleDescribeResult`.
+        #[handler]
+        fn on_describe(&self, ctx: &mut NativeCtx<'_>, mail: HandleDescribe) {
+            let max = clamp_describe_max(mail.max);
+            let snap = self.store.inspect(max);
+            ctx.reply(&snapshot_to_result(&snap));
+        }
+    }
+
+    /// Default top-N when the request asks for 0 (ADR-0049 §10 follow-up
+    /// text); clamp ceiling.
+    const DESCRIBE_DEFAULT_MAX: u32 = 16;
+    const DESCRIBE_MAX_CAP: u32 = 256;
+
+    fn clamp_describe_max(requested: u32) -> usize {
+        let n = if requested == 0 {
+            DESCRIBE_DEFAULT_MAX
+        } else {
+            requested.min(DESCRIBE_MAX_CAP)
+        };
+        n as usize
+    }
+
+    fn summary_to_wire(s: &aether_substrate::handle_store::HandleSummary) -> HandleSummary {
+        HandleSummary {
+            handle_id: s.handle_id,
+            kind_id: s.kind_id,
+            bytes_len: s.bytes_len,
+            pinned: s.pinned,
+            refcount: s.refcount,
+            created_at_ms: s.created_at_ms,
+        }
+    }
+
+    fn snapshot_to_result(
+        snap: &aether_substrate::handle_store::HandleStoreSnapshot,
+    ) -> HandleDescribeResult {
+        let cast = |n: usize| u32::try_from(n).unwrap_or(u32::MAX);
+        HandleDescribeResult {
+            total_entries: cast(snap.total_entries),
+            in_memory_entries: cast(snap.in_memory_entries),
+            on_disk_entries: cast(snap.on_disk_entries),
+            pinned_entries: cast(snap.pinned_entries),
+            in_memory_bytes: snap.in_memory_bytes,
+            on_disk_bytes: snap.on_disk_bytes,
+            on_disk_budget_bytes: snap.on_disk_budget_bytes,
+            top_by_size: snap.top_by_size.iter().map(summary_to_wire).collect(),
+            top_by_recency: snap.top_by_recency.iter().map(summary_to_wire).collect(),
         }
     }
 
@@ -259,6 +315,67 @@ mod native {
                 .expect("test setup: stored handle should be retrievable");
             assert_eq!(stored_kind, KindId(0xCAFE));
             assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
+
+            drop(chassis);
+        }
+
+        /// `aether.handle.describe` flows through the cap and returns a
+        /// `HandleDescribeResult` whose counts match the store contents
+        /// (ADR-0049 §10).
+        #[test]
+        fn capability_describe_summarizes_store() {
+            use aether_kinds::{HandleDescribe, HandleDescribeResult};
+
+            let (store, mailer, registry, rx) = fresh_substrate();
+            // Pre-populate the store: 3 entries, 1 pinned.
+            store.put(HandleId(1), KindId(0xA), vec![0u8; 100]).unwrap();
+            store.put(HandleId(2), KindId(0xB), vec![0u8; 200]).unwrap();
+            store.put(HandleId(3), KindId(0xC), vec![0u8; 50]).unwrap();
+            store.pin(HandleId(2));
+
+            let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());
+
+            let id = registry
+                .lookup(HandleCapability::NAMESPACE)
+                .expect("mailbox registered");
+            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
+                panic!("expected mailbox entry");
+            };
+
+            let req = HandleDescribe { max: 16 };
+            let bytes = postcard::to_allocvec(&req).expect("HandleDescribe serializes");
+            handler.enqueue(OwnedDispatch {
+                kind: <HandleDescribe as Kind>::ID,
+                kind_name: "aether.handle.describe".to_owned(),
+                origin: None,
+                sender: session_reply_to(),
+                payload: bytes,
+                count: 1,
+                mail_id: MailId::NONE,
+                root: MailId::NONE,
+                parent_mail: None,
+            });
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let frame = loop {
+                if let Ok(f) = rx.try_recv() {
+                    break f;
+                }
+                assert!(Instant::now() < deadline, "describe reply did not arrive");
+                thread::sleep(Duration::from_millis(5));
+            };
+            let payload = match frame {
+                EgressEvent::ToSession { payload, .. } => payload,
+                other => panic!("expected ToSession egress, got {other:?}"),
+            };
+            let result: HandleDescribeResult =
+                postcard::from_bytes(&payload).expect("HandleDescribeResult decodes");
+            assert_eq!(result.total_entries, 3);
+            assert_eq!(result.in_memory_entries, 3);
+            assert_eq!(result.pinned_entries, 1);
+            assert_eq!(result.in_memory_bytes, 350);
+            // top_by_size descending: the 200-byte entry leads.
+            assert_eq!(result.top_by_size.first().map(|s| s.bytes_len), Some(200));
 
             drop(chassis);
         }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1755,6 +1755,46 @@ mod control_plane {
         },
     }
 
+    /// `aether.handle.describe` — ask the substrate's `HandleCapability`
+    /// for a summary of the persistent store (ADR-0049 §10). Reply:
+    /// `HandleDescribeResult`. `max` caps the top-N lists; the cap
+    /// clamps it to a sane ceiling.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.handle.describe")]
+    pub struct HandleDescribe {
+        pub max: u32,
+    }
+
+    /// One handle's summary line in a `HandleDescribeResult`. Carries
+    /// the identity + size + durability fields the operator triages on.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct HandleSummary {
+        pub handle_id: aether_data::HandleId,
+        pub kind_id: aether_data::KindId,
+        pub bytes_len: u32,
+        pub pinned: bool,
+        pub refcount: u32,
+        pub created_at_ms: u64,
+    }
+
+    /// Reply to `HandleDescribe` — the store summary (ADR-0049 §10).
+    /// `top_by_size` is descending by `bytes_len`; `top_by_recency` is
+    /// descending by `created_at_ms`. Both are capped at the request's
+    /// (clamped) `max`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.handle.describe_result")]
+    pub struct HandleDescribeResult {
+        pub total_entries: u32,
+        pub in_memory_entries: u32,
+        pub on_disk_entries: u32,
+        pub pinned_entries: u32,
+        pub in_memory_bytes: u64,
+        pub on_disk_bytes: u64,
+        pub on_disk_budget_bytes: u64,
+        pub top_by_size: Vec<HandleSummary>,
+        pub top_by_recency: Vec<HandleSummary>,
+    }
+
     // ADR-0081 per-actor log storage. Each actor owns an
     // `ActorLogRing` (in `aether-actor::log`); one wire kind pair
     // drives the query path:

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -188,6 +188,46 @@ pub struct ActorLogsResponse {
     pub truncated_before: Option<u64>,
 }
 
+/// `describe_handles` arguments (ADR-0049 §10). Summarizes a
+/// substrate's persistent handle store.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeHandlesArgs {
+    /// Engine UUID to summarize (from `list_engines`).
+    pub engine_id: String,
+    /// Cap on the `top_by_size` / `top_by_recency` lists. Defaults to
+    /// 16; clamped to 256.
+    #[serde(default)]
+    pub max: Option<u32>,
+}
+
+/// One handle's summary line as `describe_handles` renders it. `handle_id`
+/// and `kind_id` are tagged-id strings (ADR-0064).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HandleSummaryJson {
+    pub handle_id: String,
+    pub kind_id: String,
+    pub bytes_len: u32,
+    pub pinned: bool,
+    pub refcount: u32,
+    pub created_at_ms: u64,
+}
+
+/// `describe_handles` response — the persistent store summary
+/// (ADR-0049 §10).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DescribeHandlesResponse {
+    pub engine_id: String,
+    pub total_entries: u32,
+    pub in_memory_entries: u32,
+    pub on_disk_entries: u32,
+    pub pinned_entries: u32,
+    pub in_memory_bytes: u64,
+    pub on_disk_bytes: u64,
+    pub on_disk_budget_bytes: u64,
+    pub top_by_size: Vec<HandleSummaryJson>,
+    pub top_by_recency: Vec<HandleSummaryJson>,
+}
+
 /// `send_mail_traced` arguments — atomic batched dispatch with a shared
 /// trace root (issue iamacoffeepot/aether#749). Every spec lands on the
 /// same engine and inherits the same chassis root, so the response carries one

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -40,10 +40,10 @@ use crate::args::ActorLogEntry;
 use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
 use crate::args::{
-    CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, EngineInfo, LoadComponentArgs,
-    MailIdJson, MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs,
-    SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, TerminateSubstrateArgs,
-    TracedMailSpec,
+    CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, DescribeHandlesArgs,
+    DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs, MailIdJson,
+    MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs,
+    SendMailTracedResponse, SpawnSubstrateArgs, TerminateSubstrateArgs, TracedMailSpec,
 };
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
@@ -59,6 +59,8 @@ const ENGINE_CAP: &str = "aether.engine";
 const COMPONENT_CAP: &str = "aether.component";
 /// Mailbox name of a substrate's render cap.
 const RENDER_CAP: &str = "aether.render";
+/// Mailbox name of a substrate's handle-store cap (ADR-0045 / ADR-0049).
+const HANDLE_CAP: &str = "aether.handle";
 
 /// Component receive-side capabilities, keyed by `(engine, mailbox)`.
 /// Populated from `load_component` / `replace_component` replies and
@@ -501,6 +503,61 @@ impl Mcp {
             None => Err(internal_msg("undecodable LogTailResult")),
         }
     }
+
+    #[tool(
+        description = "Summarize a substrate's persistent handle store (ADR-0049 §10). Sends \
+                       aether.handle.describe to the engine's aether.handle cap and decodes \
+                       aether.handle.describe_result. Returns total / in-memory / on-disk / pinned \
+                       entry counts, in-memory + on-disk bytes vs the disk budget, and the top-N \
+                       handles by size and by recency (handle_id + kind_id as tagged-id strings, \
+                       bytes_len, pinned, refcount, created_at_ms). Use it to triage \"why is my \
+                       handle store at the disk-budget cap\" without ssh-ing into the machine. \
+                       `max` defaults to 16, clamps to 256."
+    )]
+    pub async fn describe_handles(
+        &self,
+        Parameters(args): Parameters<DescribeHandlesArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let request = aether_kinds::HandleDescribe {
+            max: args.max.unwrap_or(0),
+        };
+        let reply = self
+            .session
+            .call_one(engine_envelope(engine, HANDLE_CAP, &request))
+            .await
+            .map_err(internal)?;
+        let Some(result) = aether_kinds::HandleDescribeResult::decode_from_bytes(&reply.payload)
+        else {
+            return Err(internal_msg("undecodable HandleDescribeResult"));
+        };
+        let to_json = |s: &aether_kinds::HandleSummary| HandleSummaryJson {
+            // Handle + kind ids are tagged 64-bit ids (ADR-0064); render
+            // them as the tagged-id strings the rest of the MCP wire uses.
+            // Fall back to the raw decimal only if a synthetic id lacks
+            // tag bits (test fixtures), so the tool never panics.
+            handle_id: tagged_id::encode(s.handle_id.0)
+                .unwrap_or_else(|| s.handle_id.0.to_string()),
+            kind_id: tagged_id::encode(s.kind_id.0).unwrap_or_else(|| s.kind_id.0.to_string()),
+            bytes_len: s.bytes_len,
+            pinned: s.pinned,
+            refcount: s.refcount,
+            created_at_ms: s.created_at_ms,
+        };
+        let response = DescribeHandlesResponse {
+            engine_id: args.engine_id,
+            total_entries: result.total_entries,
+            in_memory_entries: result.in_memory_entries,
+            on_disk_entries: result.on_disk_entries,
+            pinned_entries: result.pinned_entries,
+            in_memory_bytes: result.in_memory_bytes,
+            on_disk_bytes: result.on_disk_bytes,
+            on_disk_budget_bytes: result.on_disk_budget_bytes,
+            top_by_size: result.top_by_size.iter().map(to_json).collect(),
+            top_by_recency: result.top_by_recency.iter().map(to_json).collect(),
+        };
+        json(&response)
+    }
 }
 
 impl Mcp {
@@ -760,6 +817,7 @@ mod tests {
     use aether_substrate::mail::registry::Registry;
 
     use crate::args::ActorLogsArgs;
+    use crate::args::DescribeHandlesArgs;
     use crate::test_chassis::TestChassis;
     use aether_kinds::descriptors;
 
@@ -1108,5 +1166,23 @@ mod tests {
             }))
             .await;
         assert!(result.is_err(), "an unknown level should be a tool error");
+    }
+
+    /// `describe_handles` with a malformed `engine_id` rejects up front
+    /// without touching the wire.
+    #[tokio::test]
+    async fn describe_handles_bad_engine_id_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .describe_handles(Parameters(DescribeHandlesArgs {
+                engine_id: "not-a-uuid".to_owned(),
+                max: None,
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "a malformed engine_id should be a tool error"
+        );
     }
 }

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -206,7 +206,10 @@ impl DesktopChassis {
             workers,
         } = env;
 
-        let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION")).build()?;
+        // ADR-0049 §9: desktop enables on-disk handle persistence.
+        let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION"))
+            .persist_enabled(true)
+            .build()?;
 
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -143,7 +143,10 @@ impl HeadlessChassis {
             workers,
         } = env;
 
-        let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION")).build()?;
+        // ADR-0049 §9: headless enables on-disk handle persistence.
+        let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
+            .persist_enabled(true)
+            .build()?;
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -32,6 +32,9 @@ aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"
+# ADR-0049 on-disk handle store: resolve the default persistence root
+# (`dirs::data_dir()/aether/handles`). Same crate the fs cap uses.
+dirs = "6"
 postcard = { version = "1.1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
 # ADR-0081 §4 crash dump: serialize the panicking actor's ring as

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -63,6 +63,13 @@ crossbeam-channel = "0.5"
 # transitively so we stay on a single compiled copy.
 wasmparser = "0.249"
 
+# ADR-0049 §7 lockfile liveness check: `kill(pid, 0)` to detect whether
+# a lock-holding PID is still alive. Unix-only; the lockfile path is
+# gated to `#[cfg(unix)]` (substrate on Windows is deferred per
+# ADR-0049 §7).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 wat = "1"
 # Issue 552 stage 1: integration tests for the macro-emitted

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -44,8 +44,9 @@ use crate::mail::registry::MailDispatch;
 use crate::runtime::log_install;
 use crate::runtime::panic_hook;
 use crate::{
-    AETHER_DIAGNOSTICS, ComponentCtx, HubOutbound, Mailer, Registry, actor::wasm::host_fns,
-    handle_store::HandleStore,
+    AETHER_DIAGNOSTICS, ComponentCtx, HubOutbound, Mailer, Registry,
+    actor::wasm::host_fns,
+    handle_store::{HandleStore, KindResolver},
 };
 use aether_kinds::descriptors;
 
@@ -115,7 +116,7 @@ impl SubstrateBoot {
     }
 }
 
-impl<'a> SubstrateBootBuilder<'a> {
+impl SubstrateBootBuilder<'_> {
     /// Opt this chassis into ADR-0049 on-disk handle persistence. The
     /// desktop + headless chassis call this; the hub does not. Whether
     /// persistence actually activates still depends on the env
@@ -211,7 +212,7 @@ impl SubstrateBootBuilder<'_> {
         // ADR-0049 §6: the registry (already populated above) drives the
         // schema-evolution check on the boot scan — a kind whose schema
         // changed or was retired invalidates its stale on-disk entries.
-        let kind_resolver: Arc<dyn crate::handle_store::KindResolver> = registry.clone();
+        let kind_resolver: Arc<dyn KindResolver> = registry.clone();
         let handle_store = Arc::new(HandleStore::from_env_persistent(
             self.persist_enabled,
             Some(kind_resolver),

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -209,6 +209,12 @@ impl SubstrateBootBuilder<'_> {
         );
 
         let handle_store = Arc::new(HandleStore::from_env_persistent(self.persist_enabled));
+        // ADR-0049 §7: acquire the single-substrate-per-store lock
+        // before doing any writes. A live conflicting lock aborts boot
+        // with a clear error. No-op when persistence is disabled.
+        handle_store
+            .acquire_lock()
+            .map_err(|e| wasmtime::Error::msg(e.to_string()))?;
         // ADR-0049 §5: start the background disk-eviction tick. No-op
         // when persistence is disabled (hub chassis / test fixtures).
         handle_store.spawn_eviction_thread();

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -209,6 +209,9 @@ impl SubstrateBootBuilder<'_> {
         );
 
         let handle_store = Arc::new(HandleStore::from_env_persistent(self.persist_enabled));
+        // ADR-0049 §5: start the background disk-eviction tick. No-op
+        // when persistence is disabled (hub chassis / test fixtures).
+        handle_store.spawn_eviction_thread();
         let queue = Arc::new(
             Mailer::new(Arc::clone(&registry), Arc::clone(&handle_store))
                 .with_outbound(Arc::clone(&outbound)),

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -91,6 +91,13 @@ pub struct SubstrateBoot {
 pub struct SubstrateBootBuilder<'a> {
     name: &'a str,
     version: &'a str,
+    /// Whether this chassis enables on-disk handle persistence
+    /// (ADR-0049 §9). Desktop + headless set `true`; the hub leaves it
+    /// `false` (it hosts no handles, so there's nothing to persist).
+    /// Defaults to `false` so a chassis that forgets to opt in stays
+    /// in-memory-only rather than silently writing to the user's data
+    /// dir.
+    persist_enabled: bool,
 }
 
 impl SubstrateBoot {
@@ -100,7 +107,24 @@ impl SubstrateBoot {
     /// `env!("CARGO_PKG_VERSION")`.
     #[must_use]
     pub fn builder<'a>(name: &'a str, version: &'a str) -> SubstrateBootBuilder<'a> {
-        SubstrateBootBuilder { name, version }
+        SubstrateBootBuilder {
+            name,
+            version,
+            persist_enabled: false,
+        }
+    }
+}
+
+impl<'a> SubstrateBootBuilder<'a> {
+    /// Opt this chassis into ADR-0049 on-disk handle persistence. The
+    /// desktop + headless chassis call this; the hub does not. Whether
+    /// persistence actually activates still depends on the env
+    /// (`AETHER_HANDLE_STORE_PERSIST_DISABLE`, data-dir resolution) —
+    /// this is just the chassis vote.
+    #[must_use]
+    pub fn persist_enabled(mut self, enabled: bool) -> Self {
+        self.persist_enabled = enabled;
+        self
     }
 }
 
@@ -184,7 +208,7 @@ impl SubstrateBootBuilder<'_> {
             }),
         );
 
-        let handle_store = Arc::new(HandleStore::from_env());
+        let handle_store = Arc::new(HandleStore::from_env_persistent(self.persist_enabled));
         let queue = Arc::new(
             Mailer::new(Arc::clone(&registry), Arc::clone(&handle_store))
                 .with_outbound(Arc::clone(&outbound)),

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -208,7 +208,14 @@ impl SubstrateBootBuilder<'_> {
             }),
         );
 
-        let handle_store = Arc::new(HandleStore::from_env_persistent(self.persist_enabled));
+        // ADR-0049 §6: the registry (already populated above) drives the
+        // schema-evolution check on the boot scan — a kind whose schema
+        // changed or was retired invalidates its stale on-disk entries.
+        let kind_resolver: Arc<dyn crate::handle_store::KindResolver> = registry.clone();
+        let handle_store = Arc::new(HandleStore::from_env_persistent(
+            self.persist_enabled,
+            Some(kind_resolver),
+        ));
         // ADR-0049 §7: acquire the single-substrate-per-store lock
         // before doing any writes. A live conflicting lock aborts boot
         // with a clear error. No-op when persistence is disabled.

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -268,6 +268,64 @@ pub struct HandleSummary {
     pub created_at_ms: u64,
 }
 
+/// Kind-name → current-id resolver used by the schema-evolution check
+/// (ADR-0049 §6). The substrate's `Registry` implements this; the boot
+/// scan calls it once per `.meta` to detect schema drift. Decoupled
+/// from `Registry` directly so test fixtures can supply a synthetic
+/// resolver without standing up a full registry.
+pub trait KindResolver: Send + Sync {
+    /// Current id for the named kind, or `None` if the kind isn't
+    /// registered.
+    fn id_for_name(&self, name: &str) -> Option<KindId>;
+    /// Current name for the given kind id, or `None` if the id isn't
+    /// registered. Used at write time to stamp `meta.kind_name`.
+    fn name_for_id(&self, id: KindId) -> Option<String>;
+}
+
+impl KindResolver for crate::mail::registry::Registry {
+    fn id_for_name(&self, name: &str) -> Option<KindId> {
+        self.kind_id(name)
+    }
+
+    fn name_for_id(&self, id: KindId) -> Option<String> {
+        self.kind_name(id)
+    }
+}
+
+/// Outcome of validating an on-disk `.meta` against the current kind
+/// registry (ADR-0049 §6).
+enum Validation {
+    /// The entry's kind matches the current registry; keep it.
+    Valid,
+    /// The entry is stale (schema changed, kind retired, or unsupported
+    /// version); drop it. Carries the reason for `engine_logs`.
+    Drop(String),
+}
+
+/// Validate one `.meta` against the resolver (ADR-0049 §6). An
+/// unsupported `schema_version`, an unknown kind name, or a kind-id
+/// mismatch all invalidate the entry. With no resolver (test fixtures
+/// that don't model schema evolution), only the version check applies.
+fn validate_meta(meta: &HandleMeta, resolver: Option<&dyn KindResolver>) -> Validation {
+    if meta.schema_version != SCHEMA_VERSION {
+        return Validation::Drop(format!(
+            "schema_version {} unsupported (current {SCHEMA_VERSION})",
+            meta.schema_version,
+        ));
+    }
+    let Some(resolver) = resolver else {
+        return Validation::Valid;
+    };
+    match resolver.id_for_name(&meta.kind_name) {
+        Some(current) if current.0 == meta.kind_id => Validation::Valid,
+        Some(current) => Validation::Drop(format!(
+            "kind '{}' id changed: {:016x} -> {:016x}",
+            meta.kind_name, meta.kind_id, current.0,
+        )),
+        None => Validation::Drop(format!("kind '{}' no longer registered", meta.kind_name)),
+    }
+}
+
 /// Compute the `(<bin>, <meta>)` paths for a handle id under `root`.
 /// 256 prefix-shard directories keyed on the first hex byte of the id
 /// (ADR-0049 §2).
@@ -416,6 +474,11 @@ pub struct HandleStore {
     /// succeeds; its `Drop` deletes the lockfile on graceful shutdown.
     /// `None` until acquired (or when persistence is disabled).
     lock: Mutex<Option<LockGuard>>,
+    /// Kind-name → current-id resolver for the schema-evolution check
+    /// (ADR-0049 §6). Supplied at construction (the substrate's
+    /// `Registry`); `None` on fixtures that don't model schema drift —
+    /// the boot scan then only enforces the `schema_version` check.
+    kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
 }
 
 /// Reasons a `put` can fail.
@@ -479,15 +542,32 @@ impl HandleStore {
             max_bytes,
             persist: None,
             lock: Mutex::new(None),
+            kind_resolver: None,
         }
     }
 
     /// Build an in-memory store with on-disk persistence wired in. The
     /// caller resolves the [`PersistConfig`] (typically via
     /// [`PersistConfig::from_env`]); the boot scan populates the disk
-    /// index from the existing tree (ADR-0049 §3).
+    /// index from the existing tree (ADR-0049 §3). No kind resolver, so
+    /// the schema-evolution check (ADR-0049 §6) only enforces the
+    /// `schema_version` gate — use [`Self::with_persist_validated`] to
+    /// wire one.
     #[must_use]
     pub fn with_persist(max_bytes: usize, persist: Option<PersistConfig>) -> Self {
+        Self::with_persist_validated(max_bytes, persist, None)
+    }
+
+    /// Build a persistent store with a kind resolver for the
+    /// schema-evolution check (ADR-0049 §6). The resolver (the
+    /// substrate's `Registry`) lets the boot scan detect a kind whose
+    /// schema changed or was retired and drop its stale on-disk entries.
+    #[must_use]
+    pub fn with_persist_validated(
+        max_bytes: usize,
+        persist: Option<PersistConfig>,
+        kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
+    ) -> Self {
         let store = Self {
             inner: RwLock::new(Inner {
                 next_ephemeral: 1,
@@ -496,6 +576,7 @@ impl HandleStore {
             max_bytes,
             persist,
             lock: Mutex::new(None),
+            kind_resolver,
         };
         store.restore_from_disk();
         store
@@ -537,15 +618,17 @@ impl HandleStore {
     /// Build a store sized from the environment with on-disk
     /// persistence resolved from [`PersistConfig::from_env`]. `enabled`
     /// is the chassis verdict (desktop + headless `true`, hub `false`
-    /// per ADR-0049 §9). When persistence resolves to `Some`, the boot
-    /// scan (issue #985) populates the disk index from the existing
-    /// tree.
+    /// per ADR-0049 §9). `kind_resolver` (the substrate's `Registry`)
+    /// drives the schema-evolution check (ADR-0049 §6). When persistence
+    /// resolves to `Some`, the boot scan (issue #985) populates the disk
+    /// index from the existing tree, dropping schema-stale entries.
     #[must_use]
-    pub fn from_env_persistent(enabled: bool) -> Self {
-        let mut store = Self::from_env();
-        store.persist = PersistConfig::from_env(enabled);
-        store.restore_from_disk();
-        store
+    pub fn from_env_persistent(
+        enabled: bool,
+        kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
+    ) -> Self {
+        let max_bytes = Self::from_env().max_bytes;
+        Self::with_persist_validated(max_bytes, PersistConfig::from_env(enabled), kind_resolver)
     }
 
     /// Mint a fresh ephemeral handle id. Pure counter today; content-
@@ -677,10 +760,22 @@ impl HandleStore {
         pinned: bool,
     ) {
         let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+        // Stamp the kind's current name so the schema-evolution check
+        // (ADR-0049 §6) can look it up by name on restore. Falls back to
+        // the hex id when no resolver is wired (test fixtures) — a
+        // synthetic name that won't match any registry entry, so such an
+        // entry invalidates on the first registry-backed restore. That's
+        // the correct conservative behaviour.
+        let kind_name = self
+            .kind_resolver
+            .as_ref()
+            .and_then(|r| r.name_for_id(kind))
+            .unwrap_or_else(|| format!("{:016x}", kind.0));
         let meta = HandleMeta {
             schema_version: SCHEMA_VERSION,
             handle_id: id.0,
             kind_id: kind.0,
+            kind_name,
             transform_origin: origin.cloned(),
             bytes_len: u32::try_from(bytes.len()).unwrap_or(u32::MAX),
             created_at: now_millis(),
@@ -804,9 +899,11 @@ impl HandleStore {
             return;
         };
 
+        let resolver = self.kind_resolver.as_deref();
         let mut index: HashMap<HandleId, DiskEntry> = HashMap::new();
         let mut orphan_bins = 0usize;
         let mut orphan_metas = 0usize;
+        let mut invalidated = 0usize;
         let mut scrubbed = 0usize;
 
         for shard in shards.flatten() {
@@ -833,6 +930,27 @@ impl HandleStore {
                                     let _ = std::fs::remove_file(&path);
                                     orphan_metas += 1;
                                     scrubbed += 1;
+                                    continue;
+                                }
+                                // ADR-0049 §6: schema-evolution check. A
+                                // version skew, retired kind, or changed
+                                // kind id invalidates the entry — the
+                                // bytes are unsafe to decode against the
+                                // current schema, so drop both files. This
+                                // overrides pin (a pinned entry whose kind
+                                // changed is still evicted — pin protects
+                                // against budget pressure, not against
+                                // correctness invalidation).
+                                if let Validation::Drop(reason) = validate_meta(&meta, resolver) {
+                                    let _ = std::fs::remove_file(&bin);
+                                    let _ = std::fs::remove_file(&path);
+                                    invalidated += 1;
+                                    tracing::info!(
+                                        target: TARGET,
+                                        handle = %HandleId(meta.handle_id),
+                                        reason = %reason,
+                                        "handle store entry invalidated by schema evolution; dropped",
+                                    );
                                     continue;
                                 }
                                 let id = HandleId(meta.handle_id);
@@ -895,13 +1013,14 @@ impl HandleStore {
             inner.disk_index = index;
             inner.total_disk_bytes = disk_bytes;
         }
-        if scrubbed > 0 {
+        if scrubbed > 0 || invalidated > 0 {
             tracing::info!(
                 target: TARGET,
                 indexed = count,
                 orphan_bins,
                 orphan_metas,
-                "handle store boot scan complete; scrubbed inconsistent entries",
+                invalidated,
+                "handle store boot scan complete; scrubbed inconsistent + schema-stale entries",
             );
         } else {
             tracing::debug!(

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -216,6 +216,11 @@ struct HandleEntry {
     last_access: u64,
 }
 
+/// FIFO cap on the negative cache (ADR-0049 §3). Protects high-
+/// cardinality-miss pipelines from re-statting the same non-existent
+/// paths every dispatch.
+const NEGATIVE_CACHE_CAP: usize = 8 * 1024;
+
 #[derive(Default)]
 struct Inner {
     entries: HashMap<HandleId, HandleEntry>,
@@ -226,6 +231,25 @@ struct Inner {
     total_bytes: usize,
     access_clock: u64,
     next_ephemeral: u64,
+    /// Sparse "this handle is on disk but not in memory" index, built
+    /// by the boot scan from the `.meta` sidecars (ADR-0049 §3). Lets a
+    /// cache-miss `get` find the `.bin` without re-reading the meta.
+    /// ~80 bytes/entry; a 25k-entry store costs ~2MB.
+    disk_index: HashMap<HandleId, DiskEntry>,
+    /// Bounded FIFO of "checked, confirmed not on disk" ids. Capped at
+    /// [`NEGATIVE_CACHE_CAP`] with FIFO eviction.
+    negative_cache: VecDeque<HandleId>,
+}
+
+impl Inner {
+    /// Record `id` as confirmed-not-on-disk, evicting the oldest entry
+    /// if the cache is at cap.
+    fn note_negative(&mut self, id: HandleId) {
+        if self.negative_cache.len() >= NEGATIVE_CACHE_CAP {
+            self.negative_cache.pop_front();
+        }
+        self.negative_cache.push_back(id);
+    }
 }
 
 /// Refcounted, byte-budgeted handle cache shared between mailer
@@ -306,18 +330,20 @@ impl HandleStore {
 
     /// Build an in-memory store with on-disk persistence wired in. The
     /// caller resolves the [`PersistConfig`] (typically via
-    /// [`PersistConfig::from_env`]); the boot scan (issue #985)
-    /// populates the disk index from the existing tree.
+    /// [`PersistConfig::from_env`]); the boot scan populates the disk
+    /// index from the existing tree (ADR-0049 §3).
     #[must_use]
     pub fn with_persist(max_bytes: usize, persist: Option<PersistConfig>) -> Self {
-        Self {
+        let store = Self {
             inner: RwLock::new(Inner {
                 next_ephemeral: 1,
                 ..Default::default()
             }),
             max_bytes,
             persist,
-        }
+        };
+        store.restore_from_disk();
+        store
     }
 
     /// Borrow the wired persistence config, if any.
@@ -363,6 +389,7 @@ impl HandleStore {
     pub fn from_env_persistent(enabled: bool) -> Self {
         let mut store = Self::from_env();
         store.persist = PersistConfig::from_env(enabled);
+        store.restore_from_disk();
         store
     }
 
@@ -572,6 +599,183 @@ impl HandleStore {
         }
     }
 
+    /// Boot scan (ADR-0049 §3): read `pinned.set`, walk `entries/` for
+    /// `.meta` sidecars, and populate the sparse `disk_index`. Bytes are
+    /// NOT eagerly loaded — disk-resident entries materialize on first
+    /// access. A boot scrub deletes orphan `.bin` (no sibling meta) and
+    /// orphan `.meta` (no sibling bin) so a crash mid-write doesn't leave
+    /// the tree inconsistent. No-op when persistence is disabled.
+    fn restore_from_disk(&self) {
+        let Some(cfg) = self.persist.clone() else {
+            return;
+        };
+        let pinned = read_pinned_set(&cfg);
+        let entries_dir = cfg.entries_dir();
+        let Ok(shards) = std::fs::read_dir(&entries_dir) else {
+            // Fresh store (no entries/ yet) — nothing to scan.
+            return;
+        };
+
+        let mut index: HashMap<HandleId, DiskEntry> = HashMap::new();
+        let mut orphan_bins = 0usize;
+        let mut orphan_metas = 0usize;
+        let mut scrubbed = 0usize;
+
+        for shard in shards.flatten() {
+            let shard_path = shard.path();
+            if !shard_path.is_dir() {
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(&shard_path) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let path = file.path();
+                let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+                    continue;
+                };
+                match ext {
+                    "meta" => {
+                        let bin = path.with_extension("bin");
+                        match read_meta_file(&path) {
+                            Some(meta) => {
+                                if !bin.exists() {
+                                    // Orphan meta — bytes gone; the meta is
+                                    // unreachable. Scrub it.
+                                    let _ = std::fs::remove_file(&path);
+                                    orphan_metas += 1;
+                                    scrubbed += 1;
+                                    continue;
+                                }
+                                let id = HandleId(meta.handle_id);
+                                index.insert(
+                                    id,
+                                    DiskEntry {
+                                        kind_id: KindId(meta.kind_id),
+                                        bytes_len: meta.bytes_len,
+                                        pinned: meta.pinned || pinned.contains(&id),
+                                        created_at: meta.created_at,
+                                    },
+                                );
+                            }
+                            None => {
+                                // Unreadable meta — drop it + its bin.
+                                let _ = std::fs::remove_file(&path);
+                                let _ = std::fs::remove_file(&bin);
+                                scrubbed += 1;
+                            }
+                        }
+                    }
+                    "bin" => {
+                        // Defer: a bin is valid only with its meta, which
+                        // the `meta` arm indexes. An orphan bin (no meta)
+                        // is caught in the second pass below.
+                    }
+                    "tmp" => {}
+                    _ => {}
+                }
+            }
+            // Second pass: scrub orphan bins (bin without sibling meta).
+            if let Ok(files) = std::fs::read_dir(&shard_path) {
+                for file in files.flatten() {
+                    let path = file.path();
+                    if path.extension().and_then(|e| e.to_str()) == Some("bin") {
+                        let meta = path.with_extension("meta");
+                        if !meta.exists() {
+                            let _ = std::fs::remove_file(&path);
+                            orphan_bins += 1;
+                            scrubbed += 1;
+                        }
+                    }
+                    // Sweep leftover tmp files from interrupted writes.
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                        && name.contains(".tmp-")
+                    {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+            }
+        }
+
+        let count = index.len();
+        {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner.disk_index = index;
+        }
+        if scrubbed > 0 {
+            tracing::info!(
+                target: TARGET,
+                indexed = count,
+                orphan_bins,
+                orphan_metas,
+                "handle store boot scan complete; scrubbed inconsistent entries",
+            );
+        } else {
+            tracing::debug!(
+                target: TARGET,
+                indexed = count,
+                "handle store boot scan complete",
+            );
+        }
+    }
+
+    /// Resolve `id` from disk on an in-memory cache miss (ADR-0049 §3).
+    /// Materializes the bytes into the in-memory store with refcount 0
+    /// and returns them. A `.bin` that the index expected but that's
+    /// missing is treated as corruption: the index entry is dropped and
+    /// the id lands in the negative cache. Returns `None` when there's
+    /// no persistence, no index hit, or the id is negatively cached.
+    fn lookup_from_disk(&self, id: HandleId) -> Option<(KindId, Vec<u8>)> {
+        let cfg = self.persist.as_ref()?;
+        // Read the index entry + negative-cache state under a read lock.
+        let disk_entry = {
+            let inner = self
+                .inner
+                .read()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            if inner.negative_cache.contains(&id) {
+                return None;
+            }
+            inner.disk_index.get(&id).cloned()?
+        };
+        let (bin_path, _) = entry_paths(&cfg.root, id);
+        match std::fs::read(&bin_path) {
+            Ok(bytes) => {
+                let mut inner = self
+                    .inner
+                    .write()
+                    .expect("handle store lock poisoned; fail-fast per ADR-0063");
+                let last_access = bump_clock(&mut inner);
+                inner.total_bytes += bytes.len();
+                inner.entries.insert(
+                    id,
+                    HandleEntry {
+                        kind: disk_entry.kind_id,
+                        bytes: bytes.clone(),
+                        refcount: 0,
+                        pinned: disk_entry.pinned,
+                        last_access,
+                    },
+                );
+                Some((disk_entry.kind_id, bytes))
+            }
+            Err(_) => {
+                // `.bin` missing but the index said it was there —
+                // corruption. Treat as a miss + remember it.
+                let mut inner = self
+                    .inner
+                    .write()
+                    .expect("handle store lock poisoned; fail-fast per ADR-0063");
+                inner.disk_index.remove(&id);
+                inner.note_negative(id);
+                None
+            }
+        }
+    }
+
     /// Mark `id` as pinned: it won't be evicted under memory pressure
     /// regardless of `refcount`. Returns `false` if the id isn't in
     /// the store.
@@ -677,14 +881,20 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn get(&self, id: HandleId) -> Option<(KindId, Vec<u8>)> {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("handle store lock poisoned; fail-fast per ADR-0063");
-        let access = bump_clock(&mut inner);
-        let entry = inner.entries.get_mut(&id)?;
-        entry.last_access = access;
-        Some((entry.kind, entry.bytes.clone()))
+        {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            let access = bump_clock(&mut inner);
+            if let Some(entry) = inner.entries.get_mut(&id) {
+                entry.last_access = access;
+                return Some((entry.kind, entry.bytes.clone()));
+            }
+        }
+        // In-memory miss: fall through to the on-disk store (no-op when
+        // persistence is disabled or the id isn't indexed).
+        self.lookup_from_disk(id)
     }
 
     /// Park a `Mail` under `handle_id`. The mailer calls this when
@@ -771,19 +981,86 @@ impl HandleStore {
         self.max_bytes
     }
 
-    /// `true` if `id` is currently stored.
+    /// `true` if `id` is resolvable — in memory or on disk. A
+    /// disk-resident entry counts: the DAG executor's pre-dispatch
+    /// cache check (ADR-0048 §4) treats a disk hit as a hit so the
+    /// transform short-circuits and `get` materializes the bytes
+    /// (ADR-0049 §3).
     ///
     /// # Panics
     /// Panics if the inner `RwLock` is poisoned — fail-fast per
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn contains(&self, id: HandleId) -> bool {
+        let inner = self
+            .inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
+        inner.entries.contains_key(&id) || inner.disk_index.contains_key(&id)
+    }
+
+    /// `true` if `id` is currently materialized in the in-memory store
+    /// (ignores the on-disk index). Test + introspection helper for
+    /// asserting lazy-materialization behaviour.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn contains_in_memory(&self, id: HandleId) -> bool {
         self.inner
             .read()
             .expect("handle store lock poisoned; fail-fast per ADR-0063")
             .entries
             .contains_key(&id)
     }
+
+    /// Count of entries in the on-disk index (disk-resident handles
+    /// discovered by the boot scan, ADR-0049 §3). Test + observability
+    /// helper.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn disk_index_len(&self) -> usize {
+        self.inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .disk_index
+            .len()
+    }
+}
+
+/// Read `pinned.set` into a set of handle ids. The file is a flat
+/// little-endian `u64` array. Missing / unreadable / malformed (length
+/// not a multiple of 8) → empty set with a warn for the malformed case.
+fn read_pinned_set(cfg: &PersistConfig) -> std::collections::HashSet<HandleId> {
+    let path = cfg.pinned_set_path();
+    let Ok(raw) = std::fs::read(&path) else {
+        return std::collections::HashSet::new();
+    };
+    if raw.len() % 8 != 0 {
+        tracing::warn!(
+            target: TARGET,
+            path = %path.display(),
+            len = raw.len(),
+            "pinned.set length not a multiple of 8; ignoring",
+        );
+        return std::collections::HashSet::new();
+    }
+    raw.chunks_exact(8)
+        .map(|c| {
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(c);
+            HandleId(u64::from_le_bytes(bytes))
+        })
+        .collect()
+}
+
+/// Read + decode a `.meta` sidecar. Returns `None` on read or decode
+/// failure (the boot scan treats that as a corrupt entry to scrub).
+fn read_meta_file(path: &Path) -> Option<HandleMeta> {
+    let raw = std::fs::read(path).ok()?;
+    postcard::from_bytes::<HandleMeta>(&raw).ok()
 }
 
 fn bump_clock(inner: &mut Inner) -> u64 {

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -41,7 +41,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::mail::Mail;
@@ -158,6 +158,75 @@ impl PersistConfig {
     pub fn pinned_set_path(&self) -> PathBuf {
         self.root.join("pinned.set")
     }
+
+    /// The `lock.pid` file under the layout root (ADR-0049 §7).
+    #[must_use]
+    pub fn lock_path(&self) -> PathBuf {
+        self.root.join("lock.pid")
+    }
+}
+
+/// Why acquiring the on-disk store lock failed (ADR-0049 §7).
+#[derive(Debug)]
+pub enum LockError {
+    /// Another live substrate already holds the lock. Boot must abort.
+    Held { path: PathBuf, pid: i32 },
+    /// The lockfile couldn't be written (permission, disk full, etc.).
+    Io { path: PathBuf, error: std::io::Error },
+}
+
+impl std::fmt::Display for LockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Held { path, pid } => write!(
+                f,
+                "handle store at {} is locked by a live substrate (pid {pid}); \
+                 set AETHER_HANDLE_STORE_DIR to a different path or terminate that process",
+                path.display(),
+            ),
+            Self::Io { path, error } => {
+                write!(f, "failed to write handle store lock {}: {error}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for LockError {}
+
+/// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
+/// bypasses `Drop`; the stale-lock reclamation path handles that case
+/// on the next boot.
+#[derive(Debug)]
+struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
+/// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
+/// we can't signal (still counts as alive). Non-Unix: conservatively
+/// reports `false` so the lock is always reclaimable (substrate on
+/// Windows is deferred per ADR-0049 §7).
+#[cfg(unix)]
+fn is_pid_alive(pid: i32) -> bool {
+    // SAFETY: `kill` with signal 0 performs the error checks without
+    // sending a signal. No memory is touched.
+    let ret = unsafe { libc::kill(pid, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // errno == EPERM means the process exists but we lack permission.
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: i32) -> bool {
+    false
 }
 
 /// A handle known to be on disk but not (necessarily) materialized in
@@ -170,6 +239,33 @@ pub struct DiskEntry {
     pub bytes_len: u32,
     pub pinned: bool,
     pub created_at: u64,
+}
+
+/// Read-only snapshot of the store for `describe_handles` (ADR-0049
+/// §10). Built by [`HandleStore::inspect`] under a single read-lock
+/// hold so the caller can serialize without keeping the store locked.
+#[derive(Debug, Clone)]
+pub struct HandleStoreSnapshot {
+    pub total_entries: usize,
+    pub in_memory_entries: usize,
+    pub on_disk_entries: usize,
+    pub pinned_entries: usize,
+    pub in_memory_bytes: u64,
+    pub on_disk_bytes: u64,
+    pub on_disk_budget_bytes: u64,
+    pub top_by_size: Vec<HandleSummary>,
+    pub top_by_recency: Vec<HandleSummary>,
+}
+
+/// Per-handle summary line in a [`HandleStoreSnapshot`].
+#[derive(Debug, Clone)]
+pub struct HandleSummary {
+    pub handle_id: HandleId,
+    pub kind_id: KindId,
+    pub bytes_len: u32,
+    pub pinned: bool,
+    pub refcount: u32,
+    pub created_at_ms: u64,
 }
 
 /// Compute the `(<bin>, <meta>)` paths for a handle id under `root`.
@@ -316,6 +412,10 @@ pub struct HandleStore {
     /// [`Self::put_persistent`] mirrors the in-memory write to disk and
     /// pin/unpin rewrite `pinned.set`.
     persist: Option<PersistConfig>,
+    /// `lock.pid` guard (ADR-0049 §7). Held once [`Self::acquire_lock`]
+    /// succeeds; its `Drop` deletes the lockfile on graceful shutdown.
+    /// `None` until acquired (or when persistence is disabled).
+    lock: Mutex<Option<LockGuard>>,
 }
 
 /// Reasons a `put` can fail.
@@ -378,6 +478,7 @@ impl HandleStore {
             }),
             max_bytes,
             persist: None,
+            lock: Mutex::new(None),
         }
     }
 
@@ -394,6 +495,7 @@ impl HandleStore {
             }),
             max_bytes,
             persist,
+            lock: Mutex::new(None),
         };
         store.restore_from_disk();
         store
@@ -967,6 +1069,144 @@ impl HandleStore {
                 budget,
                 "handle store disk eviction pass complete",
             );
+        }
+    }
+
+    /// Acquire the on-disk store lock (ADR-0049 §7). Writes `lock.pid`
+    /// with this process's PID after checking that any existing lock is
+    /// stale. A live conflicting lock returns [`LockError::Held`] so the
+    /// caller can abort boot with a clear error. No-op (returns `Ok`)
+    /// when persistence is disabled.
+    ///
+    /// On success the store holds a [`LockGuard`] whose `Drop` deletes
+    /// the lockfile on graceful shutdown.
+    ///
+    /// # Panics
+    /// Panics if the lock mutex is poisoned — fail-fast per ADR-0063.
+    pub fn acquire_lock(&self) -> Result<(), LockError> {
+        let Some(cfg) = self.persist.as_ref() else {
+            return Ok(());
+        };
+        let path = cfg.lock_path();
+        // Inspect any existing lock.
+        if let Ok(raw) = std::fs::read_to_string(&path) {
+            match raw.trim().parse::<i32>() {
+                Ok(pid) if pid > 0 && is_pid_alive(pid) => {
+                    return Err(LockError::Held { path, pid });
+                }
+                Ok(pid) => {
+                    tracing::warn!(
+                        target: TARGET,
+                        path = %path.display(),
+                        stale_pid = pid,
+                        "reclaiming stale handle store lock from a dead process",
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        target: TARGET,
+                        path = %path.display(),
+                        "lock.pid holds garbage; reclaiming as stale",
+                    );
+                }
+            }
+        }
+        // Write our PID atomically.
+        let pid = std::process::id();
+        atomic_write(&path, pid.to_string().as_bytes())
+            .map_err(|error| LockError::Io { path: path.clone(), error })?;
+        *self
+            .lock
+            .lock()
+            .expect("handle store lock mutex poisoned; fail-fast per ADR-0063") =
+            Some(LockGuard { path });
+        Ok(())
+    }
+
+    /// Snapshot the store state for `describe_handles` (ADR-0049 §10).
+    /// Takes the read lock once, copies the summary out, releases it
+    /// before the caller serializes. `max` caps the top-N lists.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    #[must_use]
+    pub fn inspect(&self, max: usize) -> HandleStoreSnapshot {
+        let inner = self
+            .inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
+        let in_memory_entries = inner.entries.len();
+        let in_memory_bytes = inner.total_bytes as u64;
+        // On-disk entry set is the disk index; in-memory-only entries
+        // (not yet persisted, e.g. ephemeral sources) are counted under
+        // in_memory. Total is the union of ids.
+        let on_disk_entries = inner.disk_index.len();
+        let mut all_ids: std::collections::HashSet<HandleId> =
+            inner.entries.keys().copied().collect();
+        all_ids.extend(inner.disk_index.keys().copied());
+
+        // Build summaries from the union, preferring in-memory data
+        // (it has refcount + live pinned state) and falling back to the
+        // disk index.
+        let mut summaries: Vec<HandleSummary> = all_ids
+            .into_iter()
+            .map(|id| {
+                let mem = inner.entries.get(&id);
+                let disk = inner.disk_index.get(&id);
+                let kind_id = mem.map_or_else(
+                    || disk.map_or(KindId(0), |d| d.kind_id),
+                    |m| m.kind,
+                );
+                let bytes_len = mem.map_or_else(
+                    || disk.map_or(0u32, |d| d.bytes_len),
+                    |m| u32::try_from(m.bytes.len()).unwrap_or(u32::MAX),
+                );
+                let pinned = mem.map(|m| m.pinned).or(disk.map(|d| d.pinned)).unwrap_or(false);
+                let refcount = mem.map_or(0, |m| m.refcount);
+                let created_at = disk.map_or(0, |d| d.created_at);
+                HandleSummary {
+                    handle_id: id,
+                    kind_id,
+                    bytes_len,
+                    pinned,
+                    refcount,
+                    created_at_ms: created_at,
+                }
+            })
+            .collect();
+
+        let pinned_entries = summaries.iter().filter(|s| s.pinned).count();
+        let total_entries = summaries.len();
+
+        // top_by_size: descending bytes_len.
+        let mut by_size = summaries.clone();
+        by_size.sort_by(|a, b| b.bytes_len.cmp(&a.bytes_len).then(a.handle_id.0.cmp(&b.handle_id.0)));
+        by_size.truncate(max);
+
+        // top_by_recency: descending created_at.
+        summaries.sort_by(|a, b| {
+            b.created_at_ms
+                .cmp(&a.created_at_ms)
+                .then(a.handle_id.0.cmp(&b.handle_id.0))
+        });
+        summaries.truncate(max);
+
+        let (on_disk_bytes, on_disk_budget_bytes) = (
+            inner.total_disk_bytes,
+            self.persist.as_ref().map_or(0, |c| c.disk_budget_bytes),
+        );
+
+        HandleStoreSnapshot {
+            total_entries,
+            in_memory_entries,
+            on_disk_entries,
+            pinned_entries,
+            in_memory_bytes,
+            on_disk_bytes,
+            on_disk_budget_bytes,
+            top_by_size: by_size,
+            top_by_recency: summaries,
         }
     }
 

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -40,12 +40,18 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::mail::Mail;
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
 use std::env;
+
+pub mod meta;
+
+use meta::{HandleMeta, SCHEMA_VERSION, TransformOrigin};
 
 /// Default byte cap for the handle store.
 pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
@@ -54,6 +60,146 @@ pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
 /// (`SubstrateBoot::build`) and parsed as a `usize` of bytes; absent
 /// or unparseable values fall back to the default.
 pub const ENV_MAX_BYTES: &str = "AETHER_HANDLE_STORE_MAX_BYTES";
+
+/// Env var pointing at the on-disk persistence root (ADR-0049 §2).
+/// Absent or empty falls through to `dirs::data_dir()/aether/handles`.
+pub const ENV_PERSIST_DIR: &str = "AETHER_HANDLE_STORE_DIR";
+
+/// Env var that disables on-disk persistence outright. Set to `1` by
+/// the TestBench harness + CI so unit tests don't leak entries into the
+/// user's data dir.
+pub const ENV_PERSIST_DISABLE: &str = "AETHER_HANDLE_STORE_PERSIST_DISABLE";
+
+/// On-disk layout version directory under [`ENV_PERSIST_DIR`]. The
+/// `v1/` namespacing is ADR-0049 §8's forward-compatibility hook.
+pub const LAYOUT_VERSION_DIR: &str = "v1";
+
+/// Tracing target shared by every persistence diagnostic.
+const TARGET: &str = "aether_substrate::handle_store";
+
+/// Resolved on-disk persistence configuration. Carried on the
+/// [`HandleStore`] when persistence is enabled (desktop + headless
+/// chassis); `None` on the hub chassis and on test fixtures with
+/// [`ENV_PERSIST_DISABLE`] set.
+#[derive(Debug, Clone)]
+pub struct PersistConfig {
+    /// `${AETHER_HANDLE_STORE_DIR}/v1/` — the layout-versioned root that
+    /// holds `entries/`, `pinned.set`, and `lock.pid`.
+    pub root: PathBuf,
+}
+
+impl PersistConfig {
+    /// Resolve the persistence config from the environment, or `None`
+    /// when persistence is disabled (`AETHER_HANDLE_STORE_PERSIST_DISABLE=1`)
+    /// or when the data dir can't be resolved and no override is set.
+    ///
+    /// `enabled` is the chassis's verdict: desktop + headless pass
+    /// `true`; the hub passes `false` (ADR-0049 §9). A `false` chassis
+    /// vote short-circuits to `None` regardless of env.
+    #[must_use]
+    pub fn from_env(enabled: bool) -> Option<Self> {
+        if !enabled {
+            return None;
+        }
+        if env::var(ENV_PERSIST_DISABLE).is_ok_and(|v| v == "1") {
+            return None;
+        }
+        let base = match env::var(ENV_PERSIST_DIR) {
+            Ok(raw) if !raw.is_empty() => PathBuf::from(raw),
+            _ => {
+                let Some(data) = dirs::data_dir() else {
+                    tracing::warn!(
+                        target: TARGET,
+                        "no data dir and no AETHER_HANDLE_STORE_DIR; persistence disabled",
+                    );
+                    return None;
+                };
+                data.join("aether").join("handles")
+            }
+        };
+        Some(Self {
+            root: base.join(LAYOUT_VERSION_DIR),
+        })
+    }
+
+    /// The `entries/` subdirectory under the layout root.
+    #[must_use]
+    pub fn entries_dir(&self) -> PathBuf {
+        self.root.join("entries")
+    }
+
+    /// The `pinned.set` file under the layout root.
+    #[must_use]
+    pub fn pinned_set_path(&self) -> PathBuf {
+        self.root.join("pinned.set")
+    }
+}
+
+/// A handle known to be on disk but not (necessarily) materialized in
+/// memory. Populated by the boot scan (issue #985) from the `.meta`
+/// sidecars; lets a cache-miss lookup find the `.bin` without re-reading
+/// the meta.
+#[derive(Debug, Clone)]
+pub struct DiskEntry {
+    pub kind_id: KindId,
+    pub bytes_len: u32,
+    pub pinned: bool,
+    pub created_at: u64,
+}
+
+/// Compute the `(<bin>, <meta>)` paths for a handle id under `root`.
+/// 256 prefix-shard directories keyed on the first hex byte of the id
+/// (ADR-0049 §2).
+#[must_use]
+pub fn entry_paths(root: &Path, id: HandleId) -> (PathBuf, PathBuf) {
+    let hex = format!("{:016x}", id.0);
+    let dir = root.join("entries").join(&hex[0..2]);
+    (
+        dir.join(format!("{}.bin", &hex[2..])),
+        dir.join(format!("{}.meta", &hex[2..])),
+    )
+}
+
+/// Millis since the unix epoch, saturating to 0 if the clock is before
+/// the epoch (unreachable in practice).
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+/// Atomic write via tmp+rename (ADR-0041's `LocalFileAdapter` pattern):
+/// stage to a sibling `.tmp-<pid>-<nonce>`, fsync it, rename over the
+/// target. Creates the parent dir lazily. Returns the io error on
+/// failure so the caller can log + continue (persistence is best-effort
+/// per ADR-0049 §3).
+fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let nonce = now_millis();
+    let pid = std::process::id();
+    let file_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("entry");
+    let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        // fsync the tmp file so its bytes hit disk before the rename
+        // publishes it (preserves ordering across a crash).
+        f.sync_all()?;
+    }
+    match std::fs::rename(&tmp, target) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
 
 /// Per-entry store record. Bytes are the postcard-encoded `K` body
 /// (the same shape `Ref::Inline` would carry), kept owned because the
@@ -88,6 +234,11 @@ struct Inner {
 pub struct HandleStore {
     inner: RwLock<Inner>,
     max_bytes: usize,
+    /// On-disk persistence config (ADR-0049). `Some` on desktop +
+    /// headless chassis; `None` on hub + test fixtures. When present,
+    /// [`Self::put_persistent`] mirrors the in-memory write to disk and
+    /// pin/unpin rewrite `pinned.set`.
+    persist: Option<PersistConfig>,
 }
 
 /// Reasons a `put` can fail.
@@ -149,7 +300,30 @@ impl HandleStore {
                 ..Default::default()
             }),
             max_bytes,
+            persist: None,
         }
+    }
+
+    /// Build an in-memory store with on-disk persistence wired in. The
+    /// caller resolves the [`PersistConfig`] (typically via
+    /// [`PersistConfig::from_env`]); the boot scan (issue #985)
+    /// populates the disk index from the existing tree.
+    #[must_use]
+    pub fn with_persist(max_bytes: usize, persist: Option<PersistConfig>) -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                next_ephemeral: 1,
+                ..Default::default()
+            }),
+            max_bytes,
+            persist,
+        }
+    }
+
+    /// Borrow the wired persistence config, if any.
+    #[must_use]
+    pub fn persist_config(&self) -> Option<&PersistConfig> {
+        self.persist.as_ref()
     }
 
     /// Build a store sized from `AETHER_HANDLE_STORE_MAX_BYTES` if
@@ -177,6 +351,19 @@ impl HandleStore {
             Err(_) => DEFAULT_MAX_BYTES,
         };
         Self::new(max_bytes)
+    }
+
+    /// Build a store sized from the environment with on-disk
+    /// persistence resolved from [`PersistConfig::from_env`]. `enabled`
+    /// is the chassis verdict (desktop + headless `true`, hub `false`
+    /// per ADR-0049 §9). When persistence resolves to `Some`, the boot
+    /// scan (issue #985) populates the disk index from the existing
+    /// tree.
+    #[must_use]
+    pub fn from_env_persistent(enabled: bool) -> Self {
+        let mut store = Self::from_env();
+        store.persist = PersistConfig::from_env(enabled);
+        store
     }
 
     /// Mint a fresh ephemeral handle id. Pure counter today; content-
@@ -257,6 +444,134 @@ impl HandleStore {
         Ok(())
     }
 
+    /// Insert (or update) a handle and mirror it to disk when
+    /// persistence is wired (ADR-0049 §3). The in-memory `put` runs
+    /// first and is authoritative for this run; the disk write is
+    /// best-effort — a failure logs a warning but leaves the in-memory
+    /// entry valid (the caller doesn't see a different return value).
+    ///
+    /// `origin` records the transform provenance, or `None` for a
+    /// pinned source handle.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn put_persistent(
+        &self,
+        id: HandleId,
+        kind: KindId,
+        bytes: Vec<u8>,
+        origin: Option<TransformOrigin>,
+    ) -> Result<(), PutError> {
+        // In-memory write is authoritative; clone the bytes only when
+        // there's a disk target to mirror to.
+        let pinned = self
+            .inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .entries
+            .get(&id)
+            .is_some_and(|e| e.pinned);
+        if let Some(cfg) = self.persist.clone() {
+            let disk_bytes = bytes.clone();
+            self.put(id, kind, bytes)?;
+            self.write_to_disk(&cfg, id, kind, &disk_bytes, origin.as_ref(), pinned);
+            Ok(())
+        } else {
+            self.put(id, kind, bytes)
+        }
+    }
+
+    /// Write the `.bin` + `.meta` sidecar pair for `id` atomically. Best
+    /// effort: a failure on either file logs and returns without
+    /// touching the in-memory state.
+    fn write_to_disk(
+        &self,
+        cfg: &PersistConfig,
+        id: HandleId,
+        kind: KindId,
+        bytes: &[u8],
+        origin: Option<&TransformOrigin>,
+        pinned: bool,
+    ) {
+        let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+        let meta = HandleMeta {
+            schema_version: SCHEMA_VERSION,
+            handle_id: id.0,
+            kind_id: kind.0,
+            transform_origin: origin.cloned(),
+            bytes_len: u32::try_from(bytes.len()).unwrap_or(u32::MAX),
+            created_at: now_millis(),
+            pinned,
+        };
+        let meta_bytes = match postcard::to_allocvec(&meta) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    handle = %id,
+                    error = %e,
+                    "failed to encode HandleMeta; skipping disk persist",
+                );
+                return;
+            }
+        };
+        if let Err(e) = atomic_write(&bin_path, bytes) {
+            tracing::warn!(
+                target: TARGET,
+                handle = %id,
+                path = %bin_path.display(),
+                error = %e,
+                "handle store .bin write failed; in-memory entry retained (best-effort persist)",
+            );
+            return;
+        }
+        if let Err(e) = atomic_write(&meta_path, &meta_bytes) {
+            tracing::warn!(
+                target: TARGET,
+                handle = %id,
+                path = %meta_path.display(),
+                error = %e,
+                "handle store .meta write failed; orphan .bin will be scrubbed on next boot",
+            );
+        }
+    }
+
+    /// Rewrite `pinned.set` from the current in-memory pinned set. Cheap
+    /// (one `u64` per pinned id); atomic via tmp+rename. Called from
+    /// pin/unpin so the durable pinned set tracks the live set. No-op
+    /// when persistence is disabled.
+    fn persist_pinned_set(&self) {
+        let Some(cfg) = self.persist.as_ref() else {
+            return;
+        };
+        let mut ids: Vec<u64> = {
+            let inner = self
+                .inner
+                .read()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner
+                .entries
+                .iter()
+                .filter(|(_, e)| e.pinned)
+                .map(|(id, _)| id.0)
+                .collect()
+        };
+        ids.sort_unstable();
+        let mut bytes = Vec::with_capacity(ids.len() * 8);
+        for id in ids {
+            bytes.extend_from_slice(&id.to_le_bytes());
+        }
+        if let Err(e) = atomic_write(&cfg.pinned_set_path(), &bytes) {
+            tracing::warn!(
+                target: TARGET,
+                path = %cfg.pinned_set_path().display(),
+                error = %e,
+                "pinned.set write failed (best-effort persist)",
+            );
+        }
+    }
+
     /// Mark `id` as pinned: it won't be evicted under memory pressure
     /// regardless of `refcount`. Returns `false` if the id isn't in
     /// the store.
@@ -266,16 +581,22 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn pin(&self, id: HandleId) -> bool {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("handle store lock poisoned; fail-fast per ADR-0063");
-        if let Some(entry) = inner.entries.get_mut(&id) {
-            entry.pinned = true;
-            true
-        } else {
-            false
+        let pinned = {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            if let Some(entry) = inner.entries.get_mut(&id) {
+                entry.pinned = true;
+                true
+            } else {
+                false
+            }
+        };
+        if pinned {
+            self.persist_pinned_set();
         }
+        pinned
     }
 
     /// Clear the pinned flag on `id`. Doesn't drop the entry; only
@@ -286,16 +607,22 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn unpin(&self, id: HandleId) -> bool {
-        let mut inner = self
-            .inner
-            .write()
-            .expect("handle store lock poisoned; fail-fast per ADR-0063");
-        if let Some(entry) = inner.entries.get_mut(&id) {
-            entry.pinned = false;
-            true
-        } else {
-            false
+        let unpinned = {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            if let Some(entry) = inner.entries.get_mut(&id) {
+                entry.pinned = false;
+                true
+            } else {
+                false
+            }
+        };
+        if unpinned {
+            self.persist_pinned_set();
         }
+        unpinned
     }
 
     /// Increment the refcount on `id`. Returns `false` if the id isn't

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -39,12 +39,19 @@
 //! shims for component-side publish/release land in PR 3.
 
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::error::Error as StdError;
+use std::fmt;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind, Write as _};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::process;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::mail::Mail;
+use crate::mail::registry::Registry;
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
 use std::env;
@@ -66,8 +73,8 @@ pub const ENV_MAX_BYTES: &str = "AETHER_HANDLE_STORE_MAX_BYTES";
 pub const ENV_PERSIST_DIR: &str = "AETHER_HANDLE_STORE_DIR";
 
 /// Env var that disables on-disk persistence outright. Set to `1` by
-/// the TestBench harness + CI so unit tests don't leak entries into the
-/// user's data dir.
+/// the `TestBench` harness + CI so unit tests don't leak entries into
+/// the user's data dir.
 pub const ENV_PERSIST_DISABLE: &str = "AETHER_HANDLE_STORE_PERSIST_DISABLE";
 
 /// On-disk layout version directory under [`ENV_PERSIST_DIR`]. The
@@ -172,11 +179,11 @@ pub enum LockError {
     /// Another live substrate already holds the lock. Boot must abort.
     Held { path: PathBuf, pid: i32 },
     /// The lockfile couldn't be written (permission, disk full, etc.).
-    Io { path: PathBuf, error: std::io::Error },
+    Io { path: PathBuf, error: IoError },
 }
 
-impl std::fmt::Display for LockError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for LockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Held { path, pid } => write!(
                 f,
@@ -185,13 +192,17 @@ impl std::fmt::Display for LockError {
                 path.display(),
             ),
             Self::Io { path, error } => {
-                write!(f, "failed to write handle store lock {}: {error}", path.display())
+                write!(
+                    f,
+                    "failed to write handle store lock {}: {error}",
+                    path.display()
+                )
             }
         }
     }
 }
 
-impl std::error::Error for LockError {}
+impl StdError for LockError {}
 
 /// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
 /// bypasses `Drop`; the stale-lock reclamation path handles that case
@@ -203,7 +214,7 @@ struct LockGuard {
 
 impl Drop for LockGuard {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        let _ = fs::remove_file(&self.path);
     }
 }
 
@@ -221,7 +232,7 @@ fn is_pid_alive(pid: i32) -> bool {
         return true;
     }
     // errno == EPERM means the process exists but we lack permission.
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    IoError::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 #[cfg(not(unix))]
@@ -282,7 +293,7 @@ pub trait KindResolver: Send + Sync {
     fn name_for_id(&self, id: KindId) -> Option<String>;
 }
 
-impl KindResolver for crate::mail::registry::Registry {
+impl KindResolver for Registry {
     fn id_for_name(&self, name: &str) -> Option<KindId> {
         self.kind_id(name)
     }
@@ -341,6 +352,8 @@ pub fn entry_paths(root: &Path, id: HandleId) -> (PathBuf, PathBuf) {
 
 /// Parse a `u64` env var, falling back to `default` on absence or a
 /// parse failure (with a warn for the malformed case).
+// Nested match keeps the warn-log path readable (same shape as `from_env`).
+#[allow(clippy::option_if_let_else)]
 fn parse_env_u64(name: &str, default: u64) -> u64 {
     match env::var(name) {
         Ok(raw) => match raw.parse::<u64>() {
@@ -374,29 +387,28 @@ fn now_millis() -> u64 {
 /// target. Creates the parent dir lazily. Returns the io error on
 /// failure so the caller can log + continue (persistence is best-effort
 /// per ADR-0049 §3).
-fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
     if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent)?;
     }
     let nonce = now_millis();
-    let pid = std::process::id();
+    let pid = process::id();
     let file_name = target
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("entry");
     let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
     {
-        use std::io::Write as _;
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut f = fs::File::create(&tmp)?;
         f.write_all(bytes)?;
         // fsync the tmp file so its bytes hit disk before the rename
         // publishes it (preserves ordering across a crash).
         f.sync_all()?;
     }
-    match std::fs::rename(&tmp, target) {
+    match fs::rename(&tmp, target) {
         Ok(()) => Ok(()),
         Err(e) => {
-            let _ = std::fs::remove_file(&tmp);
+            let _ = fs::remove_file(&tmp);
             Err(e)
         }
     }
@@ -478,7 +490,7 @@ pub struct HandleStore {
     /// (ADR-0049 §6). Supplied at construction (the substrate's
     /// `Registry`); `None` on fixtures that don't model schema drift —
     /// the boot scan then only enforces the `schema_version` check.
-    kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
+    kind_resolver: Option<Arc<dyn KindResolver>>,
 }
 
 /// Reasons a `put` can fail.
@@ -566,7 +578,7 @@ impl HandleStore {
     pub fn with_persist_validated(
         max_bytes: usize,
         persist: Option<PersistConfig>,
-        kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
+        kind_resolver: Option<Arc<dyn KindResolver>>,
     ) -> Self {
         let store = Self {
             inner: RwLock::new(Inner {
@@ -625,7 +637,7 @@ impl HandleStore {
     #[must_use]
     pub fn from_env_persistent(
         enabled: bool,
-        kind_resolver: Option<std::sync::Arc<dyn KindResolver>>,
+        kind_resolver: Option<Arc<dyn KindResolver>>,
     ) -> Self {
         let max_bytes = Self::from_env().max_bytes;
         Self::with_persist_validated(max_bytes, PersistConfig::from_env(enabled), kind_resolver)
@@ -721,6 +733,9 @@ impl HandleStore {
     /// # Panics
     /// Panics if the inner `RwLock` is poisoned — fail-fast per
     /// ADR-0063.
+    // `origin` is taken by value: it's the caller's provenance record
+    // handed to the store, even though the disk write only borrows it.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn put_persistent(
         &self,
         id: HandleId,
@@ -822,7 +837,9 @@ impl HandleStore {
             .inner
             .write()
             .expect("handle store lock poisoned; fail-fast per ADR-0063");
-        inner.total_disk_bytes = inner.total_disk_bytes.saturating_add(u64::from(meta.bytes_len));
+        inner.total_disk_bytes = inner
+            .total_disk_bytes
+            .saturating_add(u64::from(meta.bytes_len));
         inner.disk_index.insert(
             id,
             DiskEntry {
@@ -852,7 +869,7 @@ impl HandleStore {
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
             // Union the in-memory pinned set with the on-disk pinned
             // index so a pinned disk-only entry stays in `pinned.set`.
-            let mut set: std::collections::HashSet<u64> = inner
+            let mut set: HashSet<u64> = inner
                 .entries
                 .iter()
                 .filter(|(_, e)| e.pinned)
@@ -888,13 +905,16 @@ impl HandleStore {
     /// access. A boot scrub deletes orphan `.bin` (no sibling meta) and
     /// orphan `.meta` (no sibling bin) so a crash mid-write doesn't leave
     /// the tree inconsistent. No-op when persistence is disabled.
+    // One pass over the shard tree with inline scrub + validation arms;
+    // splitting it would scatter the boot-scan invariants across helpers.
+    #[allow(clippy::too_many_lines)]
     fn restore_from_disk(&self) {
         let Some(cfg) = self.persist.clone() else {
             return;
         };
         let pinned = read_pinned_set(&cfg);
         let entries_dir = cfg.entries_dir();
-        let Ok(shards) = std::fs::read_dir(&entries_dir) else {
+        let Ok(shards) = fs::read_dir(&entries_dir) else {
             // Fresh store (no entries/ yet) — nothing to scan.
             return;
         };
@@ -911,7 +931,7 @@ impl HandleStore {
             if !shard_path.is_dir() {
                 continue;
             }
-            let Ok(files) = std::fs::read_dir(&shard_path) else {
+            let Ok(files) = fs::read_dir(&shard_path) else {
                 continue;
             };
             for file in files.flatten() {
@@ -919,76 +939,67 @@ impl HandleStore {
                 let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
                     continue;
                 };
-                match ext {
-                    "meta" => {
-                        let bin = path.with_extension("bin");
-                        match read_meta_file(&path) {
-                            Some(meta) => {
-                                if !bin.exists() {
-                                    // Orphan meta — bytes gone; the meta is
-                                    // unreachable. Scrub it.
-                                    let _ = std::fs::remove_file(&path);
-                                    orphan_metas += 1;
-                                    scrubbed += 1;
-                                    continue;
-                                }
-                                // ADR-0049 §6: schema-evolution check. A
-                                // version skew, retired kind, or changed
-                                // kind id invalidates the entry — the
-                                // bytes are unsafe to decode against the
-                                // current schema, so drop both files. This
-                                // overrides pin (a pinned entry whose kind
-                                // changed is still evicted — pin protects
-                                // against budget pressure, not against
-                                // correctness invalidation).
-                                if let Validation::Drop(reason) = validate_meta(&meta, resolver) {
-                                    let _ = std::fs::remove_file(&bin);
-                                    let _ = std::fs::remove_file(&path);
-                                    invalidated += 1;
-                                    tracing::info!(
-                                        target: TARGET,
-                                        handle = %HandleId(meta.handle_id),
-                                        reason = %reason,
-                                        "handle store entry invalidated by schema evolution; dropped",
-                                    );
-                                    continue;
-                                }
-                                let id = HandleId(meta.handle_id);
-                                index.insert(
-                                    id,
-                                    DiskEntry {
-                                        kind_id: KindId(meta.kind_id),
-                                        bytes_len: meta.bytes_len,
-                                        pinned: meta.pinned || pinned.contains(&id),
-                                        created_at: meta.created_at,
-                                    },
-                                );
-                            }
-                            None => {
-                                // Unreadable meta — drop it + its bin.
-                                let _ = std::fs::remove_file(&path);
-                                let _ = std::fs::remove_file(&bin);
-                                scrubbed += 1;
-                            }
-                        }
-                    }
-                    "bin" => {
-                        // Defer: a bin is valid only with its meta, which
-                        // the `meta` arm indexes. An orphan bin (no meta)
-                        // is caught in the second pass below.
-                    }
-                    "tmp" => {}
-                    _ => {}
+                // Only `.meta` sidecars are index entries. A `.bin`
+                // without a sibling meta is an orphan, caught in the
+                // second pass below; `.tmp` leftovers are swept there
+                // too.
+                if ext != "meta" {
+                    continue;
                 }
+                let bin = path.with_extension("bin");
+                let Some(meta) = read_meta_file(&path) else {
+                    // Unreadable meta — drop it + its bin.
+                    let _ = fs::remove_file(&path);
+                    let _ = fs::remove_file(&bin);
+                    scrubbed += 1;
+                    continue;
+                };
+                if !bin.exists() {
+                    // Orphan meta — bytes gone; the meta is unreachable.
+                    // Scrub it.
+                    let _ = fs::remove_file(&path);
+                    orphan_metas += 1;
+                    scrubbed += 1;
+                    continue;
+                }
+                // ADR-0049 §6: schema-evolution check. A version skew,
+                // retired kind, or changed kind id invalidates the entry
+                // — the bytes are unsafe to decode against the current
+                // schema, so drop both files. This overrides pin (a
+                // pinned entry whose kind changed is still evicted — pin
+                // protects against budget pressure, not against
+                // correctness invalidation).
+                if let Validation::Drop(reason) = validate_meta(&meta, resolver) {
+                    let _ = fs::remove_file(&bin);
+                    let _ = fs::remove_file(&path);
+                    invalidated += 1;
+                    tracing::info!(
+                        target: TARGET,
+                        handle = %HandleId(meta.handle_id),
+                        reason = %reason,
+                        "handle store entry invalidated by schema evolution; dropped",
+                    );
+                    continue;
+                }
+                let id = HandleId(meta.handle_id);
+                index.insert(
+                    id,
+                    DiskEntry {
+                        kind_id: KindId(meta.kind_id),
+                        bytes_len: meta.bytes_len,
+                        pinned: meta.pinned || pinned.contains(&id),
+                        created_at: meta.created_at,
+                    },
+                );
             }
             // Second pass: scrub orphan bins (bin without sibling meta).
-            if let Ok(files) = std::fs::read_dir(&shard_path) {
+            if let Ok(files) = fs::read_dir(&shard_path) {
                 for file in files.flatten() {
                     let path = file.path();
                     if path.extension().and_then(|e| e.to_str()) == Some("bin") {
                         let meta = path.with_extension("meta");
                         if !meta.exists() {
-                            let _ = std::fs::remove_file(&path);
+                            let _ = fs::remove_file(&path);
                             orphan_bins += 1;
                             scrubbed += 1;
                         }
@@ -997,7 +1008,7 @@ impl HandleStore {
                     if let Some(name) = path.file_name().and_then(|n| n.to_str())
                         && name.contains(".tmp-")
                     {
-                        let _ = std::fs::remove_file(&path);
+                        let _ = fs::remove_file(&path);
                     }
                 }
             }
@@ -1051,38 +1062,34 @@ impl HandleStore {
             inner.disk_index.get(&id).cloned()?
         };
         let (bin_path, _) = entry_paths(&cfg.root, id);
-        match std::fs::read(&bin_path) {
-            Ok(bytes) => {
-                let mut inner = self
-                    .inner
-                    .write()
-                    .expect("handle store lock poisoned; fail-fast per ADR-0063");
-                let last_access = bump_clock(&mut inner);
-                inner.total_bytes += bytes.len();
-                inner.entries.insert(
-                    id,
-                    HandleEntry {
-                        kind: disk_entry.kind_id,
-                        bytes: bytes.clone(),
-                        refcount: 0,
-                        pinned: disk_entry.pinned,
-                        last_access,
-                    },
-                );
-                Some((disk_entry.kind_id, bytes))
-            }
-            Err(_) => {
-                // `.bin` missing but the index said it was there —
-                // corruption. Treat as a miss + remember it.
-                let mut inner = self
-                    .inner
-                    .write()
-                    .expect("handle store lock poisoned; fail-fast per ADR-0063");
-                inner.disk_index.remove(&id);
-                inner.note_negative(id);
-                None
-            }
-        }
+        let Ok(bytes) = fs::read(&bin_path) else {
+            // `.bin` missing but the index said it was there —
+            // corruption. Treat as a miss + remember it.
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner.disk_index.remove(&id);
+            inner.note_negative(id);
+            return None;
+        };
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
+        let last_access = bump_clock(&mut inner);
+        inner.total_bytes += bytes.len();
+        inner.entries.insert(
+            id,
+            HandleEntry {
+                kind: disk_entry.kind_id,
+                bytes: bytes.clone(),
+                refcount: 0,
+                pinned: disk_entry.pinned,
+                last_access,
+            },
+        );
+        Some((disk_entry.kind_id, bytes))
     }
 
     /// Current approximate on-disk byte ledger (ADR-0049 §5). Test +
@@ -1105,6 +1112,10 @@ impl HandleStore {
     /// oldest-`created_at` first, two-phase (`.bin` then `.meta`), until
     /// the ledger drops below the budget or no candidates remain. No-op
     /// when persistence is disabled.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
     pub fn run_disk_eviction(&self) {
         let Some(cfg) = self.persist.clone() else {
             return;
@@ -1143,8 +1154,8 @@ impl HandleStore {
             }
             let (bin_path, meta_path) = entry_paths(&cfg.root, id);
             // Phase A: drop the bytes.
-            if let Err(e) = std::fs::remove_file(&bin_path)
-                && e.kind() != std::io::ErrorKind::NotFound
+            if let Err(e) = fs::remove_file(&bin_path)
+                && e.kind() != ErrorKind::NotFound
             {
                 tracing::warn!(
                     target: TARGET,
@@ -1156,8 +1167,8 @@ impl HandleStore {
                 continue;
             }
             // Phase B: drop the index entry.
-            if let Err(e) = std::fs::remove_file(&meta_path)
-                && e.kind() != std::io::ErrorKind::NotFound
+            if let Err(e) = fs::remove_file(&meta_path)
+                && e.kind() != ErrorKind::NotFound
             {
                 tracing::warn!(
                     target: TARGET,
@@ -1197,8 +1208,8 @@ impl HandleStore {
     /// caller can abort boot with a clear error. No-op (returns `Ok`)
     /// when persistence is disabled.
     ///
-    /// On success the store holds a [`LockGuard`] whose `Drop` deletes
-    /// the lockfile on graceful shutdown.
+    /// On success the store holds a lock guard whose `Drop` deletes the
+    /// lockfile on graceful shutdown.
     ///
     /// # Panics
     /// Panics if the lock mutex is poisoned — fail-fast per ADR-0063.
@@ -1208,7 +1219,7 @@ impl HandleStore {
         };
         let path = cfg.lock_path();
         // Inspect any existing lock.
-        if let Ok(raw) = std::fs::read_to_string(&path) {
+        if let Ok(raw) = fs::read_to_string(&path) {
             match raw.trim().parse::<i32>() {
                 Ok(pid) if pid > 0 && is_pid_alive(pid) => {
                     return Err(LockError::Held { path, pid });
@@ -1231,9 +1242,11 @@ impl HandleStore {
             }
         }
         // Write our PID atomically.
-        let pid = std::process::id();
-        atomic_write(&path, pid.to_string().as_bytes())
-            .map_err(|error| LockError::Io { path: path.clone(), error })?;
+        let pid = process::id();
+        atomic_write(&path, pid.to_string().as_bytes()).map_err(|error| LockError::Io {
+            path: path.clone(),
+            error,
+        })?;
         *self
             .lock
             .lock()
@@ -1261,8 +1274,7 @@ impl HandleStore {
         // (not yet persisted, e.g. ephemeral sources) are counted under
         // in_memory. Total is the union of ids.
         let on_disk_entries = inner.disk_index.len();
-        let mut all_ids: std::collections::HashSet<HandleId> =
-            inner.entries.keys().copied().collect();
+        let mut all_ids: HashSet<HandleId> = inner.entries.keys().copied().collect();
         all_ids.extend(inner.disk_index.keys().copied());
 
         // Build summaries from the union, preferring in-memory data
@@ -1273,15 +1285,15 @@ impl HandleStore {
             .map(|id| {
                 let mem = inner.entries.get(&id);
                 let disk = inner.disk_index.get(&id);
-                let kind_id = mem.map_or_else(
-                    || disk.map_or(KindId(0), |d| d.kind_id),
-                    |m| m.kind,
-                );
+                let kind_id = mem.map_or_else(|| disk.map_or(KindId(0), |d| d.kind_id), |m| m.kind);
                 let bytes_len = mem.map_or_else(
                     || disk.map_or(0u32, |d| d.bytes_len),
                     |m| u32::try_from(m.bytes.len()).unwrap_or(u32::MAX),
                 );
-                let pinned = mem.map(|m| m.pinned).or(disk.map(|d| d.pinned)).unwrap_or(false);
+                let pinned = mem
+                    .map(|m| m.pinned)
+                    .or_else(|| disk.map(|d| d.pinned))
+                    .unwrap_or(false);
                 let refcount = mem.map_or(0, |m| m.refcount);
                 let created_at = disk.map_or(0, |d| d.created_at);
                 HandleSummary {
@@ -1300,7 +1312,11 @@ impl HandleStore {
 
         // top_by_size: descending bytes_len.
         let mut by_size = summaries.clone();
-        by_size.sort_by(|a, b| b.bytes_len.cmp(&a.bytes_len).then(a.handle_id.0.cmp(&b.handle_id.0)));
+        by_size.sort_by(|a, b| {
+            b.bytes_len
+                .cmp(&a.bytes_len)
+                .then(a.handle_id.0.cmp(&b.handle_id.0))
+        });
         by_size.truncate(max);
 
         // top_by_recency: descending created_at.
@@ -1330,21 +1346,21 @@ impl HandleStore {
     }
 
     /// Spawn the background eviction tick (ADR-0049 §5). The thread owns
-    /// a [`Weak`] reference to avoid a reference cycle; on the store's
-    /// last `Arc` dropping, the weak fails to upgrade and the thread
-    /// exits. No-op when persistence is disabled. Call once at boot
-    /// after wrapping the store in an `Arc`.
-    pub fn spawn_eviction_thread(self: &std::sync::Arc<Self>) {
+    /// a [`std::sync::Weak`] reference to avoid a reference cycle; on the
+    /// store's last `Arc` dropping, the weak fails to upgrade and the
+    /// thread exits. No-op when persistence is disabled. Call once at
+    /// boot after wrapping the store in an `Arc`.
+    pub fn spawn_eviction_thread(self: &Arc<Self>) {
         let Some(cfg) = self.persist.clone() else {
             return;
         };
-        let weak = std::sync::Arc::downgrade(self);
-        let tick = std::time::Duration::from_secs(cfg.eviction_tick_secs.max(1));
-        std::thread::Builder::new()
+        let weak = Arc::downgrade(self);
+        let tick = Duration::from_secs(cfg.eviction_tick_secs.max(1));
+        thread::Builder::new()
             .name("handle-store-evict".to_owned())
             .spawn(move || {
                 loop {
-                    std::thread::sleep(tick);
+                    thread::sleep(tick);
                     let Some(store) = weak.upgrade() else {
                         // Store dropped; thread exits.
                         return;
@@ -1364,29 +1380,36 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn pin(&self, id: HandleId) -> bool {
-        let pinned = {
+        self.set_pinned(id, true)
+    }
+
+    /// Set the pinned flag on `id` across the in-memory entry AND the
+    /// on-disk index (so the eviction tick skips a pinned disk-resident
+    /// entry that isn't materialized in memory, ADR-0049 §5). Rewrites
+    /// `pinned.set` when either was touched. Returns `false` if `id`
+    /// isn't known in either place.
+    fn set_pinned(&self, id: HandleId, value: bool) -> bool {
+        let found = {
             let mut inner = self
                 .inner
                 .write()
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
-            let mut found = false;
-            if let Some(entry) = inner.entries.get_mut(&id) {
-                entry.pinned = true;
-                found = true;
-            }
-            // Keep the on-disk index's pinned flag in sync so the
-            // eviction tick (ADR-0049 §5) skips a pinned disk-resident
-            // entry even when it isn't materialized in memory.
-            if let Some(disk) = inner.disk_index.get_mut(&id) {
-                disk.pinned = true;
-                found = true;
-            }
-            found
+            let in_mem = inner
+                .entries
+                .get_mut(&id)
+                .map(|e| e.pinned = value)
+                .is_some();
+            let on_disk = inner
+                .disk_index
+                .get_mut(&id)
+                .map(|d| d.pinned = value)
+                .is_some();
+            in_mem || on_disk
         };
-        if pinned {
+        if found {
             self.persist_pinned_set();
         }
-        pinned
+        found
     }
 
     /// Clear the pinned flag on `id`. Doesn't drop the entry; only
@@ -1397,26 +1420,7 @@ impl HandleStore {
     /// ADR-0063: a poisoned lock means a prior holder panicked under
     /// the guard.
     pub fn unpin(&self, id: HandleId) -> bool {
-        let unpinned = {
-            let mut inner = self
-                .inner
-                .write()
-                .expect("handle store lock poisoned; fail-fast per ADR-0063");
-            let mut found = false;
-            if let Some(entry) = inner.entries.get_mut(&id) {
-                entry.pinned = false;
-                found = true;
-            }
-            if let Some(disk) = inner.disk_index.get_mut(&id) {
-                disk.pinned = false;
-                found = true;
-            }
-            found
-        };
-        if unpinned {
-            self.persist_pinned_set();
-        }
-        unpinned
+        self.set_pinned(id, false)
     }
 
     /// Increment the refcount on `id`. Returns `false` if the id isn't
@@ -1623,10 +1627,10 @@ impl HandleStore {
 /// Read `pinned.set` into a set of handle ids. The file is a flat
 /// little-endian `u64` array. Missing / unreadable / malformed (length
 /// not a multiple of 8) → empty set with a warn for the malformed case.
-fn read_pinned_set(cfg: &PersistConfig) -> std::collections::HashSet<HandleId> {
+fn read_pinned_set(cfg: &PersistConfig) -> HashSet<HandleId> {
     let path = cfg.pinned_set_path();
-    let Ok(raw) = std::fs::read(&path) else {
-        return std::collections::HashSet::new();
+    let Ok(raw) = fs::read(&path) else {
+        return HashSet::new();
     };
     if raw.len() % 8 != 0 {
         tracing::warn!(
@@ -1635,7 +1639,7 @@ fn read_pinned_set(cfg: &PersistConfig) -> std::collections::HashSet<HandleId> {
             len = raw.len(),
             "pinned.set length not a multiple of 8; ignoring",
         );
-        return std::collections::HashSet::new();
+        return HashSet::new();
     }
     raw.chunks_exact(8)
         .map(|c| {
@@ -1649,7 +1653,7 @@ fn read_pinned_set(cfg: &PersistConfig) -> std::collections::HashSet<HandleId> {
 /// Read + decode a `.meta` sidecar. Returns `None` on read or decode
 /// failure (the boot scan treats that as a corrupt entry to scrub).
 fn read_meta_file(path: &Path) -> Option<HandleMeta> {
-    let raw = std::fs::read(path).ok()?;
+    let raw = fs::read(path).ok()?;
     postcard::from_bytes::<HandleMeta>(&raw).ok()
 }
 
@@ -2023,7 +2027,7 @@ fn skip_primitive_postcard(state: &mut State<'_>, p: Primitive) -> Result<(), Wa
     reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
 )]
 mod tests {
-    use std::sync::Arc;
+    use Arc;
 
     use crate::mail::{Mail, MailboxId};
     use aether_data::{Kind, Ref};

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -74,6 +74,21 @@ pub const ENV_PERSIST_DISABLE: &str = "AETHER_HANDLE_STORE_PERSIST_DISABLE";
 /// `v1/` namespacing is ADR-0049 §8's forward-compatibility hook.
 pub const LAYOUT_VERSION_DIR: &str = "v1";
 
+/// Env var overriding the on-disk byte budget (ADR-0049 §5). When the
+/// ledger exceeds this, the eviction tick drops refcount-0 + unpinned
+/// entries oldest-first. Default [`DEFAULT_DISK_BUDGET_BYTES`].
+pub const ENV_DISK_BUDGET_BYTES: &str = "AETHER_HANDLE_STORE_DISK_BUDGET_BYTES";
+
+/// Env var overriding the eviction tick interval in seconds. Default
+/// [`DEFAULT_DISK_EVICTION_TICK_SECS`].
+pub const ENV_DISK_EVICTION_TICK_SECS: &str = "AETHER_HANDLE_STORE_DISK_EVICTION_TICK_SECS";
+
+/// Default on-disk byte budget (16 GiB per ADR-0049 §3).
+pub const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+/// Default eviction tick interval (60s per ADR-0049 §5).
+pub const DEFAULT_DISK_EVICTION_TICK_SECS: u64 = 60;
+
 /// Tracing target shared by every persistence diagnostic.
 const TARGET: &str = "aether_substrate::handle_store";
 
@@ -86,6 +101,11 @@ pub struct PersistConfig {
     /// `${AETHER_HANDLE_STORE_DIR}/v1/` — the layout-versioned root that
     /// holds `entries/`, `pinned.set`, and `lock.pid`.
     pub root: PathBuf,
+    /// On-disk byte budget (ADR-0049 §5). The eviction tick drops
+    /// candidates until the ledger falls below this.
+    pub disk_budget_bytes: u64,
+    /// Eviction tick interval in seconds.
+    pub eviction_tick_secs: u64,
 }
 
 impl PersistConfig {
@@ -119,6 +139,11 @@ impl PersistConfig {
         };
         Some(Self {
             root: base.join(LAYOUT_VERSION_DIR),
+            disk_budget_bytes: parse_env_u64(ENV_DISK_BUDGET_BYTES, DEFAULT_DISK_BUDGET_BYTES),
+            eviction_tick_secs: parse_env_u64(
+                ENV_DISK_EVICTION_TICK_SECS,
+                DEFAULT_DISK_EVICTION_TICK_SECS,
+            ),
         })
     }
 
@@ -158,6 +183,28 @@ pub fn entry_paths(root: &Path, id: HandleId) -> (PathBuf, PathBuf) {
         dir.join(format!("{}.bin", &hex[2..])),
         dir.join(format!("{}.meta", &hex[2..])),
     )
+}
+
+/// Parse a `u64` env var, falling back to `default` on absence or a
+/// parse failure (with a warn for the malformed case).
+fn parse_env_u64(name: &str, default: u64) -> u64 {
+    match env::var(name) {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    env = name,
+                    value = %raw,
+                    error = %e,
+                    default,
+                    "ignoring unparseable env var; using default",
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
 }
 
 /// Millis since the unix epoch, saturating to 0 if the clock is before
@@ -239,6 +286,12 @@ struct Inner {
     /// Bounded FIFO of "checked, confirmed not on disk" ids. Capped at
     /// [`NEGATIVE_CACHE_CAP`] with FIFO eviction.
     negative_cache: VecDeque<HandleId>,
+    /// Approximate ledger of on-disk bytes (ADR-0049 §5). Bumped on each
+    /// persistent write, decremented on disk delete; the eviction tick
+    /// uses it to decide when to evict. Approximate (content-addressed
+    /// re-writes of the same id over-count until the next boot scan
+    /// reconciles).
+    total_disk_bytes: u64,
 }
 
 impl Inner {
@@ -561,7 +614,30 @@ impl HandleStore {
                 error = %e,
                 "handle store .meta write failed; orphan .bin will be scrubbed on next boot",
             );
+            return;
         }
+        // Register the on-disk entry in the index + ledger so a later
+        // in-memory eviction still finds it on disk and the eviction
+        // tick accounts for its bytes (ADR-0049 §5). A re-write of the
+        // same id over-counts the ledger until the next boot scan
+        // reconciles — approximate by design.
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
+        inner.total_disk_bytes = inner.total_disk_bytes.saturating_add(u64::from(meta.bytes_len));
+        inner.disk_index.insert(
+            id,
+            DiskEntry {
+                kind_id: kind,
+                bytes_len: meta.bytes_len,
+                pinned,
+                created_at: meta.created_at,
+            },
+        );
+        // The entry is now genuinely on disk — clear any negative-cache
+        // shadow.
+        inner.negative_cache.retain(|cached| *cached != id);
     }
 
     /// Rewrite `pinned.set` from the current in-memory pinned set. Cheap
@@ -577,12 +653,22 @@ impl HandleStore {
                 .inner
                 .read()
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
-            inner
+            // Union the in-memory pinned set with the on-disk pinned
+            // index so a pinned disk-only entry stays in `pinned.set`.
+            let mut set: std::collections::HashSet<u64> = inner
                 .entries
                 .iter()
                 .filter(|(_, e)| e.pinned)
                 .map(|(id, _)| id.0)
-                .collect()
+                .collect();
+            set.extend(
+                inner
+                    .disk_index
+                    .iter()
+                    .filter(|(_, e)| e.pinned)
+                    .map(|(id, _)| id.0),
+            );
+            set.into_iter().collect()
         };
         ids.sort_unstable();
         let mut bytes = Vec::with_capacity(ids.len() * 8);
@@ -698,12 +784,14 @@ impl HandleStore {
         }
 
         let count = index.len();
+        let disk_bytes: u64 = index.values().map(|e| u64::from(e.bytes_len)).sum();
         {
             let mut inner = self
                 .inner
                 .write()
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
             inner.disk_index = index;
+            inner.total_disk_bytes = disk_bytes;
         }
         if scrubbed > 0 {
             tracing::info!(
@@ -776,6 +864,138 @@ impl HandleStore {
         }
     }
 
+    /// Current approximate on-disk byte ledger (ADR-0049 §5). Test +
+    /// observability accessor.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    #[must_use]
+    pub fn disk_bytes(&self) -> u64 {
+        self.inner
+            .read()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063")
+            .total_disk_bytes
+    }
+
+    /// Run one disk-eviction pass synchronously (ADR-0049 §5). Public so
+    /// the eviction thread + tests can trigger it. When over budget,
+    /// evicts disk entries that are refcount-0 in memory AND unpinned,
+    /// oldest-`created_at` first, two-phase (`.bin` then `.meta`), until
+    /// the ledger drops below the budget or no candidates remain. No-op
+    /// when persistence is disabled.
+    pub fn run_disk_eviction(&self) {
+        let Some(cfg) = self.persist.clone() else {
+            return;
+        };
+        // Snapshot candidates under a read lock, then mutate under a
+        // write lock per victim — the fs delete happens between, off the
+        // lock.
+        let (over_budget, mut candidates) = {
+            let inner = self
+                .inner
+                .read()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            if inner.total_disk_bytes <= cfg.disk_budget_bytes {
+                return;
+            }
+            // refcount-0 in memory (or not in memory at all) AND unpinned.
+            let candidates: Vec<(HandleId, u64, u32)> = inner
+                .disk_index
+                .iter()
+                .filter(|(id, e)| {
+                    !e.pinned && inner.entries.get(id).is_none_or(|m| m.refcount == 0)
+                })
+                .map(|(id, e)| (*id, e.created_at, e.bytes_len))
+                .collect();
+            (inner.total_disk_bytes, candidates)
+        };
+        // Oldest first.
+        candidates.sort_by_key(|(_, created_at, _)| *created_at);
+
+        let mut freed = 0u64;
+        let budget = cfg.disk_budget_bytes;
+        let mut evicted = 0usize;
+        for (id, _, bytes_len) in candidates {
+            if over_budget.saturating_sub(freed) <= budget {
+                break;
+            }
+            let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+            // Phase A: drop the bytes.
+            if let Err(e) = std::fs::remove_file(&bin_path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(
+                    target: TARGET,
+                    handle = %id,
+                    path = %bin_path.display(),
+                    error = %e,
+                    "eviction phase A (.bin) failed; retrying next tick",
+                );
+                continue;
+            }
+            // Phase B: drop the index entry.
+            if let Err(e) = std::fs::remove_file(&meta_path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(
+                    target: TARGET,
+                    handle = %id,
+                    path = %meta_path.display(),
+                    error = %e,
+                    "eviction phase B (.meta) failed; orphan .bin already gone, will retry",
+                );
+            }
+            // Update the ledger + index.
+            {
+                let mut inner = self
+                    .inner
+                    .write()
+                    .expect("handle store lock poisoned; fail-fast per ADR-0063");
+                inner.total_disk_bytes =
+                    inner.total_disk_bytes.saturating_sub(u64::from(bytes_len));
+                inner.disk_index.remove(&id);
+            }
+            freed = freed.saturating_add(u64::from(bytes_len));
+            evicted += 1;
+        }
+        if evicted > 0 {
+            tracing::info!(
+                target: TARGET,
+                evicted,
+                freed_bytes = freed,
+                budget,
+                "handle store disk eviction pass complete",
+            );
+        }
+    }
+
+    /// Spawn the background eviction tick (ADR-0049 §5). The thread owns
+    /// a [`Weak`] reference to avoid a reference cycle; on the store's
+    /// last `Arc` dropping, the weak fails to upgrade and the thread
+    /// exits. No-op when persistence is disabled. Call once at boot
+    /// after wrapping the store in an `Arc`.
+    pub fn spawn_eviction_thread(self: &std::sync::Arc<Self>) {
+        let Some(cfg) = self.persist.clone() else {
+            return;
+        };
+        let weak = std::sync::Arc::downgrade(self);
+        let tick = std::time::Duration::from_secs(cfg.eviction_tick_secs.max(1));
+        std::thread::Builder::new()
+            .name("handle-store-evict".to_owned())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(tick);
+                    let Some(store) = weak.upgrade() else {
+                        // Store dropped; thread exits.
+                        return;
+                    };
+                    store.run_disk_eviction();
+                }
+            })
+            .ok();
+    }
+
     /// Mark `id` as pinned: it won't be evicted under memory pressure
     /// regardless of `refcount`. Returns `false` if the id isn't in
     /// the store.
@@ -790,12 +1010,19 @@ impl HandleStore {
                 .inner
                 .write()
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            let mut found = false;
             if let Some(entry) = inner.entries.get_mut(&id) {
                 entry.pinned = true;
-                true
-            } else {
-                false
+                found = true;
             }
+            // Keep the on-disk index's pinned flag in sync so the
+            // eviction tick (ADR-0049 §5) skips a pinned disk-resident
+            // entry even when it isn't materialized in memory.
+            if let Some(disk) = inner.disk_index.get_mut(&id) {
+                disk.pinned = true;
+                found = true;
+            }
+            found
         };
         if pinned {
             self.persist_pinned_set();
@@ -816,12 +1043,16 @@ impl HandleStore {
                 .inner
                 .write()
                 .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            let mut found = false;
             if let Some(entry) = inner.entries.get_mut(&id) {
                 entry.pinned = false;
-                true
-            } else {
-                false
+                found = true;
             }
+            if let Some(disk) = inner.disk_index.get_mut(&id) {
+                disk.pinned = false;
+                found = true;
+            }
+            found
         };
         if unpinned {
             self.persist_pinned_set();

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -1,0 +1,66 @@
+//! On-disk sidecar metadata for the persistent handle store (ADR-0049
+//! §2). Each `<hash>.bin` byte blob is paired with a `<hash>.meta`
+//! postcard-encoded [`HandleMeta`] describing its identity, provenance,
+//! and durability flags.
+//!
+//! The meta is the index entry: the boot scan (issue #985) reads only
+//! the meta sidecars to populate the sparse disk index without touching
+//! the (potentially gigabyte-scale) `.bin` payloads. `bytes_len` is the
+//! cheap consistency check against the sibling `.bin`; restore asserts
+//! the lengths agree.
+
+use serde::{Deserialize, Serialize};
+
+/// On-disk `HandleMeta` schema version. Bumping this invalidates all
+/// prior entries (the boot scan treats a version mismatch as
+/// evict-on-restore) — that's the cross-substrate-version migration
+/// mechanism per ADR-0049 §6.
+pub const SCHEMA_VERSION: u8 = 1;
+
+/// Postcard-encoded sidecar describing one persistent handle. Written
+/// atomically next to the handle's `<hash>.bin` payload; the boot scan
+/// reads it to rebuild the sparse disk index without loading the bytes.
+///
+/// Ids are stored as raw `u64` rather than the typed [`aether_data::HandleId`]
+/// / [`aether_data::KindId`] newtypes so the on-disk format is a flat
+/// postcard struct independent of the tagged-id serde branch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandleMeta {
+    /// On-disk format version. Set to [`SCHEMA_VERSION`] on write; a
+    /// mismatch on read means a substrate-version skew and the entry is
+    /// dropped.
+    pub schema_version: u8,
+    /// The handle id this entry was written under. Used for collision
+    /// detection on restore (the path hash and the recorded id must
+    /// agree).
+    pub handle_id: u64,
+    /// Schema-hash of the kind type at write time (ADR-0030). The
+    /// schema-evolution check (issue #988) compares this against the
+    /// current registry's id for the same kind name.
+    pub kind_id: u64,
+    /// Provenance: the transform that produced this handle, or `None`
+    /// for pinned source handles (ADR-0049 §1).
+    pub transform_origin: Option<TransformOrigin>,
+    /// Length of the sibling `.bin` payload. Cheap consistency check on
+    /// restore.
+    pub bytes_len: u32,
+    /// Millis since the unix epoch at write time. The eviction tick
+    /// (issue #986) sorts candidates by this ascending (created_at-LRU).
+    pub created_at: u64,
+    /// Whether the user pinned this handle (ADR-0045 §9). Pinned entries
+    /// skip byte-pressure eviction.
+    pub pinned: bool,
+}
+
+/// Provenance record: which transform produced a handle and which
+/// inputs went in. The substrate's local copy of the same lineage
+/// ADR-0046 §7 surfaces at the application layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransformOrigin {
+    /// The component mailbox that computed this handle.
+    pub component_mailbox: u64,
+    /// Which transform on that component.
+    pub transform_index: u32,
+    /// The input handle ids that produced this output, slot-ordered.
+    pub input_handle_ids: Vec<u64>,
+}

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -45,7 +45,7 @@ pub struct HandleMeta {
     /// The kind's name at write time. Lets the schema-evolution check
     /// distinguish "kind retired" (no registry entry for the name) from
     /// "kind schema changed" (registry id differs from `kind_id`) —
-    /// added in schema_version 2 (issue #988).
+    /// added in `schema_version` 2 (issue #988).
     pub kind_name: String,
     /// Provenance: the transform that produced this handle, or `None`
     /// for pinned source handles (ADR-0049 §1).

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -15,7 +15,11 @@ use serde::{Deserialize, Serialize};
 /// prior entries (the boot scan treats a version mismatch as
 /// evict-on-restore) — that's the cross-substrate-version migration
 /// mechanism per ADR-0049 §6.
-pub const SCHEMA_VERSION: u8 = 1;
+///
+/// v2 (issue #988) added `kind_name` so the schema-evolution check can
+/// look the kind up in the current registry by name; v1 entries (which
+/// lack the field) are un-rescuable and evict on mismatch.
+pub const SCHEMA_VERSION: u8 = 2;
 
 /// Postcard-encoded sidecar describing one persistent handle. Written
 /// atomically next to the handle's `<hash>.bin` payload; the boot scan
@@ -38,6 +42,11 @@ pub struct HandleMeta {
     /// schema-evolution check (issue #988) compares this against the
     /// current registry's id for the same kind name.
     pub kind_id: u64,
+    /// The kind's name at write time. Lets the schema-evolution check
+    /// distinguish "kind retired" (no registry entry for the name) from
+    /// "kind schema changed" (registry id differs from `kind_id`) —
+    /// added in schema_version 2 (issue #988).
+    pub kind_name: String,
     /// Provenance: the transform that produced this handle, or `None`
     /// for pinned source handles (ADR-0049 §1).
     pub transform_origin: Option<TransformOrigin>,

--- a/crates/aether-substrate/tests/handle_store_disk_eviction.rs
+++ b/crates/aether-substrate/tests/handle_store_disk_eviction.rs
@@ -11,12 +11,14 @@
     reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
 )]
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aether_data::{HandleId, KindId};
 use aether_substrate::handle_store::meta::TransformOrigin;
@@ -25,12 +27,12 @@ use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
 static NONCE: AtomicU64 = AtomicU64::new(0);
 
 fn scratch_root(tag: &str) -> PathBuf {
-    let pid = std::process::id();
+    let pid = process::id();
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
     let n = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("aether-handle-evict-{tag}-{pid}-{millis}-{n}"));
+    let path = env::temp_dir().join(format!("aether-handle-evict-{tag}-{pid}-{millis}-{n}"));
     fs::create_dir_all(&path).expect("test setup: scratch dir creates");
     path
 }
@@ -60,7 +62,7 @@ fn actual_bin_bytes(cfg: &PersistConfig) -> u64 {
             for f in files.flatten() {
                 let p = f.path();
                 if p.extension().and_then(|e| e.to_str()) == Some("bin") {
-                    total += f.metadata().map(|m| m.len()).unwrap_or(0);
+                    total += f.metadata().map_or(0, |m| m.len());
                 }
             }
         }
@@ -107,7 +109,7 @@ fn eviction_orders_by_created_at() {
         store
             .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 1024 * 1024], None)
             .unwrap();
-        thread::sleep(std::time::Duration::from_millis(2));
+        thread::sleep(Duration::from_millis(2));
     }
     // Budget 7MB on a 10MB store → evict the 3 oldest.
     store.run_disk_eviction();
@@ -177,7 +179,7 @@ fn eviction_two_phase_handles_crash_between_phases() {
     fs::remove_file(&bin).unwrap();
     assert!(meta.exists());
     // Restart → boot scrub removes the orphan meta.
-    let restored = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    let restored = HandleStore::with_persist(64 * 1024, Some(cfg));
     assert!(!meta.exists(), "boot scrub removed orphan meta");
     assert_eq!(restored.disk_index_len(), 0);
     cleanup(&root);

--- a/crates/aether-substrate/tests/handle_store_disk_eviction.rs
+++ b/crates/aether-substrate/tests/handle_store_disk_eviction.rs
@@ -1,0 +1,256 @@
+//! Issue #986: disk eviction by created_at-LRU (ADR-0049 §5).
+//!
+//! When the on-disk byte ledger exceeds the budget, the eviction tick
+//! drops refcount-0 + unpinned entries oldest-first via a two-phase
+//! delete. Pinned + in-use entries stay. A crash between phases leaves
+//! an orphan the boot scrub catches. Tests trigger the eviction pass
+//! synchronously via `run_disk_eviction` for determinism.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_data::{HandleId, KindId};
+use aether_substrate::handle_store::meta::TransformOrigin;
+use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("aether-handle-evict-{tag}-{pid}-{millis}-{n}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn cfg_with_budget(root: &Path, budget: u64) -> PersistConfig {
+    PersistConfig {
+        root: root.join("v1"),
+        disk_budget_bytes: budget,
+        eviction_tick_secs: 60,
+    }
+}
+
+/// Sum of `.bin` file sizes under entries/ — the actual on-disk usage
+/// (the `du`-equivalent the plan references, restricted to payloads).
+fn actual_bin_bytes(cfg: &PersistConfig) -> u64 {
+    let mut total = 0u64;
+    let entries = cfg.root.join("entries");
+    let Ok(shards) = fs::read_dir(&entries) else {
+        return 0;
+    };
+    for shard in shards.flatten() {
+        if let Ok(files) = fs::read_dir(shard.path()) {
+            for f in files.flatten() {
+                let p = f.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("bin") {
+                    total += f.metadata().map(|m| m.len()).unwrap_or(0);
+                }
+            }
+        }
+    }
+    total
+}
+
+#[test]
+fn eviction_skips_pinned_handles() {
+    let root = scratch_root("skip-pinned");
+    // 10 entries × ~1MB = ~10MB; budget 1MB forces eviction.
+    let cfg = cfg_with_budget(&root, 1024 * 1024);
+    let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+    for i in 0..10u64 {
+        let id = HandleId(i + 1);
+        store
+            .put_persistent(id, KindId(7), vec![0u8; 1024 * 1024], None)
+            .unwrap();
+        if i < 5 {
+            store.pin(id);
+        }
+    }
+    store.run_disk_eviction();
+
+    for i in 0..10u64 {
+        let id = HandleId(i + 1);
+        let (bin, _) = entry_paths(&cfg.root, id);
+        if i < 5 {
+            assert!(bin.exists(), "pinned id {i} survives");
+        } else {
+            assert!(!bin.exists(), "unpinned id {i} evicted");
+        }
+    }
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_orders_by_created_at() {
+    let root = scratch_root("order");
+    let cfg = cfg_with_budget(&root, 7 * 1024 * 1024);
+    let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+    // Write 10 × 1MB with a tiny gap so created_at is monotonic.
+    for i in 0..10u64 {
+        store
+            .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 1024 * 1024], None)
+            .unwrap();
+        thread::sleep(std::time::Duration::from_millis(2));
+    }
+    // Budget 7MB on a 10MB store → evict the 3 oldest.
+    store.run_disk_eviction();
+
+    for i in 0..3u64 {
+        let (bin, _) = entry_paths(&cfg.root, HandleId(i + 1));
+        assert!(!bin.exists(), "oldest id {i} evicted");
+    }
+    for i in 3..10u64 {
+        let (bin, _) = entry_paths(&cfg.root, HandleId(i + 1));
+        assert!(bin.exists(), "newer id {i} survives");
+    }
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_skips_in_use_handles() {
+    let root = scratch_root("in-use");
+    let cfg = cfg_with_budget(&root, 0);
+    let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+    let id = HandleId(1);
+    store
+        .put_persistent(id, KindId(7), vec![0u8; 1024], None)
+        .unwrap();
+    // refcount 1 protects it.
+    store.inc_ref(id);
+    store.run_disk_eviction();
+
+    let (bin, _) = entry_paths(&cfg.root, id);
+    assert!(bin.exists(), "refcounted entry stays even at budget 0");
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_tick_yields_when_budget_clear() {
+    let root = scratch_root("under-budget");
+    let cfg = cfg_with_budget(&root, 1024 * 1024 * 1024);
+    let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+    for i in 0..5u64 {
+        store
+            .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 1024], None)
+            .unwrap();
+    }
+    store.run_disk_eviction();
+    // All 5 survive — budget far from exceeded.
+    for i in 0..5u64 {
+        let (bin, _) = entry_paths(&cfg.root, HandleId(i + 1));
+        assert!(bin.exists(), "id {i} not evicted under budget");
+    }
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_two_phase_handles_crash_between_phases() {
+    // Simulate a crash mid-eviction: delete just the .bin, leaving an
+    // orphan .meta. The boot scrub on the next start deletes the .meta.
+    let root = scratch_root("crash-between");
+    let cfg = cfg_with_budget(&root, u64::MAX);
+    let id = HandleId(0x77);
+    {
+        let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+        store
+            .put_persistent(id, KindId(1), b"payload".to_vec(), None)
+            .unwrap();
+    }
+    let (bin, meta) = entry_paths(&cfg.root, id);
+    fs::remove_file(&bin).unwrap();
+    assert!(meta.exists());
+    // Restart → boot scrub removes the orphan meta.
+    let restored = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    assert!(!meta.exists(), "boot scrub removed orphan meta");
+    assert_eq!(restored.disk_index_len(), 0);
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_recovers_from_orphan_bin() {
+    let root = scratch_root("orphan-bin");
+    let cfg = cfg_with_budget(&root, u64::MAX);
+    let id = HandleId(0x88);
+    let (bin, _) = entry_paths(&cfg.root, id);
+    fs::create_dir_all(bin.parent().unwrap()).unwrap();
+    fs::write(&bin, b"orphan-bytes").unwrap();
+    // Restart → boot scrub removes the orphan bin.
+    let _restored = HandleStore::with_persist(64 * 1024, Some(cfg));
+    assert!(!bin.exists(), "boot scrub removed orphan bin");
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_ledger_stays_consistent_under_concurrent_writes() {
+    let root = scratch_root("ledger");
+    let cfg = cfg_with_budget(&root, u64::MAX);
+    let store = Arc::new(HandleStore::with_persist(
+        256 * 1024 * 1024,
+        Some(cfg.clone()),
+    ));
+    // 10 threads × 100 distinct entries × 256 bytes.
+    let handles: Vec<_> = (0..10u64)
+        .map(|t| {
+            let store = Arc::clone(&store);
+            thread::spawn(move || {
+                for i in 0..100u64 {
+                    let id = HandleId(t * 1000 + i + 1);
+                    let origin = TransformOrigin {
+                        component_mailbox: t,
+                        transform_index: 0,
+                        input_handle_ids: vec![],
+                    };
+                    store
+                        .put_persistent(id, KindId(7), vec![0u8; 256], Some(origin))
+                        .unwrap();
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    // Distinct ids → ledger equals actual on-disk bin bytes.
+    assert_eq!(store.disk_bytes(), actual_bin_bytes(&cfg));
+    assert_eq!(store.disk_bytes(), 1000 * 256);
+    cleanup(&root);
+}
+
+#[test]
+fn eviction_after_in_memory_drop_still_finds_disk_entry() {
+    // A handle written persistently, then dropped from the in-memory
+    // store via budget pressure, remains on disk + indexed and is
+    // eviction-eligible.
+    let root = scratch_root("disk-only");
+    let cfg = cfg_with_budget(&root, 100);
+    let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+    let id = HandleId(0x99);
+    store
+        .put_persistent(id, KindId(7), vec![0u8; 4096], None)
+        .unwrap();
+    // It's both in memory and indexed on disk.
+    assert!(store.contains(id));
+    // Eviction over the 100-byte budget removes the unpinned, refcount-0
+    // disk entry.
+    store.run_disk_eviction();
+    let (bin, _) = entry_paths(&cfg.root, id);
+    assert!(!bin.exists(), "disk entry evicted under budget pressure");
+    cleanup(&root);
+}

--- a/crates/aether-substrate/tests/handle_store_lockfile.rs
+++ b/crates/aether-substrate/tests/handle_store_lockfile.rs
@@ -1,0 +1,140 @@
+//! Issue #987: on-disk store lockfile (ADR-0049 §7).
+//!
+//! `lock.pid` records the owning substrate's PID; boot reads it,
+//! reclaims a stale lock (dead PID) with a warning, and aborts on a
+//! live conflict. A `LockGuard` deletes the file on graceful shutdown.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_substrate::handle_store::{HandleStore, LockError, PersistConfig};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("aether-handle-lock-{tag}-{pid}-{millis}-{n}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn cfg_under(root: &Path) -> PersistConfig {
+    PersistConfig {
+        root: root.join("v1"),
+        disk_budget_bytes: u64::MAX,
+        eviction_tick_secs: 60,
+    }
+}
+
+#[test]
+fn lockfile_acquired_on_boot() {
+    let root = scratch_root("acquire");
+    let cfg = cfg_under(&root);
+    let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    store.acquire_lock().expect("lock acquired on fresh store");
+
+    let raw = fs::read_to_string(cfg.lock_path()).expect("lock.pid present");
+    assert_eq!(raw.trim(), std::process::id().to_string());
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_released_on_drop() {
+    let root = scratch_root("release");
+    let cfg = cfg_under(&root);
+    {
+        let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+        store.acquire_lock().unwrap();
+        assert!(cfg.lock_path().exists());
+    }
+    // Store dropped → LockGuard Drop deletes the file.
+    assert!(!cfg.lock_path().exists(), "lock removed on drop");
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_rejects_concurrent_substrate() {
+    let root = scratch_root("concurrent");
+    let cfg = cfg_under(&root);
+    let first = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    first.acquire_lock().expect("first store acquires");
+
+    // A second store against the same dir sees our own (live) PID and
+    // refuses.
+    let second = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    let err = second.acquire_lock().expect_err("second store rejected");
+    match err {
+        LockError::Held { pid, .. } => {
+            assert_eq!(pid, std::process::id() as i32);
+        }
+        other => panic!("expected Held, got {other:?}"),
+    }
+    drop(first);
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_reclaims_stale_lock() {
+    let root = scratch_root("stale");
+    let cfg = cfg_under(&root);
+    // Pre-seed a lock.pid with an almost-certainly-dead PID.
+    fs::create_dir_all(&cfg.root).unwrap();
+    fs::write(cfg.lock_path(), b"999999").unwrap();
+
+    let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    store.acquire_lock().expect("stale lock reclaimed");
+    // Now holds our PID.
+    let raw = fs::read_to_string(cfg.lock_path()).unwrap();
+    assert_eq!(raw.trim(), std::process::id().to_string());
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_reclaims_garbage_lock() {
+    let root = scratch_root("garbage");
+    let cfg = cfg_under(&root);
+    fs::create_dir_all(&cfg.root).unwrap();
+    fs::write(cfg.lock_path(), b"not-a-pid").unwrap();
+
+    let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    store.acquire_lock().expect("garbage lock reclaimed as stale");
+    let raw = fs::read_to_string(cfg.lock_path()).unwrap();
+    assert_eq!(raw.trim(), std::process::id().to_string());
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_does_not_reclaim_live_lock() {
+    let root = scratch_root("live");
+    let cfg = cfg_under(&root);
+    fs::create_dir_all(&cfg.root).unwrap();
+    // Our own PID — we're alive, so the lock must not be reclaimed.
+    fs::write(cfg.lock_path(), std::process::id().to_string()).unwrap();
+
+    let store = HandleStore::with_persist(64 * 1024, Some(cfg));
+    let err = store.acquire_lock().expect_err("live lock not reclaimed");
+    assert!(matches!(err, LockError::Held { .. }));
+    cleanup(&root);
+}
+
+#[test]
+fn lockfile_noop_when_persistence_disabled() {
+    // No PersistConfig → acquire_lock is a no-op success.
+    let store = HandleStore::new(64 * 1024);
+    store.acquire_lock().expect("no-op when persistence off");
+}

--- a/crates/aether-substrate/tests/handle_store_lockfile.rs
+++ b/crates/aether-substrate/tests/handle_store_lockfile.rs
@@ -9,8 +9,10 @@
     reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
 )]
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -19,12 +21,12 @@ use aether_substrate::handle_store::{HandleStore, LockError, PersistConfig};
 static NONCE: AtomicU64 = AtomicU64::new(0);
 
 fn scratch_root(tag: &str) -> PathBuf {
-    let pid = std::process::id();
+    let pid = process::id();
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
     let n = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("aether-handle-lock-{tag}-{pid}-{millis}-{n}"));
+    let path = env::temp_dir().join(format!("aether-handle-lock-{tag}-{pid}-{millis}-{n}"));
     fs::create_dir_all(&path).expect("test setup: scratch dir creates");
     path
 }
@@ -49,7 +51,7 @@ fn lockfile_acquired_on_boot() {
     store.acquire_lock().expect("lock acquired on fresh store");
 
     let raw = fs::read_to_string(cfg.lock_path()).expect("lock.pid present");
-    assert_eq!(raw.trim(), std::process::id().to_string());
+    assert_eq!(raw.trim(), process::id().to_string());
     cleanup(&root);
 }
 
@@ -76,13 +78,15 @@ fn lockfile_rejects_concurrent_substrate() {
 
     // A second store against the same dir sees our own (live) PID and
     // refuses.
-    let second = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    let second = HandleStore::with_persist(64 * 1024, Some(cfg));
     let err = second.acquire_lock().expect_err("second store rejected");
     match err {
         LockError::Held { pid, .. } => {
-            assert_eq!(pid, std::process::id() as i32);
+            assert_eq!(pid, i32::try_from(process::id()).unwrap());
         }
-        other => panic!("expected Held, got {other:?}"),
+        LockError::Io { path, error } => {
+            panic!("expected Held, got Io({}): {error}", path.display())
+        }
     }
     drop(first);
     cleanup(&root);
@@ -100,7 +104,7 @@ fn lockfile_reclaims_stale_lock() {
     store.acquire_lock().expect("stale lock reclaimed");
     // Now holds our PID.
     let raw = fs::read_to_string(cfg.lock_path()).unwrap();
-    assert_eq!(raw.trim(), std::process::id().to_string());
+    assert_eq!(raw.trim(), process::id().to_string());
     cleanup(&root);
 }
 
@@ -112,9 +116,11 @@ fn lockfile_reclaims_garbage_lock() {
     fs::write(cfg.lock_path(), b"not-a-pid").unwrap();
 
     let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
-    store.acquire_lock().expect("garbage lock reclaimed as stale");
+    store
+        .acquire_lock()
+        .expect("garbage lock reclaimed as stale");
     let raw = fs::read_to_string(cfg.lock_path()).unwrap();
-    assert_eq!(raw.trim(), std::process::id().to_string());
+    assert_eq!(raw.trim(), process::id().to_string());
     cleanup(&root);
 }
 
@@ -124,7 +130,7 @@ fn lockfile_does_not_reclaim_live_lock() {
     let cfg = cfg_under(&root);
     fs::create_dir_all(&cfg.root).unwrap();
     // Our own PID — we're alive, so the lock must not be reclaimed.
-    fs::write(cfg.lock_path(), std::process::id().to_string()).unwrap();
+    fs::write(cfg.lock_path(), process::id().to_string()).unwrap();
 
     let store = HandleStore::with_persist(64 * 1024, Some(cfg));
     let err = store.acquire_lock().expect_err("live lock not reclaimed");

--- a/crates/aether-substrate/tests/handle_store_persistence.rs
+++ b/crates/aether-substrate/tests/handle_store_persistence.rs
@@ -13,8 +13,10 @@
     reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
 )]
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
@@ -22,19 +24,21 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_data::{HandleId, KindId};
 use aether_substrate::handle_store::meta::{HandleMeta, SCHEMA_VERSION};
-use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
+use aether_substrate::handle_store::{
+    ENV_PERSIST_DISABLE, HandleStore, PersistConfig, entry_paths,
+};
 
 /// Process-global nonce so concurrent scratch dirs never collide even
 /// when two tests start in the same millisecond.
 static NONCE: AtomicU64 = AtomicU64::new(0);
 
 fn scratch_root(tag: &str) -> PathBuf {
-    let pid = std::process::id();
+    let pid = process::id();
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
     let n = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("aether-handle-persist-{tag}-{pid}-{millis}-{n}"));
+    let path = env::temp_dir().join(format!("aether-handle-persist-{tag}-{pid}-{millis}-{n}"));
     fs::create_dir_all(&path).expect("test setup: scratch dir creates");
     path
 }
@@ -65,9 +69,7 @@ fn persist_writes_bin_and_meta() {
     let id = HandleId(0x1234_5678);
     let kind = KindId(0xAAAA);
     let bytes = b"hello-world".to_vec();
-    store
-        .put_persistent(id, kind, bytes.clone(), None)
-        .unwrap();
+    store.put_persistent(id, kind, bytes.clone(), None).unwrap();
 
     let (bin_path, meta_path) = entry_paths(&cfg.root, id);
     assert!(bin_path.exists(), "bin written");
@@ -135,7 +137,9 @@ fn persist_writes_pinned_set_on_pin() {
     let store = HandleStore::with_persist(1024 * 1024, Some(cfg.clone()));
 
     let id = HandleId(0x42);
-    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    store
+        .put_persistent(id, KindId(1), b"x".to_vec(), None)
+        .unwrap();
     assert!(store.pin(id));
 
     let raw = fs::read(cfg.pinned_set_path()).expect("pinned.set present");
@@ -155,7 +159,9 @@ fn persist_writes_pinned_set_on_unpin() {
     let store = HandleStore::with_persist(1024 * 1024, Some(cfg.clone()));
 
     let id = HandleId(0x99);
-    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    store
+        .put_persistent(id, KindId(1), b"x".to_vec(), None)
+        .unwrap();
     store.pin(id);
     store.unpin(id);
 
@@ -175,7 +181,9 @@ fn persist_disabled_when_no_config() {
     let root = scratch_root("disabled");
     let store = HandleStore::with_persist(1024 * 1024, None);
     let id = HandleId(0x7);
-    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    store
+        .put_persistent(id, KindId(1), b"x".to_vec(), None)
+        .unwrap();
 
     assert!(store.contains(id), "in-memory entry present");
     // Nothing written to the scratch dir (we never handed it the dir).
@@ -191,10 +199,10 @@ fn persist_config_from_env_disable_flag() {
     // The disable flag wins even when the chassis votes enabled. This
     // test mutates a process-global env var; nextest runs each test in
     // its own process so the mutation is isolated.
-    let prev = std::env::var(aether_substrate::handle_store::ENV_PERSIST_DISABLE).ok();
+    let prev = env::var(ENV_PERSIST_DISABLE).ok();
     // SAFETY: single-threaded test body; nextest isolates the process.
     unsafe {
-        std::env::set_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE, "1");
+        env::set_var(ENV_PERSIST_DISABLE, "1");
     }
     assert!(
         PersistConfig::from_env(true).is_none(),
@@ -205,8 +213,8 @@ fn persist_config_from_env_disable_flag() {
     // SAFETY: restore.
     unsafe {
         match prev {
-            Some(v) => std::env::set_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE, v),
-            None => std::env::remove_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE),
+            Some(v) => env::set_var(ENV_PERSIST_DISABLE, v),
+            None => env::remove_var(ENV_PERSIST_DISABLE),
         }
     }
 }

--- a/crates/aether-substrate/tests/handle_store_persistence.rs
+++ b/crates/aether-substrate/tests/handle_store_persistence.rs
@@ -46,6 +46,8 @@ fn cleanup(path: &Path) {
 fn persist_config(root: &Path) -> PersistConfig {
     PersistConfig {
         root: root.join("v1"),
+        disk_budget_bytes: u64::MAX,
+        eviction_tick_secs: 60,
     }
 }
 
@@ -219,7 +221,11 @@ fn persist_continues_on_write_failure() {
     // under it.
     let blocker = root.join("v1");
     fs::write(&blocker, b"not-a-dir").unwrap();
-    let cfg = PersistConfig { root: blocker };
+    let cfg = PersistConfig {
+        root: blocker,
+        disk_budget_bytes: u64::MAX,
+        eviction_tick_secs: 60,
+    };
     let store = HandleStore::with_persist(1024 * 1024, Some(cfg));
 
     let id = HandleId(0x55);

--- a/crates/aether-substrate/tests/handle_store_persistence.rs
+++ b/crates/aether-substrate/tests/handle_store_persistence.rs
@@ -1,0 +1,233 @@
+//! Issue #984: on-disk layout + atomic write path for the persistent
+//! handle store (ADR-0049 §2 + §3).
+//!
+//! Exercises `HandleStore::put_persistent`, the `<hash>.bin` /
+//! `<hash>.meta` sidecar pair, the atomic tmp+rename writer, and the
+//! `pinned.set` rewrite on pin / unpin. Store-mechanics tests construct
+//! a `PersistConfig` directly against a unique scratch dir; the env-var
+//! tests drive `PersistConfig::from_env` / a boot through the
+//! persist-disabled chassis vote.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_data::{HandleId, KindId};
+use aether_substrate::handle_store::meta::{HandleMeta, SCHEMA_VERSION};
+use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
+
+/// Process-global nonce so concurrent scratch dirs never collide even
+/// when two tests start in the same millisecond.
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("aether-handle-persist-{tag}-{pid}-{millis}-{n}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn persist_config(root: &Path) -> PersistConfig {
+    PersistConfig {
+        root: root.join("v1"),
+    }
+}
+
+fn read_meta(path: &Path) -> HandleMeta {
+    let bytes = fs::read(path).expect("meta file present");
+    postcard::from_bytes(&bytes).expect("meta decodes")
+}
+
+#[test]
+fn persist_writes_bin_and_meta() {
+    let root = scratch_root("bin-meta");
+    let cfg = persist_config(&root);
+    let store = HandleStore::with_persist(1024 * 1024, Some(cfg.clone()));
+
+    let id = HandleId(0x1234_5678);
+    let kind = KindId(0xAAAA);
+    let bytes = b"hello-world".to_vec();
+    store
+        .put_persistent(id, kind, bytes.clone(), None)
+        .unwrap();
+
+    let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+    assert!(bin_path.exists(), "bin written");
+    assert!(meta_path.exists(), "meta written");
+    assert_eq!(fs::read(&bin_path).unwrap(), bytes);
+
+    let meta = read_meta(&meta_path);
+    assert_eq!(meta.schema_version, SCHEMA_VERSION);
+    assert_eq!(meta.handle_id, id.0);
+    assert_eq!(meta.kind_id, kind.0);
+    assert_eq!(meta.bytes_len as usize, bytes.len());
+    assert!(!meta.pinned);
+    assert!(meta.transform_origin.is_none());
+
+    cleanup(&root);
+}
+
+#[test]
+fn persist_atomic_under_concurrent_write() {
+    let root = scratch_root("atomic");
+    let cfg = persist_config(&root);
+    let store = Arc::new(HandleStore::with_persist(1024 * 1024, Some(cfg.clone())));
+
+    // Content-addressed: ten threads produce the same handle with the
+    // same bytes (two transforms producing the same output).
+    let id = HandleId(0xCAFE);
+    let kind = KindId(0xBEEF);
+    let bytes = b"deterministic-payload".to_vec();
+
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let store = Arc::clone(&store);
+            let bytes = bytes.clone();
+            thread::spawn(move || {
+                store.put_persistent(id, kind, bytes, None).unwrap();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+    // Exactly one final bin + meta, no leftover tmp files.
+    let shard_dir = bin_path.parent().unwrap();
+    let entries: Vec<String> = fs::read_dir(shard_dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !entries.iter().any(|e| e.contains(".tmp-")),
+        "no tmp files left behind: {entries:?}",
+    );
+    assert_eq!(fs::read(&bin_path).unwrap(), bytes);
+    let meta = read_meta(&meta_path);
+    assert_eq!(meta.bytes_len as usize, bytes.len());
+
+    cleanup(&root);
+}
+
+#[test]
+fn persist_writes_pinned_set_on_pin() {
+    let root = scratch_root("pin");
+    let cfg = persist_config(&root);
+    let store = HandleStore::with_persist(1024 * 1024, Some(cfg.clone()));
+
+    let id = HandleId(0x42);
+    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    assert!(store.pin(id));
+
+    let raw = fs::read(cfg.pinned_set_path()).expect("pinned.set present");
+    let ids: Vec<u64> = raw
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    assert!(ids.contains(&id.0), "pinned set contains the id: {ids:?}");
+
+    cleanup(&root);
+}
+
+#[test]
+fn persist_writes_pinned_set_on_unpin() {
+    let root = scratch_root("unpin");
+    let cfg = persist_config(&root);
+    let store = HandleStore::with_persist(1024 * 1024, Some(cfg.clone()));
+
+    let id = HandleId(0x99);
+    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    store.pin(id);
+    store.unpin(id);
+
+    let raw = fs::read(cfg.pinned_set_path()).expect("pinned.set present");
+    let ids: Vec<u64> = raw
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    assert!(!ids.contains(&id.0), "id removed from pinned set: {ids:?}");
+
+    cleanup(&root);
+}
+
+#[test]
+fn persist_disabled_when_no_config() {
+    // No PersistConfig — `put_persistent` behaves as an in-memory put.
+    let root = scratch_root("disabled");
+    let store = HandleStore::with_persist(1024 * 1024, None);
+    let id = HandleId(0x7);
+    store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+
+    assert!(store.contains(id), "in-memory entry present");
+    // Nothing written to the scratch dir (we never handed it the dir).
+    assert!(
+        fs::read_dir(&root).unwrap().next().is_none(),
+        "no files written when persistence is off",
+    );
+    cleanup(&root);
+}
+
+#[test]
+fn persist_config_from_env_disable_flag() {
+    // The disable flag wins even when the chassis votes enabled. This
+    // test mutates a process-global env var; nextest runs each test in
+    // its own process so the mutation is isolated.
+    let prev = std::env::var(aether_substrate::handle_store::ENV_PERSIST_DISABLE).ok();
+    // SAFETY: single-threaded test body; nextest isolates the process.
+    unsafe {
+        std::env::set_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE, "1");
+    }
+    assert!(
+        PersistConfig::from_env(true).is_none(),
+        "disable flag forces None even with chassis vote true",
+    );
+    // Chassis vote false is always None.
+    assert!(PersistConfig::from_env(false).is_none());
+    // SAFETY: restore.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE, v),
+            None => std::env::remove_var(aether_substrate::handle_store::ENV_PERSIST_DISABLE),
+        }
+    }
+}
+
+#[test]
+fn persist_continues_on_write_failure() {
+    // Point the config root at a path whose parent is a regular file,
+    // so create_dir_all fails and the disk write errors. The in-memory
+    // entry must still succeed (best-effort persistence, ADR-0049 §3).
+    let root = scratch_root("write-fail");
+    // Make `root/v1` collide with a file so entries/ can't be created
+    // under it.
+    let blocker = root.join("v1");
+    fs::write(&blocker, b"not-a-dir").unwrap();
+    let cfg = PersistConfig { root: blocker };
+    let store = HandleStore::with_persist(1024 * 1024, Some(cfg));
+
+    let id = HandleId(0x55);
+    // Does NOT return an error — the put succeeds, the disk write warns.
+    store
+        .put_persistent(id, KindId(1), b"payload".to_vec(), None)
+        .unwrap();
+    assert!(store.contains(id), "in-memory entry survives disk failure");
+
+    cleanup(&root);
+}

--- a/crates/aether-substrate/tests/handle_store_restore.rs
+++ b/crates/aether-substrate/tests/handle_store_restore.rs
@@ -48,6 +48,8 @@ fn cleanup(path: &Path) {
 fn cfg_under(root: &Path) -> PersistConfig {
     PersistConfig {
         root: root.join("v1"),
+        disk_budget_bytes: u64::MAX,
+        eviction_tick_secs: 60,
     }
 }
 

--- a/crates/aether-substrate/tests/handle_store_restore.rs
+++ b/crates/aether-substrate/tests/handle_store_restore.rs
@@ -19,8 +19,10 @@
     reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
 )]
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -31,12 +33,12 @@ use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
 static NONCE: AtomicU64 = AtomicU64::new(0);
 
 fn scratch_root(tag: &str) -> PathBuf {
-    let pid = std::process::id();
+    let pid = process::id();
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
     let n = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("aether-handle-restore-{tag}-{pid}-{millis}-{n}"));
+    let path = env::temp_dir().join(format!("aether-handle-restore-{tag}-{pid}-{millis}-{n}"));
     fs::create_dir_all(&path).expect("test setup: scratch dir creates");
     path
 }
@@ -78,7 +80,7 @@ fn restore_boot_scan_populates_index() {
         let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
         for i in 0..100u64 {
             store
-                .put_persistent(HandleId(i + 1), KindId(7), vec![i as u8; 16], None)
+                .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 16], None)
                 .unwrap();
         }
     }
@@ -172,7 +174,9 @@ fn restore_pinned_set_loads() {
         let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
         for i in 0..5u64 {
             let id = HandleId(i + 1);
-            store.put_persistent(id, KindId(7), vec![1u8; 8], None).unwrap();
+            store
+                .put_persistent(id, KindId(7), vec![1u8; 8], None)
+                .unwrap();
             store.pin(id);
         }
     }
@@ -219,7 +223,9 @@ fn restore_corrupt_bin_falls_back_to_miss() {
     let id = HandleId(0x30);
     {
         let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
-        store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+        store
+            .put_persistent(id, KindId(1), b"x".to_vec(), None)
+            .unwrap();
     }
     let restored = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
     assert_eq!(restored.disk_index_len(), 1);

--- a/crates/aether-substrate/tests/handle_store_restore.rs
+++ b/crates/aether-substrate/tests/handle_store_restore.rs
@@ -1,0 +1,230 @@
+//! Issue #985: lazy restore on cache miss + boot scan (ADR-0049 §3).
+//!
+//! The on-disk tree is truth; the in-memory store is a hot cache. A
+//! restart populates a sparse disk index from the `.meta` sidecars
+//! without eagerly loading bytes; a cache-miss `get` materializes the
+//! bytes lazily. Orphan handling + negative-cache behaviour pin the
+//! correctness contract.
+//!
+//! The DAG-level cache-hit-after-restart guarantee from the plan
+//! (`restore_dag_transform_cache_hit_after_restart`) is expressed at the
+//! store surface here (`restore_resolves_cached_handle`,
+//! `restore_does_not_eagerly_load_bytes`): the DAG executor + transform
+//! machinery (ADR-0048 Phase 3) isn't yet in the workspace, so the
+//! store-reconstruction round trip is the available expression of the
+//! same "skip recompute, hit the disk cache after restart" guarantee.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_data::{HandleId, KindId};
+use aether_substrate::handle_store::meta::{HandleMeta, SCHEMA_VERSION};
+use aether_substrate::handle_store::{HandleStore, PersistConfig, entry_paths};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("aether-handle-restore-{tag}-{pid}-{millis}-{n}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn cfg_under(root: &Path) -> PersistConfig {
+    PersistConfig {
+        root: root.join("v1"),
+    }
+}
+
+/// Hand-write a `.meta` sidecar (used by orphan tests).
+fn write_meta(cfg: &PersistConfig, id: HandleId, kind: KindId, bytes_len: u32) {
+    let (_, meta_path) = entry_paths(&cfg.root, id);
+    fs::create_dir_all(meta_path.parent().unwrap()).unwrap();
+    let meta = HandleMeta {
+        schema_version: SCHEMA_VERSION,
+        handle_id: id.0,
+        kind_id: kind.0,
+        transform_origin: None,
+        bytes_len,
+        created_at: 1,
+        pinned: false,
+    };
+    fs::write(&meta_path, postcard::to_allocvec(&meta).unwrap()).unwrap();
+}
+
+#[test]
+fn restore_boot_scan_populates_index() {
+    let root = scratch_root("scan");
+    let cfg = cfg_under(&root);
+    {
+        let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        for i in 0..100u64 {
+            store
+                .put_persistent(HandleId(i + 1), KindId(7), vec![i as u8; 16], None)
+                .unwrap();
+        }
+    }
+    let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+    assert_eq!(restored.disk_index_len(), 100);
+    cleanup(&root);
+}
+
+#[test]
+fn restore_resolves_cached_handle() {
+    let root = scratch_root("resolve");
+    let cfg = cfg_under(&root);
+    let id = HandleId(0xABCD);
+    let kind = KindId(0x1234);
+    let bytes = b"persisted-payload".to_vec();
+    {
+        let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        store.put_persistent(id, kind, bytes.clone(), None).unwrap();
+    }
+    let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+    // Not in memory until accessed.
+    assert!(!restored.contains_in_memory(id));
+    let (got_kind, got_bytes) = restored.get(id).expect("resolves from disk");
+    assert_eq!(got_kind, kind);
+    assert_eq!(got_bytes, bytes);
+    // Now materialized in memory.
+    assert!(restored.contains_in_memory(id));
+    cleanup(&root);
+}
+
+#[test]
+fn restore_does_not_eagerly_load_bytes() {
+    let root = scratch_root("lazy");
+    let cfg = cfg_under(&root);
+    {
+        let store = HandleStore::with_persist(256 * 1024 * 1024, Some(cfg.clone()));
+        for i in 0..1000u64 {
+            // 1KB each = 1MB total; the point is "indexed, not loaded".
+            store
+                .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 1024], None)
+                .unwrap();
+        }
+    }
+    let restored = HandleStore::with_persist(256 * 1024 * 1024, Some(cfg));
+    assert_eq!(restored.disk_index_len(), 1000);
+    // No bytes eagerly loaded into memory.
+    assert_eq!(restored.entry_count(), 0);
+    assert_eq!(restored.total_bytes(), 0);
+    cleanup(&root);
+}
+
+#[test]
+fn restore_handles_orphan_bin_without_meta() {
+    let root = scratch_root("orphan-bin");
+    let cfg = cfg_under(&root);
+    let id = HandleId(0x10);
+    let (bin_path, _) = entry_paths(&cfg.root, id);
+    fs::create_dir_all(bin_path.parent().unwrap()).unwrap();
+    fs::write(&bin_path, b"orphan").unwrap();
+
+    let restored = HandleStore::with_persist(64 * 1024, Some(cfg));
+    // Orphan bin not indexed (the meta is the index entry).
+    assert_eq!(restored.disk_index_len(), 0);
+    // And the boot scrub removed it.
+    assert!(!bin_path.exists(), "orphan bin scrubbed");
+    cleanup(&root);
+}
+
+#[test]
+fn restore_handles_orphan_meta_without_bin() {
+    let root = scratch_root("orphan-meta");
+    let cfg = cfg_under(&root);
+    let id = HandleId(0x20);
+    write_meta(&cfg, id, KindId(1), 8);
+    let (_, meta_path) = entry_paths(&cfg.root, id);
+    assert!(meta_path.exists());
+
+    let restored = HandleStore::with_persist(64 * 1024, Some(cfg));
+    // Orphan meta scrubbed; get returns None.
+    assert!(restored.get(id).is_none());
+    assert_eq!(restored.disk_index_len(), 0);
+    assert!(!meta_path.exists(), "orphan meta scrubbed");
+    cleanup(&root);
+}
+
+#[test]
+fn restore_pinned_set_loads() {
+    let root = scratch_root("pinned-loads");
+    let cfg = cfg_under(&root);
+    {
+        let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        for i in 0..5u64 {
+            let id = HandleId(i + 1);
+            store.put_persistent(id, KindId(7), vec![1u8; 8], None).unwrap();
+            store.pin(id);
+        }
+    }
+    let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+    // The 5 pinned ids materialize as pinned (proof: get them and they
+    // carry the pinned flag through to in-memory).
+    for i in 0..5u64 {
+        let id = HandleId(i + 1);
+        assert!(restored.contains(id), "id {i} indexed");
+        // Materialize, then assert it survives byte-pressure (pinned).
+        let _ = restored.get(id);
+    }
+    assert_eq!(restored.disk_index_len(), 5);
+    cleanup(&root);
+}
+
+#[test]
+fn restore_negative_cache_prevents_restat() {
+    // An unknown id (not in the index) hits the negative path. Repeated
+    // gets must not re-stat (the index has no entry, so lookup_from_disk
+    // returns None without ever touching the filesystem). This test
+    // pins the "no index entry => no fs op" contract.
+    let root = scratch_root("neg-cache");
+    let cfg = cfg_under(&root);
+    // Empty store (entries/ doesn't even exist).
+    let store = HandleStore::with_persist(64 * 1024, Some(cfg));
+    let unknown = HandleId(0xDEAD);
+    for _ in 0..100 {
+        assert!(store.get(unknown).is_none());
+    }
+    // No index entry means no fs stat per lookup — the absence of a
+    // panic / hang is the assertion; correctness is "always None".
+    assert!(!store.contains(unknown));
+    cleanup(&root);
+}
+
+#[test]
+fn restore_corrupt_bin_falls_back_to_miss() {
+    // Index says the entry is on disk, but the .bin is missing
+    // (corruption after the boot scan). get() drops the index entry,
+    // negatively caches, and returns None.
+    let root = scratch_root("corrupt-bin");
+    let cfg = cfg_under(&root);
+    let id = HandleId(0x30);
+    {
+        let store = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+        store.put_persistent(id, KindId(1), b"x".to_vec(), None).unwrap();
+    }
+    let restored = HandleStore::with_persist(64 * 1024, Some(cfg.clone()));
+    assert_eq!(restored.disk_index_len(), 1);
+    // Delete the .bin out from under the index.
+    let (bin_path, _) = entry_paths(&cfg.root, id);
+    fs::remove_file(&bin_path).unwrap();
+    // First get: index hit, read fails, drops the index entry.
+    assert!(restored.get(id).is_none());
+    assert!(!restored.contains(id), "index entry dropped on corruption");
+    cleanup(&root);
+}

--- a/crates/aether-substrate/tests/handle_store_restore.rs
+++ b/crates/aether-substrate/tests/handle_store_restore.rs
@@ -61,6 +61,7 @@ fn write_meta(cfg: &PersistConfig, id: HandleId, kind: KindId, bytes_len: u32) {
         schema_version: SCHEMA_VERSION,
         handle_id: id.0,
         kind_id: kind.0,
+        kind_name: "test.kind".to_owned(),
         transform_origin: None,
         bytes_len,
         created_at: 1,

--- a/crates/aether-substrate/tests/handle_store_schema_evolution.rs
+++ b/crates/aether-substrate/tests/handle_store_schema_evolution.rs
@@ -1,0 +1,198 @@
+//! Issue #988: schema-evolution invalidation via kind_id (ADR-0049 §6).
+//!
+//! On restore, the boot scan compares each entry's `meta.kind_id`
+//! against the current registry's id for the same `kind_name`. A
+//! mismatch (schema changed), a missing name (kind retired), or an
+//! unsupported `schema_version` invalidates the entry: both files are
+//! deleted and it's treated as a cache miss. The invalidation overrides
+//! pin — schema-stale bytes are unsafe to decode, so a pinned entry is
+//! still evicted on mismatch.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic-on-failure is the assertion"
+)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_data::{HandleId, KindId};
+use aether_substrate::handle_store::meta::{HandleMeta, TransformOrigin};
+use aether_substrate::handle_store::{HandleStore, KindResolver, PersistConfig, entry_paths};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("aether-handle-schema-{tag}-{pid}-{millis}-{n}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn cfg_under(root: &Path) -> PersistConfig {
+    PersistConfig {
+        root: root.join("v1"),
+        disk_budget_bytes: u64::MAX,
+        eviction_tick_secs: 60,
+    }
+}
+
+/// A synthetic kind registry: bidirectional name <-> id, for driving
+/// the schema-evolution check without standing up a real `Registry`.
+struct FakeRegistry {
+    by_name: HashMap<String, KindId>,
+    by_id: HashMap<KindId, String>,
+}
+
+impl FakeRegistry {
+    fn new(entries: &[(&str, u64)]) -> Self {
+        let mut by_name = HashMap::new();
+        let mut by_id = HashMap::new();
+        for (name, id) in entries {
+            by_name.insert((*name).to_owned(), KindId(*id));
+            by_id.insert(KindId(*id), (*name).to_owned());
+        }
+        Self { by_name, by_id }
+    }
+}
+
+impl KindResolver for FakeRegistry {
+    fn id_for_name(&self, name: &str) -> Option<KindId> {
+        self.by_name.get(name).copied()
+    }
+    fn name_for_id(&self, id: KindId) -> Option<String> {
+        self.by_id.get(&id).cloned()
+    }
+}
+
+fn store_with(cfg: &PersistConfig, registry: &[(&str, u64)]) -> HandleStore {
+    let resolver: Arc<dyn KindResolver> = Arc::new(FakeRegistry::new(registry));
+    HandleStore::with_persist_validated(64 * 1024 * 1024, Some(cfg.clone()), Some(resolver))
+}
+
+#[test]
+fn schema_evolution_evicts_changed_kind_id() {
+    let root = scratch_root("changed");
+    let cfg = cfg_under(&root);
+    let id = HandleId(1);
+    {
+        // Write under kind "demo.kind" = 0xAAAA.
+        let store = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+        store
+            .put_persistent(id, KindId(0xAAAA), b"bytes".to_vec(), None)
+            .unwrap();
+    }
+    // Restart with the registry returning 0xBBBB for the same name.
+    let restored = store_with(&cfg, &[("demo.kind", 0xBBBB)]);
+    assert_eq!(restored.disk_index_len(), 0, "stale entry dropped");
+    let (bin, meta) = entry_paths(&cfg.root, id);
+    assert!(!bin.exists() && !meta.exists(), "both files deleted");
+    cleanup(&root);
+}
+
+#[test]
+fn schema_evolution_evicts_retired_kind() {
+    let root = scratch_root("retired");
+    let cfg = cfg_under(&root);
+    let id = HandleId(2);
+    {
+        let store = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+        store
+            .put_persistent(id, KindId(0xAAAA), b"bytes".to_vec(), None)
+            .unwrap();
+    }
+    // Restart with an empty registry — kind retired.
+    let restored = store_with(&cfg, &[]);
+    assert_eq!(restored.disk_index_len(), 0, "retired-kind entry dropped");
+    let (bin, meta) = entry_paths(&cfg.root, id);
+    assert!(!bin.exists() && !meta.exists());
+    cleanup(&root);
+}
+
+#[test]
+fn schema_evolution_keeps_matching_kind() {
+    let root = scratch_root("match");
+    let cfg = cfg_under(&root);
+    let id = HandleId(3);
+    {
+        let store = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+        store
+            .put_persistent(id, KindId(0xAAAA), b"bytes".to_vec(), None)
+            .unwrap();
+    }
+    // Restart with the same id — entry survives.
+    let restored = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+    assert_eq!(restored.disk_index_len(), 1, "matching entry kept");
+    assert_eq!(restored.get(id).map(|(_, b)| b), Some(b"bytes".to_vec()));
+    cleanup(&root);
+}
+
+#[test]
+fn schema_evolution_evicts_old_schema_version() {
+    let root = scratch_root("old-version");
+    let cfg = cfg_under(&root);
+    let id = HandleId(4);
+    // Hand-craft a schema_version = 1 meta + a bin (a pre-v2 entry).
+    let (bin, meta_path) = entry_paths(&cfg.root, id);
+    fs::create_dir_all(bin.parent().unwrap()).unwrap();
+    fs::write(&bin, b"legacy").unwrap();
+    // postcard-encode a meta that claims version 1. We build the
+    // current struct and overwrite the leading version byte: the
+    // schema_version is the first field, encoded as a single byte.
+    let meta = HandleMeta {
+        schema_version: 1,
+        handle_id: id.0,
+        kind_id: 0xAAAA,
+        kind_name: "demo.kind".to_owned(),
+        transform_origin: None,
+        bytes_len: 6,
+        created_at: 1,
+        pinned: false,
+    };
+    fs::write(&meta_path, postcard::to_allocvec(&meta).unwrap()).unwrap();
+
+    let restored = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+    assert_eq!(restored.disk_index_len(), 0, "version-1 entry evicted");
+    assert!(!bin.exists() && !meta_path.exists());
+    cleanup(&root);
+}
+
+#[test]
+fn schema_evolution_pinned_entry_still_invalidates() {
+    // Contract (ADR-0049 §6): pin protects against budget pressure, not
+    // against schema-mismatch correctness eviction. A pinned entry whose
+    // kind id changed is still evicted.
+    let root = scratch_root("pinned-invalidates");
+    let cfg = cfg_under(&root);
+    let id = HandleId(5);
+    {
+        let store = store_with(&cfg, &[("demo.kind", 0xAAAA)]);
+        let origin = TransformOrigin {
+            component_mailbox: 1,
+            transform_index: 0,
+            input_handle_ids: vec![],
+        };
+        store
+            .put_persistent(id, KindId(0xAAAA), b"bytes".to_vec(), Some(origin))
+            .unwrap();
+        store.pin(id);
+    }
+    // Restart with a changed id — the pinned entry is still evicted.
+    let restored = store_with(&cfg, &[("demo.kind", 0xBBBB)]);
+    assert_eq!(restored.disk_index_len(), 0, "pinned-but-stale entry dropped");
+    let (bin, meta) = entry_paths(&cfg.root, id);
+    assert!(!bin.exists() && !meta.exists());
+    cleanup(&root);
+}

--- a/crates/aether-substrate/tests/handle_store_schema_evolution.rs
+++ b/crates/aether-substrate/tests/handle_store_schema_evolution.rs
@@ -1,4 +1,4 @@
-//! Issue #988: schema-evolution invalidation via kind_id (ADR-0049 §6).
+//! Issue #988: schema-evolution invalidation via `kind_id` (ADR-0049 §6).
 //!
 //! On restore, the boot scan compares each entry's `meta.kind_id`
 //! against the current registry's id for the same `kind_name`. A
@@ -14,8 +14,10 @@
 )]
 
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -27,12 +29,12 @@ use aether_substrate::handle_store::{HandleStore, KindResolver, PersistConfig, e
 static NONCE: AtomicU64 = AtomicU64::new(0);
 
 fn scratch_root(tag: &str) -> PathBuf {
-    let pid = std::process::id();
+    let pid = process::id();
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
     let n = NONCE.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("aether-handle-schema-{tag}-{pid}-{millis}-{n}"));
+    let path = env::temp_dir().join(format!("aether-handle-schema-{tag}-{pid}-{millis}-{n}"));
     fs::create_dir_all(&path).expect("test setup: scratch dir creates");
     path
 }
@@ -191,7 +193,11 @@ fn schema_evolution_pinned_entry_still_invalidates() {
     }
     // Restart with a changed id — the pinned entry is still evicted.
     let restored = store_with(&cfg, &[("demo.kind", 0xBBBB)]);
-    assert_eq!(restored.disk_index_len(), 0, "pinned-but-stale entry dropped");
+    assert_eq!(
+        restored.disk_index_len(),
+        0,
+        "pinned-but-stale entry dropped"
+    );
     let (bin, meta) = entry_paths(&cfg.root, id);
     assert!(!bin.exists() && !meta.exists());
     cleanup(&root);


### PR DESCRIPTION
## Summary

Phase 4 / ADR-0049: extends the in-memory handle store (ADR-0045) with on-disk persistence so content-addressed and pinned handles survive a substrate restart. Built as five stacked units on one branch; desktop + headless enable persistence, hub stays in-memory-only.

- **on-disk layout + atomic write path** (issue 984): `put_persistent` mirrors the in-memory write to a sharded `v1/entries/<hash[0:2]>/<hash[2:]>.{bin,meta}` tree via atomic tmp+rename (fsync before rename). New `handle_store::meta` module holds the postcard `HandleMeta` sidecar + `TransformOrigin`. pin/unpin rewrite `pinned.set`. Best-effort: a disk failure logs and leaves the in-memory entry valid.
- **lazy restore on cache miss + boot scan** (issue 985): the on-disk tree is truth, the in-memory store is a hot cache. Boot scan builds a sparse `disk_index` from the `.meta` sidecars without eagerly loading bytes; a boot scrub clears orphan `.bin` / `.meta` / leftover tmp files. `get` falls through to disk on an in-memory miss, with an 8K FIFO negative cache.
- **disk eviction by created_at-lru** (issue 986): an approximate byte ledger + a background tick (default 60s, `Weak`-held thread) drop refcount-0 + unpinned entries oldest-first via two-phase delete once over `AETHER_HANDLE_STORE_DISK_BUDGET_BYTES` (default 16GiB).
- **lockfile + describe_handles MCP tool** (issue 987): `lock.pid` with a `kill(pid, 0)` liveness check (Unix) aborts boot on a live conflict and reclaims a stale lock; a `LockGuard` deletes it on graceful shutdown. New `aether.handle.describe` kind pair + `on_describe` handler + `mcp__aether-hub__describe_handles` tool surfacing entry counts, bytes vs budget, pinned count, and top-N by size + recency.
- **schema-evolution invalidation via kind_id** (issue 988): revises `HandleMeta` to add `kind_name` and bump `schema_version` to 2; the boot scan compares `meta.kind_id` against the current registry's id for the same name and drops a changed / retired / version-skewed entry (treated as a cache miss). Invalidation overrides pin — stale bytes are unsafe to decode.

Env vars: `AETHER_HANDLE_STORE_DIR`, `AETHER_HANDLE_STORE_PERSIST_DISABLE`, `AETHER_HANDLE_STORE_DISK_BUDGET_BYTES`, `AETHER_HANDLE_STORE_DISK_EVICTION_TICK_SECS`.

Note: the issue-985 plan's `restore_dag_transform_cache_hit_after_restart` fixture is expressed at the store surface (store-reconstruction round trip) because the DAG executor + transform machinery (ADR-0048 Phase 3) isn't yet in the workspace; the same after-restart cache-hit guarantee is covered.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps` (rustdoc lints denied)
- [x] wasm32 component cross-build (per-package)
- [x] `cargo nextest run --workspace --all-features --profile ci` — 1056 passed
- [x] new integration suites: `handle_store_persistence`, `handle_store_restore`, `handle_store_disk_eviction`, `handle_store_lockfile`, `handle_store_schema_evolution`, plus cap + MCP tool tests

Closes iamacoffeepot/aether#984
Closes iamacoffeepot/aether#985
Closes iamacoffeepot/aether#986
Closes iamacoffeepot/aether#987
Closes iamacoffeepot/aether#988

🤖 Generated with [Claude Code](https://claude.com/claude-code)