### PR TITLE
feat(mcp): actor_logs names unknown mailbox in error

### DIFF
--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -497,7 +497,15 @@ impl Mcp {
                 };
                 json(&response)
             }
-            Some(aether_kinds::LogTailResult::Err { error }) => Err(internal_msg(&error)),
+            // Issue 963: name the agent-supplied mailbox in the error
+            // so an `actor_logs` against an unregistered mailbox (which
+            // the substrate now answers with a synthesized
+            // `LogTailResult::Err`, mailer.rs `None` arm) reads as
+            // "that mailbox doesn't exist" rather than a bare relayed
+            // substrate string.
+            Some(aether_kinds::LogTailResult::Err { error }) => {
+                Err(internal_msg(&actor_logs_err_message(&mailbox_name, &error)))
+            }
             None => Err(internal_msg("undecodable LogTailResult")),
         }
     }
@@ -705,6 +713,15 @@ fn internal(e: anyhow::Error) -> McpError {
 
 fn internal_msg(msg: &str) -> McpError {
     McpError::internal_error(msg.to_owned(), None)
+}
+
+/// Issue 963: render an `actor_logs` `LogTailResult::Err` into a
+/// tool-error message that names the agent-supplied mailbox, so an
+/// unregistered-mailbox query reads as "that mailbox doesn't exist"
+/// rather than a bare relayed substrate string. Factored out so the
+/// formatting is unit-testable without standing up a live engine.
+fn actor_logs_err_message(mailbox_name: &str, error: &str) -> String {
+    format!("actor_logs: mailbox \"{mailbox_name}\" — {error}")
 }
 
 /// Map ADR-0023 §4's level string to the `0..=4` byte the
@@ -1090,6 +1107,19 @@ mod tests {
             result.is_err(),
             "a malformed engine_id should be a tool error"
         );
+    }
+
+    /// Issue 963: the `LogTailResult::Err` arm names the agent-
+    /// supplied mailbox in the tool error. A live engine isn't needed
+    /// to inject a decoded `Err` — pin the formatting at the call
+    /// site's helper instead (the substrate-side synthesized-Err
+    /// routing is covered in `aether-substrate`'s mailer tests).
+    #[test]
+    fn actor_logs_err_message_names_mailbox() {
+        let msg =
+            actor_logs_err_message("aether.nope", "mailbox mbx-0000-0000-0000 not registered");
+        assert!(msg.contains("aether.nope"), "names the mailbox: {msg}");
+        assert!(msg.contains("not registered"), "carries the cause: {msg}");
     }
 
     /// `actor_logs` with an unknown `level` string is rejected at

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -814,11 +814,9 @@ mod tests {
 
         let unknown = MailboxId(0xDEAD_BEEF_u64);
         // Arbitrary non-`LogTail` kind id — the reply branch must not fire.
-        mailer.push(
-            Mail::new(unknown, KindId(0xABCD), vec![], 1).with_reply_to(
-                ReplyTo::with_correlation(ReplyTarget::Component(recorder_id), 0xCAFE),
-            ),
-        );
+        mailer.push(Mail::new(unknown, KindId(0xABCD), vec![], 1).with_reply_to(
+            ReplyTo::with_correlation(ReplyTarget::Component(recorder_id), 0xCAFE),
+        ));
 
         assert!(
             recorded.read().unwrap().is_empty(),

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -737,6 +737,32 @@ mod tests {
         // No panic is the test; the warn path logs and returns.
     }
 
+    /// Issue 963: recorder capture row — `(kind, correlation, payload)`
+    /// for each reply a stand-in RPC-server mailbox receives. Aliased
+    /// to keep the `Arc<RwLock<Vec<...>>>` off the `type_complexity`
+    /// lint at the two recorder sites below.
+    type RecordedReplies = Arc<RwLock<Vec<(KindId, u64, Vec<u8>)>>>;
+
+    /// Register an inline mailbox that records each reply's kind,
+    /// correlation, and payload — a stand-in for the RPC-server reply
+    /// target the MCP Call's `Component` reply hop lands at. Returns
+    /// the recorder's `MailboxId` plus the shared capture buffer.
+    fn record_inline(registry: &Registry) -> (MailboxId, RecordedReplies) {
+        let recorded: RecordedReplies = Arc::new(RwLock::new(Vec::new()));
+        let recorded_for_handler = Arc::clone(&recorded);
+        let recorder_id = registry.register_inline(
+            "test.rpc_server_reply",
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                recorded_for_handler.write().unwrap().push((
+                    dispatch.kind,
+                    dispatch.sender.correlation_id,
+                    dispatch.payload.to_vec(),
+                ));
+            }),
+        );
+        (recorder_id, recorded)
+    }
+
     /// Issue 963: `aether.log.tail` to an unregistered mailbox (no
     /// outbound) synthesizes a `LogTailResult::Err` reply routed back
     /// to the inbound's `Component` reply target instead of warn-
@@ -752,20 +778,7 @@ mod tests {
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Mailer::new(Arc::clone(&registry), store);
 
-        // Recording stand-in for the RPC-server reply target: capture
-        // each reply's kind, correlation, and payload.
-        let recorded: Arc<RwLock<Vec<(KindId, u64, Vec<u8>)>>> = Arc::new(RwLock::new(Vec::new()));
-        let recorded_for_handler = Arc::clone(&recorded);
-        let recorder_id = registry.register_inline(
-            "test.rpc_server_reply",
-            Arc::new(move |dispatch: MailDispatch<'_>| {
-                recorded_for_handler.write().unwrap().push((
-                    dispatch.kind,
-                    dispatch.sender.correlation_id,
-                    dispatch.payload.to_vec(),
-                ));
-            }),
-        );
+        let (recorder_id, recorded) = record_inline(&registry);
 
         let unknown = MailboxId(0xDEAD_BEEF_u64);
         mailer.push(
@@ -784,7 +797,9 @@ mod tests {
                 error.contains(&unknown.to_string()),
                 "error names the recipient id: {error}",
             ),
-            other => panic!("expected LogTailResult::Err, got {other:?}"),
+            other @ LogTailResult::Ok { .. } => {
+                panic!("expected LogTailResult::Err, got {other:?}")
+            }
         }
     }
 
@@ -799,18 +814,7 @@ mod tests {
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Mailer::new(Arc::clone(&registry), store);
 
-        let recorded: Arc<RwLock<Vec<(KindId, u64, Vec<u8>)>>> = Arc::new(RwLock::new(Vec::new()));
-        let recorded_for_handler = Arc::clone(&recorded);
-        let recorder_id = registry.register_inline(
-            "test.rpc_server_reply",
-            Arc::new(move |dispatch: MailDispatch<'_>| {
-                recorded_for_handler.write().unwrap().push((
-                    dispatch.kind,
-                    dispatch.sender.correlation_id,
-                    dispatch.payload.to_vec(),
-                ));
-            }),
-        );
+        let (recorder_id, recorded) = record_inline(&registry);
 
         let unknown = MailboxId(0xDEAD_BEEF_u64);
         // Arbitrary non-`LogTail` kind id — the reply branch must not fire.

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -606,6 +606,48 @@ fn route_mail(
                 trace_handle.record_finished(inbound_mail_id);
                 return;
             }
+            // Issue 963: `aether.log.tail` (`actor_logs`) to an
+            // unresolved mailbox synthesizes a `LogTailResult::Err`
+            // reply instead of silently warn-dropping, so the MCP
+            // caller's `call_one` sees one `ReplyEvent` (a clean "that
+            // mailbox doesn't exist" signal) rather than `got 0
+            // replies`. Narrow per-kind treatment (Option B) — the
+            // general `aether.mail.unresolved` reply for every
+            // reply-expecting kind is parked (Option C, lib.rs:86).
+            // Only the `Component` reply target (the path the MCP Call
+            // takes via `RpcServerCapability::handle_call`) is routed;
+            // `Session`/`EngineMailbox` targets fall through to the
+            // warn-drop, keeping the blast radius minimal.
+            if mail.kind.0 == <aether_kinds::LogTail as aether_data::Kind>::ID.0 {
+                let err = aether_kinds::LogTailResult::Err {
+                    error: format!("mailbox {recipient} not registered on engine"),
+                };
+                if let Ok(payload) = postcard::to_allocvec(&err)
+                    && let ReplyTarget::Component(target) = mail.reply_to.target
+                {
+                    let reply_to =
+                        ReplyTo::with_correlation(ReplyTarget::None, mail.reply_to.correlation_id);
+                    route_mail(
+                        Mail::new(
+                            target,
+                            <aether_kinds::LogTailResult as aether_data::Kind>::ID,
+                            payload,
+                            1,
+                        )
+                        .with_reply_to(reply_to),
+                        registry,
+                        outbound,
+                        store,
+                        chassis_router,
+                        trace_handle,
+                    );
+                }
+                // The synthesized reply is a fresh un-lineaged mail
+                // (`MailId::NONE`); the inbound still records `Finished`
+                // so its settlement chain balances (issue 838).
+                trace_handle.record_finished(inbound_mail_id);
+                return;
+            }
             tracing::warn!(
                 target: "aether_substrate::queue",
                 mailbox = %recipient,
@@ -693,6 +735,95 @@ mod tests {
         let unknown = MailboxId(0xDEAD_BEEF_u64);
         mailer.push(Mail::new(unknown, KindId(0xABCD), vec![], 0));
         // No panic is the test; the warn path logs and returns.
+    }
+
+    /// Issue 963: `aether.log.tail` to an unregistered mailbox (no
+    /// outbound) synthesizes a `LogTailResult::Err` reply routed back
+    /// to the inbound's `Component` reply target instead of warn-
+    /// dropping. Stands in the RPC-server reply mailbox with a
+    /// recording inline handler; asserts exactly one reply of kind
+    /// `LogTailResult::ID`, decoding to `Err { error }` naming the
+    /// recipient id, with the correlation echoed.
+    #[test]
+    fn unknown_mailbox_log_tail_synthesizes_err_reply() {
+        use aether_kinds::{LogTail, LogTailResult};
+
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(64 * 1024));
+        let mailer = Mailer::new(Arc::clone(&registry), store);
+
+        // Recording stand-in for the RPC-server reply target: capture
+        // each reply's kind, correlation, and payload.
+        let recorded: Arc<RwLock<Vec<(KindId, u64, Vec<u8>)>>> = Arc::new(RwLock::new(Vec::new()));
+        let recorded_for_handler = Arc::clone(&recorded);
+        let recorder_id = registry.register_inline(
+            "test.rpc_server_reply",
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                recorded_for_handler.write().unwrap().push((
+                    dispatch.kind,
+                    dispatch.sender.correlation_id,
+                    dispatch.payload.to_vec(),
+                ));
+            }),
+        );
+
+        let unknown = MailboxId(0xDEAD_BEEF_u64);
+        mailer.push(
+            Mail::new(unknown, <LogTail as Kind>::ID, vec![], 1).with_reply_to(
+                ReplyTo::with_correlation(ReplyTarget::Component(recorder_id), 0xCAFE),
+            ),
+        );
+
+        let recorded = recorded.read().unwrap();
+        assert_eq!(recorded.len(), 1, "exactly one synthesized reply");
+        let (kind, correlation, payload) = &recorded[0];
+        assert_eq!(*kind, <LogTailResult as Kind>::ID);
+        assert_eq!(*correlation, 0xCAFE, "correlation echoed onto the reply");
+        match postcard::from_bytes::<LogTailResult>(payload).unwrap() {
+            LogTailResult::Err { error } => assert!(
+                error.contains(&unknown.to_string()),
+                "error names the recipient id: {error}",
+            ),
+            other => panic!("expected LogTailResult::Err, got {other:?}"),
+        }
+    }
+
+    /// Issue 963: the synthesized-Err branch is narrow — a non-
+    /// `LogTail` kind to an unregistered mailbox still warn-drops with
+    /// no reply, even with a live `Component` reply target. Pins the
+    /// scope so the change doesn't start replying for every kind
+    /// (Option B, not Option C).
+    #[test]
+    fn unknown_mailbox_non_log_tail_still_warn_drops() {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(64 * 1024));
+        let mailer = Mailer::new(Arc::clone(&registry), store);
+
+        let recorded: Arc<RwLock<Vec<(KindId, u64, Vec<u8>)>>> = Arc::new(RwLock::new(Vec::new()));
+        let recorded_for_handler = Arc::clone(&recorded);
+        let recorder_id = registry.register_inline(
+            "test.rpc_server_reply",
+            Arc::new(move |dispatch: MailDispatch<'_>| {
+                recorded_for_handler.write().unwrap().push((
+                    dispatch.kind,
+                    dispatch.sender.correlation_id,
+                    dispatch.payload.to_vec(),
+                ));
+            }),
+        );
+
+        let unknown = MailboxId(0xDEAD_BEEF_u64);
+        // Arbitrary non-`LogTail` kind id — the reply branch must not fire.
+        mailer.push(
+            Mail::new(unknown, KindId(0xABCD), vec![], 1).with_reply_to(
+                ReplyTo::with_correlation(ReplyTarget::Component(recorder_id), 0xCAFE),
+            ),
+        );
+
+        assert!(
+            recorded.read().unwrap().is_empty(),
+            "non-LogTail unknown-mailbox mail warn-drops with no reply",
+        );
     }
 
     // ------------------------------------------------------------


### PR DESCRIPTION
Closes iamacoffeepot/aether#963

## Summary

`actor_logs` against a mailbox that isn't registered on the engine
previously returned the opaque `expected exactly one reply event, got
0`: the substrate mail router warn-dropped the `aether.log.tail` mail at
the unresolved-recipient arm, so `RpcSession::call_one` collected zero
replies.

This implements the issue's chosen approach (Option B — narrow,
per-kind Err):

- The mail router's unresolved-recipient (`None`) arm in
  `crates/aether-substrate/src/mail/mailer.rs` now, when no
  bubble-up-to-hub fires and the kind is `LogTail`, synthesizes a
  `LogTailResult::Err` reply routed back to the inbound's `Component`
  reply target (the RPC server cap's mailbox) instead of warn-dropping.
  Every other kind still warn-drops; `Session`/`EngineMailbox` targets
  fall through. The inbound still records `Finished` so settlement
  chains balance.
- The MCP `actor_logs` tool in `crates/aether-mcp/src/tools.rs` wraps
  that Err to name the agent-supplied mailbox, so the tool error reads
  as "that mailbox doesn't exist" rather than a bare relayed string.

## Tests

- `unknown_mailbox_log_tail_synthesizes_err_reply` — unknown mailbox +
  `LogTail` routes exactly one `LogTailResult::Err` reply (kind +
  correlation echoed, error names the recipient id).
- `unknown_mailbox_non_log_tail_still_warn_drops` — pins the narrow
  scope: a non-`LogTail` kind still warn-drops with no reply.
- `actor_logs_err_message_names_mailbox` — the tool error names the
  mailbox.

## Test plan

- [x] `scripts/preflight.sh` (fmt + clippy + doc + nextest 1024/1024 +
  wasm32 cross-build) green