### PR TITLE
fix(capabilities): hold the chain open across content-gen async replies

### DIFF
--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -320,6 +320,7 @@ mod native {
             }
 
             let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
+            let root = ctx.in_flight_root();
             let adapter = Arc::clone(&self.adapter);
 
             let call: BlockingCall = Box::new(move || {
@@ -330,20 +331,36 @@ mod native {
                 build_result_mail(path, request_id, result)
             });
 
-            self.dispatch
-                .submit(&self.mailer, self.self_mailbox, request_id, reply_to, call);
+            self.dispatch.submit(
+                &self.mailer,
+                self.self_mailbox,
+                root,
+                request_id,
+                reply_to,
+                call,
+            );
         }
 
         /// Re-reply to the original caller for a landed result mail.
-        /// `take_reply_to` pops the stashed `ReplyTo` (FIFO-independent
-        /// correlation by `request_id`); `on_reply_landed` frees the
-        /// in-flight slot and drains the next pending request.
+        /// `take_landed` pops the stashed `ReplyTo` + settlement hold
+        /// (FIFO-independent correlation by `request_id`);
+        /// `on_reply_landed` frees the in-flight slot and drains the
+        /// next pending request.
+        ///
+        /// ADR-0080 §12 ordering: re-reply through `reply_to` first,
+        /// then let the `LandedReply` (carrying the hold) drop at the
+        /// end of this scope so the re-reply's `Sent` event is queued
+        /// before the guard's `Release` — settlement fires exactly once
+        /// the reply is on the wire (iamacoffeepot/aether#1031).
         fn on_result_landed<K>(&mut self, ctx: &mut NativeCtx<'_>, request_id: u64, result: &K)
         where
             K: Kind + serde::Serialize,
         {
-            if let Some(reply_to) = self.dispatch.take_reply_to(request_id) {
-                OutboundReply::reply_to(ctx, reply_to, result);
+            if let Some(landed) = self.dispatch.take_landed(request_id) {
+                OutboundReply::reply_to(ctx, landed.reply_to, result);
+                // `landed.hold` drops here, after the re-reply — `Sent`
+                // precedes `Release`.
+                drop(landed);
             } else {
                 tracing::warn!(
                     target: "aether_capabilities::anthropic",

--- a/crates/aether-capabilities/src/contentgen/dispatch.rs
+++ b/crates/aether-capabilities/src/contentgen/dispatch.rs
@@ -32,9 +32,10 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::thread;
 
-use aether_data::{KindId, MailboxId, ReplyTo};
+use aether_data::{KindId, MailId, MailboxId, ReplyTo};
 use aether_substrate::Mail;
 use aether_substrate::mail::Mailer;
+use aether_substrate::runtime::trace::SettlementHold;
 
 /// Default per-cap concurrency bound when a cap doesn't override it.
 /// Doubles as rate-limit throttling for the paid provider endpoints
@@ -56,6 +57,29 @@ struct QueuedRequest {
     request_id: u64,
     reply_to: ReplyTo,
     call: BlockingCall,
+    /// The settlement hold acquired when this request was accepted (it
+    /// enqueued rather than spawning immediately). The caller is owed a
+    /// reply whether it ran at once or waited, so the chain stays held
+    /// from accept to re-reply. Moved into the correlation map when the
+    /// request later spawns (in [`InFlightDispatch::on_reply_landed`]).
+    hold: SettlementHold,
+}
+
+/// What a landed reply hands back to the cap's reply-landing handler:
+/// the original caller's `ReplyTo` plus the [`SettlementHold`] that has
+/// kept the chain root open across the async provider call. The cap
+/// re-replies through `reply_to` **first**, then drops `hold` so the
+/// re-reply's `Sent` event is queued before the guard's `Release`
+/// (ADR-0080 §12 ordering — see [`InFlightDispatch::take_landed`]).
+#[must_use = "dropping the LandedReply releases the settlement hold; re-reply through reply_to first"]
+pub struct LandedReply {
+    /// The original caller's reply target, popped from the correlation
+    /// map by `request_id`.
+    pub reply_to: ReplyTo,
+    /// The settlement hold acquired at `submit`/accept time. Drops
+    /// (firing `Release`) when the cap handler's scope ends — after the
+    /// re-reply, so `Sent` precedes `Release`.
+    pub hold: SettlementHold,
 }
 
 /// Actor-state half of the spawn-and-die dispatch model. Lives in the
@@ -65,10 +89,16 @@ pub struct InFlightDispatch {
     in_flight: usize,
     max_in_flight: usize,
     pending: VecDeque<QueuedRequest>,
-    /// `request_id -> original caller's ReplyTo`. Stashed at submit,
-    /// popped at reply-landing so the cap re-replies to the right
-    /// caller without a FIFO assumption.
-    correlations: HashMap<u64, ReplyTo>,
+    /// `request_id -> (original caller's ReplyTo, settlement hold)`.
+    /// Stashed at submit, popped at reply-landing so the cap re-replies
+    /// to the right caller without a FIFO assumption. The
+    /// [`SettlementHold`] (ADR-0080 §12) keeps the chain root open from
+    /// `submit` until the re-reply lands — without it the chain settles
+    /// the instant the handler returns, seconds before the async
+    /// provider reply exists (iamacoffeepot/aether#1031). The guard is
+    /// `!Copy` and lives in single-threaded actor state, so the
+    /// hold/release pair is structurally balanced.
+    correlations: HashMap<u64, (ReplyTo, SettlementHold)>,
 }
 
 impl InFlightDispatch {
@@ -98,38 +128,63 @@ impl InFlightDispatch {
         self.pending.len()
     }
 
-    /// Look up (and remove) the original caller's `ReplyTo` for a
-    /// landed `request_id`. The cap's reply-landing handler calls this
-    /// to re-reply to the right caller, then calls
+    /// Look up (and remove) the [`LandedReply`] — the original caller's
+    /// `ReplyTo` plus the [`SettlementHold`] that kept the chain open —
+    /// for a landed `request_id`. The cap's reply-landing handler calls
+    /// this, re-replies through the returned `reply_to` **first**, then
+    /// lets the `LandedReply` (carrying the hold) drop so the
+    /// re-reply's `Sent` precedes the guard's `Release` (ADR-0080 §12
+    /// ordering). After re-replying it calls
     /// [`on_reply_landed`](Self::on_reply_landed) to free the slot.
     /// Returns `None` for an unknown `request_id` (a double-landing or
-    /// a stale reply).
-    pub fn take_reply_to(&mut self, request_id: u64) -> Option<ReplyTo> {
-        self.correlations.remove(&request_id)
+    /// a stale reply); the chain is no longer held in that case (the
+    /// hold dropped on the prior landing).
+    pub fn take_landed(&mut self, request_id: u64) -> Option<LandedReply> {
+        self.correlations
+            .remove(&request_id)
+            .map(|(reply_to, hold)| LandedReply { reply_to, hold })
     }
 
     /// Take a request off the mail queue. If a slot is free, stash the
-    /// caller's `ReplyTo`, increment `in_flight`, and spawn the
-    /// ephemeral thread; otherwise enqueue. `mailer` + `self_id` are
-    /// the cap's own (`ctx.mailer()` / `ctx.self_id()`) so the
-    /// ephemeral thread can land its result mail back on the cap.
+    /// caller's `ReplyTo` + settlement hold, increment `in_flight`, and
+    /// spawn the ephemeral thread; otherwise enqueue (carrying the
+    /// hold). `mailer` + `self_id` are the cap's own (`ctx.mailer()` /
+    /// `ctx.self_id()`) so the ephemeral thread can land its result mail
+    /// back on the cap.
+    ///
+    /// `root` is the chain root (`ctx.in_flight_root()`). Before the
+    /// request spawns *or* enqueues, this acquires a [`SettlementHold`]
+    /// on `root` (ADR-0080 §12). Acquiring it here — before the cap's
+    /// handler returns and queues its `Finished` — means the `HoldOpen`
+    /// event is visible before `Finished`, so the chain never
+    /// transiently settles between handler-return and the async reply.
+    /// The hold lives in actor state (the correlation map or the
+    /// `pending` queue) until the re-reply lands, outliving the
+    /// ephemeral worker thread (which holds nothing).
     pub fn submit(
         &mut self,
         mailer: &Arc<Mailer>,
         self_id: MailboxId,
+        root: MailId,
         request_id: u64,
         reply_to: ReplyTo,
         call: BlockingCall,
     ) {
-        self.correlations.insert(request_id, reply_to);
+        // Acquire before spawn/enqueue so `HoldOpen` is queued ahead of
+        // the handler's `Finished`. The caller is owed a reply whether
+        // it runs now or waits, so the hold spans accept -> re-reply in
+        // both branches.
+        let hold = mailer.acquire_settlement_hold(root);
         if self.in_flight < self.max_in_flight {
             self.in_flight += 1;
+            self.correlations.insert(request_id, (reply_to, hold));
             Self::spawn(mailer, self_id, reply_to, call);
         } else {
             self.pending.push_back(QueuedRequest {
                 request_id,
                 reply_to,
                 call,
+                hold,
             });
         }
     }
@@ -138,10 +193,19 @@ impl InFlightDispatch {
     /// spawn the next pending request if there is one. Returns the
     /// freshly-dequeued request's `request_id` (or `None` when nothing
     /// was waiting) so the caller can trace drains.
+    ///
+    /// When a pending request drains, its [`SettlementHold`] (acquired
+    /// at accept time in [`Self::submit`]) moves from the `pending`
+    /// queue into the correlation map so it keeps the chain held until
+    /// that request's own re-reply lands. The landing request's hold
+    /// has already been taken (and dropped after re-reply) by
+    /// [`Self::take_landed`] in the cap handler before this call.
     pub fn on_reply_landed(&mut self, mailer: &Arc<Mailer>, self_id: MailboxId) -> Option<u64> {
         self.in_flight = self.in_flight.saturating_sub(1);
         if let Some(next) = self.pending.pop_front() {
             self.in_flight += 1;
+            self.correlations
+                .insert(next.request_id, (next.reply_to, next.hold));
             Self::spawn(mailer, self_id, next.reply_to, next.call);
             Some(next.request_id)
         } else {
@@ -175,8 +239,9 @@ impl InFlightDispatch {
 #[cfg(test)]
 mod tests {
     use super::{DEFAULT_MAX_IN_FLIGHT, InFlightDispatch};
-    use aether_data::{Kind, KindId, MailboxId, ReplyTarget, ReplyTo, SessionToken, Uuid};
+    use aether_data::{Kind, KindId, MailId, MailboxId, ReplyTarget, ReplyTo, SessionToken, Uuid};
     use aether_kinds::Pong;
+    use aether_kinds::trace::TraceEvent;
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -198,6 +263,43 @@ mod tests {
 
     fn session_reply_to(corr: u64) -> ReplyTo {
         ReplyTo::with_correlation(ReplyTarget::Session(SessionToken(Uuid::nil())), corr)
+    }
+
+    /// A synthetic chain root for a request — the value the cap handler
+    /// would read from `ctx.in_flight_root()`. Distinct per `cid` so a
+    /// multi-request test can keep each chain's hold accounting separate.
+    fn root_id(cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(1),
+            correlation_id: cid,
+        }
+    }
+
+    /// Net `held_open` count for `root` over every settlement event
+    /// currently in the mailer's trace queue: `+1` per `HoldOpen`, `-1`
+    /// per `Release`. The queue isn't drained — settlement tests poll it
+    /// repeatedly as the guard moves through actor state. A positive
+    /// value means the chain is still held (settlement gated); zero
+    /// means every acquired hold has released.
+    fn net_held_open(mailer: &Arc<Mailer>, root: MailId) -> i64 {
+        let queue = mailer.trace_handle().queue();
+        let mut net = 0;
+        let mut scratch = Vec::new();
+        while let Some(ev) = queue.pop() {
+            match &ev {
+                TraceEvent::HoldOpen { root: r, .. } if *r == root => net += 1,
+                TraceEvent::Release { root: r, .. } if *r == root => net -= 1,
+                _ => {}
+            }
+            scratch.push(ev);
+        }
+        // Restore the events so a later poll sees the full history — the
+        // hold/release pairing is cumulative across the whole submit ->
+        // reply lifecycle, not a one-shot read.
+        for ev in scratch {
+            queue.push(ev);
+        }
+        net
     }
 
     #[test]
@@ -230,6 +332,7 @@ mod tests {
         d.submit(
             &mailer,
             self_id,
+            root_id(1),
             1,
             session_reply_to(1),
             signal_call(1, done_tx.clone()),
@@ -237,6 +340,7 @@ mod tests {
         d.submit(
             &mailer,
             self_id,
+            root_id(2),
             2,
             session_reply_to(2),
             signal_call(2, done_tx.clone()),
@@ -244,6 +348,7 @@ mod tests {
         d.submit(
             &mailer,
             self_id,
+            root_id(3),
             3,
             session_reply_to(3),
             signal_call(3, done_tx),
@@ -303,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn take_reply_to_correlates_by_request_id() {
+    fn take_landed_correlates_by_request_id() {
         let mailer = test_mailer();
         let self_id = MailboxId(7);
         let mut d = InFlightDispatch::new(4);
@@ -314,6 +419,7 @@ mod tests {
         d.submit(
             &mailer,
             self_id,
+            root_id(42),
             42,
             rt_a,
             Box::new({
@@ -327,6 +433,7 @@ mod tests {
         d.submit(
             &mailer,
             self_id,
+            root_id(43),
             43,
             rt_b,
             Box::new(move || {
@@ -337,10 +444,153 @@ mod tests {
         let _ = done_rx.recv_timeout(Duration::from_secs(2));
         let _ = done_rx.recv_timeout(Duration::from_secs(2));
 
-        // Out-of-order correlation: pop request 43 first, then 42.
-        assert_eq!(d.take_reply_to(43), Some(rt_b));
-        assert_eq!(d.take_reply_to(42), Some(rt_a));
+        // Out-of-order correlation: pop request 43 first, then 42. The
+        // `LandedReply` carries the right `reply_to` (the hold rides
+        // alongside it, dropping when the binding goes out of scope).
+        let landed_b = d.take_landed(43).expect("request 43 landed");
+        assert_eq!(landed_b.reply_to, rt_b);
+        let landed_a = d.take_landed(42).expect("request 42 landed");
+        assert_eq!(landed_a.reply_to, rt_a);
         // Already taken -> None (double-landing guard).
-        assert_eq!(d.take_reply_to(42), None);
+        assert!(d.take_landed(42).is_none());
+    }
+
+    /// iamacoffeepot/aether#1031: the settlement hold spans submit ->
+    /// reply. After `submit` returns (the cap handler "finished"), the
+    /// chain root still has a net `held_open` of 1 — settlement is
+    /// gated. Only after the cap re-replies and the `LandedReply`
+    /// (carrying the hold) drops does the net return to 0, releasing
+    /// the chain.
+    #[test]
+    fn dispatch_holds_chain_until_reply() {
+        let mailer = test_mailer();
+        let self_id = MailboxId(7);
+        let root = root_id(1);
+        let mut d = InFlightDispatch::new(4);
+        let (done_tx, done_rx) = mpsc::channel::<u64>();
+
+        d.submit(
+            &mailer,
+            self_id,
+            root,
+            1,
+            session_reply_to(1),
+            signal_call(1, done_tx),
+        );
+
+        // The cap handler has returned. The worker thread may still be
+        // running (or already finished) — either way the actor-state
+        // guard keeps the chain held: net held_open == 1.
+        assert_eq!(
+            net_held_open(&mailer, root),
+            1,
+            "the chain stays held after submit returns (before the reply lands)"
+        );
+
+        // The worker ran and fired its loopback mail.
+        let _ = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the call runs");
+        // Still held — the result mail landing handler hasn't run yet.
+        assert_eq!(
+            net_held_open(&mailer, root),
+            1,
+            "the worker finishing does not release the chain; the hold lives in actor state"
+        );
+
+        // The cap handler runs on reply-landing: pop the LandedReply
+        // (re-reply happens here in production), then drop it — that
+        // fires Release.
+        let landed = d.take_landed(1).expect("request 1 landed");
+        assert_eq!(net_held_open(&mailer, root), 1, "still held before drop");
+        drop(landed);
+        let _ = d.on_reply_landed(&mailer, self_id);
+
+        // Hold released — net back to 0, so the chain may settle.
+        assert_eq!(
+            net_held_open(&mailer, root),
+            0,
+            "dropping the LandedReply after re-reply releases the chain"
+        );
+    }
+
+    /// iamacoffeepot/aether#1031: a request that overflows
+    /// `max_in_flight` and enqueues still acquires its hold at accept
+    /// time — settlement doesn't fire while it waits in `pending`, and
+    /// the hold survives the move out of the queue (in `on_reply_landed`)
+    /// into the correlation map, releasing only after its own re-reply.
+    #[test]
+    fn dispatch_holds_each_queued_request() {
+        let mailer = test_mailer();
+        let self_id = MailboxId(7);
+        let root_a = root_id(1);
+        let root_b = root_id(2);
+        // Bound of 1 so the second submit enqueues.
+        let mut d = InFlightDispatch::new(1);
+        let (done_tx, done_rx) = mpsc::channel::<u64>();
+
+        d.submit(
+            &mailer,
+            self_id,
+            root_a,
+            1,
+            session_reply_to(1),
+            signal_call(1, done_tx.clone()),
+        );
+        d.submit(
+            &mailer,
+            self_id,
+            root_b,
+            2,
+            session_reply_to(2),
+            signal_call(2, done_tx),
+        );
+        assert_eq!(d.in_flight(), 1);
+        assert_eq!(d.pending(), 1, "the second request enqueued");
+
+        // Both chains are held from accept — the queued one too.
+        assert_eq!(
+            net_held_open(&mailer, root_a),
+            1,
+            "the running request holds its chain"
+        );
+        assert_eq!(
+            net_held_open(&mailer, root_b),
+            1,
+            "the queued request also holds its chain from accept"
+        );
+
+        // First worker ran; land its reply. take_landed(1) + drop
+        // releases chain A; on_reply_landed drains the queued request 2
+        // (moving its hold into the correlation map) and spawns it.
+        let _ = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("first call runs");
+        drop(d.take_landed(1).expect("request 1 landed"));
+        let drained = d.on_reply_landed(&mailer, self_id);
+        assert_eq!(drained, Some(2), "the queued request drains");
+
+        assert_eq!(
+            net_held_open(&mailer, root_a),
+            0,
+            "chain A released after request 1's reply"
+        );
+        assert_eq!(
+            net_held_open(&mailer, root_b),
+            1,
+            "chain B still held — its reply hasn't landed yet"
+        );
+
+        // Land request 2's reply: release chain B.
+        let _ = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("second call runs");
+        drop(d.take_landed(2).expect("request 2 landed"));
+        let _ = d.on_reply_landed(&mailer, self_id);
+        assert_eq!(
+            net_held_open(&mailer, root_b),
+            0,
+            "chain B released after request 2's reply"
+        );
     }
 }

--- a/crates/aether-capabilities/src/contentgen/mod.rs
+++ b/crates/aether-capabilities/src/contentgen/mod.rs
@@ -28,5 +28,5 @@ pub use adapter::{
     GeminiArtifact, GeminiImageRequest, GeminiMusicRequest, GeminiResponse, StubAnthropicAdapter,
     StubGeminiAdapter,
 };
-pub use dispatch::{BlockingCall, DEFAULT_MAX_IN_FLIGHT, InFlightDispatch};
+pub use dispatch::{BlockingCall, DEFAULT_MAX_IN_FLIGHT, InFlightDispatch, LandedReply};
 pub use staging::{GEN_PREFIX, gen_root, stage_gen_output};

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -398,12 +398,22 @@ mod native {
     impl GeminiCapability {
         /// Re-reply to the original caller for a landed result mail and
         /// free the in-flight slot (drains the next pending request).
+        ///
+        /// ADR-0080 §12 ordering: re-reply through the stashed
+        /// `reply_to` first, then let the `LandedReply` (carrying the
+        /// settlement hold) drop at the end of this scope so the
+        /// re-reply's `Sent` event is queued before the guard's
+        /// `Release` — settlement fires exactly once the reply is on the
+        /// wire (iamacoffeepot/aether#1031).
         fn on_result_landed<K>(&mut self, ctx: &mut NativeCtx<'_>, request_id: u64, result: &K)
         where
             K: Kind + serde::Serialize,
         {
-            if let Some(reply_to) = self.dispatch.take_reply_to(request_id) {
-                OutboundReply::reply_to(ctx, reply_to, result);
+            if let Some(landed) = self.dispatch.take_landed(request_id) {
+                OutboundReply::reply_to(ctx, landed.reply_to, result);
+                // `landed.hold` drops here, after the re-reply — `Sent`
+                // precedes `Release`.
+                drop(landed);
             } else {
                 tracing::warn!(
                     target: "aether_capabilities::gemini",
@@ -592,13 +602,20 @@ mod native {
                 reference_images,
             };
             let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
+            let root = ctx.in_flight_root();
             let adapter = Arc::clone(&self.adapter);
             let call: BlockingCall = Box::new(move || {
                 let result = adapter.nanobanana_generate(req);
                 build_result_mail(MediaKind::Nanobanana, request_id, result)
             });
-            self.dispatch
-                .submit(&self.mailer, self.self_mailbox, request_id, reply_to, call);
+            self.dispatch.submit(
+                &self.mailer,
+                self.self_mailbox,
+                root,
+                request_id,
+                reply_to,
+                call,
+            );
         }
 
         /// Generate music via Lyria off the dispatcher thread.
@@ -639,13 +656,20 @@ mod native {
                 sample_count: mail.sample_count.unwrap_or(1),
             };
             let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
+            let root = ctx.in_flight_root();
             let adapter = Arc::clone(&self.adapter);
             let call: BlockingCall = Box::new(move || {
                 let result = adapter.lyria_generate(req);
                 build_result_mail(MediaKind::Lyria, request_id, result)
             });
-            self.dispatch
-                .submit(&self.mailer, self.self_mailbox, request_id, reply_to, call);
+            self.dispatch.submit(
+                &self.mailer,
+                self.self_mailbox,
+                root,
+                request_id,
+                reply_to,
+                call,
+            );
         }
 
         /// Loopback landing for a completed Nano Banana call.

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -890,6 +890,84 @@ mod tests {
         }
     }
 
+    /// iamacoffeepot/aether#1031 end-to-end: a `Call` against an actor
+    /// that replies through the content-gen `InFlightDispatch`
+    /// (spawned worker -> loopback result -> re-reply) must still
+    /// produce a `ReplyEvent` followed by a `ReplyEnd`. The settlement
+    /// hold keeps the chain open across the spawn, so the RPC server's
+    /// settlement subscription wakes only *after* the deferred reply
+    /// arrives — not when the handler returns. Pre-fix the chain settled
+    /// the instant `on_deferred_echo` returned and the deferred reply
+    /// landed in an already-closed call (no `ReplyEvent`, only a bare
+    /// `ReplyEnd`, then the late reply dropped).
+    #[test]
+    fn call_deferred_echo_settles_after_reply() {
+        use crate::rpc::test_echo::{DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest};
+        use crate::rpc::wire::{MailEnvelope, MailboxAddress};
+        use crate::trace::TraceObserverCapability;
+        use aether_actor::Actor;
+        use aether_data::{Kind, mailbox_id_from_name};
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceObserverCapability>(())
+            .with_actor::<DeferredEchoActor>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(5));
+        complete_handshake(&mut stream);
+
+        let payload = postcard::to_allocvec(&DeferredEchoRequest { value: 99 })
+            .expect("test setup: DeferredEchoRequest serializes via postcard");
+        let mailbox = mailbox_id_from_name(<DeferredEchoActor as Actor>::NAMESPACE);
+        write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: Some(0xdef),
+                envelope: MailEnvelope {
+                    to: MailboxAddress::local(mailbox),
+                    from: None,
+                    kind: <DeferredEchoRequest as Kind>::ID,
+                    correlation_id: None,
+                    payload,
+                },
+            },
+        )
+        .expect("test: write_frame Call to rpc server");
+
+        // The deferred reply arrives as a ReplyEvent — proving the chain
+        // stayed open long enough for the spawned worker's reply to be
+        // intercepted (not dropped into an already-settled call).
+        let event: WireFrame = read_frame(&mut stream).expect("read ReplyEvent");
+        let envelope = match event {
+            WireFrame::ReplyEvent { cid, envelope } => {
+                assert_eq!(cid, 0xdef);
+                envelope
+            }
+            other => panic!("expected ReplyEvent for the deferred reply, got {other:?}"),
+        };
+        assert_eq!(envelope.kind, <DeferredEchoReply as Kind>::ID);
+        let decoded: DeferredEchoReply =
+            postcard::from_bytes(&envelope.payload).expect("decode deferred reply");
+        assert_eq!(decoded.value, 99);
+
+        // ReplyEnd follows — settlement fired after the deferred reply,
+        // not when the handler returned.
+        let end: WireFrame = read_frame(&mut stream).expect("read ReplyEnd");
+        match end {
+            WireFrame::ReplyEnd { cid, result } => {
+                assert_eq!(cid, 0xdef);
+                result.expect("ReplyEnd result Ok");
+            }
+            other => panic!("expected ReplyEnd, got {other:?}"),
+        }
+    }
+
     /// Fire-and-forget `Call { cid: None }` skips reply correlation
     /// entirely — no settlement subscription is created, no
     /// `ReplyEnd` is written. Verify by sending a Call with cid None

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -84,3 +84,134 @@ mod test_echo_actor {
 
 // `TestEchoActor` is re-exported at this module's root by the
 // `#[bridge]` macro itself — no explicit `pub use` needed.
+
+/// Deferred-echo request — like [`TestEchoRequest`] but the actor
+/// answers it through the content-gen [`InFlightDispatch`] two-hop path:
+/// the handler spawns an off-thread worker that lands a result mail back
+/// on the actor, and a second handler re-replies. Exercises the
+/// settlement-hold contract (iamacoffeepot/aether#1031) end-to-end: the
+/// chain must stay open across the spawn so the RPC `Call`'s
+/// settlement subscription only fires after the deferred reply.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.deferred_echo_request")]
+pub struct DeferredEchoRequest {
+    pub value: u64,
+}
+
+/// Deferred-echo reply — the worker thread lands this on the actor's own
+/// mailbox (the loopback result mail), and the actor re-replies the same
+/// shape to the original caller.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.rpc.test.deferred_echo_reply")]
+pub struct DeferredEchoReply {
+    pub value: u64,
+}
+
+/// Test-only actor that answers [`DeferredEchoRequest`] off-thread via
+/// the content-gen [`crate::contentgen::dispatch::InFlightDispatch`],
+/// reproducing the production content-gen caps' deferred-reply shape
+/// (submit -> spawned worker -> loopback result -> re-reply). The whole
+/// point is that the reply happens *after* the handler returns, so the
+/// settlement hold must keep the chain open across the gap.
+#[aether_actor::bridge(singleton)]
+mod deferred_echo_actor {
+    use super::{DeferredEchoReply, DeferredEchoRequest};
+    use crate::contentgen::dispatch::{BlockingCall, InFlightDispatch};
+    use aether_actor::{actor, actor::ctx::OutboundReply};
+    use aether_data::{Kind, KindId, MailboxId, ReplyTo};
+    use aether_substrate::Mailer;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    pub struct DeferredEchoActor {
+        dispatch: InFlightDispatch,
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+    }
+
+    #[actor]
+    impl NativeActor for DeferredEchoActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.rpc.test.deferred_echo";
+
+        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                dispatch: InFlightDispatch::new(4),
+                mailer: ctx.mailer(),
+                self_mailbox: ctx.self_id(),
+            })
+        }
+
+        /// Submit the echo off-thread. The worker sleeps briefly so the
+        /// handler reliably returns (queuing its `Finished`) before the
+        /// reply lands — the window the bug used to settle in. With the
+        /// hold, settlement waits for the re-reply.
+        #[handler]
+        fn on_deferred_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: DeferredEchoRequest) {
+            let request_id = mail.value;
+            let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
+            let root = ctx.in_flight_root();
+            let value = mail.value;
+            let call: BlockingCall = Box::new(move || {
+                // Brief blocking work standing in for a provider call.
+                thread::sleep(Duration::from_millis(50));
+                let reply = DeferredEchoReply { value };
+                (
+                    KindId(<DeferredEchoReply as Kind>::ID.0),
+                    reply.encode_into_bytes(),
+                )
+            });
+            self.dispatch.submit(
+                &self.mailer,
+                self.self_mailbox,
+                root,
+                request_id,
+                reply_to,
+                call,
+            );
+        }
+
+        /// Loopback landing for the worker's result mail: re-reply to the
+        /// original caller, then drop the settlement hold (ADR-0080 §12
+        /// ordering — `Sent` precedes `Release`).
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_deferred_echo_result(&mut self, ctx: &mut NativeCtx<'_>, mail: DeferredEchoReply) {
+            if let Some(landed) = self.dispatch.take_landed(mail.value) {
+                OutboundReply::reply_to(ctx, landed.reply_to, &mail);
+                drop(landed);
+            }
+            let _ = self
+                .dispatch
+                .on_reply_landed(&self.mailer, self.self_mailbox);
+        }
+    }
+}
+
+// `DeferredEchoActor` is re-exported at this module's root by the
+// `#[bridge]` macro.


### PR DESCRIPTION
## Summary

The content-gen caps (aether.anthropic, aether.gemini) dispatch their blocking provider calls off-thread via InFlightDispatch, which spawned its worker with a raw thread and took no settlement hold. The cap handler returned the instant it spawned, the chain's in_flight dropped to zero with held_open == 0, and the substrate fired Settled the chain root seconds before the provider reply existed. Any settlement consumer (the RPC Call path today, the DAG Call executor next) closed its reply window and dropped the real reply.

This is a pure aether-capabilities fix honoring the ADR-0080 section 12 settlement-hold contract the substrate already provides:

- InFlightDispatch::submit takes a chain root (ctx.in_flight_root()) and acquires a SettlementHold on it before spawning or enqueuing, so the HoldOpen trace event is queued ahead of the handler's Finished. The hold lives in actor state alongside the caller's reply target.
- The reply-landing handler (take_landed) re-replies to the original caller first, then drops the guard, so the re-reply's Sent precedes the guard's Release. Settlement fires exactly once the reply is on the wire.
- Queued (over-bound) requests acquire their hold at accept time too; the hold moves from the pending queue into the correlation map when the request later drains and spawns.

Settlement stays fire-on-zero. No quiescence window, no zero_since, no drainer heartbeat, no AETHER_TRACE_QUIESCENCE_MS, and no change to TraceObserverCapability's (in_flight == 0 && held_open == 0) rule.

## Tests

- dispatch_holds_chain_until_reply: the hold spans submit to reply (net held_open stays 1 after submit returns and after the worker finishes; returns to 0 only after the LandedReply drops).
- dispatch_holds_each_queued_request: a request that overflows max_in_flight and enqueues also holds from accept; its hold survives the move out of the queue and releases after its own re-reply.
- call_deferred_echo_settles_after_reply: end-to-end through a deferred-reply actor wired into the RPC Call + TraceObserver settlement path; the ReplyEvent (the deferred reply) is intercepted before the ReplyEnd (settlement), proving settlement waited for the spawned reply.
- The synchronous-reply regression guard call_echo_round_trip_event_then_end still passes on fire-on-zero.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo doc --workspace --no-deps (rustdoc lints denied)
- [x] cargo nextest run --workspace --all-features --profile ci (1160 passed)
- [x] wasm32 component cross-build (aether-camera, aether-test-fixture-probe, aether-mesh-viewer, aether-demo-sokoban)

Closes iamacoffeepot/aether#1031