### PR TITLE
feat(substrate): queryable capability registry for mailbox accepted-kinds + fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ name = "aether-substrate-bundle"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-actor",
+ "aether-camera",
  "aether-capabilities",
  "aether-codec",
  "aether-data",

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1938,6 +1938,46 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         }
     });
 
+    // iamacoffeepot/aether#1037: override `NativeDispatch::__aether_capabilities`
+    // so native caps surface the same ADR-0033 receive-side capability
+    // shape (handler kinds + `#[fallback]` presence) a wasm component
+    // ships in its `aether.kinds.inputs` manifest. The native-cap-boot
+    // path reads this to populate the queryable `CapabilityRegistry`,
+    // unifying native + wasm dispatchability. Reply kinds are absent by
+    // design — handlers promise nothing about replies. The handler
+    // `doc` is dropped (the registry only needs ids + fallback flag),
+    // so this is independent of rustdoc extraction.
+    let capability_handler_entries = handlers.iter().map(|h| {
+        let kind_ty = &h.kind_ty;
+        quote! {
+            ::aether_substrate::actor::native::HandlerCapability {
+                id: <#kind_ty as ::aether_data::Kind>::ID,
+                name: <#kind_ty as ::aether_data::Kind>::NAME.to_owned(),
+                doc: ::core::option::Option::None,
+            }
+        }
+    });
+    let capability_fallback = if fallback.is_some() {
+        quote! {
+            ::core::option::Option::Some(
+                ::aether_substrate::actor::native::FallbackCapability {
+                    doc: ::core::option::Option::None,
+                },
+            )
+        }
+    } else {
+        quote! { ::core::option::Option::None }
+    };
+    let capabilities_override = quote! {
+        fn __aether_capabilities() -> ::aether_substrate::actor::native::ComponentCapabilities {
+            ::aether_substrate::actor::native::ComponentCapabilities {
+                handlers: ::std::vec![#(#capability_handler_entries),*],
+                fallback: #capability_fallback,
+                doc: ::core::option::Option::None,
+            }
+        }
+    };
+
     // Issue 552 stage 4: NativeActor + NativeDispatch + the inherent
     // handler-method impl all reach for `::aether_substrate::*` paths
     // and native-only types in their bodies. They're emitted under
@@ -1977,6 +2017,8 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             }
 
             #fallback_dispatch_override
+
+            #capabilities_override
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -113,6 +113,7 @@ mod native {
     use aether_substrate::actor::wasm::component::ComponentCtx;
     use aether_substrate::actor::wasm::kind_manifest;
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::capability::MailboxCaps;
     use aether_substrate::mail::helpers::register_or_match_all;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -313,7 +314,7 @@ mod native {
             // clears.
             self.mailer.capability_registry().register(
                 mailbox_id,
-                aether_substrate::mail::MailboxCaps::from_component_capabilities(&capabilities),
+                MailboxCaps::from_component_capabilities(&capabilities),
             );
 
             // ADR-0081 retired the chassis-pushed `ConfigureLogDrain`

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -303,7 +303,20 @@ mod native {
                 }
             };
 
-            // 6. ADR-0081 retired the chassis-pushed `ConfigureLogDrain`
+            // 6. iamacoffeepot/aether#1037: register the trampoline's
+            // ADR-0033 receive-side capabilities into the queryable
+            // `CapabilityRegistry` so the DAG validator can ask
+            // "does this mailbox accept kind K?". Same registry the
+            // native-cap-boot path populates — one source of truth for
+            // both transport flavours. `aether.component.replace`
+            // re-registers (same mailbox id); `aether.component.drop`
+            // clears.
+            self.mailer.capability_registry().register(
+                mailbox_id,
+                aether_substrate::mail::MailboxCaps::from_component_capabilities(&capabilities),
+            );
+
+            // ADR-0081 retired the chassis-pushed `ConfigureLogDrain`
             // mail. The freshly-spawned trampoline owns its own
             // `ActorLogRing` like every other actor; no drain
             // configuration is needed.

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -230,6 +230,12 @@ mod native {
                 // drops at end of scope, tearing down linear memory.
                 component.unwire();
             }
+            // iamacoffeepot/aether#1037: clear the trampoline's
+            // capabilities — the wasm is unloaded, so the mailbox now
+            // accepts nothing until a `replace` refills it. The
+            // trampoline (and its mailbox name) survives as an empty
+            // slot, but it has no accept-set while empty.
+            self.mailer.capability_registry().remove(self.mailbox);
             ctx.reply(&DropResult::Ok);
         }
 
@@ -376,6 +382,16 @@ mod native {
             }
 
             self.component = Some(new_component);
+
+            // iamacoffeepot/aether#1037: re-register the trampoline's
+            // capabilities against the post-replace handler set. The
+            // mailbox id is stable across replace (ADR-0022 §4), so
+            // `register` overwrites the prior entry — the validator
+            // sees the new accept-set immediately.
+            self.mailer.capability_registry().register(
+                self.mailbox,
+                aether_substrate::mail::MailboxCaps::from_component_capabilities(&capabilities),
+            );
 
             ReplaceResult::Ok { capabilities }
         }

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -88,6 +88,7 @@ mod native {
     use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
     use aether_substrate::actor::wasm::kind_manifest;
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::capability::MailboxCaps;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
@@ -390,7 +391,7 @@ mod native {
             // sees the new accept-set immediately.
             self.mailer.capability_registry().register(
                 self.mailbox,
-                aether_substrate::mail::MailboxCaps::from_component_capabilities(&capabilities),
+                MailboxCaps::from_component_capabilities(&capabilities),
             );
 
             ReplaceResult::Ok { capabilities }

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -81,6 +81,14 @@ ctrlc = "3"
 # module through `crate::test_bench::{visual, test_helpers}` directly
 # (post-issue-821, formerly via `aether-scenario`).
 aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }
+# iamacoffeepot/aether#1037: the cap-registry replace test swaps the
+# probe wasm for the camera wasm (a distinct handler set) and asserts
+# the registry reflects the new accept-set. `default-features = false`
+# pulls in only the camera kind types (`CameraCreate`, etc.) for their
+# `::ID`s — the `runtime` module's `export!()` FFI emission is wasm32-
+# only and inert in a host rlib anyway, but skipping it keeps the host
+# test build lean.
+aether-camera = { path = "../aether-camera", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -378,6 +378,18 @@ impl TestBench {
             .clone()
     }
 
+    /// Borrow the substrate's queryable [`CapabilityRegistry`]
+    /// (iamacoffeepot/aether#1037). The bench shares the same `Mailer`
+    /// every cap registers against, so `accepts(MailboxId, KindId)` /
+    /// `has_fallback(MailboxId)` here reflect the post-load /
+    /// post-replace / post-drop dispatchability surface. Surfaced for
+    /// integration tests that exercise the registry through a real
+    /// component-load lifecycle.
+    #[must_use]
+    pub fn capability_registry(&self) -> &Arc<aether_substrate::mail::CapabilityRegistry> {
+        self.queue.capability_registry()
+    }
+
     /// Bytes-level fire-and-settle send: resolve `recipient_name` in
     /// the registry, push `(kind, bytes)` as a chassis-root mail, and
     /// block until the dispatched chain settles (ADR-0080 §6). Backs

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -42,7 +42,7 @@ use aether_substrate::{
     EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, ReplyTarget, ReplyTo,
     SubstrateBoot,
     capture::CaptureQueue,
-    mail::{Mail, MailId, MailboxId},
+    mail::{CapabilityRegistry, Mail, MailId, MailboxId},
 };
 
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
@@ -386,7 +386,7 @@ impl TestBench {
     /// integration tests that exercise the registry through a real
     /// component-load lifecycle.
     #[must_use]
-    pub fn capability_registry(&self) -> &Arc<aether_substrate::mail::CapabilityRegistry> {
+    pub fn capability_registry(&self) -> &Arc<CapabilityRegistry> {
         self.queue.capability_registry()
     }
 

--- a/crates/aether-substrate-bundle/tests/cap_registry.rs
+++ b/crates/aether-substrate-bundle/tests/cap_registry.rs
@@ -1,0 +1,255 @@
+//! iamacoffeepot/aether#1037: the queryable capability registry,
+//! exercised through a real component-load lifecycle on a `TestBench`.
+//!
+//! Each test boots a `TestBench`, loads (and where relevant replaces /
+//! drops) a component, and asks the substrate's `CapabilityRegistry`
+//! whether a mailbox `accepts(kind)` and `has_fallback`. The registry
+//! is the prerequisite for the DAG validator's dispatchability check
+//! (iamacoffeepot/aether#975 Phase 2). The surface is input-side only —
+//! handler kinds + fallback presence; there is deliberately no
+//! reply-kind resolution.
+//!
+//! Skipped when no wgpu adapter is available or the component wasm
+//! hasn't been pre-built (same gates as the other bench integration
+//! tests). CI builds every discovered component crate and sets
+//! `AETHER_REQUIRE_RUNTIME=1` so a missing pre-build is loud.
+
+// Integration-test skip diagnostic: emit via stderr so `cargo test`
+// surfaces "skipping: ..." alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+
+use std::path::Path;
+
+use aether_actor::Actor;
+use aether_camera::CameraCreate;
+use aether_capabilities::{ComponentHostCapability, FsCapability};
+use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
+use aether_kinds::{
+    DropComponent, DropResult, LoadComponent, LoadResult, Ping, ReplaceComponent, ReplaceResult,
+    Tick, Write,
+};
+use aether_substrate_bundle::test_bench::{
+    BenchOp, TestBench,
+    test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots},
+};
+use aether_test_fixture_probe::SetRender;
+use std::env;
+use std::fs;
+
+// Pin the fixture rlib so its descriptor `inventory::submit!` entries
+// land in this test binary (mirrors `test_bench_scenario.rs`).
+#[allow(unused_imports)]
+use aether_test_fixture_probe as _;
+
+fn load_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId {
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &LoadComponent {
+                    wasm,
+                    name: Some(name.to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("load_component({name}): {error}"),
+    }
+}
+
+/// wgpu-only skip gate, mirroring `test_bench_scenario.rs`. fs-cap
+/// tests need wgpu (the bench builds a `Gpu` at boot) but not a
+/// component wasm.
+fn require_wgpu_only() -> bool {
+    if has_wgpu_adapter() {
+        return true;
+    }
+    let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+    assert!(
+        !strict,
+        "AETHER_REQUIRE_RUNTIME set but no wgpu adapter available",
+    );
+    eprintln!("skipping: no wgpu adapter available");
+    false
+}
+
+/// A freshly-loaded probe's trampoline mailbox accepts the kinds the
+/// probe declares `#[handler]`s for (`Tick`, `SetRender`) and rejects
+/// kinds it doesn't (`Ping`).
+#[test]
+fn cap_registry_reports_accepted_kinds() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_named(&mut bench, &wasm_path, "probe");
+    let caps = bench.capability_registry();
+
+    assert!(
+        caps.accepts(mbox, Tick::ID),
+        "probe should accept its declared Tick handler",
+    );
+    assert!(
+        caps.accepts(mbox, SetRender::ID),
+        "probe should accept its declared SetRender handler",
+    );
+    assert!(
+        !caps.accepts(mbox, Ping::ID),
+        "probe has no Ping handler and no fallback — must reject Ping",
+    );
+}
+
+/// The probe is a strict receiver — no `#[fallback]`. Its trampoline
+/// mailbox reports `has_fallback == false`, and a kind it doesn't
+/// handle is rejected. (The fallback==true arm of the surface is unit-
+/// tested in `aether_substrate::mail::capability`.)
+#[test]
+fn cap_registry_reports_fallback() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_named(&mut bench, &wasm_path, "strict");
+    let caps = bench.capability_registry();
+
+    assert!(
+        !caps.has_fallback(mbox),
+        "probe is a strict receiver; has_fallback must be false",
+    );
+    // No fallback ⇒ unknown kinds are rejected, not swallowed.
+    assert!(!caps.accepts(mbox, Ping::ID));
+}
+
+/// `aether.component.replace` swaps the probe wasm for the camera wasm
+/// (a distinct handler set). The registry reflects the post-replace
+/// accept-set at the same mailbox id (stable across replace per
+/// ADR-0022): `SetRender` flips accepted→rejected, `CameraCreate` flips
+/// rejected→accepted.
+#[test]
+fn cap_registry_updates_on_replace() {
+    let Some(probe_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let Some(camera_path) = require_runtime("aether_camera") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_named(&mut bench, &probe_path, "swappable");
+
+    // Pre-replace: probe accepts SetRender, rejects CameraCreate.
+    {
+        let caps = bench.capability_registry();
+        assert!(caps.accepts(mbox, SetRender::ID));
+        assert!(!caps.accepts(mbox, CameraCreate::ID));
+    }
+
+    let camera_wasm = fs::read(&camera_path).expect("read camera wasm");
+    let swapped = bench
+        .execute(vec![(
+            "swap",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &ReplaceComponent {
+                    mailbox_id: mbox,
+                    wasm: camera_wasm,
+                    drain_timeout_ms: None,
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match swapped
+        .reply::<ReplaceResult>("swap")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace_component: {error}"),
+    }
+
+    // Post-replace: the camera's accept-set wins.
+    let caps = bench.capability_registry();
+    assert!(
+        caps.accepts(mbox, CameraCreate::ID),
+        "camera should accept its declared CameraCreate handler after replace",
+    );
+    assert!(
+        !caps.accepts(mbox, SetRender::ID),
+        "the probe's SetRender handler must be gone after replacing with the camera",
+    );
+    // Both components declare a Tick handler, so it survives the swap.
+    assert!(caps.accepts(mbox, Tick::ID));
+}
+
+/// `aether.component.drop` clears the dropped mailbox's caps — once
+/// the wasm is unloaded the mailbox accepts nothing.
+#[test]
+fn cap_registry_clears_on_drop() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_named(&mut bench, &wasm_path, "victim");
+    assert!(
+        bench.capability_registry().accepts(mbox, Tick::ID),
+        "sanity: loaded probe accepts Tick before drop",
+    );
+
+    let dropped = bench
+        .execute(vec![(
+            "drop",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &DropComponent { mailbox_id: mbox },
+            ),
+        )])
+        .expect("drop sequence");
+    match dropped
+        .reply::<DropResult>("drop")
+        .expect("decode DropResult")
+    {
+        DropResult::Ok => {}
+        DropResult::Err { error } => panic!("drop_component: {error}"),
+    }
+
+    let caps = bench.capability_registry();
+    assert!(
+        !caps.accepts(mbox, Tick::ID),
+        "dropped component's mailbox must accept nothing",
+    );
+    assert!(!caps.has_fallback(mbox));
+}
+
+/// The native+wasm unification guard: a native cap (`aether.fs`)
+/// populates the same registry at boot, so its mailbox is queryable
+/// for the kinds it declares `#[handler]`s for (e.g. `Write`).
+#[test]
+fn cap_registry_covers_native_cap() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let sandbox = init_save_sandbox("cap-registry-fs");
+    let bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+
+    let fs_mbox = mailbox_id_from_name(FsCapability::NAMESPACE);
+    let caps = bench.capability_registry();
+    assert!(
+        caps.accepts(fs_mbox, Write::ID),
+        "the native aether.fs cap should accept its declared Write handler",
+    );
+    // A native cap with no `#[fallback]` rejects undeclared kinds.
+    assert!(
+        !caps.accepts(fs_mbox, KindId(0xDEAD_BEEF)),
+        "aether.fs is a strict receiver — undeclared kinds are rejected",
+    );
+    assert!(!caps.has_fallback(fs_mbox));
+}

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -83,6 +83,15 @@ use aether_actor::Actor;
 use crate::chassis::error::BootError;
 use crate::mail::KindId;
 
+/// Re-export of the ADR-0033 capability vocabulary so the
+/// `#[actor] impl NativeActor` macro can construct the
+/// [`NativeDispatch::__aether_capabilities`] override through
+/// `::aether_substrate::` paths — the same crate the rest of the
+/// native dispatch impl already resolves against, so native `#[actor]`
+/// consumers don't need `aether-kinds` in their own dep list
+/// (iamacoffeepot/aether#1037).
+pub use aether_kinds::{ComponentCapabilities, FallbackCapability, HandlerCapability};
+
 /// Native chassis-cap actor trait. Per-cap shape: one struct, one
 /// `#[actor] impl NativeActor for X` block. The `Config` associated
 /// type is moved into [`Self::init`] by the chassis builder; pass
@@ -179,5 +188,25 @@ pub trait NativeDispatch: Send + 'static {
         _envelope: &Envelope,
     ) -> bool {
         false
+    }
+
+    /// The native cap's ADR-0033 receive-side capability surface —
+    /// every `#[handler]` kind plus `#[fallback]` presence
+    /// (iamacoffeepot/aether#1037). The `#[actor] impl NativeActor`
+    /// macro overrides this to enumerate the cap's handlers + fallback,
+    /// the always-on native counterpart of a wasm component's
+    /// `aether.kinds.inputs` manifest. The native-cap-boot path reads
+    /// it to populate the [`CapabilityRegistry`]
+    /// (`crate::mail::CapabilityRegistry`), so a native cap (e.g.
+    /// `aether.fs`) is queryable for dispatchability just like a loaded
+    /// wasm component. Default is an empty surface — only the
+    /// (`name` / `doc`-dropping) handler ids + fallback flag are
+    /// load-bearing here; reply kinds are deliberately absent (handlers
+    /// promise nothing about replies).
+    fn __aether_capabilities() -> ComponentCapabilities
+    where
+        Self: Sized,
+    {
+        ComponentCapabilities::default()
     }
 }

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -196,13 +196,14 @@ pub trait NativeDispatch: Send + 'static {
     /// macro overrides this to enumerate the cap's handlers + fallback,
     /// the always-on native counterpart of a wasm component's
     /// `aether.kinds.inputs` manifest. The native-cap-boot path reads
-    /// it to populate the [`CapabilityRegistry`]
-    /// (`crate::mail::CapabilityRegistry`), so a native cap (e.g.
+    /// it to populate the [`CapabilityRegistry`](crate::mail::CapabilityRegistry),
+    /// so a native cap (e.g.
     /// `aether.fs`) is queryable for dispatchability just like a loaded
     /// wasm component. Default is an empty surface — only the
     /// (`name` / `doc`-dropping) handler ids + fallback flag are
     /// load-bearing here; reply kinds are deliberately absent (handlers
     /// promise nothing about replies).
+    #[must_use]
     fn __aether_capabilities() -> ComponentCapabilities
     where
         Self: Sized,

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -35,6 +35,7 @@ use crate::chassis::ctx::{ChassisCtx, FallbackRouter, MailboxClaim};
 use crate::chassis::error::BootError;
 use crate::chassis::settlement::SettlementRegistry;
 use crate::mail::MailboxId;
+use crate::mail::capability::MailboxCaps;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
@@ -545,7 +546,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // (empty) covers any cap the macro didn't touch.
         ctx.mail_send_handle().capability_registry().register(
             resources.mailbox_id,
-            crate::mail::MailboxCaps::from_component_capabilities(&A::__aether_capabilities()),
+            MailboxCaps::from_component_capabilities(&A::__aether_capabilities()),
         );
 
         // Issue 629 / Phase A: dispatcher takes Box<A> ownership.

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -536,6 +536,18 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
             }
         };
 
+        // iamacoffeepot/aether#1037: register this native cap's ADR-0033
+        // receive-side capabilities (handler kinds + `#[fallback]`
+        // presence) into the queryable `CapabilityRegistry`, the same
+        // population path a wasm component's load takes. `A` is a
+        // `NativeDispatch`, whose `__aether_capabilities` the `#[actor]`
+        // macro overrides to enumerate the cap's handlers; the default
+        // (empty) covers any cap the macro didn't touch.
+        ctx.mail_send_handle().capability_registry().register(
+            resources.mailbox_id,
+            crate::mail::MailboxCaps::from_component_capabilities(&A::__aether_capabilities()),
+        );
+
         // Issue 629 / Phase A: dispatcher takes Box<A> ownership.
         self.state = BootState::Initialized {
             resources,

--- a/crates/aether-substrate/src/mail/capability.rs
+++ b/crates/aether-substrate/src/mail/capability.rs
@@ -152,7 +152,7 @@ mod tests {
                     doc: None,
                 })
                 .collect(),
-            fallback: fallback.then(|| FallbackCapability { doc: None }),
+            fallback: fallback.then_some(FallbackCapability { doc: None }),
             doc: None,
         }
     }

--- a/crates/aether-substrate/src/mail/capability.rs
+++ b/crates/aether-substrate/src/mail/capability.rs
@@ -1,0 +1,234 @@
+// Queryable capability registry (iamacoffeepot/aether#1037).
+//
+// A sibling of the routing [`Registry`](crate::mail::registry::Registry)
+// — NOT folded into it. The routing registry is on the per-mail hot
+// path (recipient + kind resolution on every `Mailer::push`); the
+// capability metadata here is read only on the DAG validator's
+// submit/validate path (iamacoffeepot/aether#975 Phase 2), so it lives
+// off the dispatch struct.
+//
+// The surface is **input-side only**: which kinds a mailbox accepts
+// (`accepts`) and whether it carries a `#[fallback]` catch-all
+// (`has_fallback`). Handlers promise nothing about what they reply, so
+// there is deliberately no reply-kind / output-kind resolution here —
+// a request kind's reply kind is not a property of the kind and is not
+// declarable or queryable (see ADR-0047 §3, amended).
+//
+// Population is unified across native caps and wasm components: both
+// surface a `ComponentCapabilities` (ADR-0033) — wasm from the parsed
+// `aether.kinds.inputs` custom section, native from the always-on
+// `__AETHER_INPUTS_MANIFEST` the `#[actor]` macro emits — so a single
+// `register` call covers both. Register on add (component load /
+// native-cap boot), replace on `aether.component.replace` (the mailbox
+// id is stable per ADR-0022), remove on drop.
+
+// The registry's `RwLock` guard is intentionally held across the
+// read-then-membership-check pair in `accepts` — the same low-contention
+// rationale as the routing registry's guard policy.
+#![allow(clippy::significant_drop_tightening)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+use aether_kinds::ComponentCapabilities;
+
+use crate::mail::{KindId, MailboxId};
+
+/// The accepted-kinds set + fallback flag for one mailbox. Built from
+/// the mailbox's [`ComponentCapabilities`] (ADR-0033) at registration.
+#[derive(Debug, Default, Clone)]
+pub struct MailboxCaps {
+    /// Every kind id the mailbox has a `#[handler]` for.
+    pub handlers: HashSet<KindId>,
+    /// Whether the mailbox carries a `#[fallback]` catch-all. A
+    /// fallback mailbox accepts any kind at dispatch time even though
+    /// the kind isn't in `handlers`.
+    pub has_fallback: bool,
+}
+
+impl MailboxCaps {
+    /// Project a [`ComponentCapabilities`] (the ADR-0033 surface shared
+    /// by native caps and wasm components) into the dispatchability
+    /// shape this registry stores: the handler kind-id set + fallback
+    /// presence. Handler names and docs are dropped — they're
+    /// `describe_component`'s concern, not the validator's.
+    #[must_use]
+    pub fn from_component_capabilities(caps: &ComponentCapabilities) -> Self {
+        Self {
+            handlers: caps.handlers.iter().map(|h| h.id).collect(),
+            has_fallback: caps.fallback.is_some(),
+        }
+    }
+}
+
+/// Substrate-owned, queryable capability registry. Shared as
+/// `Arc<CapabilityRegistry>` off the boot path (mirroring how the
+/// routing [`Registry`](crate::mail::registry::Registry) is shared);
+/// the DAG validator reads `accepts` / `has_fallback` on the submit
+/// path, the load / replace / drop hooks mutate it.
+#[derive(Debug, Default)]
+pub struct CapabilityRegistry {
+    caps: RwLock<HashMap<MailboxId, MailboxCaps>>,
+}
+
+impl CapabilityRegistry {
+    /// A fresh, empty registry. The boot path builds one and shares it
+    /// via the [`Mailer`](crate::mail::mailer::Mailer).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            caps: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Does `mailbox` accept `kind`? True when `kind` is in the
+    /// mailbox's handler set OR the mailbox carries a `#[fallback]`
+    /// catch-all. Unknown mailboxes (never registered, or dropped)
+    /// accept nothing.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned — a poisoned lock means
+    /// a prior writer panicked mid-update, which is a substrate-level
+    /// invariant violation (fail-fast per ADR-0063).
+    #[must_use]
+    pub fn accepts(&self, mailbox: MailboxId, kind: KindId) -> bool {
+        let guard = self.caps.read().expect("capability registry lock poisoned");
+        guard
+            .get(&mailbox)
+            .is_some_and(|c| c.has_fallback || c.handlers.contains(&kind))
+    }
+
+    /// Does `mailbox` carry a `#[fallback]` catch-all? Unknown
+    /// mailboxes return `false`.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::accepts`]).
+    #[must_use]
+    pub fn has_fallback(&self, mailbox: MailboxId) -> bool {
+        let guard = self.caps.read().expect("capability registry lock poisoned");
+        guard.get(&mailbox).is_some_and(|c| c.has_fallback)
+    }
+
+    /// Register (or replace) the caps for `mailbox`. Called at
+    /// component load / native-cap boot, and again on
+    /// `aether.component.replace` (same mailbox id, fresh handler set).
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::accepts`]).
+    pub fn register(&self, mailbox: MailboxId, caps: MailboxCaps) {
+        let mut guard = self
+            .caps
+            .write()
+            .expect("capability registry lock poisoned");
+        guard.insert(mailbox, caps);
+    }
+
+    /// Remove `mailbox`'s caps. Called on `aether.component.drop`. A
+    /// no-op for an unknown mailbox.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::accepts`]).
+    pub fn remove(&self, mailbox: MailboxId) {
+        let mut guard = self
+            .caps
+            .write()
+            .expect("capability registry lock poisoned");
+        guard.remove(&mailbox);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_kinds::{FallbackCapability, HandlerCapability};
+
+    fn caps_with(handler_ids: &[u64], fallback: bool) -> ComponentCapabilities {
+        ComponentCapabilities {
+            handlers: handler_ids
+                .iter()
+                .map(|&id| HandlerCapability {
+                    id: KindId(id),
+                    name: format!("test.kind.{id}"),
+                    doc: None,
+                })
+                .collect(),
+            fallback: fallback.then(|| FallbackCapability { doc: None }),
+            doc: None,
+        }
+    }
+
+    #[test]
+    fn accepts_handled_kind_rejects_others() {
+        let reg = CapabilityRegistry::new();
+        let mbx = MailboxId(7);
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[10, 20], false)),
+        );
+        assert!(reg.accepts(mbx, KindId(10)));
+        assert!(reg.accepts(mbx, KindId(20)));
+        assert!(!reg.accepts(mbx, KindId(30)));
+    }
+
+    #[test]
+    fn fallback_accepts_anything() {
+        let reg = CapabilityRegistry::new();
+        let mbx = MailboxId(7);
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[10], true)),
+        );
+        assert!(reg.has_fallback(mbx));
+        assert!(reg.accepts(mbx, KindId(10)));
+        // Not in `handlers`, but the fallback catches it.
+        assert!(reg.accepts(mbx, KindId(999)));
+    }
+
+    #[test]
+    fn strict_receiver_has_no_fallback() {
+        let reg = CapabilityRegistry::new();
+        let mbx = MailboxId(7);
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[10], false)),
+        );
+        assert!(!reg.has_fallback(mbx));
+        assert!(!reg.accepts(mbx, KindId(999)));
+    }
+
+    #[test]
+    fn register_replaces_prior_caps() {
+        let reg = CapabilityRegistry::new();
+        let mbx = MailboxId(7);
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[10], false)),
+        );
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[20], false)),
+        );
+        assert!(!reg.accepts(mbx, KindId(10)));
+        assert!(reg.accepts(mbx, KindId(20)));
+    }
+
+    #[test]
+    fn remove_clears_caps() {
+        let reg = CapabilityRegistry::new();
+        let mbx = MailboxId(7);
+        reg.register(
+            mbx,
+            MailboxCaps::from_component_capabilities(&caps_with(&[10], true)),
+        );
+        reg.remove(mbx);
+        assert!(!reg.accepts(mbx, KindId(10)));
+        assert!(!reg.has_fallback(mbx));
+    }
+
+    #[test]
+    fn unknown_mailbox_accepts_nothing() {
+        let reg = CapabilityRegistry::new();
+        assert!(!reg.accepts(MailboxId(123), KindId(10)));
+        assert!(!reg.has_fallback(MailboxId(123)));
+    }
+}

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -28,6 +28,7 @@ use std::thread;
 
 use crate::chassis::settlement::SettlementRegistry;
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
+use crate::mail::capability::CapabilityRegistry;
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
@@ -103,6 +104,15 @@ pub struct Mailer {
     /// `start_drainer` is independent — without it, events accumulate
     /// in the queue but aren't shipped.
     trace_handle: TraceHandle,
+    /// iamacoffeepot/aether#1037 queryable capability registry. A
+    /// sibling of [`Self::registry`] — the routing registry resolves
+    /// recipients on the hot path; this one answers the DAG
+    /// validator's submit-path dispatchability questions
+    /// (`accepts(MailboxId, KindId)` / `has_fallback(MailboxId)`). The
+    /// component-load / native-cap-boot path populates it, replace
+    /// re-registers, drop clears. Allocated empty by [`Self::new`]
+    /// (like `trace_handle`) so no call site changes.
+    capability_registry: Arc<CapabilityRegistry>,
 }
 
 impl Mailer {
@@ -120,6 +130,7 @@ impl Mailer {
             chassis_router: OnceLock::new(),
             settlement_registry: OnceLock::new(),
             trace_handle: TraceHandle::new(),
+            capability_registry: Arc::new(CapabilityRegistry::new()),
         }
     }
 
@@ -289,6 +300,17 @@ impl Mailer {
     /// via the cap's config struct.
     pub fn registry(&self) -> &Arc<Registry> {
         &self.registry
+    }
+
+    /// Borrow the wired [`CapabilityRegistry`]
+    /// (iamacoffeepot/aether#1037). The component-load / native-cap-boot
+    /// path registers mailbox caps through this handle; the DAG
+    /// validator (iamacoffeepot/aether#975) reads `accepts` /
+    /// `has_fallback` on the submit path. Shared via the `Mailer` so any
+    /// actor with `ctx.mailer()` reaches the same registry — mirroring
+    /// how [`Self::registry`] surfaces the routing table.
+    pub fn capability_registry(&self) -> &Arc<CapabilityRegistry> {
+        &self.capability_registry
     }
 
     /// Hand `mail` to the substrate for dispatch. `Inbox`-bound

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -7,11 +7,13 @@
 //! interaction lives in the actor SDK (`aether_actor::Mailbox<K>`) and
 //! per-cap dispatchers.
 
+pub mod capability;
 pub mod helpers;
 pub mod mailer;
 pub mod outbound;
 pub mod registry;
 
+pub use capability::{CapabilityRegistry, MailboxCaps};
 pub use mailer::Mailer;
 pub use outbound::{DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend};
 pub use registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};


### PR DESCRIPTION
Closes iamacoffeepot/aether#1037

## Summary

Adds a substrate `CapabilityRegistry` — a sibling of the routing
`Registry`, kept off the per-mail hot path — exposing the input-side
dispatchability surface the DAG validator (iamacoffeepot/aether#975
Phase 2) needs:

- `accepts(MailboxId, KindId) -> bool` (handler-set membership OR a
  `#[fallback]` catch-all)
- `has_fallback(MailboxId) -> bool`

Shared as `Arc<CapabilityRegistry>` via the `Mailer` (allocated inside
`Mailer::new`, so no existing call site changes). Populated at wasm
component load and native-cap boot, re-registered on
`aether.component.replace` (the mailbox id is stable per ADR-0022),
cleared on `aether.component.drop`.

Population is unified across both transports from the always-on ADR-0033
`ComponentCapabilities`: wasm components ship it in their
`aether.kinds.inputs` custom section, and the native `#[actor]` macro
now emits a `NativeDispatch::__aether_capabilities` override so native
caps expose the same handler-set + fallback surface — one population
path covers both.

Input-side only by design: there is no reply-kind / output-kind
resolution and no `Kind::REPLY` — handlers promise nothing about their
replies, so a reply kind is not a property of a kind.

## Test plan

- [x] `scripts/preflight.sh` green (fmt, clippy `-D warnings`, doc,
  wasm32 cross-build, full nextest: 1082 passed)
- [x] Unit tests on `CapabilityRegistry` (accepted kinds, fallback
  true/false, register-replaces, remove, unknown mailbox)
- [x] Integration tests through a real component-load lifecycle on
  `TestBench`: reports accepted kinds, reports fallback (strict
  receiver), updates on replace (probe -> camera, distinct handler
  set), clears on drop, and covers a native cap (`aether.fs`)