### PR TITLE
feat(substrate): dag descriptor validator pipeline

### DIFF
--- a/crates/aether-substrate/src/dag/mod.rs
+++ b/crates/aether-substrate/src/dag/mod.rs
@@ -1,0 +1,17 @@
+//! ADR-0047 computation-DAG runtime (substrate side).
+//!
+//! The wire vocabulary — `DagDescriptor`, `Node`, `Edge`, the
+//! `aether.dag.{submit,cancel,status}` request kinds, the `Bundle`
+//! meta-type, and the structured [`DagError`](aether_kinds::DagError)
+//! set — lives in `aether-kinds::dag`. This module is the substrate-side
+//! machinery that consumes it.
+//!
+//! Today that's the [`validator`] (iamacoffeepot/aether#975): the
+//! three-phase submit-path check that turns a descriptor into a
+//! topologically-sorted [`ValidatedDag`](validator::ValidatedDag) the
+//! executor can dispatch from directly, or a structured
+//! [`DagError`](aether_kinds::DagError) on the first rule violation. The
+//! executor (iamacoffeepot/aether#976) and its `DagState` land as
+//! sibling modules here.
+
+pub mod validator;

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -11,7 +11,7 @@
 //!
 //! **Re-scoped 2026-05-20 ("handlers promise nothing about replies").**
 //! Phase 2 dispatchability reads accept-sets from the queryable
-//! [`CapabilityRegistry`](crate::mail::CapabilityRegistry)
+//! [`CapabilityRegistry`]
 //! (iamacoffeepot/aether#1037), *not* the routing registry — the
 //! routing table carries no accept-sets. Phase 3 type-compat checks
 //! only statically-declared output kinds: a `Call`'s output is the

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -1,0 +1,520 @@
+//! ADR-0047 §3 DAG descriptor validator (iamacoffeepot/aether#975).
+//!
+//! [`validate`] runs the §3 phases in the order the ADR fixes —
+//! version gate → structural integrity → dispatchability → type
+//! compatibility — short-circuiting on the first failure so the
+//! returned [`DagError`] localises the real problem rather than
+//! aggregating every downstream consequence of one upstream mistake.
+//! Success yields a [`ValidatedDag`]: the descriptor plus a single
+//! topological order the executor (iamacoffeepot/aether#976) dispatches
+//! from without re-running Kahn's algorithm.
+//!
+//! **Re-scoped 2026-05-20 ("handlers promise nothing about replies").**
+//! Phase 2 dispatchability reads accept-sets from the queryable
+//! [`CapabilityRegistry`](crate::mail::CapabilityRegistry)
+//! (iamacoffeepot/aether#1037), *not* the routing registry — the
+//! routing table carries no accept-sets. Phase 3 type-compat checks
+//! only statically-declared output kinds: a `Call`'s output is the
+//! `Bundle` meta-type, so an edge out of a `Call` requires the consumer
+//! to declare a `Bundle` input at the matching slot. Edges out of a
+//! `Source` are *not* type-checked — a source's output kind is whatever
+//! the cap replies, which a handler never declares. There is no
+//! reply-kind resolution anywhere in this validator.
+
+use std::collections::{BTreeSet, HashMap};
+use std::env;
+
+use aether_data::canonical::canonical_kind_bytes;
+use aether_data::{Kind, Schema, SchemaType};
+use aether_kinds::{Bundle, DagDescriptor, DagError, Edge, Node, NodeId};
+
+use crate::mail::{CapabilityRegistry, KindId, MailboxEntry, MailboxId, Registry};
+
+const TARGET: &str = "aether::dag::validator";
+
+/// Env override for the node-count cap (ADR-0047 §3). Default
+/// [`DEFAULT_MAX_NODES`].
+pub const ENV_MAX_NODES: &str = "AETHER_DAG_MAX_NODES";
+/// Env override for the edge-count cap (ADR-0047 §3). Default
+/// [`DEFAULT_MAX_EDGES`].
+pub const ENV_MAX_EDGES: &str = "AETHER_DAG_MAX_EDGES";
+/// Env override for the serialized-descriptor byte cap (ADR-0047 §3).
+/// Default [`DEFAULT_MAX_DESCRIPTOR_BYTES`].
+pub const ENV_MAX_DESCRIPTOR_BYTES: &str = "AETHER_DAG_MAX_DESCRIPTOR_BYTES";
+
+/// Default ceiling on `nodes.len()` (ADR-0047 §3).
+pub const DEFAULT_MAX_NODES: u64 = 256;
+/// Default ceiling on `edges.len()` (ADR-0047 §3).
+pub const DEFAULT_MAX_EDGES: u64 = 1024;
+/// Default ceiling on the postcard-serialized descriptor size, in
+/// bytes (ADR-0047 §3).
+pub const DEFAULT_MAX_DESCRIPTOR_BYTES: u64 = 1024 * 1024;
+
+/// The single descriptor version this substrate implements. A submit
+/// naming any other version is rejected at the Phase 0 gate
+/// (ADR-0047 §10) before node semantics are touched.
+pub const SUPPORTED_VERSION: u16 = 1;
+
+/// A descriptor that has passed every validation phase, carrying the
+/// one topological order the executor dispatches from. Kahn's algorithm
+/// runs once here (acyclicity check), so the executor never re-detects
+/// cycles or re-sorts (ADR-0047 §3 "Doors opened").
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidatedDag {
+    /// The validated descriptor, owned so the executor holds it past
+    /// the submit-path borrow.
+    pub descriptor: DagDescriptor,
+    /// Node ids in a topological order (every edge points from an
+    /// earlier entry to a later one). Length equals
+    /// `descriptor.nodes.len()`.
+    pub topo_order: Vec<NodeId>,
+}
+
+/// Validate a submitted DAG descriptor (ADR-0047 §3).
+///
+/// Runs the phases in fixed order, short-circuiting on the first
+/// failure: version gate → structural integrity → dispatchability →
+/// type compatibility. `mailboxes` is the routing-side table (existence
+/// checks via [`Registry::entry`] / reverse-name lookup); `caps` is the
+/// queryable capability registry (iamacoffeepot/aether#1037) the
+/// dispatchability phase reads accept-sets from.
+///
+/// On success the returned [`ValidatedDag`] carries the topological
+/// order the executor dispatches from directly.
+///
+/// # Errors
+/// Returns the first [`DagError`] a phase produces. See the per-phase
+/// helpers for the variant each rule maps to.
+pub fn validate(
+    descriptor: &DagDescriptor,
+    mailboxes: &Registry,
+    caps: &CapabilityRegistry,
+) -> Result<ValidatedDag, DagError> {
+    check_version(descriptor)?;
+    let structure = check_structure(descriptor)?;
+    check_dispatchability(descriptor, mailboxes, caps)?;
+    check_edge_types(descriptor, mailboxes)?;
+    Ok(ValidatedDag {
+        descriptor: descriptor.clone(),
+        topo_order: structure.topo_order,
+    })
+}
+
+/// Phase 0 — descriptor version (ADR-0047 §10). The cheapest check,
+/// run before anything touches `nodes`: an unimplemented version is
+/// rejected as a decode-boundary guard rail. There is no dedicated
+/// version `DagError` variant in the §3 set, so this reuses
+/// `TooLarge { reason }` (the same wire-churn-avoiding reuse §8
+/// applies to hub-unsupported submits).
+fn check_version(descriptor: &DagDescriptor) -> Result<(), DagError> {
+    if descriptor.version != SUPPORTED_VERSION {
+        return Err(DagError::TooLarge {
+            reason: format!(
+                "unsupported descriptor version {} (this substrate implements version {SUPPORTED_VERSION})",
+                descriptor.version,
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// The structural-integrity products Phase 1 hands forward: the node
+/// id set (used by later phases to resolve edge endpoints) and the
+/// topological order (handed to the executor in [`ValidatedDag`]).
+struct Structure {
+    topo_order: Vec<NodeId>,
+}
+
+/// Phase 1 — structural integrity (ADR-0047 §3). Node-id uniqueness,
+/// edge-endpoint existence, source/observer degree constraints,
+/// acyclicity (Kahn's algorithm), and the structural caps. Runs after
+/// the version gate and before any registry access, so a malformed
+/// shape never reaches the (more expensive) dispatchability lookups.
+fn check_structure(descriptor: &DagDescriptor) -> Result<Structure, DagError> {
+    let caps = Caps::from_env();
+
+    if descriptor.nodes.len() as u64 > caps.nodes {
+        return Err(DagError::TooLarge {
+            reason: format!(
+                "node count {} exceeds cap {}",
+                descriptor.nodes.len(),
+                caps.nodes,
+            ),
+        });
+    }
+    if descriptor.edges.len() as u64 > caps.edges {
+        return Err(DagError::TooLarge {
+            reason: format!(
+                "edge count {} exceeds cap {}",
+                descriptor.edges.len(),
+                caps.edges,
+            ),
+        });
+    }
+    let serialized = postcard::to_allocvec(descriptor)
+        .expect("descriptor postcard serialization is infallible into a growable Vec");
+    if serialized.len() as u64 > caps.descriptor_bytes {
+        return Err(DagError::TooLarge {
+            reason: format!(
+                "descriptor size {} bytes exceeds cap {}",
+                serialized.len(),
+                caps.descriptor_bytes,
+            ),
+        });
+    }
+
+    // NodeId uniqueness — a BTreeSet collects in id order; a failed
+    // insert is the first collision.
+    let mut node_ids: BTreeSet<NodeId> = BTreeSet::new();
+    for node in &descriptor.nodes {
+        if !node_ids.insert(node.id()) {
+            return Err(DagError::DuplicateNodeId(node.id()));
+        }
+    }
+
+    // Edge endpoints must reference declared node ids.
+    for edge in &descriptor.edges {
+        if !node_ids.contains(&edge.from) {
+            return Err(DagError::UnknownNodeId(edge.from));
+        }
+        if !node_ids.contains(&edge.to) {
+            return Err(DagError::UnknownNodeId(edge.to));
+        }
+    }
+
+    // Per-node incoming / outgoing degree, for the source/observer
+    // root-and-terminal constraints. `Call` and `Transform` are
+    // mid-graph and carry no degree restriction.
+    let mut incoming: HashMap<NodeId, u32> = HashMap::new();
+    let mut outgoing: HashMap<NodeId, u32> = HashMap::new();
+    for edge in &descriptor.edges {
+        *outgoing.entry(edge.from).or_insert(0) += 1;
+        *incoming.entry(edge.to).or_insert(0) += 1;
+    }
+    for node in &descriptor.nodes {
+        match node {
+            Node::Source { id, .. } => {
+                if incoming.get(id).copied().unwrap_or(0) > 0 {
+                    return Err(DagError::SourceWithIncomingEdge(*id));
+                }
+            }
+            Node::Observer { id, .. } => {
+                if outgoing.get(id).copied().unwrap_or(0) > 0 {
+                    return Err(DagError::ObserverWithOutgoingEdge(*id));
+                }
+            }
+            Node::Call { .. } | Node::Transform { .. } => {}
+        }
+    }
+
+    // Acyclicity via Kahn's algorithm. The residual after the queue
+    // drains is the cycle (ADR-0047 §3).
+    let topo_order = toposort(&node_ids, &descriptor.edges)?;
+
+    Ok(Structure { topo_order })
+}
+
+/// Kahn's algorithm. Returns the full topological order on success; on a
+/// cycle, returns `Cycle(residual)` where the residual is every node id
+/// that never reached in-degree zero.
+fn toposort(node_ids: &BTreeSet<NodeId>, edges: &[Edge]) -> Result<Vec<NodeId>, DagError> {
+    let mut indegree: HashMap<NodeId, u32> = node_ids.iter().map(|id| (*id, 0)).collect();
+    for edge in edges {
+        *indegree.entry(edge.to).or_insert(0) += 1;
+    }
+
+    // Seed the queue with every zero-in-degree node, in id order for a
+    // deterministic topological order.
+    let mut queue: Vec<NodeId> = node_ids
+        .iter()
+        .copied()
+        .filter(|id| indegree.get(id).copied().unwrap_or(0) == 0)
+        .collect();
+    let mut order: Vec<NodeId> = Vec::with_capacity(node_ids.len());
+
+    while let Some(id) = queue.pop() {
+        order.push(id);
+        // Drop the in-degree contribution of `id`'s outgoing edges; any
+        // successor that hits zero joins the queue.
+        let mut freshly_ready: Vec<NodeId> = Vec::new();
+        for edge in edges.iter().filter(|e| e.from == id) {
+            if let Some(d) = indegree.get_mut(&edge.to) {
+                *d = d.saturating_sub(1);
+                if *d == 0 {
+                    freshly_ready.push(edge.to);
+                }
+            }
+        }
+        // Sort the newly-ready ids so the order is reproducible.
+        freshly_ready.sort_unstable();
+        queue.extend(freshly_ready);
+    }
+
+    if order.len() < node_ids.len() {
+        // The residual — every node still carrying a positive in-degree
+        // — is the cycle. Emit it in id order (the test asserts set
+        // membership, not vec order).
+        let residual: Vec<NodeId> = node_ids
+            .iter()
+            .copied()
+            .filter(|id| !order.contains(id))
+            .collect();
+        return Err(DagError::Cycle(residual));
+    }
+
+    Ok(order)
+}
+
+/// Phase 2 — dispatchability (ADR-0047 §3). Each effectful node's target
+/// mailbox must exist (routing `Registry`) and accept the node's kind
+/// (`CapabilityRegistry`). `Transform` nodes always fail here in this
+/// issue's scope — no native transform is registered yet, so a
+/// `Transform` is wire-reserved but dispatch-disabled
+/// (iamacoffeepot/aether#976 lights it up).
+fn check_dispatchability(
+    descriptor: &DagDescriptor,
+    mailboxes: &Registry,
+    caps: &CapabilityRegistry,
+) -> Result<(), DagError> {
+    for node in &descriptor.nodes {
+        match node {
+            Node::Source {
+                id,
+                mailbox,
+                kind_id,
+                ..
+            } => {
+                if !mailbox_exists(mailboxes, *mailbox) {
+                    return Err(DagError::UnknownSink(mailbox_label(mailboxes, *mailbox)));
+                }
+                if !caps.accepts(*mailbox, *kind_id) {
+                    return Err(DagError::KindNotAccepted {
+                        node: *id,
+                        kind_id: *kind_id,
+                        mailbox_or_recipient: mailbox_label(mailboxes, *mailbox),
+                    });
+                }
+            }
+            Node::Call {
+                id,
+                recipient,
+                kind_id,
+            } => {
+                // A `Call` is an ordinary cap dispatch that happens
+                // mid-graph: the same existence + accept check a source
+                // runs (ADR-0047 §3).
+                if !mailbox_exists(mailboxes, *recipient) {
+                    return Err(DagError::UnknownRecipient(mailbox_label(
+                        mailboxes, *recipient,
+                    )));
+                }
+                if !caps.accepts(*recipient, *kind_id) {
+                    return Err(DagError::KindNotAccepted {
+                        node: *id,
+                        kind_id: *kind_id,
+                        mailbox_or_recipient: mailbox_label(mailboxes, *recipient),
+                    });
+                }
+            }
+            Node::Observer {
+                id,
+                recipient,
+                kind_id,
+            } => {
+                if !mailbox_exists(mailboxes, *recipient) {
+                    return Err(DagError::UnknownRecipient(mailbox_label(
+                        mailboxes, *recipient,
+                    )));
+                }
+                // An observer's kind is accepted if the recipient
+                // handles it OR carries a `#[fallback]` catch-all.
+                if !caps.accepts(*recipient, *kind_id) && !caps.has_fallback(*recipient) {
+                    return Err(DagError::KindNotAccepted {
+                        node: *id,
+                        kind_id: *kind_id,
+                        mailbox_or_recipient: mailbox_label(mailboxes, *recipient),
+                    });
+                }
+            }
+            Node::Transform {
+                id, transform_id, ..
+            } => {
+                // No native-transform catalog exists yet
+                // (iamacoffeepot/aether#976) — a Transform node is
+                // wire-reserved but dispatch-disabled, so every one
+                // fails Phase 2 here. This is the intended surface.
+                return Err(DagError::UnknownTransform {
+                    node: *id,
+                    transform_id: *transform_id,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Phase 3 — type compatibility on edges (ADR-0047 §3, re-scoped). Only
+/// statically-declared output kinds are checkable. The single such kind
+/// in this issue's scope is a `Call`'s output, which is always the
+/// `Bundle` meta-type: an edge out of a `Call` requires the consumer at
+/// `to` to declare a `Bundle` input at the matching `slot`. Edges out of
+/// a `Source` are skipped — a source's output kind depends on what the
+/// cap replies, which a handler never declares. (When transforms land,
+/// a `Transform`-output arm joins here, checking the consumer's slot
+/// against `Transform.output_kind_id`.)
+fn check_edge_types(descriptor: &DagDescriptor, mailboxes: &Registry) -> Result<(), DagError> {
+    // Node lookup by id for resolving each edge's producer / consumer.
+    let by_id: HashMap<NodeId, &Node> = descriptor.nodes.iter().map(|n| (n.id(), n)).collect();
+
+    for (edge_index, edge) in descriptor.edges.iter().enumerate() {
+        let Some(producer) = by_id.get(&edge.from) else {
+            // Endpoint existence was already enforced in Phase 1; an
+            // unknown producer here would be a logic bug, so skip
+            // defensively rather than panic.
+            continue;
+        };
+
+        // Only a `Call` has a statically-knowable output kind in this
+        // issue's scope (the `Bundle` meta-type). Everything else —
+        // sources especially — is not type-checked.
+        if !matches!(producer, Node::Call { .. }) {
+            continue;
+        }
+
+        let Some(consumer) = by_id.get(&edge.to) else {
+            continue;
+        };
+        let consumer_kind = match consumer {
+            Node::Observer { kind_id, .. } | Node::Call { kind_id, .. } => *kind_id,
+            // A `Call` cannot feed a `Source` (sources have no incoming
+            // edges, enforced in Phase 1) and `Transform` consumers have
+            // no registered input schema yet, so nothing else is
+            // checkable here.
+            Node::Source { .. } | Node::Transform { .. } => continue,
+        };
+
+        // The consumer's slot maps to a `Ref<K>` field of its
+        // assembled-request schema. Resolve `K`'s schema; the edge is
+        // type-valid iff that `K` is a `Bundle`.
+        let slot_schema = consumer_slot_kind(mailboxes, consumer_kind, edge.slot);
+        let accepts_bundle = slot_schema.as_ref().is_some_and(|s| {
+            canonical_kind_bytes("", s) == canonical_kind_bytes("", &Bundle::SCHEMA)
+        });
+        if !accepts_bundle {
+            let got_kind = slot_schema
+                .as_ref()
+                .map_or(KindId(0), |s| declared_kind_id(mailboxes, s));
+            return Err(DagError::EdgeTypeMismatch {
+                edge_index: u32::try_from(edge_index).unwrap_or(u32::MAX),
+                expected_kind: Bundle::ID,
+                got_kind,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the inner kind schema a consumer declares at `slot`: walk the
+/// consumer's `kind_id` schema for its `Ref<K>` struct fields (in
+/// declaration order) and return the `K` schema at index `slot`. Returns
+/// `None` if the kind isn't registered, the schema isn't a struct, or
+/// the slot index is out of range / the field at that index isn't a
+/// `Ref`.
+fn consumer_slot_kind(
+    mailboxes: &Registry,
+    consumer_kind: KindId,
+    slot: u32,
+) -> Option<SchemaType> {
+    let descriptor = mailboxes.kind_descriptor(consumer_kind)?;
+    let SchemaType::Struct { fields, .. } = &descriptor.schema else {
+        return None;
+    };
+    // Slots index the consumer's `Ref<K>` fields in declaration order.
+    fields
+        .iter()
+        .filter_map(|f| match &f.ty {
+            SchemaType::Ref(cell) => Some((**cell).clone()),
+            _ => None,
+        })
+        .nth(slot as usize)
+}
+
+/// Best-effort kind-id for a declared input schema, for the `got_kind`
+/// field of an `EdgeTypeMismatch` diagnostic. Searches the registered
+/// kind vocabulary for a descriptor whose schema canonically matches
+/// `schema` and returns its id; falls back to `KindId(0)` when no
+/// registered kind matches (the schema names a kind this substrate
+/// doesn't know — still a mismatch, just without a precise id to name).
+fn declared_kind_id(mailboxes: &Registry, schema: &SchemaType) -> KindId {
+    let target = canonical_kind_bytes("", schema);
+    mailboxes
+        .list_kind_descriptors()
+        .into_iter()
+        .find(|d| canonical_kind_bytes("", &d.schema) == target)
+        .map_or(KindId(0), |d| {
+            mailboxes.kind_id(&d.name).unwrap_or(KindId(0))
+        })
+}
+
+/// Does `id` resolve to a live (non-dropped) mailbox in the routing
+/// registry? An `entry` of `None` is an unregistered id; the
+/// `Registry::entry` accessor already filters dropped slots out of
+/// `lookup`, but returns the `Dropped` entry verbatim — so a dropped
+/// mailbox is treated as absent here.
+fn mailbox_exists(mailboxes: &Registry, id: MailboxId) -> bool {
+    matches!(
+        mailboxes.entry(id),
+        Some(MailboxEntry::Inbox(_) | MailboxEntry::Inline(_))
+    )
+}
+
+/// Human-readable label for a mailbox id, for the `UnknownSink` /
+/// `UnknownRecipient` / `KindNotAccepted` diagnostics. Uses the
+/// registry's reverse name map when the id is known; falls back to the
+/// raw tagged id otherwise (an unknown id by definition has no name).
+fn mailbox_label(mailboxes: &Registry, id: MailboxId) -> String {
+    mailboxes
+        .mailbox_name(id)
+        .unwrap_or_else(|| format!("{id:?}"))
+}
+
+/// Resolved structural caps (ADR-0047 §3), read once per validation from
+/// the environment with the documented defaults.
+struct Caps {
+    nodes: u64,
+    edges: u64,
+    descriptor_bytes: u64,
+}
+
+impl Caps {
+    fn from_env() -> Self {
+        Self {
+            nodes: parse_env_u64(ENV_MAX_NODES, DEFAULT_MAX_NODES),
+            edges: parse_env_u64(ENV_MAX_EDGES, DEFAULT_MAX_EDGES),
+            descriptor_bytes: parse_env_u64(ENV_MAX_DESCRIPTOR_BYTES, DEFAULT_MAX_DESCRIPTOR_BYTES),
+        }
+    }
+}
+
+/// Parse a `u64` env var, warning and falling back to `default` on a
+/// malformed value (same shape as the handle-store cap parser).
+#[allow(clippy::option_if_let_else)]
+fn parse_env_u64(name: &str, default: u64) -> u64 {
+    match env::var(name) {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    env = name,
+                    value = %raw,
+                    error = %e,
+                    default,
+                    "ignoring unparseable DAG cap env var; using default",
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -43,6 +43,7 @@ pub mod actor;
 pub mod boot;
 pub mod capture;
 pub mod chassis;
+pub mod dag;
 pub mod handle_store;
 pub mod lifecycle;
 pub mod mail;

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -1,0 +1,647 @@
+//! ADR-0047 §3 DAG validator phase tests (iamacoffeepot/aether#975).
+//!
+//! Each test builds a `DagDescriptor`, a routing `Registry` (mailbox
+//! existence + consumer kind schemas), and a `CapabilityRegistry`
+//! (accept-sets), then asserts the validator returns `Ok(ValidatedDag)`
+//! or the first `DagError` the relevant phase produces. The fixtures
+//! register consumer kinds via `register_kind_with_descriptor` so the
+//! Phase 3 slot-walk resolves a real `Ref<K>` field.
+
+use std::collections::BTreeSet;
+
+use aether_data::{Kind, KindDescriptor, MailboxId, Ref, Schema, TransformId};
+use aether_kinds::{Bundle, DagDescriptor, DagError, Edge, Node, NodeId};
+use aether_substrate::dag::validator::{self, DEFAULT_MAX_NODES};
+use aether_substrate::mail::registry::noop_handler;
+use aether_substrate::mail::{CapabilityRegistry, KindId, MailboxCaps, Registry};
+
+use aether_kinds::{ComponentCapabilities, HandlerCapability};
+
+/// A simple source/observer payload kind — no `Ref` fields, registered
+/// purely so its id sits in a mailbox accept set.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.dag.signal")]
+struct Signal {
+    seq: u32,
+}
+
+/// A consumer kind that declares a single `Ref<Bundle>` input slot —
+/// the shape a node downstream of a `Call` must have.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.dag.bundle_consumer")]
+struct BundleConsumer {
+    input: Ref<Bundle>,
+}
+
+/// A consumer kind that declares a `Ref<Signal>` input slot — accepts a
+/// `Signal`, not a `Bundle`, so an edge out of a `Call` into it is a
+/// type mismatch.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.dag.signal_consumer")]
+struct SignalConsumer {
+    input: Ref<Signal>,
+}
+
+fn descriptor_of<K: Kind + Schema>() -> KindDescriptor {
+    KindDescriptor {
+        name: K::NAME.to_owned(),
+        schema: K::SCHEMA,
+    }
+}
+
+/// Register a mailbox by name and return its id. The handler is a no-op;
+/// the validator only checks existence, never dispatches.
+fn register_mailbox(reg: &Registry, name: &str) -> MailboxId {
+    reg.register_inbox(name, noop_handler())
+}
+
+/// Register `mailbox` in the capability registry as accepting exactly
+/// `accepted` (no fallback).
+fn register_caps(caps: &CapabilityRegistry, mailbox: MailboxId, accepted: &[KindId]) {
+    register_caps_with_fallback(caps, mailbox, accepted, false);
+}
+
+fn register_caps_with_fallback(
+    caps: &CapabilityRegistry,
+    mailbox: MailboxId,
+    accepted: &[KindId],
+    fallback: bool,
+) {
+    let component = ComponentCapabilities {
+        handlers: accepted
+            .iter()
+            .map(|&id| HandlerCapability {
+                id,
+                name: format!("test.kind.{}", id.0),
+                doc: None,
+            })
+            .collect(),
+        fallback: fallback.then_some(aether_kinds::FallbackCapability { doc: None }),
+        doc: None,
+    };
+    caps.register(
+        mailbox,
+        MailboxCaps::from_component_capabilities(&component),
+    );
+}
+
+/// A minimal valid DAG: one source feeding one observer over one edge,
+/// with both mailboxes registered and accepting their kinds, and the
+/// observer declaring a (here unchecked, since the producer is a source)
+/// `Ref<Signal>` input.
+#[test]
+fn validator_accepts_minimal_dag() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+
+    let src_mbx = register_mailbox(&reg, "test.source");
+    let obs_mbx = register_mailbox(&reg, "test.observer");
+    reg.register_kind_with_descriptor(descriptor_of::<Signal>())
+        .expect("register Signal");
+    reg.register_kind_with_descriptor(descriptor_of::<SignalConsumer>())
+        .expect("register SignalConsumer");
+    register_caps(&caps, src_mbx, &[Signal::ID]);
+    register_caps(&caps, obs_mbx, &[SignalConsumer::ID]);
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: src_mbx,
+                kind_id: Signal::ID,
+                payload: vec![],
+            },
+            Node::Observer {
+                id: NodeId(1),
+                recipient: obs_mbx,
+                kind_id: SignalConsumer::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let validated = validator::validate(&descriptor, &reg, &caps).expect("minimal dag validates");
+    assert_eq!(validated.topo_order.len(), 2);
+    // Source must precede the observer in topo order.
+    let src_pos = validated.topo_order.iter().position(|n| *n == NodeId(0));
+    let obs_pos = validated.topo_order.iter().position(|n| *n == NodeId(1));
+    assert!(src_pos < obs_pos);
+}
+
+#[test]
+fn validator_rejects_unsupported_version() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let descriptor = DagDescriptor {
+        version: 99,
+        nodes: vec![],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::TooLarge { reason }) => {
+            assert!(
+                reason.contains("version"),
+                "reason should mention version: {reason}"
+            );
+            assert!(
+                reason.contains("99"),
+                "reason should mention the bad version: {reason}"
+            );
+        }
+        other => panic!("expected TooLarge version reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_duplicate_node_id() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Observer {
+                id: NodeId(0),
+                recipient: mbx,
+                kind_id: Signal::ID,
+            },
+            Node::Observer {
+                id: NodeId(0),
+                recipient: mbx,
+                kind_id: Signal::ID,
+            },
+        ],
+        edges: vec![],
+    };
+    assert_eq!(
+        validator::validate(&descriptor, &reg, &caps),
+        Err(DagError::DuplicateNodeId(NodeId(0)))
+    );
+}
+
+#[test]
+fn validator_rejects_unknown_endpoint() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Observer {
+            id: NodeId(0),
+            recipient: mbx,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(99),
+            slot: 0,
+        }],
+    };
+    assert_eq!(
+        validator::validate(&descriptor, &reg, &caps),
+        Err(DagError::UnknownNodeId(NodeId(99)))
+    );
+}
+
+#[test]
+fn validator_rejects_cycle() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    // Three calls in a loop: 0 -> 1 -> 2 -> 0. Calls are mid-graph so
+    // they carry no degree constraint; the cycle is the only violation.
+    let make_call = |id| Node::Call {
+        id,
+        recipient: mbx,
+        kind_id: Signal::ID,
+    };
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            make_call(NodeId(0)),
+            make_call(NodeId(1)),
+            make_call(NodeId(2)),
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(2),
+                to: NodeId(0),
+                slot: 0,
+            },
+        ],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::Cycle(residual)) => {
+            let set: BTreeSet<NodeId> = residual.into_iter().collect();
+            assert_eq!(set, [NodeId(0), NodeId(1), NodeId(2)].into_iter().collect());
+        }
+        other => panic!("expected Cycle, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_source_with_incoming_edge() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: mbx,
+                kind_id: Signal::ID,
+                payload: vec![],
+            },
+            Node::Source {
+                id: NodeId(1),
+                mailbox: mbx,
+                kind_id: Signal::ID,
+                payload: vec![],
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(1),
+            to: NodeId(0),
+            slot: 0,
+        }],
+    };
+    assert_eq!(
+        validator::validate(&descriptor, &reg, &caps),
+        Err(DagError::SourceWithIncomingEdge(NodeId(0)))
+    );
+}
+
+#[test]
+fn validator_rejects_observer_with_outgoing_edge() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Observer {
+                id: NodeId(0),
+                recipient: mbx,
+                kind_id: Signal::ID,
+            },
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx,
+                kind_id: Signal::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+    assert_eq!(
+        validator::validate(&descriptor, &reg, &caps),
+        Err(DagError::ObserverWithOutgoingEdge(NodeId(0)))
+    );
+}
+
+#[test]
+fn validator_rejects_unknown_sink() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    // Source mailbox id never registered.
+    let ghost = MailboxId::from_name("test.ghost.source");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Source {
+            id: NodeId(0),
+            mailbox: ghost,
+            kind_id: Signal::ID,
+            payload: vec![],
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::UnknownSink(_)) => {}
+        other => panic!("expected UnknownSink, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_unknown_recipient() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let ghost = MailboxId::from_name("test.ghost.observer");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Observer {
+            id: NodeId(0),
+            recipient: ghost,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::UnknownRecipient(_)) => {}
+        other => panic!("expected UnknownRecipient, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_kind_not_accepted() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let src_mbx = register_mailbox(&reg, "test.source");
+    // Mailbox exists but accepts a different kind.
+    register_caps(&caps, src_mbx, &[KindId(0xDEAD)]);
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Source {
+            id: NodeId(0),
+            mailbox: src_mbx,
+            kind_id: Signal::ID,
+            payload: vec![],
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::KindNotAccepted { node, kind_id, .. }) => {
+            assert_eq!(node, NodeId(0));
+            assert_eq!(kind_id, Signal::ID);
+        }
+        other => panic!("expected KindNotAccepted, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_observer_kind_not_accepted_no_fallback() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let obs_mbx = register_mailbox(&reg, "test.observer");
+    register_caps(&caps, obs_mbx, &[KindId(0xBEEF)]);
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Observer {
+            id: NodeId(0),
+            recipient: obs_mbx,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::KindNotAccepted { node, .. }) => assert_eq!(node, NodeId(0)),
+        other => panic!("expected KindNotAccepted, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_accepts_observer_via_fallback() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let obs_mbx = register_mailbox(&reg, "test.observer");
+    // Does not handle Signal, but carries a fallback.
+    register_caps_with_fallback(&caps, obs_mbx, &[KindId(0xBEEF)], true);
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Observer {
+            id: NodeId(0),
+            recipient: obs_mbx,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    assert!(validator::validate(&descriptor, &reg, &caps).is_ok());
+}
+
+#[test]
+fn validator_rejects_too_large_nodes() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let mbx = register_mailbox(&reg, "test.mbx");
+    let nodes: Vec<Node> = (0..=DEFAULT_MAX_NODES)
+        .map(|i| Node::Observer {
+            id: NodeId(u32::try_from(i).expect("test node count fits u32")),
+            recipient: mbx,
+            kind_id: Signal::ID,
+        })
+        .collect();
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes,
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::TooLarge { reason }) => {
+            assert!(reason.contains("node count"), "reason: {reason}");
+        }
+        other => panic!("expected TooLarge node-count reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_transform_node() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Transform {
+            id: NodeId(0),
+            transform_id: TransformId(0x1234),
+            output_kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::UnknownTransform { node, transform_id }) => {
+            assert_eq!(node, NodeId(0));
+            assert_eq!(transform_id, TransformId(0x1234));
+        }
+        other => panic!("expected UnknownTransform, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_accepts_call_node() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+
+    let src_mbx = register_mailbox(&reg, "test.source");
+    let call_mbx = register_mailbox(&reg, "test.call_recipient");
+    let obs_mbx = register_mailbox(&reg, "test.observer");
+    reg.register_kind_with_descriptor(descriptor_of::<Signal>())
+        .expect("register Signal");
+    reg.register_kind_with_descriptor(descriptor_of::<BundleConsumer>())
+        .expect("register BundleConsumer");
+    register_caps(&caps, src_mbx, &[Signal::ID]);
+    register_caps(&caps, call_mbx, &[Signal::ID]);
+    register_caps(&caps, obs_mbx, &[BundleConsumer::ID]);
+
+    // source(0) -> call(1) -> observer(2). The observer consumes a
+    // `Bundle` at slot 0, matching the call's `Bundle` output.
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: src_mbx,
+                kind_id: Signal::ID,
+                payload: vec![],
+            },
+            Node::Call {
+                id: NodeId(1),
+                recipient: call_mbx,
+                kind_id: Signal::ID,
+            },
+            Node::Observer {
+                id: NodeId(2),
+                recipient: obs_mbx,
+                kind_id: BundleConsumer::ID,
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+        ],
+    };
+
+    validator::validate(&descriptor, &reg, &caps).expect("call dag validates");
+}
+
+#[test]
+fn validator_rejects_call_unknown_recipient() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let ghost = MailboxId::from_name("test.ghost.call");
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Call {
+            id: NodeId(0),
+            recipient: ghost,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::UnknownRecipient(_)) => {}
+        other => panic!("expected UnknownRecipient, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_call_kind_not_accepted() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+    let call_mbx = register_mailbox(&reg, "test.call_recipient");
+    register_caps(&caps, call_mbx, &[KindId(0xFEED)]);
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![Node::Call {
+            id: NodeId(0),
+            recipient: call_mbx,
+            kind_id: Signal::ID,
+        }],
+        edges: vec![],
+    };
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::KindNotAccepted { node, kind_id, .. }) => {
+            assert_eq!(node, NodeId(0));
+            assert_eq!(kind_id, Signal::ID);
+        }
+        other => panic!("expected KindNotAccepted, got {other:?}"),
+    }
+}
+
+#[test]
+fn validator_rejects_call_consumer_not_accepting_bundle() {
+    let reg = Registry::new();
+    let caps = CapabilityRegistry::new();
+
+    let call_mbx = register_mailbox(&reg, "test.call_recipient");
+    let obs_mbx = register_mailbox(&reg, "test.observer");
+    reg.register_kind_with_descriptor(descriptor_of::<Signal>())
+        .expect("register Signal");
+    reg.register_kind_with_descriptor(descriptor_of::<SignalConsumer>())
+        .expect("register SignalConsumer");
+    register_caps(&caps, call_mbx, &[Signal::ID]);
+    register_caps(&caps, obs_mbx, &[SignalConsumer::ID]);
+
+    // call(0) -> observer(1), but the observer declares a `Ref<Signal>`
+    // input, not a `Ref<Bundle>` — type mismatch on the edge.
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Call {
+                id: NodeId(0),
+                recipient: call_mbx,
+                kind_id: Signal::ID,
+            },
+            Node::Observer {
+                id: NodeId(1),
+                recipient: obs_mbx,
+                kind_id: SignalConsumer::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    match validator::validate(&descriptor, &reg, &caps) {
+        Err(DagError::EdgeTypeMismatch {
+            edge_index,
+            expected_kind,
+            ..
+        }) => {
+            assert_eq!(edge_index, 0);
+            assert_eq!(expected_kind, Bundle::ID);
+        }
+        other => panic!("expected EdgeTypeMismatch, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements the ADR-0047 §3 DAG descriptor validator (the dag-validate
unit). New module crates/aether-substrate/src/dag/validator.rs exposing
validate(descriptor, mailboxes, caps) -> Result<ValidatedDag, DagError>,
plus a parent dag/mod.rs for the executor and validator siblings.

Runs the four phases in fixed order, short-circuiting on the first
failure so the returned DagError localises the real problem:

- Phase 0 — descriptor version gate (unimplemented version rejected via
  the TooLarge reuse, ADR-0047 §10).
- Phase 1 — structural integrity: node-id uniqueness, edge-endpoint
  existence, source/observer degree constraints (Call and Transform are
  mid-graph, no degree restriction), Kahn acyclicity (residual emitted
  as the Cycle), and the node/edge/byte structural caps (env-overridable,
  documented defaults).
- Phase 2 — dispatchability: mailbox existence via the routing Registry,
  accept-sets via the merged CapabilityRegistry (iamacoffeepot/aether#1037).
  Source/Call run the same existence + accept check; Observer also passes
  on a fallback; every Transform fails with UnknownTransform (no native
  transform catalog yet).
- Phase 3 — edge type compatibility, statically-declared outputs only: an
  edge out of a Call requires the consumer to declare a Bundle input at
  the matching slot. Source-output edges are not type-checked, and there
  is no reply-kind resolution anywhere (the re-scoped stance).

Success yields a ValidatedDag carrying the single topological order the
executor (iamacoffeepot/aether#976) dispatches from directly.

18 integration tests in crates/aether-substrate/tests/dag_validator.rs
cover every phase's accept and reject paths.

Closes iamacoffeepot/aether#975

## Test plan

- [x] cargo nextest run --workspace --profile ci (1100 passed)
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo doc --workspace --no-deps (rustdoc lints denied)
- [x] wasm32 component cross-build
- [x] 18 dag_validator phase tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)